### PR TITLE
Fix missing file timsdata.dll in Skyline 4.2 32 bit installer.

### DIFF
--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -2764,6 +2764,10 @@
       <Link>unimod.xml</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Condition=" '$(Platform)' == 'x86' " Include="..\Shared\ProteowizardWrapper\obj\x86\timsdata.dll">
+      <Link>timsdata.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Condition=" '$(Platform)' == 'x64' " Include="..\Shared\ProteowizardWrapper\obj\x64\timsdata.dll">
       <Link>timsdata.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Here's the fix for the Skyline 4.2 installer.
It looks like timsdata.dll started being included in the 32 bit build on December 4, 2018.
Our unit tests did not catch this new dependency because timsdata.dll had been included in TestSettings_x86.testsettings ever since September, even though that file probably had no effect at the time.