### PR TITLE
Skyline: Fix SkylineTester issues that have mostly crept in with the …

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
@@ -196,7 +196,9 @@ namespace SkylineTester
                     {
                         using (var deleteWindow = new DeleteWindow(deleteDir, IsUnattended))
                         {
-                            deleteWindow.ShowDialog();
+                            deleteWindow.ShowDialog(GetParentForm());
+                            if (deleteWindow.IsCancelled)
+                                break;
                         }
                         if (Directory.Exists(deleteDir))
                         {
@@ -227,7 +229,10 @@ namespace SkylineTester
                     }
                     catch (Exception e)
                     {
-                        Log(Environment.NewLine + "!!!! COMMAND FAILED !!!! " + e);
+                        if (e is Win32Exception && e.Message.Contains("cannot find"))
+                            Log(Environment.NewLine + "!!!! COMMAND FAILED !!!! Command not found " + command);
+                        else
+                            Log(Environment.NewLine + "!!!! COMMAND FAILED !!!! " + e);
                         CommandsDone(EXIT_TYPE.error_stop);    // Quit if any command fails
                     }
                     _workingDirectory = DefaultDirectory;
@@ -236,6 +241,20 @@ namespace SkylineTester
             }
 
             CommandsDone(EXIT_TYPE.success);
+        }
+
+        private Form GetParentForm()
+        {
+            Control parent = this;
+            while (parent != null)
+            {
+                var parentForm = parent as Form;
+                if (parentForm != null)
+                    return parentForm;
+                parent = parent.Parent;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/SkylineTester/DeleteWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/DeleteWindow.cs
@@ -61,6 +61,11 @@ namespace SkylineTester
             _updateTimer.Start();
         }
 
+        public bool IsCancelled
+        {
+            get { return _deleteWorker.CancellationPending; }
+        }
+
         private void RunUI(Action action)
         {
             Invoke(action);

--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -38,9 +38,6 @@ namespace SkylineTester
 
         private void RunOrStopByUser()
         {
-            // Used only in the nightly tab to invoke an immediate nightly run
-            ShiftKeyPressed = (ModifierKeys == Keys.Shift);
-
             // Stop running task.
             if (_runningTab != null && (_runningTab.IsRunning() || _runningTab.IsWaiting()))
             {
@@ -91,7 +88,12 @@ namespace SkylineTester
         /// </summary>
         private void RunOrStop_Clicked(object sender, EventArgs e)
         {
+            // Used only in the nightly tab to invoke an immediate nightly run
+            ShiftKeyPressed = (ModifierKeys == Keys.Shift);
+
             RunOrStopByUser();
+
+            ShiftKeyPressed = false;
         }
 
         /// <summary>
@@ -396,10 +398,20 @@ namespace SkylineTester
 
         public void AddRun(Summary.Run run, ComboBox combo)
         {
+            combo.Items.Insert(0, GetRunDisplayText(run));
+        }
+
+        public void UpdateRun(Summary.Run run, ComboBox combo)
+        {
+            combo.Items[0] = GetRunDisplayText(run);
+        }
+
+        private static string GetRunDisplayText(Summary.Run run)
+        {
             var text = run.Date.ToString("M/d  h:mm tt");
             if (!string.IsNullOrEmpty(run.Revision))
                 text += "    (rev. " + run.Revision + ")";
-            combo.Items.Insert(0, text);
+            return text;
         }
 
         public string GetSelectedLog(ComboBox combo)

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -1507,6 +1507,17 @@ namespace SkylineTester
             if (e.RowIndex < 0 || e.ColumnIndex > 1)
                 return;
 
+            // If there is an active run, stop it and then restart.
+            bool restart = _runningTab != null;
+            if (restart && !ReferenceEquals(_runningTab, _tabForms))
+            {
+                MessageBox.Show(this,
+                    "Tests are running in a different tab. Click Stop before showing forms.");
+                return;
+            }
+
+            _restart = restart;
+
             if (e.ColumnIndex == 1)
             {
                 var testLink = formsGrid.Rows[e.RowIndex].Cells[1].Value;
@@ -1521,9 +1532,6 @@ namespace SkylineTester
                     }
                 }
             }
-
-            // If there is an active run, stop it and then restart.
-            _restart = (_runningTab != null);
 
             // Start new run.
             RunOrStopByUser();

--- a/pwiz_tools/Skyline/SkylineTester/Summary.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Summary.cs
@@ -29,16 +29,16 @@ namespace SkylineTester
     {
         public class Run
         {
-            public DateTime Date;
-            public string Revision;
-            public int RunMinutes;
-            public int TestsRun;
-            public int Failures;
-            public int Leaks;
-            public int ManagedMemory;
-            public int TotalMemory;
-            public int UserHandles;
-            public int GdiHandles;
+            public DateTime Date { get; set; }
+            public string Revision { get; set; }
+            public int RunMinutes { get; set; }
+            public int TestsRun { get; set; }
+            public int Failures { get; set; }
+            public int Leaks { get; set; }
+            public int ManagedMemory { get; set; }
+            public int TotalMemory { get; set; }
+            public int UserHandles { get; set; }
+            public int GdiHandles { get; set; }
         }
 
         public static Run ParseRunFromStatusLine(string statusLine)

--- a/pwiz_tools/Skyline/SkylineTester/TabForms.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabForms.cs
@@ -53,12 +53,12 @@ namespace SkylineTester
             if (MainWindow.ShowFormNames.Checked)
                 args.Append(" showformnames=on");
 
-            MainWindow.AddTestRunner(args.ToString());
-            MainWindow.RunCommands();
-
             _updateTimer = new Timer { Interval = 1000 };
             _updateTimer.Tick += (s, a) => UpdateForms();
             _updateTimer.Start();
+
+            MainWindow.AddTestRunner(args.ToString());
+            MainWindow.RunCommands();
 
             return true;
         }


### PR DESCRIPTION
…move to Git

- Handle correctly killing git processes when the stop button is clicked
- Fix updating of Run revision number when testing master in Nightly tab
- Fix canceling from the delete dialog and parent it to the main window
- Better error when TestRunner.exe is not present for some reason
- Only handle pressed ShiftKeyPressed on a user button click
- Show an error message if a form link is clicked while another tab is running