### PR TITLE
Fix Linux runtime error due to bad RPATH

### DIFF
--- a/libraries/boost-build/src/tools/features/dll-feature.jam
+++ b/libraries/boost-build/src/tools/features/dll-feature.jam
@@ -9,7 +9,7 @@ import feature ;
 
 feature.feature dll-path
     :
-    : free path ;
+    : free ;
 
 feature.feature hardcode-dll-paths
     : true false


### PR DESCRIPTION
* removed 'path' attribute from 'dll-path' feature so '$ORIGIN' can be passed verbatim to the linker on Linux