### PR TITLE
Remove "Shimadzu.LabSolutions.IO.IoModule.dll" and "QTFLProtoCS.dll" …

### DIFF
--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -2691,14 +2691,6 @@
       <Link>x64\QTFLDebugLog.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\..\pwiz_aux\msrc\utility\vendor_api\Shimadzu\Shimadzu.LabSolutions.IO.IoModule.dll">
-      <Link>Shimadzu.LabSolutions.IO.IoModule.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\pwiz_aux\msrc\utility\vendor_api\Shimadzu\QTFLProtoCS.dll">
-      <Link>QTFLProtoCS.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="..\BiblioSpec\src\unimod.xml">
       <Link>unimod.xml</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
…from Skyline.csproj.

These .dll's are already referenced by pwiz_data_cli.dll, and their presence in Skyline.csproj causes a "An item with the same key has already been added" when you try to bring up "Options" on Skyline's publish properties.