### PR TITLE
Replace BiblioSpec's mzXML parser with MSData

### DIFF
--- a/pwiz_tools/BiblioSpec/src/mzxmlParser.cpp
+++ b/pwiz_tools/BiblioSpec/src/mzxmlParser.cpp
@@ -2,6 +2,7 @@
 #include "mzxmlParser.h"
 #include "Verbosity.h"
 #include "BlibUtils.h" // For IONMOBILITY_TYPE enum
+#include "pwiz/utility/misc/optimized_lexical_cast.hpp"
 
 #include <cstdlib>
 
@@ -10,306 +11,70 @@ using namespace pwiz::msdata;
 using namespace std;
 
 MzXMLParser::MzXMLParser()
-    : file_(NULL), discardCount_(0), currentSpectrum_(NULL) {
+    : lastIndex_(-1) {
 }
 
 MzXMLParser::~MzXMLParser() {
-    delete file_;
-    delete currentSpectrum_;
 }
 
-void MzXMLParser::startElement(const XML_Char *el, const XML_Char **attr) {
-    if (state_.empty()) {
-        if (isIElement("msRun", el)) {
-            state_.push(MS_RUN_STATE);
-        }
-        return;
-    }
-
-    switch (state_.top()) {
-    case MS_RUN_STATE:
-        if (isIElement("scan", el)) {
-            state_.push(SCAN_STATE);
-            currentSpectrum_ = startSpectrum(attr);
-        }
-        break;
-    case SCAN_STATE:
-        if (isIElement("scan", el)) {
-            abortSpectrum();
-            state_.push(SCAN_STATE);
-            currentSpectrum_ = startSpectrum(attr);
-        } else if (isIElement("precursorMz", el)) {
-            state_.push(PRECURSOR_MZ_STATE);
-            charBuf_.clear();
-
-            string dt(getAttrValue("DT", attr)); // As in SpectrumMill output
-            if (!dt.empty()) {
-                currentSpectrum_->ionMobility = static_cast<float>(atof(dt.c_str()));
-                currentSpectrum_->ionMobilityType = IONMOBILITY_DRIFTTIME_MSEC;
-            }
-            string ccs(getAttrValue("CCS", attr));  // As in SpectrumMill output
-            if (!ccs.empty()) {
-                currentSpectrum_->ccs = static_cast<float>(atof(ccs.c_str()));
-            }
-        } else if (isIElement("peaks", el)) {
-            state_.push(PEAKS_STATE);
-            charBuf_.clear();
-
-            string contentType(getAttrValue("contentType", attr));
-            if (!contentType.empty() && contentType != "m/z-int") {
-                Verbosity::warn("Unsupported content type for peaks: must be m/z-int (spectrum %d)",
-                                currentSpectrum_->id);
-                abortSpectrum();
-                break;
-            }
-
-            string precision = getAttrValue("precision", attr);
-            string byteOrder = getAttrValue("byteOrder", attr);
-            string compression = getAttrValue("compressionType", attr);
-
-            bdeConfig_.precision = (precision == "64")
-                ? BinaryDataEncoder::Precision_64
-                : BinaryDataEncoder::Precision_32;
-            bdeConfig_.byteOrder = (!byteOrder.empty() && byteOrder != "network")
-                ? BinaryDataEncoder::ByteOrder_LittleEndian
-                : BinaryDataEncoder::ByteOrder_BigEndian;
-            bdeConfig_.compression = (compression == "zlib")
-                ? BinaryDataEncoder::Compression_Zlib
-                : BinaryDataEncoder::Compression_None;
-        }
-        break;
-    }
-}
-
-void MzXMLParser::endElement(const XML_Char *el) {
-    if (state_.empty())
-        return;
-
-    switch (state_.top()) {
-    case MS_RUN_STATE:
-        if (isIElement("msRun", el)) {
-            state_.pop();
-        }
-        break;
-    case SCAN_STATE:
-        if (isIElement("scan", el) && currentSpectrum_) {
-            state_.pop();
-
-            spectra_.push_back(currentSpectrum_);
-            currentSpectrum_ = NULL;
-        }
-        break;
-    case PRECURSOR_MZ_STATE:
-        if (isIElement("precursorMz", el)) {
-            state_.pop();
-
-            currentSpectrum_->mz = atof(charBuf_.c_str());
-        }
-        break;
-    case PEAKS_STATE:
-        if (isIElement("peaks", el)) {
-            state_.pop();
-
-            BinaryDataEncoder encoder(bdeConfig_);
-            vector<double> decoded;
-            encoder.decode(charBuf_, decoded);
-            size_t numDecodedPeaks = decoded.size() / 2;
-
-            if (decoded.size() % 2 == 0) {
-                if (currentSpectrum_->numPeaks < 0) {
-                    currentSpectrum_->numPeaks = numDecodedPeaks;
-                } else if (currentSpectrum_->numPeaks != numDecodedPeaks) {
-                    Verbosity::warn("Expected %d peaks for spectrum %d, but found %d",
-                                    currentSpectrum_->numPeaks, currentSpectrum_->id, decoded.size() / 2);
-                    abortSpectrum();
-                    break;
-                }
-            } else {
-                Verbosity::warn("Error reading peaks for spectrum %d", currentSpectrum_->id);
-                abortSpectrum();
-                break;
-            }
-
-            currentSpectrum_->mzs = new double[numDecodedPeaks];
-            currentSpectrum_->intensities = new float[numDecodedPeaks];
-            for (size_t i = 0, j = 0; j < decoded.size(); i++, j += 2) {
-                currentSpectrum_->mzs[i] = decoded[j];
-                currentSpectrum_->intensities[i] = (float)decoded[j + 1];
-            }
-        }
-        break;
-    }
-}
-
-void MzXMLParser::characters(const XML_Char *s, int len) {
-    if (state_.empty())
-        return;
-
-    switch (state_.top()) {
-    case PRECURSOR_MZ_STATE:
-    case PEAKS_STATE:
-        charBuf_.append(s, len);
-        break;
-    }
-}
-
-SpecData* MzXMLParser::startSpectrum(const XML_Char **attr) {
-    SpecData* spectrum = new SpecData();
-    spectrum->id = getIntRequiredAttrValue("num", attr);
-    string rtStr(getAttrValue("retentionTime", attr));
-    double rt;
-    if (sscanf(rtStr.c_str(), "PT%lfS", &rt) > 0) {
-        spectrum->retentionTime = rt / 60;
-    } else if (!rtStr.empty()) {
-        spectrum->retentionTime = atof(rtStr.c_str()) / 60;
-    }
-    string numPeaksStr(getAttrValue("peaksCount", attr));
-    if (!numPeaksStr.empty()) {
-        spectrum->numPeaks = atoi(numPeaksStr.c_str());
-    }
-    return spectrum;
-}
-
-void MzXMLParser::abortSpectrum() {
-    if (!currentSpectrum_) {
-        Verbosity::warn("not aborting non-existent spectrum");
-        return;
-    }
-    delete currentSpectrum_;
-    currentSpectrum_ = NULL;
-    while (!state_.empty() && state_.top() != SCAN_STATE) {
-        state_.pop();
-    }
-    if (!state_.empty() && state_.top() == SCAN_STATE) {
-        state_.pop();
-    } else if (state_.empty()) {
-        Verbosity::error("abortSpectrum called with no scan on stack");
-    }
-}
-
-void MzXMLParser::parseChunk() {
-    if (!file_ || file_->bad()) {
-        throw BlibException(true, "MzXMLParser: filestream error");
-    }
-
-    char buf[65536];
-    file_->read(buf, sizeof(buf));
-    if (!XML_Parse(m_parser_, buf, file_->gcount(), false)) {
-        string error = generateError(getParserError());
-        throw BlibException(true, error.c_str());
-    }
-
-    if (file_->eof()) {
-        delete file_;
-        file_ = NULL;
-        if (!XML_Parse(m_parser_, buf, 0, true)) {
-            string error = generateError(getParserError());
-            throw BlibException(true, error.c_str());
-        }
-    }
-}
-
-bool MzXMLParser::peekSpectrum(SpecData* dst) {
-    if (spectra_.empty() || !dst) {
-        return false;
-    }
-    *dst = *(spectra_.front());
-    return true;
-}
-
-bool MzXMLParser::popSpectrum(SpecData* dst) {
-    if (spectra_.empty()) {
-        return false;
-    }
-    SpecData* src = spectra_.front();
-    if (dst) {
-        *dst = *src;
-    }
-    delete src;
-    spectra_.erase(spectra_.begin());
-    ++discardCount_;
-    return true;
-}
 
 void MzXMLParser::openFile(const char* filename, bool mzSort) {
-    setFileName(filename);
-
-    // Reset variables
-    delete file_;
-    XML_ParserFree(m_parser_);
-    initParser();
-
-    while (!state_.empty()) {
-        state_.pop();
-    }
-    charBuf_.clear();
-    discardCount_ = 0;
-    spectra_.clear();
-    if (currentSpectrum_) {
-        delete currentSpectrum_;
-        currentSpectrum_ = NULL;
-    }
-
-    file_ = new ifstream(filename);
-    if (!file_->good()) {
-        throw BlibException(true, "MzXMLParser: Failed to open file");
-    }
+    filename_ = filename;
+    msd_ = MSDataPtr(new MSDataFile(filename));
 }
 
 bool MzXMLParser::getSpectrum(int identifier, SpecData& returnData, SPEC_ID_TYPE findBy, bool getPeaks) {
-    do {
-        switch (findBy) {
-        case SCAN_NUM_ID:
-            while (!spectra_.empty()) {
-                int current = spectra_.front()->id;
-                if (identifier < current) {
-                    // Already been discarded
-                    return false;
-                } else if (identifier == current) {
-                    peekSpectrum(&returnData);
-                    return true;
-                } else {
-                    popSpectrum();
-                }
-            }
-            break;
-        case INDEX_ID:
-            if (identifier < discardCount_) {
-                // Already been discarded
-                return false;
-            } else if (discardCount_ <= identifier && identifier <= discardCount_ + (int)spectra_.size() - 1) {
-                // In current range
-                while (discardCount_ < identifier) {
-                    popSpectrum();
-                }
-                peekSpectrum(&returnData);
-                return true;
-            }
-            while (popSpectrum());
-            break;
-        case NAME_ID:
-            return getSpectrum("", returnData, getPeaks);
+    size_t index;
+    switch (findBy)
+    {
+        case SCAN_NUM_ID: index = msd_->run.spectrumListPtr->find("scan=" + boost::lexical_cast<string>(identifier)); break;
+        default: index = identifier;  break;
+    }
+
+    if (index >= msd_->run.spectrumListPtr->size()) {
+        Verbosity::error("index %d out of range in mzXML file '%s'", index, filename_.c_str());
+        return false;
+    }
+
+    SpectrumPtr s = msd_->run.spectrumListPtr->spectrum(index, true);
+    returnData.id = s->index;
+    returnData.retentionTime = s->scanList.scans[0].cvParam(MS_scan_start_time).timeInSeconds() / 60;
+    returnData.numPeaks = s->defaultArrayLength;
+
+    if (s->precursors.size() > 0 && s->precursors[0].selectedIons.size() > 0)
+        returnData.mz = s->precursors[0].selectedIons[0].cvParamValueOrDefault(MS_selected_ion_m_z, 0.0);
+
+    if (s->scanList.scans.size() > 0) {
+        CVParam driftTime = s->scanList.scans[0].cvParam(MS_ion_mobility_drift_time);
+        if (!driftTime.empty())
+        {
+            returnData.ionMobility = driftTime.valueAs<float>();
+            returnData.ionMobilityType = IONMOBILITY_DRIFTTIME_MSEC;
         }
-        if (!file_) {
-            // End of file reached and spectrum not found
-            return false;
-        }
-        // Parse more of the file and try again
-        parseChunk();
-    } while (true);
+
+        UserParam ccs = s->scanList.scans[0].userParam("CCS");
+        if (!ccs.empty())
+            returnData.ccs = ccs.valueAs<float>();
+    }
+
+    returnData.mzs = new double[returnData.numPeaks];
+    returnData.intensities = new float[returnData.numPeaks];
+    const auto& mzArray = s->getMZArray()->data;
+    const auto& intensityArray = s->getIntensityArray()->data;
+    for (size_t i = 0; i < returnData.numPeaks; ++i) {
+        returnData.mzs[i] = mzArray[i];
+        returnData.intensities[i] = intensityArray[i];
+    }
+    lastIndex_ = index;
+    return true;
 }
 
-bool MzXMLParser::getSpectrum(string identifier, SpecData& returnData, bool getPeaks) {
-    throw BlibException(false, "Lookup by scan name is not implemented");
+bool MzXMLParser::getSpectrum(string identifier, SpecData& returnData,  bool getPeaks) {
+    return getSpectrum((int) msd_->run.spectrumListPtr->find(identifier), returnData, INDEX_ID, getPeaks);
 }
 
 bool MzXMLParser::getNextSpectrum(SpecData& returnData, bool getPeaks) {
-    while (spectra_.empty()) {
-        if (!file_) {
-            return false;
-        }
-        parseChunk();
-    }
-    popSpectrum(&returnData);
-    return true;
+    bool result = getSpectrum(lastIndex_+1, returnData, INDEX_ID, getPeaks);
+    ++lastIndex_;
+    return result;
 }

--- a/pwiz_tools/BiblioSpec/src/mzxmlParser.h
+++ b/pwiz_tools/BiblioSpec/src/mzxmlParser.h
@@ -1,8 +1,7 @@
 #ifndef MZXML_PARSER_H
 #define MZXML_PARSER_H
 
-#include "pwiz/data/msdata/BinaryDataEncoder.hpp"
-#include "saxhandler.h"
+#include "pwiz/data/msdata/MSDataFile.hpp"
 #include "SpecFileReader.h"
 
 #include <fstream>
@@ -12,15 +11,10 @@
 
 namespace BiblioSpec {
 
-class MzXMLParser : public SAXHandler, public SpecFileReader {
+class MzXMLParser : public SpecFileReader {
 public:
     MzXMLParser();
     virtual ~MzXMLParser();
-
-    // SAXHandler functions
-    virtual void startElement(const XML_Char *el, const XML_Char **attr);
-    virtual void endElement(const XML_Char *el);
-    virtual void characters(const XML_Char *s, int len);
 
     // SpecFileReader functions
     virtual void openFile(const char*, bool mzSort = false);
@@ -30,26 +24,9 @@ public:
     virtual bool getNextSpectrum(SpecData& returnData, bool getPeaks = true);
 
 protected:
-    enum STATE {
-        MS_RUN_STATE,
-        SCAN_STATE,
-        PRECURSOR_MZ_STATE,
-        PEAKS_STATE
-    };
-
-    SpecData* startSpectrum(const XML_Char **attr);
-    void abortSpectrum();
-    void parseChunk();
-    bool peekSpectrum(SpecData* dst);
-    bool popSpectrum(SpecData* dst = NULL);
-
-    std::ifstream* file_;
-    std::stack<STATE> state_;
-    std::string charBuf_;
-    int discardCount_;
-    std::vector<SpecData*> spectra_;
-    SpecData* currentSpectrum_;
-    pwiz::msdata::BinaryDataEncoder::Config bdeConfig_;
+    pwiz::msdata::MSDataPtr msd_;
+    int lastIndex_;
+    std::string filename_;
 };
 
 }


### PR DESCRIPTION
MSData's parser doesn't require mzXML's scans to be in ascending scan number order, and apparently PEAKS' mzXML export is out of order like that.

- added support for non-standard attributes "DT" and "CCS" in SpectrumList_mzXML (from SpectrumMill export)
- made SpectrumList_mzXML::find() work with "scan=xxx" even when vendor format is identifiable so ids are actually vendor nativeIDs, e.g. Thermo "controllerType=0 controllerNumber=1 scan=123"
* replaced BiblioSpec's mzXML parser with MSData