### PR TITLE
Add a "Record new tutorial audit logs" checkbox to SkylineTester's "T…

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
@@ -299,6 +299,7 @@ namespace SkylineTester
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.myTreeView1 = new SkylineTester.MyTreeView();
             this.nightlyRunIndefinitely = new System.Windows.Forms.CheckBox();
+            this.recordAuditLogs = new System.Windows.Forms.CheckBox();
             this.mainPanel.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.tabs.SuspendLayout();
@@ -897,7 +898,7 @@ namespace SkylineTester
             this.groupBox15.Controls.Add(this.testsJapanese);
             this.groupBox15.Controls.Add(this.testsChinese);
             this.groupBox15.Controls.Add(this.testsEnglish);
-            this.groupBox15.Location = new System.Drawing.Point(11, 300);
+            this.groupBox15.Location = new System.Drawing.Point(11, 326);
             this.groupBox15.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox15.Name = "groupBox15";
             this.groupBox15.Padding = new System.Windows.Forms.Padding(4);
@@ -966,7 +967,7 @@ namespace SkylineTester
             // windowsGroup
             // 
             this.windowsGroup.Controls.Add(this.offscreen);
-            this.windowsGroup.Location = new System.Drawing.Point(11, 234);
+            this.windowsGroup.Location = new System.Drawing.Point(11, 260);
             this.windowsGroup.Margin = new System.Windows.Forms.Padding(4);
             this.windowsGroup.Name = "windowsGroup";
             this.windowsGroup.Padding = new System.Windows.Forms.Padding(4);
@@ -988,6 +989,7 @@ namespace SkylineTester
             // 
             // iterationsGroup
             // 
+            this.iterationsGroup.Controls.Add(this.recordAuditLogs);
             this.iterationsGroup.Controls.Add(this.testsRunSmallMoleculeVersions);
             this.iterationsGroup.Controls.Add(this.randomize);
             this.iterationsGroup.Controls.Add(this.repeat);
@@ -1002,7 +1004,7 @@ namespace SkylineTester
             this.iterationsGroup.Margin = new System.Windows.Forms.Padding(4);
             this.iterationsGroup.Name = "iterationsGroup";
             this.iterationsGroup.Padding = new System.Windows.Forms.Padding(4);
-            this.iterationsGroup.Size = new System.Drawing.Size(280, 176);
+            this.iterationsGroup.Size = new System.Drawing.Size(280, 202);
             this.iterationsGroup.TabIndex = 1;
             this.iterationsGroup.TabStop = false;
             this.iterationsGroup.Text = "Run options";
@@ -1012,7 +1014,7 @@ namespace SkylineTester
             this.testsRunSmallMoleculeVersions.AutoSize = true;
             this.testsRunSmallMoleculeVersions.Checked = true;
             this.testsRunSmallMoleculeVersions.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.testsRunSmallMoleculeVersions.Location = new System.Drawing.Point(5, 152);
+            this.testsRunSmallMoleculeVersions.Location = new System.Drawing.Point(5, 173);
             this.testsRunSmallMoleculeVersions.Name = "testsRunSmallMoleculeVersions";
             this.testsRunSmallMoleculeVersions.Size = new System.Drawing.Size(179, 17);
             this.testsRunSmallMoleculeVersions.TabIndex = 9;
@@ -1071,7 +1073,7 @@ namespace SkylineTester
             this.testsAddSmallMoleculeNodes.AutoSize = true;
             this.testsAddSmallMoleculeNodes.Checked = true;
             this.testsAddSmallMoleculeNodes.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.testsAddSmallMoleculeNodes.Location = new System.Drawing.Point(5, 129);
+            this.testsAddSmallMoleculeNodes.Location = new System.Drawing.Point(5, 150);
             this.testsAddSmallMoleculeNodes.Name = "testsAddSmallMoleculeNodes";
             this.testsAddSmallMoleculeNodes.Size = new System.Drawing.Size(168, 17);
             this.testsAddSmallMoleculeNodes.TabIndex = 8;
