### PR TITLE
Fix problem where Skyline would display the wrong chromatogram if the…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -1140,7 +1140,7 @@ namespace pwiz.Skyline.Controls.Graphs
             var nodeGroup = _nodeGroups != null ? _nodeGroups.FirstOrDefault() : null;
             if (nodeGroup == null)
                 nodeTranSelected = null;
-            var info = chromGroupInfo.GetTransitionInfo(null, 0, TransformChrom.raw);
+            var info = chromGroupInfo.GetTransitionInfo(null, 0, TransformChrom.raw, chromatograms.OptimizationFunction);
 
             TransitionChromInfo tranPeakInfo = null;
             if (nodeGroup != null)
@@ -1267,7 +1267,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 {
                     var nodeTran = displayTrans[i];
                     // Get chromatogram info for this transition
-                    arrayChromInfo[i] = chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance, TransformChrom.raw);
+                    arrayChromInfo[i] = chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance, TransformChrom.raw, chromatograms.OptimizationFunction);
                 }
             }
 
@@ -1923,7 +1923,7 @@ namespace pwiz.Skyline.Controls.Graphs
                     {
                         continue;
                     }
-                    var info = chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance, TransformChrom.raw);
+                    var info = chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance, TransformChrom.raw, chromatograms.OptimizationFunction);
                     if (info == null)
                         continue;
 
@@ -2056,7 +2056,7 @@ namespace pwiz.Skyline.Controls.Graphs
                     ChromFileInfoId fileId = chromatograms.FindFile(chromGroupInfo);
                     foreach (var nodeTran in precursor.Transitions)
                     {
-                        var info = chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance, TransformChrom.raw);
+                        var info = chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance, TransformChrom.raw, chromatograms.OptimizationFunction);
                         if (info == null)
                             continue;
                         if (sumInfo == null)

--- a/pwiz_tools/Skyline/Model/ExportChromatograms.cs
+++ b/pwiz_tools/Skyline/Model/ExportChromatograms.cs
@@ -202,7 +202,7 @@ namespace pwiz.Skyline.Model
                         continue;
                     int productCharge = nodeTran.Transition.Charge;
                     float productMz = (float)nodeTran.Mz;
-                    var chromInfo = chromGroupInfo.GetTransitionInfo(nodeTran, _matchTolerance);
+                    var chromInfo = chromGroupInfo.GetTransitionInfo(nodeTran, _matchTolerance, chromatograms.OptimizationFunction);
                     // Sometimes a transition in the transition group does not have results for a particular file
                     // If this happens just skip it for that file
                     if (chromInfo == null)

--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -2115,12 +2115,12 @@ namespace pwiz.Skyline.Model.Results
             return _allTransitions[_groupHeaderInfo.StartTransitionIndex + transitionIndex];
         }
 
-        public ChromatogramInfo GetTransitionInfo(TransitionDocNode nodeTran, float tolerance)
+        public ChromatogramInfo GetTransitionInfo(TransitionDocNode nodeTran, float tolerance, OptimizableRegression regression)
         {
-            return GetTransitionInfo(nodeTran, tolerance, TransformChrom.interpolated);
+            return GetTransitionInfo(nodeTran, tolerance, TransformChrom.interpolated, regression);
         }
 
