### PR TITLE
Speed up BiblioSpecLiteLibrary.AnnotationsForObservedMz

### DIFF
--- a/pwiz_tools/Shared/Common/Common.csproj
+++ b/pwiz_tools/Shared/Common/Common.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Database\NHibernate\SessionFactoryFactory.cs" />
     <Compile Include="Database\NHibernate\SessionWithLock.cs" />
     <Compile Include="Database\NHibernate\StatelessSessionWithLock.cs" />
+    <Compile Include="Database\SqliteOperations.cs" />
     <Compile Include="DataBinding\AbstractViewContext.cs" />
     <Compile Include="DataBinding\AggregateOperation.cs" />
     <Compile Include="DataBinding\Attributes\AdvancedAttribute.cs" />
@@ -176,7 +177,9 @@
     <Compile Include="DataBinding\Controls\ManageLayoutsForm.Designer.cs">
       <DependentUpon>ManageLayoutsForm.cs</DependentUpon>
     </Compile>
-    <Compile Include="DataBinding\Controls\NameLayoutForm.cs" />
+    <Compile Include="DataBinding\Controls\NameLayoutForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="DataBinding\Controls\NameLayoutForm.Designer.cs">
       <DependentUpon>NameLayoutForm.cs</DependentUpon>
     </Compile>

--- a/pwiz_tools/Shared/Common/Database/SqliteOperations.cs
+++ b/pwiz_tools/Shared/Common/Database/SqliteOperations.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2018 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Data;
+using System.Data.SQLite;
+
+namespace pwiz.Common.Database
+{
+    public static class SqliteOperations
+    {
+        public static bool TableExists(IDbConnection connection, string tableName)
+        {
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?"; // Not L10N
+                cmd.Parameters.Add(new SQLiteParameter { Value = tableName });
+                using (var reader = cmd.ExecuteReader())
+                {
+                    return reader.Read();
+                }
+            }
+        }
+    }
+}

--- a/pwiz_tools/Shared/ProteomeDb/API/ProteomeDb.cs
+++ b/pwiz_tools/Shared/ProteomeDb/API/ProteomeDb.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Threading;
 using NHibernate;
 using NHibernate.Criterion;
+using pwiz.Common.Database;
 using pwiz.Common.Database.NHibernate;
 using pwiz.Common.SystemUtil;
 using pwiz.ProteomeDatabase.DataModel;
