### PR TITLE
Skyline: prevent an occasionally seen out-of-range exception thrown b…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -322,7 +322,12 @@ namespace pwiz.Skyline.Controls.Graphs
         {
             // Update overall progress bar.
             if (_partialProgressList.Count == 0)
-                progressBarTotal.Value = status.PercentComplete;
+            {
+                if (status.PercentComplete >= 0) // -1 value means "unknown" (possible if we are mid-completion). Just leave things alone in that case.
+                {
+                    progressBarTotal.Value = status.PercentComplete;
+                }
+            }
             else
             {
                 int percentComplete = 0;


### PR DESCRIPTION
…y System.Windows.Forms.ProgressBar.set_Value() when passed -1 (meaning "unknown") which can during wrap up of a large file import operation.