### PR TITLE
Skyline: more generous timeouts for testing under debug builds (which…

### DIFF
--- a/pwiz_tools/Skyline/Test/MSstats/WithRunQuantification/GroupComparisonRunQuantificationTest.cs
+++ b/pwiz_tools/Skyline/Test/MSstats/WithRunQuantification/GroupComparisonRunQuantificationTest.cs
@@ -20,6 +20,7 @@ namespace pwiz.SkylineTest.MSstats.WithRunQuantification
     public class GroupComparisonRunQuantificationTest : AbstractUnitTest
     {
         [TestMethod]
+        [Timeout(36000000)]  // These can take a long time in code coverage mode
         public void TestRunQuantification()
         {
             var cache = new QrFactorizationCache();
@@ -46,6 +47,7 @@ namespace pwiz.SkylineTest.MSstats.WithRunQuantification
         }
 
         [TestMethod]
+        [Timeout(36000000)]  // These can take a long time in code coverage mode
         public void TestGroupComparisonWithRunQuantification()
         {
             var csvReader = new DsvFileReader(GetTextReader("quant.csv"), ',');

--- a/pwiz_tools/Skyline/TestFunctional/FiguresOfMeritTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/FiguresOfMeritTest.cs
@@ -39,6 +39,7 @@ namespace pwiz.SkylineTestFunctional
     public class FiguresOfMeritTest : AbstractFunctionalTest
     {
         [TestMethod]
+        [Timeout(36000000)]  // These can take a long time in code coverage mode
         public void TestFiguresOfMerit()
         {
             TestFilesZip = @"TestFunctional\FiguresOfMeritTest.zip";

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -473,10 +473,10 @@ namespace pwiz.SkylineTestUtil
                 waitCycles *= Program.UnitTestTimeoutMultiplier;
             }
 
-            // Wait a little longer for debug build.
+            // Wait a little longer for debug build. (This may also imply code coverage testing, slower yet)
             if (ExtensionTestContext.IsDebugMode)
             {
-                waitCycles = waitCycles * 150 / 100;
+                waitCycles = waitCycles * 4;
             }
 
             return waitCycles;


### PR DESCRIPTION
… may imply code coverage runs on TeamCity)