### PR TITLE
Fix problem where people who got the latest update of Skyline-Daily d…

### DIFF
--- a/pwiz_tools/Skyline/Model/PersistedViews.cs
+++ b/pwiz_tools/Skyline/Model/PersistedViews.cs
@@ -112,7 +112,7 @@ namespace pwiz.Skyline.Model
         }
 
         public int RevisionIndex { get; private set; }
-        public int RevisionIndexCurrent { get { return 9; } }
+        public int RevisionIndexCurrent { get { return 10; } }
         public override void ReadXml(XmlReader reader)
         {
             RevisionIndex = reader.GetIntAttribute(Attr.revision);
@@ -161,11 +161,11 @@ namespace pwiz.Skyline.Model
             {
                 reportStrings.Add(REPORTS_V8);
             }
-
-            if (revisionIndex >= 9)
+            if (revisionIndex >= 10)
             {
-                reportStrings.Add(REPORTS_V9);
+                reportStrings.Add(REPORTS_V10);
             }
+
             var list = new List<KeyValuePair<ViewGroupId, ViewSpec>>();
             var xmlSerializer = new XmlSerializer(typeof(ViewSpecList));
             foreach (var reportString in reportStrings)
@@ -315,7 +315,7 @@ namespace pwiz.Skyline.Model
     <column name='Precursor.Mz' />
     <column name='Precursor.Charge' />
     <column name='Precursor.CollisionEnergy' />
-    <column name='ExplicitCollisionEnergy' />
+    <column name='Precursor.ExplicitCollisionEnergy' />
     <column name='Precursor.Peptide.ExplicitRetentionTime' />
     <column name='Precursor.Peptide.ExplicitRetentionTimeWindow' />
     <column name='ProductMz' />
@@ -348,7 +348,7 @@ namespace pwiz.Skyline.Model
     <column name='Precursor.Mz' />
     <column name='Precursor.Charge' />
     <column name='Precursor.CollisionEnergy' />
-    <column name='ExplicitCollisionEnergy' />
+    <column name='Precursor.ExplicitCollisionEnergy' />
     <column name='Precursor.Peptide.ExplicitRetentionTime' />
     <column name='Precursor.Peptide.ExplicitRetentionTimeWindow' />
     <column name='ProductMz' />
@@ -447,7 +447,10 @@ namespace pwiz.Skyline.Model
   </view>
 </views>
 ";
-        private const string REPORTS_V9 = @"<views>
+
+        // There is no REPORTS_V9 in order to work around a problem where V4 was changed.
+
+        private const string REPORTS_V10 = @"<views>
   <view name='Mixed Transition List' rowsource='pwiz.Skyline.Model.Databinding.Entities.Transition' sublist='Results!*' uimode='mixed'>
     <column name='Precursor.Peptide.Protein.Name' />
     <column name='Precursor.Peptide.ModifiedSequence' />

--- a/pwiz_tools/Skyline/TestFunctional/BatchCalibrationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/BatchCalibrationTest.cs
@@ -135,12 +135,19 @@ namespace pwiz.SkylineTestFunctional
                 documentGrid.FindColumn(propertyPathResults.Property(nameof(PeptideResult.Quantification)));
             for (int iRow = 0; iRow < documentGrid.RowCount; iRow++)
             {
-                var row = documentGrid.DataGridView.Rows[iRow];
-                var peptide = (Peptide) row.Cells[colPeptide.Index].Value;
-                var replicate = (Replicate) row.Cells[colReplicate.Index].Value;
-                var calibrationCurve = (LinkValue<CalibrationCurve>) row.Cells[colCalibrationCurve.Index].Value;
-                var replicateCalibrationCurve =
-                    (LinkValue<CalibrationCurve>) row.Cells[colReplicateCalibrationCurve.Index].Value;
+                Peptide peptide = null;
+                Replicate replicate = null;
+                var calibrationCurve = default(LinkValue<CalibrationCurve>);
+                var replicateCalibrationCurve = default(LinkValue<CalibrationCurve>);
+                RunUI(() =>
+                {
+                    var row = documentGrid.DataGridView.Rows[iRow];
+                    peptide = (Peptide)row.Cells[colPeptide.Index].Value;
+                    replicate = (Replicate)row.Cells[colReplicate.Index].Value;
+                    calibrationCurve = (LinkValue<CalibrationCurve>)row.Cells[colCalibrationCurve.Index].Value;
+                    replicateCalibrationCurve =
+                        (LinkValue<CalibrationCurve>)row.Cells[colReplicateCalibrationCurve.Index].Value;
+                });
                 if (hasBatchNames)
                 {
                     Assert.AreNotEqual(calibrationCurve.Value.PointCount, replicateCalibrationCurve.Value.PointCount);


### PR DESCRIPTION
…id not get the newest definition of the "Mixed Transition List" and "Small Molecule Transition List" reports.

The definition of "REPORTS_V4" is now set back to what it was originally, and REPORTS_V9 gets renamed to REPORTS_V10 so people who were stuck with the old definition of the reports will now get the latest definition.