### PR TITLE
Skyline: deal with a race condition in some tutorial tests (TestMs1Tu…

### DIFF
--- a/pwiz_tools/Shared/Common/Collections/ValueSet.cs
+++ b/pwiz_tools/Shared/Common/Collections/ValueSet.cs
@@ -74,6 +74,7 @@ namespace pwiz.Common.Collections
         public string AuditLogText { get { return string.Format("\"{0}\"", ToString()); } }
         // ReSharper restore LocalizableElement
         public bool IsName { get { return false; } }
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
 
         #region Equality Members
         public override int GetHashCode()

--- a/pwiz_tools/Shared/Common/DataBinding/ColumnSpec.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/ColumnSpec.cs
@@ -182,6 +182,8 @@ namespace pwiz.Common.DataBinding
             get { return true; }
         }
 
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
+
         public bool Equals(ColumnSpec other)
         {
             if (ReferenceEquals(null, other)) return false;

--- a/pwiz_tools/Shared/Common/DataBinding/Layout/ColumnId.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Layout/ColumnId.cs
@@ -101,5 +101,7 @@ namespace pwiz.Common.DataBinding.Layout
         {
             get { return true; }
         }
+
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
     }
 }

--- a/pwiz_tools/Shared/Common/DataBinding/Layout/PivotSpec.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Layout/PivotSpec.cs
@@ -138,6 +138,7 @@ namespace pwiz.Common.DataBinding.Layout
 
             public string AuditLogText { get { return SourceColumn.Name; } }
             public bool IsName { get { return true; }}
+            public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
         }
 
         public class AggregateColumn : Column

--- a/pwiz_tools/Shared/Common/DataBinding/Layout/ViewLayout.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Layout/ViewLayout.cs
@@ -57,6 +57,8 @@ namespace pwiz.Common.DataBinding.Layout
             get { return true; }
         }
 
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
+
         protected bool Equals(ViewLayout other)
         {
             return string.Equals(Name, other.Name) && 

--- a/pwiz_tools/Shared/Common/DataBinding/ViewSpecList.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/ViewSpecList.cs
@@ -87,6 +87,7 @@ namespace pwiz.Common.DataBinding
 
             public string AuditLogText { get { return ViewSpec.Name; } }
             public bool IsName { get { return true; } }
+            public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
         }
 
         public ViewSpecList FilterRowSources(ICollection<string> rowSources)

--- a/pwiz_tools/Shared/Common/SystemUtil/TrackAttribute.cs
+++ b/pwiz_tools/Shared/Common/SystemUtil/TrackAttribute.cs
@@ -193,6 +193,8 @@ namespace pwiz.Common.SystemUtil
         // Determines whether the AuditLogText is a name or a string representation
         // of the object
         bool IsName { get; }
+        // Allows an object instance to declare itself as MISSING (generally if it's empty) or {}. A null object is always listed as MISSING.
+        bool IsMissing { get; }
     }
 
     internal static class CharToResourceStringMap
@@ -278,6 +280,9 @@ namespace pwiz.Common.SystemUtil
         {
             get { return true; }
         }
+
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
+
     }
 
     // These values get written into audit logs by index and can therefore

--- a/pwiz_tools/Skyline/Controls/Graphs/AlignmentForm.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AlignmentForm.cs
@@ -67,7 +67,7 @@ namespace pwiz.Skyline.Controls.Graphs
             zedGraphControl.GraphPane.XAxis.MinorTic.IsOpposite = false;
             zedGraphControl.GraphPane.Chart.Border.IsVisible = false;
 
-            _rowUpdateQueue.RunAsync(ParallelEx.GetThreadCount(), "Alignment Rows");
+            _rowUpdateQueue.RunAsync(ParallelEx.GetThreadCount(), @"Alignment Rows");
         }
 
         private PlotTypeRT _plotType;

--- a/pwiz_tools/Skyline/EditUI/UniquePeptidesDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/UniquePeptidesDlg.cs
@@ -604,6 +604,7 @@ namespace pwiz.Skyline.EditUI
 
             public string AuditLogText { get { return ProteinName; } }
             public bool IsName { get { return true; } }
