### PR TITLE
Skyline - volcano plot fixes

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AreaCVToolbar.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AreaCVToolbar.cs
@@ -199,6 +199,9 @@ namespace pwiz.Skyline.Controls.Graphs
         {
             var document = _graphSummary.DocumentUIContainer.DocumentUI;
 
+            if (!document.Settings.HasResults)
+                return;
+
             var groupsVisible = AreaGraphController.GroupByGroup != null;
             toolStripLabel1.Visible = toolStripComboGroup.Visible = groupsVisible;
 

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.Designer.cs
@@ -28,11 +28,13 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CreateMatchExpressionDlg));
             this.cancelButton = new System.Windows.Forms.Button();
             this.okButton = new System.Windows.Forms.Button();
-            this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.dataGridView1 = new pwiz.Skyline.Controls.DataGridViewEx();
             this.nameColumn = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.bindingSource1 = new System.Windows.Forms.BindingSource(this.components);
             this.expressionTextBox = new System.Windows.Forms.TextBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.label5 = new System.Windows.Forms.Label();
@@ -43,6 +45,7 @@
             this.matchComboBox = new System.Windows.Forms.ComboBox();
             this.linkRegex = new System.Windows.Forms.LinkLabel();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.bindingSource1)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -66,9 +69,12 @@
             this.dataGridView1.AllowUserToDeleteRows = false;
             this.dataGridView1.AllowUserToResizeRows = false;
             resources.ApplyResources(this.dataGridView1, "dataGridView1");
+            this.dataGridView1.AutoGenerateColumns = false;
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.nameColumn});
+            this.dataGridView1.DataSource = this.bindingSource1;
+            this.dataGridView1.MaximumColumnCount = null;
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.ReadOnly = true;
             this.dataGridView1.RowHeadersVisible = false;
@@ -78,6 +84,7 @@
             // nameColumn
             // 
             this.nameColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.nameColumn.DataPropertyName = "Value";
             resources.ApplyResources(this.nameColumn, "nameColumn");
             this.nameColumn.Name = "nameColumn";
             this.nameColumn.ReadOnly = true;
@@ -147,7 +154,7 @@
             this.linkRegex.TabStop = true;
             this.linkRegex.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkRegex_LinkClicked);
             // 
-            // CreateMatchExpression
+            // CreateMatchExpressionDlg
             // 
             this.AcceptButton = this.okButton;
             resources.ApplyResources(this, "$this");
@@ -167,6 +174,7 @@
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.bindingSource1)).EndInit();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
@@ -178,7 +186,7 @@
 
         private System.Windows.Forms.Button cancelButton;
         private System.Windows.Forms.Button okButton;
-        private System.Windows.Forms.DataGridView dataGridView1;
+        private DataGridViewEx dataGridView1;
         private System.Windows.Forms.TextBox expressionTextBox;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.Label label5;
@@ -188,6 +196,7 @@
         private System.Windows.Forms.ComboBox foldChangeComboBox;
         private System.Windows.Forms.ComboBox matchComboBox;
         private System.Windows.Forms.LinkLabel linkRegex;
+        private System.Windows.Forms.BindingSource bindingSource1;
         private System.Windows.Forms.DataGridViewLinkColumn nameColumn;
     }
 }

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.cs
@@ -19,8 +19,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 using pwiz.Skyline.Model.Databinding.Entities;
 using pwiz.Skyline.Model.GroupComparison;
@@ -34,6 +36,8 @@ namespace pwiz.Skyline.Controls.GroupComparison
         private readonly FoldChangeBindingSource.FoldChangeRow[] _foldChangeRows;
         private readonly bool _allowUpdateGrid;
         private readonly VolcanoPlotFormattingDlg _formattingDlg;
+        private CancellationTokenSource _cancellationTokenSource;
+        private IList<StringWrapper> _filteredRows;
 
         private FoldChangeVolcanoPlot _volcanoPlot
         {
@@ -60,7 +64,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
             SetSelectedItems(rgbHexColor);
             _allowUpdateGrid = true;
 
-            UpdateGrid();
+            FilterRows();
         }
 
         private void PopulateComboBoxes()
