### PR TITLE
Skyline - fixed TestStartPageShowPathChooser failure that caused Test…

### DIFF
--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -185,7 +185,7 @@ namespace pwiz.SkylineTestTutorial
                 });
                 PauseForScreenShot<TransitionSettingsUI.FilterTab>("Transition Settings - Filter tab", 9);
 
-                OkDialog(transitionSettingsUI, transitionSettingsUI.OkDialog, true);
+                OkDialog(transitionSettingsUI, transitionSettingsUI.OkDialog);
 
                 var tranSettingsFullScan = SkylineWindow.Document.Settings.TransitionSettings;
                 Assert.AreEqual(FullScanPrecursorIsotopes.Count, tranSettingsFullScan.FullScan.PrecursorIsotopes);

--- a/pwiz_tools/Skyline/Util/CreateHandleDebugBase.cs
+++ b/pwiz_tools/Skyline/Util/CreateHandleDebugBase.cs
@@ -82,7 +82,7 @@ namespace pwiz.Skyline.Util
         [Localizable(false)]
         private void ControlCreateHandle()
         {
-            Program.Log?.Invoke("Begin ControlCreateHandle\r\n");
+            Program.Log?.Invoke("\r\nBegin ControlCreateHandle\r\n");
             var formType = typeof(Form);
             var controlType = typeof(Control);
 


### PR DESCRIPTION
…Runner to hang

- OkDialog was throwing a null reference exception, since the TestStartPageShowPathChooser
  only opens the start page and not Skyline, thus SkylineWindow is null. When this exception
  gets thrown, EndTest is called but it only closes the SkylineWindow and not the StartPage,
  which causes the StartPage to remain open indefinitely.

- removed waitForDocChange from OkDialog, it's not too useful after all

- also added a newline to create handle debug code to make logs more readable