### PR TITLE
Fix problem reading Thermo raw files that have scans with multiple pr…

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -1826,8 +1826,8 @@ vector<double> RawFileImpl::getIsolationWidths(long scanNumber) const
     if ((int) msOrder == 1)
         return isolationWidths;
 
-    long numMSOrders = (int) msOrder > 0 ? msOrder-1 : 0;
-    for (long i = 0; i < numMSOrders; i++)
+	long massCount = filter->MassCount;
+    for (long i = 0; i < massCount; i++)
     {
         isolationWidths.push_back(filter->GetIsolationWidth(i));
     }

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -1826,7 +1826,7 @@ vector<double> RawFileImpl::getIsolationWidths(long scanNumber) const
     if ((int) msOrder == 1)
         return isolationWidths;
 
-	long massCount = filter->MassCount;
+    long massCount = filter->MassCount;
     for (long i = 0; i < massCount; i++)
     {
         isolationWidths.push_back(filter->GetIsolationWidth(i));


### PR DESCRIPTION
There is a .raw file here which cannot be opened by current builds of ProteoWizard.
https://skyline.ms/announcements/home/support/download.view?entityId=c482aa73-aebe-1036-8cc6-e465a393e3d4&name=Skyline_share_topdown_prm.zip

The existing code does not make sense. It appears that "msOrder" is the MS level, and I would not expect that to be equal to the number of isolation windows.

This change fixes the problem but I have not run any unit tests yet.