@@ -3109,6 +3111,17 @@ namespace SkylineTester
             this.nightlyRunIndefinitely.Text = "Run indefinitely";
             this.nightlyRunIndefinitely.UseVisualStyleBackColor = true;
             // 
+            // recordAuditLogs
+            // 
+            this.recordAuditLogs.AutoSize = true;
+            this.recordAuditLogs.Location = new System.Drawing.Point(5, 127);
+            this.recordAuditLogs.Name = "recordAuditLogs";
+            this.recordAuditLogs.Size = new System.Drawing.Size(166, 17);
+            this.recordAuditLogs.TabIndex = 10;
+            this.recordAuditLogs.Text = "Record new tutorial audit logs";
+            this.toolTip1.SetToolTip(this.recordAuditLogs, "Create new or updated audit logs for tutorial tests");
+            this.recordAuditLogs.UseVisualStyleBackColor = true;
+            // 
             // SkylineTesterWindow
             // 
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
@@ -3439,5 +3452,6 @@ namespace SkylineTester
         private Panel panel2;
         private Panel panel4;
         private CheckBox nightlyRunIndefinitely;
+        private CheckBox recordAuditLogs;
     }
 }

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -1016,6 +1016,7 @@ namespace SkylineTester
                 testsAddSmallMoleculeNodes,
                 repeat,
                 randomize,
+                recordAuditLogs,
                 offscreen,
                 testsEnglish,
                 testsChinese,
@@ -1469,6 +1470,7 @@ namespace SkylineTester
         public CheckBox         TestsAddSmallMoleculeNodes { get { return testsAddSmallMoleculeNodes; } }
         public CheckBox         TestsRunSmallMoleculeVersions { get {  return testsRunSmallMoleculeVersions;} }
         public CheckBox         TestsRandomize              { get { return randomize; } }
+        public CheckBox         TestsRecordAuditLogs        { get { return recordAuditLogs; } }
         public ComboBox         TestsRepeatCount            { get { return repeat; } }
         public MyTreeView       TestsTree                   { get { return testsTree; } }
         public CheckBox         TestsChinese                { get { return testsChinese; } }

--- a/pwiz_tools/Skyline/SkylineTester/TabTests.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabTests.cs
@@ -76,6 +76,9 @@ namespace SkylineTester
             if (MainWindow.TestsRandomize.Checked)
                 args.Append(" random=on");
 
+            if (MainWindow.TestsRecordAuditLogs.Checked)
+                args.Append(" recordauditlogs=on");
+
             int count;
             if (!int.TryParse(MainWindow.TestsRepeatCount.Text, out count))
                 count = 0;

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -192,6 +192,7 @@ namespace TestRunner
                 "quality=off;pass0=off;pass1=off;" +
                 "perftests=off;" +
                 "runsmallmoleculeversions=off;" +
+                "recordauditlogs=off;" +
                 "testsmallmolecules=off;" +
                 "clipboardcheck=off;profile=off;vendors=on;language=fr-FR,en-US;" +
                 "log=TestRunner.log;report=TestRunner.log;dmpdir=Minidumps;teamcitytestdecoration=off";
@@ -386,6 +387,7 @@ namespace TestRunner
             bool perftests = commandLineArgs.ArgAsBool("perftests");
             bool addsmallmoleculenodes = commandLineArgs.ArgAsBool("testsmallmolecules"); // Add the magic small molecule test node to every document?
             bool runsmallmoleculeversions = commandLineArgs.ArgAsBool("runsmallmoleculeversions"); // Run the various tests that are versions of other tests with the document completely converted to small molecules?
+            bool recordauditlogs = commandLineArgs.ArgAsBool("recordauditlogs"); // Replace or create audit logs for tutorial tests
             bool useVendorReaders = commandLineArgs.ArgAsBool("vendors");
             bool showStatus = commandLineArgs.ArgAsBool("status");
             bool showFormNames = commandLineArgs.ArgAsBool("showformnames");
