### PR TITLE
Skyline: Fixes for working with gas phase fractionated DIA data

### DIFF
--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -1668,11 +1668,12 @@ namespace pwiz.Skyline
                 _out.WriteLine(Resources.CommandArgs_ParseArgsInternal_Error____import_naming_pattern_cannot_be_used_with_the___import_file_option_);
                 return false;
             }
-            if(ImportingSourceDirectory && !string.IsNullOrEmpty(ReplicateName))
-            {
-                _out.WriteLine(Resources.CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_the___import_all_option_);
-                return false;
-            }
+            // This is now handled by creating a single replicate with the contents of the directory
+//            if(ImportingSourceDirectory && !string.IsNullOrEmpty(ReplicateName))
+//            {
+//                _out.WriteLine(Resources.CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_the___import_all_option_);
+//                return false;
+//            }
             
             // Use the original file as the output file, if not told otherwise.
             if (Saving && String.IsNullOrEmpty(SaveFile))

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -346,6 +346,7 @@ namespace pwiz.Skyline
                 if (!ImportResultsInDir(commandArgs.ImportSourceDirectory,
                         commandArgs.ImportRecursive,
                         commandArgs.ImportNamingPattern,
+                        commandArgs.ReplicateName,
                         commandArgs.LockMassParameters,
                         commandArgs.ImportBeforeDate,
                         commandArgs.ImportOnOrAfterDate,
@@ -779,7 +780,7 @@ namespace pwiz.Skyline
             return BackgroundProteomeList.GetDefault();
         }
 
-        public bool ImportResultsInDir(string sourceDir, bool recursive, Regex namingPattern, 
+        public bool ImportResultsInDir(string sourceDir, bool recursive, Regex namingPattern, string replicateName,
             LockMassParameters lockMassParameters,
             DateTime? importBefore, DateTime? importOnOrAfter,
             OptimizableRegression optimize, bool disableJoining, bool warnOnFailure)
@@ -789,7 +790,11 @@ namespace pwiz.Skyline
             {
                 return false;
             }
-
+            // If there is a single name for everything then it should override any naming from GetDataSources
+            if (!string.IsNullOrEmpty(replicateName))
+            {
+                listNamedPaths = new[] { new KeyValuePair<string, MsDataFileUri[]>(replicateName, listNamedPaths.SelectMany(s => s.Value).ToArray()) };
+            }
             return ImportDataFiles(listNamedPaths, lockMassParameters, importBefore, importOnOrAfter, optimize, disableJoining, warnOnFailure);
         }
 

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -1147,6 +1147,12 @@ namespace pwiz.Skyline.Model
                             docImport.Settings.PeptideSettings.Modifications,
                             docNew.Settings.PeptideSettings.Modifications,
                             staticMods, heavyMods);
