### PR TITLE
Skyline: adding these files (see https://docs.microsoft.com/en-us/vis…

### DIFF
--- a/pwiz_tools/Shared/Common/Directory.Build.props
+++ b/pwiz_tools/Shared/Common/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project> 
+<PropertyGroup>
+ <!-- Suppress MSBuild errors: --> 
+ <!-- MSB3178: Assembly xxx is incorrectly specified as a file. --> 
+ <!-- MSB3187: Referenced assembly xxx targets a different processor than the application. --> 
+ <!-- MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference xxx, "AMD64". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project. --> 
+ <MSBuildWarningsAsMessages>MSB3187;MSB3270;MSB3178</MSBuildWarningsAsMessages> 
+ </PropertyGroup> 
+ </Project>

--- a/pwiz_tools/Skyline/Directory.Build.props
+++ b/pwiz_tools/Skyline/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project> 
+<PropertyGroup>
+ <!-- Suppress MSBuild errors: --> 
+ <!-- MSB3178: Assembly xxx is incorrectly specified as a file. --> 
+ <!-- MSB3187: Referenced assembly xxx targets a different processor than the application. --> 
+ <!-- MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference xxx, "AMD64". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project. --> 
+ <MSBuildWarningsAsMessages>MSB3187;MSB3270;MSB3178</MSBuildWarningsAsMessages> 
+ </PropertyGroup> 
+ </Project>


### PR DESCRIPTION
…ualstudio/msbuild/customize-your-build) to suppress selected MSBuild errors:

 MSB3178: Assembly xxx is incorrectly specified as a file.
 MSB3187: Referenced assembly xxx targets a different processor than the application.
 MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference xxx, "AMD64". This mismatch may cause runtime failures. Please consider changing the targeted processor architecture of your project through the Configuration Manager so as to align the processor architectures between your project and references, or take a dependency on references with a processor architecture that matches the targeted processor architecture of your project.