-        public virtual ChromatogramInfo GetTransitionInfo(TransitionDocNode nodeTran, float tolerance, TransformChrom transform)
+        public virtual ChromatogramInfo GetTransitionInfo(TransitionDocNode nodeTran, float tolerance, TransformChrom transform, OptimizableRegression regression)
         {
             var productMz = nodeTran != null ? nodeTran.Mz : SignedMz.ZERO;
             int startTran = _groupHeaderInfo.StartTransitionIndex;
@@ -2131,11 +2131,19 @@ namespace pwiz.Skyline.Model.Results
             {
                 if (IsProductGlobalMatch(i, nodeTran, tolerance))
                 {
-                    // If there is optimization data, return only the middle value, which
-                    // was the regression value.
-                    int startOptTran, endOptTran;
-                    GetOptimizationBounds(productMz, i, startTran, endTran, out startOptTran, out endOptTran);
-                    int iMiddle = (startOptTran + endOptTran) / 2;
+                    int iMiddle;
+                    if (regression == null)
+                    {
+                        iMiddle = i;
+                    }
+                    else
+                    {
+                        // If there is optimization data, return only the middle value, which
+                        // was the regression value.
+                        int startOptTran, endOptTran;
+                        GetOptimizationBounds(productMz, i, startTran, endTran, out startOptTran, out endOptTran);
+                        iMiddle = (startOptTran + endOptTran) / 2;
+                    }
 
                     double deltaMz = Math.Abs(productMz - GetProductGlobal(iMiddle));
                     if (deltaMz < deltaNearestMz)
@@ -2162,7 +2170,7 @@ namespace pwiz.Skyline.Model.Results
             listChromInfo.Clear();
             if (regression == null)
             {
-                var info = GetTransitionInfo(nodeTran, tolerance, transform);
+                var info = GetTransitionInfo(nodeTran, tolerance, transform, regression);
                 if (info != null)
                     listChromInfo.Add(info);
                 return;

--- a/pwiz_tools/Skyline/Model/Results/Scoring/PeakFeatureEnumerator.cs
+++ b/pwiz_tools/Skyline/Model/Results/Scoring/PeakFeatureEnumerator.cs
@@ -502,7 +502,7 @@ namespace pwiz.Skyline.Model.Results.Scoring
                         var listPeakData = new ITransitionPeakData<ISummaryPeakData>[nodeGroup.TransitionCount];
                         foreach (var nodeTran in nodeGroup.Transitions)
                         {
-                            var tranInfo = _chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance);
+                            var tranInfo = _chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance, chromatogramSet.OptimizationFunction);
                             if (tranInfo == null)
                                 continue;
                             listPeakData[totalCount++] = new SummaryTransitionPeakData(document, nodeTran, chromatogramSet, tranInfo);

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -2526,7 +2526,7 @@ namespace pwiz.Skyline.Model
             {
                 if (tranId != null && !ReferenceEquals(tranId, nodeTran.Id))
                     continue;
-                var chromInfo = chromGroupInfo.GetTransitionInfo(nodeTran, (float)mzMatchTolerance);
+                var chromInfo = chromGroupInfo.GetTransitionInfo(nodeTran, (float)mzMatchTolerance, regression);
                 if (chromInfo == null)
                     continue;
                 int indexPeak = chromInfo.IndexOfPeak(retentionTime);
@@ -2546,7 +2546,7 @@ namespace pwiz.Skyline.Model
             double startMin = double.MaxValue, endMax = double.MinValue;
             foreach (TransitionDocNode nodeTran in Children)
             {
-                var chromInfo = chromGroupInfo.GetTransitionInfo(nodeTran, (float)mzMatchTolerance);
+                var chromInfo = chromGroupInfo.GetTransitionInfo(nodeTran, (float)mzMatchTolerance, regression);
                 if (chromInfo == null)
                     continue;
                 ChromPeak peakNew = chromInfo.GetPeak(indexPeakBest);

--- a/pwiz_tools/Skyline/TestFunctional/SrmSmMolChromTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SrmSmMolChromTest.cs
@@ -62,7 +62,7 @@ namespace pwiz.SkylineTestFunctional
                         Assert.AreEqual(1, chromatogramGroups.Length);
                         foreach (var transition in precursor.Transitions)
                         {
-                            var chromatogram = chromatogramGroups[0].GetTransitionInfo(transition, tolerance);
+                            var chromatogram = chromatogramGroups[0].GetTransitionInfo(transition, tolerance, chromatogramSet.OptimizationFunction);
                             Assert.IsNotNull(chromatogram);
                         }
                     }

--- a/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
@@ -95,7 +95,7 @@ namespace pwiz.SkylineTestTutorial
         private readonly string[] EXPECTED_COEFFICIENTS =
         {
             "-0.0171|-1.1499|0.2410|2.4345|1.1974|0.0452|0.1725|0.1607| null |0.4456|6.3767|-0.0651|0.5293|0.6186| null | null | null | null | null ", // Not L10N
-            "0.2904| null | null | null |5.9903|-0.0621|0.6717|0.7981| null | null | null | null | null | null | null | null | null | null | null ", // Not L10N
+            "0.2903| null | null | null |5.9906|-0.0621|0.6717|0.7982| null | null | null | null | null | null | null | null | null | null | null ", // Not L10N
         };
 
         protected override void DoTest()

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestPeakPickingTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestPeakPickingTutorial.log
@@ -264,11 +264,11 @@ Summary   : Reintegrated peaks using "testDIA"
 All Info  :
 Reintegrated peaks using "testDIA"
 Reintegrate > Peak scoring model is "testDIA"
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Intensity", Weight = "0.290444331054205", Percentage Contribution = "0.0670249559141521" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Shape (weighted)", Weight = "5.99026487072222", Percentage Contribution = "0.519695317879292" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution (weighted)", Weight = "-0.0621464381117047", Percentage Contribution = "0.102426581446901" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution count", Weight = "0.671703707055547", Percentage Contribution = "0.150442269235405" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Signal to noise", Weight = "0.798076471648133", Percentage Contribution = "0.160410875524251" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Intensity", Weight = "0.290264577098698", Percentage Contribution = "0.0669829735661601" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Shape (weighted)", Weight = "5.99055025337349", Percentage Contribution = "0.519724540620551" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution (weighted)", Weight = "-0.0621408145756032", Percentage Contribution = "0.10241819268899" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution count", Weight = "0.671702488627679", Percentage Contribution = "0.150443288495498" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Signal to noise", Weight = "0.798169762490071", Percentage Contribution = "0.160431004628801" }
 Reintegrate > Peak scoring model > Use decoys is False
 Reintegrate > Peak scoring model > Uses second best peaks is True
 Reintegrate > Integrate all peaks is True
@@ -279,28 +279,28 @@ Extra Info: Peak scoring model = "testDIA":
     [
         {
             Score Name = "Intensity",
-            Weight = "0.290444331054205",
-            Percentage Contribution = "0.0670249559141521"
+            Weight = "0.290264577098698",
+            Percentage Contribution = "0.0669829735661601"
         },
         {
             Score Name = "Shape (weighted)",
-            Weight = "5.99026487072222",
-            Percentage Contribution = "0.519695317879292"
+            Weight = "5.99055025337349",
+            Percentage Contribution = "0.519724540620551"
         },
         {
             Score Name = "Co-elution (weighted)",
-            Weight = "-0.0621464381117047",
-            Percentage Contribution = "0.102426581446901"
+            Weight = "-0.0621408145756032",
+            Percentage Contribution = "0.10241819268899"
         },
         {
             Score Name = "Co-elution count",
-            Weight = "0.671703707055547",
-            Percentage Contribution = "0.150442269235405"
+            Weight = "0.671702488627679",
+            Percentage Contribution = "0.150443288495498"
         },
         {
             Score Name = "Signal to noise",
-            Weight = "0.798076471648133",
-            Percentage Contribution = "0.160410875524251"
+            Weight = "0.798169762490071",
+            Percentage Contribution = "0.160431004628801"
         }
     ],
     Use decoys = False,

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestPeakPickingTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestPeakPickingTutorial.log
@@ -264,11 +264,11 @@ Summary   : Reintegrated peaks using "testDIA"
 All Info  :
 Reintegrated peaks using "testDIA"
 Reintegrate > Peak scoring model is "testDIA"
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Intensity", Weight = "0,290444331054205", Percentage Contribution = "0,0670249559141521" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Shape (weighted)", Weight = "5,99026487072222", Percentage Contribution = "0,519695317879292" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution (weighted)", Weight = "-0,0621464381117047", Percentage Contribution = "0,102426581446901" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution count", Weight = "0,671703707055547", Percentage Contribution = "0,150442269235405" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Signal to noise", Weight = "0,798076471648133", Percentage Contribution = "0,160410875524251" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Intensity", Weight = "0,290264577098698", Percentage Contribution = "0,0669829735661601" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Shape (weighted)", Weight = "5,99055025337349", Percentage Contribution = "0,519724540620551" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution (weighted)", Weight = "-0,0621408145756032", Percentage Contribution = "0,10241819268899" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution count", Weight = "0,671702488627679", Percentage Contribution = "0,150443288495498" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Signal to noise", Weight = "0,798169762490071", Percentage Contribution = "0,160431004628801" }
 Reintegrate > Peak scoring model > Use decoys is False
 Reintegrate > Peak scoring model > Uses second best peaks is True
 Reintegrate > Integrate all peaks is True
@@ -279,28 +279,28 @@ Extra Info: Peak scoring model = "testDIA":
     [
         {
             Score Name = "Intensity",
-            Weight = "0,290444331054205",
-            Percentage Contribution = "0,0670249559141521"
+            Weight = "0,290264577098698",
+            Percentage Contribution = "0,0669829735661601"
         },
         {
             Score Name = "Shape (weighted)",
-            Weight = "5,99026487072222",
-            Percentage Contribution = "0,519695317879292"
+            Weight = "5,99055025337349",
+            Percentage Contribution = "0,519724540620551"
         },
         {
             Score Name = "Co-elution (weighted)",
-            Weight = "-0,0621464381117047",
-            Percentage Contribution = "0,102426581446901"
+            Weight = "-0,0621408145756032",
+            Percentage Contribution = "0,10241819268899"
         },
         {
             Score Name = "Co-elution count",
-            Weight = "0,671703707055547",
-            Percentage Contribution = "0,150442269235405"
+            Weight = "0,671702488627679",
+            Percentage Contribution = "0,150443288495498"
         },
         {
             Score Name = "Signal to noise",
-            Weight = "0,798076471648133",
-            Percentage Contribution = "0,160410875524251"
+            Weight = "0,798169762490071",
+            Percentage Contribution = "0,160431004628801"
         }
     ],
     Use decoys = False,

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/ja/TestPeakPickingTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/ja/TestPeakPickingTutorial.log
@@ -264,11 +264,11 @@ Summary   : Reintegrated peaks using "testDIA"
 All Info  :
 Reintegrated peaks using "testDIA"
 Reintegrate > Peak scoring model is "testDIA"
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "強度", Weight = "0.290444331054205", Percentage Contribution = "0.0670249559141521" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "形（加重）", Weight = "5.99026487072222", Percentage Contribution = "0.519695317879292" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "共溶出（加重）", Weight = "-0.0621464381117047", Percentage Contribution = "0.102426581446901" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "共溶出数", Weight = "0.671703707055547", Percentage Contribution = "0.150442269235405" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "信号対ノイズ比", Weight = "0.798076471648133", Percentage Contribution = "0.160410875524251" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "強度", Weight = "0.290264577098698", Percentage Contribution = "0.0669829735661601" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "形（加重）", Weight = "5.99055025337349", Percentage Contribution = "0.519724540620551" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "共溶出（加重）", Weight = "-0.0621408145756032", Percentage Contribution = "0.10241819268899" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "共溶出数", Weight = "0.671702488627679", Percentage Contribution = "0.150443288495498" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "信号対ノイズ比", Weight = "0.798169762490071", Percentage Contribution = "0.160431004628801" }
 Reintegrate > Peak scoring model > Use decoys is False
 Reintegrate > Peak scoring model > Uses second best peaks is True
 Reintegrate > Integrate all peaks is True
@@ -279,28 +279,28 @@ Extra Info: Peak scoring model = "testDIA":
     [
         {
             Score Name = "強度",
-            Weight = "0.290444331054205",
-            Percentage Contribution = "0.0670249559141521"
+            Weight = "0.290264577098698",
+            Percentage Contribution = "0.0669829735661601"
         },
         {
             Score Name = "形（加重）",
-            Weight = "5.99026487072222",
-            Percentage Contribution = "0.519695317879292"
+            Weight = "5.99055025337349",
+            Percentage Contribution = "0.519724540620551"
         },
         {
             Score Name = "共溶出（加重）",
-            Weight = "-0.0621464381117047",
-            Percentage Contribution = "0.102426581446901"
+            Weight = "-0.0621408145756032",
+            Percentage Contribution = "0.10241819268899"
         },
         {
             Score Name = "共溶出数",
-            Weight = "0.671703707055547",
-            Percentage Contribution = "0.150442269235405"
+            Weight = "0.671702488627679",
+            Percentage Contribution = "0.150443288495498"
         },
         {
             Score Name = "信号対ノイズ比",
-            Weight = "0.798076471648133",
-            Percentage Contribution = "0.160410875524251"
+            Weight = "0.798169762490071",
+            Percentage Contribution = "0.160431004628801"
         }
     ],
     Use decoys = False,

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestPeakPickingTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestPeakPickingTutorial.log
@@ -264,11 +264,11 @@ Summary   : Reintegrated peaks using "testDIA"
 All Info  :
 Reintegrated peaks using "testDIA"
 Reintegrate > Peak scoring model is "testDIA"
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Intensity", Weight = "0,290444331054205", Percentage Contribution = "0,0670249559141521" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Shape (weighted)", Weight = "5,99026487072222", Percentage Contribution = "0,519695317879292" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution (weighted)", Weight = "-0,0621464381117047", Percentage Contribution = "0,102426581446901" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution count", Weight = "0,671703707055547", Percentage Contribution = "0,150442269235405" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Signal to noise", Weight = "0,798076471648133", Percentage Contribution = "0,160410875524251" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Intensity", Weight = "0,290264577098698", Percentage Contribution = "0,0669829735661601" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Shape (weighted)", Weight = "5,99055025337349", Percentage Contribution = "0,519724540620551" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution (weighted)", Weight = "-0,0621408145756032", Percentage Contribution = "0,10241819268899" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Co-elution count", Weight = "0,671702488627679", Percentage Contribution = "0,150443288495498" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "Signal to noise", Weight = "0,798169762490071", Percentage Contribution = "0,160431004628801" }
 Reintegrate > Peak scoring model > Use decoys is False
 Reintegrate > Peak scoring model > Uses second best peaks is True
 Reintegrate > Integrate all peaks is True
@@ -279,28 +279,28 @@ Extra Info: Peak scoring model = "testDIA":
     [
         {
             Score Name = "Intensity",
-            Weight = "0,290444331054205",
-            Percentage Contribution = "0,0670249559141521"
+            Weight = "0,290264577098698",
+            Percentage Contribution = "0,0669829735661601"
         },
         {
             Score Name = "Shape (weighted)",
-            Weight = "5,99026487072222",
-            Percentage Contribution = "0,519695317879292"
+            Weight = "5,99055025337349",
+            Percentage Contribution = "0,519724540620551"
         },
         {
             Score Name = "Co-elution (weighted)",
-            Weight = "-0,0621464381117047",
-            Percentage Contribution = "0,102426581446901"
+            Weight = "-0,0621408145756032",
+            Percentage Contribution = "0,10241819268899"
         },
         {
             Score Name = "Co-elution count",
-            Weight = "0,671703707055547",
-            Percentage Contribution = "0,150442269235405"
+            Weight = "0,671702488627679",
+            Percentage Contribution = "0,150443288495498"
         },
         {
             Score Name = "Signal to noise",
-            Weight = "0,798076471648133",
-            Percentage Contribution = "0,160410875524251"
+            Weight = "0,798169762490071",
+            Percentage Contribution = "0,160431004628801"
         }
     ],
     Use decoys = False,

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/zh/TestPeakPickingTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/zh/TestPeakPickingTutorial.log
@@ -264,11 +264,11 @@ Summary   : Reintegrated peaks using "testDIA"
 All Info  :
 Reintegrated peaks using "testDIA"
 Reintegrate > Peak scoring model is "testDIA"
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "强度", Weight = "0.290444331054205", Percentage Contribution = "0.0670249559141521" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "形状（权重）", Weight = "5.99026487072222", Percentage Contribution = "0.519695317879292" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "共洗脱（权重）", Weight = "-0.0621464381117047", Percentage Contribution = "0.102426581446901" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "共洗脱计数", Weight = "0.671703707055547", Percentage Contribution = "0.150442269235405" }
-Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "噪声信号", Weight = "0.798076471648133", Percentage Contribution = "0.160410875524251" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "强度", Weight = "0.290264577098698", Percentage Contribution = "0.0669829735661601" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "形状（权重）", Weight = "5.99055025337349", Percentage Contribution = "0.519724540620551" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "共洗脱（权重）", Weight = "-0.0621408145756032", Percentage Contribution = "0.10241819268899" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "共洗脱计数", Weight = "0.671702488627679", Percentage Contribution = "0.150443288495498" }
+Reintegrate > Peak scoring model > Feature scores : contains { Score Name = "噪声信号", Weight = "0.798169762490071", Percentage Contribution = "0.160431004628801" }
 Reintegrate > Peak scoring model > Use decoys is False
 Reintegrate > Peak scoring model > Uses second best peaks is True
 Reintegrate > Integrate all peaks is True
