### PR TITLE
Fix problem where changing the precursor resolution could result in a…

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
@@ -2349,8 +2349,9 @@ namespace pwiz.Skyline.Model.DocSettings
                               // MS1 filtering changed select peaks
                               newTran.FullScan.PrecursorIsotopes != oldTran.FullScan.PrecursorIsotopes ||
                               newTran.FullScan.PrecursorIsotopeFilter != oldTran.FullScan.PrecursorIsotopeFilter ||
-                              (newTran.FullScan.PrecursorIsotopes != FullScanPrecursorIsotopes.None && enrichmentsChanged)
-                              ;
+                              (newTran.FullScan.PrecursorIsotopes != FullScanPrecursorIsotopes.None && enrichmentsChanged) ||
+                              !Equals(newTran.FullScan.PrecursorRes, oldTran.FullScan.PrecursorRes) ||
+                              !Equals(newTran.FullScan.PrecursorResMz, oldTran.FullScan.PrecursorResMz);
 
             // If the library loded state has changed, make sure the library properties are up to date,
             // but avoid changing the chosen transitions.


### PR DESCRIPTION
… document that could not be opened because the expected set of transitions was incorrect.

(Changing the resolution might result in the sulfur part of the M+2 peak not being included in the isolation window, which might result in that peak becoming less than TransitionFullScan.MIN_ISOTOPE_PEAK_ABUNDANCE).