### PR TITLE
Skyline: performance improvements on import of lengthy small molecule…

### DIFF
--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -754,7 +754,11 @@ namespace pwiz.Skyline.Model
             }
 
             // Note document contents type: proteomic, small molecule, or mixed (empty reports as proteomic)
-            docClone.SetDocumentType();
+            if (!DeferSettingsChanges)
+            {
+                docClone.SetDocumentType();
+            }
+            
             // If this document has associated results, update the results
             // for any peptides that have changed.
             if (!Settings.HasResults || DeferSettingsChanges)


### PR DESCRIPTION
… transition lists. A 12,000 line mz-only list now imports in 30 seconds where it used to take 2 minutes 52 seconds (nearly 6x faster)