### PR TITLE
Fix WIFF issues (4.2)

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
@@ -39,6 +39,7 @@
 
 #pragma managed
 #include "pwiz/utility/misc/cpp_cli_utilities.hpp"
+#include <msclr/auto_gcroot.h>
 #using <System.Xml.dll>
 using namespace pwiz::util;
 using namespace System;
@@ -67,8 +68,8 @@ class WiffFileImpl : public WiffFile
 
     gcroot<DataProvider^> provider;
     gcroot<Batch^> batch;
-    mutable gcroot<Clearcore2::Data::DataAccess::SampleData::Sample^> sample;
-    mutable gcroot<MassSpectrometerSample^> msSample;
+    mutable msclr::auto_gcroot<Clearcore2::Data::DataAccess::SampleData::Sample^> sample;
+    mutable msclr::auto_gcroot<MassSpectrometerSample^> msSample;
 
     virtual int getSampleCount() const;
     virtual int getPeriodCount(int sample) const;

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -51,6 +51,9 @@ class WiffFile2Impl : public WiffFile
         delete dataReader;
     }
 
+    // prevent multiple Wiff2 files from opening at once, because it currently rewrites DataReader.config every time
+    static gcroot<System::Object^> mutex;
+
     msclr::auto_gcroot<IDataReader^> dataReader;
     mutable gcroot<IList<ISampleInformation^>^> allSamples;
     mutable gcroot<ISampleInformation^> msSample;
@@ -226,20 +229,25 @@ void ToStdVectorsFromXyData(IXyData<double>^ xyData, std::vector<double>& xVecto
 }
 
 
+gcroot<System::Object^> WiffFile2Impl::mutex = gcnew System::Object();
+
 WiffFile2Impl::WiffFile2Impl(const string& wiffpath)
 : currentSampleIndex(-1), currentPeriod(-1), currentExperiment(-1), currentCycle(-1), wiffpath_(wiffpath)
 {
     try
     {
+        System::Threading::Monitor::Enter(mutex);
         dataReader = DataReaderFactory::CreateReader();
         allSamples = dataReader->ExtractSampleInformation(ToSystemString(wiffpath));
+        System::Threading::Monitor::Exit(mutex);
 
         // This caused WIFF files where the first sample had been interrupted to
         // throw before they could be successfully constructed, which made investigators
         // unhappy when they were seeking access to later, successfully acquired samples.
         // setSample(1);
     }
-    CATCH_AND_FORWARD
+    catch (std::exception&) { System::Threading::Monitor::Exit(mutex); throw; }
+    catch (System::Exception^ e) { System::Threading::Monitor::Exit(mutex); throw std::runtime_error(trimFunctionMacro(__FUNCTION__, "") + pwiz::util::ToStdString(e->Message)); }
 }
 
 


### PR DESCRIPTION
- fixed errors when opening multiple WIFF2s at the same time
- addressed issue with WiffFile's MassSpectrometerSample not being disposed (unverified, no repro)