### PR TITLE
Skyline/bugfix/20180706

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/SpectraChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectraChromDataProvider.cs
@@ -918,7 +918,7 @@ namespace pwiz.Skyline.Model.Results
                             continue;
 
                         // Skip quickly through the chromatographic lead-in and tail when possible 
-                        if (msLevel > 1) // We need all MS1 for TIC and BPC
+                        if (msLevel > 1 || !_filter.IsFilteringFullGradientMs1) // We need all MS1 for TIC and BPC
                         {
                             // Only do these checks if we can get the information instantly. Otherwise,
                             // this will slow down processing in more complex cases.

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -25,6 +25,7 @@ using System.Xml.Serialization;
 using pwiz.Common.Chemistry;
 using pwiz.ProteowizardWrapper;
 using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Results.RemoteApi.GeneratedCode;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
@@ -163,10 +164,11 @@ namespace pwiz.Skyline.Model.Results
                             ionMobility = IonMobilityAndCCS.EMPTY;
                         }
 
-                        
+
+                        ExplicitPeakBounds peakBoundaries = null;
                         if (_fullScan.RetentionTimeFilterType != RetentionTimeFilterType.none)
                         {
-                            var peakBoundaries = document.Settings.GetExplicitPeakBounds(nodePep, msDataFileUri);
+                            peakBoundaries = document.Settings.GetExplicitPeakBounds(nodePep, msDataFileUri);
                             if (peakBoundaries != null)
                             {
                                 minTime = peakBoundaries.StartTime - _fullScan.RetentionTimeFilterLength;
@@ -174,25 +176,25 @@ namespace pwiz.Skyline.Model.Results
                                 _isSharedTime = false;
                             }
                         }
-                        if (canSchedule)
+                        if (canSchedule && peakBoundaries == null)
                         {
                             if (RetentionTimeFilterType.scheduling_windows == _fullScan.RetentionTimeFilterType)
                             {
                                 double? centerTime = null;
                                 double windowRT = 0;
-                                    if (retentionTimePredictor != null)
+                                if (retentionTimePredictor != null)
+                                {
+                                    centerTime = retentionTimePredictor.GetPredictedRetentionTime(nodePep);
+                                }
+                                else
+                                {
+                                    var prediction = document.Settings.PeptideSettings.Prediction;
+                                    if (prediction.RetentionTime == null || !prediction.RetentionTime.IsAutoCalculated)
                                     {
-                                        centerTime = retentionTimePredictor.GetPredictedRetentionTime(nodePep);
+                                        centerTime = document.Settings.PeptideSettings.Prediction.PredictRetentionTimeForChromImport(
+                                            document, nodePep, nodeGroup, out windowRT);
                                     }
-                                    else
-                                    {
-                                        var prediction = document.Settings.PeptideSettings.Prediction;
-                                        if (prediction.RetentionTime == null || !prediction.RetentionTime.IsAutoCalculated)
-                                        {
-                                            centerTime = document.Settings.PeptideSettings.Prediction.PredictRetentionTimeForChromImport(
-                                                document, nodePep, nodeGroup, out windowRT);
-                                        }
-                                    }
+                                }
                                 // Force the center time to be at least zero
                                 if (centerTime.HasValue && centerTime.Value < 0)
                                     centerTime = 0;
@@ -363,6 +365,11 @@ namespace pwiz.Skyline.Model.Results
         }
 
         public bool IsFirstPass { get; private set; }
+
+        public bool IsFilteringFullGradientMs1
+        {
+            get { return !IsFirstPass; }
+        }
 
         public bool IsWatersFile
         {

--- a/pwiz_tools/Skyline/SkylineCmd/Program.cs
+++ b/pwiz_tools/Skyline/SkylineCmd/Program.cs
@@ -47,6 +47,7 @@ namespace pwiz.SkylineCmd
             }
             var programClass = assembly.GetType("pwiz.Skyline.Program"); // Not L10N
             var mainFunction = programClass.GetMethod("Main"); // Not L10N
+            // ReSharper disable once PossibleNullReferenceException
             return (int) mainFunction.Invoke(null, new object[]{args});
         }
     }

