### PR TITLE
Drift Time & CCS fixes

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -3474,11 +3474,11 @@ namespace pwiz.Skyline.Model.DocSettings
             return ChangeProp(ImClone(this), im => im.IonMobilityLibrary = prop);
         }
 
-        public IonMobilityPredictor ChangeMeasuredIonMobilityValuesFromResults(SrmDocument document, string documentFilePath, IProgressMonitor progressMonitor = null)
+        public IonMobilityPredictor ChangeMeasuredIonMobilityValuesFromResults(SrmDocument document, string documentFilePath, bool useHighEnergyOffset, IProgressMonitor progressMonitor = null)
         {
             // Overwrite any existing measurements with newly derived ones
             Dictionary<LibKey, IonMobilityAndCCS> measured;
-            using (var finder = new IonMobilityFinder(document, documentFilePath, progressMonitor))
+            using (var finder = new IonMobilityFinder(document, documentFilePath, progressMonitor) {UseHighEnergyOffset = useHighEnergyOffset})
             {
                 measured = finder.FindIonMobilityPeaks(); // Returns null on cancel
             }

--- a/pwiz_tools/Skyline/Model/Results/IonMobilityFinder.cs
+++ b/pwiz_tools/Skyline/Model/Results/IonMobilityFinder.cs
@@ -70,6 +70,8 @@ namespace pwiz.Skyline.Model.Results
             _progressMonitor = progressMonitor;
         }
 
+        public bool UseHighEnergyOffset { get; set; }
+
         /// <summary>
         /// Looks through the result and finds ion mobility values.
         /// Note that this method only returns new values that were found in results.
@@ -221,7 +223,10 @@ namespace pwiz.Skyline.Model.Results
             // Determine apex RT for DT measurement using most intense MS1 peak
             var apexRT = GetApexRT(nodeGroup, resultIndex, chromFileInfo, true) ??
                 GetApexRT(nodeGroup, resultIndex, chromFileInfo, false);
-
+            if (!apexRT.HasValue)
+            {
+                return true;
+            }
             Assume.IsTrue(chromInfo.PrecursorMz.CompareTolerant(pair.NodeGroup.PrecursorMz, 1.0E-9f) == 0 , "mismatch in precursor values"); // Not L10N
             // Only use the transitions currently enabled
             var transitionPointSets = chromInfo.TransitionPointSets.Where(
@@ -353,7 +358,7 @@ namespace pwiz.Skyline.Model.Results
                 ms1IonMobilityBest = IonMobilityValue.EMPTY;
             }
 
