### PR TITLE
Skyline: use a more accurate means of detecting when "Labels" tab of …

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
@@ -488,9 +488,9 @@ namespace pwiz.Skyline.SettingsUI
                     PeptideModifications.MIN_MAX_NEUTRAL_LOSSES, PeptideModifications.MAX_MAX_NEUTRAL_LOSSES, out maxNeutralLosses))
                 return null;
 
-            var standardTypes = labelStandardType.Visible
-               ? _driverLabelType.InternalStandardTypes
-               : _driverSmallMolInternalStandardTypes.InternalStandardTypes;
+            var standardTypes = SmallMoleculeLabelsTabEnabled
+                ? _driverSmallMolInternalStandardTypes.InternalStandardTypes
+                : _driverLabelType.InternalStandardTypes;
             PeptideModifications modifications = new PeptideModifications(
                 _driverStaticMod.Chosen, maxVariableMods, maxNeutralLosses,
                 _driverLabelType.GetHeavyModifications(), standardTypes);


### PR DESCRIPTION
…Molecule/Peptide Settings is in use for deciding which control will provide current internal standard type information