+                        if (nodePepModified.GlobalStandardType != null)
+                        {
+                            // Try to keep settings change from changing the children of standards being imported
+                            nodePepModified = (PeptideDocNode)nodePepModified.ChangeAutoManageChildren(false)
+                                .ChangeChildrenChecked(nodePepModified.TransitionGroups.Select(nodeGroup => nodeGroup.ChangeAutoManageChildren(false)).ToArray());
+                        }
                         peptidesNew.Add(nodePepModified);
                     }
                     var nodePepGroupNew = (PeptideGroupDocNode)nodePepGroup.ChangeChildrenChecked(peptidesNew.ToArray());

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -4280,16 +4280,6 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error: --import-replicate-name cannot be used with the --import-all option..
-        /// </summary>
-        public static string CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_the___import_all_option_ {
-            get {
-                return ResourceManager.GetString("CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_" +
-                        "the___import_all_option_", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Error: Attempting to exclude an unknown feature name &apos;{0}&apos;. Try one of the following:.
         /// </summary>
         public static string CommandArgs_ParseArgsInternal_Error__Attempting_to_exclude_an_unknown_feature_name___0____Try_one_of_the_following_ {

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -6816,9 +6816,6 @@
   <data name="IonMobilityTest_TestGetIonMobilityDBErrorHandling_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
     <value>イオン移動度ライブラリファイル{0}を見つけることができませんでした。作成するための十分な権限がないようです。</value>
   </data>
-  <data name="CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_the___import_all_option_" xml:space="preserve">
-    <value>エラー：--import-replicate-nameを--import-allオプションとともに使用することはできません。</value>
-  </data>
   <data name="SpectrumLibraryInfoDlg_SetDetailsText_Matched_spectra" xml:space="preserve">
     <value>一致したスペクトル</value>
   </data>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -6816,9 +6816,6 @@ You may be able to avoid this problem by installing a 64-bit version of {0}.</va
   <data name="IonMobilityTest_TestGetIonMobilityDBErrorHandling_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
     <value>The ion mobility library file {0} could not be found. Perhaps you did not have sufficient privileges to create it?</value>
   </data>
-  <data name="CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_the___import_all_option_" xml:space="preserve">
-    <value>Error: --import-replicate-name cannot be used with the --import-all option.</value>
-  </data>
   <data name="SpectrumLibraryInfoDlg_SetDetailsText_Matched_spectra" xml:space="preserve">
     <value>Matched spectra</value>
   </data>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -6816,9 +6816,6 @@
   <data name="IonMobilityTest_TestGetIonMobilityDBErrorHandling_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
     <value>离子迁移库文件{0}无法找到。可能您没有足够的权限来创建它？</value>
   </data>
-  <data name="CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_the___import_all_option_" xml:space="preserve">
-    <value>错误：“--导入重复测定名称”无法与“--导入所有”选项连用。</value>
-  </data>
   <data name="SpectrumLibraryInfoDlg_SetDetailsText_Matched_spectra" xml:space="preserve">
     <value>匹配的谱图</value>
   </data>

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -46,8 +46,8 @@
     <PublisherName>MacCoss Lab, UW</PublisherName>
     <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
     <WebPage>index.html</WebPage>
-    <ApplicationRevision>11799</ApplicationRevision>
-    <ApplicationVersion>4.1.1.11799</ApplicationVersion>
+    <ApplicationRevision>18151</ApplicationRevision>
+    <ApplicationVersion>4.1.1.18151</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/pwiz_tools/Skyline/TestA/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestA/CommandLineTest.cs
@@ -1273,6 +1273,8 @@ namespace pwiz.SkylineTestA
 
 
             var docPath = testFilesDir.GetTestPath("test.sky");
+            var outPath0 = testFilesDir.GetTestPath("Imported_multiple0.sky");
+            FileEx.SafeDelete(outPath0);
             var outPath1 = testFilesDir.GetTestPath("Imported_multiple1.sky");
             FileEx.SafeDelete(outPath1);
             var outPath2 = testFilesDir.GetTestPath("Imported_multiple2.sky");
@@ -1296,14 +1298,20 @@ namespace pwiz.SkylineTestA
 
 
 
-            // Test: Cannot use --import-replicate-name with --import-all
+            // Test: Use --import-replicate-name with --import-all for single-replicate, multi-file import
+            const string singleName = "Unscheduled01";
             msg = RunCommand("--in=" + docPath,
-                             "--import-replicate-name=Unscheduled01",
-                             "--import-all=" + testFilesDir.FullPath,
-                             "--out=" + outPath1);
-            Assert.IsTrue(msg.Contains(Resources.CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_the___import_all_option_), msg);
-            // output file should not exist
-            Assert.IsFalse(File.Exists(outPath1));
+                             "--import-replicate-name=" + singleName,
+                             "--import-all=" + testFilesDir.GetTestPath("REP01"),
+                             "--out=" + outPath0);
+            // Used to give this error
+//            Assert.IsTrue(msg.Contains(Resources.CommandArgs_ParseArgsInternal_Error____import_replicate_name_cannot_be_used_with_the___import_all_option_), msg);
+//            // output file should not exist
+            Assert.IsTrue(File.Exists(outPath0), msg);            
+            SrmDocument doc0 = ResultsUtil.DeserializeDocument(outPath0);
+            Assert.AreEqual(1, doc0.Settings.MeasuredResults.Chromatograms.Count);
+            Assert.IsTrue(doc0.Settings.MeasuredResults.ContainsChromatogram(singleName));
+            Assert.AreEqual(2, doc0.Settings.MeasuredResults.Chromatograms[0].MSDataFileInfos.Count);
 
 
 


### PR DESCRIPTION
- Allow --import-all and --import-replicate-name together for importing multiple files in a folder to a single replicate
- Try to keep Skyline changing settings from removing transitions from copy-pasted standard peptides (e.g. iRT standards with only precursor transitions into a fragment-only DIA document)