### PR TITLE
MSConvertGUI fixes

### DIFF
--- a/pwiz/utility/bindings/CLI/analysis/spectrum_processing.cpp
+++ b/pwiz/utility/bindings/CLI/analysis/spectrum_processing.cpp
@@ -79,15 +79,25 @@ public ref class Version
 
 void SpectrumListFactory::wrap(msdata::MSData^ msd, System::String^ wrapper)
 {
-    b::SpectrumListFactory::wrap(msd->base(), ToStdString(wrapper));
+    wrap(msd, wrapper, nullptr);
+}
+
+void SpectrumListFactory::wrap(msdata::MSData^ msd, System::String^ wrapper, util::IterationListenerRegistry^ ilr)
+{
+    b::SpectrumListFactory::wrap(msd->base(), ToStdString(wrapper), ilr ? &ilr->base() : nullptr);
 }
 
 void SpectrumListFactory::wrap(msdata::MSData^ msd, System::Collections::Generic::IList<System::String^>^ wrappers)
 {
+    wrap(msd, wrappers, nullptr);
+}
+
+void SpectrumListFactory::wrap(msdata::MSData^ msd, System::Collections::Generic::IList<System::String^>^ wrappers, util::IterationListenerRegistry^ ilr)
+{
     std::vector<std::string> nativeWrappers;
     for each(System::String^ wrapper in wrappers)
         nativeWrappers.push_back(ToStdString(wrapper));
-    b::SpectrumListFactory::wrap(msd->base(), nativeWrappers);
+    b::SpectrumListFactory::wrap(msd->base(), nativeWrappers, ilr ? &ilr->base() : nullptr);
 }
 
 System::String^ SpectrumListFactory::usage()

--- a/pwiz/utility/bindings/CLI/analysis/spectrum_processing.hpp
+++ b/pwiz/utility/bindings/CLI/analysis/spectrum_processing.hpp
@@ -30,6 +30,7 @@
 
 #ifdef PWIZ_BINDINGS_CLI_COMBINED
     #include "../msdata/MSData.hpp"
+    #include "../common/IterationListener.hpp"
 #else
     #include "../common/SharedCLI.hpp"
     #using "pwiz_bindings_cli_common.dll" as_friend
@@ -102,9 +103,19 @@ public ref class SpectrumListFactory abstract
     static void wrap(msdata::MSData^ msd, System::String^ wrapper);
 
     /// <summary>
+    /// instantiate the SpectrumListWrapper indicated by wrapper
+    /// </summary>
+    static void wrap(msdata::MSData^ msd, System::String^ wrapper, util::IterationListenerRegistry^ ilr);
+
+    /// <summary>
     /// instantiate a list of SpectrumListWrappers
     /// </summary>
     static void wrap(msdata::MSData^ msd, System::Collections::Generic::IList<System::String^>^ wrappers);
+
+    /// <summary>
+    /// instantiate a list of SpectrumListWrappers
+    /// </summary>
+    static void wrap(msdata::MSData^ msd, System::Collections::Generic::IList<System::String^>^ wrappers, util::IterationListenerRegistry^ ilr);
 
     /// <summary>
     /// user-friendly documentation

--- a/pwiz_tools/MSConvertGUI/MainForm.cs
+++ b/pwiz_tools/MSConvertGUI/MainForm.cs
@@ -396,7 +396,8 @@ namespace MSConvertGUI
 
         private void FileBox_TextChanged(object sender, EventArgs e)
         {
-            if (FileBox.Tag is string) FileBox.Tag = FileBox.Text;
+            string fileBoxText = FileBox.Text.Trim();
+            if (FileBox.Tag == null || FileBox.Tag is string) FileBox.Tag = fileBoxText;
             AddFileButton.Enabled = IsValidSource(FileBox.Tag);
         }
 
@@ -612,14 +613,21 @@ namespace MSConvertGUI
                                                });
                     break;
                 case "Subset":
