### PR TITLE
Add "Auto Select Peptides", "Auto Select Precursors" and "Auto Select…

### DIFF
--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.Designer.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.Designer.cs
@@ -178,6 +178,33 @@ namespace pwiz.Skyline.Model.Databinding.Entities {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Auto Select Peptides.
+        /// </summary>
+        public static string AutoSelectPeptides {
+            get {
+                return ResourceManager.GetString("AutoSelectPeptides", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Select Precursors.
+        /// </summary>
+        public static string AutoSelectPrecursors {
+            get {
+                return ResourceManager.GetString("AutoSelectPrecursors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto Select Transitions.
+        /// </summary>
+        public static string AutoSelectTransitions {
+            get {
+                return ResourceManager.GetString("AutoSelectTransitions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Average Mass Error PPM.
         /// </summary>
         public static string AverageMassErrorPPM {

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.resx
@@ -138,6 +138,15 @@
   <data name="AreaRatio">
     <value>Area Ratio</value>
   </data>
+  <data name="AutoSelectPeptides">
+    <value>Auto Select Peptides</value>
+  </data>
+  <data name="AutoSelectPrecursors">
+    <value>Auto Select Precursors</value>
+  </data>
+  <data name="AutoSelectTransitions">
+    <value>Auto Select Transitions</value>
+  </data>
   <data name="AverageMassErrorPPM">
     <value>Average Mass Error PPM</value>
   </data>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.Designer.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.Designer.cs
@@ -182,6 +182,33 @@ namespace pwiz.Skyline.Model.Databinding.Entities {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to If true, then Skyline will automatically add or remove peptides based on the Peptide Settings Filter..
+        /// </summary>
+        public static string AutoSelectPeptides {
+            get {
+                return ResourceManager.GetString("AutoSelectPeptides", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If true, then Skyline will automatically add or remove precursors based on the Transition Settings Filter, spectral library, etc..
+        /// </summary>
+        public static string AutoSelectPrecursors {
+            get {
+                return ResourceManager.GetString("AutoSelectPrecursors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If true, then Skyline will automatically add or remove transitions from the precursor depending on the Transition Settings Filter, spectral library, etc..
+        /// </summary>
+        public static string AutoSelectTransitions {
+            get {
+                return ResourceManager.GetString("AutoSelectTransitions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Average Mass Error PPM.
         /// </summary>
         public static string AverageMassErrorPPM {

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.resx
@@ -130,6 +130,15 @@ in the document.</value>
 first internal standard label type, before version 0.7 this was always light/heavy, and
 appeared on the heavy transitions.</value>
   </data>
+  <data name="AutoSelectPeptides">
+    <value>If true, then Skyline will automatically add or remove peptides based on the Peptide Settings Filter.</value>
+  </data>
+  <data name="AutoSelectPrecursors">
+    <value>If true, then Skyline will automatically add or remove precursors based on the Transition Settings Filter, spectral library, etc.</value>
+  </data>
+  <data name="AutoSelectTransitions">
+    <value>If true, then Skyline will automatically add or remove transitions from the precursor depending on the Transition Settings Filter, spectral library, etc.</value>
+  </data>
   <data name="AverageMassErrorPPM">
     <value>Average Mass Error PPM</value>
   </data>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Peptide.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Peptide.cs
@@ -457,6 +457,29 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             get { return IsSmallMolecule() ? DocNode.CustomMolecule.AccessionNumbers.GetSMILES() ?? string.Empty : string.Empty; }
         }
 
+        [Importable]
+        public bool AutoSelectPrecursors
+        {
+            get { return DocNode.AutoManageChildren; }
+            set
+            {
+                if (value == AutoSelectPrecursors)
+                {
+                    return;
+                }
+                ChangeDocNode(EditDescription.SetColumn(nameof(AutoSelectPrecursors), value), docNode =>
+                {
+                    docNode = (PeptideDocNode) docNode.ChangeAutoManageChildren(value);
+                    if (docNode.AutoManageChildren)
+                    {
+                        var srmSettingsDiff = new SrmSettingsDiff(false, false, true, false, false, false);
+                        docNode = docNode.ChangeSettings(SrmDocument.Settings, srmSettingsDiff);
+                    }
+                    return docNode;
+                });
+            }
+        }
+
         protected override NodeRef NodeRefPrototype
         {
             get { return MoleculeRef.PROTOTYPE; }

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
@@ -516,6 +516,31 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             return string.Format(Resources.Precursor_GetDeleteConfirmation_Are_you_sure_you_want_to_delete_these__0__precursors_, nodeCount);
         }
 
+        [Importable]
+        public bool AutoSelectTransitions
+        {
+            get { return DocNode.AutoManageChildren; }
+            set
+            {
+                if (value == AutoSelectTransitions)
+                {
+                    return;
+                }
+                ChangeDocNode(EditDescription.SetColumn(nameof(AutoSelectTransitions), value), docNode =>
+                    {
+                        docNode = (TransitionGroupDocNode) docNode.ChangeAutoManageChildren(value);
+                        if (docNode.AutoManageChildren)
+                        {
+                            var srmSettingsDiff = new SrmSettingsDiff(false, false, false, false, true, false);
+                            docNode = docNode.ChangeSettings(SrmDocument.Settings, Peptide.DocNode, Peptide.DocNode.ExplicitMods,
+                                srmSettingsDiff);
+                        }
+
+                        return docNode;
+                    });
+            }
+        }
+
         [InvariantDisplayName("PrecursorLocator")]
         public string Locator { get { return GetLocator(); } }
 

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Protein.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Protein.cs
@@ -133,6 +133,30 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         {
             get { return DocNode.PeptideGroup.Sequence; }
         }
+
+        [Importable]
+        public bool AutoSelectPeptides
+        {
+            get { return DocNode.AutoManageChildren; }
+            set
+            {
+                if (value == AutoSelectPeptides)
+                {
+                    return;
+                }
+                ChangeDocNode(EditDescription.SetColumn(nameof(AutoSelectPeptides), value), docNode=>
+                {
+                    docNode = (PeptideGroupDocNode) docNode.ChangeAutoManageChildren(value);
+                    if (docNode.AutoManageChildren)
+                    {
+                        var srmSettingsDiff = new SrmSettingsDiff(true, false, false, false, false, false);
+                        docNode = docNode.ChangeSettings(SrmDocument.Settings, srmSettingsDiff);
+                    }
+
+                    return docNode;
+                });
+            }
+        }
         [InvariantDisplayName("ProteinNote")]
         [Importable]
         public string Note

--- a/pwiz_tools/Skyline/Model/Databinding/SkylineViewContext.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/SkylineViewContext.cs
@@ -429,6 +429,7 @@ namespace pwiz.Skyline.Model.Databinding
                 if (columnDescriptor.PropertyType == typeof(Protein))
                 {
                     columnsToRemove.Add(PropertyPath.Root.Property("Name"));
+                    columnsToRemove.Add(PropertyPath.Root.Property(nameof(Protein.AutoSelectPeptides)));
                     if (docHasOnlyCustomIons)
                     {
                         // Peptide-oriented fields that make no sense in a small molecule context
@@ -442,6 +443,7 @@ namespace pwiz.Skyline.Model.Databinding
                 }
                 else if (columnDescriptor.PropertyType == typeof(Entities.Peptide))
                 {
+                    columnsToRemove.Add(PropertyPath.Root.Property(nameof(Entities.Peptide.AutoSelectPrecursors)));
                     columnsToRemove.Add(PropertyPath.Root.Property("Sequence"));
                     columnsToRemove.Add(PropertyPath.Root.Property("SequenceLength"));
                     columnsToRemove.Add(PropertyPath.Root.Property("PreviousAa"));
@@ -453,6 +455,7 @@ namespace pwiz.Skyline.Model.Databinding
                     columnsToRemove.Add(PropertyPath.Root.Property("CalibrationCurve"));
                     columnsToRemove.Add(PropertyPath.Root.Property("FiguresOfMerit"));
                     columnsToRemove.Add(PropertyPath.Root.Property("NormalizationMethod"));
+                    columnsToRemove.Add(PropertyPath.Root.Property(nameof(Entities.Peptide.AutoSelectPrecursors)));
                     foreach (var prop in MoleculeAccessionNumbers.PREFERRED_ACCESSION_TYPE_ORDER)
                         columnsToRemove.Add(PropertyPath.Root.Property(prop)); // By default don't show CAS, InChI etc
                     if (docHasOnlyCustomIons)
@@ -508,6 +511,7 @@ namespace pwiz.Skyline.Model.Databinding
                     columnsToRemove.Add(PropertyPath.Root.Property("ExplicitSLens"));
                     columnsToRemove.Add(PropertyPath.Root.Property("ExplicitConeVoltage"));
                     columnsToRemove.Add(PropertyPath.Root.Property("PrecursorConcentration"));
+                    columnsToRemove.Add(PropertyPath.Root.Property(nameof(Precursor.AutoSelectTransitions)));
                     addRoot = true;
                 }
                 else if (columnDescriptor.PropertyType == typeof(Entities.Transition))

--- a/pwiz_tools/Skyline/TestFunctional/AutoSelectTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AutoSelectTest.cs
@@ -1,0 +1,215 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2019 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.DataBinding;
+using pwiz.Common.DataBinding.Controls.Editor;
+using pwiz.Skyline.Controls.Databinding;
+using pwiz.Skyline.EditUI;
+using pwiz.Skyline.Model.Databinding.Entities;
+using pwiz.Skyline.Properties;
+using pwiz.Skyline.SettingsUI;
+using pwiz.Skyline.Util.Extensions;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTestFunctional
+{
+    /// <summary>
+    /// Tests changing "AutoSelectPeptides", "AutoSelectPrecursors", and "AutoSelectTransitions" in the Document Grid.
+    /// </summary>
+    [TestClass]
+    public class AutoSelectTest : AbstractFunctionalTest
+    {
+        [TestMethod]
+        public void TestAutoSelect()
+        {
+            RunFunctionalTest();
+        }
+
+        protected override void DoTest()
+        {
+            RunDlg<PasteDlg>(SkylineWindow.ShowPastePeptidesDlg, pasteDlg=>
+            {
+                SetClipboardText(TextUtil.LineSeparate("ELVIS\tProtein1", "LIVES\tProtein2"));
+                pasteDlg.PastePeptides();
+                pasteDlg.OkDialog();
+            });
+            RunUI(()=>SkylineWindow.ShowDocumentGrid(true));
+
+            VerifyAutoSelectPeptides();
+            VerifyAutoSelectPrecursors();
+            VerifyAutoSelectTransitions();
+        }
+
+        private void VerifyAutoSelectPeptides()
+        {
+            var documentGrid = FindOpenForm<DocumentGridForm>();
+            RunUI(() => documentGrid.ChooseView(Resources.SkylineViewContext_GetDocumentGridRowSources_Proteins));
+            RunDlg<ViewEditor>(documentGrid.NavBar.CustomizeView, viewEditor =>
+            {
+                viewEditor.ChooseColumnsTab.AddColumn(PropertyPath.Root.Property(nameof(SkylineDocument.Proteins))
+                    .LookupAllItems().Property(nameof(Protein.AutoSelectPeptides)));
+                viewEditor.ViewName = "MyProteins";
+                viewEditor.OkDialog();
+            });
+            WaitForConditionUI(() => documentGrid.IsComplete);
+            Assert.AreEqual(2, documentGrid.RowCount);
+
+            // Turn Auto Manage Children on for the first PeptideGroup, and off for the second PeptideGroup
+            RunUI(() =>
+            {
+                var dataGridView = documentGrid.DataGridView;
+                var colAutoSelect =
+                    documentGrid.FindColumn(PropertyPath.Root.Property(nameof(Protein.AutoSelectPeptides)));
+                dataGridView.CurrentCell = dataGridView.Rows[0].Cells[colAutoSelect.Index];
+                SetClipboardText(TextUtil.LineSeparate(true.ToString(), false.ToString()));
+                dataGridView.SendPaste();
+            });
+            CollectionAssert.AreEqual(new[] { true, false },
+                SkylineWindow.Document.MoleculeGroups.Select(m => m.AutoManageChildren).ToArray());
+
+            // Add a variable modification which will cause the modified variants to get added to the PeptideGroup that has AutoManageChildren turned on
+            var peptideSettingsUi = ShowDialog<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI);
+            RunUI(() =>
+            {
+                peptideSettingsUi.SelectedTab = PeptideSettingsUI.TABS.Modifications;
+            });
+            const string phosphoModName = "Phospho (ST)";
+            AddStaticMod(phosphoModName, true, peptideSettingsUi);
+            RunUI(() => peptideSettingsUi.PickedStaticMods =
+                peptideSettingsUi.PickedStaticMods.Append(phosphoModName).ToArray());
+            OkDialog(peptideSettingsUi, peptideSettingsUi.OkDialog);
+            Assert.AreEqual(2, SkylineWindow.Document.MoleculeGroups.First().Children.Count);
+            Assert.AreEqual(1, SkylineWindow.Document.MoleculeGroups.Skip(1).First().Children.Count);
+
+            // Now, set the auto manage children on the second PeptideGroup, and make sure it gets the expected new child
+            RunUI(() =>
+            {
+                var dataGridView = documentGrid.DataGridView;
+                var colAutoSelect =
+                    documentGrid.FindColumn(PropertyPath.Root.Property(nameof(Protein.AutoSelectPeptides)));
+                dataGridView.CurrentCell = dataGridView.Rows[0].Cells[colAutoSelect.Index];
+                SetClipboardText(TextUtil.LineSeparate(true.ToString(), true.ToString()));
+                dataGridView.SendPaste();
+            });
+            Assert.AreEqual(2, SkylineWindow.Document.MoleculeGroups.Skip(1).First().Children.Count);
+
+        }
+
+        private void VerifyAutoSelectPrecursors()
+        {
+            var documentGrid = FindOpenForm<DocumentGridForm>();
+            RunUI(() => documentGrid.ChooseView(Resources.SkylineViewContext_GetDocumentGridRowSources_Peptides));
+            RunDlg<ViewEditor>(documentGrid.NavBar.CustomizeView, viewEditor =>
+            {
+                viewEditor.ChooseColumnsTab.AddColumn(PropertyPath.Root
+                    .Property(nameof(SkylineDocument.Proteins)).LookupAllItems()
+                    .Property(nameof(Protein.Peptides)).LookupAllItems()
+                    .Property(nameof(Peptide.AutoSelectPrecursors)));
+                viewEditor.ViewName = "MyPeptides";
+                viewEditor.OkDialog();
+            });
+            WaitForConditionUI(() => documentGrid.IsComplete);
+            Assert.AreEqual(4, documentGrid.RowCount);
+            RunUI(() =>
+            {
+                var dataGridView = documentGrid.DataGridView;
+                var colAutoSelect =
+                    documentGrid.FindColumn(PropertyPath.Root.Property(nameof(Peptide.AutoSelectPrecursors)));
+                dataGridView.CurrentCell = dataGridView.Rows[0].Cells[colAutoSelect.Index];
+                SetClipboardText(string.Join(Environment.NewLine, true, false, false, true));
+                dataGridView.SendPaste();
+            });
+            CollectionAssert.AreEqual(new[] { true, false, false, true },
+                SkylineWindow.Document.Molecules.Select(m => m.AutoManageChildren).ToArray());
+            RunDlg<TransitionSettingsUI>(SkylineWindow.ShowTransitionSettingsUI,
+                transitionSettingsUi =>
+                {
+                    transitionSettingsUi.SelectedTab = TransitionSettingsUI.TABS.Filter;
+                    transitionSettingsUi.PrecursorCharges = "1, 2";
+                    transitionSettingsUi.RangeFrom = Resources.TransitionFilter_FragmentStartFinders_ion_1;
+                    transitionSettingsUi.RangeTo = Resources.TransitionFilter_FragmentEndFinders_3_ions;
+                    transitionSettingsUi.OkDialog();
+                });
+            CollectionAssert.AreEqual(new[] { 2, 1, 1, 2 }, SkylineWindow.Document.Molecules.Select(m => m.Children.Count).ToArray());
+            RunUI(() =>
+            {
+                var dataGridView = documentGrid.DataGridView;
+                var colAutoSelect =
+                    documentGrid.FindColumn(PropertyPath.Root.Property(nameof(Peptide.AutoSelectPrecursors)));
+                dataGridView.CurrentCell = dataGridView.Rows[0].Cells[colAutoSelect.Index];
+                SetClipboardText(string.Join(Environment.NewLine, true, true, true, true));
+                dataGridView.SendPaste();
+            });
+            CollectionAssert.AreEqual(new[] { 2, 2, 2, 2 }, SkylineWindow.Document.Molecules.Select(m => m.Children.Count).ToArray());
+            CollectionAssert.AreEqual(new[] {3, 3, 3, 3, 3, 3, 3, 3},
+                SkylineWindow.Document.MoleculeTransitionGroups.Select(m => m.Children.Count).ToArray());
+        }
+
+        private void VerifyAutoSelectTransitions()
+        {
+            var documentGrid = FindOpenForm<DocumentGridForm>();
+            RunUI(() => documentGrid.ChooseView(Resources.SkylineViewContext_GetDocumentGridRowSources_Precursors));
+            RunDlg<ViewEditor>(documentGrid.NavBar.CustomizeView, viewEditor =>
+            {
+                viewEditor.ChooseColumnsTab.AddColumn(PropertyPath.Root
+                    .Property(nameof(SkylineDocument.Proteins)).LookupAllItems()
+                    .Property(nameof(Protein.Peptides)).LookupAllItems()
+                    .Property(nameof(Peptide.Precursors)).LookupAllItems()
+                    .Property(nameof(Precursor.AutoSelectTransitions)));
+                viewEditor.ViewName = "MyPrecursors";
+                viewEditor.OkDialog();
+            });
+            WaitForConditionUI(() => documentGrid.IsComplete);
+            Assert.AreEqual(8, documentGrid.RowCount);
+            RunUI(() =>
+            {
+                var dataGridView = documentGrid.DataGridView;
+                var colAutoSelect =
+                    documentGrid.FindColumn(PropertyPath.Root.Property(nameof(Precursor.AutoSelectTransitions)));
+                dataGridView.CurrentCell = dataGridView.Rows[0].Cells[colAutoSelect.Index];
+                SetClipboardText(string.Join(Environment.NewLine, true, false, true, true, false, false, false, true));
+                dataGridView.SendPaste();
+            });
+            CollectionAssert.AreEqual(new[] { 3, 3, 3, 3, 3, 3, 3, 3 },
+                SkylineWindow.Document.MoleculeTransitionGroups.Select(m => m.Children.Count).ToArray());
+            RunDlg<TransitionSettingsUI>(SkylineWindow.ShowTransitionSettingsUI,
+                transitionSettingsUi =>
+                {
+                    transitionSettingsUi.SelectedTab = TransitionSettingsUI.TABS.Filter;
+                    transitionSettingsUi.RangeTo = Resources.TransitionFilter_FragmentEndFinders_4_ions;
+                    transitionSettingsUi.OkDialog();
+                });
+            CollectionAssert.AreEqual(new[] { 4, 3, 4, 4, 3, 3, 3, 4 },
+                SkylineWindow.Document.MoleculeTransitionGroups.Select(m => m.Children.Count).ToArray());
+            RunUI(() =>
+            {
+                var dataGridView = documentGrid.DataGridView;
+                var colAutoSelect =
+                    documentGrid.FindColumn(PropertyPath.Root.Property(nameof(Precursor.AutoSelectTransitions)));
+                dataGridView.CurrentCell = dataGridView.Rows[0].Cells[colAutoSelect.Index];
+                SetClipboardText(string.Join(Environment.NewLine, true, false, true, true, true, true, false, true));
+                dataGridView.SendPaste();
+            });
+            CollectionAssert.AreEqual(new[] { 4, 3, 4, 4, 4, 4, 3, 4 },
+                SkylineWindow.Document.MoleculeTransitionGroups.Select(m => m.Children.Count).ToArray());
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -154,6 +154,7 @@
     <Compile Include="AssociateProteinsDlgTest.cs" />
     <Compile Include="AuditLogSavingTest.cs" />
     <Compile Include="AuditLogTest.cs" />
+    <Compile Include="AutoSelectTest.cs" />
     <Compile Include="BackgroundEventThreadsTest.cs" />
     <Compile Include="BlibIrtTest.cs" />
     <Compile Include="CalibrationScenariosTest.cs" />


### PR DESCRIPTION
… Transitions" columns to the Document Grid.

These properties change the "AutoManageChildren" on PeptideGroupDocNode's, PeptideDocNode's, and TransitionGroupDocNode's.