### PR TITLE
- fixed Thermo PDA spectra not being enumerated in 64-bit

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Detail.cpp
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Detail.cpp
@@ -135,7 +135,15 @@ vector<InstrumentConfiguration> createInstrumentConfigurations(RawFile& rawfile)
     if (firstInletType != CVID_Unknown)
         commonSource.set(firstInletType);
 
-    return createInstrumentConfigurations(commonSource, model);
+    auto configurations = createInstrumentConfigurations(commonSource, model);
+
+    if (rawfile.getNumberOfControllersOfType(Controller_PDA) > 0)
+    {
+        configurations.push_back(InstrumentConfiguration());
+        configurations.back().componentList.push_back(Component(MS_PDA, 1));
+    }
+
+    return configurations;
 }
 
 

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
@@ -62,11 +62,12 @@ enum PWIZ_API_DECL ControllerType
 #ifdef _WIN64
     Controller_UV,
     Controller_PDA,
-    Controller_Other
+    Controller_Other,
 #else
     Controller_PDA,
-    Controller_UV
+    Controller_UV,
 #endif
+    Controller_Count
 };
 
 


### PR DESCRIPTION
- added instrumentConfiguration for PDA spectra
* added support for preferOnlyMsLevel to SpectrumList_Thermo and made it exclude PDA spectra when non-zero
* moved Thermo mutex out of RawFile back into SpectrumList_Thermo: the reader is still stateful at the controller level, so asking for a PDA spectrum when MS controller is selected is an error

@nickshulman should fix the "Line" issue with 32-bit, and restores PDA enumeration in 64-bit, but at the same time lets Skyline exclude them with the preferOnlyMsLevel option (which I assumed is set for all formats, not just Bruker TDF, but I didn't check).