### PR TITLE
Skyline: fix a problem where manually changing a molecule's chemical …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,9 @@ Reader*Test.data
 SkylineTester Results
 /b64.bat
 /b32.bat
+/BrowseOnly/pwiz.tlog/unsuccessfulbuild
+/BrowseOnly/pwiz.tlog/pwiz.lastbuildstate
+/BrowseOnly/pwiz.tlog/metagen.write.1.tlog
+/BrowseOnly/pwiz.tlog/CL.write.1.tlog
+/BrowseOnly/pwiz.tlog/CL.read.1.tlog
+/BrowseOnly/pwiz.tlog/CL.command.1.tlog

--- a/pwiz_tools/Skyline/Model/DocSettings/TransitionSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/TransitionSettings.cs
@@ -992,7 +992,7 @@ namespace pwiz.Skyline.Model.DocSettings
             PeptideIonTypes = ParseTypes(reader.GetAttribute(ATTR.fragment_types), new[] { IonType.y });
             SmallMoleculePrecursorAdducts = ArrayUtil.Parse(reader.GetAttribute(ATTR.precursor_adducts), Adduct.FromStringAssumeChargeOnly, TextUtil.SEPARATOR_CSV, Transition.DEFAULT_MOLECULE_CHARGES);
             SmallMoleculeFragmentAdducts = ArrayUtil.Parse(reader.GetAttribute(ATTR.product_adducts), Adduct.FromStringAssumeChargeOnly, TextUtil.SEPARATOR_CSV, Transition.DEFAULT_MOLECULE_FRAGMENT_CHARGES);
-            SmallMoleculeIonTypes = ParseSmallMoleculeTypes(reader.GetAttribute(ATTR.small_molecule_fragment_types), Transition.MOLECULE_ION_TYPES);
+            SmallMoleculeIonTypes = ParseSmallMoleculeTypes(reader.GetAttribute(ATTR.small_molecule_fragment_types), Transition.DEFAULT_MOLECULE_FILTER_ION_TYPES);
             FragmentRangeFirstName = reader.GetAttribute(ATTR.fragment_range_first);
             FragmentRangeLastName = reader.GetAttribute(ATTR.fragment_range_last);
             PrecursorMzWindow = reader.GetDoubleAttribute(ATTR.precursor_mz_window);

--- a/pwiz_tools/Skyline/Model/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Transition.cs
@@ -111,7 +111,8 @@ namespace pwiz.Skyline.Model
         public static readonly IonType[] PEPTIDE_ION_TYPES =
             {IonType.y, IonType.b, IonType.z, IonType.c, IonType.x, IonType.a};
         // And its small molecule equivalent
-        public static readonly IonType[] MOLECULE_ION_TYPES = {IonType.custom};
+        public static readonly IonType[] MOLECULE_ION_TYPES = { IonType.custom };
+        public static readonly IonType[] DEFAULT_MOLECULE_FILTER_ION_TYPES = { IonType.custom, IonType.precursor }; // Small molecule users are typically interested in precursors as much or more that fragments
 
         public static readonly int[] PEPTIDE_ION_TYPES_ORDERS;
 

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -138,13 +138,21 @@ namespace pwiz.Skyline.Model
             Assume.IsTrue(IsCustomIon);
             var children = new List<TransitionDocNode>();
             groupNew = groupNew ?? new TransitionGroup(parentNew ?? TransitionGroup.Peptide, TransitionGroup.PrecursorAdduct, TransitionGroup.LabelType, false, TransitionGroup.DecoyMassShift);
