### PR TITLE
SkylineNightly: temporarily back out the recently added reporting of …

### DIFF
--- a/pwiz_tools/Skyline/Skyline.sln
+++ b/pwiz_tools/Skyline/Skyline.sln
@@ -66,6 +66,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestConnected", "TestConnec
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkylineCmd", "SkylineCmd\SkylineCmd.csproj", "{FA16A0EF-EDF7-4515-BD93-44BADD7AB98A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkylineNightlyShim", "SkylineNightlyShim\SkylineNightlyShim.csproj", "{3C7F5209-6507-42C5-80CE-472AE6A51CD1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -250,6 +252,14 @@ Global
 		{FA16A0EF-EDF7-4515-BD93-44BADD7AB98A}.Release|x64.Build.0 = Release|x64
 		{FA16A0EF-EDF7-4515-BD93-44BADD7AB98A}.Release|x86.ActiveCfg = Release|x86
 		{FA16A0EF-EDF7-4515-BD93-44BADD7AB98A}.Release|x86.Build.0 = Release|x86
+		{3C7F5209-6507-42C5-80CE-472AE6A51CD1}.Debug|x64.ActiveCfg = Debug|x64
+		{3C7F5209-6507-42C5-80CE-472AE6A51CD1}.Debug|x64.Build.0 = Debug|x64
+		{3C7F5209-6507-42C5-80CE-472AE6A51CD1}.Debug|x86.ActiveCfg = Debug|x86
+		{3C7F5209-6507-42C5-80CE-472AE6A51CD1}.Debug|x86.Build.0 = Debug|x86
+		{3C7F5209-6507-42C5-80CE-472AE6A51CD1}.Release|x64.ActiveCfg = Release|x64
+		{3C7F5209-6507-42C5-80CE-472AE6A51CD1}.Release|x64.Build.0 = Release|x64
+		{3C7F5209-6507-42C5-80CE-472AE6A51CD1}.Release|x86.ActiveCfg = Release|x86
+		{3C7F5209-6507-42C5-80CE-472AE6A51CD1}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -39,8 +39,6 @@ namespace SkylineNightly
     // ReSharper disable NonLocalizedString
     public class Nightly
     {
-        private const bool SUPPORT_HANDLE_LEAK_TRACKING = false; // TODO restore this once test server is updated to deal with handle leak info
-
 
         private const string NIGHTLY_TASK_NAME = "Skyline nightly build";
 
@@ -605,13 +603,10 @@ namespace SkylineNightly
                     test["duration"] = duration;
                     test["managed"] = managed;
                     test["total"] = total;
-                    if (SUPPORT_HANDLE_LEAK_TRACKING) // TODO restore this once test server is updated to deal with handle leak info
-                    {
-                        if (!string.IsNullOrEmpty(user))
-                            test["user"] = user;
-                        if (!string.IsNullOrEmpty(gdi))
-                            test["gdi"] = gdi;
-                    }
+                    if (!string.IsNullOrEmpty(user))
+                        test["user"] = user;
+                    if (!string.IsNullOrEmpty(gdi))
+                        test["gdi"] = gdi;
                 }
 
                 testCount++;
@@ -658,16 +653,13 @@ namespace SkylineNightly
                 leak["name"] = match.Groups[1].Value;
                 leak["bytes"] = match.Groups[2].Value;
             }
-            if (SUPPORT_HANDLE_LEAK_TRACKING) // TODO restore this once test server is updated to deal with handle leak info
+            var leakHandlesPattern = new Regex(@"!!! (\S+) HANDLE-LEAKED ([.0-9]+) (\S+)", RegexOptions.Compiled);
+            for (var match = leakHandlesPattern.Match(log); match.Success; match = match.NextMatch())
             {
-                var leakHandlesPattern = new Regex(@"!!! (\S+) HANDLE-LEAKED ([.0-9]+) (\S+)", RegexOptions.Compiled);
-                for (var match = leakHandlesPattern.Match(log); match.Success; match = match.NextMatch())
-                {
-                    var leak = _leaks.Append("leak");
-                    leak["name"] = match.Groups[1].Value;
-                    leak["handles"] = match.Groups[2].Value;
-                    leak["type"] = match.Groups[3].Value;
-                }
+                var leak = _leaks.Append("leak");
+                leak["name"] = match.Groups[1].Value;
+                leak["handles"] = match.Groups[2].Value;
+                leak["type"] = match.Groups[3].Value;
             }
         }
 

