### PR TITLE
Set "UseShellExecute=false" in order to fix a handle leak in TestSkyl…

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/SkylineCmdTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SkylineCmdTest.cs
@@ -64,7 +64,10 @@ namespace pwiz.SkylineTestFunctional
 
         private ProcessStartInfo GetProcessStartInfo(string arguments)
         {
-            var processStartInfo = new ProcessStartInfo(FindSkylineCmdExe(), arguments);
+            var processStartInfo = new ProcessStartInfo(FindSkylineCmdExe(), arguments)
+            {
+                UseShellExecute = false
+            };
             if (Program.SkylineOffscreen)
             {
                 processStartInfo.WindowStyle = ProcessWindowStyle.Hidden;


### PR DESCRIPTION
…ineCmd