### PR TITLE
Fix managed passthrough

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -711,7 +711,7 @@ install executables
     ;
 
 install gui_tools
-    : VERSION
+    : pwiz_tools/commandline//msconvert
     : <conditional>@install-type
       <conditional>@install-location
       <conditional>@install-identdata-dependencies
@@ -719,6 +719,7 @@ install gui_tools
       <conditional>@dotNET-dependencies
       <conditional>@gcc-install-dll-path
       <toolset>msvc:<dependency>install-msvc-runtime-dlls
+      <dependency>VERSION
     ;
 
 install package_docs
@@ -1199,6 +1200,7 @@ searched-lib msparser : : <conditional>@msparser-requirements : : <conditional>@
     Microsoft.VC140.CRT/x86/api-ms-win-crt-string-l1-1-0.dll 
     Microsoft.VC140.CRT/x86/api-ms-win-crt-time-l1-1-0.dll 
     Microsoft.VC140.CRT/x86/api-ms-win-crt-utility-l1-1-0.dll 
+    Microsoft.VC140.CRT/x86/concrt140.dll
     Microsoft.VC140.CRT/x86/mfc140.dll 
     Microsoft.VC140.CRT/x86/msvcp140.dll 
     Microsoft.VC140.CRT/x86/ucrtbase.dll 
@@ -1470,7 +1472,6 @@ tar.create boost_$(BOOST_VERSION:J=_).tar.bz2
     "exclude:pwiz_tools/Shared/Lib/x64"
     "exclude:pwiz_tools/Shared/Lib/mysql.*"
     "exclude:pwiz_tools/Shared/Lib/zlib.*"
-    "exclude:pwiz_tools/Shared/Lib/Microsoft.VC*"
     "exclude:pwiz_aux/msrc/utility/vendor_api/ABI/Clearcore*.dll"
     "exclude:pwiz_aux/msrc/utility/vendor_api/ABI/Sciex*.dll"
     "exclude:pwiz_aux/msrc/utility/vendor_api/ABI/OFX*.dll"

--- a/pwiz/utility/bindings/CLI/common/BinaryData.hpp
+++ b/pwiz/utility/bindings/CLI/common/BinaryData.hpp
@@ -30,6 +30,7 @@
 using namespace System;
 
 #include "vector.hpp" // for RANGE_CHECK and ValidateCopyToArrayArgs