--- a/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.cs
@@ -102,7 +102,7 @@ namespace SkylineNightly
                     td.RegistrationInfo.Description = "Skyline nightly build/test"; // Not L10N
                     td.Principal.LogonType = TaskLogonType.InteractiveToken;
 
-                    // Add a trigger that will fire the task every other day
+                    // Add a trigger that will fire the task every day
                     var dt = (DailyTrigger) td.Triggers.Add(new DailyTrigger { DaysInterval = 1 });
                     var scheduledTime = startTime.Value;
                     var now = DateTime.Now;
@@ -129,9 +129,9 @@ namespace SkylineNightly
                     //   TaskPriority = 8, I/O Priority = Normal, Memory Priority = 5
                     td.Settings.Priority = ProcessPriorityClass.High; 
 
-                    // Add an action that will launch SkylineTester whenever the trigger fires
+                    // Add an action that will launch SkylineNightlyShim whenever the trigger fires
                     var assembly = Assembly.GetExecutingAssembly();
-                    td.Actions.Add(new ExecAction(assembly.Location, runType)); // Not L10N
+                    td.Actions.Add(new ExecAction(assembly.Location.Replace(".exe", "Shim.exe"), runType)); // Not L10N
 
                     // Register the task in the root folder
                     ts.RootFolder.RegisterTaskDefinition(Nightly.NightlyTaskNameWithUser, td);

--- a/pwiz_tools/Skyline/SkylineNightlyShim/App.config
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+    </startup>
+</configuration>

--- a/pwiz_tools/Skyline/SkylineNightlyShim/Program.cs
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/Program.cs
@@ -23,18 +23,13 @@
 // Accepts same argmuments as SkylineNightly, but first updates local SkylineNightly.exe from GitHub artifacts before invoking it
 // 
 
+// ReSharper disable NonLocalizedString
+
 using System;
 using System.Diagnostics;
-using System.Drawing;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Xml.Linq;
 using Ionic.Zip;
 
 namespace SkylineNightlyShim

