### PR TITLE
- added 'target' parameter to mzPrecursors filter...

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
@@ -861,7 +861,14 @@ SpectrumListPtr filterCreator_mzPrecursors(const MSData& msd, const string& carg
     string arg = carg;
 
     auto mzTol = parseKeyValuePair<MZTolerance, 2>(arg, "mzTol=", MZTolerance(10, MZTolerance::PPM));
+    auto targetStr = parseKeyValuePair<string>(arg, "target=", "selected");
     auto mode = parseKeyValuePair<SpectrumList_Filter::Predicate::FilterMode>(arg, "mode=", SpectrumList_Filter::Predicate::FilterMode_Include);
+
+    auto target = SpectrumList_FilterPredicate_PrecursorMzSet::TargetMode_Selected;
+    if (targetStr == "isolated")
+        target = SpectrumList_FilterPredicate_PrecursorMzSet::TargetMode_Isolated;
+    else if (targetStr != "selected")
+        throw user_error("[SpectrumListFactory::filterCreator_mzPrecursors()] invalid value for 'target' parameter: " + targetStr);
 
     char open='\0', comma='\0', close='\0';
     std::set<double> setMz;
@@ -879,20 +886,18 @@ SpectrumListPtr filterCreator_mzPrecursors(const MSData& msd, const string& carg
     iss >> close;
 
     if (open!='[' || close!=']')
-    {
-        cerr << "mzPrecursors filter expected a list of m/z values formatted something like \"[123.4,567.8,789.0]\"" << endl;
-        return SpectrumListPtr();
-    }
+        throw user_error("[SpectrumListFactory::filterCreator_mzPrecursors()] expected a list of m/z values formatted like \"[123.4,567.8,789.0]\"");
 
     return SpectrumListPtr(new
         SpectrumList_Filter(msd.run.spectrumListPtr,
-                            SpectrumList_FilterPredicate_PrecursorMzSet(setMz, mzTol, mode)));
+                            SpectrumList_FilterPredicate_PrecursorMzSet(setMz, mzTol, mode, target)));
 }
-UsageInfo usage_mzPrecursors = {"<precursor_mz_list> [mzTol=<mzTol (10 ppm)>] [mode=<include|exclude (include)>]",
+UsageInfo usage_mzPrecursors = {"<precursor_mz_list> [mzTol=<mzTol (10 ppm)>] [target=<selected|isolated> (selected)] [mode=<include|exclude (include)>]",
     "Filters spectra based on precursor m/z values found in the <precursor_mz_list>, with <mzTol> m/z tolerance. To retain "
     "only spectra with precursor m/z values of 123.4 and 567.8, use --filter \"mzPrecursors [123.4,567.8]\". "
     "Note that this filter will drop MS1 scans unless you include 0.0 in the list of precursor values."
     "   <mzTol> is optional and must be specified as a number and units (PPM or MZ). For example, \"5 PPM\" or \"2.1 MZ\".\n"
+    "   <target> is optional and must be either \"selected\" (the default) or \"isolated\". It determines whether the isolated m/z or the selected m/z is used for the \"precursor m/z\"\n"
     "   <mode> is optional and must be either \"include\" (the default) or \"exclude\".  If \"exclude\" is "
     "used, the filter drops spectra that match the various criteria instead of keeping them."
     };

--- a/pwiz/analysis/spectrum_processing/SpectrumListFactoryTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactoryTest.cpp
@@ -568,6 +568,38 @@ void testWrapPrecursorMzSet()
         unit_assert_operator_equal("scan=21", sl->spectrumIdentity(2).id);
         unit_assert_operator_equal("sample=1 period=1 cycle=23 experiment=1", sl->spectrumIdentity(3).id);
     }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "mzPrecursors [0,445.34] target=selected");
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(4, sl->size());
+        unit_assert_operator_equal("scan=19", sl->spectrumIdentity(0).id);
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(1).id);
+        unit_assert_operator_equal("scan=21", sl->spectrumIdentity(2).id);
+        unit_assert_operator_equal("sample=1 period=1 cycle=23 experiment=1", sl->spectrumIdentity(3).id);
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "mzPrecursors [445.3] target=isolated");
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(1, sl->size());
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(0).id);
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "mzPrecursors [445.34] target=isolated"); // tolerance too tight to match to 445.3
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(0, sl->size());
+    }
+
+    msd.run.spectrumListPtr = originalSL;
+    unit_assert_throws_what(SpectrumListFactory::wrap(msd, "mzPrecursors mode=include"), user_error, "[SpectrumListFactory::filterCreator_mzPrecursors()] expected a list of m/z values formatted like \"[123.4,567.8,789.0]\"");
+
+    msd.run.spectrumListPtr = originalSL;
+    unit_assert_throws_what(SpectrumListFactory::wrap(msd, "mzPrecursors [0,445.34] target=42"), user_error, "[SpectrumListFactory::filterCreator_mzPrecursors()] invalid value for 'target' parameter: 42");
 }
 
 void testWrapMZPresent()

