### PR TITLE
Fix PwizFileInfoTest "multiple runs not supported"

### DIFF
--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -94,6 +94,12 @@ namespace pwiz.ProteowizardWrapper
             return FULL_READER_LIST.readIds(path);
         }
 
+        public static bool SupportsMultipleSamples(string path)
+        {
+            path = path.ToLowerInvariant();
+            return path.EndsWith(@".wiff") || path.EndsWith(@".wiff2");
+        }
+
         public const string PREFIX_TOTAL = "SRM TIC ";
         public const string PREFIX_SINGLE = "SRM SIC ";
         public const string PREFIX_PRECURSOR = "SIM SIC ";

--- a/pwiz_tools/Skyline/TestData/PwizFileInfoTest.cs
+++ b/pwiz_tools/Skyline/TestData/PwizFileInfoTest.cs
@@ -134,6 +134,9 @@ namespace pwiz.SkylineTestData
 
         private static void VerifyTicChromatogram(string path, int count, double maxIntensity, int sampleIndex = 0)
         {
+            if (!MsDataFileImpl.SupportsMultipleSamples(path))
+                sampleIndex = 0;
+
             using (var msDataFile = new MsDataFileImpl(path, sampleIndex))
             {
                 var tic = msDataFile.GetTotalIonCurrent();


### PR DESCRIPTION
* added MsDataFileImpl.SupportsMultipleSamples() and used it to ignore sampleIndex for non-WIFF files in PwizFileInfoTest