### PR TITLE
Waters/UNIFI MS^e low and high energy as MS1 and MS2

### DIFF
--- a/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI.cpp
+++ b/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI.cpp
@@ -113,7 +113,7 @@ void fillInMetadata(const string& sampleResultUrl, MSData& msd, const UnifiDataP
     //if (cl) cl->setDataProcessingPtr(dpPwiz);
 
     InstrumentConfigurationPtr ic(new InstrumentConfiguration("IC1"));
-    ic->set(MS_instrument_model);
+    ic->set(MS_Waters_instrument_model);
     ic->softwarePtr = acquisitionSoftware;
     msd.instrumentConfigurationPtrs.push_back(ic);
     msd.run.defaultInstrumentConfigurationPtr = ic;

--- a/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI_Detail.cpp
+++ b/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI_Detail.cpp
@@ -144,11 +144,11 @@ PWIZ_API_DECL CVID translate(Polarity polarity)
 {
     switch (polarity)
     {
-        case Positive:
+        case Polarity::Positive:
             return MS_positive_scan;
-        case Negative:
+        case Polarity::Negative:
             return MS_negative_scan;
-        case Unknown:
+        case Polarity::Unknown:
         default:
             return CVID_Unknown;
     }

--- a/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI_Test.data/08Mar17_HDMSe_25fmolMix1_01-combineIMS.mzML
+++ b/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI_Test.data/08Mar17_HDMSe_25fmolMix1_01-combineIMS.mzML
@@ -16,13 +16,13 @@
     <software id="UNIFI" version="1.0">
       <cvParam cvRef="MS" accession="MS:1001796" name="UNIFY" value=""/>
     </software>
-    <software id="pwiz_Reader_UNIFI" version="3.0.18255">
+    <software id="pwiz_Reader_UNIFI" version="3.0.18278">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
   <instrumentConfigurationList count="1">
     <instrumentConfiguration id="IC1">
-      <cvParam cvRef="MS" accession="MS:1000031" name="instrument model" value=""/>
+      <cvParam cvRef="MS" accession="MS:1000126" name="Waters instrument model" value=""/>
       <softwareRef ref="UNIFI"/>
     </instrumentConfiguration>
   </instrumentConfigurationList>
@@ -47,8 +47,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.103210449219" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.847534179688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -69,8 +69,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="1" id="scan=2" defaultArrayLength="93141">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -80,12 +80,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.561305999756" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.4951171875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="262516">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>

--- a/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI_Test.data/08Mar17_HDMSe_25fmolMix1_01.mzML
+++ b/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI_Test.data/08Mar17_HDMSe_25fmolMix1_01.mzML
@@ -16,13 +16,13 @@
     <software id="UNIFI" version="1.0">
       <cvParam cvRef="MS" accession="MS:1001796" name="UNIFY" value=""/>
     </software>
-    <software id="pwiz_Reader_UNIFI" version="3.0.18255">
+    <software id="pwiz_Reader_UNIFI" version="3.0.18278">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
   <instrumentConfigurationList count="1">
     <instrumentConfiguration id="IC1">
-      <cvParam cvRef="MS" accession="MS:1000031" name="instrument model" value=""/>
+      <cvParam cvRef="MS" accession="MS:1000126" name="Waters instrument model" value=""/>
       <softwareRef ref="UNIFI"/>
     </instrumentConfiguration>
   </instrumentConfigurationList>
@@ -34,7 +34,7 @@
     </dataProcessing>
   </dataProcessingList>
   <run id="_x0030_8Mar17_HDMSe_25fmolMix1_01" defaultInstrumentConfigurationRef="IC1" startTimeStamp="2017-03-08T10:06:51Z" defaultSourceFileRef="UNIFI">
-    <spectrumList count="800" defaultDataProcessingRef="pwiz_Reader_UNIFI_conversion">
+    <spectrumList count="402" defaultDataProcessingRef="pwiz_Reader_UNIFI_conversion">
       <spectrum index="0" id="scan=1" defaultArrayLength="8">
         <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
         <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
@@ -48,8 +48,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="145.667816162109" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="158.906478881836" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -82,8 +82,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="117.354911804199" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="117.359046936035" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -114,6 +114,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.3" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -142,6 +148,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.4" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -172,8 +184,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="73.804229736328" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="182.866775512695" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -204,6 +216,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.6" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -232,6 +250,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.7" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -262,8 +286,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="140.147766113281" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="229.720260620117" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -296,8 +320,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="104.279777526855" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="216.408416748047" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -328,6 +352,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.0" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -358,8 +388,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="123.733390808105" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="158.892059326172" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -390,6 +420,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.2" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -420,8 +456,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="132.837783813477" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="201.944732666016" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -452,6 +488,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.4" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -482,8 +524,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="68.971092224121" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="68.974258422852" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -516,8 +558,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="144.026382446289" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="202.812683105469" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -550,8 +592,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="176.516754150391" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="176.521820068359" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -584,8 +626,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1739.39111328125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1739.407104492188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -618,8 +660,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1743.655883789063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1743.671752929688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -652,8 +694,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="227.000442504883" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="227.006195068359" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -686,8 +728,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="178.146759033203" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="178.151840209961" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -718,6 +760,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.2" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -746,6 +794,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.3" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -774,6 +828,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.4" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -804,8 +864,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="221.461853027344" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="221.467514038086" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -836,6 +896,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.6" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -864,6 +930,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.7" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -892,6 +964,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.8" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -920,6 +998,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.9" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -948,6 +1032,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.0" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -976,6 +1066,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.1" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -1006,8 +1102,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="134.490997314453" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="134.495422363281" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1038,6 +1134,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.3" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -1066,6 +1168,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.4" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -1094,6 +1202,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.5" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -1124,8 +1238,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="287.903625488281" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1933.543212890625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1156,6 +1270,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.7" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -1186,8 +1306,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="205.300170898438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="288.859832763672" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1220,8 +1340,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1680.98388671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1680.99951171875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1252,6 +1372,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="4.0" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -1282,8 +1408,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="285.235534667969" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="474.221588134766" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1316,8 +1442,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="298.928680419922" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="386.820770263672" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1348,6 +1474,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="4.3" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -1378,8 +1510,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="206.509414672852" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="448.799530029297" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1412,8 +1544,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="255.937026977539" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="673.783386230469" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1446,8 +1578,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="359.957946777344" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="417.78271484375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1480,8 +1612,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="182.662292480469" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="446.857513427734" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1514,8 +1646,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="274.3125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="818.960632324219" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1548,8 +1680,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="231.886871337891" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1303.162841796875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1582,8 +1714,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="214.833160400391" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="784.626708984375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1616,8 +1748,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="199.874649047852" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="694.970825195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1650,8 +1782,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="153.434539794922" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="986.493408203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1684,8 +1816,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="238.820770263672" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1073.4892578125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1718,8 +1850,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="232.902206420898" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1097.43408203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1752,8 +1884,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="201.847213745117" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1078.383911132813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1786,8 +1918,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="168.749801635742" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1085.369995117188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1820,8 +1952,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="131.033248901367" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1266.320190429688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1854,8 +1986,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="98.99430847168" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1194.41748046875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1888,8 +2020,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="98.999366760254" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1586.87255859375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1922,8 +2054,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="174.993438720703" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1389.194458007813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1956,8 +2088,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="178.000885009766" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1390.521362304688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -1990,8 +2122,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="174.98503112793" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1381.317749023438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2024,8 +2156,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="51.723892211914" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1520.155151367188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2058,8 +2190,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="98.995574951172" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1898.408813476563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2092,8 +2224,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="215.013900756836" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1569.270751953125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2126,8 +2258,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="114.001541137695" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1560.340942382813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2160,8 +2292,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="165.022476196289" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.716430664063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2194,8 +2326,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="191.590118408203" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1804.304321289063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2228,8 +2360,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="242.04118347168" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1618.216186523438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2262,8 +2394,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="177.460327148438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1575.101928710938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2296,8 +2428,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="60.19649887085" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1804.909057617188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2330,8 +2462,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="70.431259155273" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1797.162963867188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2364,8 +2496,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="207.033981323242" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1836.250854492188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2398,8 +2530,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="78.364959716797" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1860.14111328125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2432,8 +2564,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="202.269989013672" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1948.046264648438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2466,8 +2598,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="80.047065734863" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1946.86279296875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2500,8 +2632,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="96.514846801758" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1841.243408203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2534,8 +2666,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="74.061065673828" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.25634765625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2568,8 +2700,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="70.883209228516" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1959.378295898438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2602,8 +2734,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="144.119445800781" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1973.119384765625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2636,8 +2768,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="66.371810913086" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1954.076171875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2670,8 +2802,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="163.081878662109" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.0947265625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2704,8 +2836,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="106.542633056641" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1996.11474609375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2738,8 +2870,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="61.913677215576" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.148315429688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2772,8 +2904,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="205.551574707031" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1996.080688476563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2806,8 +2938,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.152751922607" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.244995117188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2840,8 +2972,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="174.187286376953" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1997.244995117188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2874,8 +3006,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="201.376159667969" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1990.235717773438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2908,8 +3040,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="192.476104736328" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1988.285522460938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2942,8 +3074,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="221.076141357422" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.435180664063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -2976,8 +3108,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="63.854942321777" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1980.194580078125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3010,8 +3142,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="73.497703552246" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1984.082275390625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3044,8 +3176,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="208.024597167969" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.9052734375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3078,8 +3210,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="209.037780761719" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1991.279296875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3112,8 +3244,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="53.532997131348" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1988.540649414063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3146,8 +3278,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="76.106307983398" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1981.190185546875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3180,8 +3312,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.103210449219" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1992.60107421875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3214,8 +3346,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="54.81090927124" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1979.900512695313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3248,8 +3380,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="55.258808135986" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1984.546630859375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3282,8 +3414,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="68.319221496582" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1932.257934570313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3316,8 +3448,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="61.243404388428" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.138916015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3350,8 +3482,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="51.14958190918" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1985.747192382813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3384,8 +3516,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="51.941688537598" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1966.180786132813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3418,8 +3550,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="74.457572937012" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1945.769287109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3452,8 +3584,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="54.283325195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1978.30029296875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3486,8 +3618,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="60.890789031982" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1967.116577148438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3520,8 +3652,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="51.554000854492" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1976.175048828125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3554,8 +3686,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="56.362201690674" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.264892578125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3588,8 +3720,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="67.038284301758" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1928.655883789063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3622,8 +3754,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="67.202812194824" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.775756835938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3656,8 +3788,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.253574371338" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1968.464111328125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3690,8 +3822,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="85.071556091309" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1985.939819335938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3724,8 +3856,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="67.090324401855" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.796264648438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3758,8 +3890,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="53.900043487549" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.4794921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3792,8 +3924,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="155.546813964844" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.443725585938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3826,8 +3958,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="68.28980255127" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.091430664063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3860,8 +3992,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="88.150588989258" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.88916015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3894,8 +4026,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="55.437534332275" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.6611328125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3928,8 +4060,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="263.330413818359" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.38134765625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3962,8 +4094,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="92.846656799316" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.011962890625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -3996,8 +4128,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="68.702178955078" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.790649414063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4030,8 +4162,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="57.959327697754" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1997.352905273438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4064,8 +4196,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="55.831932067871" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.610107421875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4098,8 +4230,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="191.847076416016" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.892700195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4132,8 +4264,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="147.749298095703" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1995.274291992188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4166,8 +4298,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="297.171020507813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.472290039063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4200,8 +4332,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="87.471672058105" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1989.41357421875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4234,8 +4366,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="95.381851196289" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.531616210938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4268,8 +4400,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="430.090454101563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1971.23974609375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4302,8 +4434,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="65.398895263672" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.847534179688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4336,8 +4468,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="348.252716064453" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1961.41552734375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4370,8 +4502,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="470.332336425781" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1901.140014648438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4404,8 +4536,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="54.116756439209" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1961.167846679688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4438,8 +4570,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="792.024780273438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.25244140625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4472,8 +4604,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="80.231399536133" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1983.204833984375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4506,8 +4638,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="76.98706817627" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1985.350708007813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4540,8 +4672,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="636.532165527344" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1961.134155273438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4574,8 +4706,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="979.28076171875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1986.245727539063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4608,8 +4740,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.46374130249" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1969.332641601563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4642,8 +4774,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.689727783203" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1974.090698242188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4676,8 +4808,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="60.960235595703" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1996.194213867188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4710,8 +4842,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="60.974132537842" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.292236328125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4744,8 +4876,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.544437408447" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1987.900146484375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4778,8 +4910,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="66.237258911133" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.066284179688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4812,8 +4944,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="81.874649047852" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.267700195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4846,8 +4978,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="53.297039031982" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.301879882813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4880,8 +5012,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="372.808227539063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1979.340576171875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4914,8 +5046,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.041358947754" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.534912109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4948,8 +5080,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="933.322875976563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.165405273438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -4982,8 +5114,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="54.908821105957" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.426879882813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5016,8 +5148,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="56.925659179688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1995.3935546875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5050,8 +5182,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="913.839050292969" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1991.154418945313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5084,8 +5216,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="53.962585449219" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.377319335938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5118,8 +5250,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="94.233329772949" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.293334960938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5152,8 +5284,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="53.178329467773" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1997.432373046875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5186,8 +5318,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="74.124519348145" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.199462890625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5220,8 +5352,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="79.713073730469" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1996.597412109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5254,8 +5386,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="74.326019287109" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1989.305908203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5288,8 +5420,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="137.464233398438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.520263671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5322,8 +5454,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="95.876556396484" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.557373046875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5356,8 +5488,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1440.869018554688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.26953125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5390,8 +5522,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="325.67041015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1991.846435546875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5424,8 +5556,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1130.613159179688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.239379882813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5458,8 +5590,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1522.733276367188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1969.84033203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5492,8 +5624,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1042.991333007813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1965.538330078125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5526,8 +5658,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="113.245513916016" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.321655273438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5560,8 +5692,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1037.5634765625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1960.351806640625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5594,8 +5726,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="200.857009887695" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1959.012573242188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5628,8 +5760,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1143.07568359375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1921.4560546875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5662,8 +5794,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="117.749053955078" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1949.712890625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5696,8 +5828,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1061.222412109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.892700195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5730,8 +5862,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1653.957763671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1879.465942382813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5764,8 +5896,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="79.638191223145" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1743.815063476563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5798,8 +5930,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1274.9423828125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1992.578369140625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5832,8 +5964,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="256.321502685547" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1806.32958984375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5866,8 +5998,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="468.944061279297" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1978.667724609375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5898,6 +6030,12 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.013955454792" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="17.7" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
         <binaryDataArrayList count="2">
@@ -5928,8 +6066,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="57.912887573242" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1936.4619140625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5962,8 +6100,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="212.364334106445" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1900.796508789063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -5996,8 +6134,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="54.59468460083" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="188.47998046875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6030,8 +6168,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="56.048686981201" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1913.419067382813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6064,8 +6202,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="52.111301422119" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1924.3544921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6098,8 +6236,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1871.880249023438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1871.896728515625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6132,8 +6270,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1241.560791015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1490.8408203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6166,8 +6304,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="55.93550491333" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1708.885620117188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6200,8 +6338,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="66.615379333496" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1465.750854492188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6234,8 +6372,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.970874786377" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1583.19873046875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6268,8 +6406,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="66.703590393066" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1670.629272460938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6302,8 +6440,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="53.642791748047" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1991.23388671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6336,8 +6474,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.927574157715" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1106.636840820313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6370,8 +6508,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="466.184631347656" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="466.19287109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6404,8 +6542,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="57.771751403809" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="84.694473266602" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6438,8 +6576,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="60.211292266846" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="69.531700134277" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6472,8 +6610,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.647468566895" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="96.226608276367" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6506,8 +6644,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.368076324463" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="100.301200866699" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6540,8 +6678,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="54.746936798096" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="95.83797454834" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6574,8 +6712,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="55.11905670166" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="125.669441223145" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6608,8 +6746,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="53.359230041504" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="108.352935791016" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6642,8 +6780,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="77.814575195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="91.550506591797" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6676,8 +6814,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="55.975437164307" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1387.541625976563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -6698,8 +6836,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="200" id="scan=201" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6708,8 +6846,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.1" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6726,8 +6887,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="201" id="scan=202" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6736,8 +6897,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.2" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6754,8 +6938,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="202" id="scan=203" defaultArrayLength="3">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6766,12 +6950,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="194.008026123047" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="194.011566162109" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6788,8 +6989,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="203" id="scan=204" defaultArrayLength="3">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6800,12 +7001,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="144.592880249023" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="144.595932006836" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6822,8 +7040,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="204" id="scan=205" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6832,8 +7050,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.5" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6850,8 +7091,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="205" id="scan=206" defaultArrayLength="3">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6862,12 +7103,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="90.766532897949" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="90.76895904541" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6884,8 +7142,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="206" id="scan=207" defaultArrayLength="3">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6896,12 +7154,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="161.125335693359" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="161.128555297852" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6918,8 +7193,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="207" id="scan=208" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6928,8 +7203,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.8" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6946,8 +7244,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="208" id="scan=209" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6956,8 +7254,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="0.9" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -6974,8 +7295,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="209" id="scan=210" defaultArrayLength="3">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -6986,12 +7307,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="79.708534240723" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="79.710800170898" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7008,8 +7346,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="210" id="scan=211" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7020,12 +7358,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="133.18962097168" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="133.19401550293" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7042,8 +7397,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="211" id="scan=212" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7052,8 +7407,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.2" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7070,8 +7448,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="212" id="scan=213" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7082,12 +7460,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="67.06950378418" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="67.072631835938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="32">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7104,8 +7499,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="213" id="scan=214" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7114,8 +7509,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.4" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7132,8 +7550,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="214" id="scan=215" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7142,8 +7560,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.5" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7160,8 +7601,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="215" id="scan=216" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7170,8 +7611,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.6" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7188,8 +7652,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="216" id="scan=217" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7198,8 +7662,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.7" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7216,8 +7703,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="217" id="scan=218" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7226,8 +7713,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.8" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7244,8 +7754,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="218" id="scan=219" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7254,8 +7764,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="1.9" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7272,8 +7805,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="219" id="scan=220" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7284,12 +7817,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="79.075439453125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="79.078826904297" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="32">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7306,8 +7856,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="220" id="scan=221" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7316,8 +7866,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.1" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7334,8 +7907,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="221" id="scan=222" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7344,8 +7917,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.2" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7362,8 +7958,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="222" id="scan=223" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7372,8 +7968,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.3" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7390,8 +8009,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="223" id="scan=224" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7400,8 +8019,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.4" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7418,8 +8060,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="224" id="scan=225" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7428,8 +8070,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.5" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7446,8 +8111,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="225" id="scan=226" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7456,8 +8121,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.6" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7474,8 +8162,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="226" id="scan=227" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7484,8 +8172,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.7" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7502,8 +8213,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="227" id="scan=228" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7512,8 +8223,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.8" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7530,8 +8264,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="228" id="scan=229" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7540,8 +8274,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="2.9" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7558,8 +8315,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="229" id="scan=230" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7568,8 +8325,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.0" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7586,8 +8366,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="230" id="scan=231" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7596,8 +8376,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.1" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7614,8 +8417,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="231" id="scan=232" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7624,8 +8427,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.2" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7642,8 +8468,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="232" id="scan=233" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7654,12 +8480,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="137.203552246094" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="137.208023071289" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7676,8 +8519,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="233" id="scan=234" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7686,8 +8529,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.4" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7704,8 +8570,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="234" id="scan=235" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7714,8 +8580,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.5" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7732,8 +8621,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="235" id="scan=236" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7744,12 +8633,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="162.431625366211" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="162.436477661133" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7766,8 +8672,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="236" id="scan=237" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7776,8 +8682,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.7" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7794,8 +8723,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="237" id="scan=238" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7804,8 +8733,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.8" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7822,8 +8774,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="238" id="scan=239" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7832,8 +8784,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="3.9" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7850,8 +8825,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="239" id="scan=240" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7862,12 +8837,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="616.457824707031" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="616.46728515625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7884,8 +8876,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="240" id="scan=241" defaultArrayLength="8">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7896,12 +8888,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="289.733245849609" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="469.662719726563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="48">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7918,8 +8927,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="241" id="scan=242" defaultArrayLength="12">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7930,12 +8939,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="271.306182861328" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="535.681518554688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="60">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7952,8 +8978,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="242" id="scan=243" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7964,12 +8990,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="288.017944335938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="288.0244140625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -7986,8 +9029,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="243" id="scan=244" defaultArrayLength="16">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -7998,12 +9041,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="232.826553344727" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="443.743469238281" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="88">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8020,8 +9080,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="244" id="scan=245" defaultArrayLength="26">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8032,12 +9092,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="230.339080810547" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="402.243255615234" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="136">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8054,8 +9131,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="245" id="scan=246" defaultArrayLength="42">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8066,12 +9143,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="184.847061157227" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="513.726806640625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="200">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8088,8 +9182,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="246" id="scan=247" defaultArrayLength="56">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8100,12 +9194,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="185.881927490234" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="609.540771484375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="240">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8122,8 +9233,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="247" id="scan=248" defaultArrayLength="89">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8134,12 +9245,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="231.341354370117" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="658.652709960938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="372">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8156,8 +9284,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="248" id="scan=249" defaultArrayLength="70">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8168,12 +9296,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="115.960090637207" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="639.566284179688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="316">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8190,8 +9335,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="249" id="scan=250" defaultArrayLength="120">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8202,12 +9347,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="156.979995727539" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="886.451293945313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="484">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8224,8 +9386,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="250" id="scan=251" defaultArrayLength="118">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8236,12 +9398,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="80.975433349609" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1187.51318359375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8258,8 +9437,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="251" id="scan=252" defaultArrayLength="213">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8270,12 +9449,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="62.419780731201" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="877.727111816406" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="812">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8292,8 +9488,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="252" id="scan=253" defaultArrayLength="191">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8304,12 +9500,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="98.977867126465" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1014.373718261719" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="736">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8326,8 +9539,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="253" id="scan=254" defaultArrayLength="210">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8338,12 +9551,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="80.97428894043" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="979.356323242188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="804">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8360,8 +9590,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="254" id="scan=255" defaultArrayLength="320">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8372,12 +9602,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="98.982925415039" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1048.318115234375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1188">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8394,8 +9641,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="255" id="scan=256" defaultArrayLength="348">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8406,12 +9653,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="98.981658935547" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1030.333374023438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1276">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8428,8 +9692,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="256" id="scan=257" defaultArrayLength="416">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8440,12 +9704,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="115.960090637207" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1255.11865234375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1508">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8462,8 +9743,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="257" id="scan=258" defaultArrayLength="484">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8474,12 +9755,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="58.96032333374" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1116.404541015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1728">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8496,8 +9794,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="258" id="scan=259" defaultArrayLength="628">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8508,12 +9806,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="80.969718933105" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1871.19287109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2216">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8530,8 +9845,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="259" id="scan=260" defaultArrayLength="854">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8542,12 +9857,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="80.97428894043" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1261.575317382813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2996">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8564,8 +9896,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="260" id="scan=261" defaultArrayLength="817">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8576,12 +9908,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="98.979133605957" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1642.04345703125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2864">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8598,8 +9947,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="261" id="scan=262" defaultArrayLength="796">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8610,12 +9959,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="92.948333740234" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1537.963500976563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2776">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8632,8 +9998,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="262" id="scan=263" defaultArrayLength="937">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8644,12 +10010,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="90.901000976563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1319.179565429688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="3224">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8666,8 +10049,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="263" id="scan=264" defaultArrayLength="1038">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8678,12 +10061,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="127.884864807129" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1479.232055664063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="3596">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8700,8 +10100,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="264" id="scan=265" defaultArrayLength="1131">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8712,12 +10112,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="58.96227645874" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1426.440673828125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="3872">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8734,8 +10151,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="265" id="scan=266" defaultArrayLength="1240">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8746,12 +10163,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="136.916351318359" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1539.00048828125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4284">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8768,8 +10202,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="266" id="scan=267" defaultArrayLength="1176">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8780,12 +10214,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="122.97388458252" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1568.148071289063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4080">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8802,8 +10253,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="267" id="scan=268" defaultArrayLength="1187">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8814,12 +10265,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="147.062561035156" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1951.0263671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4072">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8836,8 +10304,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="268" id="scan=269" defaultArrayLength="1395">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8848,12 +10316,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="58.967155456543" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1445.161499023438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4784">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8870,8 +10355,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="269" id="scan=270" defaultArrayLength="1507">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8882,12 +10367,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="73.046173095703" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1643.156127929688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5132">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8904,8 +10406,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="270" id="scan=271" defaultArrayLength="1480">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8916,12 +10418,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="89.089889526367" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1838.462890625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5032">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8938,8 +10457,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="271" id="scan=272" defaultArrayLength="1568">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8950,12 +10469,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="58.17919921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1700.205810546875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -8972,8 +10508,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="272" id="scan=273" defaultArrayLength="1622">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -8984,12 +10520,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="73.052688598633" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1641.12158203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5512">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9006,8 +10559,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="273" id="scan=274" defaultArrayLength="1609">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9018,12 +10571,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="68.648452758789" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1742.005615234375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5428">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9040,8 +10610,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="274" id="scan=275" defaultArrayLength="1601">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9052,12 +10622,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="74.045745849609" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1982.304931640625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9074,8 +10661,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="275" id="scan=276" defaultArrayLength="1988">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9086,12 +10673,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="128.007080078125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1933.990356445313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6656">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9108,8 +10712,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="276" id="scan=277" defaultArrayLength="2064">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9120,12 +10724,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="108.043556213379" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1962.44580078125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6924">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9142,8 +10763,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="277" id="scan=278" defaultArrayLength="1934">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9154,12 +10775,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="119.622604370117" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1763.050415039063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6496">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9176,8 +10814,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="278" id="scan=279" defaultArrayLength="2103">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9188,12 +10826,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="73.04182434082" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1944.07080078125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6972">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9210,8 +10865,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="279" id="scan=280" defaultArrayLength="2006">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9222,12 +10877,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="111.119766235352" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1913.241088867188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6752">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9244,8 +10916,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="280" id="scan=281" defaultArrayLength="2004">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9256,12 +10928,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="136.917846679688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1866.939575195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6692">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9278,8 +10967,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="281" id="scan=282" defaultArrayLength="2160">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9290,12 +10979,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="99.872657775879" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1972.882202148438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7216">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9312,8 +11018,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="282" id="scan=283" defaultArrayLength="2327">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9324,12 +11030,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="133.007781982422" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1954.435791015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7740">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9346,8 +11069,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="283" id="scan=284" defaultArrayLength="2193">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9358,12 +11081,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="102.895553588867" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1772.204711914063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9380,8 +11120,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="284" id="scan=285" defaultArrayLength="2341">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9392,12 +11132,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="97.026252746582" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1985.084594726563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7736">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9414,8 +11171,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="285" id="scan=286" defaultArrayLength="2414">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9426,12 +11183,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="52.501071929932" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1977.04541015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="8020">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9448,8 +11222,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="286" id="scan=287" defaultArrayLength="2222">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9460,12 +11234,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="73.046173095703" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1978.125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9482,8 +11273,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="287" id="scan=288" defaultArrayLength="2205">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9494,12 +11285,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="73.04182434082" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1982.899169921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7280">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9516,8 +11324,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="288" id="scan=289" defaultArrayLength="2318">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9528,12 +11336,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="148.070831298828" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1976.93798828125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7656">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9550,8 +11375,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="289" id="scan=290" defaultArrayLength="2306">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9562,12 +11387,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="130.893600463867" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1989.056396484375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7512">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9584,8 +11426,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="290" id="scan=291" defaultArrayLength="2322">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9596,12 +11438,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="147.062561035156" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1987.214477539063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7600">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9618,8 +11477,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="291" id="scan=292" defaultArrayLength="2342">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9630,12 +11489,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="193.277526855469" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1990.536254882813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7580">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9652,8 +11528,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="292" id="scan=293" defaultArrayLength="2381">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9664,12 +11540,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="147.051773071289" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1997.108642578125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7692">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9686,8 +11579,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="293" id="scan=294" defaultArrayLength="2372">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9698,12 +11591,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="147.070266723633" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.134399414063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7644">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9720,8 +11630,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="294" id="scan=295" defaultArrayLength="2332">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9732,12 +11642,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="101.811508178711" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1980.975219726563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9754,8 +11681,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="295" id="scan=296" defaultArrayLength="2189">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9766,12 +11693,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.561305999756" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.483520507813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7136">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9788,8 +11732,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="296" id="scan=297" defaultArrayLength="2391">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9800,12 +11744,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="147.061019897461" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1932.839111328125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7704">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9822,8 +11783,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="297" id="scan=298" defaultArrayLength="2247">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9834,12 +11795,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="68.318168640137" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1898.115234375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7276">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9856,8 +11834,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="298" id="scan=299" defaultArrayLength="2213">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9868,12 +11846,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="89.525924682617" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1969.078857421875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="7128">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9890,8 +11885,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="299" id="scan=300" defaultArrayLength="2114">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9902,12 +11897,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.730461120605" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1957.881958007813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6864">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9924,8 +11936,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="300" id="scan=301" defaultArrayLength="2072">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9936,12 +11948,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="86.78589630127" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1887.801391601563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6600">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9958,8 +11987,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="301" id="scan=302" defaultArrayLength="1961">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -9970,12 +11999,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="147.064102172852" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1806.388916015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="6380">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -9992,8 +12038,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="302" id="scan=303" defaultArrayLength="1783">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10004,12 +12050,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="147.061019897461" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1978.854370117188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5756">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10026,8 +12089,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="303" id="scan=304" defaultArrayLength="1802">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10038,12 +12101,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.900024414063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1565.4111328125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5800">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10060,8 +12140,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="304" id="scan=305" defaultArrayLength="1718">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10072,12 +12152,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="82.097930908203" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1860.629028320313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10094,8 +12191,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="305" id="scan=306" defaultArrayLength="1720">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10106,12 +12203,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="66.607078552246" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1773.87451171875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5520">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10128,8 +12242,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="306" id="scan=307" defaultArrayLength="1763">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10140,12 +12254,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="73.297332763672" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1781.752807617188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5640">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10162,8 +12293,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="307" id="scan=308" defaultArrayLength="1652">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10174,12 +12305,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="85.380172729492" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1898.580444335938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="5292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10196,8 +12344,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="308" id="scan=309" defaultArrayLength="1531">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10208,12 +12356,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="54.177551269531" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1990.020263671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4840">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10230,8 +12395,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="309" id="scan=310" defaultArrayLength="1579">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10242,12 +12407,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="81.987403869629" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1952.34033203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4992">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10264,8 +12446,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="310" id="scan=311" defaultArrayLength="1407">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10276,12 +12458,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="54.178489685059" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1768.551879882813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4484">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10298,8 +12497,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="311" id="scan=312" defaultArrayLength="1451">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10310,12 +12509,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="91.107139587402" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1899.671630859375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4596">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10332,8 +12548,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="312" id="scan=313" defaultArrayLength="1398">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10344,12 +12560,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="221.079925537109" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1858.387329101563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4420">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10366,8 +12599,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="313" id="scan=314" defaultArrayLength="1316">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10378,12 +12611,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="58.277160644531" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1988.823974609375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4176">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10400,8 +12650,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="314" id="scan=315" defaultArrayLength="1352">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10412,12 +12662,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="86.354232788086" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1973.960693359375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="4240">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10434,8 +12701,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="315" id="scan=316" defaultArrayLength="1192">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10446,12 +12713,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="71.259330749512" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1977.746215820313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="3824">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10468,8 +12752,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="316" id="scan=317" defaultArrayLength="1105">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10480,12 +12764,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="177.147216796875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1953.239013671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="3492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10502,8 +12803,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="317" id="scan=318" defaultArrayLength="1160">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10514,12 +12815,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="164.810272216797" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1947.816284179688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="3664">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10536,8 +12854,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="318" id="scan=319" defaultArrayLength="1052">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10548,12 +12866,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="148.066192626953" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1992.283325195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="3256">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10570,8 +12905,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="319" id="scan=320" defaultArrayLength="1072">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10582,12 +12917,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.105838775635" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1970.421508789063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="3360">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10604,8 +12956,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="320" id="scan=321" defaultArrayLength="933">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10616,12 +12968,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="136.559631347656" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.898315429688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2940">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10638,8 +13007,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="321" id="scan=322" defaultArrayLength="885">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10650,12 +13019,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="355.074432373047" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1980.912963867188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2800">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10672,8 +13058,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="322" id="scan=323" defaultArrayLength="919">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10684,12 +13070,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="160.520858764648" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1966.180786132813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2880">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10706,8 +13109,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="323" id="scan=324" defaultArrayLength="886">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10718,12 +13121,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="56.193424224854" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1980.777221679688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2788">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10740,8 +13160,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="324" id="scan=325" defaultArrayLength="791">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10752,12 +13172,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="69.811798095703" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1918.838256835938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2488">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10774,8 +13211,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="325" id="scan=326" defaultArrayLength="863">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10786,12 +13223,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="57.790107727051" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1950.352661132813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2712">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10808,8 +13262,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="326" id="scan=327" defaultArrayLength="780">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10820,12 +13274,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="419.577270507813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1967.122192382813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2428">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10842,8 +13313,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="327" id="scan=328" defaultArrayLength="763">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10854,12 +13325,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="261.070526123047" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1879.857177734375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2364">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10876,8 +13364,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="328" id="scan=329" defaultArrayLength="769">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10888,12 +13376,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="198.421737670898" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1939.7353515625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2424">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10910,8 +13415,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="329" id="scan=330" defaultArrayLength="668">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10922,12 +13427,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="494.117065429688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1889.850952148438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2120">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10944,8 +13466,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="330" id="scan=331" defaultArrayLength="543">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10956,12 +13478,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="272.173614501953" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1977.97802734375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1728">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -10978,8 +13517,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="331" id="scan=332" defaultArrayLength="680">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -10990,12 +13529,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="155.683166503906" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1967.556274414063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2140">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11012,8 +13568,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="332" id="scan=333" defaultArrayLength="663">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11024,12 +13580,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="107.002326965332" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1985.1015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="2092">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11046,8 +13619,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="333" id="scan=334" defaultArrayLength="515">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11058,12 +13631,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="320.224975585938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1952.626831054688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1660">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11080,8 +13670,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="334" id="scan=335" defaultArrayLength="542">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11092,12 +13682,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="181.381286621094" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1828.394165039063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1740">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11114,8 +13721,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="335" id="scan=336" defaultArrayLength="506">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11126,12 +13733,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="87.829856872559" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1978.08544921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1620">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11148,8 +13772,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="336" id="scan=337" defaultArrayLength="474">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11160,12 +13784,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="107.669975280762" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1911.517944335938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11182,8 +13823,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="337" id="scan=338" defaultArrayLength="421">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11194,12 +13835,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="331.002166748047" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1897.23486328125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11216,8 +13874,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="338" id="scan=339" defaultArrayLength="507">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11228,12 +13886,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="797.09814453125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1938.005981445313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1612">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11250,8 +13925,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="339" id="scan=340" defaultArrayLength="411">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11262,12 +13937,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="191.208526611328" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1903.296508789063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1320">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11284,8 +13976,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="340" id="scan=341" defaultArrayLength="380">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11296,12 +13988,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="870.973205566406" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1958.196899414063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1232">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11318,8 +14027,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="341" id="scan=342" defaultArrayLength="337">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11330,12 +14039,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="372.435272216797" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1906.197875976563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1108">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11352,8 +14078,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="342" id="scan=343" defaultArrayLength="344">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11364,12 +14090,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.988807678223" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1958.494995117188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1160">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11386,8 +14129,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="343" id="scan=344" defaultArrayLength="310">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11398,12 +14141,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="780.814636230469" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1961.20166015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1036">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11420,8 +14180,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="344" id="scan=345" defaultArrayLength="380">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11432,12 +14192,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="931.506469726563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1978.08544921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1236">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11454,8 +14231,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="345" id="scan=346" defaultArrayLength="354">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11466,12 +14243,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1050.904296875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1998.256225585938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1152">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11488,8 +14282,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="346" id="scan=347" defaultArrayLength="269">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11500,12 +14294,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="929.792541503906" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1975.3671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="880">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11522,8 +14333,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="347" id="scan=348" defaultArrayLength="299">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11534,12 +14345,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="64.271041870117" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1996.387329101563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="1008">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11556,8 +14384,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="348" id="scan=349" defaultArrayLength="257">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11568,12 +14396,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1247.722045898438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1996.131713867188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="836">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11590,8 +14435,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="349" id="scan=350" defaultArrayLength="215">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11602,12 +14447,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="895.857604980469" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1975.305053710938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="732">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11624,8 +14486,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="350" id="scan=351" defaultArrayLength="255">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11636,12 +14498,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.945285797119" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.4951171875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="852">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11658,8 +14537,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="351" id="scan=352" defaultArrayLength="210">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11670,12 +14549,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="758.199829101563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1988.002197265625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="720">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11692,8 +14588,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="352" id="scan=353" defaultArrayLength="168">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11704,12 +14600,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1010.620422363281" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.3984375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="596">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11726,8 +14639,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="353" id="scan=354" defaultArrayLength="209">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11738,12 +14651,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="879.920166015625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1995.183471679688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="720">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11760,8 +14690,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="354" id="scan=355" defaultArrayLength="189">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11772,12 +14702,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="817.982421875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1983.4765625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="664">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11794,8 +14741,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="355" id="scan=356" defaultArrayLength="207">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11806,12 +14753,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="52.167285919189" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1996.324829101563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="736">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11828,8 +14792,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="356" id="scan=357" defaultArrayLength="154">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11840,12 +14804,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="919.542358398438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1965.346801757813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="556">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11862,8 +14843,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="357" id="scan=358" defaultArrayLength="119">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11874,12 +14855,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1431.355834960938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.053833007813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="424">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11896,8 +14894,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="358" id="scan=359" defaultArrayLength="135">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11908,12 +14906,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="97.293113708496" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1995.160766601563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11930,8 +14945,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="359" id="scan=360" defaultArrayLength="107">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11942,12 +14957,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="867.581665039063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1997.455200195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="400">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11964,8 +14996,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="360" id="scan=361" defaultArrayLength="109">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -11976,12 +15008,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1131.42529296875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1990.178955078125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="400">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -11998,8 +15047,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="361" id="scan=362" defaultArrayLength="113">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12010,12 +15059,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="90.384269714355" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1989.192504882813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="412">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12032,8 +15098,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="362" id="scan=363" defaultArrayLength="82">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12044,12 +15110,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1068.02392578125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1979.521606445313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="316">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12066,8 +15149,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="363" id="scan=364" defaultArrayLength="72">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12078,12 +15161,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="72.047988891602" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.330200195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="300">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12100,8 +15200,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="364" id="scan=365" defaultArrayLength="71">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12112,12 +15212,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1409.645141601563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1989.424926757813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12134,8 +15251,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="365" id="scan=366" defaultArrayLength="59">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12146,12 +15263,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="760.967346191406" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.4794921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="256">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12168,8 +15302,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="366" id="scan=367" defaultArrayLength="41">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12180,12 +15314,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1182.765502929688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1988.438598632813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="184">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12202,8 +15353,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="367" id="scan=368" defaultArrayLength="39">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12214,12 +15365,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1529.645385742188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1975.9716796875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="184">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12236,8 +15404,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="368" id="scan=369" defaultArrayLength="65">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12248,12 +15416,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1573.488037109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1993.0947265625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="268">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12270,8 +15455,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="369" id="scan=370" defaultArrayLength="52">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12282,12 +15467,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1609.494750976563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1974.276977539063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="212">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12304,8 +15506,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="370" id="scan=371" defaultArrayLength="22">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12316,12 +15518,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1460.39794921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1994.388671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="100">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12338,8 +15557,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="371" id="scan=372" defaultArrayLength="55">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12350,12 +15569,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1549.669921875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1947.361938476563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="228">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12372,8 +15608,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="372" id="scan=373" defaultArrayLength="42">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12384,12 +15620,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="328.419555664063" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1960.301147460938" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="184">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12406,8 +15659,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="373" id="scan=374" defaultArrayLength="23">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12418,12 +15671,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1163.666137695313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1948.180908203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="108">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12440,8 +15710,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="374" id="scan=375" defaultArrayLength="28">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12452,12 +15722,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1470.37255859375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.290405273438" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="132">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12474,8 +15761,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="375" id="scan=376" defaultArrayLength="18">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12486,12 +15773,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="174.558212280273" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1972.447509765625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="96">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12508,8 +15812,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="376" id="scan=377" defaultArrayLength="31">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12520,12 +15824,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1038.689697265625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1937.060424804688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="140">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12542,8 +15863,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="377" id="scan=378" defaultArrayLength="15">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12554,12 +15875,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="989.757751464844" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1965.944091796875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="80">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12576,8 +15914,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="378" id="scan=379" defaultArrayLength="19">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12588,12 +15926,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="179.339691162109" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1987.038818359375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="96">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12610,8 +15965,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="379" id="scan=380" defaultArrayLength="20">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12622,12 +15977,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="146.391265869141" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1816.413208007813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="96">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12644,8 +16016,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="380" id="scan=381" defaultArrayLength="23">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12656,12 +16028,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="178.652679443359" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1918.509765625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="116">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12678,8 +16067,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="381" id="scan=382" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12690,12 +16079,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1790.842407226563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1790.858642578125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12712,8 +16118,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="382" id="scan=383" defaultArrayLength="7">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12724,12 +16130,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1188.63037109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1965.549682617188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="40">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12746,8 +16169,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="383" id="scan=384" defaultArrayLength="15">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12758,12 +16181,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1463.377075195313" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1996.29638671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="76">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12780,8 +16220,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="384" id="scan=385" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12792,12 +16232,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1741.40087890625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1741.416748046875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12814,8 +16271,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="385" id="scan=386" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12824,8 +16281,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="18.6" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12842,8 +16322,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="386" id="scan=387" defaultArrayLength="3">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12854,12 +16334,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1931.263549804688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1931.274658203125" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12876,8 +16373,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="387" id="scan=388" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12888,12 +16385,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1351.436279296875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1351.450317382813" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12910,8 +16424,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="388" id="scan=389" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12920,8 +16434,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="18.9" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12938,8 +16475,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="389" id="scan=390" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12948,8 +16485,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="19.0" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -12966,8 +16526,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="390" id="scan=391" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -12978,12 +16538,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="74.817756652832" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="74.82105255127" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="32">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13000,8 +16577,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="391" id="scan=392" defaultArrayLength="7">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13012,12 +16589,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="56.963066101074" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1599.713745117188" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13034,8 +16628,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="392" id="scan=393" defaultArrayLength="12">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13046,12 +16640,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="53.444683074951" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1905.848266601563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="72">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13068,8 +16679,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="393" id="scan=394" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13080,12 +16691,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="80.363525390625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="80.366943359375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13102,8 +16730,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="394" id="scan=395" defaultArrayLength="7">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13114,12 +16742,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1502.36181640625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1959.552734375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="40">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13136,8 +16781,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="395" id="scan=396" defaultArrayLength="3">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13148,12 +16793,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="59.912815093994" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="59.914779663086" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13170,8 +16832,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="396" id="scan=397" defaultArrayLength="8">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13182,12 +16844,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="52.09937286377" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="74.270141601563" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="52">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13204,8 +16883,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="397" id="scan=398" defaultArrayLength="4">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13216,12 +16895,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="1837.051513671875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1837.06787109375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="28">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13238,8 +16934,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="398" id="scan=399" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13248,8 +16944,31 @@
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.023176169614" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
             <cvParam cvRef="MS" accession="MS:1002476" name="ion mobility drift time" value="19.9" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+            <scanWindowList count="1">
+              <scanWindow>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </scanWindow>
+            </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="0">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13266,8 +16985,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="399" id="scan=400" defaultArrayLength="8">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -13278,12 +16997,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="81.213516235352" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="82.727958679199" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="52">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -13312,8 +17048,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="89.259132385254" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1928.689331054688" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -13346,8 +17082,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="136.22119140625" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="229.015701293945" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>

--- a/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI_Test.data/08Mar17_MSe_25fmolMix1_01.mzML
+++ b/pwiz/data/vendor_readers/UNIFI/Reader_UNIFI_Test.data/08Mar17_MSe_25fmolMix1_01.mzML
@@ -16,13 +16,13 @@
     <software id="UNIFI" version="1.0">
       <cvParam cvRef="MS" accession="MS:1001796" name="UNIFY" value=""/>
     </software>
-    <software id="pwiz_Reader_UNIFI" version="3.0.18255">
+    <software id="pwiz_Reader_UNIFI" version="3.0.18278">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
   <instrumentConfigurationList count="1">
     <instrumentConfiguration id="IC1">
-      <cvParam cvRef="MS" accession="MS:1000031" name="instrument model" value=""/>
+      <cvParam cvRef="MS" accession="MS:1000126" name="Waters instrument model" value=""/>
       <softwareRef ref="UNIFI"/>
     </instrumentConfiguration>
   </instrumentConfigurationList>
@@ -47,8 +47,8 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.063716888428" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.968505859375" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
@@ -69,8 +69,8 @@
         </binaryDataArrayList>
       </spectrum>
       <spectrum index="1" id="scan=2" defaultArrayLength="122298">
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
         <scanList count="1">
@@ -80,12 +80,29 @@
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <scanWindowList count="1">
               <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.528858184814" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1999.934326171875" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
               </scanWindow>
             </scanWindowList>
           </scan>
         </scanList>
+        <precursorList count="1">
+          <precursor>
+            <isolationWindow>
+              <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="925.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="1025.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+            </isolationWindow>
+            <selectedIonList count="1">
+              <selectedIon>
+                <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="975.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </selectedIon>
+            </selectedIonList>
+            <activation>
+              <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+            </activation>
+          </precursor>
+        </precursorList>
         <binaryDataArrayList count="2">
           <binaryDataArray encodedLength="335152">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>

--- a/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
+++ b/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
@@ -136,10 +136,26 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Waters::spectrum(size_t index, DetailLeve
     CVID spectrumType;
     translateFunctionType(WatersToPwizFunctionType(rawdata_->Info.GetFunctionType(ie.function)), msLevel, spectrumType);
 
+    double collisionEnergy = 0;
+    string collisionEnergyStr = rawdata_->GetScanStat(ie.function, scanStatIndex, MassLynxScanItem::COLLISION_ENERGY);
+    if (!collisionEnergyStr.empty())
+        collisionEnergy = lexical_cast<double>(collisionEnergyStr);
+
+    // heuristic to detect high-energy MSe function (must run for DetailLevel_InstantMetadata so that msLevel is the same at all detail levels)
+    if (msLevel == 1 && ie.function == 1 && collisionEnergy > 0)
+    {
+        double collisionEnergyFunction1 = 0;
+        string collisionEnergyStrFunction1 = rawdata_->GetScanStat(0, scanStatIndex, MassLynxScanItem::COLLISION_ENERGY);
+        if (collisionEnergy > collisionEnergyFunction1)
+        {
+            msLevel = 2;
+            spectrumType = MS_MSn_spectrum;
+        }
+    }
+
     result->set(spectrumType);
     result->set(MS_ms_level, msLevel);
-
-    scan.set(MS_preset_scan_configuration, ie.function+1);
+    scan.set(MS_preset_scan_configuration, ie.function + 1);
 
     if (detailLevel == DetailLevel_InstantMetadata)
         return result;
@@ -205,29 +221,27 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Waters::spectrum(size_t index, DetailLeve
     {
         string setMassStr = rawdata_->GetScanStat(ie.function, scanStatIndex, MassLynxScanItem::SET_MASS);
 
+        double setMass = 0;
         if (!setMassStr.empty())
+            setMass = lexical_cast<double>(setMassStr);
+
+        Precursor precursor;
+        if (setMass == 0)
         {
-            double setMass = lexical_cast<double>(setMassStr);
-            if (setMass > 0)
-            {
-                Precursor precursor;
-                SelectedIon selectedIon(setMass);
-                precursor.isolationWindow.set(MS_isolation_window_target_m_z, setMass, MS_m_z);
-
-                precursor.activation.set(MS_beam_type_collision_induced_dissociation); // AFAIK there is no Waters instrument with a trap collision cell
-
-                string collisionEnergyStr = rawdata_->GetScanStat(ie.function, scanStatIndex, MassLynxScanItem::COLLISION_ENERGY);
-                if (!collisionEnergyStr.empty())
-                {
-                    double collisionEnergy = lexical_cast<double>(collisionEnergyStr);
-                    if (collisionEnergy > 0)
-                        precursor.activation.set(MS_collision_energy, collisionEnergy, UO_electronvolt);
-                }
-
-                precursor.selectedIons.push_back(selectedIon);
-                result->precursors.push_back(precursor);
-            }
+            setMass = (maxMZ - minMZ) / 2;
+            precursor.isolationWindow.set(MS_isolation_window_upper_offset, maxMZ - setMass, MS_m_z);
+            precursor.isolationWindow.set(MS_isolation_window_lower_offset, setMass - minMZ, MS_m_z);
         }
+        precursor.isolationWindow.set(MS_isolation_window_target_m_z, setMass, MS_m_z);
+
+        precursor.activation.set(MS_beam_type_collision_induced_dissociation); // AFAIK there is no Waters instrument with a trap collision cell
+
+        if (collisionEnergy > 0)
+            precursor.activation.set(MS_collision_energy, collisionEnergy, UO_electronvolt);
+
+        SelectedIon selectedIon(setMass);
+        precursor.selectedIons.push_back(selectedIon);
+        result->precursors.push_back(precursor);
     }
 
     if (detailLevel < DetailLevel_FullMetadata)

--- a/pwiz_aux/msrc/utility/vendor_api/UNIFI/UnifiData.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/UNIFI/UnifiData.hpp
@@ -130,15 +130,16 @@ typedef boost::shared_ptr<Experiment> ExperimentPtr;
 typedef std::map<std::pair<int, int>, ExperimentPtr> ExperimentsMap;*/
 
 
-enum PWIZ_API_DECL Polarity
+enum class PWIZ_API_DECL Polarity
 {
     Unknown = 0,
     Negative = 1,
     Positive = 2
 };
 
-enum PWIZ_API_DECL EnergyLevel
+enum class PWIZ_API_DECL EnergyLevel
 {
+    Unknown = 0,
     Low = 1,
     High = 2
 };
@@ -149,6 +150,7 @@ struct PWIZ_API_DECL UnifiSpectrum
     Polarity scanPolarity;
     EnergyLevel energyLevel;
     double driftTime;
+    std::pair<double, double> scanRange;
 
     size_t arrayLength;
     std::vector<double> mzArray;
@@ -177,7 +179,6 @@ class PWIZ_API_DECL UnifiData
     bool canConvertDriftTimeAndCCS() const;
     double driftTimeToCCS(double driftTimeInMilliseconds, double mz, int charge) const;
     double ccsToDriftTime(double ccs, double mz, int charge) const;
-
 
     private:
     class Impl;

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -609,8 +609,7 @@ namespace pwiz.Skyline.Model.Results
                 else
                 {
                     // Waters - mse level 1 in raw data "function 1", mse level 2 in raw data "function 2", and "function 3" which we ignore (lockmass?)
-                    // All are declared mslevel=1, but we can tell these apart by inspecting the Id which is formatted as <function>.<process>.<scan>
-                    _mseLevel = int.Parse(dataSpectrum.Id.Split('.')[0]);
+                    _mseLevel = dataSpectrum.WatersFunctionNumber;
                     returnval = _mseLevel; 
                 }
                 _mseLastSpectrumLevel = returnval;


### PR DESCRIPTION
- converted Waters and UNIFI readers to interpret low and high energy levels from MS^e data as MS1 and MS2, respectively; the MS2s have placeholder isolation windows and selected m/z
- fixed UNIFI scan window to use configured values rather than observed
- fixed UNIFI to use much less memory on 32-bit builds