### PR TITLE
Investigate making "inputs.tar.bz2" managed by Git Large File Service.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 #  .gitattributes for pwiz
-
 # Don't change line endings on potentially indexed mass spec data
 *.mzml binary
 *.mzxml binary
+pwiz_tools/BiblioSpec/tests/inputs.tar.bz2 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This change makes it so that the file "pwiz_tools/BiblioSpec/tests/inputs.tar.bz2" gets managed by **git lfs**. That file is 54MB and has a long revision history.
If you do not have the **git lfs** extension installed, then instead of getting the big file, you will just get a tiny text file that looks like this:
`version https://git-lfs.github.com/spec/v1
oid sha256:eaa9e8cb1ec77ee1c24e04f14e3c35b55b51fe0f97347d562a5ffa6ed20f9768
size 55884441`

I assume this change will not pass on TeamCity, since I imagine it does not have **git lfs** installed, but I wanted us to start thinking about using git lfs for our larger files.