### PR TITLE
Rename "Views" dropdown on Document Grid to "Reports"

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ManageViewsForm.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ManageViewsForm.resx
@@ -460,7 +460,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Manage Views</value>
+    <value>Manage Reports</value>
   </data>
   <data name="&gt;&gt;openViewEditorContextMenuItem.Name" xml:space="preserve">
     <value>openViewEditorContextMenuItem</value>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ViewEditor.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ViewEditor.resx
@@ -181,13 +181,13 @@
     <value>3, 6</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 13</value>
+    <value>73, 13</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>View &amp;Name:</value>
+    <value>Report &amp;Name:</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -276,6 +276,21 @@
   <data name="&gt;&gt;tabPageColumns.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="tabPageSource.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tabPageSource.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tabPageSource.Size" type="System.Drawing.Size, System.Drawing">
+    <value>614, 309</value>
+  </data>
+  <data name="tabPageSource.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tabPageSource.Text" xml:space="preserve">
+    <value>Source</value>
+  </data>
   <data name="&gt;&gt;tabPageSource.Name" xml:space="preserve">
     <value>tabPageSource</value>
   </data>
@@ -312,60 +327,9 @@
   <data name="&gt;&gt;tabControl1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tabPageSource.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tabPageSource.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tabPageSource.Size" type="System.Drawing.Size, System.Drawing">
-    <value>614, 309</value>
-  </data>
-  <data name="tabPageSource.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="tabPageSource.Text" xml:space="preserve">
-    <value>Source</value>
-  </data>
-  <data name="&gt;&gt;tabPageSource.Name" xml:space="preserve">
-    <value>tabPageSource</value>
-  </data>
-  <data name="&gt;&gt;tabPageSource.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPageSource.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabPageSource.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="toolStrip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="toolStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>622, 25</value>
-  </data>
-  <data name="toolStrip.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="toolStrip.Text" xml:space="preserve">
-    <value>toolStrip1</value>
-  </data>
-  <data name="&gt;&gt;toolStrip.Name" xml:space="preserve">
-    <value>toolStrip</value>
-  </data>
-  <data name="&gt;&gt;toolStrip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStrip.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;toolStrip.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="toolButtonUndo.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -490,6 +454,48 @@
   <data name="helpToolStripButton.ToolTipText" xml:space="preserve">
     <value>Show Column Documentation</value>
   </data>
+  <data name="toolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="toolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>622, 25</value>
+  </data>
+  <data name="toolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="toolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Name" xml:space="preserve">
+    <value>toolStrip</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnPreview.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnPreview.Location" type="System.Drawing.Point, System.Drawing">
+    <value>535, 0</value>
+  </data>
+  <data name="btnPreview.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnPreview.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="btnPreview.Text" xml:space="preserve">
+    <value>Preview...</value>
+  </data>
+  <data name="btnPreview.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="&gt;&gt;btnPreview.Name" xml:space="preserve">
     <value>btnPreview</value>
   </data>
@@ -525,36 +531,6 @@
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="btnPreview.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnPreview.Location" type="System.Drawing.Point, System.Drawing">
-    <value>535, 0</value>
-  </data>
-  <data name="btnPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="btnPreview.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="btnPreview.Text" xml:space="preserve">
-    <value>Preview...</value>
-  </data>
-  <data name="btnPreview.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;btnPreview.Name" xml:space="preserve">
-    <value>btnPreview</value>
-  </data>
-  <data name="&gt;&gt;btnPreview.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPreview.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;btnPreview.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="panelViewEditor.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -620,7 +596,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Customize View</value>
+    <value>Customize Report</value>
   </data>
   <data name="&gt;&gt;toolButtonUndo.Name" xml:space="preserve">
     <value>toolButtonUndo</value>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/NavBar.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/NavBar.resx
@@ -137,10 +137,10 @@
     <value>Magenta</value>
   </data>
   <data name="navBarButtonViews.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 22</value>
+    <value>60, 22</value>
   </data>
   <data name="navBarButtonViews.Text" xml:space="preserve">
