### PR TITLE
Memory dump fixes

### DIFF
--- a/pwiz_tools/Skyline/TestRunnerLib/MiniDump.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/MiniDump.cs
@@ -55,7 +55,7 @@ namespace TestRunnerLib
             MiniDumpValidTypeFlags = 0x007fffff
         };
 
-        [DllImport(@"Dbghelp.dll")]
+        [DllImport(@"Dbghelp.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.I1)]
         private static extern bool MiniDumpWriteDump(IntPtr hProcess, uint ProcessId, IntPtr hFile, MINIDUMP_TYPE DumpType, IntPtr ExceptionParam, IntPtr UserStreamParam, IntPtr CallbackParam);
 


### PR DESCRIPTION
- now mini dump names contain the test name, test number, pass, language and timestamp
- mini dumps are now stored in the same directory as the log file, that way they are not deleted after multiple nightly runs