@@ -68,21 +72,21 @@ namespace pwiz.Skyline.Controls.GroupComparison
             // Match
             AddComboBoxItems(matchComboBox, new MatchOptionStringPair(null, GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_None));
 
+            if (_volcanoPlot.AnyProteomic)
+            {
+                AddComboBoxItems(matchComboBox,
+                    new MatchOptionStringPair(MatchOption.ProteinName,
+                        GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_Protein_Name),
+                    new MatchOptionStringPair(MatchOption.ProteinAccession,
+                        GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_Protein_Accession),
+                    new MatchOptionStringPair(MatchOption.ProteinPreferredName,
+                        GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_Protein_Preferred_Name),
+                    new MatchOptionStringPair(MatchOption.ProteinGene,
+                        GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_Protein_Gene));
+            }
+
             if (_volcanoPlot.PerProtein)
             {
-                if (_volcanoPlot.AnyProteomic)
-                {
-                    AddComboBoxItems(matchComboBox,
-                        new MatchOptionStringPair(MatchOption.ProteinName,
-                            GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_Protein_Name),
-                        new MatchOptionStringPair(MatchOption.ProteinAccession,
-                            GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_Protein_Accession),
-                        new MatchOptionStringPair(MatchOption.ProteinPreferredName,
-                            GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_Protein_Preferred_Name),
-                        new MatchOptionStringPair(MatchOption.ProteinGene,
-                            GroupComparisonStrings.CreateMatchExpression_PopulateComboBoxes_Protein_Gene));
-                }
-
                 if (_volcanoPlot.AnyMolecules)
                 {
                     AddComboBoxItems(matchComboBox,
@@ -137,12 +141,12 @@ namespace pwiz.Skyline.Controls.GroupComparison
         {
             var matchExpr = rgbHexColor.MatchExpression ?? _formattingDlg.GetDefaultMatchExpression(rgbHexColor.Expression);
 
-            expressionTextBox.Text = matchExpr.RegExpr;
-
             matchComboBox.SelectedItem = GetSelectedItem(matchComboBox, matchExpr.matchOptions);
             foldChangeComboBox.SelectedItem =
                 GetSelectedItem(foldChangeComboBox, matchExpr.matchOptions);
             pValueComboBox.SelectedItem = GetSelectedItem(pValueComboBox, matchExpr.matchOptions);
+
+            expressionTextBox.Text = matchExpr.RegExpr;
         }
 
         private static MatchOptionStringPair GetSelectedItem(ComboBox comboBox, IEnumerable<MatchOption> matchOptions)
@@ -206,14 +210,25 @@ namespace pwiz.Skyline.Controls.GroupComparison
             return new MatchExpression(regExpr, matchOptions);
         }
 
+        private class StringWrapper
+        {
+            public StringWrapper(string str)
+            {
+                Value = str;
+            }
+
+            // ReSharper disable once MemberCanBePrivate.Local
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public string Value { get; set; }
+        }
+
         private void UpdateGrid()
         {
             if (!_allowUpdateGrid)
                 return;
            
             var expr = GetCurrentMatchExpression();
-            dataGridView1.Rows.Clear();
-
+            bindingSource1.DataSource = null;
             expressionTextBox.ForeColor = Color.Black;
 
             if (!expr.IsRegexValid())
@@ -222,21 +237,93 @@ namespace pwiz.Skyline.Controls.GroupComparison
                 return;
             }
 
-            foreach (var row in _foldChangeRows)
+            if (_filteredRows != null)
             {
-                if (expr.Matches(_volcanoPlot.Document, row.Protein, row.Peptide, row.FoldChangeResult, FoldChangeVolcanoPlot.CutoffSettings))
-                    dataGridView1.Rows.Add(expr.GetMatchString(_volcanoPlot.Document, row.Protein, row.Peptide) ?? TextUtil.EXCEL_NA);
-            }            
+                bindingSource1.DataSource = new BindingList<StringWrapper>(_filteredRows);
+                _filteredRows = null;
+            }
+            else
+            {
+                bindingSource1.DataSource = new BindingList<StringWrapper>(_foldChangeRows.Select(row =>
+                    RowToString(expr, row)).ToArray());
+            }
+        }
+
+        private StringWrapper RowToString(MatchExpression expr, FoldChangeBindingSource.FoldChangeRow row)
+        {
+            return new StringWrapper(expr.GetDisplayString(_volcanoPlot.Document, row.Protein, row.Peptide) ??
+                              TextUtil.EXCEL_NA);
+        }
+
+        private void FilterRows()
+        {
+            if (!_allowUpdateGrid)
+                return;
+
+            if (_cancellationTokenSource != null)
+                _cancellationTokenSource.Cancel();
+
+            _cancellationTokenSource = new CancellationTokenSource();
+            _filteredRows = null;
+            var expr = GetCurrentMatchExpression();
+            if (expr.IsRegexValid())
+            {
+                Cursor = Cursors.WaitCursor;
+
+                ActionUtil.RunAsync(() =>
+                {
+                    GetFilteredRows(_cancellationTokenSource.Token, _foldChangeRows, expr);
+                });
+            }
+            else
+            {
+                _filteredRows = new List<StringWrapper>();
+                UpdateGrid();
+            }
         }
 
         private void expressionTextBox_TextChanged(object sender, EventArgs e)
         {
-            UpdateGrid();
+            FilterRows();
+        }
+
+        private void GetFilteredRows(CancellationToken canellationToken, FoldChangeBindingSource.FoldChangeRow[] rows, MatchExpression expr)
+        {
+            IList<StringWrapper> filteredRows = new List<StringWrapper>();
+
+            foreach (var row in rows)
+            {
+                if (expr.Matches(_volcanoPlot.Document, row.Protein, row.Peptide,
+                    row.FoldChangeResult, FoldChangeVolcanoPlot.CutoffSettings))
+                {
+                    filteredRows.Add(RowToString(expr, row));
+                }
+
+                if (canellationToken.IsCancellationRequested)
+                    return;
+            }
+
+            try
+            {
+                _formattingDlg.BeginInvoke(new Action(() =>
+                {
+                    if (!canellationToken.IsCancellationRequested)
+                    {
+                        _filteredRows = filteredRows;
+                        Cursor = Cursors.Default;
+                        UpdateGrid();
+                    }
+                }));
+            }
+            catch (Exception)
+            {
+                // ignore
+            }
         }
 
         private void comboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-            UpdateGrid();
