### PR TITLE
Fixed TestTargetedMSMSTutorialAsSmallMolecules

### DIFF
--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -370,6 +370,8 @@ namespace pwiz.SkylineTestTutorial
             {
                 // Convert the document and just-created libraries to small molecules
                 ConvertDocumentToSmallMolecules(AsSmallMoleculesTestMode);
+                var originalDoc = doc;
+                RunUI(() => importPeptideSearchDlg.SetDocument(SkylineWindow.Document, originalDoc));
                 doc = SkylineWindow.Document;
                 documentFile = SkylineWindow.DocumentFilePath;
             }

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -440,8 +440,8 @@ namespace pwiz.SkylineTestTutorial
 
             const int expectedMoleculeCount = 9;
             const int expectedTransitionGroupCount = 10; // Expect this many with results
-            var expected20TransitionCount = AsSmallMoleculeMasses ? 87 : 88; // Expect this many with results
-            var expected80TransitionCount = AsSmallMoleculeMasses ? 88 : 87;
+            var expected20TransitionCount = AsSmallMolecules ? 87 : 88; // Expect this many with results
+            var expected80TransitionCount = AsSmallMolecules ? 88 : 87;
 
             AssertResult.IsDocumentResultsState(SkylineWindow.Document, shortLowRes20FileName, expectedMoleculeCount, expectedTransitionGroupCount, 0, expected20TransitionCount, 0);
             AssertResult.IsDocumentResultsState(SkylineWindow.Document, shortLowRes80FileName, expectedMoleculeCount, expectedTransitionGroupCount, 0, expected80TransitionCount, 0);


### PR DESCRIPTION
Fixed TargetedMSMSTutorialTest when run as small molecules (88 vs 87 transitions failure; The document was converted to small molecules in between pages of the ImportPeptideSearchDlg, which didn't change the internal document copy maintained by the wizard)