+#include "SharedCLI.hpp"
 
 namespace pwiz {
 namespace CLI {
@@ -91,8 +92,12 @@ public:
     /// </summary>
     virtual cli::array<double>^ Storage()
     {
-        System::Runtime::InteropServices::GCHandle handle = (System::Runtime::InteropServices::GCHandle) System::IntPtr(base().managedStorage());
-        return (cli::array<double>^) handle.Target;
+        try
+        {
+            System::Runtime::InteropServices::GCHandle handle = (System::Runtime::InteropServices::GCHandle) System::IntPtr(base().managedStorage());
+            return (cli::array<double>^) handle.Target;
+        }
+        CATCH_AND_FORWARD
     }
 
     ref struct Enumerator : System::Collections::Generic::IEnumerator<double>

--- a/pwiz/utility/bindings/CLI/msdata/MSDataTest.cpp
+++ b/pwiz/utility/bindings/CLI/msdata/MSDataTest.cpp
@@ -182,6 +182,9 @@ void testExample()
     Precursor^ p = s->precursors[0];
     IsolationWindow^ iw = p->isolationWindow;
     unit_assert_equal(s->precursors[0]->isolationWindow->cvParam(CVID::MS_isolation_window_lower_offset)->value, 0.5, 1e-6);
+
+    auto mzArray = s->getMZArray()->data;
+    unit_assert_operator_equal(10, mzArray->Storage()->Length);
 }
 
 

--- a/pwiz/utility/misc/BinaryData.cpp
+++ b/pwiz/utility/misc/BinaryData.cpp
@@ -53,8 +53,219 @@ class BinaryData<T>::Impl
         nativeStorage_()
     {}
 
+    Impl(void* cliNumericArray)
+    {      
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        GCHandle handle = __VOIDPTR_TO_GCHANDLE(cliNumericArray); // freed by caller
+        managedStorage_ = (cli::array<T>^) handle.Target;
+#else
+        throw std::runtime_error("[BinaryData<T>::ctor(void*)] only supported with MSVC C++/CLI");
+#endif
+    }
+
     ~Impl()
     {
+    }
+
+    template <typename T> Impl& operator=(void* cliNumericArray)
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        GCHandle handle = __VOIDPTR_TO_GCHANDLE(cliNumericArray); // freed by caller
+        managedStorage_ = (cli::array<T>^) handle.Target;
+        return *this;
+#else
+        throw std::runtime_error("[BinaryData<T>::operator=(void*)] only supported with MSVC C++/CLI");
+#endif
+    }
+
+    template <typename T> void _alloc(size_type elements, const T &t)
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr)
+        {
+            managedStorage_ = gcnew array<T>((int)elements);
+            if (t != T())
+                std::fill(begin_, begin_ + elements, t);
+            return;
+        }
+#endif
+        nativeStorage_.assign(elements, t);
+    }
+
+    template <typename T> void _resize(size_type elements)
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr)
+        {
+            cli::array<T>^% storageRef = (array<T>^) managedStorage_;
+            System::Array::Resize<T>(storageRef, (int)elements);
+            managedStorage_ = storageRef;
+            return;
+        }
+#endif
+        nativeStorage_.resize(elements);
+    }
+
+    template <typename T> void _resize(size_type elements, const T &FillWith)
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr)
+        {
+            cli::array<T>^% storageRef = (array<T>^) managedStorage_;
+            System::Array::Resize<T>(storageRef, (int)elements);
+            managedStorage_ = storageRef;
+            std::fill(begin_, end_, FillWith);
+            return;
+        }
+#endif
+        nativeStorage_.resize(elements, FillWith);
+    }
+
+    template <typename T> void _swap(std::vector<T>& that)
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr)
+        {
+            if (managedStorage_->Length == that.size())
+            {
+                // swap the managed array to the vector and vice versa
+                pin_ptr<T> pinnedArrayPtr = &managedStorage_[0];
+                T* nativeArrayPtr = &that[0];
+                std::swap_ranges(nativeArrayPtr, nativeArrayPtr + that.size(), (T*)&pinnedArrayPtr[0]);
+            }
+            else
+            {
+                // create temporary managed array and copy over the native array's contents
+                auto tmp = gcnew cli::array<T>((int)that.size());
+                {
+                    pin_ptr<T> pinnedTmpPtr = &tmp[0];
+                    memcpy(&pinnedTmpPtr[0], &that[0], that.size());
+                }
+
+                // copy the managed array's contents to the native array
+                {
+                    pin_ptr<T> pinnedArrayPtr = &managedStorage_[0];
+                    that.resize(managedStorage_->Length);
+                    memcpy(&that[0], &pinnedArrayPtr[0], that.size() * sizeof(T));
+                }
+
+                // replace the managed array with the temporary one
+                managedStorage_ = tmp;
+            }
+            return;
+        }
+#endif
+        nativeStorage_.swap(that);
+    }
+
+    template <typename T> void* managedStorage()
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ == nullptr)
+        {
+            managedStorage_ = gcnew cli::array<T>((int)nativeStorage_.size());
+
+            if (nativeStorage_.empty())
+                return managedStorage_.handle();
+
+            // copy the source native array's contents to the target managed array
+            pin_ptr<T> pinnedArrayPtr = &managedStorage_[0];
+            memcpy(&pinnedArrayPtr[0], &nativeStorage_[0], nativeStorage_.size() * sizeof(T));
+        }
+
+        return managedStorage_.handle();
+#else
+        throw std::runtime_error("[BinaryData<T>::managedStorage()] only supported with MSVC C++/CLI");
+#endif
+    }
+
+    template <typename T> void _assign(const Impl& that)
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (that.managedStorage_ != nullptr)
+        {
+            // if the lengths are not the same, the target array must be reallocated
+            if (managedStorage_ == nullptr ||
+                managedStorage_->Length != that.managedStorage_->Length)
+            {
+                managedStorage_ = gcnew cli::array<T>(that.managedStorage_->Length);
+            }
+
+            System::Array::Copy(that.managedStorage_, managedStorage_, managedStorage_->Length);
+            return;
+        }
+#endif
+        _assign(that.nativeStorage_);
+    }
+
+    template <typename T> void _assign(const std::vector<T>& that)
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr)
+        {
+            // if the lengths are not the same, the target array must be reallocated
+            if (managedStorage_->Length != that.size())
+                managedStorage_ = gcnew cli::array<T>((int)that.size());
+
+            // copy the source native array's contents to the target managed array
+            pin_ptr<T> pinnedArrayPtr = &managedStorage_[0];
+            memcpy(&pinnedArrayPtr[0], &that[0], that.size() * sizeof(T));
+            return;
+        }
+#endif
+        nativeStorage_ = that;
+    }
+
+    template <typename T> typename size_type _size() const
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr)
+            return managedStorage_->Length;
+#endif
+        return nativeStorage_.size();
+    }
+
+    template <typename T> typename size_type _capacity() const
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr && managedStorage_->Length > nativeStorage_.capacity())
+        {
+            return managedStorage_->Length;
+        }
+#endif
+        return nativeStorage_.capacity();
+    }
+
+    template <typename T> operator const std::vector<T>&() const
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr)
+        {
+            if (nativeStorage_.empty())
+                nativeStorage_.insert(nativeStorage_.end(), cbegin_, cend_);
+            else if (managedStorage_->Length != nativeStorage_.size())
+                throw std::length_error("managed and native storage have different sizes");
+        }
+#endif
+        return nativeStorage_;
+    }
+
+    template <typename T, typename Itr> void makeIterator(Itr& itr, bool begin)
+    {
+#ifdef PWIZ_MANAGED_PASSTHROUGH
+        if (managedStorage_ != nullptr && managedStorage_->Length > 0)
+        {
+            //auto arrayPtr = (cli::array<T>^) binaryData._impl->managedStorage_;
+            //pin_ptr<T> pinnedArrayPtr = &arrayPtr[0]; // the array is already pinned in binaryData, so when this goes out of scope it should not unpin
+            T* pinnedArrayPtr = static_cast<T*>((&managedStorage_).ToPointer());
+            itr.current_ = begin ? &pinnedArrayPtr[0] : (&pinnedArrayPtr[managedStorage_->Length - 1]) + 1;
+            return;
+        }
+#endif
+        if (!nativeStorage_.empty())
+            itr.current_ = begin ? &nativeStorage_.front() : (&nativeStorage_.back()) + 1;
+        else
+            itr.current_ = 0;
     }
 
     void cacheIterators(BinaryData& binaryData)