+                    string scanTimeLow = null, scanTimeHigh = null;
+                    if (!String.IsNullOrEmpty(ScanTimeLow.Text) || !String.IsNullOrEmpty(ScanTimeHigh.Text))
+                    {
+                        scanTimeLow = String.IsNullOrEmpty(ScanTimeLow.Text) ? "0" : ScanTimeLow.Text;
+                        scanTimeHigh = String.IsNullOrEmpty(ScanTimeHigh.Text) ? "1e8" : ScanTimeHigh.Text;
+                    }
+
                     if (!String.IsNullOrEmpty(MSLevelLow.Text) || !String.IsNullOrEmpty(MSLevelHigh.Text))
                         FilterDGV.Rows.Add(new[] { "msLevel", String.Format("{0}-{1}", MSLevelLow.Text, MSLevelHigh.Text) });
                     if (!String.IsNullOrEmpty(ScanNumberLow.Text) || !String.IsNullOrEmpty(ScanNumberHigh.Text))
                         FilterDGV.Rows.Add(new[] { "scanNumber", String.Format("{0}-{1}", ScanNumberLow.Text, ScanNumberHigh.Text) });
-                    if (!String.IsNullOrEmpty(ScanTimeLow.Text) || !String.IsNullOrEmpty(ScanTimeHigh.Text))
-                        FilterDGV.Rows.Add(new[] { "scanTime", String.Format("[{0},{1}]", ScanTimeLow.Text, ScanTimeHigh.Text) });
+                    if (!String.IsNullOrEmpty(scanTimeLow) || !String.IsNullOrEmpty(scanTimeHigh))
+                        FilterDGV.Rows.Add(new[] { "scanTime", String.Format("[{0},{1}]", scanTimeLow, scanTimeHigh) });
                     if (!String.IsNullOrEmpty(ScanEventLow.Text) || !String.IsNullOrEmpty(ScanEventHigh.Text))
-                        FilterDGV.Rows.Add(new[] { "scanEvent", String.Format("[{0},{1}]", ScanEventLow.Text, ScanEventHigh.Text) });
+                        FilterDGV.Rows.Add(new[] { "scanEvent", String.Format("{0}-{1}", ScanEventLow.Text, ScanEventHigh.Text) });
                     if (!String.IsNullOrEmpty(ChargeStatesLow.Text) || !String.IsNullOrEmpty(ChargeStatesHigh.Text))
                         FilterDGV.Rows.Add(new[] { "chargeStates", String.Format("{0}-{1}", ChargeStatesLow.Text, ChargeStatesHigh.Text) });
                     if (!String.IsNullOrEmpty(DefaultArrayLengthLow.Text) || !String.IsNullOrEmpty(DefaultArrayLengthHigh.Text))

--- a/pwiz_tools/MSConvertGUI/MainLogic.cs
+++ b/pwiz_tools/MSConvertGUI/MainLogic.cs
@@ -506,10 +506,13 @@ namespace MSConvertGUI
                             MSDataFile.calculateSHA1Checksums(msd);
                         }
 
+                        var ilr = new IterationListenerRegistry();
+                        ilr.addListenerWithTimer(this, 1);
+
                         LogUpdate?.Invoke("Processing...", _info);
                         StatusUpdate?.Invoke("Processing...", ProgressBarStyle.Marquee, _info);
 
-                        SpectrumListFactory.wrap(msd, config.Filters);
+                        SpectrumListFactory.wrap(msd, config.Filters, ilr);
 
                         if ((msd.run.spectrumList == null) || msd.run.spectrumList.empty())
                         {
@@ -539,8 +542,6 @@ namespace MSConvertGUI
                                          ProgressBarStyle.Continuous, _info);
 
                         // write out the new data file
-                        var ilr = new IterationListenerRegistry();
-                        ilr.addListenerWithTimer(this, 1);
                         msg = String.Format("Writing \"{0}\"...", deduplicatedFilename);
                         LogUpdate?.Invoke(msg, _info);
                         StatusUpdate?.Invoke(msg, ProgressBarStyle.Continuous, _info);


### PR DESCRIPTION
* added IterationListenerRegistry overloads for CLI bindings of SpectrumListFactory and enabled progress feedback for spectrum list filtering in MSConvertGUI
- fixed exceptions when typing filename into MSConvertGUI text box and fixed scan event and scan time filter syntax when only lower or upper bound is set