### PR TITLE
Revert "* added Skyline testing to AppVeyor config"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: '{build}.{branch}'
 clone_depth: 1
-build_script: >-
-    & .\scripts\misc\tcbuild-apps.bat 64 --i-agree-to-the-vendor-licenses -j2 pwiz_tools\Skyline pwiz_tools\Topograph toolset=msvc-12.0
-    & .\quickbuild.bat address-model=64 --i-agree-to-the-vendor-licenses -j2 --abbreviate-paths pwiz executables toolset=msvc-12.0
+build_script:
+- ps: '& .\quickbuild.bat address-model=64 --i-agree-to-the-vendor-licenses -j2 --abbreviate-paths pwiz executables toolset=msvc-12.0'
+test: off
 
 skip_commits:
   files:


### PR DESCRIPTION
This reverts commit 1a349f38752d6da061e47e79c48ac22c3bd9d8f2.

Can't build Skyline/Bibliospec without Mascot Parser and Thermo MSFileReader.