@@ -75,6 +286,8 @@ class BinaryData<T>::Impl
     iterator begin_, end_;
     const_iterator cbegin_, cend_;
 };
+
+#pragma managed(push, off)
 
 PWIZ_API_DECL template <typename T> BinaryData<T>::BinaryData(size_type elements, T t)
     : _impl(new Impl)
@@ -99,42 +312,21 @@ PWIZ_API_DECL template <typename T> BinaryData<T>::BinaryData(const_iterator fir
 PWIZ_API_DECL template <typename T> BinaryData<T>::~BinaryData() {}
 
 PWIZ_API_DECL template <typename T> BinaryData<T>::BinaryData(void* cliNumericArray)
-    : _impl(new Impl)
+    : _impl(new Impl(cliNumericArray))
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    GCHandle handle = __VOIDPTR_TO_GCHANDLE(cliNumericArray); // freed by caller
-    _impl->managedStorage_ = (cli::array<T>^) handle.Target;
     _impl->cacheIterators(*this);
-#else
-    throw std::runtime_error("[BinaryData<T>::ctor(void*)] only supported with MSVC C++/CLI");
-#endif
 }
 
 PWIZ_API_DECL template <typename T> BinaryData<T>& BinaryData<T>::operator=(void* cliNumericArray)
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    GCHandle handle = __VOIDPTR_TO_GCHANDLE(cliNumericArray); // freed by caller
-    _impl->managedStorage_ = (cli::array<T>^) handle.Target;
+    _impl->operator=(cliNumericArray);
     _impl->cacheIterators(*this);
     return *this;