+            FilterRows();
         }
 
         private void linkRegex_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.resx
@@ -126,10 +126,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>379, 309</value>
+    <value>603, 475</value>
+  </data>
+  <data name="cancelButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>112, 35</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
@@ -157,10 +160,13 @@
     <value>NoControl</value>
   </data>
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>298, 309</value>
+    <value>482, 475</value>
+  </data>
+  <data name="okButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>112, 35</value>
   </data>
   <data name="okButton.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -189,11 +195,17 @@
   <data name="nameColumn.HeaderText" xml:space="preserve">
     <value>Matched</value>
   </data>
+  <metadata name="bindingSource1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="dataGridView1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 130</value>
+    <value>18, 200</value>
+  </data>
+  <data name="dataGridView1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="dataGridView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>442, 173</value>
+    <value>698, 266</value>
   </data>
   <data name="dataGridView1.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -202,7 +214,7 @@
     <value>dataGridView1</value>
   </data>
   <data name="&gt;&gt;dataGridView1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline-daily, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridView1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -217,10 +229,13 @@
     <value>Test</value>
   </data>
   <data name="expressionTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 25</value>
+    <value>18, 38</value>
+  </data>
+  <data name="expressionTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="expressionTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>315, 20</value>
+    <value>470, 26</value>
   </data>
   <data name="expressionTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -244,10 +259,13 @@
     <value>True</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>174, 22</value>
