### PR TITLE
Skyline/bugfix/20180910 testing

### DIFF
--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -435,14 +435,6 @@ namespace pwiz.ProteowizardWrapper
             return ionMobilityValue.Mobility.HasValue ? IonMobilitySpectrumList.ionMobilityToCCS(ionMobilityValue.Mobility.Value, mz, charge) : 0;
         }
 
-        public enum eIonMobilityUnits
-        {
-            none,
-            drift_time_msec,
-            inverse_K0_Vsec_per_cm2,
-            compensation_V
-        }
-
         public eIonMobilityUnits IonMobilityUnits
         {
             get
@@ -1113,6 +1105,14 @@ namespace pwiz.ProteowizardWrapper
         public string FilePath { get; private set; }
     }
 
+    public enum eIonMobilityUnits
+    {
+        none,
+        drift_time_msec,
+        inverse_K0_Vsec_per_cm2,
+        compensation_V
+    }
+
     public sealed class MsDataConfigInfo
     {
         public int Spectra { get; set; }
@@ -1252,26 +1252,26 @@ namespace pwiz.ProteowizardWrapper
 
     public sealed class IonMobilityValue : IComparable<IonMobilityValue>, IComparable
     {
-        public static IonMobilityValue EMPTY = new IonMobilityValue(null, MsDataFileImpl.eIonMobilityUnits.none);
+        public static IonMobilityValue EMPTY = new IonMobilityValue(null, eIonMobilityUnits.none);
 
         // Private so we can issue EMPTY in the common case of no ion mobility info
-        private IonMobilityValue(double? mobility, MsDataFileImpl.eIonMobilityUnits units)
+        private IonMobilityValue(double? mobility, eIonMobilityUnits units)
         {
             Mobility = mobility;
             Units = units;
         }
 
-        public static IonMobilityValue GetIonMobilityValue(double mobility, MsDataFileImpl.eIonMobilityUnits units)
+        public static IonMobilityValue GetIonMobilityValue(double mobility, eIonMobilityUnits units)
         {
-            return (units == MsDataFileImpl.eIonMobilityUnits.none)
+            return (units == eIonMobilityUnits.none)
                 ? EMPTY
                 : new IonMobilityValue(mobility, units);
         }
 
 
-        public static IonMobilityValue GetIonMobilityValue(double? value, MsDataFileImpl.eIonMobilityUnits units)
+        public static IonMobilityValue GetIonMobilityValue(double? value, eIonMobilityUnits units)
         {
-            return (units == MsDataFileImpl.eIonMobilityUnits.none || !value.HasValue)
+            return (units == eIonMobilityUnits.none || !value.HasValue)
                 ? EMPTY
                 : new IonMobilityValue(value, units);
         }
@@ -1285,13 +1285,13 @@ namespace pwiz.ProteowizardWrapper
             {
                 return true; // Anything orders after nothing
             }
-            if (left.Units == MsDataFileImpl.eIonMobilityUnits.inverse_K0_Vsec_per_cm2)
+            if (left.Units == eIonMobilityUnits.inverse_K0_Vsec_per_cm2)
             {
                 return (right.Mobility??0) < (left.Mobility??0);
             }
             return (left.Mobility??0) < (right.Mobility??0);
         }
-        public IonMobilityValue ChangeIonMobility(double? value, MsDataFileImpl.eIonMobilityUnits units)
+        public IonMobilityValue ChangeIonMobility(double? value, eIonMobilityUnits units)
         {
             return value == Mobility && units == Units ? this : GetIonMobilityValue(value, units);
         }
@@ -1301,20 +1301,20 @@ namespace pwiz.ProteowizardWrapper
         }
         [Track]
         public double? Mobility { get; private set; }
-        public MsDataFileImpl.eIonMobilityUnits Units { get; private set; }
+        public eIonMobilityUnits Units { get; private set; }
         public bool HasValue { get { return Mobility.HasValue; } }
 
-        public static string GetUnitsString(MsDataFileImpl.eIonMobilityUnits units)
+        public static string GetUnitsString(eIonMobilityUnits units)
         {
             switch (units)
             {
-                case MsDataFileImpl.eIonMobilityUnits.none:
+                case eIonMobilityUnits.none:
                     return "#N/A"; // Not L10N
-                case MsDataFileImpl.eIonMobilityUnits.drift_time_msec:
+                case eIonMobilityUnits.drift_time_msec:
                     return "msec"; // Not L10N
-                case MsDataFileImpl.eIonMobilityUnits.inverse_K0_Vsec_per_cm2:
+                case eIonMobilityUnits.inverse_K0_Vsec_per_cm2:
                     return "Vs/cm^2"; // Not L10N
-                case MsDataFileImpl.eIonMobilityUnits.compensation_V:
+                case eIonMobilityUnits.compensation_V:
                     return "V"; // Not L10N
             }
             return "unknown ion mobility type"; // Not L10N

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
@@ -809,7 +809,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 0, // compressedSize
                 0, // uncompressedsize
                 0,  //location
-                0, -1, -1, null, null, null, MsDataFileImpl.eIonMobilityUnits.none); // CONSIDER(bspratt) IMS in chromatogram libraries?
+                0, -1, -1, null, null, null, eIonMobilityUnits.none); // CONSIDER(bspratt) IMS in chromatogram libraries?
             var driftTimeFilter = IonMobilityFilter.EMPTY; // CONSIDER(bspratt) IMS in chromatogram libraries?
             var groupInfo = new ChromatogramGroupInfo(header,
                     new Dictionary<Type, int>(),

--- a/pwiz_tools/Skyline/EditUI/PasteDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.cs
@@ -862,7 +862,7 @@ namespace pwiz.Skyline.EditUI
             var helpText = Resources.PasteDlg_btnTransitionListHelp_Click_ +
                 string.Join(", ", SmallMoleculeTransitionListColumnHeaders.KnownHeaders) + // Not L10N
                 "\r\n" + // Not L10N
-                string.Format(Resources.PasteDlg_btnTransitionListHelp_Click_Supported_values_for__0__are___1_, SmallMoleculeTransitionListColumnHeaders.imUnits, string.Join(", ", Enum.GetNames(typeof(MsDataFileImpl.eIonMobilityUnits)))) + // Not L10N
+                string.Format(Resources.PasteDlg_btnTransitionListHelp_Click_Supported_values_for__0__are___1_, SmallMoleculeTransitionListColumnHeaders.imUnits, string.Join(", ", Enum.GetNames(typeof(eIonMobilityUnits)))) + // Not L10N
                 "\r\n\r\n" + // Not L10N
                 Resources.PasteDlg_btnTransitionListHelp_Click_2_ +
                 "\r\n\r\n" + // Not L10N

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
@@ -319,12 +319,12 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         {
             get
             {
-                return DocNode.ExplicitValues.IonMobilityUnits == MsDataFileImpl.eIonMobilityUnits.drift_time_msec ? DocNode.ExplicitValues.IonMobility : null;
+                return DocNode.ExplicitValues.IonMobilityUnits == eIonMobilityUnits.drift_time_msec ? DocNode.ExplicitValues.IonMobility : null;
             }
             set
             {
                 ChangeDocNode(EditDescription.SetColumn("ExplicitDriftTimeMsec", value), // Not L10N
-                    docNode => docNode.ChangeExplicitValues(docNode.ExplicitValues.ChangeIonMobility(value, MsDataFileImpl.eIonMobilityUnits.drift_time_msec)));
+                    docNode => docNode.ChangeExplicitValues(docNode.ExplicitValues.ChangeIonMobility(value, eIonMobilityUnits.drift_time_msec)));
             }
         }
 
@@ -333,7 +333,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         {
             get
             {
-                return DocNode.ExplicitValues.IonMobilityUnits == MsDataFileImpl.eIonMobilityUnits.drift_time_msec ? DocNode.ExplicitValues.IonMobilityHighEnergyOffset : null;
+                return DocNode.ExplicitValues.IonMobilityUnits == eIonMobilityUnits.drift_time_msec ? DocNode.ExplicitValues.IonMobilityHighEnergyOffset : null;
             }
             set
             {
@@ -363,7 +363,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             }
             set
             {
-                MsDataFileImpl.eIonMobilityUnits eValue;
+                eIonMobilityUnits eValue;
                 if (SmallMoleculeTransitionListReader.IonMobilityUnitsSynonyms.TryGetValue(value.Trim(), out eValue))
                     ChangeDocNode(EditDescription.SetColumn("ExplicitIonMobilityUnits", eValue), // Not L10N
                         docNode=>docNode.ChangeExplicitValues(docNode.ExplicitValues.ChangeIonMobility(docNode.ExplicitValues.IonMobility, eValue)));

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ResultFile.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ResultFile.cs
@@ -87,7 +87,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
 
         public double? TicArea { get { return ChromFileInfo.TicArea; } }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return ChromFileInfo.IonMobilityUnits; } }
+        public eIonMobilityUnits IonMobilityUnits { get { return ChromFileInfo.IonMobilityUnits; } }
 
         public TChromInfo FindChromInfo<TChromInfo>(Results<TChromInfo> chromInfos) where TChromInfo : ChromInfo
         {

--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -1699,7 +1699,7 @@ namespace pwiz.Skyline.Model.DocSettings
             if (ionMobilityValue.HasValue)
             {
                 IonMobilityInfo =  IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(ionMobilityValue.Value,
-                    MsDataFileImpl.eIonMobilityUnits.drift_time_msec), 
+                    eIonMobilityUnits.drift_time_msec), 
                     reader.GetNullableDoubleAttribute(ATTR.ccs),
                     reader.GetDoubleAttribute(ATTR.high_energy_drift_time_offset, 0));
             }
