### PR TITLE
Skyline/work/20190104 list fixes2

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
@@ -510,6 +510,9 @@ namespace pwiz.Skyline.Model.DocSettings
             // Change the name, and remove results information which is document specific
             SrmSettings settingsSavable = (SrmSettings) ChangeName(saveName);
             settingsSavable = settingsSavable.ChangePeptideLibraries(lib => lib.ChangeDocumentLibrary(false));
+            var dataSettings = settingsSavable.DataSettings;
+            dataSettings = dataSettings.ChangeListDefs(dataSettings.Lists.Select(list => list.DeleteAllRows()));
+            settingsSavable = settingsSavable.ChangeDataSettings(dataSettings);
             settingsSavable.MeasuredResults = null;
             return settingsSavable;
         }


### PR DESCRIPTION
Fix for Lists feature:
Remove all of the list items before writing the list definition to the user settings.
List items only are allowed to exist when the list is inside of an SrmDocument.