+            public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
         }
 
         public UniquePeptideSettings FormSettings

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.cs
@@ -66,7 +66,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         public class BuildPeptideSearchLibrarySettings : AuditLogOperationSettings<BuildPeptideSearchLibrarySettings>
         {
-            public static BuildPeptideSearchLibrarySettings DEFAULT = new BuildPeptideSearchLibrarySettings(0.0, new List<string>(), null, false,
+            public static BuildPeptideSearchLibrarySettings DEFAULT = new BuildPeptideSearchLibrarySettings(0.0, new List<string>(), IrtStandard.EMPTY, false,
                 false, ImportPeptideSearchDlg.Workflow.dda);
 
             public override MessageInfo MessageInfo
@@ -137,7 +137,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         public IrtStandard IrtStandards
         {
-            get { return comboStandards.SelectedItem as IrtStandard; }
+            get { return comboStandards.SelectedItem as IrtStandard ?? IrtStandard.EMPTY; }
             set
             {
                 if (value == null)
@@ -355,7 +355,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
             var selectedIrtStandard = comboStandards.SelectedItem as IrtStandard;
             var addedIrts = false;
-            if (selectedIrtStandard != null && selectedIrtStandard != IrtStandard.NULL)
+            if (selectedIrtStandard != null && selectedIrtStandard != IrtStandard.EMPTY)
                 addedIrts = AddIrtLibraryTable(docLibSpec.FilePath, selectedIrtStandard);
 
             var docNew = ImportPeptideSearch.AddDocumentSpectralLibrary(DocumentContainer.Document, docLibSpec);

--- a/pwiz_tools/Skyline/Model/Annotations.cs
+++ b/pwiz_tools/Skyline/Model/Annotations.cs
@@ -131,6 +131,7 @@ namespace pwiz.Skyline.Model
 
             public string AuditLogText { get { return Name; } }
             public bool IsName { get { return true; } }
+            public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
 
             protected bool Equals(Annotation other)
             {

--- a/pwiz_tools/Skyline/Model/AuditLog/AuditLogObject.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/AuditLogObject.cs
@@ -44,6 +44,18 @@ namespace pwiz.Skyline.Model.AuditLog
             get { return false; }
         }
 
+        public bool IsMissing
+        {
+            get
+            {
+                if (Object == null)
+                    return true;
+                if (Object is AuditLogObject obj)
+                    return obj.IsMissing; // Some classes check for emptiness and call that MISSING as well.
+                return false;
+            } 
+        } 
+
         public object Object { get; private set; }
 
         public static object GetObject(IAuditLogObject auditLogObj)
@@ -95,6 +107,8 @@ namespace pwiz.Skyline.Model.AuditLog
         {
             get { return true; }
         }
+
+        public bool IsMissing { get { return string.IsNullOrEmpty(Path); } } // Check for emptiness and call that MISSING as well.
 
         protected bool Equals(AuditLogPath other)
         {

--- a/pwiz_tools/Skyline/Model/AuditLog/LogMessage.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/LogMessage.cs
@@ -331,7 +331,7 @@ namespace pwiz.Skyline.Model.AuditLog
             if (s == null)
                 return null;
 
-            return string.Format("\"{0}\"", s);
+            return string.Format(@"""{0}""", s);
         }
 
         public override string ToString()

--- a/pwiz_tools/Skyline/Model/AuditLog/ReflectorToString.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/ReflectorToString.cs
@@ -109,6 +109,10 @@ namespace pwiz.Skyline.Model.AuditLog
             if (node.Nodes.Count == 0)
             {
                 var obj = node.Objects.First();
+
+                if (obj is IAuditLogObject auditLogObj1 && auditLogObj1.IsMissing)
+                    return LogMessage.MISSING;
+
                 if (obj is IAuditLogObject auditLogObj && (auditLogObj.IsName || GetProperties(obj.GetType()).Count == 0))
                 {
                     var text = auditLogObj.IsName && !(obj is DocNode)
@@ -146,6 +150,9 @@ namespace pwiz.Skyline.Model.AuditLog
             var obj = node.Objects.First();
             var property = node.Property;
             var auditLogObj = AuditLogObject.GetAuditLogObject(obj);
+
+            if (auditLogObj.IsMissing)
+                return LogMessage.MISSING; // Some class prefer empty objects to be reported as MISSING rather than {}
 
             var result = @"{0}";
             string format;

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Transition.cs
@@ -183,8 +183,8 @@ namespace pwiz.Skyline.Model.Databinding.Entities
                 if (IsCustomTransition())
                     return null;
                 return DocNode.HasLoss && DocNode.Losses.Losses.All(l => l.Loss.Formula != null)
-                        ? string.Join(", ", DocNode.Losses.Losses.Select(l => l.Loss.Formula))
-                        : string.Empty;  // Not L10N
+                        ? string.Join(@", ", DocNode.Losses.Losses.Select(l => l.Loss.Formula))
+                        : string.Empty; 
             }
         }
 

--- a/pwiz_tools/Skyline/Model/DocNode.cs
+++ b/pwiz_tools/Skyline/Model/DocNode.cs
@@ -333,6 +333,8 @@ namespace pwiz.Skyline.Model
         {
             get { return true; }
         }
+
+        public virtual bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
     }
 
     /// <summary>

--- a/pwiz_tools/Skyline/Model/DocSettings/FullScanAcquisitionMethod.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/FullScanAcquisitionMethod.cs
@@ -116,6 +116,9 @@ namespace pwiz.Skyline.Model.DocSettings
 
         bool IAuditLogObject.IsName => true;
 
+        bool IAuditLogObject.IsMissing => false; // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
+
+
         [Pure]
         public bool Equals(FullScanAcquisitionMethod other)
         {

--- a/pwiz_tools/Skyline/Model/DocSettings/Modification.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Modification.cs
@@ -828,6 +828,7 @@ namespace pwiz.Skyline.Model.DocSettings
 
         public string AuditLogText { get { return LabelType.ToString(); } }
         public bool IsName { get { return true; }}
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
     }
 
     public sealed class ExplicitMods : Immutable
@@ -1304,6 +1305,8 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             get { return true; }
         }
+
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
 
         public object GetDefaultObject(ObjectInfo<object> info)
         {

--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -1919,6 +1919,8 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             get { return false; }
         }
+
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
     }
 
     /// <summary>

--- a/pwiz_tools/Skyline/Model/DocSettings/XmlNamedElement.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/XmlNamedElement.cs
@@ -72,6 +72,7 @@ namespace pwiz.Skyline.Model.DocSettings
 
         public virtual string AuditLogText { get { return Name; } }
         public virtual bool IsName { get { return true; } }
+        public virtual bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
 
         #region Property change methods
 

--- a/pwiz_tools/Skyline/Model/Irt/IrtStandard.cs
+++ b/pwiz_tools/Skyline/Model/Irt/IrtStandard.cs
@@ -10,7 +10,7 @@ namespace pwiz.Skyline.Model.Irt
 {
     public class IrtStandard : IAuditLogObject
     {
-        public static readonly IrtStandard NULL = new IrtStandard(string.Empty, null, new DbIrtPeptide[0]);
+        public static readonly IrtStandard EMPTY = new IrtStandard(string.Empty, null, new DbIrtPeptide[0]);
 
         public static readonly IrtStandard BIOGNOSYS_10 = new IrtStandard(@"Biognosys-10 (iRT-C18)", @"Biognosys10.sky",
             new[] {
@@ -303,7 +303,7 @@ namespace pwiz.Skyline.Model.Irt
             });
 
         public static readonly ImmutableList<IrtStandard> ALL = ImmutableList.ValueOf(new[] {
-            NULL, BIOGNOSYS_10, BIOGNOSYS_11, PIERCE, REPLICAL, RTBEADS, SCIEX, SIGMA, APOA1, CIRT_SHORT
+            EMPTY, BIOGNOSYS_10, BIOGNOSYS_11, PIERCE, REPLICAL, RTBEADS, SCIEX, SIGMA, APOA1, CIRT_SHORT
         });
 
         private static readonly HashSet<Target> ALL_TARGETS = new HashSet<Target>(ALL.SelectMany(l => l.Peptides.Select(p => p.ModifiedTarget)));
@@ -341,6 +341,7 @@ namespace pwiz.Skyline.Model.Irt
 
         public string AuditLogText { get { return Name; } }
         public bool IsName { get { return true; } }
+        public bool IsMissing { get { return Equals(this, EMPTY); } } // Declare empty instance as MISSING rather than {}
 
         public TextReader DocumentReader
         {
@@ -458,7 +459,7 @@ namespace pwiz.Skyline.Model.Irt
 
         public static IrtStandard WhichStandard(ICollection<Target> peptides, out HashSet<Target> missingPeptides)
         {
-            var standard = ALL.FirstOrDefault(s => s.ContainsAll(peptides.Select(p => MakePeptide(p.Sequence, 0)).ToList(), null)) ?? NULL;
+            var standard = ALL.FirstOrDefault(s => s.ContainsAll(peptides.Select(p => MakePeptide(p.Sequence, 0)).ToList(), null)) ?? EMPTY;
             missingPeptides = new HashSet<Target>(standard.Peptides.Where(s => !peptides.Any(p => p.Equals(s.Target))).Select(s => s.Target));
             return standard;
         }

--- a/pwiz_tools/Skyline/Model/IsotopeLabelType.cs
+++ b/pwiz_tools/Skyline/Model/IsotopeLabelType.cs
@@ -80,6 +80,7 @@ namespace pwiz.Skyline.Model
 
         public string AuditLogText { get { return LogMessage.Quote(Title); } }
         public bool IsName { get { return false; } }
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
 
         #region object overrides
 

--- a/pwiz_tools/Skyline/Model/Lib/Library.cs
+++ b/pwiz_tools/Skyline/Model/Lib/Library.cs
@@ -388,7 +388,7 @@ namespace pwiz.Skyline.Model.Lib
         {
             var monitor = new LibraryBuildMonitor(this, container);
             var buildState = new BuildState(builder.LibrarySpec, BuildLibraryBackground);
-            ActionUtil.RunAsync(() => callback(buildState, BuildLibraryBackground(container, builder, monitor, buildState)), "Library Build");
+            ActionUtil.RunAsync(() => callback(buildState, BuildLibraryBackground(container, builder, monitor, buildState)), @"Library Build");
         }
 
         public bool BuildLibraryBackground(IDocumentContainer container, ILibraryBuilder builder, IProgressMonitor monitor, BuildState buildState)
@@ -419,7 +419,7 @@ namespace pwiz.Skyline.Model.Lib
                         buildState.ExtraMessage = biblioSpecLiteBuilder.AmbiguousMatchesMessage;
                     }
                     if (biblioSpecLiteBuilder.IrtStandard != null &&
-                        biblioSpecLiteBuilder.IrtStandard != IrtStandard.NULL)
+                        biblioSpecLiteBuilder.IrtStandard != IrtStandard.EMPTY)
                     {
                         buildState.IrtStandard = biblioSpecLiteBuilder.IrtStandard;
                     }
@@ -1569,6 +1569,7 @@ namespace pwiz.Skyline.Model.Lib
 
         public string AuditLogText { get { return Label; } }
         public bool IsName { get { return true; } }
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
 
         private bool Equals(PeptideRankId other)
         {

--- a/pwiz_tools/Skyline/Model/Lists/ListData.cs
+++ b/pwiz_tools/Skyline/Model/Lists/ListData.cs
@@ -453,5 +453,7 @@ namespace pwiz.Skyline.Model.Lists
         {
             get { return true; }
         }
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
+
     }
 }

--- a/pwiz_tools/Skyline/Model/Peptide.cs
+++ b/pwiz_tools/Skyline/Model/Peptide.cs
@@ -821,5 +821,7 @@ namespace pwiz.Skyline.Model
 
         public string AuditLogText { get { return ToSerializableString(); } }
         public bool IsName { get { return true; } }
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
+
     }
 }