@@ -72,14 +73,10 @@ namespace pwiz.ProteomeDatabase.API
             using (var session = OpenSession())
             {
                 // Is this even a proper protDB file? (https://skyline.gs.washington.edu/labkey/announcements/home/issues/exceptions/thread.view?rowId=14893)
-                using (IDbCommand command = session.Connection.CreateCommand())
+                if (!SqliteOperations.TableExists(session.Connection, "ProteomeDbProteinName")) // Not L10N
                 {
-                    command.CommandText =
-                        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='ProteomeDbProteinName'"; // Not L10N
-                    var obj = command.ExecuteScalar();
-                    if (Convert.ToInt32(obj) == 0)
-                        throw new FileLoadException(
-                            String.Format(Resources.ProteomeDb_ProteomeDb__0__does_not_appear_to_be_a_valid___protDB__background_proteome_file_, path));
+                    throw new FileLoadException(
+                        String.Format(Resources.ProteomeDb_ProteomeDb__0__does_not_appear_to_be_a_valid___protDB__background_proteome_file_, path));
                 }
 
                 // Do we need to update the db to current version?
@@ -119,35 +116,29 @@ namespace pwiz.ProteomeDatabase.API
 
         private void ReadVersion(ISession session)
         {
-            using (IDbCommand cmd = session.Connection.CreateCommand())
+            // do we even have a version? 0th-gen protdb doesn't have this.
+            if (!SqliteOperations.TableExists(session.Connection, "ProteomeDbSchemaVersion"))
             {
-                // do we even have a version? 0th-gen protdb doesn't have this.
-                cmd.CommandText =
-                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='ProteomeDbSchemaVersion'"; // Not L10N
-                var obj = cmd.ExecuteScalar();
-                if (Convert.ToInt32(obj) == 0)
-                {
-                    _schemaVersionMajor = SCHEMA_VERSION_MAJOR_0; // an ancient, unversioned file
-                    _schemaVersionMinor = SCHEMA_VERSION_MINOR_0; // an ancient, unversioned file
-                }
-                else
-                {
-                    using (IDbCommand cmd2 = session.Connection.CreateCommand())
-                    {
-                        cmd2.CommandText = "SELECT SchemaVersionMajor FROM ProteomeDbSchemaVersion"; // Not L10N
-                        var obj2 = cmd2.ExecuteScalar();
-                        _schemaVersionMajor = Convert.ToInt32(obj2);
-                    }
-                    using (IDbCommand cmd3 = session.Connection.CreateCommand())
-                    {
-                        cmd3.CommandText = "SELECT SchemaVersionMinor FROM ProteomeDbSchemaVersion"; // Not L10N
-                        var obj3 = cmd3.ExecuteScalar();
-                        _schemaVersionMinor = Convert.ToInt32(obj3);
-                    }
-                }
-                _schemaVersionMajorAsRead = _schemaVersionMajor;
-                _schemaVersionMinorAsRead = _schemaVersionMinor;
+                _schemaVersionMajor = SCHEMA_VERSION_MAJOR_0; // an ancient, unversioned file
+                _schemaVersionMinor = SCHEMA_VERSION_MINOR_0; // an ancient, unversioned file
             }
+            else
+            {
+                using (IDbCommand cmd2 = session.Connection.CreateCommand())
+                {
+                    cmd2.CommandText = "SELECT SchemaVersionMajor FROM ProteomeDbSchemaVersion"; // Not L10N
+                    var obj2 = cmd2.ExecuteScalar();
+                    _schemaVersionMajor = Convert.ToInt32(obj2);
+                }
+                using (IDbCommand cmd3 = session.Connection.CreateCommand())
+                {
+                    cmd3.CommandText = "SELECT SchemaVersionMinor FROM ProteomeDbSchemaVersion"; // Not L10N
+                    var obj3 = cmd3.ExecuteScalar();
+                    _schemaVersionMinor = Convert.ToInt32(obj3);
+                }
+            }
+            _schemaVersionMajorAsRead = _schemaVersionMajor;
+            _schemaVersionMinorAsRead = _schemaVersionMinor;
         }
 
         public bool IsDigested()
@@ -451,13 +442,7 @@ namespace pwiz.ProteomeDatabase.API
 
         internal static bool CheckHasSubsequenceTable(IDbConnection connection)
         {
-            using (IDbCommand command = connection.CreateCommand())
-            {
-                command.CommandText =
-                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='ProteomeDbSubsequence'"; // Not L10N
-                var obj = command.ExecuteScalar();
-                return Convert.ToInt32(obj) != 0;
-            }
+            return SqliteOperations.TableExists(connection, "ProteomeDbSubsequence");
         }
 
         private bool? _hasSubsequencesTable;

--- a/pwiz_tools/Skyline/CommonTest/CommonTest.csproj
+++ b/pwiz_tools/Skyline/CommonTest/CommonTest.csproj
@@ -68,6 +68,10 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.SQLite">
+      <HintPath>..\..\..\libraries\SQLite\$(Platform)\System.Data.SQLite.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -91,6 +95,7 @@
     <Compile Include="DataBinding\ViewLayoutListTest.cs" />
     <Compile Include="FastaImporterTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqliteOperationsTest.cs" />
     <Compile Include="ViewSpecTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/pwiz_tools/Skyline/CommonTest/SqliteOperationsTest.cs
+++ b/pwiz_tools/Skyline/CommonTest/SqliteOperationsTest.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2018 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Data.SQLite;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Database;
+using pwiz.SkylineTestUtil;
+
+namespace CommonTest
+{
+    [TestClass]
+    public class SqliteOperationsTest : AbstractUnitTest
+    {
+        [TestMethod]
+        public void TestTableExists()
+        {
+            using (var connection = new SQLiteConnection(new SQLiteConnectionStringBuilder
+            {
+                DataSource = ":memory:"
+            }.ToString()))
+            {
+                connection.Open();
+                using (var cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = "CREATE TABLE Table1(Id INTEGER)";
+                    cmd.ExecuteNonQuery();
+                }
+                using (var cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = "CREATE TABLE \"Table With Space\"(Id INTEGER)";
+                    cmd.ExecuteNonQuery();
+                }
+                Assert.IsTrue(SqliteOperations.TableExists(connection, "Table1"));
+                Assert.IsFalse(SqliteOperations.TableExists(connection, "Table2"));
+                Assert.IsTrue(SqliteOperations.TableExists(connection, "Table With Space"));
+                Assert.IsFalse(SqliteOperations.TableExists(connection, "Other Table With Space"));
+            }
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -28,6 +28,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using pwiz.BiblioSpec;
 using pwiz.Common.Collections;
+using pwiz.Common.Database;
 using pwiz.Common.PeakFinding;
 using pwiz.Common.SystemUtil;
 using pwiz.ProteowizardWrapper;
@@ -1068,49 +1069,45 @@ namespace pwiz.Skyline.Model.Lib
             {
                 return resultDict;
             }
-            // Read fragment annotations if any
-            try
+            if (!SqliteOperations.TableExists(connection.Connection, "RefSpectraPeakAnnotations")) // Not L10N
             {
-                // For small molecules, see if there are any peak annotations (for peptides, we can generate our own fragment info)
-                using (var select = connection.Connection.CreateCommand())
+                return resultDict;
+            }
+            // Read fragment annotations if any
+            // For small molecules, see if there are any peak annotations (for peptides, we can generate our own fragment info)
+            using (var select = connection.Connection.CreateCommand())
+            {
+                select.CommandText = "SELECT * FROM [RefSpectraPeakAnnotations] WHERE [RefSpectraID] = ?"; // Not L10N
+                select.Parameters.Add(new SQLiteParameter(DbType.UInt64, (long)refSpectraId));
+                using (SQLiteDataReader reader = @select.ExecuteReader())
                 {
-                    select.CommandText = "SELECT * FROM [RefSpectraPeakAnnotations] WHERE [RefSpectraID] = ?"; // Not L10N
-                    select.Parameters.Add(new SQLiteParameter(DbType.UInt64, (long)refSpectraId));
-                    using (SQLiteDataReader reader = @select.ExecuteReader())
+                    // N.B. this code needs to track any changes to RefSpectraPeakAnnotations, which is to say changes in BlibMaker.cpp 
+                    while (reader.Read())
                     {
-                        // N.B. this code needs to track any changes to RefSpectraPeakAnnotations, which is to say changes in BlibMaker.cpp 
-                        while (reader.Read())
+                        // var refSpectraID = reader.GetInt32(RefSpectraPeakAnnotations.RefSpectraID);
+                        var peakIndex = reader.GetInt32(RefSpectraPeakAnnotations.peakIndex);
+                        var fragname = reader.GetString(RefSpectraPeakAnnotations.name);
+                        var formula = reader.GetString(RefSpectraPeakAnnotations.formula);
+                        var inchkey = reader.GetString(RefSpectraPeakAnnotations.inchiKey);
+                        var otherKeys = reader.GetString(RefSpectraPeakAnnotations.otherKeys);
+                        var charge = reader.GetInt32(RefSpectraPeakAnnotations.charge);
+                        var adductString = reader.GetString(RefSpectraPeakAnnotations.adduct);
+                        var comment = reader.GetString(RefSpectraPeakAnnotations.comment);
+                        var mzTheoretical = reader.GetDouble(RefSpectraPeakAnnotations.mzTheoretical);
+                        var mzObserved = reader.GetDouble(RefSpectraPeakAnnotations.mzObserved);
+                        var molecule = SmallMoleculeLibraryAttributes.Create(fragname, formula, inchkey, otherKeys);
+                        var adduct = string.IsNullOrEmpty(adductString)
+                            ? Adduct.FromChargeNoMass(charge)
+                            : Adduct.FromStringAssumeChargeOnly(adductString);
+                        AnnotationsForObservedMz annotations;
+                        if (!resultDict.TryGetValue(peakIndex, out annotations))
                         {
-                            // var refSpectraID = reader.GetInt32(RefSpectraPeakAnnotations.RefSpectraID);
-                            var peakIndex = reader.GetInt32(RefSpectraPeakAnnotations.peakIndex);
-                            var fragname = reader.GetString(RefSpectraPeakAnnotations.name);
-                            var formula = reader.GetString(RefSpectraPeakAnnotations.formula);
-                            var inchkey = reader.GetString(RefSpectraPeakAnnotations.inchiKey);
-                            var otherKeys = reader.GetString(RefSpectraPeakAnnotations.otherKeys);
-                            var charge = reader.GetInt32(RefSpectraPeakAnnotations.charge);
-                            var adductString = reader.GetString(RefSpectraPeakAnnotations.adduct);
-                            var comment = reader.GetString(RefSpectraPeakAnnotations.comment);
-                            var mzTheoretical = reader.GetDouble(RefSpectraPeakAnnotations.mzTheoretical);
-                            var mzObserved = reader.GetDouble(RefSpectraPeakAnnotations.mzObserved);
-                            var molecule = SmallMoleculeLibraryAttributes.Create(fragname, formula, inchkey, otherKeys);
-                            var adduct = string.IsNullOrEmpty(adductString)
-                                ? Adduct.FromChargeNoMass(charge)
-                                : Adduct.FromStringAssumeChargeOnly(adductString);
-                            AnnotationsForObservedMz annotations;
-                            if (!resultDict.TryGetValue(peakIndex, out annotations))
-                            {
-                                resultDict.Add(peakIndex, annotations = new AnnotationsForObservedMz(mzObserved, new List<SpectrumPeakAnnotation>()));
-                            }
-                            var annotation = SpectrumPeakAnnotation.Create(molecule, adduct, comment, mzTheoretical);
-                            annotations.Annotations.Add(annotation);
+                            resultDict.Add(peakIndex, annotations = new AnnotationsForObservedMz(mzObserved, new List<SpectrumPeakAnnotation>()));
                         }
+                        var annotation = SpectrumPeakAnnotation.Create(molecule, adduct, comment, mzTheoretical);
+                        annotations.Annotations.Add(annotation);
                     }
                 }
-            }
-            // In case there is no RefSpectraPeakAnnotationss table
-            // CONSIDER: Could also be a failure to read the SQLite file
-            catch (SQLiteException)
-            {
             }
             return resultDict;
         }
@@ -1651,24 +1648,7 @@ namespace pwiz.Skyline.Model.Lib
 
         private bool HasRedundanModificationsTable()
         {
-            using (SQLiteCommand select = new SQLiteCommand(_sqliteConnectionRedundant.Connection))
-            {
-                select.CommandText = "SELECT count(*) FROM [sqlite_master] WHERE type='table' AND name='Modifications'"; // Not L10N
-
-                try
-                {
-                    using (SQLiteDataReader reader = select.ExecuteReader())
-                    {
-                        reader.Read();
-                        int modTableCount = reader.GetInt32(0);
-                        return modTableCount > 0;
-                    }
-                }
-                catch (SQLiteException)
-                {
-                    return false;
-                }
-            }
+            return SqliteOperations.TableExists(_sqliteConnectionRedundant.Connection, "Modifications");
         }
 
         public void DeleteDataFiles(string[] filenames, IProgressMonitor monitor)


### PR DESCRIPTION
We were spending much too long in "BiblioSpecLiteLibrary.AnnotationsForObservedMz" if the table "RefSpectraPeakAnnotations" did not exist.
I changed it so that we check that the table exists by querying the sqlite_master table, instead of catching an exception and it seems to be hundreds of times faster.
I added the utility class "SqliteOperations" with the method "TableExists" and I changed the other places where we were checking for table existence to use this new method.

I am currently running unit tests on my machine.