### PR TITLE
Fix InvalidOperationException in SkylineTester that sometimes happens…

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/SafeDataGridView.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SafeDataGridView.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2017 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Windows.Forms;
+
+namespace SkylineTester
+{
+    /// <summary>
+    /// Subclass of DataGridView which works around known bugs.
+    /// </summary>
+    public class SafeDataGridView : DataGridView
+    {
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            // An exception is possible in "PerformLayoutPrivate" if ColumnHeadersHeightSizeMode is AutoSize
+            // when the handle is created.
+            RunWithSafeColumnHeaderHeightSizeMode(() => base.OnHandleCreated(e));
+        }
+
+        protected void RunWithSafeColumnHeaderHeightSizeMode(Action action)
+        {
+            DataGridViewColumnHeadersHeightSizeMode? columnHeadersHeightSizeModeOld = null;
+            if (ColumnHeadersHeightSizeMode == DataGridViewColumnHeadersHeightSizeMode.AutoSize)
+            {
+                columnHeadersHeightSizeModeOld = ColumnHeadersHeightSizeMode;
+                ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.EnableResizing;
+            }
+            try
+            {
+                action();
+            }
+            finally
+            {
+                if (columnHeadersHeightSizeModeOld.HasValue)
+                {
+                    ColumnHeadersHeightSizeMode = columnHeadersHeightSizeModeOld.Value;
+                }
+            }
+        }
+
+    }
+}

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTester.csproj
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTester.csproj
@@ -167,6 +167,9 @@
       <DependentUpon>MyTreeView.cs</DependentUpon>
     </Compile>
     <Compile Include="ProcessUtilities.cs" />
+    <Compile Include="SafeDataGridView.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="SkylineTesterWindow.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
@@ -88,7 +88,7 @@ namespace SkylineTester
             this.labelSelectedFormsCount = new System.Windows.Forms.ToolStripLabel();
             this.clearSeenButton = new System.Windows.Forms.ToolStripButton();
             this.labelFormsSeenPercent = new System.Windows.Forms.ToolStripLabel();
-            this.formsGrid = new System.Windows.Forms.DataGridView();
+            this.formsGrid = new SkylineTester.SafeDataGridView();
             this.FormColumn = new System.Windows.Forms.DataGridViewLinkColumn();
             this.TestColumn = new System.Windows.Forms.DataGridViewLinkColumn();
             this.SeenColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -259,7 +259,7 @@ namespace SkylineTester
             this.comboBoxRunStatsCompare = new System.Windows.Forms.ComboBox();
             this.comboBoxRunStats = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
-            this.dataGridRunStats = new System.Windows.Forms.DataGridView();
+            this.dataGridRunStats = new SkylineTester.SafeDataGridView();
             this.TestName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Iterations = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Duration = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -3383,7 +3383,7 @@ namespace SkylineTester
         private GroupBox groupBox21;
         private CheckBox showFormNamesTutorial;
         private CheckBox testsTurkish;
-        private DataGridView formsGrid;
+        private SafeDataGridView formsGrid;
         private ToolStrip toolStrip1;
         private ToolStripLabel labelSelectedFormsCount;
         private ToolStripButton clearSeenButton;
@@ -3409,7 +3409,7 @@ namespace SkylineTester
         private GroupBox groupBox17;
         private TableLayoutPanel nightlyTrendsTable;
         private TabPage tabRunStats;
-        private DataGridView dataGridRunStats;
+        private SafeDataGridView dataGridRunStats;
         private Label label1;
         private ComboBox comboBoxRunStats;
         private DataGridViewTextBoxColumn TestName;


### PR DESCRIPTION
… when constructing a DataGridView with the mouse pointer located in certain spots when the grid is created.