### PR TITLE
Fix the "Write Index" in MSConvertGUI so that its value gets passed a…

### DIFF
--- a/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
+++ b/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
@@ -109,7 +109,7 @@ void MSDataFile::write(MSData^ msd, System::String^ filename, WriteConfig^ confi
 static void translateConfig(MSDataFile::WriteConfig^ config, b::MSDataFile::WriteConfig& config2)
 {
     config2.gzipped = config->gzipped;
-	config2.indexed = config->indexed;
+    config2.indexed = config->indexed;
     config2.binaryDataEncoderConfig.precision = (b::BinaryDataEncoder::Precision) config->precision;
     config2.binaryDataEncoderConfig.byteOrder = (b::BinaryDataEncoder::ByteOrder) config->byteOrder;
     config2.binaryDataEncoderConfig.compression = (b::BinaryDataEncoder::Compression) config->compression;

--- a/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
+++ b/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
@@ -109,6 +109,7 @@ void MSDataFile::write(MSData^ msd, System::String^ filename, WriteConfig^ confi
 static void translateConfig(MSDataFile::WriteConfig^ config, b::MSDataFile::WriteConfig& config2)
 {
     config2.gzipped = config->gzipped;
+	config2.indexed = config->indexed;
     config2.binaryDataEncoderConfig.precision = (b::BinaryDataEncoder::Precision) config->precision;
     config2.binaryDataEncoderConfig.byteOrder = (b::BinaryDataEncoder::ByteOrder) config->byteOrder;
     config2.binaryDataEncoderConfig.compression = (b::BinaryDataEncoder::Compression) config->compression;


### PR DESCRIPTION
…long and the index does not get written out in .mzML and .mzXML files.

As far as I can tell, the "Write Index" checkbox in MSConvertGUI has never worked.