### PR TITLE
Skyline: my previous commit contained a test which failed under local…

### DIFF
--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -1482,6 +1482,13 @@ namespace pwiz.Skyline.Model
             var endLine = csvText.IndexOf('\n'); // Not L10N 
             var line = (endLine != -1 ? csvText.Substring(endLine+1) : csvText);
             MassListImporter.IsColumnar(line, out formatProvider, out separator, out columnTypes);
+            // Double check that separator - does it appear in header row, or was it just an unlucky hit in a text field?
+            var header = (endLine != -1 ? csvText.Substring(0, endLine) : csvText);
+            if (!header.Contains(separator))
+            {
+                // Try again, this time without the distraction of a plausible but clearly incorrect seperator
+                MassListImporter.IsColumnar(line.Replace(separator,'_'), out formatProvider, out separator, out columnTypes);
+            }
             _cultureInfo = formatProvider;
             var reader = new StringReader(csvText);
             _csvReader = new DsvFileReader(reader, separator, SmallMoleculeTransitionListColumnHeaders.KnownHeaderSynonyms);


### PR DESCRIPTION
…e fr because of a ";" in a text field which tricked the CSV reader into thinking that was the field separator. Now we check to see if the identified field separator actually appears in the header line or not, and make a better guess if it does not.