### PR TITLE
mzRefinery bug fixes and PASEF support

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
@@ -689,6 +689,7 @@ SpectrumListPtr filterCreator_mzRefine(const MSData& msd, const string& arg, pwi
     string thresholdSet = "-1e-10";          // Remove this default?
     double thresholdStep = 0.0;
     int maxSteps = 0;
+    bool assumeHighRes = false;
     string msLevelSets = "1-";
 
     string nextStr;
@@ -733,6 +734,10 @@ SpectrumListPtr filterCreator_mzRefine(const MSData& msd, const string& arg, pwi
             {
                 maxSteps = boost::lexical_cast<int>(paramVal);
             }
+            else if (keyword == "assumeHighRes")
+            {
+                assumeHighRes = boost::lexical_cast<bool>(paramVal);
+            }
         }
     }
     // expand the filenames by globbing to handle wildcards
@@ -776,7 +781,7 @@ SpectrumListPtr filterCreator_mzRefine(const MSData& msd, const string& arg, pwi
         }
     }
 
-    return SpectrumListPtr(new SpectrumList_MZRefiner(msd, identFilePath, thresholdCV, thresholdSet, msLevelsToRefine, thresholdStep, maxSteps, ilr));
+    return SpectrumListPtr(new SpectrumList_MZRefiner(msd, identFilePath, thresholdCV, thresholdSet, msLevelsToRefine, thresholdStep, maxSteps, assumeHighRes, ilr));
 }
 UsageInfo usage_mzRefine = { "input1.pepXML input2.mzid [msLevels=<1->] [thresholdScore=<CV_Score_Name>] [thresholdValue=<floatset>] [thresholdStep=<float>] [maxSteps=<count>]", "This filter recalculates the m/z and charges, adjusting precursors for MS2 spectra and spectra masses for MS1 spectra. "
 "It uses an ident file with a threshold field and value to calculate the error and will then choose a shifting mechanism to correct masses throughout the file. "

--- a/pwiz/analysis/spectrum_processing/SpectrumList_MZRefiner.hpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_MZRefiner.hpp
@@ -61,7 +61,7 @@ namespace analysis {
 class PWIZ_API_DECL SpectrumList_MZRefiner : public msdata::SpectrumListWrapper
 {
     public:
-    SpectrumList_MZRefiner(const msdata::MSData& msd, const std::string& identFilePath, const std::string& cvTerm, const std::string& rangeSet, const util::IntegerSet& msLevelsToRefine, double step = 0.0, int maxStep = 0, pwiz::util::IterationListenerRegistry* ilr = NULL);
+    SpectrumList_MZRefiner(const msdata::MSData& msd, const std::string& identFilePath, const std::string& cvTerm, const std::string& rangeSet, const util::IntegerSet& msLevelsToRefine, double step = 0.0, int maxStep = 0, bool assumeHighRes = false, pwiz::util::IterationListenerRegistry* ilr = NULL);
 
     /// \name SpectrumList interface
     //@{

--- a/pwiz/data/identdata/Serializer_pepXML.cpp
+++ b/pwiz/data/identdata/Serializer_pepXML.cpp
@@ -2153,6 +2153,32 @@ PWIZ_API_DECL string stripChargeFromConventionalSpectrumId(const string& id)
 }
 
 
+PWIZ_API_DECL CVID pepXMLSoftwareNameToCVID(const std::string& softwareName)
+{
+    return AnalysisSoftwareTranslator::instance->translate(softwareName);
+}
+
+PWIZ_API_DECL const std::string& softwareCVIDToPepXMLSoftwareName(CVID softwareCVID)
+{
+    return AnalysisSoftwareTranslator::instance->translate(softwareCVID);
+}
+
+PWIZ_API_DECL CVID pepXMLScoreNameToCVID(CVID softwareCVID, const std::string& scoreName)
+{
+    return ScoreTranslator::instance->translate(softwareCVID, scoreName);
+}
+
+PWIZ_API_DECL const std::string& scoreCVIDToPepXMLScoreName(CVID softwareCVID, CVID scoreCVID)
+{
+    return ScoreTranslator::instance->translate(softwareCVID, scoreCVID);
+}
+
+PWIZ_API_DECL CVID pepXMLSpectrumToNativeIdCVID(const std::string& id)
+{
+    return NativeIdTranslator::instance->translate(id);
+}
+
+
 } // namespace identdata
 } // namespace pwiz
 

