### PR TITLE
Skyline - fixed HiResMetabolomicsTutorialTest and DriftTimePredictorT…

### DIFF
--- a/pwiz_tools/Shared/Common/SystemUtil/TrackAttribute.cs
+++ b/pwiz_tools/Shared/Common/SystemUtil/TrackAttribute.cs
@@ -214,6 +214,11 @@ namespace pwiz.Common.SystemUtil
             return _values.Any(v => ReferenceEquals(v, obj));
         }
 
+        public virtual bool IgnoreIfDefault
+        {
+            get { return false; }
+        }
+
         public static DefaultValues CreateInstance(Type defaultValuesType)
         {
             if (defaultValuesType == null)

--- a/pwiz_tools/Skyline/Model/AuditLog/Property.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/Property.cs
@@ -164,7 +164,12 @@ namespace pwiz.Skyline.Model.AuditLog
 
             var localizer = CustomLocalizer;
             if (localizer != null)
-                name = localizer.Localize(objectInfo) ?? name;
+            {
+                name = localizer.Localize(objectInfo);
+                if (_propertyInfo.DeclaringType != null)
+                    name = _propertyInfo.DeclaringType.Name + '_' + name;
+            }
+                
 
             return "{0:" + name + "}"; // Not L10N
         }

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.Designer.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.Designer.cs
@@ -1420,6 +1420,15 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Adduct.
+        /// </summary>
+        public static string IonMobilityRow_Adduct {
+            get {
+                return ResourceManager.GetString("IonMobilityRow_Adduct", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Charge.
         /// </summary>
         public static string IonMobilityRow_Charge {
@@ -1641,15 +1650,6 @@ namespace pwiz.Skyline.Model.AuditLog {
         public static string ManageResultsSettings_RemoveCorrespondingReplicates {
             get {
                 return ResourceManager.GetString("ManageResultsSettings_RemoveCorrespondingReplicates", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Mass accuracy.
-        /// </summary>
-        public static string MassAccuracy {
-            get {
-                return ResourceManager.GetString("MassAccuracy", resourceCulture);
             }
         }
         
@@ -2806,24 +2806,6 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Resolution.
-        /// </summary>
-        public static string Resolution {
-            get {
-                return ResourceManager.GetString("Resolution", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Resolving power.
-        /// </summary>
-        public static string ResolvingPower {
-            get {
-                return ResourceManager.GetString("ResolvingPower", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to iRT database path.
         /// </summary>
         public static string RetentionScoreCalculatorSpec_AuditLogPersistencePath {
@@ -3301,6 +3283,15 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Mass accuracy.
+        /// </summary>
+        public static string TransitionFullScan_MassAccuracy {
+            get {
+                return ResourceManager.GetString("TransitionFullScan_MassAccuracy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Peaks.
         /// </summary>
         public static string TransitionFullScan_PrecursorIsotopeFilter {
@@ -3355,6 +3346,24 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Resolution.
+        /// </summary>
+        public static string TransitionFullScan_Resolution {
+            get {
+                return ResourceManager.GetString("TransitionFullScan_Resolution", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resolving power.
+        /// </summary>
+        public static string TransitionFullScan_ResolvingPower {
+            get {
+                return ResourceManager.GetString("TransitionFullScan_ResolvingPower", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Retention time filter length.
         /// </summary>
         public static string TransitionFullScan_RetentionTimeFilterLength {
@@ -3396,6 +3405,15 @@ namespace pwiz.Skyline.Model.AuditLog {
         public static string TransitionGroupDocNode_LabelType {
             get {
                 return ResourceManager.GetString("TransitionGroupDocNode_LabelType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Adduct.
+        /// </summary>
+        public static string TransitionGroupDocNode_PrecursorAdduct {
+            get {
+                return ResourceManager.GetString("TransitionGroupDocNode_PrecursorAdduct", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.resx
@@ -375,10 +375,10 @@
   <data name="DigestSettings_MaxMissedCleavages" xml:space="preserve">
     <value>Max missed cleavages</value>
   </data>
-  <data name="MassAccuracy" xml:space="preserve">
+  <data name="TransitionFullScan_MassAccuracy" xml:space="preserve">
     <value>Mass accuracy</value>
   </data>
-  <data name="Resolution" xml:space="preserve">
+  <data name="TransitionFullScan_Resolution" xml:space="preserve">
     <value>Resolution</value>
   </data>
   <data name="IonMobilityWindowWidthCalculator_ResolvingPower" xml:space="preserve">
@@ -665,7 +665,7 @@
   <data name="OptimizationLibrary_DatabasePathAuditLog" xml:space="preserve">
     <value>Optimization library path</value>
   </data>
-  <data name="ResolvingPower" xml:space="preserve">
+  <data name="TransitionFullScan_ResolvingPower" xml:space="preserve">
     <value>Resolving power</value>
   </data>
   <data name="FragmentLoss_AverageMass" xml:space="preserve">
@@ -878,8 +878,8 @@
   <data name="IonMobilityAndCCS_Units" xml:space="preserve">
     <value>Ion mobility units</value>
   </data>
-  <data name="IonMobilityRow_Charge" xml:space="preserve">
-    <value>Charge</value>
+  <data name="IonMobilityRow_Adduct" xml:space="preserve">
+    <value>Adduct</value>
   </data>
   <data name="IonMobilityRow_Sequence" xml:space="preserve">
     <value>Modified Sequence</value>
@@ -1333,5 +1333,11 @@
   </data>
   <data name="ColumnSort_ListSortDirection" xml:space="preserve">
     <value>Direction</value>
+  </data>
+  <data name="IonMobilityRow_Charge" xml:space="preserve">
+    <value>Charge</value>
+  </data>
+  <data name="TransitionGroupDocNode_PrecursorAdduct" xml:space="preserve">
+    <value>Adduct</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -18,8 +18,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;

--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -18,6 +18,8 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -26,6 +28,7 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using pwiz.Common.Collections;
 using pwiz.Common.DataAnalysis;
+using pwiz.Common.DataBinding;
 using pwiz.Common.SystemUtil;
 using pwiz.ProteowizardWrapper;
 using pwiz.Skyline.Model.AuditLog;
@@ -3350,17 +3353,40 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             public IonMobilityRow(LibKey libKey, IonMobilityAndCCS value)
             {
-                Sequence = libKey.Sequence;
-                Charge = libKey.Charge;
+                Sequence = libKey.Target.AuditLogText;
+                Adduct = libKey.Adduct;
                 Value = value;
             }
 
             [Track]
             public string Sequence { get; set; }
-            [Track]
-            public int Charge { get; set; }
+            [Track(customLocalizer: typeof(AdductLocalizer))]
+            public Adduct Adduct { get; set; }
             [TrackChildren(ignoreName:true)]
             public IonMobilityAndCCS Value { get; set; }
+        }
+
+        public class AdductLocalizer : CustomPropertyLocalizer
+        {
+            private static readonly string CHARGE = "Charge"; // Not L10N
+            private static readonly string ADDUCT = "Adduct"; // Not L10N
+            public override string[] PossibleResourceNames
+            {
+                get { return new[] {CHARGE, ADDUCT}; }
+            }
+
+            protected override string Localize(ObjectPair<object> objectPair)
+            {
+                var newAdduct = (Adduct) objectPair.NewObject;
+
+                return newAdduct.IsProteomic
+                    ? CHARGE
+                    : ADDUCT; // Not L10N
+            }
+
+            public AdductLocalizer() : base(PropertyPath.Parse("Adduct"), true) // Not L10N
+            {
+            }
         }
 
         [TrackChildren]
@@ -3368,11 +3394,17 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             get
             {
-                return MeasuredMobilityIons != null
-                    ? MeasuredMobilityIons.ToDictionary(pair => pair.Key,
-                        pair => new IonMobilityRow(pair.Key, pair.Value))
-                    : null;
+                if (MeasuredMobilityIons == null)
+                    return new Dictionary<LibKey, IonMobilityRow>();
+
+                return new SortedDictionary<LibKey, IonMobilityRow>(MeasuredMobilityIons.ToDictionary(pair => pair.Key,
+                    pair => new IonMobilityRow(pair.Key, pair.Value)), Comparer<LibKey>.Create(CompareLibKeys));
             }
+        }
+
+        private int CompareLibKeys(LibKey x, LibKey y)
+        {
+            return (x.Target, x.Adduct).CompareTo((y.Target, y.Adduct));
         }
 
         public IDictionary<LibKey, IonMobilityAndCCS> MeasuredMobilityIons

--- a/pwiz_tools/Skyline/Model/DocSettings/TransitionSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/TransitionSettings.cs
@@ -2278,6 +2278,10 @@ namespace pwiz.Skyline.Model.DocSettings
 
         private abstract class ResLocalizer : CustomPropertyLocalizer
         {
+            private static readonly string MASS_ACCURACY = "MassAccuracy"; // Not L10N
+            private static readonly string RESOLUTION = "Resolution"; // Not L10N
+            private static readonly string RESOLVING_POWER = "ResolvingPower"; // Not L10N
+
             protected ResLocalizer(PropertyPath path) : base(path, true) { }
 
             private string LocalizeInternal(object obj)
@@ -2290,13 +2294,13 @@ namespace pwiz.Skyline.Model.DocSettings
                 switch (massAnalyzer)
                 {
                     case FullScanMassAnalyzerType.centroided:
-                        return "MassAccuracy"; // Not L10N
+                        return MASS_ACCURACY;
                     case FullScanMassAnalyzerType.qit:
-                        return "Resolution"; // Not L10N
+                        return RESOLUTION;
                     case FullScanMassAnalyzerType.tof:
                     case FullScanMassAnalyzerType.orbitrap:
                     case FullScanMassAnalyzerType.ft_icr:
-                        return "ResolvingPower"; // Not L10N
+                        return RESOLVING_POWER;
                     default:
                         return null;
                 }
@@ -2309,7 +2313,7 @@ namespace pwiz.Skyline.Model.DocSettings
 
             public override string[] PossibleResourceNames
             {
-                get { return new[] { "MassAccuracy", "Resolution", "ResolvingPower" }; } // Not L10N
+                get { return new[] { MASS_ACCURACY, RESOLUTION, RESOLVING_POWER }; }
             }
         }
 

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -214,9 +214,14 @@ namespace pwiz.Skyline.Model
                 var docNode = (TransitionGroupDocNode)parentObject;
                 return !docNode.IsCustomIon;
             }
+
+            public override bool IgnoreIfDefault
+            {
+                get { return true; }
+            }
         }
 
-        [TrackChildren(ignoreName:true, defaultValues: typeof(SmallMoleculeOnly))]
+        [Track(defaultValues: typeof(SmallMoleculeOnly))]
         public Adduct PrecursorAdduct { get { return TransitionGroup.PrecursorAdduct; } }
 
         [Track(defaultValues: typeof(SmallMoleculeOnly))]

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -2310,7 +2310,7 @@ namespace pwiz.Skyline
                 if (peptides.Length == 1)
                 {
                     type = MessageType.set_standard_type;
-                    changedPeptides = SelectedNode.Text;
+                    changedPeptides = peptides[0].AuditLogText;
                 }
                 else
                 {

--- a/pwiz_tools/Skyline/TestFunctional/AuditLogTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AuditLogTest.cs
@@ -115,11 +115,11 @@ namespace pwiz.SkylineTestFunctional
                             var localizer = property.CustomLocalizer;
                             if (localizer != null)
                             {
-                                names = localizer.PossibleResourceNames;
+                                names = localizer.PossibleResourceNames.Select(name => property.DeclaringType.Name + '_' + name).ToArray();
                             }
                             else
                             {
-                                names = ImmutableList.Singleton(property.DeclaringType.Name + "_" + property.PropertyName)
+                                names = ImmutableList.Singleton(property.DeclaringType.Name + '_' + property.PropertyName)
                                     .ToArray();
                             }
 
@@ -1011,7 +1011,7 @@ namespace pwiz.SkylineTestFunctional
                         "\"none\"",
                         "\"qit\""),
                     new LogMessage(LogLevel.all_info, MessageType.changed_from_to, string.Empty, false,
-                        "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_FullScan}{2:PropertySeparator}{0:Resolution}",
+                        "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_FullScan}{2:PropertySeparator}{0:TransitionFullScan_Resolution}",
                         "{2:Missing}",
                         "{3:0.7}"),
                 }),

--- a/pwiz_tools/Skyline/TestPerf/HiResMetabolomicsTutorial.cs
+++ b/pwiz_tools/Skyline/TestPerf/HiResMetabolomicsTutorial.cs
@@ -55,6 +55,7 @@ namespace TestPerf // This would be in TestTutorials if it didn't involve a 2GB 
             LinkPdf = "https://skyline.gs.washington.edu/labkey/_webdav/home/software/Skyline/%40files/tutorials/HiResMetabolomics.pdf";
             ForceMzml = true; // Prefer mzML as being the more efficient download
 
+            TestFilesPersistent = new[] { ExtWatersRaw };
             TestFilesZipPaths = new[]
             {
                 (UseRawFiles
@@ -65,9 +66,14 @@ namespace TestPerf // This would be in TestTutorials if it didn't involve a 2GB 
             RunFunctionalTest();
         }
 
+        private string GetDataFolder()
+        {
+            return UseRawFiles ? "HiResMetabolomics" : "HiResMetabolomics_mzML";
+        }
+
         private string GetTestPath(string relativePath = null)
         {
-            string folderSmallMolecule = UseRawFiles ? "HiResMetabolomics" : "HiResMetabolomics_mzML";
+            string folderSmallMolecule = GetDataFolder();
             string fullRelativePath = relativePath != null ? Path.Combine(folderSmallMolecule, relativePath) : folderSmallMolecule;
             return TestFilesDirs[0].GetTestPath(fullRelativePath);
         }
@@ -206,7 +212,7 @@ namespace TestPerf // This would be in TestTutorials if it didn't involve a 2GB 
                         importResultsDlg1.GetDataSourcePathsFile(null));
                     RunUI(() =>
                     {
-                        openDataSourceDialog1.CurrentDirectory = new MsDataFilePath(GetTestPath());
+                        openDataSourceDialog1.CurrentDirectory = new MsDataFilePath(Path.Combine(TestFilesDirs.First().PersistentFilesDir, GetDataFolder()));
                         openDataSourceDialog1.SelectAllFileType(ExtWatersRaw);
                     });
                     PauseForScreenShot<ImportResultsSamplesDlg>("Import Results Files form", 6);

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -583,8 +583,8 @@ namespace TestRunner
                             }
                             if (!runTests.Run(test, pass, testNumber))
                             {
-                                removeList.Add(test);
-                                i = languages.Length - 1;   // Don't run other languages.
+                                //removeList.Add(test);
+                                //i = languages.Length - 1;   // Don't run other languages.
                                 break;
                             }
                             if ( maxSecondsPerTest > 0)

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -583,8 +583,8 @@ namespace TestRunner
                             }
                             if (!runTests.Run(test, pass, testNumber))
                             {
-                                //removeList.Add(test);
-                                //i = languages.Length - 1;   // Don't run other languages.
+                                removeList.Add(test);
+                                i = languages.Length - 1;   // Don't run other languages.
                                 break;
                             }
                             if ( maxSecondsPerTest > 0)

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestHiResMetabolomicsTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestHiResMetabolomicsTutorial.log
@@ -12,10 +12,10 @@ Fatty Acid	FA 22:6 omega-3 (DHA)	C22H32O2	[M-H]	327.23295438	-1		1.1
 Fatty Acid	FA 22:6 omega-3 (DHA)	C22H27H'5O2	[M-H]	332.2643381	-1	heavy	1.1
 							
 
-Undo Redo : Set standard type for Fatty Acid
+Undo Redo : Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Summary   : Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "Surrogate Standard"
 All Info  :
-Set standard type for Fatty Acid
+Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "Surrogate Standard"
 
 Undo Redo : Transition Settings changed

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestHiResMetabolomicsTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestHiResMetabolomicsTutorial.log
@@ -12,10 +12,10 @@ Fatty Acid	FA 22:6 omega-3 (DHA)	C22H32O2	[M-H]	327,23295438	-1		1,1
 Fatty Acid	FA 22:6 omega-3 (DHA)	C22H27H'5O2	[M-H]	332,2643381	-1	heavy	1,1
 							
 
-Undo Redo : Set standard type for Fatty Acid
+Undo Redo : Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Summary   : Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "Surrogate Standard"
 All Info  :
-Set standard type for Fatty Acid
+Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "Surrogate Standard"
 
 Undo Redo : Transition Settings changed

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/ja/TestHiResMetabolomicsTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/ja/TestHiResMetabolomicsTutorial.log
@@ -12,10 +12,10 @@ Fatty Acid	FA 22:6 omega-3 (DHA)	C22H32O2	[M-H]	327.23295438	-1		1.1
 Fatty Acid	FA 22:6 omega-3 (DHA)	C22H27H'5O2	[M-H]	332.2643381	-1	heavy	1.1
 							
 
-Undo Redo : Set standard type for Fatty Acid
+Undo Redo : Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Summary   : Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "サロゲート標準"
 All Info  :
-Set standard type for Fatty Acid
+Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "サロゲート標準"
 
 Undo Redo : Transition Settings changed

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestHiResMetabolomicsTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestHiResMetabolomicsTutorial.log
@@ -12,10 +12,10 @@ Fatty Acid	FA 22:6 omega-3 (DHA)	C22H32O2	[M-H]	327,23295438	-1		1,1
 Fatty Acid	FA 22:6 omega-3 (DHA)	C22H27H'5O2	[M-H]	332,2643381	-1	heavy	1,1
 							
 
-Undo Redo : Set standard type for Fatty Acid
+Undo Redo : Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Summary   : Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "Surrogate Standard"
 All Info  :
-Set standard type for Fatty Acid
+Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "Surrogate Standard"
 
 Undo Redo : Transition Settings changed

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/zh/TestHiResMetabolomicsTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/zh/TestHiResMetabolomicsTutorial.log
@@ -12,10 +12,10 @@ Fatty Acid	FA 22:6 omega-3 (DHA)	C22H32O2	[M-H]	327.23295438	-1		1.1
 Fatty Acid	FA 22:6 omega-3 (DHA)	C22H27H'5O2	[M-H]	332.2643381	-1	heavy	1.1
 							
 
-Undo Redo : Set standard type for Fatty Acid
+Undo Redo : Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Summary   : Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "替代标准"
 All Info  :
-Set standard type for Fatty Acid
+Set standard type for FA 22:6 omega-3 (DHA) (C22H32O2)
 Targets > Fatty Acid > FA 22:6 omega-3 (DHA) (C22H32O2) > Standard type changed from Missing to "替代标准"
 
 Undo Redo : Transition Settings changed

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -71,7 +71,7 @@ namespace pwiz.Skyline.Util
         public IEnumerable<Adduct> Keys { get { return _dict.Keys; } }
     }
 
-    public class Adduct : Immutable, IComparable, IEquatable<Adduct>
+    public class Adduct : Immutable, IComparable, IEquatable<Adduct>, IAuditLogObject
     {
         // CONSIDER(bspratt): Nick suggests we change this ImmutableDictionary to Molecule once that is performant, and supports negative counts
         private ImmutableDictionary<string, int> Composition { get; set; } // The chemical makeup of the adduct
@@ -462,10 +462,8 @@ namespace pwiz.Skyline.Util
         // N.B. "AdductCharge" and "AdductFormula" seem like weirdly redundant names, until you consider that 
         // they can show up in reports, at which point "Charge" and "Formula" are a bit overloaded.
 
-        [Track]
         public int AdductCharge { get; private set; }  // The charge that the adduct gives to a molecule
 
-        [Track]
         public string AdductFormula // Return adduct description - will produce [M+H] format for protonation
         {
             get
@@ -1672,5 +1670,15 @@ namespace pwiz.Skyline.Util
         }
 
         #endregion
+
+        public string AuditLogText
+        {
+            get { return ToString(); }
+        }
+
+        public bool IsName
+        {
+            get { return true; }
+        }
     }
 }


### PR DESCRIPTION
…utorialTest

- Setting the standard type for a peptide type wasn't using the correct selected node, causing the HiResMetabolomicsTutorialTest to fail
- the order of measured ion mobilities changed, causing the DriftTimePredictorTutorialTest to fail
- also made some small changes to custom localizers, now the class containing the Property
  that uses a custom localizer is prepended to the resource name (for instance, see ResLocalizer)
- improved localization of adducts ("charge" for pep, "adduct" for mol)
- added IgnoreIfDefault property to DefaultValues class, this can be used if the property that
  is using the DefaultValues class is an IAuditLogObject with IsName=true and should not
  be shown in the audit log if it has its default value. (For instance, when setting the collision energy
  regression to "None" in the transition settings this should be shown in the audit log, although "None" is the default object
  and its subproperties are not shown. A property using the SmallMoleculeOnly DefaultValues class however should not be displayed at all
  if it has its default value, thus IgnoreIfDefault is used)