### PR TITLE
* fixed Quameter to skip MS2s before the first MS1

### DIFF
--- a/pwiz_tools/Bumbershoot/quameter/quameter.cpp
+++ b/pwiz_tools/Bumbershoot/quameter/quameter.cpp
@@ -779,7 +779,7 @@ namespace quameter
 
                         if (precursor.spectrumID.empty())
                         {
-                            if (lastMS1NativeId)
+                            if (lastMS1NativeId.empty())
                                 continue; // skip MS2s before the first MS1
 
                             scanInfo.precursorNativeID = lastMS1NativeId;

--- a/pwiz_tools/Bumbershoot/quameter/quameter.cpp
+++ b/pwiz_tools/Bumbershoot/quameter/quameter.cpp
@@ -779,6 +779,9 @@ namespace quameter
 
                         if (precursor.spectrumID.empty())
                         {
+                            if (lastMS1NativeId)
+                                continue; // skip MS2s before the first MS1
+
                             scanInfo.precursorNativeID = lastMS1NativeId;
                         }
                         else


### PR DESCRIPTION
* fixed Quameter to skip MS2s before the first MS1 instead of including them in metrics