@@ -279,28 +279,28 @@ Extra Info: Peak scoring model = "testDIA":
     [
         {
             Score Name = "强度",
-            Weight = "0.290444331054205",
-            Percentage Contribution = "0.0670249559141521"
+            Weight = "0.290264577098698",
+            Percentage Contribution = "0.0669829735661601"
         },
         {
             Score Name = "形状（权重）",
-            Weight = "5.99026487072222",
-            Percentage Contribution = "0.519695317879292"
+            Weight = "5.99055025337349",
+            Percentage Contribution = "0.519724540620551"
         },
         {
             Score Name = "共洗脱（权重）",
-            Weight = "-0.0621464381117047",
-            Percentage Contribution = "0.102426581446901"
+            Weight = "-0.0621408145756032",
+            Percentage Contribution = "0.10241819268899"
         },
         {
             Score Name = "共洗脱计数",
-            Weight = "0.671703707055547",
-            Percentage Contribution = "0.150442269235405"
+            Weight = "0.671702488627679",
+            Percentage Contribution = "0.150443288495498"
         },
         {
             Score Name = "噪声信号",
-            Weight = "0.798076471648133",
-            Percentage Contribution = "0.160410875524251"
+            Weight = "0.798169762490071",
+            Percentage Contribution = "0.160431004628801"
         }
     ],
     Use decoys = False,


### PR DESCRIPTION
… product m/z values differed by 0.01m/z.

Now, "IsOptimizationSpacing" only gets called if the ChromatogramSet has an OptimizableRegression.