### PR TITLE
Change Sciex peak picker to multiply Y (area) values by 100

### DIFF
--- a/pwiz/data/msdata/SpectrumWorkerThreads.cpp
+++ b/pwiz/data/msdata/SpectrumWorkerThreads.cpp
@@ -78,7 +78,7 @@ class SpectrumWorkerThreads::Impl
 
         useThreads_ = useWorkerThreads && !(isBruker || (isDemultiplexed)); // Bruker library is not thread-friendly
         //useThreads_ = !(isBruker); // Bruker library is not thread-friendly
-        cout << "useThreads: " << useThreads_ << endl;
+
         if (sl.size() > 0 && useThreads_)
         {
             // create one task per spectrum

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
@@ -53,6 +53,10 @@ using namespace Clearcore2::Data::DataAccess::SampleData;
 using namespace Clearcore2::RawXYProcessing;
 #endif
 
+// peak areas from Sciex are very small values relative to peak heights;
+// multiplying them by this scaling factor makes them more comparable
+const int PEAK_AREA_SCALE_FACTOR = 100;
+
 #include "WiffFile2.ipp"
 
 namespace pwiz {
@@ -790,7 +794,7 @@ void SpectrumImpl::getData(bool doCentroid, pwiz::util::BinaryData<double>& mz, 
             {
                 PeakClass^ peak = peakList[(int)i];
                 mz[i] = peak->xValue;
-                intensities[i] = peak->area * 100;
+                intensities[i] = peak->area * PEAK_AREA_SCALE_FACTOR;
             }
         }
         else

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
@@ -568,7 +568,7 @@ void ExperimentImpl::getSIC(size_t index, pwiz::util::BinaryData<double>& times,
     try
     {
         if (index >= transitionCount)
-            throw std::out_of_range("[Experiment::getSIC()] index out of range");
+            throw std::out_of_range("[Experiment::getSIC()] index " + lexical_cast<string>(index) + " out of range");
 
         ExtractedIonChromatogramSettings^ option = gcnew ExtractedIonChromatogramSettings(index);
         ExtractedIonChromatogram^ xic = msExperiment->GetExtractedIonChromatogram(option);
@@ -592,7 +592,8 @@ void ExperimentImpl::getAcquisitionMassRange(double& startMz, double& stopMz) co
 {
     try
     {
-        if ((ExperimentType) msExperiment->Details->ExperimentType != MRM)
+        if ((ExperimentType) msExperiment->Details->ExperimentType != MRM &&
+            (ExperimentType) msExperiment->Details->ExperimentType != SIM)
         {
             startMz = msExperiment->Details->StartMass;
             stopMz = msExperiment->Details->EndMass;
@@ -789,7 +790,7 @@ void SpectrumImpl::getData(bool doCentroid, pwiz::util::BinaryData<double>& mz, 
             {
                 PeakClass^ peak = peakList[(int)i];
                 mz[i] = peak->xValue;
-                intensities[i] = peak->area;
+                intensities[i] = peak->area * 100;
             }
         }
         else

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -212,7 +212,7 @@ struct Spectrum2Impl : public Spectrum
 typedef boost::shared_ptr<Spectrum2Impl> Spectrum2ImplPtr;
 
 
-void ToStdVectorsFromXyData(IXyData<double>^ xyData, pwiz::util::BinaryData<double>& xVector, pwiz::util::BinaryData<double>& yVector)
+void ToStdVectorsFromXyData(IXyData<double>^ xyData, pwiz::util::BinaryData<double>& xVector, pwiz::util::BinaryData<double>& yVector, double yScaleFactor = 1.0)
 {
     xVector.clear();
     yVector.clear();
@@ -223,7 +223,7 @@ void ToStdVectorsFromXyData(IXyData<double>^ xyData, pwiz::util::BinaryData<doub
         for (size_t i = 0, end = xyData->Count; i < end; ++i)
         {
             xVector.push_back(xyData->GetXValue(i));
-            yVector.push_back(xyData->GetYValue(i));
+            yVector.push_back(xyData->GetYValue(i) * yScaleFactor);
         }
     }
 }
@@ -787,7 +787,7 @@ void Spectrum2Impl::getData(bool doCentroid, pwiz::util::BinaryData<double>& mz,
             }
         }
 
-        ToStdVectorsFromXyData(spectrumData, mz, intensities);        
+        ToStdVectorsFromXyData(spectrumData, mz, intensities, doCentroid ? 100 : 1);        
     }
     CATCH_AND_FORWARD
 }

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -787,7 +787,7 @@ void Spectrum2Impl::getData(bool doCentroid, pwiz::util::BinaryData<double>& mz,
             }
         }
 
-        ToStdVectorsFromXyData(spectrumData, mz, intensities, doCentroid ? 100 : 1);        
+        ToStdVectorsFromXyData(spectrumData, mz, intensities, doCentroid ? PEAK_AREA_SCALE_FACTOR : 1);        
     }
     CATCH_AND_FORWARD
 }


### PR DESCRIPTION
 - changed Sciex peak picker to multiply Y (area) values by 100 to put them on a more similar scale to the profile peak heights
- removed useThreads message