--- a/pwiz_tools/Skyline/Model/Results/Scoring/IPeakScoringModel.cs
+++ b/pwiz_tools/Skyline/Model/Results/Scoring/IPeakScoringModel.cs
@@ -426,6 +426,7 @@ namespace pwiz.Skyline.Model.Results.Scoring
 
         public string AuditLogText { get { return Name; } }
         public bool IsName { get { return true; }}
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
     }
 
     /// <summary>
@@ -457,6 +458,7 @@ namespace pwiz.Skyline.Model.Results.Scoring
 
         public string AuditLogText { get { return Name; } }
         public bool IsName { get { return true; } }
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
     }
 
     /// <summary>

--- a/pwiz_tools/Skyline/Model/StandardType.cs
+++ b/pwiz_tools/Skyline/Model/StandardType.cs
@@ -59,5 +59,6 @@ namespace pwiz.Skyline.Model
 
         public string AuditLogText { get { return Title; } }
         public bool IsName { get { return true; } }
+        public bool IsMissing { get { return false; } } // Only a null reference will be reported as MISSING. (Some classes check for emptiness and call that MISSING as well.)
     }
 }

--- a/pwiz_tools/Skyline/Model/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Transition.cs
@@ -778,7 +778,7 @@ namespace pwiz.Skyline.Model
 
         public override string ToString()
         {
-            return Transition + (Losses != null ? " -" + Losses.Mass : string.Empty);
+            return Transition + (Losses != null ? @" -" + Losses.Mass : string.Empty);
         }
 
         #endregion

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.cs
@@ -646,7 +646,7 @@ namespace pwiz.Skyline.SettingsUI
 
         public IrtStandard IrtStandard
         {
-            get { return comboStandards.SelectedItem as IrtStandard ?? IrtStandard.NULL; }
+            get { return comboStandards.SelectedItem as IrtStandard ?? IrtStandard.EMPTY; }
             set { comboStandards.SelectedIndex = comboStandards.Items.IndexOf(value); }
         }
 

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryNotification.cs
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryNotification.cs
@@ -379,7 +379,7 @@ namespace pwiz.Skyline.SettingsUI
                             {
                                 MessageDlg.Show(TopMostApplicationForm, buildState.ExtraMessage);
                             }