@@ -1728,7 +1728,7 @@ namespace pwiz.Skyline.Model.DocSettings
             // Write tag attributes
             writer.WriteAttribute(ATTR.modified_sequence, Target.ToSerializableString()); // CONSIDER(bspratt): different attribute for small molecule?
             writer.WriteAttribute(ATTR.charge, Target.IsProteomic ? Charge.ToString() : Charge.AdductFormula);
-            if (IonMobilityInfo.IonMobility.Units != MsDataFileImpl.eIonMobilityUnits.none)
+            if (IonMobilityInfo.IonMobility.Units != eIonMobilityUnits.none)
             {
                 writer.WriteAttributeNullable(ATTR.ion_mobility, IonMobilityInfo.IonMobility.Mobility);
                 writer.WriteAttribute(ATTR.high_energy_ion_mobility_offset, IonMobilityInfo.HighEnergyIonMobilityValueOffset);
@@ -2990,7 +2990,7 @@ namespace pwiz.Skyline.Model.DocSettings
             return (IonMobility.CompareTo(value) == 0) ? this : GetIonMobilityFilter(value, IonMobilityExtractionWindowWidth, CollisionalCrossSectionSqA);
         }
 
-        public IonMobilityFilter ChangeIonMobilityValue(double? value, MsDataFileImpl.eIonMobilityUnits units)
+        public IonMobilityFilter ChangeIonMobilityValue(double? value, eIonMobilityUnits units)
         {
             var im = IonMobility.ChangeIonMobility(value, units);
             return (IonMobility.CompareTo(im) == 0) ? this : GetIonMobilityFilter(im, IonMobilityExtractionWindowWidth, CollisionalCrossSectionSqA);
@@ -3018,22 +3018,22 @@ namespace pwiz.Skyline.Model.DocSettings
         public IonMobilityValue IonMobility { get; private set; }
         public double? CollisionalCrossSectionSqA { get; private set; } // The CCS value used to get the ion mobility, if known
         public double? IonMobilityExtractionWindowWidth { get; private set; }
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return HasIonMobilityValue ? IonMobility.Units : MsDataFileImpl.eIonMobilityUnits.none; } }
+        public eIonMobilityUnits IonMobilityUnits { get { return HasIonMobilityValue ? IonMobility.Units : eIonMobilityUnits.none; } }
 
         public bool HasIonMobilityValue { get { return IonMobility.HasValue; } }
         public bool IsEmpty { get { return !HasIonMobilityValue; } }
 
-        public static string IonMobilityUnitsL10NString(MsDataFileImpl.eIonMobilityUnits units)
+        public static string IonMobilityUnitsL10NString(eIonMobilityUnits units)
         {
             switch (units)
             {
-                case MsDataFileImpl.eIonMobilityUnits.inverse_K0_Vsec_per_cm2:
+                case eIonMobilityUnits.inverse_K0_Vsec_per_cm2:
                     return Resources.IonMobilityFilter_IonMobilityUnitsString__1_K0__Vs_cm_2_;
-                case MsDataFileImpl.eIonMobilityUnits.drift_time_msec:
+                case eIonMobilityUnits.drift_time_msec:
                     return Resources.IonMobilityFilter_IonMobilityUnitsString_Drift_Time__ms_;
-                case MsDataFileImpl.eIonMobilityUnits.compensation_V:
+                case eIonMobilityUnits.compensation_V:
                     return Resources.IonMobilityFilter_IonMobilityUnitsString_Compensation_Voltage__V_;
-                case MsDataFileImpl.eIonMobilityUnits.none:
+                case eIonMobilityUnits.none:
                     return Resources.IonMobilityFilter_IonMobilityUnitsL10NString_None;
                 default:
                     return null;
@@ -3062,7 +3062,7 @@ namespace pwiz.Skyline.Model.DocSettings
             {
                 var driftTimeWindow = reader.GetNullableDoubleAttribute(DocumentSerializer.ATTR.drift_time_window);
                 ionMobilityFilter = GetIonMobilityFilter(IonMobilityValue.GetIonMobilityValue(driftTime.Value,
-                    MsDataFileImpl.eIonMobilityUnits.drift_time_msec), driftTimeWindow, ccs);
+                    eIonMobilityUnits.drift_time_msec), driftTimeWindow, ccs);
             }
             else
             {
@@ -3117,13 +3117,13 @@ namespace pwiz.Skyline.Model.DocSettings
             string ionMobilityAbbrev = "im"; // Not L10N
             switch (IonMobility.Units)
             {
-                case MsDataFileImpl.eIonMobilityUnits.drift_time_msec:
+                case eIonMobilityUnits.drift_time_msec:
                     ionMobilityAbbrev = "dt"; // Not L10N
                     break;
-                case MsDataFileImpl.eIonMobilityUnits.inverse_K0_Vsec_per_cm2:
+                case eIonMobilityUnits.inverse_K0_Vsec_per_cm2:
                     ionMobilityAbbrev = "irim"; // Not L10N
                     break;
-                case MsDataFileImpl.eIonMobilityUnits.compensation_V:
+                case eIonMobilityUnits.compensation_V:
                     ionMobilityAbbrev = "cv"; // Not L10N
                     break;
             }
@@ -3443,19 +3443,19 @@ namespace pwiz.Skyline.Model.DocSettings
             }
         }
 
-        public MsDataFileImpl.eIonMobilityUnits GetIonMobilityUnits()
+        public eIonMobilityUnits GetIonMobilityUnits()
         {
-            foreach (MsDataFileImpl.eIonMobilityUnits units in Enum.GetValues(typeof(MsDataFileImpl.eIonMobilityUnits)))
+            foreach (eIonMobilityUnits units in Enum.GetValues(typeof(eIonMobilityUnits)))
             {
-                if (units != MsDataFileImpl.eIonMobilityUnits.none && IsUsable(units))
+                if (units != eIonMobilityUnits.none && IsUsable(units))
                 {
                     return units;
                 }
             }
-            return MsDataFileImpl.eIonMobilityUnits.none;
+            return eIonMobilityUnits.none;
         }
 
-        public bool IsUsable(MsDataFileImpl.eIonMobilityUnits units)
+        public bool IsUsable(eIonMobilityUnits units)
         {
             // We're usable if we have measured ion mobility values, or a CCS library
             bool usable = (_measuredMobilityIons != null) && _measuredMobilityIons.Any(m => m.IonMobility.Units == units);

--- a/pwiz_tools/Skyline/Model/ExplicitTransitionGroupValues.cs
+++ b/pwiz_tools/Skyline/Model/ExplicitTransitionGroupValues.cs
@@ -34,7 +34,7 @@ namespace pwiz.Skyline.Model
         public ExplicitTransitionGroupValues(double? explicitCollisionEnergy,
             double? explicitIonMobility,
             double? explicitIonMobilityHighEnergyOffset,
-            MsDataFileImpl.eIonMobilityUnits explicitIonMobilityUnits,
+            eIonMobilityUnits explicitIonMobilityUnits,
             double? explicitCollisionalCrossSectionSqA,
             double? explicitSLens,
             double? explicitConeVoltage,
@@ -57,7 +57,7 @@ namespace pwiz.Skyline.Model
                 (other == null) ? null : other.CollisionEnergy,
                 (other == null) ? null : other.IonMobility,
                 (other == null) ? null : other.IonMobility,
-                (other == null) ? MsDataFileImpl.eIonMobilityUnits.none : other.IonMobilityUnits,
+                (other == null) ? eIonMobilityUnits.none : other.IonMobilityUnits,
                 (other == null) ? null : other.CollisionalCrossSectionSqA,
                 (other == null) ? null : other.SLens,
                 (other == null) ? null : other.ConeVoltage,
@@ -79,16 +79,16 @@ namespace pwiz.Skyline.Model
         {
             get
             {
-                return IonMobilityUnits == MsDataFileImpl.eIonMobilityUnits.compensation_V ? IonMobility : null;
+                return IonMobilityUnits == eIonMobilityUnits.compensation_V ? IonMobility : null;
             }
             private set
             {
-                if (!value.HasValue && IonMobilityUnits != MsDataFileImpl.eIonMobilityUnits.compensation_V)
+                if (!value.HasValue && IonMobilityUnits != eIonMobilityUnits.compensation_V)
                 {
                     return; // This changes nothing
                 }
                 IonMobility = value;
-                IonMobilityUnits = value.HasValue ? MsDataFileImpl.eIonMobilityUnits.compensation_V : MsDataFileImpl.eIonMobilityUnits.none;
+                IonMobilityUnits = value.HasValue ? eIonMobilityUnits.compensation_V : eIonMobilityUnits.none;
             }
         } 
         [Track]
@@ -98,7 +98,7 @@ namespace pwiz.Skyline.Model
         [Track]
         public double? IonMobilityHighEnergyOffset { get; private set; } // For import formats with explicit values for DT
         [Track]
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get; private set; } // For import formats with explicit values for DT
+        public eIonMobilityUnits IonMobilityUnits { get; private set; } // For import formats with explicit values for DT
 
         public ExplicitTransitionGroupValues ChangeCollisionEnergy(double? ce)
         {
@@ -110,7 +110,7 @@ namespace pwiz.Skyline.Model
             return ChangeProp(ImClone(this), (im, v) => im.IonMobilityHighEnergyOffset = v, dtOffset);
         }
 
-        public ExplicitTransitionGroupValues ChangeIonMobility(double? imNew, MsDataFileImpl.eIonMobilityUnits unitsNew)
+        public ExplicitTransitionGroupValues ChangeIonMobility(double? imNew, eIonMobilityUnits unitsNew)
         {
             var explicitTransitionGroupValues = ChangeProp(ImClone(this), (im, v) => im.IonMobility = v, imNew);
             return ChangeProp(ImClone(explicitTransitionGroupValues), (im, v) => im.IonMobilityUnits = v, unitsNew);

--- a/pwiz_tools/Skyline/Model/IonMobility/IonMobilityDb.cs
+++ b/pwiz_tools/Skyline/Model/IonMobility/IonMobilityDb.cs
@@ -114,7 +114,7 @@ namespace pwiz.Skyline.Model.IonMobility
         {
             DbIonMobilityPeptide pep;
             if (DictLibrary.TryGetValue(key, out pep))
-                return IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(regression.GetY(pep.CollisionalCrossSection), MsDataFileImpl.eIonMobilityUnits.drift_time_msec), pep.CollisionalCrossSection, pep.HighEnergyDriftTimeOffsetMsec);
+                return IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(regression.GetY(pep.CollisionalCrossSection), eIonMobilityUnits.drift_time_msec), pep.CollisionalCrossSection, pep.HighEnergyDriftTimeOffsetMsec);
             return null;
         }
 

