### PR TITLE
Skyline: Disable system heap walking for perf tests to see if it fixe…

### DIFF
--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -82,6 +82,11 @@ namespace TestRunnerLib
         public bool RunsSmallMoleculeVersions { get; set; }
         public bool LiveReports { get; set; }
 
+        public bool ReportSystemHeaps
+        {
+            get { return !RunPerfTests; }   // 12-hour perf runs get much slower with system heap reporting
+        }
+
         public static readonly List<LeakingTest> LeakingTestList = new List<LeakingTest>
         {
             new LeakingTest("TestDocumentSizeError", 15),
@@ -270,7 +275,7 @@ namespace TestRunnerLib
 
             MemoryManagement.FlushMemory();
             _process.Refresh();
-            var heapCounts = MemoryManagement.GetProcessHeapSizes();
+            var heapCounts = ReportSystemHeaps ? MemoryManagement.GetProcessHeapSizes() : new MemoryManagement.HeapAllocationSizes[1];
             var processBytes = heapCounts[0].Committed; // Process heap : useful for debugging - though included in committed bytes
             var managedBytes = GC.GetTotalMemory(true); // Managed heap
             var committedBytes = heapCounts.Sum(h => h.Committed);
@@ -316,7 +321,9 @@ namespace TestRunnerLib
             if (exception == null)
             {
                 // Test succeeded.
-                Log("{0,3} failures, {1:F2}/{2:F2}/{3:F1} MB, {4}/{5} handles, {6} sec.\r\n",
+                Log(ReportSystemHeaps
+                        ? "{0,3} failures, {1:F2}/{2:F2}/{3:F1} MB, {4}/{5} handles, {6} sec.\r\n"
+                        : "{0,3} failures, {1:F2}/{3:F1} MB, {4}/{5} handles, {6} sec.\r\n",
                     FailureCount, 
                     ManagedMemory,
                     CommittedMemory,


### PR DESCRIPTION
…s losses in nightly run counts