### PR TITLE
Fixes for bugs reported by Paul Auger with AutoQC Loader and Skyline 4.2

### DIFF
--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -315,14 +315,25 @@ namespace pwiz.Skyline
             if (commandArgs.ImportingReplicateFile)
             {
                 var listNamedPaths = new List<KeyValuePair<string, MsDataFileUri[]>>();
-                if (!string.IsNullOrEmpty(commandArgs.ReplicateName))
+
+                MsDataFileUri[] files;
+                try
                 {
-                    var files = commandArgs.ReplicateFile.SelectMany(DataSourceUtil.ListSubPaths).ToArray();
+                    files = commandArgs.ReplicateFile.SelectMany(DataSourceUtil.ListSubPaths).ToArray();
+                }
+                catch (Exception e)
+                {
+                    _out.WriteLine(Resources.CommandLine_GeneralException_Error___0_, e.Message);
+                    return false;
+                }
+
+                if (!string.IsNullOrEmpty(commandArgs.ReplicateName))
+                { 
                     listNamedPaths.Add(new KeyValuePair<string, MsDataFileUri[]>(commandArgs.ReplicateName, files));
                 }
                 else
                 {
-                    foreach (var dataFile in commandArgs.ReplicateFile.SelectMany(DataSourceUtil.ListSubPaths))
+                    foreach (var dataFile in files)
                     {
                         listNamedPaths.Add(new KeyValuePair<string, MsDataFileUri[]>(
                             dataFile.GetSampleName() ?? dataFile.GetFileNameWithoutExtension(),

--- a/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
+++ b/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
@@ -24,6 +24,7 @@ using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.IonMobility;
 using pwiz.Skyline.Model.Irt;
 using pwiz.Skyline.Model.Lib;
+using pwiz.Skyline.Model.Optimization;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Model.RetentionTimes;
 using pwiz.Skyline.Properties;
@@ -200,6 +201,10 @@ namespace pwiz.Skyline.Model
             IrtDbManager = new IrtDbManager();
             IrtDbManager.Register(this);
             Register(IrtDbManager);
+
+            OptimizationDbManager = new OptimizationDbManager();
+            OptimizationDbManager.Register(this);
+            Register(OptimizationDbManager);
         }
 
         public ChromatogramManager ChromatogramManager { get; private set; }
@@ -211,6 +216,9 @@ namespace pwiz.Skyline.Model
         public IonMobilityLibraryManager IonMobilityManager { get; private set; }
 
         public IrtDbManager IrtDbManager { get; private set; }
+
+        public OptimizationDbManager OptimizationDbManager { get; private set; }
+
 
         public override void ResetProgress()
         {


### PR DESCRIPTION
1. Register OptimizationDbManager with MemoryDocumentContainer
2. Catch and log exception while trying to list sample files in a WIFF file. This can happen if the file is still locked by the instrument software.