--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -1586,8 +1586,8 @@ namespace pwiz.Skyline.Model.Lib
                         IonMobilityAndCCS ionMobilityInfo = IonMobilityAndCCS.EMPTY;
                         if (hasGeneralIonMobility)
                         {
-                            var ionMobilityType = (MsDataFileImpl.eIonMobilityUnits)NullSafeToInteger(reader.GetValue(iIonMobilityType));
-                            if (!ionMobilityType.Equals(MsDataFileImpl.eIonMobilityUnits.none))
+                            var ionMobilityType = (eIonMobilityUnits)NullSafeToInteger(reader.GetValue(iIonMobilityType));
+                            if (!ionMobilityType.Equals(eIonMobilityUnits.none))
                             {
                                 var ionMobility = reader.GetDouble(iIonMobility);
                                 var collisionalCrossSectionSqA = reader.GetDouble(iCCS);
@@ -1602,7 +1602,7 @@ namespace pwiz.Skyline.Model.Lib
                             var collisionalCrossSectionSqA = reader.GetDouble(iCCS);
                             var highEnergyDriftTimeOffsetMsec = reader.GetDouble(iIonMobilityHighEnergyOffset);
                             if (!(driftTimeMsec == 0 && collisionalCrossSectionSqA == 0 && highEnergyDriftTimeOffsetMsec == 0))
-                               ionMobilityInfo =  IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(driftTimeMsec, MsDataFileImpl.eIonMobilityUnits.drift_time_msec) , collisionalCrossSectionSqA, highEnergyDriftTimeOffsetMsec);
+                               ionMobilityInfo =  IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(driftTimeMsec, eIonMobilityUnits.drift_time_msec) , collisionalCrossSectionSqA, highEnergyDriftTimeOffsetMsec);
                         }
                         else if (hasDTvsCCS)
                         {
@@ -1612,7 +1612,7 @@ namespace pwiz.Skyline.Model.Lib
                             {
                                 double? val = reader.GetDouble(iDTorCCS);
                                 var ionMobility = type == 1 
-                                    ? IonMobilityValue.GetIonMobilityValue(val, MsDataFileImpl.eIonMobilityUnits.drift_time_msec)
+                                    ? IonMobilityValue.GetIonMobilityValue(val, eIonMobilityUnits.drift_time_msec)
                                     : IonMobilityValue.EMPTY;
                                 ionMobilityInfo =  IonMobilityAndCCS.GetIonMobilityAndCCS(ionMobility, type != 1 ? val : null,
                                     (iIonMobilityHighEnergyOffset > 0) ? reader.GetDouble(iIonMobilityHighEnergyOffset) : 0);
@@ -1967,7 +1967,7 @@ namespace pwiz.Skyline.Model.Lib
                             GetDouble(Column.collisionalCrossSectionSqA).GetValueOrDefault();
                         double highEnergyOffset =
                             GetDouble(Column.ionMobilityHighEnergyOffset).GetValueOrDefault();
-                        var units = (MsDataFileImpl.eIonMobilityUnits)GetInt(Column.ionMobilityType).GetValueOrDefault();
+                        var units = (eIonMobilityUnits)GetInt(Column.ionMobilityType).GetValueOrDefault();
                         if (mobility == 0 && collisionalCrossSection == 0 &&
                             highEnergyOffset == 0)
                         {
@@ -1989,7 +1989,7 @@ namespace pwiz.Skyline.Model.Lib
                         {
                             return IonMobilityAndCCS.EMPTY;
                         }
-                        return IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(driftTimeMsec, MsDataFileImpl.eIonMobilityUnits.drift_time_msec),
+                        return IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(driftTimeMsec, eIonMobilityUnits.drift_time_msec),
                             collisionalCrossSection, highEnergyOffset);
                     }
                     case 3:
@@ -2003,7 +2003,7 @@ namespace pwiz.Skyline.Model.Lib
                             return IonMobilityAndCCS.EMPTY;
                         }
                         bool isCcs = ionMobilityType == (int) IonMobilityType.collisionalCrossSection;
-                        return IonMobilityAndCCS.GetIonMobilityAndCCS(isCcs ? IonMobilityValue.EMPTY : IonMobilityValue.GetIonMobilityValue(ionMobilityValue, MsDataFileImpl.eIonMobilityUnits.drift_time_msec), isCcs ? ionMobilityValue : (double?)null, highEnergyOffset);
+                        return IonMobilityAndCCS.GetIonMobilityAndCCS(isCcs ? IonMobilityValue.EMPTY : IonMobilityValue.GetIonMobilityValue(ionMobilityValue, eIonMobilityUnits.drift_time_msec), isCcs ? ionMobilityValue : (double?)null, highEnergyOffset);
                     }
                 }
             }
@@ -2242,7 +2242,7 @@ namespace pwiz.Skyline.Model.Lib
                 for (int j = 0; j < driftTimeCount; j++)
                 {
                     double ionMobility = PrimitiveArrays.ReadOneValue<double>(stream);
-                    MsDataFileImpl.eIonMobilityUnits units = (MsDataFileImpl.eIonMobilityUnits)PrimitiveArrays.ReadOneValue<int>(stream);
+                    eIonMobilityUnits units = (eIonMobilityUnits)PrimitiveArrays.ReadOneValue<int>(stream);
                     double collisionalCrossSectionSqA = PrimitiveArrays.ReadOneValue<double>(stream);
                     double highEnergyOffset = PrimitiveArrays.ReadOneValue<double>(stream);
                     var ionMobilityInfo = ionMobility == 0 && collisionalCrossSectionSqA == 0 && highEnergyOffset == 0 ?

--- a/pwiz_tools/Skyline/Model/Lib/BlibData/BlibDb.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BlibData/BlibDb.cs
@@ -714,7 +714,7 @@ namespace pwiz.Skyline.Model.Lib.BlibData
                     IonMobility = null,
                     IonMobilityHighEnergyOffset = null,
                     CollisionalCrossSectionSqA = null,
-                    IonMobilityType = (int)MsDataFileImpl.eIonMobilityUnits.none
+                    IonMobilityType = (int)eIonMobilityUnits.none
                 };
                 if (null != spectrum.IonMobilityInfo && spectrum.IonMobilityInfo.HasIonMobilityValue)
                 {

--- a/pwiz_tools/Skyline/Model/Results/CachedChromatogramDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/CachedChromatogramDataProvider.cs
@@ -93,7 +93,7 @@ namespace pwiz.Skyline.Model.Results
             get { return _chromKeyIndices.Select((v, i) => new ChromKeyProviderIdPair(v.Key, i)); }
         }
 
-        public override MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return _cache != null ? _cache.CachedFiles[_fileIndex].IonMobilityUnits : MsDataFileImpl.eIonMobilityUnits.none; } }
+        public override eIonMobilityUnits IonMobilityUnits { get { return _cache != null ? _cache.CachedFiles[_fileIndex].IonMobilityUnits : eIonMobilityUnits.none; } }
 
         public override bool GetChromatogram(int id, Target modifiedSequence, Color peptideColor, out ChromExtra extra, out TimeIntensities timeIntensities)
         {

--- a/pwiz_tools/Skyline/Model/Results/ChorusResponseChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChorusResponseChromDataProvider.cs
@@ -63,7 +63,7 @@ namespace pwiz.Skyline.Model.Results
                 out extra, out timeIntensities);
         }
 
-        public override MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return MsDataFileImpl.eIonMobilityUnits.none; } }
+        public override eIonMobilityUnits IonMobilityUnits { get { return eIonMobilityUnits.none; } }
 
 
         public override double? MaxRetentionTime

--- a/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
@@ -89,7 +89,7 @@ namespace pwiz.Skyline.Model.Results
 
         public virtual double? TicArea { get { return FileInfo.TicArea; } }
 
