### PR TITLE
Skyline: deal with an audit logging backward compatibility issue where the way we re…

### DIFF
--- a/pwiz_tools/Skyline/Model/AuditLog/AuditLogEntry.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/AuditLogEntry.cs
@@ -193,13 +193,13 @@ namespace pwiz.Skyline.Model.AuditLog
             writer.WriteEndDocument();
         }
 
-        public static bool ReadFromFile(string fileName, out string documentHash, out AuditLogList result)
+        public static bool ReadFromFile(string fileName, out string loggedSkylineDocumentHash, out AuditLogList result)
         {
             try
             {
                 using (var reader = new XmlTextReader(fileName))
                 {
-                    return ReadFromXmlTextReader(reader, out documentHash, out result);
+                    return ReadFromXmlTextReader(reader, out loggedSkylineDocumentHash, out result);
                 }
             }
             catch(Exception ex)
@@ -214,14 +214,14 @@ namespace pwiz.Skyline.Model.AuditLog
                     alert.ShowParentlessDialog();
                 }
 
-                documentHash = null;
+                loggedSkylineDocumentHash = null;
                 result = null;
 
                 return false;
             }
         }
 
-        public static bool ReadFromXmlTextReader(XmlTextReader reader, out string documentHash, out AuditLogList result)
+        public static bool ReadFromXmlTextReader(XmlTextReader reader, out string loggedSkylineDocumentHash, out AuditLogList result)
         {
             reader.ReadToFollowing(DOCUMENT_ROOT);
             DocumentFormat? docFormat = null;
@@ -234,7 +234,27 @@ namespace pwiz.Skyline.Model.AuditLog
 
             reader.ReadStartElement();
 
-            documentHash = reader.ReadElementString(EL.document_hash.ToString());
+            loggedSkylineDocumentHash = reader.ReadElementString(EL.document_hash.ToString());
+            if (docFormat == null && !string.IsNullOrEmpty(loggedSkylineDocumentHash))
+            {
+                // If the docFormat is null, this is an old audit log and the document hash was formatted using byte.ToString(@"X2") instead of Base64
+                try
+                {
+                    var bytes = new List<byte>();
+                    var s = loggedSkylineDocumentHash;
+                    foreach (var bbHex in Enumerable.Range(0, loggedSkylineDocumentHash.Length / 2)
+                        .Select(i => s.Substring(i * 2, 2)))
+                    {
+                        bytes.Add(Convert.ToByte(bbHex, 16));
+                    }
+                    loggedSkylineDocumentHash = Convert.ToBase64String(bytes.ToArray());
+                }
+                // ReSharper disable once EmptyGeneralCatchClause
+                catch
+                {
+                }
+            }
+
             string rootHash = null;
             if (reader.IsStartElement(EL.root_hash.ToString()))
                 rootHash = reader.ReadElementString(EL.root_hash.ToString());

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -2051,17 +2051,17 @@ namespace pwiz.Skyline.Model
             AuditLog = AuditLog ?? new AuditLogList();
         }
 
-        public SrmDocument ReadAuditLog(string documentPath, string expectedHash, Func<AuditLogEntry> getDefaultEntry)
+        public SrmDocument ReadAuditLog(string documentPath, string expectedSkylineDocumentHash, Func<AuditLogEntry> getDefaultEntry)
         {
             var auditLog = new AuditLogList();
             var auditLogPath = GetAuditLogPath(documentPath);
             if (File.Exists(auditLogPath))
             {
-                if (AuditLogList.ReadFromFile(auditLogPath, out var actualHash, out var auditLogList))
+                if (AuditLogList.ReadFromFile(auditLogPath, out var loggedSkylineDocumentHash, out var auditLogList))
                 {
                     auditLog = auditLogList;
 
-                    if (expectedHash != actualHash)
+                    if (expectedSkylineDocumentHash != loggedSkylineDocumentHash)
                     {
                         var entry = getDefaultEntry() ?? AuditLogEntry.CreateUndocumentedChangeEntry();
                         auditLog = new AuditLogList(entry.ChangeParent(auditLog.AuditLogEntries));
@@ -2069,7 +2069,7 @@ namespace pwiz.Skyline.Model
                 }
             }
 
-            return ChangeDocumentHash(expectedHash).ChangeAuditLog(auditLog);
+            return ChangeDocumentHash(expectedSkylineDocumentHash).ChangeAuditLog(auditLog);
         }
 
         public void WriteXml(XmlWriter writer)

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -296,15 +296,15 @@ namespace pwiz.Skyline
                 {
                     longWaitDlg.PerformWork(parentWindow ?? this, 500, progressMonitor =>
                     {
-                        string hash;
+                        string skylineDocumentHash;
                         using (var reader = new HashingStreamReaderWithProgress(path, progressMonitor))
                         {
                             XmlSerializer ser = new XmlSerializer(typeof (SrmDocument));
                             document = (SrmDocument) ser.Deserialize(reader);
-                            hash = reader.Stream.Done();
+                            skylineDocumentHash = reader.Stream.Done();
                         }
 
-                        document = document.ReadAuditLog(path, hash, AskForLogEntry);
+                        document = document.ReadAuditLog(path, skylineDocumentHash, AskForLogEntry);
                     });
 
                     if (longWaitDlg.IsCanceled)

--- a/pwiz_tools/Skyline/Test/AuditLogListTest.cs
+++ b/pwiz_tools/Skyline/Test/AuditLogListTest.cs
@@ -53,9 +53,10 @@ namespace pwiz.SkylineTest
             datetime = AuditLogEntry.ParseSerializedTimeStamp("2018-12-31T23:02:03-04", out tzoffset);
             Assume.AreEqual(datetime, AuditLogEntry.ParseSerializedTimeStamp("2019-01-01T03:02:03Z", out tzoffset));
 
-            // Test backward compatibility - this file with 4.2 log should load without any problems77
-            Assume.IsTrue(AuditLogList.ReadFromXmlTextReader(new XmlTextReader(new StringReader(Test42FormatSkyl)), out var _, out var old));
+            // Test backward compatibility - this file with 4.2 log should load without any problems
+            Assume.IsTrue(AuditLogList.ReadFromXmlTextReader(new XmlTextReader(new StringReader(Test42FormatSkyl)), out var loggedSkylineDocumentHash, out var old));
             Assume.AreEqual("tgnQ8fDiKLMIS236kpdJIXNR+fw=", old.RootHash.ActualHash.HashString);
+            Assume.AreEqual("AjigWTmQeAO94/jAlwubVMp4FRg=", loggedSkylineDocumentHash); // Note that this is a base64 representation of the 4.2 hex representation "<document_hash>0238A05939907803BDE3F8C0970B9B54CA781518</document_hash>
 
             var then = DateTime.Parse("2019-03-08 00:02:03Z", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal).ToUniversalTime(); // Just before DST
             const int entryCount = 20000; // Enough to ensure stack overflow in case of some design error per Nick
@@ -110,7 +111,7 @@ namespace pwiz.SkylineTest
         private static string Test42FormatSkyl =
         "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
         "<audit_log_root>\n" +
-         "<document_hash>0238A05939907803BDE3F8C0970B9B54CA781518</document_hash>\n" +
+         "<document_hash>0238A05939907803BDE3F8C0970B9B54CA781518</document_hash>\n" + // Note that this is not how we serialize hashes any more, we use base64 instead of byte.ToString("@"X2")
          "<audit_log>\n" +
           "<audit_log_entry format_version=\"4.21\" time_stamp=\"03/07/2019 19:09:05\" user=\"bspratt-UW2\\bspratt\">\n" +
            "<extra_info>foo</extra_info>\n" +


### PR DESCRIPTION
…present the Skyline document hash changed after 4.2. Formerly we used an ASCII representation of 16 bit hex values e'g' "0238A05939907803BDE3F8C0970B9B54CA781518", now we use base64 e.g. "AjigWTmQeAO94/jAlwubVMp4FRg=". These examples both represent the same value but we were flagging them as a mismatch and asking the user to provide a reason for the document being changed outside of Skyline.