### PR TITLE
Filter peaks in parent scan isolation window to bring total peak count below maxNumberPeaks

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumList_ChargeFromIsotope.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ChargeFromIsotope.cpp
@@ -896,7 +896,7 @@ void SpectrumList_ChargeFromIsotope::getParentPeaks(const SpectrumPtr s,const ve
             while ( peaksInWindow > maxNumberPeaks ) 
             {
 
-                vector<double>::iterator minIt = min_element( peakIntensities.begin(), peakIntensities.end() );
+                BinaryData<double>::iterator minIt = min_element( peakIntensities.begin(), peakIntensities.end() );
 
                 for (int w=0, wend = peakIntensities.size(); w < wend; ++w)
                 {
@@ -953,7 +953,7 @@ void SpectrumList_ChargeFromIsotope::getParentPeaks(const SpectrumPtr s,const ve
             while ( peaksInWindow > maxNumberPeaks ) 
             {
 
-                vector<double>::iterator minIt = min_element( peakIntensities.begin(), peakIntensities.end() );
+                BinaryData<double>::iterator minIt = min_element( peakIntensities.begin(), peakIntensities.end() );
 
                 for (int w=0, wend = peakIntensities.size(); w < wend; ++w)
                 {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ChargeFromIsotope.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ChargeFromIsotope.cpp
@@ -888,6 +888,32 @@ void SpectrumList_ChargeFromIsotope::getParentPeaks(const SpectrumPtr s,const ve
                 peakMZs.erase( peakMZs.begin() + elementsForDeletion[j] - j );
             }
 
+            /**
+            Reduce number of peaks in window to maxNumberPeaks if needed 
+            **/
+            int peaksInWindow = peakIntensities.size();
+            elementsForDeletion.clear();
+            while ( peaksInWindow > maxNumberPeaks ) 
+            {
+
+                vector<double>::iterator minIt = min_element( peakIntensities.begin(), peakIntensities.end() );
+
+                for (int w=0, wend = peakIntensities.size(); w < wend; ++w)
+                {
+                    if ( peakIntensities[w] == *minIt )
+                        elementsForDeletion.push_back( w ); 
+                }
+    
+                for (int w=0, wend = elementsForDeletion.size(); w < wend; ++w )
+                {
+                    peakIntensities.erase( peakIntensities.begin() + elementsForDeletion[w] - w );
+                    peakMZs.erase( peakMZs.begin() + elementsForDeletion[w] - w );
+                }
+
+                peaksInWindow = peakIntensities.size();
+
+            }
+
             mzs.push_back( peakMZs );
             intensities.push_back( peakIntensities );
 
@@ -917,6 +943,32 @@ void SpectrumList_ChargeFromIsotope::getParentPeaks(const SpectrumPtr s,const ve
             {
                 peakIntensities.erase( peakIntensities.begin() + elementsForDeletion[j] - j );
                 peakMZs.erase( peakMZs.begin() + elementsForDeletion[j] - j );
+            }
+
+            /**
+            Reduce number of peaks in window to maxNumberPeaks if needed 
+            **/
+            int peaksInWindow = peakIntensities.size();
+            elementsForDeletion.clear();
+            while ( peaksInWindow > maxNumberPeaks ) 
+            {
+
+                vector<double>::iterator minIt = min_element( peakIntensities.begin(), peakIntensities.end() );
+
+                for (int w=0, wend = peakIntensities.size(); w < wend; ++w)
+                {
+                    if ( peakIntensities[w] == *minIt )
+                        elementsForDeletion.push_back( w ); 
+                }
+    
+                for (int w=0, wend = elementsForDeletion.size(); w < wend; ++w )
+                {
+                    peakIntensities.erase( peakIntensities.begin() + elementsForDeletion[w] - w );
+                    peakMZs.erase( peakMZs.begin() + elementsForDeletion[w] - w );
+                }
+
+                peaksInWindow = peakIntensities.size();
+
             }
 
             mzs.push_back( peakMZs );


### PR DESCRIPTION
This change (which only affects the functionality of msconvert's Turbocharger precursor charge algorithm) prevents a runtime error from being thrown in the event that there are greater than maxNumberPeaks (currently set to 40) in parent scan's isolation window. These changes simply use the 40 most intense peaks within the isolation window and discard the remaining peaks. 

This change was requested by Professor David Tabb several months ago as data from a SCIEX TripleTOF was frequently exceeding maxNumberPeaks. 

In case you're wondering, the reason we hard-coded this number is that Turbocharger simulates the total intensity and relative intensities for scoring and needs some place to store those simulated data for computing p values during analysis. The vector storing these simulated data must have some finite size, and computing this size on the fly would be expensive. We chose a conservative value of 40 when I was originally developing this code, based on results from various datasets.