-        public abstract MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get; }
+        public abstract eIonMobilityUnits IonMobilityUnits { get; }
 
         public abstract bool IsProcessedScans { get; }
 
@@ -270,7 +270,7 @@ namespace pwiz.Skyline.Model.Results
             get { return _chromIds; }
         }
 
-        public override MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return MsDataFileImpl.eIonMobilityUnits.none; } }
+        public override eIonMobilityUnits IonMobilityUnits { get { return eIonMobilityUnits.none; } }
 
         public override bool GetChromatogram(int id, Target modifiedSequence, Color color, out ChromExtra extra, out TimeIntensities timeIntensities)
         {

--- a/pwiz_tools/Skyline/Model/Results/ChromDataSet.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataSet.cs
@@ -153,9 +153,9 @@ namespace pwiz.Skyline.Model.Results
             get { return _listChromData.Count > 0 ? BestChromatogram.Key.CollisionalCrossSectionSqA : null; }
         }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits
+        public eIonMobilityUnits IonMobilityUnits
         {
-            get { return _listChromData.Count > 0 ? BestChromatogram.Key.IonMobilityUnits : MsDataFileImpl.eIonMobilityUnits.none; }
+            get { return _listChromData.Count > 0 ? BestChromatogram.Key.IonMobilityUnits : eIonMobilityUnits.none; }
         }
 
         public ChromExtractor Extractor

--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -210,7 +210,7 @@ namespace pwiz.Skyline.Model.Results
                                      int statusId, int statusRank,
                                      float? startTime, float? endTime,
                                      double? collisionalCrossSection, 
-                                     MsDataFileImpl.eIonMobilityUnits ionMobilityUnits)
+                                     eIonMobilityUnits ionMobilityUnits)
             : this(precursor, -1, 0, fileIndex, numTransitions, startTransitionIndex,
                    numPeaks, startPeakIndex, startScoreIndex, maxPeakIndex, numPoints,
                    compressedSize, uncompressedSize, location, flags, statusId, statusRank,
@@ -227,7 +227,7 @@ namespace pwiz.Skyline.Model.Results
                                      int numPoints, int compressedSize, int uncompressedSize, long location, FlagValues flags,
                                      int statusId, int statusRank,
                                      float? startTime, float? endTime,
-                                     double? collisionalCrossSection, MsDataFileImpl.eIonMobilityUnits ionMobilityUnits)
+                                     double? collisionalCrossSection, eIonMobilityUnits ionMobilityUnits)
             : this()
         {
             _precursor = precursor.Value;
@@ -287,7 +287,7 @@ namespace pwiz.Skyline.Model.Results
             -1,
             headerInfo.LocationPoints,
             0, -1, -1,
-            null, null, null, MsDataFileImpl.eIonMobilityUnits.none)
+            null, null, null, eIonMobilityUnits.none)
         {
         }
 
@@ -395,11 +395,11 @@ namespace pwiz.Skyline.Model.Results
             }
         }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits
+        public eIonMobilityUnits IonMobilityUnits
         {
             get
             {
-                return (MsDataFileImpl.eIonMobilityUnits)((int)(Flags & FlagValues.ion_mobility_type_bitmask) >> 8);
+                return (eIonMobilityUnits)((int)(Flags & FlagValues.ion_mobility_type_bitmask) >> 8);
             }
         }
 
@@ -1378,13 +1378,13 @@ namespace pwiz.Skyline.Model.Results
             return (flags & FlagValues.has_midas_spectra) != 0;
         }
 
-        public static MsDataFileImpl.eIonMobilityUnits IonMobilityUnitsFromFlags(FlagValues flags)
+        public static eIonMobilityUnits IonMobilityUnitsFromFlags(FlagValues flags)
         {
-            return (MsDataFileImpl.eIonMobilityUnits)((int)(flags & FlagValues.ion_mobility_type_bitmask) >> 4);
+            return (eIonMobilityUnits)((int)(flags & FlagValues.ion_mobility_type_bitmask) >> 4);
         }
 
         public ChromCachedFile(MsDataFileUri filePath, FlagValues flags, DateTime fileWriteTime, DateTime? runStartTime,
-                               float maxRT, float maxIntensity, MsDataFileImpl.eIonMobilityUnits ionMobilityUnits, IEnumerable<MsInstrumentConfigInfo> instrumentInfoList)
+                               float maxRT, float maxIntensity, eIonMobilityUnits ionMobilityUnits, IEnumerable<MsInstrumentConfigInfo> instrumentInfoList)
             : this(filePath, flags, fileWriteTime, runStartTime, maxRT, maxIntensity, 0, 0, default(float?), ionMobilityUnits, instrumentInfoList)
         {
         }
@@ -1398,7 +1398,7 @@ namespace pwiz.Skyline.Model.Results
                                int sizeScanIds,
                                long locationScanIds,
                                float? ticArea,
-                               MsDataFileImpl.eIonMobilityUnits ionMobilityUnits,
+                               eIonMobilityUnits ionMobilityUnits,
                                IEnumerable<MsInstrumentConfigInfo> instrumentInfoList)
         {
             FilePath = filePath;
@@ -1423,7 +1423,7 @@ namespace pwiz.Skyline.Model.Results
         public long LocationScanIds { get; private set; }
         public ImmutableList<MsInstrumentConfigInfo> InstrumentInfoList { get; private set; }
         public float? TicArea { get; private set; }
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return IonMobilityUnitsFromFlags(Flags); } }
+        public eIonMobilityUnits IonMobilityUnits { get { return IonMobilityUnitsFromFlags(Flags); } }
 
         public bool IsCurrent
         {
@@ -1681,7 +1681,7 @@ namespace pwiz.Skyline.Model.Results
         public Target Target { get; private set; }  // Modified sequence or custom ion id
         public SignedMz Precursor { get; private set; }
         public double? CollisionalCrossSectionSqA { get { return IonMobilityFilter == null ? null : IonMobilityFilter.CollisionalCrossSectionSqA; }  }
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return IonMobilityFilter == null ? MsDataFileImpl.eIonMobilityUnits.none : IonMobilityFilter.IonMobility.Units; } }
+        public eIonMobilityUnits IonMobilityUnits { get { return IonMobilityFilter == null ? eIonMobilityUnits.none : IonMobilityFilter.IonMobility.Units; } }
         public IonMobilityFilter IonMobilityFilter { get; private set; }
         public SignedMz Product { get; private set; }
         public float CollisionEnergy { get; private set; }
@@ -2449,7 +2449,7 @@ namespace pwiz.Skyline.Model.Results
             get { return FloatToNullableDouble(ChromTransition.IonMobilityExtractionWidth); }
         }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits
+        public eIonMobilityUnits IonMobilityUnits
         {
             get { return Header.IonMobilityUnits; }
         }

--- a/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
+++ b/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
@@ -792,7 +792,7 @@ namespace pwiz.Skyline.Model.Results
                 writer.WriteAttribute(ATTR.has_midas_spectra, fileInfo.HasMidasSpectra, false);
                 writer.WriteAttributeNullable(ATTR.explicit_global_standard_area, fileInfo.ExplicitGlobalStandardArea);
                 writer.WriteAttributeNullable(ATTR.tic_area, fileInfo.TicArea);
-                if (fileInfo.IonMobilityUnits != MsDataFileImpl.eIonMobilityUnits.none)
+                if (fileInfo.IonMobilityUnits != eIonMobilityUnits.none)
                     writer.WriteAttribute(ATTR.ion_mobility_type, fileInfo.IonMobilityUnits.ToString());
 
                 // instrument information
@@ -942,7 +942,7 @@ namespace pwiz.Skyline.Model.Results
         public bool HasMidasSpectra { get; private set; }
         public double? ExplicitGlobalStandardArea { get; private set; }
         public double? TicArea { get; private set; }
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get; private set; }
+        public eIonMobilityUnits IonMobilityUnits { get; private set; }
 
         public IList<MsInstrumentConfigInfo> InstrumentInfoList
         {
@@ -969,7 +969,7 @@ namespace pwiz.Skyline.Model.Results
             return ChangeProp(ImClone(this), im => im.HasMidasSpectra = prop);
         }
 
-        public ChromFileInfo ChangeIonMobilityUnits(MsDataFileImpl.eIonMobilityUnits prop)
+        public ChromFileInfo ChangeIonMobilityUnits(eIonMobilityUnits prop)
         {
             return ChangeProp(ImClone(this), im => im.IonMobilityUnits = prop);
         }

--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -1154,8 +1154,8 @@ namespace pwiz.Skyline.Model.Results
                     var product = new SignedMz(tranInfo.Product, groupInfo.NegativeCharge);
                     float extractionWidth = tranInfo.ExtractionWidth;
                     var units = groupInfo.IonMobilityUnits;
-                    if (units == MsDataFileImpl.eIonMobilityUnits.none && extractionWidth != 0)
-                        units = MsDataFileImpl.eIonMobilityUnits.drift_time_msec; // Backward compatibility - drift time is all we had before
+                    if (units == eIonMobilityUnits.none && extractionWidth != 0)
+                        units = eIonMobilityUnits.drift_time_msec; // Backward compatibility - drift time is all we had before
                     ChromSource source = tranInfo.Source;
                     ionMobilityValue = ionMobilityValue == null ? 
                         IonMobilityValue.GetIonMobilityValue(tranInfo.IonMobilityValue, units) :