--- a/pwiz_tools/Skyline/SkylineTool/RemoteService.cs
+++ b/pwiz_tools/Skyline/SkylineTool/RemoteService.cs
@@ -93,6 +93,7 @@ namespace SkylineTool
                     {
                         var remoteInvoke = (RemoteInvoke) DeserializeObject(ReadAllBytes(stream));
                         var method = GetType().GetMethod(remoteInvoke.MethodName);
+                        // ReSharper disable once PossibleNullReferenceException
                         var returnValue = method.Invoke(this, remoteInvoke.Arguments);
                         bytesResponse = SerializeObject(new RemoteResponse {ReturnValue = returnValue});
                     }

--- a/pwiz_tools/Skyline/TestFunctional/FiguresOfMeritTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/FiguresOfMeritTest.cs
@@ -48,7 +48,7 @@ namespace pwiz.SkylineTestFunctional
         protected override void DoTest()
         {
             int seed = (int) DateTime.Now.Ticks;
-            Console.WriteLine("FiguresOfMeritTest: using random seed {0}", seed);
+            // Console.WriteLine("FiguresOfMeritTest: using random seed {0}", seed);
             var random = new Random(seed);
             RunUI(()=>SkylineWindow.OpenFile(TestFilesDir.GetTestPath("FiguresOfMeritTest.sky")));
             var documentGrid = ShowDialog<DocumentGridForm>(() => SkylineWindow.ShowDocumentGrid(true));

--- a/pwiz_tools/Skyline/TestRunner/MemoryProfiler.cs
+++ b/pwiz_tools/Skyline/TestRunner/MemoryProfiler.cs
@@ -47,6 +47,7 @@ namespace TestRunner
             {
                 var profilerAssembly = Assembly.LoadFrom(profilerDll);
                 var profiler = profilerAssembly.GetType(PROFILER_TYPE);
+                // ReSharper disable once PossibleNullReferenceException
                 if (profiler != null && (bool)profiler.GetMethod("get_IsProfiling").Invoke(null, null))
                 {
                     FULL_SNAP_SHOT =

--- a/pwiz_tools/Skyline/TestRunnerLib/InvokeSkyline.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/InvokeSkyline.cs
@@ -27,16 +27,19 @@ namespace TestRunnerLib
 
         public void Run(string method, params object[] args)
         {
+            // ReSharper disable once PossibleNullReferenceException
             _skylineProgram.GetMethod(method).Invoke(null, args);
         }
 
         public void Set(string field, object value)
         {
+            // ReSharper disable once PossibleNullReferenceException
             _skylineProgram.GetMethod("set_" + field).Invoke(null, new[] {value});
         }
 
         public T Get<T>(string field)
         {
+            // ReSharper disable once PossibleNullReferenceException
             return (T) _skylineProgram.GetMethod("get_" + field).Invoke(null, null);
         }
     }

--- a/pwiz_tools/Skyline/Util/DotTraceProfile.cs
+++ b/pwiz_tools/Skyline/Util/DotTraceProfile.cs
@@ -75,6 +75,7 @@ namespace pwiz.Skyline.Util
         {
             get
             {
+                // ReSharper disable once PossibleNullReferenceException
                 var isActive = (PROFILER != null) && (bool)PROFILER.GetMethod("get_IsActive").Invoke(null, null);
                 return isActive;
             }
@@ -90,6 +91,7 @@ namespace pwiz.Skyline.Util
             {
                 _profilerStopped = false;
                 LOG.Info("Start profiler");
+                // ReSharper disable once PossibleNullReferenceException
                 PROFILER.GetMethod("Start").Invoke(null, null);
             }
         }
@@ -106,6 +108,7 @@ namespace pwiz.Skyline.Util
                 _profilerStopped = true;
                 if (!suppressLog)
                     LOG.Info("Stop profiler");
+                // ReSharper disable once PossibleNullReferenceException
                 PROFILER.GetMethod("Stop").Invoke(null, null);
             }
         }
@@ -118,6 +121,7 @@ namespace pwiz.Skyline.Util
             if (IsProfiling)
             {
                 LOG.Info("Save profile snapshot");
+                // ReSharper disable once PossibleNullReferenceException
                 PROFILER.GetMethod("EndSave").Invoke(null, null);
                 Thread.Sleep(500);  // Sometimes the snapshot doesn't open if there isn't a short delay.
             }


### PR DESCRIPTION
Importing results hung on 50 or so VMs at ETH at about 80% through the first pass iRT extraction. I had forgotten to choose ID times and the combination of explicit peak bounds and settings that specified minutes from predicted retention time caused the hang.