### PR TITLE
Missing MaxQuant modifications error

### DIFF
--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
@@ -567,7 +567,7 @@ void MaxQuantReader::storeLine(MaxQuantLine& entry)
     }
     catch (const MaxQuantWrongSequenceException& e)
     {
-        Verbosity::warn(e.what());
+        Verbosity::error(e.what());
         delete curMaxQuantPSM_;
         return;
     }

--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.h
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.h
@@ -220,7 +220,7 @@ class MaxQuantWrongSequenceException : public std::exception {
 public:
     MaxQuantWrongSequenceException(const std::string& mod, const std::string& seq, int line) {
         std::stringstream ss;
-        ss << "No matching mod for " << mod << " in sequence " << seq << " (line " << line << ")";
+        ss << "No matching mod for " << mod << " in sequence " << seq << " (line " << line << "). Make sure you have provided the correct modifications[.local].xml file.";
         message_ = ss.str();
     }
     virtual ~MaxQuantWrongSequenceException() throw () {}


### PR DESCRIPTION
- made missing MaxQuant modifications an error rather than a warning and improved the error message a bit