--- a/pwiz_tools/Skyline/Model/Results/MsDataFileScanHelper.cs
+++ b/pwiz_tools/Skyline/Model/Results/MsDataFileScanHelper.cs
@@ -115,7 +115,7 @@ namespace pwiz.Skyline.Model.Results
             get { return ScanProvider != null && ScanProvider.ProvidesCollisionalCrossSectionConverter; }
         }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits
+        public eIonMobilityUnits IonMobilityUnits
         {
             get
             {
@@ -258,13 +258,13 @@ namespace pwiz.Skyline.Model.Results
                 return _scanProvider.CCSFromIonMobility(ionMobility, mz, charge);
             }
 
-            public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits
+            public eIonMobilityUnits IonMobilityUnits
             {
                 get
                 {
                     return _scanProvider != null
                         ? _scanProvider.IonMobilityUnits
-                        : MsDataFileImpl.eIonMobilityUnits.none;
+                        : eIonMobilityUnits.none;
                 } }
 
             public bool ProvidesCollisionalCrossSectionConverter { get { return _scanProvider != null && _scanProvider.ProvidesCollisionalCrossSectionConverter; } }

--- a/pwiz_tools/Skyline/Model/Results/RemoteApi/Chorus/ChorusScanProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/RemoteApi/Chorus/ChorusScanProvider.cs
@@ -66,7 +66,7 @@ namespace pwiz.Skyline.Model.Results.RemoteApi.Chorus
             return null; // Unsupported
         }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return MsDataFileImpl.eIonMobilityUnits.none; } }
+        public eIonMobilityUnits IonMobilityUnits { get { return eIonMobilityUnits.none; } }
 
         public bool Adopt(IScanProvider scanProvider)
         {

--- a/pwiz_tools/Skyline/Model/Results/RemoteApi/Chorus/ChorusSession.cs
+++ b/pwiz_tools/Skyline/Model/Results/RemoteApi/Chorus/ChorusSession.cs
@@ -250,7 +250,7 @@ namespace pwiz.Skyline.Model.Results.RemoteApi.Chorus
                 var driftTime = jDriftTime.ToObject<double>();
                 if (driftTime != 0)
                 {
-                    ionMobility = IonMobilityValue.GetIonMobilityValue(driftTime, MsDataFileImpl.eIonMobilityUnits.drift_time_msec);
+                    ionMobility = IonMobilityValue.GetIonMobilityValue(driftTime, eIonMobilityUnits.drift_time_msec);
                 }
             }
             MsDataSpectrum spectrum = new MsDataSpectrum

--- a/pwiz_tools/Skyline/Model/Results/RemoteChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/RemoteChromDataProvider.cs
@@ -137,7 +137,7 @@ namespace pwiz.Skyline.Model.Results
             get { return null; }
         }
 
-        public override MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return MsDataFileImpl.eIonMobilityUnits.none; } }
+        public override eIonMobilityUnits IonMobilityUnits { get { return eIonMobilityUnits.none; } }
 
         public override double? MaxIntensity
         {

--- a/pwiz_tools/Skyline/Model/Results/ScanProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/ScanProvider.cs
@@ -51,7 +51,7 @@ namespace pwiz.Skyline.Model.Results
         MsDataSpectrum[] GetMsDataFileSpectraWithCommonRetentionTime(int dataFileSpectrumStartIndex); // Return a collection of consecutive scans with common retention time and changing ion mobility (or a single scan if no drift info in file)
         bool ProvidesCollisionalCrossSectionConverter { get; }
         double? CCSFromIonMobility(IonMobilityValue ionMobilityValue, double mz, int charge); // Return a collisional cross section for this ion mobility value at this mz and charge, if reader supports this
-        MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get; } 
+        eIonMobilityUnits IonMobilityUnits { get; } 
         bool Adopt(IScanProvider scanProvider);
     }
 
@@ -83,12 +83,12 @@ namespace pwiz.Skyline.Model.Results
             return _dataFile.CCSFromIonMobilityValue(ionMobilityValue, mz, charge);
         }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits
+        public eIonMobilityUnits IonMobilityUnits
         {
             get
             {
                 if (_dataFile == null)
-                    return MsDataFileImpl.eIonMobilityUnits.none;
+                    return eIonMobilityUnits.none;
                 return _dataFile.IonMobilityUnits;
             }
         }

--- a/pwiz_tools/Skyline/Model/Results/SpectraChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectraChromDataProvider.cs
@@ -196,7 +196,7 @@ namespace pwiz.Skyline.Model.Results
             return true;
         }
 
-        public override MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return _filter.IonMobilityUnits; } }
+        public override eIonMobilityUnits IonMobilityUnits { get { return _filter.IonMobilityUnits; } }
 
         private void ExtractionComplete()
         {
@@ -1346,7 +1346,7 @@ namespace pwiz.Skyline.Model.Results
         }
 
         public bool ProvidesCollisionalCrossSectionConverter { get { return _dataFile.ProvidesCollisionalCrossSectionConverter; } }
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get { return _dataFile.IonMobilityUnits; } }
+        public eIonMobilityUnits IonMobilityUnits { get { return _dataFile.IonMobilityUnits; } }
 
         public IonMobilityValue IonMobilityFromCCS(double ccs, double mz, int charge)
         {

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -42,7 +42,7 @@ namespace pwiz.Skyline.Model.Results
     public interface IIonMobilityFunctionsProvider
     {
         bool ProvidesCollisionalCrossSectionConverter { get; }
-        MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get; } // Reports ion mobility units in use by the mass spec
+        eIonMobilityUnits IonMobilityUnits { get; } // Reports ion mobility units in use by the mass spec
         IonMobilityValue IonMobilityFromCCS(double ccs, double mz, int charge); // Convert from Collisional Cross Section to ion mobility
         double CCSFromIonMobility(IonMobilityValue im, double mz, int charge); // Convert from ion mobility to Collisional Cross Section
     }
@@ -102,14 +102,14 @@ namespace pwiz.Skyline.Model.Results
             var ionMobilityMax = maxObservedIonMobilityValue ?? 0;
 
             // TIC and Base peak are meaningless with FAIMS, where we can't know the actual overall ion counts -also can't share times
