### PR TITLE
Fix IndexOutOfRangeException in DisplayAllIonsSumary

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -1192,7 +1192,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                                true,
                                                null,
                                                0,
-                                               COLORS_GROUPS[(int)extractor],
+                                               COLORS_GROUPS[(int)extractor % COLORS_GROUPS.Count],
                                                FontSize,
                                                LineWidth);
             _graphHelper.AddChromatogram(new PaneKey(nodeGroup), graphItem);


### PR DESCRIPTION
This exception happens if you have only one color in your color scheme.