--- a/pwiz/analysis/spectrum_processing/SpectrumList_Filter.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_Filter.cpp
@@ -352,8 +352,8 @@ PWIZ_API_DECL boost::logic::tribool SpectrumList_FilterPredicate_ChargeStateSet:
 //
 
 
-PWIZ_API_DECL SpectrumList_FilterPredicate_PrecursorMzSet::SpectrumList_FilterPredicate_PrecursorMzSet(const std::set<double>& precursorMzSet, chemistry::MZTolerance tolerance, FilterMode mode)
-:   precursorMzSet_(precursorMzSet), tolerance_(tolerance), mode_(mode)
+PWIZ_API_DECL SpectrumList_FilterPredicate_PrecursorMzSet::SpectrumList_FilterPredicate_PrecursorMzSet(const std::set<double>& precursorMzSet, chemistry::MZTolerance tolerance, FilterMode mode, TargetMode target)
+:   precursorMzSet_(precursorMzSet), tolerance_(tolerance), mode_(mode), target_(target)
 {}
 
 
@@ -382,11 +382,23 @@ PWIZ_API_DECL double SpectrumList_FilterPredicate_PrecursorMzSet::getPrecursorMz
 {
     for (size_t i = 0; i < spectrum.precursors.size(); i++)
     {
-        for (size_t j = 0; j < spectrum.precursors[i].selectedIons.size(); j++)
+        switch (target_)
         {
-            CVParam param = spectrum.precursors[i].selectedIons[j].cvParam(MS_selected_ion_m_z);
-            if (param.cvid != CVID_Unknown)
-                return lexical_cast<double>(param.value);
+            case TargetMode_Selected:
+            {
+                for (size_t j = 0; j < spectrum.precursors[i].selectedIons.size(); j++)
+                {
+                    CVParam param = spectrum.precursors[i].selectedIons[j].cvParam(MS_selected_ion_m_z);
+                    if (param.cvid != CVID_Unknown)
+                        return lexical_cast<double>(param.value);
+                }
+            }
+            case TargetMode_Isolated:
+            {
+                CVParam param = spectrum.precursors[i].isolationWindow.cvParam(MS_isolation_window_target_m_z);
+                if (param.cvid != CVID_Unknown)
+                    return lexical_cast<double>(param.value);
+            }
         }
     }
     return 0;

--- a/pwiz/analysis/spectrum_processing/SpectrumList_Filter.hpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_Filter.hpp
@@ -177,7 +177,14 @@ class PWIZ_API_DECL SpectrumList_FilterPredicate_ChargeStateSet : public Spectru
 class PWIZ_API_DECL SpectrumList_FilterPredicate_PrecursorMzSet : public SpectrumList_Filter::Predicate
 {
     public:
-    SpectrumList_FilterPredicate_PrecursorMzSet(const std::set<double>& precursorMzSet, chemistry::MZTolerance tolerance, FilterMode mode);
+
+    enum TargetMode
+    {
+        TargetMode_Selected,
+        TargetMode_Isolated
+    };
+
+    SpectrumList_FilterPredicate_PrecursorMzSet(const std::set<double>& precursorMzSet, chemistry::MZTolerance tolerance, FilterMode mode, TargetMode target = TargetMode_Selected);
     virtual boost::logic::tribool accept(const msdata::SpectrumIdentity& spectrumIdentity) const {return boost::logic::indeterminate;}
     virtual boost::logic::tribool accept(const msdata::Spectrum& spectrum) const;
 
@@ -185,6 +192,7 @@ class PWIZ_API_DECL SpectrumList_FilterPredicate_PrecursorMzSet : public Spectru
     std::set<double> precursorMzSet_;
     chemistry::MZTolerance tolerance_;
     FilterMode mode_;
+    TargetMode target_;
 
     double getPrecursorMz(const msdata::Spectrum& spectrum) const;
 };


### PR DESCRIPTION
...for telling it to filter on 'selected ion m/z' (the default) or 'isolation window target m/z'