### PR TITLE
SkylineNightly: TeamCity now requires TLS1.2 for SSL connection for d…

### DIFF
--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -422,6 +422,8 @@ namespace SkylineNightly
 
         private void DownloadSkylineTester(string skylineTesterZip, RunMode mode)
         {
+            // Make sure we can negotiate with HTTPS servers that demand TLS 1.2 (default in dotNet 4.6, but has to be turned on in 4.5)
+            ServicePointManager.SecurityProtocol |= (SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12);
             using (var client = new WebClient())
             {
                 client.Credentials = new NetworkCredential(TEAM_CITY_USER_NAME, TEAM_CITY_USER_PASSWORD);


### PR DESCRIPTION
…ownloading SkylineTester