### PR TITLE
Fix problem where warning about iRT regression failing during first p…

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromCacheBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromCacheBuilder.cs
@@ -423,7 +423,7 @@ namespace pwiz.Skyline.Model.Results
                 // All threads must complete scoring before we complete the first pass.
                 _chromDataSets.Wait();
                 doSecondPass = _retentionTimePredictor.CreateConversion();
-                if (!doSecondPass && listChromData.Any(data => null != data && !IsFirstPassPeptide(data)))
+                if (!doSecondPass)
                 {
                     _status = _status.ChangeWarningMessage(
                         Resources.ChromCacheBuilder_Read_Unable_to_finish_importing_chromatograms_because_the_retention_time_predictor_linear_regression_failed_);


### PR DESCRIPTION
…ass of chromatogram extraction would not actually get shown.

(I am working on writing a unit test for this, but it requires large files and will probably have to be a perf test)
I think we should commit this change to the 4.2 branch, since it really confuses users when this happens.