-            if (instrumentInfo != null && instrumentInfo.IonMobilityUnits == MsDataFileImpl.eIonMobilityUnits.compensation_V)
+            if (instrumentInfo != null && instrumentInfo.IonMobilityUnits == eIonMobilityUnits.compensation_V)
             {
                 foreach (var pair in document.MoleculePrecursorPairs)
                 {
                     double windowIM;
                     var ionMobility = document.Settings.PeptideSettings.Prediction.GetIonMobility(
                         pair.NodePep, pair.NodeGroup, libraryIonMobilityInfo, _ionMobilityFunctionsProvider, ionMobilityMax, out windowIM);
-                    _isFAIMS = ionMobility.HasIonMobilityValue && (ionMobility.IonMobility.Units == MsDataFileImpl.eIonMobilityUnits.compensation_V);
+                    _isFAIMS = ionMobility.HasIonMobilityValue && (ionMobility.IonMobility.Units == eIonMobilityUnits.compensation_V);
                     if (_isFAIMS)
                     {
                         break;
@@ -312,13 +312,13 @@ namespace pwiz.Skyline.Model.Results
 
         public bool ProvidesCollisionalCrossSectionConverter { get { return _ionMobilityFunctionsProvider != null;  } }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits
+        public eIonMobilityUnits IonMobilityUnits
         {
             get
             {
                 return ProvidesCollisionalCrossSectionConverter
                     ? _ionMobilityFunctionsProvider.IonMobilityUnits
-                    : MsDataFileImpl.eIonMobilityUnits.none;
+                    : eIonMobilityUnits.none;
             } }
 
         public IonMobilityValue IonMobilityFromCCS(double ccs, double mz, int charge)

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilterPair.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilterPair.cs
@@ -474,7 +474,7 @@ namespace pwiz.Skyline.Model.Results
         public bool HasIonMobilityFAIMS()
         {
             return IonMobilityInfo.HasIonMobilityValue && 
-                   IonMobilityInfo.IonMobility.Units == MsDataFileImpl.eIonMobilityUnits.compensation_V;
+                   IonMobilityInfo.IonMobility.Units == eIonMobilityUnits.compensation_V;
         }
 
         public bool ContainsIonMobilityValue(IonMobilityValue ionMobility, bool highEnergy)

--- a/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs
+++ b/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs
@@ -104,7 +104,7 @@ namespace pwiz.Skyline.Model.Serialization
             float? ionMobilityMS1 = reader.GetNullableFloatAttribute(ATTR.drift_time_ms1);
             float? ionMobilityFragment = reader.GetNullableFloatAttribute(ATTR.drift_time_fragment);
             float? ionMobilityWindow = reader.GetNullableFloatAttribute(ATTR.drift_time_window);
-            var ionMobilityUnits = MsDataFileImpl.eIonMobilityUnits.drift_time_msec;
+            var ionMobilityUnits = eIonMobilityUnits.drift_time_msec;
             if (!ionMobilityWindow.HasValue)
             {
                 ionMobilityUnits = GetAttributeMobilityUnits(reader, ATTR.ion_mobility_type, fileInfo);
@@ -163,13 +163,13 @@ namespace pwiz.Skyline.Model.Serialization
                 userSet);
         }
 
-        private static MsDataFileImpl.eIonMobilityUnits GetAttributeMobilityUnits(XmlReader reader, string attrName, ChromFileInfo fileInfo)
+        private static eIonMobilityUnits GetAttributeMobilityUnits(XmlReader reader, string attrName, ChromFileInfo fileInfo)
         {
             string ionMobilityUnitsString = reader.GetAttribute(attrName);
-            MsDataFileImpl.eIonMobilityUnits ionMobilityUnits =
+            eIonMobilityUnits ionMobilityUnits =
               string.IsNullOrEmpty( ionMobilityUnitsString) ?
-              (fileInfo == null ? MsDataFileImpl.eIonMobilityUnits.none : fileInfo.IonMobilityUnits) : // Use the file-level declaration if no local declaration
-              TypeSafeEnum.Parse<MsDataFileImpl.eIonMobilityUnits>(ionMobilityUnitsString);
+              (fileInfo == null ? eIonMobilityUnits.none : fileInfo.IonMobilityUnits) : // Use the file-level declaration if no local declaration
+              TypeSafeEnum.Parse<eIonMobilityUnits>(ionMobilityUnitsString);
             return ionMobilityUnits;
         }
 
@@ -404,7 +404,7 @@ namespace pwiz.Skyline.Model.Serialization
                 UserSet userSet = reader.GetEnumAttribute(ATTR.user_set, UserSetFastLookup.Dict,
                     UserSet.FALSE, XmlUtil.EnumCase.upper);
                 double? ionMobility = reader.GetNullableDoubleAttribute(ATTR.drift_time);
-                MsDataFileImpl.eIonMobilityUnits ionMobilityUnits = MsDataFileImpl.eIonMobilityUnits.drift_time_msec;
+                eIonMobilityUnits ionMobilityUnits = eIonMobilityUnits.drift_time_msec;
                 if (!ionMobility.HasValue)
                 {
                     ionMobility = reader.GetNullableDoubleAttribute(ATTR.ion_mobility);
@@ -773,10 +773,10 @@ namespace pwiz.Skyline.Model.Serialization
             double? importedIonMobilityHighEnergyOffset =
                 reader.GetNullableDoubleAttribute(ATTR.explicit_drift_time_high_energy_offset_msec) ??
                 reader.GetNullableDoubleAttribute(ATTR.explicit_ion_mobility_high_energy_offset);
-            var importedIonMobilityUnits = MsDataFileImpl.eIonMobilityUnits.none;
+            var importedIonMobilityUnits = eIonMobilityUnits.none;
             if (importedDriftTimeMsec.HasValue)
             {
-                importedIonMobilityUnits = MsDataFileImpl.eIonMobilityUnits.drift_time_msec;
+                importedIonMobilityUnits = eIonMobilityUnits.drift_time_msec;
             }
             else
             {

--- a/pwiz_tools/Skyline/Model/Serialization/DocumentWriter.cs
+++ b/pwiz_tools/Skyline/Model/Serialization/DocumentWriter.cs
@@ -524,7 +524,7 @@ namespace pwiz.Skyline.Model.Serialization
             writer.WriteAttributeNullable(ATTR.start_time, chromInfo.StartRetentionTime);
             writer.WriteAttributeNullable(ATTR.end_time, chromInfo.EndRetentionTime);
             writer.WriteAttributeNullable(ATTR.ccs, chromInfo.IonMobilityInfo.CollisionalCrossSection);
-            if (chromInfo.IonMobilityInfo.IonMobilityUnits != MsDataFileImpl.eIonMobilityUnits.none)
+            if (chromInfo.IonMobilityInfo.IonMobilityUnits != eIonMobilityUnits.none)
             {
                 writer.WriteAttributeNullable(ATTR.ion_mobility_ms1, chromInfo.IonMobilityInfo.IonMobilityMS1);
                 writer.WriteAttributeNullable(ATTR.ion_mobility_fragment, chromInfo.IonMobilityInfo.IonMobilityFragment);

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -700,22 +700,22 @@ namespace pwiz.Skyline.Model
                 : new MoleculeAccessionNumbers(moleculeIdKeys);
         }
 
-        public static MsDataFileImpl.eIonMobilityUnits IonMobilityUnitsFromAttributeValue(string xmlAttributeValue)
+        public static eIonMobilityUnits IonMobilityUnitsFromAttributeValue(string xmlAttributeValue)
         {
             return string.IsNullOrEmpty(xmlAttributeValue) ?
-                MsDataFileImpl.eIonMobilityUnits.none :
-                TypeSafeEnum.Parse<MsDataFileImpl.eIonMobilityUnits>(xmlAttributeValue);
+                eIonMobilityUnits.none :
+                TypeSafeEnum.Parse<eIonMobilityUnits>(xmlAttributeValue);
         }
         
 
         // Recognize XML attribute values, enum strings, and various other synonyms
-        public static readonly Dictionary<string, MsDataFileImpl.eIonMobilityUnits> IonMobilityUnitsSynonyms =
-             Enum.GetValues(typeof(MsDataFileImpl.eIonMobilityUnits)).Cast<MsDataFileImpl.eIonMobilityUnits>().ToDictionary(e => e.ToString(), e => e)
-            .Concat(new Dictionary<string, MsDataFileImpl.eIonMobilityUnits> {
-            { "msec", MsDataFileImpl.eIonMobilityUnits.drift_time_msec }, // Not L10N         
-            { "Vsec/cm2", MsDataFileImpl.eIonMobilityUnits.inverse_K0_Vsec_per_cm2 }, // Not L10N
-            { "Vsec/cm^2", MsDataFileImpl.eIonMobilityUnits.inverse_K0_Vsec_per_cm2 }, // Not L10N
-            { "1/K0", MsDataFileImpl.eIonMobilityUnits.inverse_K0_Vsec_per_cm2 } // Not L10N
+        public static readonly Dictionary<string, eIonMobilityUnits> IonMobilityUnitsSynonyms =
+             Enum.GetValues(typeof(eIonMobilityUnits)).Cast<eIonMobilityUnits>().ToDictionary(e => e.ToString(), e => e)
+            .Concat(new Dictionary<string, eIonMobilityUnits> {
+            { "msec", eIonMobilityUnits.drift_time_msec }, // Not L10N         
+            { "Vsec/cm2", eIonMobilityUnits.inverse_K0_Vsec_per_cm2 }, // Not L10N
+            { "Vsec/cm^2", eIonMobilityUnits.inverse_K0_Vsec_per_cm2 }, // Not L10N
+            { "1/K0", eIonMobilityUnits.inverse_K0_Vsec_per_cm2 } // Not L10N
             }).ToDictionary(x => x.Key, x=> x.Value);
 
         public static string GetAcceptedIonMobilityUnitsString()
@@ -926,12 +926,12 @@ namespace pwiz.Skyline.Model
                 }
             }
             double? ionMobility = null;
-            var ionMobilityUnits = MsDataFileImpl.eIonMobilityUnits.none;
+            var ionMobilityUnits = eIonMobilityUnits.none;
 
             if (row.GetCellAsDouble(INDEX_MOLECULE_DRIFT_TIME_MSEC, out dtmp))
             {
                 ionMobility = dtmp;
-                ionMobilityUnits = MsDataFileImpl.eIonMobilityUnits.drift_time_msec;
+                ionMobilityUnits = eIonMobilityUnits.drift_time_msec;
             }
             else if (!String.IsNullOrEmpty(row.GetCell(INDEX_MOLECULE_DRIFT_TIME_MSEC)))
             {
@@ -947,7 +947,7 @@ namespace pwiz.Skyline.Model
             if (row.GetCellAsDouble(INDEX_HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC, out dtmp))
             {
                 ionMobilityHighEnergyOffset = dtmp;
-                ionMobilityUnits = MsDataFileImpl.eIonMobilityUnits.drift_time_msec;
+                ionMobilityUnits = eIonMobilityUnits.drift_time_msec;
             }
             else if (!String.IsNullOrEmpty(row.GetCell(INDEX_HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC)))
             {
@@ -1128,7 +1128,7 @@ namespace pwiz.Skyline.Model
                 {
                     ionMobilityHighEnergyOffset = null; // Offset without a base value isn't useful
                 }
-                if (ionMobility.HasValue && ionMobilityUnits == MsDataFileImpl.eIonMobilityUnits.none)
+                if (ionMobility.HasValue && ionMobilityUnits == eIonMobilityUnits.none)
                 {
                     ShowTransitionError(new PasteError
                     {

--- a/pwiz_tools/Skyline/Model/TransitionGroupIonMobilityInfo.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupIonMobilityInfo.cs
@@ -35,14 +35,14 @@ namespace pwiz.Skyline.Model
             IonMobilityMS1 = null,
             IonMobilityFragment = null,
             IonMobilityWindow = null,
-            IonMobilityUnits = MsDataFileImpl.eIonMobilityUnits.none
+            IonMobilityUnits = eIonMobilityUnits.none
         };
         private TransitionGroupIonMobilityInfo() { } // This is private to force use of GetTransitionGroupIonMobilityInfo (for memory efficiency, as most uses are empty)
 
 
         // Serialization support
         public static TransitionGroupIonMobilityInfo GetTransitionGroupIonMobilityInfo(double? ccs, double? ionMobilityMS1,
-            double? ionMobilityFragment, double? ionMobilityWindow, MsDataFileImpl.eIonMobilityUnits units)
+            double? ionMobilityFragment, double? ionMobilityWindow, eIonMobilityUnits units)
         {
             if (ccs.HasValue || ionMobilityMS1.HasValue || ionMobilityFragment.HasValue || ionMobilityWindow.HasValue)
                 return new TransitionGroupIonMobilityInfo()
@@ -56,7 +56,7 @@ namespace pwiz.Skyline.Model
             return EMPTY;
         }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits { get; private set; }
+        public eIonMobilityUnits IonMobilityUnits { get; private set; }
         public double? CollisionalCrossSection { get; private set; }
         public double? IonMobilityMS1 { get; private set; }
         public double? IonMobilityFragment { get; private set; }
@@ -64,9 +64,9 @@ namespace pwiz.Skyline.Model
 
         public bool IsEmpty { get { return Equals(EMPTY); } }
 
-        public double? DriftTimeMS1 { get { return IonMobilityUnits == MsDataFileImpl.eIonMobilityUnits.drift_time_msec ? IonMobilityMS1 : null; } }
-        public double? DriftTimeFragment { get { return IonMobilityUnits == MsDataFileImpl.eIonMobilityUnits.drift_time_msec ? IonMobilityFragment : null; } }
-        public double? DriftTimeWindow { get { return IonMobilityUnits == MsDataFileImpl.eIonMobilityUnits.drift_time_msec ? IonMobilityWindow : null; } }
+        public double? DriftTimeMS1 { get { return IonMobilityUnits == eIonMobilityUnits.drift_time_msec ? IonMobilityMS1 : null; } }
+        public double? DriftTimeFragment { get { return IonMobilityUnits == eIonMobilityUnits.drift_time_msec ? IonMobilityFragment : null; } }
+        public double? DriftTimeWindow { get { return IonMobilityUnits == eIonMobilityUnits.drift_time_msec ? IonMobilityWindow : null; } }
 
 
         // Used by TransitionGroupDocNode.AddChromInfo to aggregate ion mobility information from all transitions
@@ -74,7 +74,7 @@ namespace pwiz.Skyline.Model
         {
             var val = Equals(ionMobility.IonMobilityExtractionWindowWidth, IonMobilityWindow) ? this : ChangeProp(ImClone(this), im => im.IonMobilityWindow = ionMobility.IonMobilityExtractionWindowWidth);
 
-            if (ionMobility.IonMobility.Units != IonMobilityUnits &&  ionMobility.IonMobility.Units != MsDataFileImpl.eIonMobilityUnits.none)
+            if (ionMobility.IonMobility.Units != IonMobilityUnits &&  ionMobility.IonMobility.Units != eIonMobilityUnits.none)
                val = ChangeProp(ImClone(val), im => im.IonMobilityUnits = ionMobility.IonMobility.Units);
 
             // Filling in MS1 or MS2 data, or just more of what we already know

--- a/pwiz_tools/Skyline/SettingsUI/EditCustomMoleculeDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditCustomMoleculeDlg.cs
@@ -105,7 +105,7 @@ namespace pwiz.Skyline.SettingsUI
             var heightDelta = 0;
 
             // Initialise the ion mobility units dropdown with L10N values
-            foreach (MsDataFileImpl.eIonMobilityUnits t in Enum.GetValues(typeof(MsDataFileImpl.eIonMobilityUnits)))
+            foreach (eIonMobilityUnits t in Enum.GetValues(typeof(eIonMobilityUnits)))
                 comboBoxIonMobilityUnits.Items.Add(IonMobilityFilter.IonMobilityUnitsL10NString(t));
 
             if (explicitAttributes == null)
@@ -516,13 +516,13 @@ namespace pwiz.Skyline.SettingsUI
             } // Negative values are normal here
         }
 
-        public MsDataFileImpl.eIonMobilityUnits IonMobilityUnits
+        public eIonMobilityUnits IonMobilityUnits
         {
             get
             {
                 return comboBoxIonMobilityUnits.SelectedIndex >= 0
-                    ? (MsDataFileImpl.eIonMobilityUnits) comboBoxIonMobilityUnits.SelectedIndex
-                    : MsDataFileImpl.eIonMobilityUnits.none;
+                    ? (eIonMobilityUnits) comboBoxIonMobilityUnits.SelectedIndex
+                    : eIonMobilityUnits.none;
             }
             set { comboBoxIonMobilityUnits.SelectedIndex = (int) value; }
         }

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/EditDriftTimePredictorDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/EditDriftTimePredictorDlg.cs
@@ -57,9 +57,9 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
             _showRegressions = true;
 
             InitializeComponent();
-            foreach (MsDataFileImpl.eIonMobilityUnits units in Enum.GetValues(typeof(MsDataFileImpl.eIonMobilityUnits)))
+            foreach (eIonMobilityUnits units in Enum.GetValues(typeof(eIonMobilityUnits)))
             {
-                if (units != MsDataFileImpl.eIonMobilityUnits.none) // Don't present "none" as an option
+                if (units != eIonMobilityUnits.none) // Don't present "none" as an option
                 {
                     comboBoxIonMobilityUnits.Items.Add(IonMobilityFilter.IonMobilityUnitsL10NString(units));
                 }
@@ -122,10 +122,10 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
             }
         }
 
-        private MsDataFileImpl.eIonMobilityUnits Units
+        private eIonMobilityUnits Units
         {
             set { comboBoxIonMobilityUnits.SelectedIndex = (int)value - 1; } // We don't present "none" as an option
-            get { return (MsDataFileImpl.eIonMobilityUnits)comboBoxIonMobilityUnits.SelectedIndex + 1; }
+            get { return (eIonMobilityUnits)comboBoxIonMobilityUnits.SelectedIndex + 1; }
         }
 
         private void UpdateMeasuredDriftTimesControl(IonMobilityPredictor predictor)
@@ -353,7 +353,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
 
         #region Functional test support
 
-        public void SetIonMobilityUnits(MsDataFileImpl.eIonMobilityUnits units)
+        public void SetIonMobilityUnits(eIonMobilityUnits units)
         {
             Units = units;
         }
@@ -518,7 +518,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
             _gridMeasuredDriftTimePeptides = gridMeasuredDriftTimePeptides;
         }
 
-        public Dictionary<LibKey, IonMobilityAndCCS> GetTableMeasuredIonMobility(bool useHighEnergyOffsets, MsDataFileImpl.eIonMobilityUnits units)
+        public Dictionary<LibKey, IonMobilityAndCCS> GetTableMeasuredIonMobility(bool useHighEnergyOffsets, eIonMobilityUnits units)
         {
             var e = new CancelEventArgs();
             var dict = new Dictionary<LibKey, IonMobilityAndCCS>();

--- a/pwiz_tools/Skyline/SkylineTester/TabNightly.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabNightly.cs
@@ -657,8 +657,12 @@ namespace SkylineTester
         {
             CurveItem nearestCurve;
             int index;
-            if (_mouseDownLocation == Point.Empty && sender.GraphPane.FindNearestPoint(new PointF(e.X, e.Y), out nearestCurve, out index))
+            if (_mouseDownLocation == Point.Empty &&
+                sender.GraphPane.FindNearestPoint(new PointF(e.X, e.Y), out nearestCurve, out index))
+            {
                 sender.Cursor = Cursors.Hand;
+                return true;
+            }
             return false;
         }
 

--- a/pwiz_tools/Skyline/Test/Results/MeasuredDriftValuesTest.cs
+++ b/pwiz_tools/Skyline/Test/Results/MeasuredDriftValuesTest.cs
@@ -107,9 +107,9 @@ namespace pwiz.SkylineTest.Results
                 // Check ability to update, and to preserve unchanged
                 var revised = new Dictionary<LibKey, IonMobilityAndCCS>();
                 var libKey = result.Keys.First();
-                revised.Add(libKey, IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(4, MsDataFileImpl.eIonMobilityUnits.drift_time_msec), null, 0.234));  // N.B. CCS handling would require actual raw data in this test, it's covered in a perf test
+                revised.Add(libKey, IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(4, eIonMobilityUnits.drift_time_msec), null, 0.234));  // N.B. CCS handling would require actual raw data in this test, it's covered in a perf test
                 var libKey2 = new LibKey("DEADEELS", asSmallMolecules ? Adduct.NonProteomicProtonatedFromCharge(2) : Adduct.DOUBLY_PROTONATED);
-                revised.Add(libKey2, IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(5, MsDataFileImpl.eIonMobilityUnits.drift_time_msec), null, 0.123));
+                revised.Add(libKey2, IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(5, eIonMobilityUnits.drift_time_msec), null, 0.123));
                 document =
                     document.ChangeSettings(
                         document.Settings.ChangePeptidePrediction(prediction => new PeptidePrediction(null, new IonMobilityPredictor("test", revised, null, null, IonMobilityWindowWidthCalculator.IonMobilityPeakWidthType.resolving_power, 40, 0, 0))));

--- a/pwiz_tools/Skyline/TestA/IonMobilityUnitTest.cs
+++ b/pwiz_tools/Skyline/TestA/IonMobilityUnitTest.cs
@@ -101,7 +101,7 @@ namespace pwiz.SkylineTestA
             Assert.AreEqual(molser, CustomMolecule.FromSerializableString(text));
 
             var dictCCS2 = new Dictionary<LibKey, IonMobilityAndCCS[]>();
-            var ccs3 = new List<IonMobilityAndCCS> { IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(4, MsDataFileImpl.eIonMobilityUnits.drift_time_msec), null, HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC), IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(5, MsDataFileImpl.eIonMobilityUnits.drift_time_msec), null, HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC) }; // Drift times
+            var ccs3 = new List<IonMobilityAndCCS> { IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(4, eIonMobilityUnits.drift_time_msec), null, HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC), IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(5, eIonMobilityUnits.drift_time_msec), null, HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC) }; // Drift times
             const string seq3 = "KLMNJ";
             dictCCS2.Add(new LibKey(seq3, Adduct.SINGLY_PROTONATED), ccs3.ToArray());
             lib.Add(new LibraryIonMobilityInfo("test2", dictCCS2));