--- a/pwiz/data/identdata/Serializer_pepXML.cpp
+++ b/pwiz/data/identdata/Serializer_pepXML.cpp
@@ -2173,7 +2173,7 @@ PWIZ_API_DECL const std::string& scoreCVIDToPepXMLScoreName(CVID softwareCVID, C
     return ScoreTranslator::instance->translate(softwareCVID, scoreCVID);
 }
 
-PWIZ_API_DECL CVID pepXMLSpectrumToNativeIdCVID(const std::string& id)
+PWIZ_API_DECL CVID nativeIdStringToCVID(const std::string& id)
 {
     return NativeIdTranslator::instance->translate(id);
 }

--- a/pwiz/data/identdata/Serializer_pepXML.hpp
+++ b/pwiz/data/identdata/Serializer_pepXML.hpp
@@ -76,6 +76,24 @@ PWIZ_API_DECL PepXMLSpecificity pepXMLSpecificity(const Enzyme& ez);
 PWIZ_API_DECL std::string stripChargeFromConventionalSpectrumId(const std::string& id);
 
 
+/// converts a software name stored in pepXML software element into its corresponding CVID, or CVID_Unknown if no mapping was found
+PWIZ_API_DECL CVID pepXMLSoftwareNameToCVID(const std::string& softwareName);
+
+/// converts a software CVID to the preferred name for that software in pepXML; an unrecognized software name will return an empty string
+PWIZ_API_DECL const std::string& softwareCVIDToPepXMLSoftwareName(CVID softwareCVID);
+
+
+/// for a given software CVID, converts a pepXML score name into its corresponding CVID, or CVID_Unknown if no mapping was found
+PWIZ_API_DECL CVID pepXMLScoreNameToCVID(CVID softwareCVID, const std::string& scoreName);
+
+/// for a given software CVID, converts a score CVID into the preferred name for that score in pepXML; an invalid combination of software/score will return an empty string
+PWIZ_API_DECL const std::string& scoreCVIDToPepXMLScoreName(CVID softwareCVID, CVID scoreCVID);
+
+
+/// attempts to convert a period-delimited id into a nativeID format (e.g. "1.0.123" appears to be a Thermo nativeID)
+PWIZ_API_DECL CVID pepXMLSpectrumToNativeIdCVID(const std::string& id);
+
+
 } // namespace identdata
 } // namespace pwiz 
 

--- a/pwiz/data/identdata/Serializer_pepXML.hpp
+++ b/pwiz/data/identdata/Serializer_pepXML.hpp
@@ -91,7 +91,7 @@ PWIZ_API_DECL const std::string& scoreCVIDToPepXMLScoreName(CVID softwareCVID, C
 
 
 /// attempts to convert a period-delimited id into a nativeID format (e.g. "1.0.123" appears to be a Thermo nativeID)
-PWIZ_API_DECL CVID pepXMLSpectrumToNativeIdCVID(const std::string& id);
+PWIZ_API_DECL CVID nativeIdStringToCVID(const std::string& id);
 
 
 } // namespace identdata

--- a/pwiz/data/identdata/Serializer_pepXML_Test.cpp
+++ b/pwiz/data/identdata/Serializer_pepXML_Test.cpp
@@ -421,8 +421,8 @@ void testTranslation()
     unit_assert_operator_equal("", scoreCVIDToPepXMLScoreName(MS_MyriMatch, MS_Comet_xcorr));
 
 
-    unit_assert_operator_equal(MS_Thermo_nativeID_format, pepXMLSpectrumToNativeIdCVID("1.0.1234"));
-    unit_assert_operator_equal(MS_WIFF_nativeID_format, pepXMLSpectrumToNativeIdCVID("1.1.2.1234"));
+    unit_assert_operator_equal(MS_Thermo_nativeID_format, nativeIdStringToCVID("controllerType=1 controllerNumber=0 scan=1234"));
+    unit_assert_operator_equal(MS_WIFF_nativeID_format, nativeIdStringToCVID("sample=1 period=1 cycle=1234 experiment=2"));
 }
 
 

