### PR TITLE
Fix stale WIFF2 logic from resolving conflict

### DIFF
--- a/pwiz_tools/Skyline/TestA/PwizFileInfoTest.cs
+++ b/pwiz_tools/Skyline/TestA/PwizFileInfoTest.cs
@@ -54,12 +54,6 @@ namespace pwiz.SkylineTestA
             {
                 VerifyInstrumentInfo(testFilesDir.GetTestPath("051309_digestion.wiff"),
                     "4000 QTRAP", "electrospray ionization", "quadrupole/quadrupole/axial ejection linear ion trap", "electron multiplier");
-                if (System.DateTime.Now.Year > 2018 /* start failing after the new year */ ||
-                    (System.Environment.Is64BitProcess && !Program.SkylineOffscreen &&  /* wiff2 access leaks thread and event handles, so avoid it during nightly tests when offscreen */
-                     (CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator != "," || /* wiff2 access fails under french language settings */
-                      CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator != "\xA0")) /* no break space */ )
-                    VerifyInstrumentInfo(testFilesDir.GetTestPath("OnyxTOFMS.wiff2"),
-                        "TripleTOF 5600", "electrospray ionization", "quadrupole/quadrupole/time-of-flight", "electron multiplier");
             }
 
             if (ExtensionTestContext.CanImportAbWiff2)

--- a/pwiz_tools/Skyline/TestA/PwizFileInfoTest.cs
+++ b/pwiz_tools/Skyline/TestA/PwizFileInfoTest.cs
@@ -17,11 +17,9 @@
  * limitations under the License.
  */
 
-using System.Globalization;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.ProteowizardWrapper;
-using pwiz.Skyline;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTestA


### PR DESCRIPTION
Turns out I hadn't removed the old conditional from the release branch code, almost certainly due to an error I made resolving a conflict.