--- a/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
@@ -50,7 +50,7 @@ namespace pwiz.SkylineTestFunctional
         const double testRT = 234.56;
         const double testRTWindow = 4.56;
 
-        public static readonly ExplicitTransitionGroupValues TESTVALUES = new ExplicitTransitionGroupValues(1.23, 2.34, -.345, MsDataFileImpl.eIonMobilityUnits.drift_time_msec, 345.6, 4.56, 5.67, 6.78, 7.89); // Using this helps catch untested functionality as we add members
+        public static readonly ExplicitTransitionGroupValues TESTVALUES = new ExplicitTransitionGroupValues(1.23, 2.34, -.345, eIonMobilityUnits.drift_time_msec, 345.6, 4.56, 5.67, 6.78, 7.89); // Using this helps catch untested functionality as we add members
 
         protected override void DoTest()
         {

--- a/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
@@ -61,7 +61,7 @@ namespace pwiz.SkylineTestFunctional
             using (var testFilesDir = new TestFilesDir(TestContext, TestFilesZip))
             {
                 // Make sure we haven't forgotten to update anything if a new IMS type has been added
-                foreach(MsDataFileImpl.eIonMobilityUnits units in Enum.GetValues(typeof(MsDataFileImpl.eIonMobilityUnits)))
+                foreach(eIonMobilityUnits units in Enum.GetValues(typeof(eIonMobilityUnits)))
                 {
                     Assume.IsNotNull(IonMobilityFilter.IonMobilityUnitsL10NString(units));
                 }
@@ -171,7 +171,7 @@ namespace pwiz.SkylineTestFunctional
                 const double resolvingPower = 123.4;
                 RunUI(() =>
                 {
-                    driftTimePredictorDlg.SetIonMobilityUnits(MsDataFileImpl.eIonMobilityUnits.drift_time_msec); 
+                    driftTimePredictorDlg.SetIonMobilityUnits(eIonMobilityUnits.drift_time_msec); 
                     driftTimePredictorDlg.SetResolvingPower(resolvingPower);
                     driftTimePredictorDlg.SetPredictorName(predictorName);
                     SetClipboardText("1\t2\t3\n2\t4\t5"); // Silly values: z=1 s=2 i=3, z=2 s=4 i=5
@@ -285,7 +285,7 @@ namespace pwiz.SkylineTestFunctional
                                deadeelsDTHighEnergyOffset.ToString(CultureInfo.CurrentCulture);
                 RunUI(() =>
                 {
-                    driftTimePredictorDlg3.SetIonMobilityUnits(MsDataFileImpl.eIonMobilityUnits.drift_time_msec); 
+                    driftTimePredictorDlg3.SetIonMobilityUnits(eIonMobilityUnits.drift_time_msec); 
                     driftTimePredictorDlg3.SetResolvingPower(resolvingPower);
                     driftTimePredictorDlg3.SetPredictorName("test3");
                     SetClipboardText("1\t2\t3\n2\t4\t5"); // Silly values: z=1 s=2 i=3, z=2 s=4 i=5
@@ -724,7 +724,7 @@ namespace pwiz.SkylineTestFunctional
             const double resolvingPower = 123.4;
             RunUI(() =>
             {
-                driftTimePredictorDlg.SetIonMobilityUnits(MsDataFileImpl.eIonMobilityUnits.drift_time_msec); 
+                driftTimePredictorDlg.SetIonMobilityUnits(eIonMobilityUnits.drift_time_msec); 
                 driftTimePredictorDlg.SetResolvingPower(resolvingPower);
                 driftTimePredictorDlg.SetPredictorName(predictorName);
                 driftTimePredictorDlg.GetDriftTimesFromResults();
@@ -775,7 +775,7 @@ namespace pwiz.SkylineTestFunctional
             var driftTimePredictorDoomedDlg = ShowDialog<EditDriftTimePredictorDlg>(peptideSettingsDlg.AddDriftTimePredictor);
             RunUI(() =>
             {
-                driftTimePredictorDoomedDlg.SetIonMobilityUnits(MsDataFileImpl.eIonMobilityUnits.drift_time_msec); 
+                driftTimePredictorDoomedDlg.SetIonMobilityUnits(eIonMobilityUnits.drift_time_msec); 
                 driftTimePredictorDoomedDlg.SetResolvingPower(resolvingPower);
                 driftTimePredictorDoomedDlg.SetPredictorName(predictorName+"_doomed");
             });

--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -279,7 +279,7 @@ namespace pwiz.SkylineTestFunctional
                 line1 = BuildTestLine(imTypeIsDrift);
                 var expectedIM = imTypeIsDrift ? precursorDT : compensationVoltage;
                 double? expectedCV = imTypeIsDrift ? (double?)null : compensationVoltage;
-                var expectedTypeIM = imTypeIsDrift ? MsDataFileImpl.eIonMobilityUnits.drift_time_msec : MsDataFileImpl.eIonMobilityUnits.compensation_V;
+                var expectedTypeIM = imTypeIsDrift ? eIonMobilityUnits.drift_time_msec : eIonMobilityUnits.compensation_V;
                 TestError(line1 + line2start.Replace("CH3O", "CH29") + "\t\t1\t\t\t\t\t\t\t\tM+H", String.Empty, fullColumnOrder);
                 var docTest = WaitForDocumentChange(docEmpty);
                 var testTransitionGroups = docTest.MoleculeTransitionGroups.ToArray();
@@ -521,7 +521,7 @@ namespace pwiz.SkylineTestFunctional
 
         private static string BuildTestLine(bool asDriftTime)
         {
-            MsDataFileImpl.eIonMobilityUnits imType = asDriftTime ? MsDataFileImpl.eIonMobilityUnits.drift_time_msec : MsDataFileImpl.eIonMobilityUnits.compensation_V;
+            eIonMobilityUnits imType = asDriftTime ? eIonMobilityUnits.drift_time_msec : eIonMobilityUnits.compensation_V;
             var dtValueStr = asDriftTime ? precursorDT.ToString(CultureInfo.CurrentCulture) : string.Empty;
             var imValueStr = asDriftTime ? precursorDT.ToString(CultureInfo.CurrentCulture) : compensationVoltage.ToString(CultureInfo.CurrentCulture);
             var cvValueStr = asDriftTime ? string.Empty : compensationVoltage.ToString(CultureInfo.CurrentCulture);

--- a/pwiz_tools/Skyline/TestPerf/PerfImportAgilentSpectrumMillRampedIMSTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportAgilentSpectrumMillRampedIMSTest.cs
@@ -442,7 +442,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
 
             CheckFieldByName(documentGrid, "IonMobilityMS1", row, _testCase == 1 ? 18.43 : 23.50, msg);
             CheckFieldByName(documentGrid, "IonMobilityFragment", row, (double?)null, msg); // Document is all precursor
-            CheckFieldByName(documentGrid, "IonMobilityUnits", row, IonMobilityValue.GetUnitsString(MsDataFileImpl.eIonMobilityUnits.drift_time_msec), msg);
+            CheckFieldByName(documentGrid, "IonMobilityUnits", row, IonMobilityValue.GetUnitsString(eIonMobilityUnits.drift_time_msec), msg);
             CheckFieldByName(documentGrid, "IonMobilityWindow", row, expectedDtWindow, msg);
             CheckFieldByName(documentGrid, "CollisionalCrossSection", row, _testCase == 1 ? 292.4 : 333.34, msg);
             // And clean up after ourselves

--- a/pwiz_tools/Skyline/TestPerf/PerfImportResultsAgilentIMSTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportResultsAgilentIMSTest.cs
@@ -113,7 +113,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
              
             var chroms0 = doc0.Settings.MeasuredResults.Chromatograms[chromIndex];
             // Original file was saved before we had a sense of ion mobility type
-            chroms0 = chroms0.ChangeMSDataFileInfos(chroms0.MSDataFileInfos.Select(m => m.ChangeIonMobilityUnits(MsDataFileImpl.eIonMobilityUnits.drift_time_msec)).ToList());
+            chroms0 = chroms0.ChangeMSDataFileInfos(chroms0.MSDataFileInfos.Select(m => m.ChangeIonMobilityUnits(eIonMobilityUnits.drift_time_msec)).ToList());
             var chroms1 = doc1.Settings.MeasuredResults.Chromatograms[chromIndex];
             Assert.AreEqual(StripPathInfo(chroms0), StripPathInfo(chroms1));
 


### PR DESCRIPTION
Found that eIonMobilityUnits being inside MSDataFileImpl caused pwiz_data_cli.dll to be loaded during simple document deserialization. 

Also, committed a fix to mouse-move handling over TabNightly summary graphs. The cursor used to get stuck as a cross and take a long time to update when moved outside the summary graphs. It was driving me a little crazy.