-                            if (buildState.IrtStandard != null && buildState.IrtStandard != IrtStandard.NULL && AddIrts(buildState))
+                            if (buildState.IrtStandard != null && buildState.IrtStandard != IrtStandard.EMPTY && AddIrts(buildState))
                             {
                                 AddRetentionTimePredictor(buildState);
                             }

--- a/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.cs
@@ -134,7 +134,7 @@ namespace pwiz.Skyline.SettingsUI.Irt
             get
             {
                 return comboStandards.Items.Cast<IrtStandard>().FirstOrDefault(standard => standard.IsMatch(StandardPeptideList, IRT_TOLERANCE))
-                    ?? IrtStandard.NULL;
+                    ?? IrtStandard.EMPTY;
             }
         }
 
@@ -1245,7 +1245,7 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
             if (!IrtStandard.AllStandards(StandardPeptideList, IRT_TOLERANCE))
             {
-                comboStandards.SelectedItem = IrtStandard.NULL;
+                comboStandards.SelectedItem = IrtStandard.EMPTY;
                 MessageDlg.Show(this,
                     Resources.EditIrtCalcDlg_comboStandards_SelectedIndexChanged_The_list_of_standard_peptides_must_contain_only_recognized_iRT_C18_standards_to_switch_to_a_predefined_set_of_iRT_C18_standards_);
                 return;

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -3323,7 +3323,7 @@ namespace pwiz.Skyline
         {
             missingPeptides = new HashSet<Target>();
             var calcPeptides = RCalcIrt.IrtPeptides(Document).ToArray();
-            return calcPeptides.Any() ? IrtStandard.WhichStandard(calcPeptides, out missingPeptides) : IrtStandard.NULL;
+            return calcPeptides.Any() ? IrtStandard.WhichStandard(calcPeptides, out missingPeptides) : IrtStandard.EMPTY;
         }
 
         private void transitionSettingsMenuItem_Click(object sender, EventArgs e)

--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -404,7 +404,7 @@ namespace pwiz.SkylineTestFunctional
             BuildLibraryIrt(true, true, true);
             RunUI(() => Assert.IsTrue(PeptideSettingsUI.Prediction.RetentionTime.Name.Equals("library_test_irt4")));
             var editIrtDlg4 = ShowDialog<EditIrtCalcDlg>(PeptideSettingsUI.EditCalculator);
-            RunUI(() => Assert.IsTrue(editIrtDlg4.IrtStandards == IrtStandard.NULL));
+            RunUI(() => Assert.IsTrue(editIrtDlg4.IrtStandards == IrtStandard.EMPTY));
             OkDialog(editIrtDlg4, editIrtDlg4.CancelDialog);
 
             OkDialog(PeptideSettingsUI, PeptideSettingsUI.CancelDialog);
@@ -579,7 +579,7 @@ namespace pwiz.SkylineTestFunctional
                 buildLibraryDlg.LibraryFilterPeptides = filterPeptides;
                 buildLibraryDlg.LibraryBuildAction = (append ?
                     LibraryBuildAction.Append : LibraryBuildAction.Create);
-                if (irtStandard != null && !irtStandard.Equals(IrtStandard.NULL))
+                if (irtStandard != null && !irtStandard.Equals(IrtStandard.EMPTY))
                     buildLibraryDlg.IrtStandard = irtStandard;
                 buildLibraryDlg.OkWizardPage();
                 if (inputPaths != null)

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -1686,5 +1686,7 @@ namespace pwiz.Skyline.Util
         {
             get { return true; }
         }
+
+        public bool IsMissing { get { return Equals(this, EMPTY); } } // Check for emptiness and call that MISSING as well
     }
 }