+    <value>261, 34</value>
+  </data>
+  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 13</value>
+    <value>114, 20</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -268,10 +286,13 @@
     <value>0</value>
   </data>
   <data name="pValueComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>177, 38</value>
+    <value>266, 58</value>
+  </data>
+  <data name="pValueComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="pValueComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>180, 28</value>
   </data>
   <data name="pValueComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -292,10 +313,13 @@
     <value>True</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 22</value>
+    <value>9, 34</value>
+  </data>
+  <data name="label4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
+    <value>149, 20</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -316,10 +340,13 @@
     <value>2</value>
   </data>
   <data name="foldChangeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 38</value>
+    <value>9, 58</value>
+  </data>
+  <data name="foldChangeComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="foldChangeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>180, 28</value>
   </data>
   <data name="foldChangeComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -337,10 +364,16 @@
     <value>3</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 51</value>
+    <value>22, 78</value>
+  </data>
+  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="groupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>439, 73</value>
+    <value>693, 112</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -367,10 +400,13 @@
     <value>True</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>330, 8</value>
+    <value>492, 12</value>
+  </data>
+  <data name="label3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
+    <value>57, 20</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -394,10 +430,13 @@
     <value>Top, Right</value>
   </data>
   <data name="matchComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>333, 24</value>
+    <value>496, 37</value>
+  </data>
+  <data name="matchComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="matchComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>219, 28</value>
   </data>
   <data name="matchComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -418,10 +457,13 @@
     <value>True</value>
   </data>
   <data name="linkRegex.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 8</value>
+    <value>18, 12</value>
+  </data>
+  <data name="linkRegex.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="linkRegex.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
+    <value>149, 20</value>
   </data>
   <data name="linkRegex.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -445,10 +487,13 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>9, 20</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>466, 345</value>
+    <value>734, 531</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -461,6 +506,12 @@
   </data>
   <data name="&gt;&gt;nameColumn.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewLinkColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;bindingSource1.Name" xml:space="preserve">
+    <value>bindingSource1</value>
+  </data>
+  <data name="&gt;&gt;bindingSource1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.BindingSource, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>CreateMatchExpressionDlg</value>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.cs
@@ -102,7 +102,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
         public SrmDocument Document
         {
-            get { return _skylineWindow != null ? _skylineWindow.DocumentUI : null; }
+            get { return _skylineWindow != null ? _skylineWindow.Document : null; }
         }
 
         public bool AnyProteomic

--- a/pwiz_tools/Skyline/Model/GroupComparison/MatchExpression.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/MatchExpression.cs
@@ -206,12 +206,21 @@ namespace pwiz.Skyline.Model.GroupComparison
                 return proteomic ? ProteinMetadataManager.ProteinModalDisplayText(protein.DocNode) : protein.Name;
         }
 
-        public static string GetProteinText(Protein protein, ProteinMetadataManager.ProteinDisplayMode proteinDisplayMode)
+        public static string GetProteinText(Protein protein, MatchOption matchOption)
         {
-            return protein != null ? ProteinMetadataManager.ProteinModalDisplayText(protein.DocNode.ProteinMetadata, proteinDisplayMode) : null;
+            return protein != null
+                ? ProteinMetadataManager.ProteinModalDisplayText(protein.DocNode.ProteinMetadata,
+                    MatchOptionToDisplayMode(matchOption))
+                : null;
         }
 