@@ -440,7 +442,7 @@ namespace TestRunner
 
             var runTests = new RunTests(
                 demoMode, buildMode, offscreen, internet, showStatus, perftests, addsmallmoleculenodes,
-                runsmallmoleculeversions, teamcityTestDecoration,
+                runsmallmoleculeversions, recordauditlogs, teamcityTestDecoration,
                 pauseDialogs, pauseSeconds, useVendorReaders, timeoutMultiplier, 
                 results, log);
             

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -84,6 +84,7 @@ namespace TestRunnerLib
         public long ManagedMemoryBytes { get; private set; }
         public bool AccessInternet { get; set; }
         public bool RunPerfTests { get; set; }
+        public bool RecordAuditLogs { get; set; }
         public bool AddSmallMoleculeNodes{ get; set; }
         public bool RunsSmallMoleculeVersions { get; set; }
         public bool LiveReports { get; set; }
@@ -103,6 +104,7 @@ namespace TestRunnerLib
             bool perftests,
             bool addsmallmoleculenodes,
             bool runsmallmoleculeversions,
+            bool recordauditlogs,
             bool teamcityTestDecoration,
             IEnumerable<string> pauseForms,
             int pauseSeconds = 0,
@@ -136,6 +138,7 @@ namespace TestRunnerLib
             RunPerfTests = perftests;
             AddSmallMoleculeNodes= addsmallmoleculenodes;  // Add the magic small molecule test node to all documents?
             RunsSmallMoleculeVersions = runsmallmoleculeversions;  // Run the small molecule version of various tests?
+            RecordAuditLogs = recordauditlogs; // Replace or create audit logs for tutorial tests
             LiveReports = true;
             TeamCityTestDecoration = teamcityTestDecoration;
 
@@ -244,6 +247,7 @@ namespace TestRunnerLib
                 TestContext.Properties["LiveReports"] = LiveReports.ToString();
                 TestContext.Properties["TestName"] = test.TestMethod.Name;
                 TestContext.Properties["TestRunResultsDirectory"] = testResultsDir;
+                TestContext.Properties["RecordAuditLogs"] = RecordAuditLogs.ToString();
 
                 if (test.SetTestContext != null)
                 {

--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
@@ -67,6 +67,15 @@ namespace pwiz.SkylineTestUtil
         }
 
         /// <summary>
+        /// Determines whether or not to (re)record audit logs for tests.
+        /// </summary>
+        protected bool RecordAuditLogs
+        {
+            get { return GetBoolValue("RecordAuditLogs", false); }  // Return false if unspecified
+            set { TestContext.Properties["RecordAuditLogs"] = value ? "true" : "false"; }
+        }
+
+        /// <summary>
         /// This controls whether we run the various tests that are small molecule versions of our standard tests,
         /// for example DocumentExportImportTestAsSmallMolecules().  Such tests convert the entire document to small
         /// molecule representations before proceeding.

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -921,9 +921,9 @@ namespace pwiz.SkylineTestUtil
             get { return IsTutorial; }
         }
 
-        public static bool IsRecordAuditLogForTutorials
+        public bool IsRecordAuditLogForTutorials
         {
-            get { return false; }
+            get { return IsTutorial && RecordAuditLogs; }
         }
 
         public static bool IsShowMatchingTutorialPages { get; set; }
@@ -1174,9 +1174,9 @@ namespace pwiz.SkylineTestUtil
                 // Copy the just recorded file to the project for comparison or commit
                 File.Copy(recordedFile, projectFile, true);
                 if (!existsInProject)
-                    Assert.Fail("Successfully recorded tutorial audit log");
+                    Console.WriteLine(@"Successfully recorded tutorial audit log");
                 else
-                    AssertEx.NoDiff(expected, actual, "Successfully recorded changed tutorial audit log:");
+                    Console.WriteLine(@"Successfully recorded changed tutorial audit log");
             }
         }
 


### PR DESCRIPTION
…ests" tab. This eliminates the need to hack the code (by changing IsRecordAuditLogForTutorials to return hardcoded true instead of hardcoded false). It also allows recording all languages at one go - formerly we issued a fail after each recording, to ensure that nobody accidentally checked in their hacked code.