### PR TITLE
Skyline: Fixes for DIA Course

### DIFF
--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -44,6 +44,7 @@ namespace pwiz.Skyline
         public int ImportThreads { get; private set; }
         public bool ImportAppend { get; private set; }
         public bool ImportDisableJoining { get; private set; }
+        public bool ImportRecursive { get; private set; }
         public string ImportSourceDirectory { get; private set; }
         public Regex ImportNamingPattern { get; private set; }
         public DateTime? RemoveBeforeDate { get; private set; }
@@ -1032,6 +1033,12 @@ namespace pwiz.Skyline
                 }
 
                 else if (IsNameValue(pair, "import-all"))
+                {
+                    ImportSourceDirectory = GetFullPath(pair.Value);
+                    ImportRecursive = true;
+                    RequiresSkylineDocument = true;
+                }
+                else if (IsNameValue(pair, "import-all-files"))
                 {
                     ImportSourceDirectory = GetFullPath(pair.Value);
                     RequiresSkylineDocument = true;

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -338,6 +338,7 @@ namespace pwiz.Skyline
             {
                 // If expected results are not imported successfully, terminate
                 if (!ImportResultsInDir(commandArgs.ImportSourceDirectory,
+                        commandArgs.ImportRecursive,
                         commandArgs.ImportNamingPattern,
                         commandArgs.LockMassParameters,
                         commandArgs.ImportBeforeDate,
@@ -772,12 +773,12 @@ namespace pwiz.Skyline
             return BackgroundProteomeList.GetDefault();
         }
 
-        public bool ImportResultsInDir(string sourceDir, Regex namingPattern, 
+        public bool ImportResultsInDir(string sourceDir, bool recursive, Regex namingPattern, 
             LockMassParameters lockMassParameters,
             DateTime? importBefore, DateTime? importOnOrAfter,
             OptimizableRegression optimize, bool disableJoining, bool warnOnFailure)
         {
-            var listNamedPaths = GetDataSources(sourceDir, namingPattern, lockMassParameters);
+            var listNamedPaths = GetDataSources(sourceDir, recursive, namingPattern, lockMassParameters);
             if (listNamedPaths == null)
             {
                 return false;
@@ -924,13 +925,13 @@ namespace pwiz.Skyline
             public MsDataFileUri FilePath { get; private set; }
         }
 
-        private IList<KeyValuePair<string, MsDataFileUri[]>> GetDataSources(string sourceDir, Regex namingPattern, LockMassParameters lockMassParameters)
+        private IList<KeyValuePair<string, MsDataFileUri[]>> GetDataSources(string sourceDir, bool recursive, Regex namingPattern, LockMassParameters lockMassParameters)
         {   
             // get all the valid data sources (files and sub directories) in this directory.
             IList<KeyValuePair<string, MsDataFileUri[]>> listNamedPaths;
             try
             {
-                listNamedPaths = DataSourceUtil.GetDataSources(sourceDir).ToArray();
+                listNamedPaths = DataSourceUtil.GetDataSources(sourceDir, recursive).ToArray();
             }
             catch(IOException e)
             {

--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -417,7 +417,7 @@ namespace pwiz.Skyline.Model
             return Import(progressMonitor, sourceFile, indices, dictNameSeq, out irtPeptides, out librarySpectra, out errorList);
         }
 
-        public static IEnumerable<string> IrtColumnNames { get { return new[] { "tr_recalibrated", "irt" }; } } // Not L10N
+        public static IEnumerable<string> IrtColumnNames { get { return new[] { "irt", "normalizedretentiontime", "tr_recalibrated" }; } } // Not L10N
         public static IEnumerable<string> LibraryColumnNames { get { return new[] { "libraryintensity", "relativeintensity", "relative_intensity", "relativefragmentintensity", "library_intensity" }; } } // Not L10N
 
         public IEnumerable<PeptideGroupDocNode> Import(IProgressMonitor progressMonitor,

--- a/pwiz_tools/Skyline/Model/MultiFileLoader.cs
+++ b/pwiz_tools/Skyline/Model/MultiFileLoader.cs
@@ -103,11 +103,11 @@ namespace pwiz.Skyline.Model
                         break;
 
                     case ImportResultsSimultaneousFileOptions.several: // Several is 1/4 logical processors (i.e. 2 for an i7)
-                        _threadCount = Math.Max(1, Environment.ProcessorCount / 4);
+                        _threadCount = Math.Max(2, Environment.ProcessorCount / 4); // Min of 2, because you really expect more than 1
                         break;
 
                     case ImportResultsSimultaneousFileOptions.many: // Many is 1/2 logical processors (i.e. 4 for an i7)
-                        _threadCount = Math.Max(1, Environment.ProcessorCount / 2);
+                        _threadCount = Math.Max(2, Environment.ProcessorCount / 2); // Min of 2, because you really expect more than 1
                         break;
                 }
                 _threadCount = Math.Min(MAX_PARALLEL_LOAD_FILES, _threadCount);

--- a/pwiz_tools/Skyline/TestA/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestA/CommandLineTest.cs
@@ -1279,6 +1279,8 @@ namespace pwiz.SkylineTestA
             FileEx.SafeDelete(outPath2);
             var outPath3 = testFilesDir.GetTestPath("Imported_multiple3.sky");
             FileEx.SafeDelete(outPath3);
+            var outPath4 = testFilesDir.GetTestPath("Imported_multiple4.sky");
+            FileEx.SafeDelete(outPath4);
 
             var rawPath = new MsDataFilePath(testFilesDir.GetTestPath(@"REP01\CE_Vantage_15mTorr_0001_REP1_01" + extRaw));
             
@@ -1467,6 +1469,32 @@ namespace pwiz.SkylineTestA
                     string.Format(
                         Resources.CommandLine_CheckReplicateFiles_Error__Replicate__0__in_the_document_has_an_unexpected_file__1__,"REP01",
                         rawPath3)), msg);
+
+            
+
+            // Test: Import non-recursive
+            // Make sure only files directly in the folder get imported
+            string badFilePath = testFilesDir.GetTestPath("bad_file" + extRaw);
+            string badFileMoved = badFilePath + ".save";
+            if (File.Exists(badFilePath))
+                File.Move(badFilePath, badFileMoved);
+            string fullScanPath = testFilesDir.GetTestPath("FullScan" + extRaw);
+            string fullScanMoved = fullScanPath + ".save";
+            File.Move(fullScanPath, fullScanMoved);
+
+            msg = RunCommand("--in=" + docPath,
+                "--import-all-files=" + testFilesDir.FullPath,
+                "--out=" + outPath4);
+
+            Assert.IsTrue(File.Exists(outPath4), msg);
+            doc = ResultsUtil.DeserializeDocument(outPath4);
+            Assert.IsTrue(doc.Settings.HasResults);
+            Assert.AreEqual(4, doc.Settings.MeasuredResults.Chromatograms.Count,
+                string.Format("Expected 4 replicates from files, found: {0}",
+                    string.Join(", ", doc.Settings.MeasuredResults.Chromatograms.Select(chromSet => chromSet.Name).ToArray())));
+            if (File.Exists(badFileMoved))
+                File.Move(badFileMoved, badFilePath);
+            File.Move(fullScanMoved, fullScanPath);
 
         }
 

--- a/pwiz_tools/Skyline/Util/DataSourceUtil.cs
+++ b/pwiz_tools/Skyline/Util/DataSourceUtil.cs
@@ -204,9 +204,9 @@ namespace pwiz.Skyline.Util
 
         // This method can throw an IOException if there is an error reading .wiff files in 
         // the given directory.
-        public static IEnumerable<KeyValuePair<string, MsDataFileUri[]>> GetDataSources(string dirRoot)
+        public static IEnumerable<KeyValuePair<string, MsDataFileUri[]>> GetDataSources(string dirRoot, bool addSourcesInSubDirs = true)
         {
-            return GetDataSources(dirRoot, true, true);
+            return GetDataSources(dirRoot, true, addSourcesInSubDirs);
         }
 
         public static IEnumerable<KeyValuePair<string, MsDataFileUri[]>> GetDataSourcesInSubdirs(string dirRoot)


### PR DESCRIPTION
- Add support for NormalizedRetentionTime column in assay library import
- Force several and many threaded imports to use at least 2 threads
- Add new --import-all-files command-line argument that is not recursive