--- a/pwiz_tools/Skyline/Util/FormEx.cs
+++ b/pwiz_tools/Skyline/Util/FormEx.cs
@@ -58,7 +58,8 @@ namespace pwiz.Skyline.Util
             if (Program.FunctionalTest && IsCreatingHandle())
             {
                 Program.Log?.Invoke(string.Format(
-                    "\r\n[WARNING] STATE_CREATINGHANDLE set after handle creation in form of type '{0}'. Stack Trace:\r\n{1}\r\n\r\n", // Not L10N
+                    // ReSharper disable once LocalizableElement
+                    "\r\n[WARNING] STATE_CREATINGHANDLE set after handle creation in form of type '{0}'. Stack Trace:\r\n{1}\r\n\r\n", 
                     GetType(), Environment.StackTrace));
             }
         }
@@ -162,7 +163,8 @@ namespace pwiz.Skyline.Util
                 // and return so that we don't call base.Dispose and maybe get to find out what
                 // the "current exception" is
                 Program.Log?.Invoke(string.Format(
-                    "\r\n[WARNING] Attempting to dispose form of type '{0}' during handle creation. StackTrace:\r\n{1}\r\n\r\n", // Not L10N
+                    // ReSharper disable once LocalizableElement
+                    "\r\n[WARNING] Attempting to dispose form of type '{0}' during handle creation. StackTrace:\r\n{1}\r\n\r\n",
                     GetType(), Environment.StackTrace));
 
                 return;


### PR DESCRIPTION
…torial, TestTargetedMSMSTutorial, TestTargetedMSMSTutorialAsSmallMoleculeMasses, TestTargetedMSMSTutorialAsSmallMolecules) that could result in an unselected irtStandard being audit logged as either "{}" or "MISSING" depending on whether UI events had time to fire during the test. In some cases we'd read it as null, in others we'd read it as irtStandard.EMPTY. In both cases we'd want to log it as MISSING so I've added a mechanism for classes to declare an instance as MISSING, usually because it's identified as being empty. In Skyline we generally avoid nulls and have the idea of an instance that's empty instead. (Formerly irtStandard.EMPTY was called irtStandard.NULL, which does not follow our usual naming convention)