+            var nodeGroupTemp = new TransitionGroupDocNode(groupNew, Annotations, settings, null, LibInfo, ExplicitValues, Results, null, false); // Just need this for the revised isotope distribution
             foreach (var nodeTran in Transitions)
             {
                 var transition = nodeTran.Transition;
+                var adduct = transition.IonType == IonType.precursor
+                             ? groupNew.PrecursorAdduct : transition.Adduct;
+                var molecule = transition.IonType == IonType.precursor
+                             ? groupNew.CustomMolecule : transition.CustomIon;
                 var tranNew = new Transition(groupNew, transition.IonType, transition.CleavageOffset,
-                    transition.MassIndex, transition.Adduct, transition.DecoyMassShift, transition.CustomIon);
+                    transition.MassIndex, adduct, transition.DecoyMassShift, molecule);
+                var moleculeMass = transition.IonType == IonType.precursor
+                    ? nodeGroupTemp.IsotopeDist.GetMassI(transition.MassIndex) : nodeTran.GetMoleculeMass();
+
                 var nodeTranNew = new TransitionDocNode(tranNew, nodeTran.Annotations, nodeTran.Losses,
-                    nodeTran.GetMoleculeMass(), nodeTran.QuantInfo, nodeTran.Results);
+                    moleculeMass, nodeTran.QuantInfo, nodeTran.Results);
                 children.Add(nodeTranNew);
             }
             return new TransitionGroupDocNode(groupNew, Annotations, settings, null, LibInfo, ExplicitValues, Results, children.ToArray(), AutoManageChildren);

--- a/pwiz_tools/Skyline/Properties/Settings.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.cs
@@ -2900,7 +2900,7 @@ namespace pwiz.Skyline.Properties
                         new[] { IonType.y }, // PeptideFragmentTypes
                         new[] { Adduct.M_PLUS_H, }, // SmallMoleculePrecursorCharges
                         new[] { Adduct.M_PLUS, }, // SmallMoleculeProductCharges
-                        Transition.MOLECULE_ION_TYPES, // SmallMoleculeFragmentTypes
+                        Transition.DEFAULT_MOLECULE_FILTER_ION_TYPES, // SmallMoleculeFragmentTypes, and precursor
                         TransitionFilter.DEFAULT_START_FINDER,  // FragmentRangeFirst
                         TransitionFilter.DEFAULT_END_FINDER,    // FragmentRangeLast
                         new[] {MeasuredIonList.NTERM_PROLINE},  // MeasuredIon

--- a/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
@@ -26,6 +26,7 @@ using pwiz.ProteowizardWrapper;
 using pwiz.Skyline.Alerts;
 using pwiz.Skyline.Controls.SeqNode;
 using pwiz.Skyline.Model;
+using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.SettingsUI;
 using pwiz.Skyline.Util;
@@ -34,7 +35,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class EditCustomMoleculeDlgTest : AbstractFunctionalTest
+    public class EditCustomMoleculeDlgTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestEditCustomMoleculeDlg()
@@ -54,6 +55,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
+            TestEditWithIsotopeDistribution();
             AsMasses();
             AsFormulas();
             TestEditTransitionNoFormula();
@@ -816,18 +818,140 @@ namespace pwiz.SkylineTestFunctional
                 SetClipboardText(transitionList);
                 SkylineWindow.Paste();
             });
