### PR TITLE
Skyline: fix a problem with the Target tree "Modify..." right-click o…

### DIFF
--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -2123,7 +2123,7 @@ namespace pwiz.Skyline
                     Transition.MIN_PRODUCT_CHARGE,
                     Transition.MAX_PRODUCT_CHARGE,
                     Document.Settings,
-                    nodeGroupTree.DocNode.CustomMolecule,
+                    nodeTran.Transition.CustomIon,
                     nodeTran.Transition.Adduct, null, null, null))
                 {
                     dlg.SetResult(nodeTran.Transition.CustomIon, nodeTran.Transition.Adduct);


### PR DESCRIPTION
…n small molecule fragments specified without a molecular formula - the Edit Molecule dialog was being mistakenly given the precursor formula in absence of a fragment formula, which yielded incorrect mz values (a hangover from the pre-4.x days).