### PR TITLE
Skyline: fix a small problem with TargetResolver and small molecules …

### DIFF
--- a/pwiz_tools/Skyline/Model/TargetResolver.cs
+++ b/pwiz_tools/Skyline/Model/TargetResolver.cs
@@ -81,7 +81,7 @@ namespace pwiz.Skyline.Model
 
         private string GetTargetName(Target target)
         {
-            return target.ToString();
+            return target.DisplayName;
         }
 
         public Target ResolveTarget(string text)


### PR DESCRIPTION
…- it was using ToString() instead of DisplayName to show molecule to user, which was confusing.