### PR TITLE
Fix bug in logic for determining adduct for small molecule transition…

### DIFF
--- a/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs
+++ b/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs
@@ -1299,7 +1299,7 @@ namespace pwiz.Skyline.Model.Serialization
                 }
                 // Watch all-mass declaration with mz same as mass with a charge-only adduct, which older versions don't describe succinctly
                 if (!isPrecursor && isPre362NonReporterCustom &&
-                    Math.Abs(declaredProductMz.Value - customMolecule.MonoisotopicMass) < .001)
+                    Math.Abs(declaredProductMz.Value - customMolecule.MonoisotopicMass / Math.Abs(adduct.AdductCharge)) < .001)
                 {
                     string newFormula = null;
                     if (!string.IsNullOrEmpty(customMolecule.Formula) &&


### PR DESCRIPTION
…s from version 3.7. Code was not working correctly if the transition charge was a number other than 1.

This is from this support request:
https://skyline.ms/announcements/home/support/thread.view?rowId=38314