### PR TITLE
Fix "Can only get parent m/z for product scans" error

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -676,7 +676,7 @@ void Experiment2Impl::getIsolationInfo(int cycle, double& centerMz, double& lowe
 
 void Experiment2Impl::getPrecursorInfo(int cycle, double& centerMz, int& charge) const
 {
-    if (!getHasIsolationInfo())
+    if (!getHasIsolationInfo() || basePeakIntensities().at(cycle - 1) == 0)
         return;
 
     try

--- a/pwiz_tools/Skyline/Util/DataSourceUtil.cs
+++ b/pwiz_tools/Skyline/Util/DataSourceUtil.cs
@@ -45,10 +45,10 @@ namespace pwiz.Skyline.Util
         public const string EXT_WATERS_RAW = ".raw";
         public const string EXT_AGILENT_BRUKER_RAW = ".d";
 
-        public const string TYPE_WIFF = "ABSciex WIFF";
-        public const string TYPE_AGILENT = "Agilent Data";
-        public const string TYPE_BRUKER = "Bruker Data";
-        public const string TYPE_SHIMADZU = "Shimadzu Data";
+        public const string TYPE_WIFF = "Sciex WIFF/WIFF2";
+        public const string TYPE_AGILENT = "Agilent MassHunter Data";
+        public const string TYPE_BRUKER = "Bruker BAF/TDF";
+        public const string TYPE_SHIMADZU = "Shimadzu LCD";
         public const string TYPE_THERMO_RAW = "Thermo RAW";
         public const string TYPE_WATERS_RAW = "Waters RAW";
         public const string TYPE_MZML = "mzML";


### PR DESCRIPTION
- added workaround for "Can only get parent m/z for product scans" error when reading MS2s from WIFF2 files
- renamed some Skyline vendor file type strings to clarify which formats are supported