### PR TITLE
Skyline: Fix immutability loophole where ratios can get changed direc…

### DIFF
--- a/pwiz_tools/Skyline/Model/PeptideDocNode.cs
+++ b/pwiz_tools/Skyline/Model/PeptideDocNode.cs
@@ -1465,7 +1465,7 @@ namespace pwiz.Skyline.Model
                         // first as a shortcut
                         var infoNew = info;
                         if (!ReferenceEquals(ratios, info.Ratios) && !ArrayUtil.EqualsDeep(ratios, info.Ratios))
-                            infoNew = infoNew.ChangeRatios(false, ratios);
+                            infoNew = infoNew.ChangeRatios(ratios);
                         if (isMatching && calc.IsSetMatching && !info.IsUserSetMatched)
                             infoNew = infoNew.ChangeUserSet(UserSet.MATCHED);
                         if (!ReferenceEquals(info, infoNew) && listInfoNew == null)

--- a/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
@@ -614,18 +614,8 @@ namespace pwiz.Skyline.Model.Results
             return chromInfo;
         }
 
-        /// <summary>
-        /// Because creating a copy shows up in a profiler, and this is currently only used
-        /// during calculation of this object, a copy flag was added to allow modified
-        /// immutability with direct setting allowed during extended creation time.
-        /// </summary>
-        public TransitionChromInfo ChangeRatios(bool copy, IList<float?> prop)
+        public TransitionChromInfo ChangeRatios(IList<float?> prop)
         {
-            if (!copy)
-            {
-                Ratios = prop;
-                return this;
-            }
             return ChangeProp(ImClone(this), im => im.Ratios = prop);
         }
 


### PR DESCRIPTION
…tly on a transition result

- Profiling gets mentioned in the comment, but it already looks like this is protected for only when the ratios are changing