-            const int maxHighEnergyDriftOffsetMsec = 2; // CONSIDER(bspratt): user definable? or dynamically set by looking at scan to scan drift delta? Or resolving power?
+            double maxHighEnergyDriftOffsetMsec = UseHighEnergyOffset ? 2 : 0; // CONSIDER(bspratt): user definable? or dynamically set by looking at scan to scan drift delta? Or resolving power?
             foreach (var scan in _msDataFileScanHelper.MsDataSpectra.Where(scan => scan != null))
             {
                 if (!scan.IonMobility.HasValue || !scan.Mzs.Any())

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/EditDriftTimePredictorDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/EditDriftTimePredictorDlg.cs
@@ -435,7 +435,8 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
             try
             {
                 var driftTable = new MeasuredDriftTimeTable(gridMeasuredDriftTimes);
-                var tempDriftTimePredictor = new IonMobilityPredictor("tmp", driftTable.GetTableMeasuredIonMobility(cbOffsetHighEnergySpectra.Checked, Units), null, null, IonMobilityWindowWidthCalculator.IonMobilityPeakWidthType.resolving_power, 30, 0, 0); // Not L10N
+                bool useHighEnergyOffset = cbOffsetHighEnergySpectra.Checked;
+                var tempDriftTimePredictor = new IonMobilityPredictor("tmp", driftTable.GetTableMeasuredIonMobility(useHighEnergyOffset, Units), null, null, IonMobilityWindowWidthCalculator.IonMobilityPeakWidthType.resolving_power, 30, 0, 0); // Not L10N
                 using (var longWaitDlg = new LongWaitDlg
                 {
                     Text = Resources.EditDriftTimePredictorDlg_GetDriftTimesFromResults_Finding_ion_mobility_values_for_peaks,
@@ -445,7 +446,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
                 {
                     longWaitDlg.PerformWork(this, 100, broker =>
                     {
-                        tempDriftTimePredictor = tempDriftTimePredictor.ChangeMeasuredIonMobilityValuesFromResults(Program.MainWindow.Document, Program.MainWindow.DocumentFilePath, broker);
+                        tempDriftTimePredictor = tempDriftTimePredictor.ChangeMeasuredIonMobilityValuesFromResults(Program.MainWindow.Document, Program.MainWindow.DocumentFilePath, useHighEnergyOffset, broker);
                     });
                     if (!longWaitDlg.IsCanceled && tempDriftTimePredictor != null)
                     {

--- a/pwiz_tools/Skyline/Test/Results/MeasuredDriftValuesTest.cs
+++ b/pwiz_tools/Skyline/Test/Results/MeasuredDriftValuesTest.cs
@@ -96,7 +96,7 @@ namespace pwiz.SkylineTest.Results
 
                 // Verify ability to extract predictions from raw data
                 var newPred = document.Settings.PeptideSettings.Prediction.IonMobilityPredictor.ChangeMeasuredIonMobilityValuesFromResults(
-                        document, docContainer.DocumentFilePath);
+                        document, docContainer.DocumentFilePath, true);
                 var result = newPred.MeasuredMobilityIons;
                 Assert.AreEqual(TestSmallMolecules ? 2 : 1, result.Count);
                 const double expectedDT = 4.0019;
@@ -115,7 +115,7 @@ namespace pwiz.SkylineTest.Results
                         document.Settings.ChangePeptidePrediction(prediction => new PeptidePrediction(null, new IonMobilityPredictor("test", revised, null, null, IonMobilityWindowWidthCalculator.IonMobilityPeakWidthType.resolving_power, 40, 0, 0))));
                 newPred = document.Settings.PeptideSettings.Prediction.ChangeDriftTimePredictor(
                     document.Settings.PeptideSettings.Prediction.IonMobilityPredictor.ChangeMeasuredIonMobilityValuesFromResults(
-                        document, docContainer.DocumentFilePath)).IonMobilityPredictor;
+                        document, docContainer.DocumentFilePath, true)).IonMobilityPredictor;
                 result = newPred.MeasuredMobilityIons;
                 Assert.AreEqual(TestSmallMolecules ? 3 : 2, result.Count);
                 Assert.AreEqual(expectedDT, result[libKey].IonMobility.Mobility.Value, .001);

--- a/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
@@ -751,6 +751,7 @@ namespace pwiz.SkylineTestFunctional
                 driftTimePredictorDlg.SetIonMobilityUnits(eIonMobilityUnits.drift_time_msec); 
                 driftTimePredictorDlg.SetResolvingPower(resolvingPower);
                 driftTimePredictorDlg.SetPredictorName(predictorName);
+                driftTimePredictorDlg.SetOffsetHighEnergySpectraCheckbox(true);
                 driftTimePredictorDlg.GetDriftTimesFromResults();
                 driftTimePredictorDlg.OkDialog();
             });

--- a/pwiz_tools/Topograph/TopographTestProject/ChromatogramGeneratorTest.cs
+++ b/pwiz_tools/Topograph/TopographTestProject/ChromatogramGeneratorTest.cs
@@ -34,8 +34,7 @@ namespace pwiz.Topograph.Test
     [TestClass]
     public class ChromatogramGeneratorTest : BaseTest
     {
-        // TODO(nicksh): Re-enable this test when I can get it to pass again.
-        //[TestMethod]
+        [TestMethod]
         public void TestChromatogramGenerator()
         {
             String dbPath = Path.Combine(TestContext.TestDir, "test" + Guid.NewGuid() + ".tpg");

--- a/pwiz_tools/Topograph/TopographTestProject/ChromatogramGeneratorTest.cs
+++ b/pwiz_tools/Topograph/TopographTestProject/ChromatogramGeneratorTest.cs
@@ -34,7 +34,8 @@ namespace pwiz.Topograph.Test
     [TestClass]
     public class ChromatogramGeneratorTest : BaseTest
     {
-        [TestMethod]
+        // TODO(nicksh): Re-enable this test when I can get it to pass again.
+        //[TestMethod]
         public void TestChromatogramGenerator()
         {
             String dbPath = Path.Combine(TestContext.TestDir, "test" + Guid.NewGuid() + ".tpg");


### PR DESCRIPTION
1. Fix InvalidOperationException when "apexRT" does not have a value (in "IonMobilityFinder.ProcessChromInfo").

2. When doing "use results" on "EditDriftTimePredictorDlg", pay attention to whether "Use high energy offset" is checked. If it's not checked, then always use 0 for the high energy offset.