### PR TITLE
Fix problem where user could be left with invalid precursor transitio…

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
@@ -2509,7 +2509,9 @@ namespace pwiz.Skyline.Model.DocSettings
                                  // if a library is in use.
                                  (newLib.HasLibraries && DiffTransitions) ||
                                  // If using MS1 isotopes, an enrichment change can change transition masses
-                                 (newTran.FullScan.PrecursorIsotopes != FullScanPrecursorIsotopes.None && enrichmentsChanged)
+                                 (newTran.FullScan.PrecursorIsotopes != FullScanPrecursorIsotopes.None && enrichmentsChanged) ||
+                                  !Equals(newTran.FullScan.PrecursorRes, oldTran.FullScan.PrecursorRes) ||
+                                  !Equals(newTran.FullScan.PrecursorResMz, oldTran.FullScan.PrecursorResMz)
                                  ;
 
             // If the results changed, then update the results information which has changed


### PR DESCRIPTION
There's a problem where if the user sets their full scan mass resolution high enough, they might be left with some precursor transitions whose abundance is too low for Skyline to think acceptable. This makes it impossible to reopen the document.

Back in July, this was partially fixed when I made it so that changing the PrecursorRes would set "SrmSettingsDiff.DiffTransitions". However, that only fixed this in the case where AutoManageChildren was true.
To fix this in the case where the children have been explicitly chosen, I also need to ensure that "DiffTransitionProps" gets set to true when this setting changes.

Now, with this change, TransitionGroupDocNode.ChangeSettings will call "TransitionDocNode.IsValidIsotopeTransition" on each transition (that code was already there) to make sure that the transition still belongs in the document.