--- a/pwiz/data/identdata/Serializer_pepXML_Test.cpp
+++ b/pwiz/data/identdata/Serializer_pepXML_Test.cpp
@@ -389,6 +389,43 @@ void testStripChargeFromConventionalSpectrumId()
 }
 
 
+void testTranslation()
+{
+    unit_assert_operator_equal(MS_SEQUEST, pepXMLSoftwareNameToCVID("SEQUEST"));
+    unit_assert_operator_equal(MS_SEQUEST, pepXMLSoftwareNameToCVID("Sequest"));
+    unit_assert_operator_equal("Sequest", softwareCVIDToPepXMLSoftwareName(MS_SEQUEST));
+
+    unit_assert_operator_equal(MS_MyriMatch, pepXMLSoftwareNameToCVID("MyriMatch"));
+    unit_assert_operator_equal(MS_MyriMatch, pepXMLSoftwareNameToCVID("Myrimatch"));
+    unit_assert_operator_equal("MyriMatch", softwareCVIDToPepXMLSoftwareName(MS_MyriMatch));
+
+    unit_assert_operator_equal(MS_Comet, pepXMLSoftwareNameToCVID("Comet"));
+    unit_assert_operator_equal("Comet", softwareCVIDToPepXMLSoftwareName(MS_Comet));
+
+    unit_assert_operator_equal(MS_X_Tandem, pepXMLSoftwareNameToCVID("X! Tandem"));
+    unit_assert_operator_equal(MS_X_Tandem, pepXMLSoftwareNameToCVID("X!Tandem"));
+    unit_assert_operator_equal(MS_X_Tandem, pepXMLSoftwareNameToCVID("X! Tandem (k-score)"));
+    unit_assert_operator_equal("X! Tandem", softwareCVIDToPepXMLSoftwareName(MS_X_Tandem));
+
+
+    unit_assert_operator_equal(MS_MyriMatch_MVH, pepXMLScoreNameToCVID(MS_MyriMatch, "mvh"));
+    unit_assert_operator_equal("mvh", scoreCVIDToPepXMLScoreName(MS_MyriMatch, MS_MyriMatch_MVH));
+
+    unit_assert_operator_equal(MS_SEQUEST_xcorr, pepXMLScoreNameToCVID(MS_SEQUEST, "xcorr"));
+    unit_assert_operator_equal("xcorr", scoreCVIDToPepXMLScoreName(MS_SEQUEST, MS_SEQUEST_xcorr));
+
+    unit_assert_operator_equal(MS_Comet_xcorr, pepXMLScoreNameToCVID(MS_Comet, "xcorr"));
+    unit_assert_operator_equal("xcorr", scoreCVIDToPepXMLScoreName(MS_Comet, MS_Comet_xcorr));
+
+    unit_assert_operator_equal(CVID_Unknown, pepXMLScoreNameToCVID(MS_MyriMatch, "xcorr"));
+    unit_assert_operator_equal("", scoreCVIDToPepXMLScoreName(MS_MyriMatch, MS_Comet_xcorr));
+
+
+    unit_assert_operator_equal(MS_Thermo_nativeID_format, pepXMLSpectrumToNativeIdCVID("1.0.1234"));
+    unit_assert_operator_equal(MS_WIFF_nativeID_format, pepXMLSpectrumToNativeIdCVID("1.1.2.1234"));
+}
+
+
 int main(int argc, char** argv)
 {
     TEST_PROLOG(argc, argv)
@@ -398,6 +435,7 @@ int main(int argc, char** argv)
         if (argc>1 && !strcmp(argv[1],"-v")) os_ = &cout;
         testPepXMLSpecificity();
         testStripChargeFromConventionalSpectrumId();
+        testTranslation();
         testSerialize();
     }
     catch (exception& e)


### PR DESCRIPTION
- changed mzRefiner to only check mass analyzer of first scan
- fixed mzRefiner for merged data (e.g. Bruker PASEF data with --combineIonMobilitySpectra)
- added `assumeHighRes` option for overriding analyzer logic in mzRefiner
* switched mzRefiner fragment matching from a vector<int> to a more concise (and slightly more efficient by my informal benchmarks) find_nearest() based on lower_bound()
* made Serializer_pepXML's translation functions public and switched mzRefiner to use them instead of internal versions