### PR TITLE
Fix SpectrumList_IonMobility bugs

### DIFF
--- a/pwiz/analysis/spectrum_processing/Jamfile.jam
+++ b/pwiz/analysis/spectrum_processing/Jamfile.jam
@@ -157,6 +157,7 @@ run-if-exists SpectrumList_IonMobility_Test.cpp pwiz_analysis_spectrum_processin
     : # args
       [ sequence.transform path.native : $(PWIZ_ROOT_PATH)/pwiz/data/vendor_readers/Agilent/Reader_Agilent_Test.data/ImsSynth_Chrom.d
                                          $(PWIZ_ROOT_PATH)/pwiz/data/vendor_readers/Waters/Reader_Waters_Test.data/HDMSe_Short_noLM.raw
+                                         $(PWIZ_ROOT_PATH)/pwiz/data/vendor_readers/Waters/Reader_Waters_Test.data/MSe_Short.raw
                                          $(PWIZ_ROOT_PATH)/pwiz/data/vendor_readers/Waters/Reader_Waters_Test.data/HDMSe_Short_noLM.mzML
       ]
     : # input-files

--- a/pwiz/analysis/spectrum_processing/SpectrumList_IonMobility_Test.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_IonMobility_Test.cpp
@@ -35,7 +35,7 @@ using namespace pwiz::analysis;
 
 ostream* os_ = 0;
 
-const int EXPECTED_TEST_COUNT = 3;
+const int EXPECTED_TEST_COUNT = 4;
 
 void test(const string& filepath, const ReaderList& readerList, int& testCount)
 {
@@ -71,9 +71,6 @@ void test(const string& filepath, const ReaderList& readerList, int& testCount)
         unit_assert_to_stream(SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec == slim2.getIonMobilityUnits(), failedTests);
         unit_assert_to_stream(slim2.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec), failedTests);
         unit_assert_to_stream(!slim2.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::inverse_reduced_ion_mobility_Vsec_per_cm2), failedTests);
-
-        if (!failedTests.str().empty())
-            throw runtime_error(failedTests.str());
     }
     else if (bal::ends_with(filepath, "HDMSe_Short_noLM.raw"))
     {
@@ -91,22 +88,27 @@ void test(const string& filepath, const ReaderList& readerList, int& testCount)
         unit_assert_to_stream(SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec == slim2.getIonMobilityUnits(), failedTests);
         unit_assert_to_stream(slim2.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec), failedTests);
         unit_assert_to_stream(!slim2.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::inverse_reduced_ion_mobility_Vsec_per_cm2), failedTests);
-
-        if (!failedTests.str().empty())
-            throw runtime_error(failedTests.str());
+    }
+    else if (bal::ends_with(filepath, "MSe_Short.raw"))
+    {
+        unit_assert_to_stream(!slim.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec), failedTests);
+        unit_assert_to_stream(!slim.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::inverse_reduced_ion_mobility_Vsec_per_cm2), failedTests);
     }
     else if (bal::ends_with(filepath, "HDMSe_Short_noLM.mzML"))
     {
-        unit_assert_to_stream(SpectrumList_IonMobility::IonMobilityUnits::none == slim.getIonMobilityUnits(), failedTests);
+        unit_assert_operator_equal_to_stream((int) SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec, (int) slim.getIonMobilityUnits(), failedTests);
         unit_assert_to_stream(!slim.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec), failedTests);
         unit_assert_to_stream(!slim.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::inverse_reduced_ion_mobility_Vsec_per_cm2), failedTests);
-
-        unit_assert_to_stream(SpectrumList_IonMobility::IonMobilityUnits::none == slim2.getIonMobilityUnits(), failedTests);
+        
+        unit_assert_operator_equal_to_stream((int) SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec, (int) slim2.getIonMobilityUnits(), failedTests);
         unit_assert_to_stream(!slim2.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::drift_time_msec), failedTests);
         unit_assert_to_stream(!slim2.canConvertIonMobilityAndCCS(SpectrumList_IonMobility::IonMobilityUnits::inverse_reduced_ion_mobility_Vsec_per_cm2), failedTests);
     }
     else
         throw runtime_error("Unhandled test file: " + filepath);
+
+    if (!failedTests.str().empty())
+        throw runtime_error(failedTests.str());
 
     ++testCount;
 }

--- a/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
+++ b/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
@@ -281,7 +281,7 @@ PWIZ_API_DECL bool SpectrumList_Waters::hasIonMobility() const
 
 PWIZ_API_DECL bool SpectrumList_Waters::canConvertIonMobilityAndCCS() const
 {
-    return true;
+    return rawdata_->HasCcsCalibration();
 }
 
 PWIZ_API_DECL double SpectrumList_Waters::ionMobilityToCCS(double ionMobility, double mz, int charge) const

--- a/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
@@ -191,6 +191,11 @@ struct PWIZ_API_DECL RawData
         return Info.GetDriftTime(functionIndex, driftBin);
     }
 
+    bool HasCcsCalibration() const
+    {
+        return bfs::exists(rawpath_ + "/mob_cal.csv");
+    }
+
     float DriftTimeToCCS(float driftTime, float mass, int charge) const
     {
         return Info.GetCollisionalCrossSection(driftTime, mass, charge);

--- a/pwiz_tools/MSConvertGUI/MainForm.cs
+++ b/pwiz_tools/MSConvertGUI/MainForm.cs
@@ -1031,7 +1031,7 @@ namespace MSConvertGUI
             setToolTip(this.ChargeStatesLow, "Lowest charge state (or possible charge state) for scans to be included in the conversion.", "Subset");
             setToolTip(this.ChargeStatesHigh, "Highest charge state (or possible charge state) for scans to be included in the conversion (may be left blank).", "Subset");
             setToolTip(this.DefaultArrayLengthLabel, "Use this filter to exclude scans with too few or too many data points (or peaks for centroid scans).", "Subset");
-            setToolTip(this.DefaultArrayLengthLow, "Lowest number of data points (or pekas for centroid scans) for scans to be included in the conversion.", "Subset");
+            setToolTip(this.DefaultArrayLengthLow, "Lowest number of data points (or peaks for centroid scans) for scans to be included in the conversion.", "Subset");
             setToolTip(this.DefaultArrayLengthHigh, "Highest number of data points (or peaks for centroid scans) for scans to be included in the conversion (may be left blank).", "Subset");
             setToolTip(this.ScanNumberLabel, "Use this filter to include only scans with a limited range of scan numbers.", "Subset");
             setToolTip(this.ScanNumberHigh, "Highest scan number to include in the conversion (may be left blank).", "Subset");


### PR DESCRIPTION
* added `WaterRawFile::HasCcsCalibration()` 
- fixed `SpectrumList_Waters::canConvertIonMobilityAndCCS()` to only return true if `WaterRawFile::HasCcsCalibration()` does
* fixed some SpectrumList_IonMobility_Test tests not actually being enforced
* fixed typo in MSConvertGUI tooltip