-#else
-    throw std::runtime_error("[BinaryData<T>::operator=(void*)] only supported with MSVC C++/CLI");
-#endif
 }
 
 PWIZ_API_DECL template <typename T> void BinaryData<T>::_alloc(size_type elements, const T &t)
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ != nullptr)
-    {
-        _impl->managedStorage_ = gcnew array<T>((int)elements);
-        if (t != T())
-            std::fill(begin(), begin() + elements, t);
-        _impl->cacheIterators(*this);
-        return;
-    }
-#endif
-    _impl->nativeStorage_.assign(elements, t);
+    _impl->_alloc(elements, t);
     _impl->cacheIterators(*this);
 }
 
@@ -148,34 +340,13 @@ PWIZ_API_DECL template <typename T> void BinaryData<T>::_reserve(size_type eleme
 
 PWIZ_API_DECL template <typename T> void BinaryData<T>::_resize(size_type elements)
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ != nullptr)
-    {
-        cli::array<T>^% storageRef = (array<T>^) _impl->managedStorage_;
-        System::Array::Resize<T>(storageRef, (int)elements);
-        _impl->managedStorage_ = storageRef;
-        _impl->cacheIterators(*this);
-        return;
-    }
-#endif
-    _impl->nativeStorage_.resize(elements);
+    _impl->_resize<T>(elements);
     _impl->cacheIterators(*this);
 }
 
 PWIZ_API_DECL template <typename T> void BinaryData<T>::_resize(size_type elements, const T &FillWith)
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ != nullptr)
-    {
-        cli::array<T>^% storageRef = (array<T>^) _impl->managedStorage_;
-        System::Array::Resize<T>(storageRef, (int)elements);
-        _impl->managedStorage_ = storageRef;
-        std::fill(begin(), end(), FillWith);
-        _impl->cacheIterators(*this);
-        return;
-    }
-#endif
-    _impl->nativeStorage_.resize(elements, FillWith);
+    _impl->_resize<T>(elements, FillWith);
     _impl->cacheIterators(*this);
 }
 
@@ -190,62 +361,13 @@ PWIZ_API_DECL template <typename T> void BinaryData<T>::_swap(BinaryData& that)
 
 PWIZ_API_DECL template <typename T> void BinaryData<T>::_swap(std::vector<T>& that)
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ != nullptr)
-    {
-        if (_impl->managedStorage_->Length == that.size())
-        {
-            // swap the managed array to the vector and vice versa
-            pin_ptr<T> pinnedArrayPtr = &_impl->managedStorage_[0];
-            T* nativeArrayPtr = &that[0];
-            std::swap_ranges(nativeArrayPtr, nativeArrayPtr + that.size(), (T*) &pinnedArrayPtr[0]);
-        }
-        else
-        {
-            // create temporary managed array and copy over the native array's contents
-            auto tmp = gcnew cli::array<T>((int) that.size());
-            {
-                pin_ptr<T> pinnedTmpPtr = &tmp[0];
-                memcpy(&pinnedTmpPtr[0], &that[0], that.size());
-            }
-
-            // copy the managed array's contents to the native array
-            {
-                pin_ptr<T> pinnedArrayPtr = &_impl->managedStorage_[0];
-                that.resize(_impl->managedStorage_->Length);
-                memcpy(&that[0], &pinnedArrayPtr[0], that.size() * sizeof(T));
-            }
-
-            // replace the managed array with the temporary one
-            _impl->managedStorage_ = tmp;
-        }
-        _impl->cacheIterators(*this);
-        return;
-    }
-#endif
-    _impl->nativeStorage_.swap(that);
+    _impl->_swap<T>(that);
     _impl->cacheIterators(*this);
 }
 
 PWIZ_API_DECL template <typename T> void* BinaryData<T>::managedStorage() const
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ == nullptr)
-    {
-        _impl->managedStorage_ = gcnew cli::array<T>((int) _impl->nativeStorage_.size());
-
-        if (_impl->nativeStorage_.empty())
-            return _impl->managedStorage_.handle();
-
-        // copy the source native array's contents to the target managed array
-        pin_ptr<T> pinnedArrayPtr = &_impl->managedStorage_[0];
-        memcpy(&pinnedArrayPtr[0], &_impl->nativeStorage_[0], _impl->nativeStorage_.size() * sizeof(T));
-    }
-
-    return _impl->managedStorage_.handle();
-#else
-    throw std::runtime_error("[BinaryData<T>::managedStorage()] only supported with MSVC C++/CLI");
-#endif
+    return _impl->managedStorage<T>();
 }
 
 PWIZ_API_DECL template <typename T> void BinaryData<T>::_assign(const BinaryData<T>& that)