-        public string GetMatchString(SrmDocument document, Protein protein, Databinding.Entities.Peptide peptide)
+        public string GetDisplayString(SrmDocument document, Protein protein, Databinding.Entities.Peptide peptide)
+        {
+            return GetRowString(document, protein, peptide, true);
+        }
+
+        private string GetRowString(SrmDocument document, Protein protein, Databinding.Entities.Peptide peptide,
+            bool showProteinForPeptides)
         {
             if (protein == null)
                 return null;
@@ -225,7 +234,10 @@ namespace pwiz.Skyline.Model.GroupComparison
                     case MatchOption.ProteinAccession:
                     case MatchOption.ProteinPreferredName:
                     case MatchOption.ProteinGene:
-                        return GetProteinText(protein, MatchOptionToDisplayMode(m));
+                        if (!perProtein && showProteinForPeptides)
+                            return string.Format("{0} ({1})", GetRowDisplayText(protein, peptide), // Not L10N
+                                GetProteinText(protein, m));
+                        return GetProteinText(protein, m);
                     case MatchOption.PeptideSequence:
                         if (!perProtein)
                             return peptide.Sequence;
@@ -235,7 +247,7 @@ namespace pwiz.Skyline.Model.GroupComparison
                             return peptide.ModifiedSequence.ToString();
                         break;
                     case MatchOption.MoleculeGroupName:
-                            return protein.Name;
+                        return protein.Name;
                     case MatchOption.MoleculeName:
                         if (!perProtein)
                             return peptide.MoleculeName;
@@ -255,10 +267,12 @@ namespace pwiz.Skyline.Model.GroupComparison
                 }
             }
 
-            if (protein.DocNode.IsProteomic)
-                return GetRowDisplayText(protein, peptide);
+            return GetRowDisplayText(protein, peptide);
+        }
 
-            return perProtein ? protein.Name : peptide.MoleculeName;
+        public string GetMatchString(SrmDocument document, Protein protein, Databinding.Entities.Peptide peptide)
+        {
+            return GetRowString(document, protein, peptide, false);
         }
 
         public bool Matches(SrmDocument document, Protein protein, Databinding.Entities.Peptide peptide, FoldChangeResult foldChangeResult, CutoffSettings cutoffSettings)
@@ -280,7 +294,7 @@ namespace pwiz.Skyline.Model.GroupComparison
                     case MatchOption.InChiKey:
                     {
                         var matchString = GetMatchString(document, protein, peptide);
-                        if (matchString == null || !Regex.IsMatch(matchString, RegExpr))
+                        if (matchString == null || !IsRegexValid() || !Regex.IsMatch(matchString, RegExpr))
                             return false;
                         break;
                     }

--- a/pwiz_tools/Skyline/TestFunctional/VolcanoPlotFormattingTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/VolcanoPlotFormattingTest.cs
@@ -302,11 +302,13 @@ namespace pwiz.SkylineTestFunctional
                             exprInfo.MatchExpression.matchOptions);
 
                     createExprDlg.Expression = exprInfo.MatchExpression.RegExpr;
-
-                    CollectionAssert.AreEqual(exprInfo.ExpectedMatches, createExprDlg.MatchingRows.ToArray(),
-                        string.Format("Expected: {0}\nActual: {1}", string.Join(", ", exprInfo.ExpectedMatches), string.Join(", ", createExprDlg.MatchingRows)));
-                        
                 });
+
+                WaitForConditionUI(() => exprInfo.ExpectedMatches.Count == createExprDlg.MatchingRows.Count(), "Different number of rows");
+
+                RunUI(() => CollectionAssert.AreEqual(exprInfo.ExpectedMatches, createExprDlg.MatchingRows.ToArray(),
+                    string.Format("Expected: {0}\nActual: {1}", string.Join(", ", exprInfo.ExpectedMatches),
+                        string.Join(", ", createExprDlg.MatchingRows))));
 
                 OkDialog(createExprDlg, createExprDlg.OkDialog);
             }


### PR DESCRIPTION
- fixed slow filtering (filtering is now done on background thread and
  list of matching rows uses a data source)
- now allowing user to filter by protein name/accession/preferred/name/gene for peptides
- fixed nullreferenceexception in AreaCVToolbar (see exceptions 36514, 36515, 36883)