### PR TITLE
* set <preserve-test-targets>off for MSVC debug builds

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -357,6 +357,8 @@ project pwiz
         <variant>debug,<toolset>gcc:<cxxflags>"-include pwiz/utility/misc/Exception.hpp"
         <variant>debug,<toolset>darwin:<cxxflags>"-include pwiz/utility/misc/Exception.hpp"
 
+        <toolset>msvc,<debug-symbols>on:<preserve-test-targets>off # save space on debug builds by deleting test artifacts which run successfully
+
         $(TEAMCITY_TEST_DECORATION)
 
     : build-dir $(PWIZ_BUILD_PATH)

--- a/libraries/boost-build/src/tools/testing.jam
+++ b/libraries/boost-build/src/tools/testing.jam
@@ -571,9 +571,9 @@ rule capture-output ( target : source : properties * )
     }
 }
 
-.types-to-remove = EXE OBJ ;
+.types-to-remove = EXE OBJ PDB ;
 
-local rule remove-test-targets ( target )
+local rule get-test-targets ( target )
 {
     local action = [ on $(target) return $(.action) ] ;
     local associated-targets = [ virtual-target.traverse [ $(action).targets ] ] ;
@@ -585,7 +585,12 @@ local rule remove-test-targets ( target )
             targets-to-remove += [ $(t).actual-name ] ;
         }
     }
-    rmtemp-sources $(target) : $(targets-to-remove) ;
+    return $(targets-to-remove) ;
+}
+
+local rule remove-test-targets ( target )
+{
+    rmtemp-sources $(target) : [ get-test-targets $(target) ] ;
 }
 
 local rule rmtemp-sources ( target : sources * )
@@ -672,6 +677,14 @@ if --verbose-test in [ modules.peek : ARGV ]
 
 .RM = [ common.rm-command ] ;
 
+
+# used to delete test targets for unit-test rule
+rule remove-test-targets-shell ( target )
+{
+    local target-path = [ on $(target) return $(LOCATE) ] ;
+    local result = [ get-test-targets $(target) ] ;
+    result = $(.RM) "$(target-path)/$(result:BS)" ;
+}
 
 actions capture-output bind INPUT_FILES output-file
 {
@@ -792,7 +805,11 @@ rule unit-test ( target : source : properties * )
         ## On VMS set default launcher to MCR
         if [ os.name ] = VMS { LAUNCHER on $(target) = MCR ; }
     }
-}
+
+    if [ feature.get-values preserve-test-targets : $(properties) ] = off
+    {
+        REMOVE_TEST_TARGETS on $(target) = [ remove-test-targets-shell $(target) ] ;
+    }
 
 
 actions unit-test
@@ -804,6 +821,7 @@ actions unit-test
     $(.SET_STATUS)
     if $(.STATUS_0)
       $(.MAKE_FILE) "$(<)"
+      $(REMOVE_TEST_TARGETS)
     $(.ENDIF)
     $(TEST_POSTCOMMAND:E=echo) $(TEST_POSTCOMMAND_OUTPUT)
     exit $(.STATUS)

--- a/libraries/boost-build/src/tools/testing.jam
+++ b/libraries/boost-build/src/tools/testing.jam
@@ -683,7 +683,7 @@ rule remove-test-targets-shell ( target )
 {
     local target-path = [ on $(target) return $(LOCATE) ] ;
     local result = [ get-test-targets $(target) ] ;
-    result = $(.RM) "$(target-path)/$(result:BS)" ;
+    result = $(.RM) [ sequence.transform path.native : "$(target-path)/$(result:BS)" ] ;
 }
 
 actions capture-output bind INPUT_FILES output-file

--- a/libraries/boost-build/src/tools/testing.jam
+++ b/libraries/boost-build/src/tools/testing.jam
@@ -810,6 +810,7 @@ rule unit-test ( target : source : properties * )
     {
         REMOVE_TEST_TARGETS on $(target) = [ remove-test-targets-shell $(target) ] ;
     }
+}
 
 
 actions unit-test


### PR DESCRIPTION
* set <preserve-test-targets>off for MSVC debug builds to save gigs of space taken up by successful test EXE/OBJ/PDBs