-            // Position ourselves on the second transition
-            SelectNode(SrmDocument.Level.Transitions, 1);
+            VerifyFragmentTransitionMz(186.18633804, 186.18633804, 1);
+        }
+
+        private void VerifyFragmentTransitionMz(double mzMono, double mzAverage, int index)
+        {
+            // Position ourselves on the nth transition
+            SelectNode(SrmDocument.Level.Transitions, index);
             var editMoleculeDlg = ShowDialog<EditCustomMoleculeDlg>(
                 () => SkylineWindow.ModifyTransition((TransitionTreeNode)SkylineWindow.SequenceTree.SelectedNode));
             RunUI(() =>
             {
                 var massPrecisionTolerance = 0.00001;
-                Assert.AreEqual(186.18633804, double.Parse(editMoleculeDlg.FormulaBox.MonoText), massPrecisionTolerance);
-                Assert.AreEqual(186.18633804, double.Parse(editMoleculeDlg.FormulaBox.AverageText), massPrecisionTolerance);
+                Assert.AreEqual(mzMono, double.Parse(editMoleculeDlg.FormulaBox.MonoText), massPrecisionTolerance);
+                Assert.AreEqual(mzAverage, double.Parse(editMoleculeDlg.FormulaBox.AverageText), massPrecisionTolerance);
+            });
+            OkDialog(editMoleculeDlg, editMoleculeDlg.OkDialog);
+        }
+
+        private void VerifyPrecursorTransitionMz(double mz, int index)
+        {
+            // Position ourselves on the nth transition
+            SelectNode(SrmDocument.Level.Transitions, index);
+            RunUI(() =>
+            {
+                var node = (TransitionTreeNode)SkylineWindow.SequenceTree.SelectedNode;
+                var massPrecisionTolerance = 0.00001;
+                Assert.AreEqual(mz, node.DocNode.Mz, massPrecisionTolerance);
+            });
+        }
+
+        /// <summary>
+        /// Test the fix for updating isotope distributions a auto-managed precursors
+        /// </summary>
+        private void TestEditWithIsotopeDistribution()
+        {
+            // Clear out the document
+            RunUI(() =>
+            {
+                SkylineWindow.NewDocument(true);
+                var transitionList =
+                    "Molecule List Name,Precursor Name,Precursor Formula,Precursor Adduct,Precursor m/z,Precursor Charge,Product Name,Product Formula,Product Adduct,Product m/z,Product Charge,Note\n" +
+                    "Cer,Cer 12:0;2/12:0,C24H49NO3,[M-H]1-,398.3639681499,-1,F,C12H22O,[M-H]1-,181.1597889449,-1,\n" +
+                    "Cer,Cer 12:0;2/12:0,C24H49NO3,[M-H]1-,398.3639681499,-1,V',,[M-H]1-,186.1863380499,-1,\n" +
+                    "Cer,Cer 12:0;2/12:0,C24H49NO3,[M2C13-H]1-,,-1,F,C12H22O,[M-H]1-,181.1597889449,-1,\n" +
+                    "Cer,Cer 12:0;2/12:0,C24H49NO3,[M2C13-H]1-,,-1,V',,[M-H]1-,186.1863380499,-1,";
+                SetClipboardText(transitionList);
+                SkylineWindow.Paste();
+            });
+            var doc = WaitForDocumentLoaded();
+            AssertEx.IsDocumentState(doc, null, 1, 1, 2, 4);
+
+            // Use transition filter settings to add isotope distribution
+            var fullScanDlg = ShowTransitionSettings(TransitionSettingsUI.TABS.Filter);
+            // Switch isolation scheme.
+            RunUI(() =>
+            {
+                fullScanDlg.SmallMoleculePrecursorAdducts = "[M+H],[M-H]";
+                fullScanDlg.SmallMoleculeFragmentTypes = "f,p";
+                fullScanDlg.SetAutoSelect = true;
+                fullScanDlg.SelectedTab = TransitionSettingsUI.TABS.FullScan;
+                fullScanDlg.PrecursorIsotopesCurrent = FullScanPrecursorIsotopes.Count;
+                fullScanDlg.Peaks = 3;
+            });
+            OkDialog(fullScanDlg, fullScanDlg.OkDialog);
+            using (new CheckDocumentState(1, 1, 2, 10))
+            {
+                RunUI(() => SkylineWindow.ExpandPrecursors());
+                VerifyPrecursorTransitionMz(398.3639681499, 0); // M
+                VerifyPrecursorTransitionMz(399.367318, 1); // M+1
+                VerifyPrecursorTransitionMz(400.37031047, 2); // M+2
+                VerifyFragmentTransitionMz(186.18633804, 186.18633804, 4); // fragment
+
+                VerifyPrecursorTransitionMz(400.3706782806, 5); // M heavy
+                VerifyPrecursorTransitionMz(401.3740266997, 6); // M+1 heavy
+                VerifyPrecursorTransitionMz(402.376963848659, 7); // M+2 heavy
+                VerifyFragmentTransitionMz(186.18633804, 186.18633804, 9); // fragment
+
+            }
+
+            // Position ourselves on the molecule, then edit its chemical formula
+            SelectNode(SrmDocument.Level.Molecules, 0);
+            var editMoleculeDlg = ShowDialog<EditCustomMoleculeDlg>(
+                () => SkylineWindow.ModifyPeptide());
+            RunUI(() =>
+            {
+                var massPrecisionTolerance = 0.00001;
+                Assert.AreEqual(399.371245, double.Parse(editMoleculeDlg.FormulaBox.MonoText), massPrecisionTolerance);
+                Assert.AreEqual(399.65436, double.Parse(editMoleculeDlg.FormulaBox.AverageText), massPrecisionTolerance);
+                editMoleculeDlg.FormulaBox.Formula = "C24H50NO3"; // Change formula adding another Hydrogen
+                Assert.AreEqual(400.37907, double.Parse(editMoleculeDlg.FormulaBox.MonoText), massPrecisionTolerance);
+                Assert.AreEqual(400.6623, double.Parse(editMoleculeDlg.FormulaBox.AverageText), massPrecisionTolerance);
             });
             OkDialog(editMoleculeDlg, editMoleculeDlg.OkDialog);
 
+            // Verify that this updated all the precursor isotope mz values
+            VerifyPrecursorTransitionMz(399.37179364, 0); // M
+            VerifyPrecursorTransitionMz(400.375144672365, 1); // M+1
+            VerifyPrecursorTransitionMz(401.378138442236, 2); // M+2
+            VerifyFragmentTransitionMz(186.18633804, 186.18633804, 4); // fragment should not change
+
+            VerifyPrecursorTransitionMz(401.3785033156, 5); // M heavy
+            VerifyPrecursorTransitionMz(402.381853413823, 6); // M+1 heavy
+            VerifyPrecursorTransitionMz(403.38479203566, 7); // M+2 heavy
+            VerifyFragmentTransitionMz(186.18633804, 186.18633804, 4); // fragment should not change
+
+
+            // Change the adduct 
+            SelectNode(SrmDocument.Level.TransitionGroups, 0);
+            var editTransitionGroupDlg = ShowDialog<EditCustomMoleculeDlg>(
+                () => SkylineWindow.ModifySmallMoleculeTransitionGroup());
+            RunUI(() =>
+            {
+                var massPrecisionTolerance = 0.00001;
+                Assert.AreEqual(399.37179364, double.Parse(editTransitionGroupDlg.FormulaBox.MonoText), massPrecisionTolerance);
+                Assert.AreEqual(399.655024, double.Parse(editTransitionGroupDlg.FormulaBox.AverageText), massPrecisionTolerance);
+                editTransitionGroupDlg.Adduct = Adduct.M_MINUS_2H;
+                Assert.AreEqual(199.182259, double.Parse(editTransitionGroupDlg.FormulaBox.MonoText), massPrecisionTolerance);
+                Assert.AreEqual(199.323874, double.Parse(editTransitionGroupDlg.FormulaBox.AverageText), massPrecisionTolerance);
+
+            });
+            OkDialog(editTransitionGroupDlg, editTransitionGroupDlg.OkDialog);
+            // Verify that this updated all the precursor isotope mz values
+            VerifyPrecursorTransitionMz(199.182259, 0); // M
+            VerifyPrecursorTransitionMz(199.683934336183, 1); // M+1
+            VerifyPrecursorTransitionMz(200.185431221118, 2); // M+2
+            VerifyFragmentTransitionMz(186.18633804, 186.18633804, 4); // fragment should not change
+
+            // But the heavy adduct wasn't changed, make sure no change to mz
+            VerifyPrecursorTransitionMz(401.3785033156, 5); // M heavy
+            VerifyPrecursorTransitionMz(402.381853413823, 6); // M+1 heavy
+            VerifyPrecursorTransitionMz(403.38479203566, 7); // M+2 heavy
+            VerifyFragmentTransitionMz(186.18633804, 186.18633804, 4); // fragment should not change
+
         }
+
     }
 }


### PR DESCRIPTION
…formula, or its adduct, would not update the mz value of associated precursor transitions.  Also, make "f,p" (fragments and precursors) the default transition filter value for small molecules (formerly just "f").