### PR TITLE
Installer fixes

### DIFF
--- a/scripts/wix/pwiz-setup.py
+++ b/scripts/wix/pwiz-setup.py
@@ -74,7 +74,7 @@ def contextMenuRegistries() :
     for appName in appNames :
         txt = componentText.replace("_MY_APPU_",appName.upper())
         txt = txt.replace("__MY_APP__","Open with "+appName)
-        txt = txt.replace("__MY_PATH__","[APPLICATIONROOTDIRECTORY]"+appName+".exe")
+        txt = txt.replace("__MY_PATH__","[APPLICATIONFOLDER]"+appName+".exe")
         registries = registries + txt
     return registries
 

--- a/scripts/wix/pwiz-setup.wxs.template
+++ b/scripts/wix/pwiz-setup.wxs.template
@@ -33,7 +33,7 @@
       <Media Id="1" Cabinet="ProteoWizard.cab" EmbedCab="yes" />
       <Icon Id="seems_Icon.exe" SourceFile="msvc-release\seems.exe" />
       <Property Id="ARPPRODUCTICON" Value="seems_Icon.exe" />
-      <Property Id="ApplicationFolderName" Value="ProteoWizard {numeric-version} $(var.AddressModel)-bit" />
+      <Property Id="ApplicationFolderName" Value="ProteoWizard {version}" />
       <Property Id="WixAppFolder" Value="WixPerUserFolder" />
       <!--<WixVariable Id="WixUIBannerBmp" Value="..\Resources\SetupBanner.bmp" />
       <WixVariable Id="WixUIDialogBmp" Value="..\Resources\SetupBackground.bmp" />-->
@@ -158,8 +158,12 @@
 
     <PropertyRef Id="ApplicationFolderName" />
 
-    <CustomAction Id="WixSetDefaultPerUserFolder2" Property="WixPerUserFolder" Value="[LocalAppDataFolder]Apps\[ApplicationFolderName]" Execute="immediate" />
-    <CustomAction Id="WixSetDefaultPerMachineFolder2" Property="WixPerMachineFolder" Value="[ProgramFilesFolder][ApplicationFolderName]" Execute="immediate" />
+    <?if $(var.AddressModel)=64 ?>
+      <CustomAction Id="WixSetDefaultPerMachineFolder2" Property="WixPerMachineFolder" Value="[ProgramFiles64Folder][ApplicationFolderName]" Execute="immediate" />
+    <?else?>
+      <CustomAction Id="WixSetDefaultPerMachineFolder2" Property="WixPerMachineFolder" Value="[ProgramFilesFolder][ApplicationFolderName]" Execute="immediate" />
+    <?endif?>
+    <CustomAction Id="WixSetDefaultPerUserFolder2" Property="WixPerUserFolder" Value="[LocalAppDataFolder]Apps\[ApplicationFolderName] $(var.AddressModel)-bit" Execute="immediate" />
     <CustomAction Id="WixSetPerUserFolder2" Property="APPLICATIONFOLDER" Value="[WixPerUserFolder]" Execute="immediate" />
     <CustomAction Id="WixSetPerMachineFolder2" Property="APPLICATIONFOLDER" Value="[WixPerMachineFolder]" Execute="immediate" />
 


### PR DESCRIPTION
- fixed MSConvertGUI/SeeMS context menu shortcuts that were broken with the recent change to dual-scope installer
- fixed default install location for 64-bit: it will now go to %PROGRAMFILES% instead of %PROGRAMFILES(x86)%; also the version will again have the git hash suffix and only per-user installs will have the 64-bit/32-bit suffix