### PR TITLE
Skyline - debugging code for memory dumps and ExportMethodDlg failure

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -707,7 +707,9 @@ namespace TestRunner
                 runTests.AddSmallMoleculeNodes = addsmallmoleculenodes && (flip = !flip); // Do this in every other pass, so we get it both ways
             }
 
-            if (asNightly && !string.IsNullOrEmpty(dmpDir))
+            runTests.Log("# asNightly: {0}; dmpDir: {1}; exists: {2}", asNightly, dmpDir, Directory.Exists(dmpDir));
+
+            if (asNightly && !string.IsNullOrEmpty(dmpDir) && Directory.Exists(dmpDir))
             {
                 runTests.Log("# Deleting memory dumps.\r\n");
 

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -221,8 +221,9 @@ namespace TestRunnerLib
 
                     Directory.CreateDirectory(dmpDir);
 
-                    if(!MiniDump.WriteMiniDump(Path.Combine(dmpDir, "pre_" + dumpFileName)))
-                        Log("[WARNING] Failed to write pre mini dump (GetLastError() = {0})", Marshal.GetLastWin32Error());
+                    var path = Path.Combine(dmpDir, "pre_" + dumpFileName);
+                    if (!MiniDump.WriteMiniDump(path))
+                        Log("[WARNING] Failed to write pre mini dump to '{0}' (GetLastError() = {1})", path, Marshal.GetLastWin32Error());
                 }
                 catch(Exception ex)
                 {
@@ -307,8 +308,9 @@ namespace TestRunnerLib
                     var leak = (TotalMemoryBytes - previousPrivateBytes) / MB;
                     if (leak > test.MinidumpLeakThreshold.Value)
                     {
-                        if (!MiniDump.WriteMiniDump(Path.Combine(dmpDir, "post_" + dumpFileName)))
-                            Log("[WARNING] Failed to write post mini dump (GetLastError() = {0})", Marshal.GetLastWin32Error());
+                        var path = Path.Combine(dmpDir, "post_" + dumpFileName);
+                        if (!MiniDump.WriteMiniDump(path))
+                            Log("[WARNING] Failed to write post mini dump to '{0}' (GetLastError() = {1})", path, Marshal.GetLastWin32Error());
                     }
                     else
                     {

--- a/pwiz_tools/Skyline/Util/CreateHandleDebugBase.cs
+++ b/pwiz_tools/Skyline/Util/CreateHandleDebugBase.cs
@@ -82,6 +82,7 @@ namespace pwiz.Skyline.Util
         [Localizable(false)]
         private void ControlCreateHandle()
         {
+            Program.Log?.Invoke(string.Format("\r\nStacktrace: {0}\r\n", Environment.StackTrace));
             Program.Log?.Invoke("\r\nBegin ControlCreateHandle\r\n");
             var formType = typeof(Form);
             var controlType = typeof(Control);


### PR DESCRIPTION
- added code to determine why memory dumps are not being deleted
- now printing stack trace when CreateHandle gets called for ExportMethodDlg,
  since it seems like it gets called twice when the Ms1TutorialTest fails