### PR TITLE
Copy a couple of fixes from the 4.1 branch on Subversion that got los…

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/Library.cs
+++ b/pwiz_tools/Skyline/Model/Lib/Library.cs
@@ -880,7 +880,7 @@ namespace pwiz.Skyline.Model.Lib
 
         public override bool ContainsAny(Target target)
         {
-            return LibraryEntriesWithSequence(target).Any();
+            return _libraryEntries.ItemsWithUnmodifiedSequence(target).Any();
         }
 
         public override bool Contains(LibKey key)
@@ -1060,7 +1060,7 @@ namespace pwiz.Skyline.Model.Lib
 
         protected IEnumerable<TInfo> LibraryEntriesWithSequence(Target target)
         {
-            return _libraryEntries.ItemsWithUnmodifiedSequence(target);
+            return _libraryEntries.ItemsMatching(new LibKey(target, Adduct.EMPTY).LibraryKey, false);
         }
 
         // ReSharper disable PossibleMultipleEnumeration

--- a/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs
+++ b/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs
@@ -1346,7 +1346,10 @@ namespace pwiz.Skyline.Model.Serialization
 
                 var node = new TransitionDocNode(transition, info.Losses, massH, TransitionDocNode.TransitionQuantInfo.DEFAULT);
                 curList.Add(node);
-                ValidateSerializedVsCalculatedProductMz(declaredProductMz, node); // Sanity check
+                if (peptide.IsCustomMolecule)
+                {
+                    ValidateSerializedVsCalculatedProductMz(declaredProductMz, node); // Sanity check
+                }
             }
 
             // Use collected information to create the DocNodes.
@@ -1497,7 +1500,10 @@ namespace pwiz.Skyline.Model.Serialization
                 throw new InvalidDataException(Resources.SrmDocument_ReadTransitionXml_All_transitions_of_decoy_precursors_must_have_a_decoy_mass_shift);
             var node = new TransitionDocNode(transition, info.Annotations, losses,
                 mass, new TransitionDocNode.TransitionQuantInfo(isotopeDistInfo, info.LibInfo, info.Quantitative), info.Results);
-            ValidateSerializedVsCalculatedProductMz(declaredProductMz, node);  // Sanity check
+            if (group.Peptide.IsCustomMolecule)
+            {
+                ValidateSerializedVsCalculatedProductMz(declaredProductMz, node);  // Sanity check
+            }
             return node;
         }
 

--- a/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
@@ -115,11 +115,24 @@ namespace pwiz.Skyline.SettingsUI
             string selDT = (Prediction.IonMobilityPredictor == null ? null : Prediction.IonMobilityPredictor.Name);
             _driverDT.LoadList(selDT);
             cbUseSpectralLibraryDriftTimes.Checked = textSpectralLibraryDriftTimesResolvingPower.Enabled = Prediction.UseLibraryIonMobilityValues;
-            if (Prediction.LibraryIonMobilityWindowWidthCalculator != null)
+            var imsWindowCalc = Prediction.LibraryIonMobilityWindowWidthCalculator;
+            if (imsWindowCalc != null)
             {
-                textSpectralLibraryDriftTimesResolvingPower.Text = Prediction.LibraryIonMobilityWindowWidthCalculator.ResolvingPower.ToString(LocalizationHelper.CurrentCulture);
-                textSpectralLibraryDriftTimesWidthAtDt0.Text = Prediction.LibraryIonMobilityWindowWidthCalculator.PeakWidthAtIonMobilityValueZero.ToString(LocalizationHelper.CurrentCulture);
-                textSpectralLibraryDriftTimesWidthAtDtMax.Text = Prediction.LibraryIonMobilityWindowWidthCalculator.PeakWidthAtIonMobilityValueMax.ToString(LocalizationHelper.CurrentCulture);
+                cbLinear.Checked = imsWindowCalc.PeakWidthMode == IonMobilityWindowWidthCalculator.IonMobilityPeakWidthType.linear_range;
+                if (cbLinear.Checked)
+                {
+                    textSpectralLibraryDriftTimesResolvingPower.Text = string.Empty;
+                    textSpectralLibraryDriftTimesWidthAtDt0.Text = imsWindowCalc.PeakWidthAtIonMobilityValueZero.ToString(LocalizationHelper.CurrentCulture);
+                    textSpectralLibraryDriftTimesWidthAtDtMax.Text = imsWindowCalc.PeakWidthAtIonMobilityValueMax.ToString(LocalizationHelper.CurrentCulture);
+                }
+                else
+                {
+                    textSpectralLibraryDriftTimesResolvingPower.Text = imsWindowCalc.ResolvingPower != 0
+                        ? imsWindowCalc.ResolvingPower.ToString(LocalizationHelper.CurrentCulture)
+                        : string.Empty;
+                    textSpectralLibraryDriftTimesWidthAtDt0.Text = string.Empty;
+                    textSpectralLibraryDriftTimesWidthAtDtMax.Text = string.Empty;
+                }                
             }
 
             // Initialize filter settings
@@ -679,8 +692,11 @@ namespace pwiz.Skyline.SettingsUI
         private void cbUseSpectralLibraryDriftTimes_CheckChanged(object sender, EventArgs e)
         {
             bool enable = cbUseSpectralLibraryDriftTimes.Checked;
+            labelResolvingPower.Enabled =
             textSpectralLibraryDriftTimesResolvingPower.Enabled = enable;
+            labelWidthAtDt0Units.Enabled = labelWidthDtZero.Enabled =
             textSpectralLibraryDriftTimesWidthAtDt0.Enabled = enable;
+            labelWidthAtDtMaxUnits.Enabled = labelWidthDtMax.Enabled =
             textSpectralLibraryDriftTimesWidthAtDtMax.Enabled = enable;
             cbLinear.Enabled = enable;
             // If disabling the text box, and it has content, make sure it is


### PR DESCRIPTION
…t when we originally created this git repository:

Revision: 11869
Author: brendanx
Date: Thursday, March 22, 2018 7:00:55 PM
Message:
Skyline: Fix PeptideSettingsUI handling for Sonar settings
\-\-\-\-
Modified : /branches/skyline_4_1/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs

Revision: 11860
Author: nickshulman
Date: Tuesday, March 20, 2018 4:01:00 PM
Message:
Fix bug where libraries were disregarding modifications when returning retention times.

Disable assert about peptide m/z matching calculated value. We keep the assert enabled for small molecules.
\-\-\-\-
Modified : /branches/skyline_4_1/pwiz_tools/Skyline/Model/Lib/Library.cs
Modified : /branches/skyline_4_1/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs