### PR TITLE
Skyline/work/20190315 mass only im predicitor

### DIFF
--- a/pwiz_tools/Skyline/Model/CustomMolecule.cs
+++ b/pwiz_tools/Skyline/Model/CustomMolecule.cs
@@ -293,10 +293,11 @@ namespace pwiz.Skyline.Model
         {
         }
 
-        public CustomMolecule(SmallMoleculeLibraryAttributes libraryAttributes)
-            : this(libraryAttributes.ChemicalFormula, libraryAttributes.MoleculeName, libraryAttributes.CreateMoleculeID())
+        public static CustomMolecule FromSmallMoleculeLibraryAttributes(SmallMoleculeLibraryAttributes libraryAttributes)
         {
             Assume.IsFalse(libraryAttributes.IsEmpty);
+            SmallMoleculeLibraryAttributes.ParseMolecularFormulaOrMassesString(libraryAttributes.ChemicalFormulaOrMassesString, out var formula, out var monoMass, out var averageMass);
+            return new CustomMolecule(formula, monoMass, averageMass, libraryAttributes.MoleculeName, libraryAttributes.CreateMoleculeID());
         }
 
         public CustomMolecule(string formula, TypedMass monoisotopicMass, TypedMass averageMass, string name, MoleculeAccessionNumbers moleculeAccessionNumbers)
@@ -360,6 +361,7 @@ namespace pwiz.Skyline.Model
         public SmallMoleculeLibraryAttributes GetSmallMoleculeLibraryAttributes()
         {
             return SmallMoleculeLibraryAttributes.Create(Name, Formula,
+                MonoisotopicMass, AverageMass, // In case forumla is empty
                 AccessionNumbers.GetInChiKey(), AccessionNumbers.GetNonInChiKeys());
         }
 
@@ -375,11 +377,18 @@ namespace pwiz.Skyline.Model
             return FromTSV(tsv);
         }
 
+        public const char MASS_SPLITTER = '/';
+
+        public static string FormattedMasses(double monoisotopicMass, double averageMass)
+        {
+            return string.Format(CultureInfo.InvariantCulture, @"{0:F09}/{1:F09}", monoisotopicMass, averageMass);
+        }
+
         public List<string> AsFields()
         {
             var massOrFormula = !string.IsNullOrEmpty(Formula) ?
                 Formula :
-                string.Format(CultureInfo.InvariantCulture, @"{0:F09}/{1:F09}", MonoisotopicMass, AverageMass);
+                FormattedMasses(MonoisotopicMass, AverageMass);
             var parts = new[] { Name, massOrFormula, AccessionNumbers.ToString() };
             return (parts.All(string.IsNullOrEmpty) ? new[] { InvariantName } : parts).ToList();
         }
@@ -414,12 +423,12 @@ namespace pwiz.Skyline.Model
                     }
                 }
             }
-            else if (formula != null && formula.Contains(@"/"))
+            else if (formula != null && formula.Contains(MASS_SPLITTER))
             {
                 // "formula" is actually mono and average masses
                 try
                 {
-                    var values = formula.Split('/');
+                    var values = formula.Split(MASS_SPLITTER);
                     var massMono = new TypedMass(double.Parse(values[0], CultureInfo.InvariantCulture), MassType.Monoisotopic);
                     var massAvg = new TypedMass(double.Parse(values[1], CultureInfo.InvariantCulture), MassType.Average);
                     return new CustomMolecule(massMono, massAvg, name, new MoleculeAccessionNumbers(keysTSV));

--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -3638,6 +3638,7 @@ namespace pwiz.Skyline.Model.DocSettings
 
         public override void ReadXml(XmlReader reader)
         {
+            var name = reader.Name;
             // Read start tag attributes
             base.ReadXml(reader);
             WindowWidthCalculator = new IonMobilityWindowWidthCalculator(reader);
@@ -3672,8 +3673,10 @@ namespace pwiz.Skyline.Model.DocSettings
             if (dict.Any())
                 MeasuredMobilityIons = dict;
 
-            reader.Read();             // Consume end tag
-
+            if (reader.Name.Equals(name)) // Make sure we haven't stepped off the end
+            {
+                reader.Read();             // Consume end tag
+            }
             Validate();
         }
 

--- a/pwiz_tools/Skyline/Model/ExplicitTransitionGroupValues.cs
+++ b/pwiz_tools/Skyline/Model/ExplicitTransitionGroupValues.cs
@@ -56,7 +56,7 @@ namespace pwiz.Skyline.Model
             : this(
                 (other == null) ? null : other.CollisionEnergy,
                 (other == null) ? null : other.IonMobility,
-                (other == null) ? null : other.IonMobility,
+                (other == null) ? null : other.IonMobilityHighEnergyOffset,
                 (other == null) ? eIonMobilityUnits.none : other.IonMobilityUnits,
                 (other == null) ? null : other.CollisionalCrossSectionSqA,
                 (other == null) ? null : other.SLens,

--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -691,7 +691,7 @@ namespace pwiz.Skyline.Model.Lib
                             var otherKeys = iOtherKeys >= 0 && !reader.IsDBNull(iOtherKeys) ? reader.GetString(iOtherKeys) : null;
                             smallMoleculeLibraryAttributes = SmallMoleculeLibraryAttributes.Create(moleculeName, chemicalFormula, inChiKey, otherKeys);
                             // Construct a custom molecule so we can be sure we're using the same keys
-                            var mol = new CustomMolecule(smallMoleculeLibraryAttributes);
+                            var mol = CustomMolecule.FromSmallMoleculeLibraryAttributes(smallMoleculeLibraryAttributes);
                             sequence = mol.PrimaryEquivalenceKey;
                         }
 

--- a/pwiz_tools/Skyline/Model/Lib/LibKeyIndex.cs
+++ b/pwiz_tools/Skyline/Model/Lib/LibKeyIndex.cs
@@ -162,8 +162,10 @@ namespace pwiz.Skyline.Model.Lib
                 var thatPeptideKey = thatItem.LibraryKey as PeptideLibraryKey;
                 if (thatPeptideKey == null)
                 {
-                    result.Add(thatItem.LibraryKey);
-                    nonPeptideKeySet.Add(thatItem.LibraryKey);
+                    if (nonPeptideKeySet.Add(thatItem.LibraryKey))
+                    {
+                        result.Add(thatItem.LibraryKey); // First time we've seen it, add to list
+                    }
                     continue;
                 }
                 PeptideLibraryKey[] thisKeysWithUnmodSeq;

--- a/pwiz_tools/Skyline/Model/Lib/LibraryKey.cs
+++ b/pwiz_tools/Skyline/Model/Lib/LibraryKey.cs
@@ -325,7 +325,7 @@ namespace pwiz.Skyline.Model.Lib
 
         public override Target Target
         {
-            get { return new Target(new CustomMolecule(SmallMoleculeLibraryAttributes)); }
+            get { return new Target(CustomMolecule.FromSmallMoleculeLibraryAttributes(SmallMoleculeLibraryAttributes)); }
         }
 
         protected internal override LibraryKeyProto ToLibraryKeyProto()
@@ -335,7 +335,7 @@ namespace pwiz.Skyline.Model.Lib
                 KeyType = LibraryKeyProto.Types.KeyType.SmallMolecule,
                 Adduct = Adduct.AdductFormula ?? string.Empty,
                 MoleculeName = SmallMoleculeLibraryAttributes.MoleculeName ?? string.Empty,
-                ChemicalFormula = SmallMoleculeLibraryAttributes.ChemicalFormula ?? string.Empty,
+                ChemicalFormula = SmallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString ?? string.Empty,
                 InChiKey = SmallMoleculeLibraryAttributes.InChiKey ?? string.Empty,
                 OtherKeys = SmallMoleculeLibraryAttributes.OtherKeys ?? string.Empty
             };
@@ -377,13 +377,13 @@ namespace pwiz.Skyline.Model.Lib
             }
 
             if (null == smallMoleculeLibraryAttributes.MoleculeName ||
-                null == smallMoleculeLibraryAttributes.ChemicalFormula ||
+                null == smallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString ||
                 null == smallMoleculeLibraryAttributes.InChiKey || 
                 null == smallMoleculeLibraryAttributes.OtherKeys)
             {
                 smallMoleculeLibraryAttributes = SmallMoleculeLibraryAttributes.Create(
                     smallMoleculeLibraryAttributes.MoleculeName ?? string.Empty,
-                    smallMoleculeLibraryAttributes.ChemicalFormula ?? string.Empty,
+                    smallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString ?? string.Empty,
                     smallMoleculeLibraryAttributes.InChiKey ?? string.Empty,
                     smallMoleculeLibraryAttributes.OtherKeys ?? string.Empty);
             }
@@ -393,7 +393,7 @@ namespace pwiz.Skyline.Model.Lib
                 {
                     smallMoleculeLibraryAttributes = valueCache.CacheValue(SmallMoleculeLibraryAttributes.Create(
                         valueCache.CacheValue(smallMoleculeLibraryAttributes.MoleculeName),
-                        valueCache.CacheValue(smallMoleculeLibraryAttributes.ChemicalFormula),
+                        valueCache.CacheValue(smallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString),
                         valueCache.CacheValue(smallMoleculeLibraryAttributes.InChiKey),
                         valueCache.CacheValue(smallMoleculeLibraryAttributes.OtherKeys)
                     ));

--- a/pwiz_tools/Skyline/Model/LibKeyModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/LibKeyModificationMatcher.cs
@@ -301,7 +301,7 @@ namespace pwiz.Skyline.Model
             Peptide peptide;
             if (smallMoleculeKey != null)
             {
-                peptide = new Peptide(new CustomMolecule(smallMoleculeKey.SmallMoleculeLibraryAttributes));
+                peptide = new Peptide(CustomMolecule.FromSmallMoleculeLibraryAttributes(smallMoleculeKey.SmallMoleculeLibraryAttributes));
             }
             else if (peptideKey != null)
             {

--- a/pwiz_tools/Skyline/Model/Peptide.cs
+++ b/pwiz_tools/Skyline/Model/Peptide.cs
@@ -714,7 +714,7 @@ namespace pwiz.Skyline.Model
 
         public Target(SmallMoleculeLibraryAttributes molecule) 
         {
-            Molecule = new CustomMolecule(molecule);
+            Molecule = CustomMolecule.FromSmallMoleculeLibraryAttributes(molecule);
         }
 
         public string Sequence { get; private set; }

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -404,7 +404,10 @@ namespace pwiz.Skyline.Model
         /// Quick access to document type proteomic/small_molecules/mixed, based on the assumption that 
         /// TransitionGroups are purely proteomic or small molecule, but the document is not.
         /// 
-        /// Empty documents report as proteomic.
+        /// Empty documents report as none.
+        ///
+        /// These enum names are used on persisted settings for UI mode, so don't rename them as
+        /// it will confuse existing installations.
         /// 
         /// </summary>
         public enum DOCUMENT_TYPE

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -26768,6 +26768,15 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Average mass.
+        /// </summary>
+        public static string SmallMoleculeLibraryAttributes_KeyValuePairs_Average_mass {
+            get {
+                return ResourceManager.GetString("SmallMoleculeLibraryAttributes_KeyValuePairs_Average_mass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Formula.
         /// </summary>
         public static string SmallMoleculeLibraryAttributes_KeyValuePairs_Formula {
@@ -26782,6 +26791,15 @@ namespace pwiz.Skyline.Properties {
         public static string SmallMoleculeLibraryAttributes_KeyValuePairs_InChIKey {
             get {
                 return ResourceManager.GetString("SmallMoleculeLibraryAttributes_KeyValuePairs_InChIKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Monoisotopic mass.
+        /// </summary>
+        public static string SmallMoleculeLibraryAttributes_KeyValuePairs_Monoisotopic_mass {
+            get {
+                return ResourceManager.GetString("SmallMoleculeLibraryAttributes_KeyValuePairs_Monoisotopic_mass", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -9913,6 +9913,12 @@ Recognized isotopes include: {2}</value>
   <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Formula" xml:space="preserve">
     <value>Formula</value>
   </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Monoisotopic_mass" xml:space="preserve">
+    <value>Monoisotopic mass</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Average_mass" xml:space="preserve">
+    <value>Average mass</value>
+  </data>
   <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_InChIKey" xml:space="preserve">
     <value>InChIKey</value>
   </data>

--- a/pwiz_tools/Skyline/Test/CustomMoleculeTest.cs
+++ b/pwiz_tools/Skyline/Test/CustomMoleculeTest.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Lib;
+using pwiz.Skyline.Util;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTest
@@ -39,14 +40,19 @@ namespace pwiz.SkylineTest
             });
             var smallMoleculeLibraryAttributes = 
                 SmallMoleculeLibraryAttributes.Create("MyMolecule", "H2O", "MyInChiKey", moleculeAccessionNumbers.GetNonInChiKeys());
-            var customMolecule = new CustomMolecule(smallMoleculeLibraryAttributes);
-            var target = new Target(customMolecule);
-            var serializableString = target.ToSerializableString();
+            for (var loop = 0; loop < 2; loop++)
+            {
+                var customMolecule = CustomMolecule.FromSmallMoleculeLibraryAttributes(smallMoleculeLibraryAttributes);
+                var target = new Target(customMolecule);
+                var serializableString = target.ToSerializableString();
 
-            var roundTrip = Target.FromSerializableString(serializableString);
-            Assert.AreEqual(target, roundTrip);
-            Assert.AreEqual(customMolecule, roundTrip.Molecule);
-            Assert.AreEqual(customMolecule.AccessionNumbers, roundTrip.Molecule.AccessionNumbers);
+                var roundTrip = Target.FromSerializableString(serializableString);
+                Assert.AreEqual(target, roundTrip);
+                Assert.AreEqual(customMolecule, roundTrip.Molecule);
+                Assert.AreEqual(customMolecule.AccessionNumbers, roundTrip.Molecule.AccessionNumbers);
+                smallMoleculeLibraryAttributes = // Masses instead of formula
+                    SmallMoleculeLibraryAttributes.Create("MyMolecule", null, new TypedMass(123.4, MassType.Monoisotopic), new TypedMass(123.45, MassType.Average), "MyInChiKey", moleculeAccessionNumbers.GetNonInChiKeys());
+            }
         }
     }
 }

--- a/pwiz_tools/Skyline/Test/IonMobilityUnitTest.cs
+++ b/pwiz_tools/Skyline/Test/IonMobilityUnitTest.cs
@@ -96,9 +96,14 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC, validatingIonMobilityPeptides[1].HighEnergyDriftTimeOffsetMsec);
 
             // Test serialization of molecule with '$' in it, which we use as a tab replacement against XML parser variability
-            var molser = new CustomMolecule(SmallMoleculeLibraryAttributes.Create("caffeine$", caffeineFormula, caffeineInChiKey, caffeineHMDB));
+            var molser = CustomMolecule.FromSmallMoleculeLibraryAttributes(SmallMoleculeLibraryAttributes.Create("caffeine$", caffeineFormula, caffeineInChiKey, caffeineHMDB));
             var text = molser.ToSerializableString();
             Assert.AreEqual(molser, CustomMolecule.FromSerializableString(text));
+
+            // Test handling of SmallMoleculeLibraryAttributes for mass-only descriptions
+            var molserB = CustomMolecule.FromSmallMoleculeLibraryAttributes(SmallMoleculeLibraryAttributes.Create("caffeine$", null, new TypedMass(123.4, MassType.Monoisotopic), new TypedMass(123.45, MassType.Average), caffeineInChiKey, caffeineHMDB));
+            var textB = molserB.ToSerializableString();
+            Assert.AreEqual(molserB, CustomMolecule.FromSerializableString(textB));
 
             var dictCCS2 = new Dictionary<LibKey, IonMobilityAndCCS[]>();
             var ccs3 = new List<IonMobilityAndCCS> { IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(4, eIonMobilityUnits.drift_time_msec), null, HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC), IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(5, eIonMobilityUnits.drift_time_msec), null, HIGH_ENERGY_DRIFT_TIME_OFFSET_MSEC) }; // Drift times


### PR DESCRIPTION
John F discovered that deriving ion mobility from loaded mass spec results didn't work for molecules defined by mass only. This fixes the problem and allows TargetResolver to work properly with molecules defined by mass only by tweaking the LibraryKey class.