--- a/pwiz_tools/Skyline/SkylineNightlyShim/Program.cs
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/Program.cs
@@ -1,0 +1,100 @@
+﻿/*
+ * Original author: Brian Pratt <bspratt .at. proteinms dot net>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2018 University of Washington - Seattle, WA
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+//
+// Small wrapper program for SkylineNightly
+// Accepts same argmuments as SkylineNightly, but first updates local SkylineNightly.exe from GitHub artifacts before invoking it
+// 
+
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Xml.Linq;
+using Ionic.Zip;
+
+namespace SkylineNightlyShim
+{
+    class Program
+    {
+        private const string TEAM_CITY_ZIP_URL =
+            "https://teamcity.labkey.org/guestAuth/repository/download/{0}/.lastFinished/SkylineNightly.zip{1}";
+
+        private const string TEAM_CITY_BUILD_TYPE_64_MASTER = "bt209";
+        private const string TEAM_CITY_USER_NAME = "guest";
+        private const string TEAM_CITY_USER_PASSWORD = "guest";
+        private const string SKYLINENIGHTLY_ZIP = "SkylineNightly.zip";
+
+        static void Main(string[] args)
+        {
+        
+            // Make sure we can negotiate with HTTPS servers that demand TLS 1.2 (default in dotNet 4.6, but has to be turned on in 4.5)
+            ServicePointManager.SecurityProtocol |= (SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12);
+            var currentDirectory = Directory.GetCurrentDirectory();
+            try
+            {
+                using (var client = new WebClient())
+                {
+                    // Attempt to update SkylineNightly.exe
+                    client.Credentials = new NetworkCredential(TEAM_CITY_USER_NAME, TEAM_CITY_USER_PASSWORD);
+                    string zipFileLink = string.Format(TEAM_CITY_ZIP_URL, TEAM_CITY_BUILD_TYPE_64_MASTER, "?branch=master");
+                    Console.Write("Download SkylineTester zip file as " + zipFileLink);
+                    var fileName = Path.Combine(currentDirectory, SKYLINENIGHTLY_ZIP);
+                    client.DownloadFile(zipFileLink, fileName);
+                    using (var zipFile = new ZipFile(fileName))
+                    {
+                        zipFile.ExtractSelectedEntries("SkylineNightly.*", ExtractExistingFileAction.OverwriteSilently);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                Console.WriteLine("Trouble downloading SkylineNightly.zip, proceeding with existing installation");
+            }
+
+            // Invoke SkylineNightly with any args provided
+            Process nightly = new Process
+            {
+                StartInfo =
+                {
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    FileName = "SkylineNightly.exe",
+                    WorkingDirectory = currentDirectory,
+                    Arguments = string.Join(" ", args.Select(arg => string.Format("\"{0}\"", arg))),
+                    CreateNoWindow = true
+                }
+            };
+
+            nightly.Start();
+        }
+    }
+
+}
+

--- a/pwiz_tools/Skyline/SkylineNightlyShim/Properties/AssemblyInfo.cs
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SkylineNightlyShim")]
+[assembly: AssemblyDescription("Thin wrapper for SkylineNightly, updates SkylineNightly from TeamCity then executes it, passing along any provided args")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("University of Washington")]
+[assembly: AssemblyProduct("SkylineNightlyShim")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2eb622df-575d-48bc-825d-7c6bf6b1a1df")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/pwiz_tools/Skyline/SkylineNightlyShim/SkylineNightlyShim.csproj
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/SkylineNightlyShim.csproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3C7F5209-6507-42C5-80CE-472AE6A51CD1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SkylineNightlyShim</RootNamespace>
+    <AssemblyName>SkylineNightlyShim</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>..\bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+    <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="DotNetZip">
+      <HintPath>..\..\Shared\Lib\DotNetZip\DotNetZip.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http">
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/pwiz_tools/Skyline/SkylineTester/CreateZipInstallerWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CreateZipInstallerWindow.cs
@@ -100,6 +100,7 @@ namespace SkylineTester
                     // Add files to top level of zip file.
                     var files = new[]
                     {
+                        "SkylineNightlyShim.exe",
                         "SkylineNightly.exe",
                         "SkylineNightly.pdb",
                         "Microsoft.Win32.TaskScheduler.dll",

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -44,9 +44,10 @@ namespace TestRunner
     {
         private static readonly string[] TEST_DLLS = { "Test.dll", "TestA.dll", "TestConnected.dll", "TestFunctional.dll", "TestTutorial.dll", "CommonTest.dll", "TestPerf.dll" };
         private const int LeakThreshold = 250000;
-        // TODO: Turn on leak detection for handles by lowering the limits below
-        private const double LeakGdiThreshold = 2;
-        private const double LeakUserThreshold = 2;
+        // TODO: Turn on leak detection for handles by lowering the limits below (2 is enough to trigger on some test machines)
+        private const int LEAKED_HANDLES_THRESHOLD = 5;
+        private const double LeakGdiThreshold = LEAKED_HANDLES_THRESHOLD;
+        private const double LeakUserThreshold = LEAKED_HANDLES_THRESHOLD;
         private const int CrtLeakThreshold = 1000;
         private const int LeakCheckIterations = 24;
 


### PR DESCRIPTION
…handle leaks until we can get the test server updated to deal with that. In anticipation of that, change the SkylineNightly automation scheme such that TaskScheduler now kicks off SkylineNightlyShim.exe, which pulls the latest SkylineNightly.exe from TeamCity and runs that. So, hopefuly in future no more manually updating each of our fleet of test machines any time SkylineNightly behavior needs to change.