-    <value>Views</value>
+    <value>Reports</value>
   </data>
   <data name="bindingNavigatorMoveFirstItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/pwiz_tools/Shared/Common/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Shared/Common/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace pwiz.Common.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -380,7 +380,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is already a view named &apos;{0}&apos;..
+        ///   Looks up a localized string similar to There is already a report named &apos;{0}&apos;..
         /// </summary>
         internal static string ChooseViewsControl_listView1_AfterLabelEdit_There_is_already_a_view_named___0___ {
             get {
@@ -489,7 +489,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do you want to overwrite the existing view named &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Do you want to overwrite the existing report named &apos;{0}&apos;.
         /// </summary>
         internal static string CustomizeViewForm_ValidateViewName_Do_you_want_to_overwrite_the_existing_view_named___0__ {
             get {
@@ -499,7 +499,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is already a built in view named &apos;{0}&apos;..
+        ///   Looks up a localized string similar to There is already a built in report named &apos;{0}&apos;..
         /// </summary>
         internal static string CustomizeViewForm_ValidateViewName_There_is_already_a_built_in_view_named___0___ {
             get {
@@ -508,7 +508,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to View name cannot be blank..
+        ///   Looks up a localized string similar to Report name cannot be blank..
         /// </summary>
         internal static string CustomizeViewForm_ValidateViewName_View_name_cannot_be_blank_ {
             get {
@@ -757,7 +757,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to delete the view &apos;{0}&apos;?.
+        ///   Looks up a localized string similar to Are you sure you want to delete the report &apos;{0}&apos;?.
         /// </summary>
         internal static string ManageViewsForm_BtnRemoveOnClick_Are_you_sure_you_want_to_delete_the_view___0___ {
             get {
@@ -766,7 +766,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to delete these {0} views?.
+        ///   Looks up a localized string similar to Are you sure you want to delete these {0} reports?.
         /// </summary>
         internal static string ManageViewsForm_BtnRemoveOnClick_Are_you_sure_you_want_to_delete_these__0__views_ {
             get {
@@ -833,7 +833,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Customize View....
+        ///   Looks up a localized string similar to Customize Report....
         /// </summary>
         internal static string NavBar_NavBarButtonViewsOnDropDownOpening_Customize_View {
             get {
@@ -842,7 +842,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit View....
+        ///   Looks up a localized string similar to Edit Report....
         /// </summary>
         internal static string NavBar_NavBarButtonViewsOnDropDownOpening_Edit_View___ {
             get {
@@ -851,7 +851,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Manage Views....
+        ///   Looks up a localized string similar to Manage Reports....
         /// </summary>
         internal static string NavBar_NavBarButtonViewsOnDropDownOpening_Manage_Views___ {
             get {
@@ -1257,7 +1257,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is already a view named &apos;{0}&apos;..
+        ///   Looks up a localized string similar to There is already a report named &apos;{0}&apos;..
         /// </summary>
         internal static string ViewEditor_ValidateViewName_There_is_already_a_view_named___0___ {
             get {
@@ -1266,7 +1266,7 @@ namespace pwiz.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Built In Views.
+        ///   Looks up a localized string similar to Built In Reports.
         /// </summary>
         internal static string ViewGroup_BUILT_IN_Built_In_Views {
             get {

--- a/pwiz_tools/Shared/Common/Properties/Resources.resx
+++ b/pwiz_tools/Shared/Common/Properties/Resources.resx
@@ -194,13 +194,13 @@
     <value>This column does not exist</value>
   </data>
   <data name="CustomizeViewForm_ValidateViewName_View_name_cannot_be_blank_" xml:space="preserve">
-    <value>View name cannot be blank.</value>
+    <value>Report name cannot be blank.</value>
   </data>
   <data name="CustomizeViewForm_ValidateViewName_There_is_already_a_built_in_view_named___0___" xml:space="preserve">
-    <value>There is already a built in view named '{0}'.</value>
+    <value>There is already a built in report named '{0}'.</value>
   </data>
   <data name="CustomizeViewForm_ValidateViewName_Do_you_want_to_overwrite_the_existing_view_named___0__" xml:space="preserve">
-    <value>Do you want to overwrite the existing view named '{0}'</value>
+    <value>Do you want to overwrite the existing report named '{0}'</value>
   </data>
   <data name="CustomizeViewForm_UpdatePropertySheet_Column_Properties" xml:space="preserve">
     <value>Column Properties</value>
@@ -221,13 +221,13 @@
     <value>(Transforming data...)</value>
   </data>
   <data name="NavBar_NavBarButtonViewsOnDropDownOpening_Edit_View___" xml:space="preserve">
-    <value>Edit View...</value>
+    <value>Edit Report...</value>
   </data>
   <data name="NavBar_NavBarButtonViewsOnDropDownOpening_Manage_Views___" xml:space="preserve">
-    <value>Manage Views...</value>
+    <value>Manage Reports...</value>
   </data>
   <data name="NavBar_NavBarButtonViewsOnDropDownOpening_Customize_View" xml:space="preserve">
-    <value>Customize View...</value>
+    <value>Customize Report...</value>
   </data>
   <data name="PropertyPath_Parse_Invalid_character____" xml:space="preserve">
     <value>Invalid character '*'</value>
@@ -272,10 +272,10 @@
     <value>Writing row {0:#,0}/{1:#,0}</value>
   </data>
   <data name="ManageViewsForm_BtnRemoveOnClick_Are_you_sure_you_want_to_delete_the_view___0___" xml:space="preserve">
-    <value>Are you sure you want to delete the view '{0}'?</value>
+    <value>Are you sure you want to delete the report '{0}'?</value>
   </data>
   <data name="ManageViewsForm_BtnRemoveOnClick_Are_you_sure_you_want_to_delete_these__0__views_" xml:space="preserve">
-    <value>Are you sure you want to delete these {0} views?</value>
+    <value>Are you sure you want to delete these {0} reports?</value>
   </data>
   <data name="RecordNavBar_UpdateNow__Filtered_from__0__" xml:space="preserve">
     <value>(Filtered from {0})</value>
@@ -343,10 +343,10 @@
     <value>Name cannot be blank</value>
   </data>
   <data name="ChooseViewsControl_listView1_AfterLabelEdit_There_is_already_a_view_named___0___" xml:space="preserve">
-    <value>There is already a view named '{0}'.</value>
+    <value>There is already a report named '{0}'.</value>
   </data>
   <data name="ViewGroup_BUILT_IN_Built_In_Views" xml:space="preserve">
-    <value>Built In Views</value>
+    <value>Built In Reports</value>
   </data>
   <data name="AbstractViewContext_CopyViewsToGroup_The_name___0___already_exists__Do_you_want_to_replace_it_" xml:space="preserve">
     <value>The name '{0}' already exists. Do you want to replace it?</value>
@@ -358,7 +358,7 @@
     <value>Do you want to replace them?</value>
   </data>
   <data name="ViewEditor_ValidateViewName_There_is_already_a_view_named___0___" xml:space="preserve">
-    <value>There is already a view named '{0}'.</value>
+    <value>There is already a report named '{0}'.</value>
   </data>
   <data name="DocumentationGenerator_GetHtmlForType_Map_of__0__to__1_" xml:space="preserve">
     <value>Map of {0} to {1}</value>

--- a/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
@@ -332,9 +332,9 @@ namespace pwiz.SkylineTestTutorial
             RunUI(() =>
                 manageViewsForm.ImportViews(TestFilesDir.GetTestPath(@"CustomReports\Summary_stats.skyr"))
             );
-            PauseForScreenShot<ManageViewsForm>("Manage Views form", 19);
+            PauseForScreenShot<ManageViewsForm>("Manage Reports form", 19);
             OkDialog(manageViewsForm, manageViewsForm.Close);
-            PauseForScreenShot<DocumentGridForm>("Click the views dropdown and highlight 'Summary_stats'", 20);
+            PauseForScreenShot<DocumentGridForm>("Click the Reports dropdown and highlight 'Summary_stats'", 20);
 
             RunUI(() => documentGridForm.ChooseView("Summary Statistics"));
             WaitForConditionUI(() => documentGridForm.IsComplete);


### PR DESCRIPTION
Rename "Views" dropdown on Document Grid to "Reports", and replace all occurrences of things like "Manage Views" to "Manage Reports", etc.