@@ -253,22 +375,8 @@ PWIZ_API_DECL template <typename T> void BinaryData<T>::_assign(const BinaryData
     if (that.empty())
         return;
 
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (that._impl->managedStorage_ != nullptr)
-    {
-        // if the lengths are not the same, the target array must be reallocated
-        if (_impl->managedStorage_ == nullptr ||
-            _impl->managedStorage_->Length != that._impl->managedStorage_->Length)
-        {
-            _impl->managedStorage_ = gcnew cli::array<T>(that._impl->managedStorage_->Length);
-        }
-
-        System::Array::Copy(that._impl->managedStorage_, _impl->managedStorage_, _impl->managedStorage_->Length);
-        _impl->cacheIterators(*this);
-        return;
-    }
-#endif
-    _assign(that._impl->nativeStorage_);
+    _impl->_assign<T>(*that._impl);
+    _impl->cacheIterators(*this);
 }
 
 PWIZ_API_DECL template <typename T> void BinaryData<T>::_assign(const std::vector<T>& that)
@@ -279,42 +387,18 @@ PWIZ_API_DECL template <typename T> void BinaryData<T>::_assign(const std::vecto
         return;
     }
 
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ != nullptr)
-    {
-        // if the lengths are not the same, the target array must be reallocated
-        if (_impl->managedStorage_->Length != that.size())
-            _impl->managedStorage_ = gcnew cli::array<T>((int) that.size());
-
-        // copy the source native array's contents to the target managed array
-        pin_ptr<T> pinnedArrayPtr = &_impl->managedStorage_[0];
-        memcpy(&pinnedArrayPtr[0], &that[0], that.size() * sizeof(T));
-        _impl->cacheIterators(*this);
-        return;
-    }
-#endif
-    _impl->nativeStorage_ = that;
+    _impl->_assign<T>(that);
     _impl->cacheIterators(*this);
 }
 
 PWIZ_API_DECL template <typename T> typename BinaryData<T>::size_type BinaryData<T>::_size() const
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ != nullptr)
-        return _impl->managedStorage_->Length;
-#endif
-    return _impl->nativeStorage_.size();
+    return _impl->_size<T>();
 }
 
 PWIZ_API_DECL template <typename T> typename BinaryData<T>::size_type BinaryData<T>::_capacity() const
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ != nullptr && _impl->managedStorage_->Length > _impl->nativeStorage_.capacity())
-    {
-        return _impl->managedStorage_->Length;
-    }
-#endif
-    return _impl->nativeStorage_.capacity();
+    return _impl->_capacity<T>();
 }
 
 /*PWIZ_API_DECL template <typename T> BinaryData<T>::operator std::vector<T>&()
@@ -333,16 +417,7 @@ PWIZ_API_DECL template <typename T> typename BinaryData<T>::size_type BinaryData
 
 PWIZ_API_DECL template <typename T> BinaryData<T>::operator const std::vector<T>&() const
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (_impl->managedStorage_ != nullptr)
-    {
-        if (_impl->nativeStorage_.empty())
-            _impl->nativeStorage_.insert(_impl->nativeStorage_.end(), cbegin(), cend());
-        else if (_impl->managedStorage_->Length != _impl->nativeStorage_.size())
-            throw std::length_error("managed and native storage have different sizes");
-    }
-#endif
-    return _impl->nativeStorage_;
+    return static_cast<const std::vector<T>&>(*_impl);
 }
 
 /*PWIZ_API_DECL template <typename T> BinaryData<T>::operator std::vector<double>() const
@@ -372,42 +447,18 @@ PWIZ_API_DECL template <typename T> typename BinaryData<T>::reference BinaryData
 
 PWIZ_API_DECL template <typename T> BinaryData<T>::const_iterator::const_iterator(const BinaryData& binaryData, bool begin)
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (binaryData._impl->managedStorage_ != nullptr && binaryData._impl->managedStorage_->Length > 0)
-    {
-        //auto arrayPtr = (cli::array<T>^) binaryData._impl->managedStorage_;
-        //pin_ptr<T> pinnedArrayPtr = &arrayPtr[0]; // the array is already pinned in binaryData, so when this goes out of scope it should not unpin
-        T* pinnedArrayPtr = static_cast<T*>((&binaryData._impl->managedStorage_).ToPointer());
-        current_ = begin ? &pinnedArrayPtr[0] : (&pinnedArrayPtr[binaryData._impl->managedStorage_->Length - 1]) + 1;
-        return;
-    }
-#endif
-    if (!binaryData._impl->nativeStorage_.empty())
-        current_ = begin ? &binaryData._impl->nativeStorage_.front() : (&binaryData._impl->nativeStorage_.back())+1;
-    else
-        current_ = 0;
+    binaryData._impl->makeIterator<T>(*this, begin);
 }
 
 PWIZ_API_DECL template <typename T> BinaryData<T>::iterator::iterator(BinaryData& binaryData, bool begin)
 {
-#ifdef PWIZ_MANAGED_PASSTHROUGH
-    if (binaryData._impl->managedStorage_ != nullptr && binaryData._impl->managedStorage_->Length > 0)
-    {
-        //auto arrayPtr = (cli::array<T>^) binaryData._impl->managedStorage_;
-        //pin_ptr<T> pinnedArrayPtr = &arrayPtr[0]; // the array is already pinned in binaryData, so when this goes out of scope it should not unpin
-        T* pinnedArrayPtr = static_cast<T*>((&binaryData._impl->managedStorage_).ToPointer());
-        current_ = begin ? &pinnedArrayPtr[0] : (&pinnedArrayPtr[binaryData._impl->managedStorage_->Length - 1]) + 1;
-        return;
-    }
-#endif
-    if (!binaryData._impl->nativeStorage_.empty())
-        current_ = begin ? &binaryData._impl->nativeStorage_.front() : (&binaryData._impl->nativeStorage_.back()) + 1;
-    else
-        current_ = 0;
+    binaryData._impl->makeIterator<T>(*this, begin);
 }
 
 PWIZ_API_DECL template class BinaryData<double>;
 PWIZ_API_DECL template class BinaryData<float>;
+
+#pragma managed(pop)
 
 } // util
 } // pwiz

--- a/pwiz/utility/misc/Jamfile.jam
+++ b/pwiz/utility/misc/Jamfile.jam
@@ -29,7 +29,6 @@ project
 ;
 
 
-lib ole32 : : <name>ole32 ; # for CoInitialize/CoUninitialize
 lib oleaut32 : : <name>oleaut32 ; # for Variant/SafeArray functions
 lib psapi : : <name>psapi ; # for GetMappedFileNameW
 lib SHA1 : SHA1.cpp : <link>static ;
@@ -38,18 +37,12 @@ lib SHA1 : SHA1.cpp : <link>static ;
 #cpp-pch Std : Std.hpp : <include>. ;
 alias Std ;
 
-rule BinaryData ( properties * )
-{
-    if <using-clr>true in $(properties)
-    {
-        return <define>PWIZ_MANAGED_PASSTHROUGH ;
-    }
-}
+obj BinaryData : BinaryData.cpp : <toolset>msvc:<using-clr>true ;
 
 lib pwiz_utility_misc
     : # sources
         Base64.cpp
-        BinaryData.cpp
+        BinaryData
         IntegerSet.cpp
         IterationListener.cpp
         Filesystem.cpp
@@ -62,8 +55,6 @@ lib pwiz_utility_misc
     : # requirements
         <warnings>all
         <toolset>msvc:<source>automation_vector.cpp
-        <toolset>msvc:<source>COMInitializer.cpp
-        <toolset>msvc:<library>ole32
         <toolset>msvc:<library>oleaut32
         <toolset>msvc:<library>psapi
         <library>/ext/boost//thread
@@ -80,10 +71,8 @@ lib pwiz_utility_misc
         <library>/ext/boost//date_time
         <library>/ext/boost//nowide
         <library>/ext/zlib//z
-        <toolset>msvc:<library>ole32
         <toolset>msvc:<library>oleaut32
         <toolset>msvc:<library>psapi
-        <conditional>@BinaryData
     ;
 
 
@@ -154,7 +143,7 @@ if [ modules.peek : NT ]
 {
     unit-test-if-exists BinaryDataTestManaged : BinaryDataTest.cpp pwiz_utility_misc Std : <using-clr>true ;
     unit-test-if-exists automation_vector_test : automation_vector_test.cpp pwiz_utility_misc Std : <conditional>@msvc-requirement ;
-    unit-test-if-exists COMInitializerTest : COMInitializerTest.cpp pwiz_utility_misc Std : <conditional>@msvc-requirement ;
+    #unit-test-if-exists COMInitializerTest : COMInitializerTest.cpp pwiz_utility_misc Std : <conditional>@msvc-requirement ;
 }
 
 exe sha1calc : sha1calc.cpp pwiz_utility_misc ;

--- a/pwiz/utility/misc/cpp_cli_utilities.hpp
+++ b/pwiz/utility/misc/cpp_cli_utilities.hpp
@@ -26,6 +26,10 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOGDI
 
+#ifndef NOMINMAX
+# define NOMINMAX
+#endif
+
 #include <gcroot.h>
 #include <vcclr.h>
 #pragma unmanaged

--- a/pwiz_aux/msrc/utility/vendor_api/UNIFI/UnifiData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/UNIFI/UnifiData.cpp
@@ -284,7 +284,7 @@ ref class ParallelDownloadQueue
                     try
                     {
                         requestStart = DateTime::UtcNow;
-                        request = gcnew System::Net::Http::HttpRequestMessage(System::Net::Http::HttpMethod::Get, spectrumEndpoint(taskIndex, min(_numSpectra, taskIndex + _chunkSize)));
+                        request = gcnew System::Net::Http::HttpRequestMessage(System::Net::Http::HttpMethod::Get, spectrumEndpoint(taskIndex, Math::Min(_numSpectra, (int) taskIndex + _chunkSize)));
                         response = httpClient->SendAsync(request, System::Net::Http::HttpCompletionOption::ResponseHeadersRead)->Result;
                         if (response->IsSuccessStatusCode)
                             break;
@@ -523,7 +523,7 @@ class UnifiData::Impl
             getNumberOfSpectra();
             //Console::WriteLine("numLogicalSpectra: {0}, numNetworkSpectra: {1}", _numLogicalSpectra, _numNetworkSpectra);
 
-            _chunkSize = (int) std::ceil(_numNetworkSpectra /100.0);//200;
+            _chunkSize = Math::Max(100, (int) std::ceil(_numNetworkSpectra /100.0));//200;
 #ifdef _WIN64
             _chunkReadahead = 3;
 #else


### PR DESCRIPTION
* fixed managed passthrough: the non-pimpl functions must be compiled under #pragma unmanaged
* added test for managed passthrough
* fixed more warnings about min/max macros
* changed minimum chunk size for UNIFI to 100
* removed MSVC redist from exclusion for subset tarballs
* added concrt140.dll to x86 redist list
* removed COMInitializer from build since it's not used anymore
* fixed gui_tools target