### PR TITLE
Fix implementation of "FullScanAcquisitionMethod.ToString()" so that …

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/FullScanAcquisitionMethod.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/FullScanAcquisitionMethod.cs
@@ -69,7 +69,7 @@ namespace pwiz.Skyline.Model.DocSettings
 
         public override string ToString()
         {
-            return Label;
+            return Name;
         }
 
         public static FullScanAcquisitionMethod FromName(string name)


### PR DESCRIPTION
…it always returns the invariant string.

This fixes a potential problem in SerializeTransitionFullScanTest.