### PR TITLE
Skyline: Don't attempt Uniprot lookup of proteins for which we don't …

### DIFF
--- a/pwiz_tools/Shared/ProteomeDb/Fasta/WebEnabledFastaImporter.cs
+++ b/pwiz_tools/Shared/ProteomeDb/Fasta/WebEnabledFastaImporter.cs
@@ -727,6 +727,11 @@ namespace pwiz.ProteomeDatabase.Fasta
                     }
                 }
 
+                if (prot.SeqLength == 0)
+                {
+                    prot.SetWebSearchCompleted(); // Searching is too ambiguous without a sequence length, so we'd have to go one by one: don't attempt it
+                }
+
                 if (prot.GetProteinMetadata().NeedsSearch())
                 {
                     // if you feed uniprot a partial search term you get a huge response                    


### PR DESCRIPTION
…have sequence - too much potential ambiguity (also, it's slow since we go one by one when all proteins have the same length - 0 in this case)