### PR TITLE
Fix quameter id-free error "No MS1 spectrum found before <first MS2>"

### DIFF
--- a/pwiz_tools/Bumbershoot/quameter/quameter.cpp
+++ b/pwiz_tools/Bumbershoot/quameter/quameter.cpp
@@ -779,8 +779,6 @@ namespace quameter
 
                         if (precursor.spectrumID.empty())
                         {
-                            if (lastMS1NativeId.empty())
-                                throw runtime_error("No MS1 spectrum found before " + spectrum->id);
                             scanInfo.precursorNativeID = lastMS1NativeId;
                         }
                         else
@@ -803,7 +801,8 @@ namespace quameter
                         if (scanInfo.precursorMZ == 0)
                             throw runtime_error("No precursor m/z for " + spectrum->id);
 
-                        scanInfo.precursorScanStartTime = ms1ScanMap.get<nativeID>().find(scanInfo.precursorNativeID)->scanStartTime;
+                        auto findItr = ms1ScanMap.get<nativeID>().find(scanInfo.precursorNativeID);
+                        scanInfo.precursorScanStartTime = findItr == ms1ScanMap.get<nativeID>().end() ? 0 : findItr->scanStartTime;
 
                         ms2ScanMap.push_back(scanInfo);
                     }


### PR DESCRIPTION
- fixed quameter id-free error "No MS1 spectrum found before <first MS2>" because some files explicitly acquire some (presumably non-DDA) MS2s before the first MS1