### PR TITLE
Skyline: Updates to command-line

### DIFF
--- a/pwiz_tools/Skyline/CommandArgUsage.Designer.cs
+++ b/pwiz_tools/Skyline/CommandArgUsage.Designer.cs
@@ -484,6 +484,15 @@ namespace pwiz.Skyline {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A regular expression that is applied to file names to select the ones that will be imported..
+        /// </summary>
+        internal static string _import_filename_pattern {
+            get {
+                return ResourceManager.GetString("_import_filename_pattern", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Waters lockmass correction m/z for negative ion scans..
         /// </summary>
         internal static string _import_lockmass_negative {
@@ -561,6 +570,15 @@ namespace pwiz.Skyline {
         internal static string _import_replicate_name {
             get {
                 return ResourceManager.GetString("_import_replicate_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A regular expression that is applied to sample names (e.g. in a multi-injection .wiff file) to select the ones that will be imported..
+        /// </summary>
+        internal static string _import_samplename_pattern {
+            get {
+                return ResourceManager.GetString("_import_samplename_pattern", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/CommandArgUsage.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.resx
@@ -712,4 +712,10 @@ greater peak area.</value>
   <data name="CommandArgs_GROUP_REFINEMENT_W_RESULTS" xml:space="preserve">
     <value>Refining the targets list based on imported results</value>
   </data>
+  <data name="_import_filename_pattern" xml:space="preserve">
+    <value>A regular expression that is applied to file names to select the ones that will be imported.</value>
+  </data>
+  <data name="_import_samplename_pattern" xml:space="preserve">
+    <value>A regular expression that is applied to sample names (e.g. in a multi-injection .wiff file) to select the ones that will be imported.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -199,6 +199,10 @@ namespace pwiz.Skyline
             (c, p) => c.ImportSourceDirectory = p.ValueFullPath);
         public static readonly Argument ARG_IMPORT_NAMING_PATTERN = new DocArgument(@"import-naming-pattern", REGEX_VALUE,
             (c, p) => c.ParseImportNamingPattern(p));
+        public static readonly Argument ARG_IMPORT_FILENAME_PATTERN = new DocArgument(@"import-filename-pattern", REGEX_VALUE,
+            (c, p) => c.ParseImportFileNamePattern(p));
+        public static readonly Argument ARG_IMPORT_SAMPLENAME_PATTERN = new DocArgument(@"import-samplename-pattern", REGEX_VALUE,
+            (c, p) => c.ParseImportSampleNamePattern(p));
         public static readonly Argument ARG_IMPORT_BEFORE = new DocArgument(@"import-before", DATE_VALUE,
             (c, p) => c.ImportBeforeDate = p.ValueDate);
         public static readonly Argument ARG_IMPORT_ON_OR_AFTER = new DocArgument(@"import-on-or-after", DATE_VALUE,
@@ -225,9 +229,9 @@ namespace pwiz.Skyline
 
         private static readonly ArgumentGroup GROUP_IMPORT = new ArgumentGroup(() => CommandArgUsage.CommandArgs_GROUP_IMPORT_Importing_results_replicates, false,
             ARG_IMPORT_FILE, ARG_IMPORT_REPLICATE_NAME, ARG_IMPORT_OPTIMIZING, ARG_IMPORT_APPEND, ARG_IMPORT_ALL,
-            ARG_IMPORT_ALL_FILES, ARG_IMPORT_NAMING_PATTERN, ARG_IMPORT_BEFORE, ARG_IMPORT_ON_OR_AFTER, ARG_IMPORT_NO_JOIN,
-            ARG_IMPORT_PROCESS_COUNT, ARG_IMPORT_THREADS, ARG_IMPORT_WARN_ON_FAILURE, ARG_IMPORT_LOCKMASS_POSITIVE,
-            ARG_IMPORT_LOCKMASS_NEGATIVE, ARG_IMPORT_LOCKMASS_TOLERANCE);
+            ARG_IMPORT_ALL_FILES, ARG_IMPORT_NAMING_PATTERN, ARG_IMPORT_FILENAME_PATTERN, ARG_IMPORT_SAMPLENAME_PATTERN,
+            ARG_IMPORT_BEFORE, ARG_IMPORT_ON_OR_AFTER, ARG_IMPORT_NO_JOIN, ARG_IMPORT_PROCESS_COUNT, ARG_IMPORT_THREADS,
+            ARG_IMPORT_WARN_ON_FAILURE, ARG_IMPORT_LOCKMASS_POSITIVE, ARG_IMPORT_LOCKMASS_NEGATIVE, ARG_IMPORT_LOCKMASS_TOLERANCE);
 
         public static readonly Argument ARG_REMOVE_BEFORE = new DocArgument(@"remove-before", DATE_VALUE,
             (c, p) => c.SetRemoveBefore(p.ValueDate));
@@ -272,6 +276,8 @@ namespace pwiz.Skyline
         public bool ImportRecursive { get; private set; }
         public string ImportSourceDirectory { get; private set; }
         public Regex ImportNamingPattern { get; private set; }
+        public Regex ImportFileNamePattern { get; private set; }
+        public Regex ImportSampleNamePattern { get; private set; }
         public bool ImportWarnOnFailure { get; private set; }
         public bool RemovingResults { get; private set; }
         public DateTime? RemoveBeforeDate { get; private set; }
@@ -320,6 +326,32 @@ namespace pwiz.Skyline
                 return false;
             }
 
+            return true;
+        }
+
+        private bool ParseImportFileNamePattern(NameValuePair pair)
+        {
+            return ParseRegexArgument(pair, r => ImportFileNamePattern = r);
+        }
+
+        private bool ParseImportSampleNamePattern(NameValuePair pair)
+        {
+            return ParseRegexArgument(pair, r => ImportSampleNamePattern = r);
+        }
+
+        private bool ParseRegexArgument(NameValuePair pair, Action<Regex> assign)
+        {
+            var regexText = pair.Value;
+            try
+            {
+                assign(new Regex(regexText));
+            }
+            catch (Exception e)
+            {
+                WriteLine(Resources.CommandArgs_ParseRegexArgument_Error__Regular_expression___0___for__1__cannot_be_parsed_, regexText, pair.Match.ArgumentText);
+                WriteLine(e.Message);
+                return false;
+            }
             return true;
         }
 

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -327,7 +327,7 @@ namespace pwiz.Skyline
 
             if (commandArgs.ImportingReplicateFile)
             {
-                var listNamedPaths = new List<KeyValuePair<string, MsDataFileUri[]>>();
+                IList<KeyValuePair<string, MsDataFileUri[]>> listNamedPaths = new List<KeyValuePair<string, MsDataFileUri[]>>();
 
                 MsDataFileUri[] files;
                 try
@@ -339,7 +339,7 @@ namespace pwiz.Skyline
                     _out.WriteLine(Resources.CommandLine_GeneralException_Error___0_, e.Message);
                     return false;
                 }
-
+                
                 if (!string.IsNullOrEmpty(commandArgs.ReplicateName))
                 { 
                     listNamedPaths.Add(new KeyValuePair<string, MsDataFileUri[]>(commandArgs.ReplicateName, files));
@@ -352,6 +352,30 @@ namespace pwiz.Skyline
                             dataFile.GetSampleName() ?? dataFile.GetFileNameWithoutExtension(),
                             new[] {dataFile}));
                     }
+
+                }
+
+                if (!ApplyFileAndSampleNameRegex(commandArgs.ImportFileNamePattern, commandArgs.ImportSampleNamePattern, ref listNamedPaths))
+                {
+                    return false;
+                }
+
+                if (string.IsNullOrEmpty(commandArgs.ReplicateName) && !commandArgs.ImportAppend)
+                {
+                    // A named path will be removed if the document contains a replicate with the same name and file path.
+                    if (!RemoveImportedFiles(listNamedPaths, out var listNewPaths))
+                    {
+                        return false;
+                    }
+
+                    if (listNewPaths.Count == 0)
+                    {
+                        _out.WriteLine(Resources.CommandLine_ImportResults_No_replicates_left_to_import_);
+                        return false;
+                    }
+
+                    listNamedPaths = listNewPaths;
+                    MakeReplicateNamesUnique(listNamedPaths);
                 }
 
                 // If expected results are not imported successfully, terminate
@@ -375,6 +399,8 @@ namespace pwiz.Skyline
                         commandArgs.LockMassParameters,
                         commandArgs.ImportBeforeDate,
                         commandArgs.ImportOnOrAfterDate,
+                        commandArgs.ImportFileNamePattern,
+                        commandArgs.ImportSampleNamePattern,
                         optimize,
                         commandArgs.ImportDisableJoining,
                         commandArgs.ImportWarnOnFailure))
@@ -959,19 +985,134 @@ namespace pwiz.Skyline
         public bool ImportResultsInDir(string sourceDir, bool recursive, Regex namingPattern, string replicateName,
             LockMassParameters lockMassParameters,
             DateTime? importBefore, DateTime? importOnOrAfter,
+            Regex fileNameRegex, Regex sampleNameRegex,
             OptimizableRegression optimize, bool disableJoining, bool warnOnFailure)
         {
             var listNamedPaths = GetDataSources(sourceDir, recursive, namingPattern, lockMassParameters);
-            if (listNamedPaths == null)
+            if (listNamedPaths == null || listNamedPaths.Count == 0)
             {
                 return false;
             }
+
+            if (!ApplyFileAndSampleNameRegex(fileNameRegex, sampleNameRegex, ref listNamedPaths))
+            {
+                return false;
+            }
+
             // If there is a single name for everything then it should override any naming from GetDataSources
             if (!string.IsNullOrEmpty(replicateName))
             {
+                // If the name exists, files should get imported into it
                 listNamedPaths = new[] { new KeyValuePair<string, MsDataFileUri[]>(replicateName, listNamedPaths.SelectMany(s => s.Value).ToArray()) };
             }
-            return ImportDataFiles(listNamedPaths, lockMassParameters, importBefore, importOnOrAfter, optimize, disableJoining, warnOnFailure);
+            else
+            {
+                // Otherwise, new replicates will be created and should have new unique names.  
+                MakeReplicateNamesUnique(listNamedPaths);
+            }
+
+            return ImportDataFiles(listNamedPaths, lockMassParameters, importBefore, importOnOrAfter,
+                optimize, disableJoining, warnOnFailure);
+        }
+
+        private void MakeReplicateNamesUnique(IList<KeyValuePair<string, MsDataFileUri[]>> listNamedPaths)
+        {
+            var replicatesInDoc =
+                _doc.Settings.HasResults ? _doc.MeasuredResults.Chromatograms.Select(chrom => chrom.Name).ToHashSet() : new HashSet<string>();
+            var replicatesInNamedPaths = listNamedPaths.Select(path => path.Key).ToList();
+            var newNames = Helpers.EnsureUniqueNames(replicatesInNamedPaths, replicatesInDoc);
+            for (var i = 0; i < listNamedPaths.Count; i++)
+            {
+                var namedPath = listNamedPaths[i];
+                if (!Equals(newNames[i], namedPath.Key))
+                {
+                    _out.WriteLine(
+                        Resources.CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_document__using___1___instead_,
+                        namedPath.Key, newNames[i]);
+                    listNamedPaths[i] = new KeyValuePair<string, MsDataFileUri[]>(newNames[i], namedPath.Value);
+                }
+            }
+        }
+
+        private bool ApplyFileAndSampleNameRegex(Regex fileNameRegex, Regex sampleNameRegex, ref IList<KeyValuePair<string, MsDataFileUri[]>> listNamedPaths)
+        {
+            listNamedPaths = ApplyNameRegex(listNamedPaths, ApplyFileNameRegex, fileNameRegex);
+            if (listNamedPaths.Count == 0)
+            {
+                _out.WriteLine(Resources.CommandLine_ApplyFileAndSampleNameRegex_No_files_match_the_file_name_pattern___0___, fileNameRegex);
+                return false;
+            }
+
+            listNamedPaths = ApplyNameRegex(listNamedPaths, ApplySampleNameRegex, sampleNameRegex);
+            if (listNamedPaths.Count == 0)
+            {
+                _out.WriteLine(Resources.CommandLine_ApplyFileAndSampleNameRegex_No_files_match_the_sample_name_pattern___0___, sampleNameRegex);
+                return false;
+            }
+
+            return true;
+        }
+
+        private IList<KeyValuePair<string, MsDataFileUri[]>> ApplyNameRegex(IList<KeyValuePair<string, MsDataFileUri[]>> listNamedPaths,
+                        Func<MsDataFileUri, Regex, bool> applyRegex,  Regex regex)
+        {
+            var newNamedPaths = new List<KeyValuePair<string, MsDataFileUri[]>>();
+            if (regex == null)
+            {
+                newNamedPaths.AddRange(listNamedPaths);
+                return newNamedPaths;
+            }
+
+            for (var i = 0; i < listNamedPaths.Count; i++)
+            {
+                var namedPath = listNamedPaths[i];
+                var files = namedPath.Value;
+
+                var newFiles = files.Where(file => applyRegex(file, regex)).ToArray();
+                if (newFiles.Length > 0)
+                {
+                    newNamedPaths.Add(new KeyValuePair<string, MsDataFileUri[]>(namedPath.Key, newFiles));
+                }
+            }
+            
+            return newNamedPaths;
+        }
+
+        private bool ApplyFileNameRegex(MsDataFileUri file, Regex regex)
+        {
+            if(!ApplyRegex(file.GetFileName(), regex))
+            {
+                _out.WriteLine(Resources.CommandLine_ApplyFileNameRegex_File_name___0___does_not_match_the_pattern___1____Ignoring__2_, file.GetFileName(), regex, file);
+                return false;
+            }
+            return true;
+        }
+        
+        private bool ApplySampleNameRegex(MsDataFileUri file, Regex regex)
+        {
+            if (string.IsNullOrEmpty(file.GetSampleName()))
+            {
+                _out.WriteLine(Resources.CommandLine_ApplySampleNameRegex_File___0___does_not_have_a_sample__Cannot_apply_sample_name_pattern__Ignoring_, file);
+                return false;
+            }
+
+            if (!ApplyRegex(file.GetSampleName(), regex))
+            {
+                _out.WriteLine(Resources.CommandLine_ApplySampleNameRegex_Sample_name___0___does_not_match_the_pattern___1____Ignoring__2_, file.GetSampleName(), regex, file);
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool ApplyRegex(string name, Regex regex)
+        {
+            if (regex != null)
+            {
+                var match = regex.Match(name);
+                return match.Success;
+            }
+            return true;
         }
 
         private bool ImportDataFiles(IList<KeyValuePair<string, MsDataFileUri[]>> listNamedPaths, LockMassParameters lockMassParameters,
@@ -1152,12 +1293,6 @@ namespace pwiz.Skyline
                 listNamedPaths = listRenamedPaths;
             }
 
-            // Make sure the existing replicate does not have any "unexpected" files.
-            if(!CheckReplicateFiles(listNamedPaths, lockMassParameters))
-            {
-                return null;
-            }
-
             // remove replicates and/or files that have already been imported into the document
             List<KeyValuePair<string, MsDataFileUri[]>> listNewPaths;
             if(!RemoveImportedFiles(listNamedPaths, out listNewPaths))
@@ -1205,47 +1340,6 @@ namespace pwiz.Skyline
             return true;
         }
 
-        private bool CheckReplicateFiles(IEnumerable<KeyValuePair<string, MsDataFileUri[]>> listNamedPaths, LockMassParameters lockMassParameters)
-        {
-            if (!_doc.Settings.HasResults)
-            {
-                return true;
-            }
-
-            // Make sure the existing replicate does not have any "unexpected" files.
-            // All existing files must be present in the current 
-            // list of files that we are trying to import to this replicate.
-            
-            foreach (var namedPaths in listNamedPaths)
-            {
-                var replicateName = namedPaths.Key;
-
-                // check if the document already has a replicate with this name
-                int indexChrom;
-                ChromatogramSet chromatogram;
-                if (_doc.Settings.MeasuredResults.TryGetChromatogramSet(replicateName, out chromatogram, out indexChrom))
-                {
-                    // and whether the files it contains match what is expected
-                    // compare case-insensitive on Windows
-                    var filePaths = new HashSet<MsDataFileUri>(namedPaths.Value.Select(path =>
-                        path.ChangeParameters(_doc, lockMassParameters).ToLower()));
-                    foreach (var dataFilePath in chromatogram.MSDataFilePaths)
-                    {
-
-                        if (!filePaths.Contains(dataFilePath.ToLower()))
-                        {
-                            _out.WriteLine(
-                                Resources.CommandLine_CheckReplicateFiles_Error__Replicate__0__in_the_document_has_an_unexpected_file__1__,
-                                replicateName,
-                                dataFilePath);
-                            return false;
-                        }
-                    }
-                }
-            }
-            return true;
-        }
-        
         private bool RemoveImportedFiles(IEnumerable<KeyValuePair<string, MsDataFileUri[]>> listNamedPaths,
                                          out List<KeyValuePair<string, MsDataFileUri[]>> listNewNamedPaths)
         {
@@ -1328,7 +1422,7 @@ namespace pwiz.Skyline
                         _doc.Settings.MeasuredResults.TryGetChromatogramSet(replicateName, out chromatogram, out index);
 
                         string replicateFileString = replicateFile.ToString();
-                        if (chromatogram.MSDataFilePaths.Any(filePath => StringComparer.OrdinalIgnoreCase.Equals(filePath, replicateFileString)))
+                        if (chromatogram.MSDataFilePaths.Any(filePath => StringComparer.OrdinalIgnoreCase.Equals(filePath.ToString(), replicateFileString)))
                         {
                             _out.WriteLine(Resources.CommandLine_ImportResultsFile__0______1___Note__The_file_has_already_been_imported__Ignoring___, replicateName, replicateFile);
                         }

--- a/pwiz_tools/Skyline/FileUI/ImportResultsDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportResultsDlg.cs
@@ -496,30 +496,12 @@ namespace pwiz.Skyline.FileUI
             return false;
         }
 
-        public static List<string> EnsureUniqueNames(List<string> names, HashSet<string> reservedNames = null)
-        {
-            var setUsedNames = reservedNames ?? new HashSet<string>();
-            var result = new List<string>();
-            for (int i = 0; i < names.Count; i++)
-            {
-                string baseName = names[i];
-                // Make sure the next name added is unique
-                string name = (baseName.Length != 0 ? baseName : @"1");
-                for (int suffix = 2; setUsedNames.Contains(name); suffix++)
-                    name = baseName + suffix;
-                result.Add(name);
-                // Add this name to the used set
-                setUsedNames.Add(name);
-            }
-            return result;
-        }
-
         private void EnsureUniqueNames()
         {
             var setUsedNames = new HashSet<string>();
             foreach (var item in comboName.Items)
                 setUsedNames.Add(item.ToString());
-            var names = EnsureUniqueNames(NamedPathSets.Select(n => n.Key).ToList(), setUsedNames);
+            var names = Helpers.EnsureUniqueNames(NamedPathSets.Select(n => n.Key).ToList(), setUsedNames);
             for (int i = 0; i < NamedPathSets.Length; i++)
             {
                 var namedPathSet = NamedPathSets[i];

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportResultsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportResultsControl.cs
@@ -72,7 +72,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             var result = new List<ImportPeptideSearch.FoundResultsFile>();
             // Enforce uniqueness in names (might be constructed from list of files a.raw, a.mzML)
-            var names = ImportResultsDlg.EnsureUniqueNames(files.Select(f => f.Name).ToList());
+            var names = Helpers.EnsureUniqueNames(files.Select(f => f.Name).ToList());
             for (var i = 0; i < files.Count; i++)
             {
                 result.Add(new ImportPeptideSearch.FoundResultsFile(names[i], files[i].Path));

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -4476,6 +4476,16 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error: Regular expression &apos;{0}&apos; for {1} cannot be parsed..
+        /// </summary>
+        public static string CommandArgs_ParseRegexArgument_Error__Regular_expression___0___for__1__cannot_be_parsed_ {
+            get {
+                return ResourceManager.GetString("CommandArgs_ParseRegexArgument_Error__Regular_expression___0___for__1__cannot_be_" +
+                        "parsed_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The primary transition count {0} must be between {1} and {2}..
         /// </summary>
         public static string CommandArgs_PrimaryTransitionCount_The_primary_transition_count__0__must_be_between__1__and__2__ {
@@ -4552,6 +4562,36 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No files match the file name pattern &apos;{0}&apos;..
+        /// </summary>
+        public static string CommandLine_ApplyFileAndSampleNameRegex_No_files_match_the_file_name_pattern___0___ {
+            get {
+                return ResourceManager.GetString("CommandLine_ApplyFileAndSampleNameRegex_No_files_match_the_file_name_pattern___0_" +
+                        "__", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No files match the sample name pattern &apos;{0}&apos;..
+        /// </summary>
+        public static string CommandLine_ApplyFileAndSampleNameRegex_No_files_match_the_sample_name_pattern___0___ {
+            get {
+                return ResourceManager.GetString("CommandLine_ApplyFileAndSampleNameRegex_No_files_match_the_sample_name_pattern___" +
+                        "0___", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File name &apos;{0}&apos; does not match the pattern &apos;{1}&apos;. Ignoring {2}.
+        /// </summary>
+        public static string CommandLine_ApplyFileNameRegex_File_name___0___does_not_match_the_pattern___1____Ignoring__2_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ApplyFileNameRegex_File_name___0___does_not_match_the_pattern___1____" +
+                        "Ignoring__2_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error: {0} does not match the regular expression..
         /// </summary>
         public static string CommandLine_ApplyNamingPattern_Error___0__does_not_match_the_regular_expression_ {
@@ -4577,6 +4617,26 @@ namespace pwiz.Skyline.Properties {
             get {
                 return ResourceManager.GetString("CommandLine_ApplyNamingPattern_Error__Match_to_regular_expression_is_empty_for__0" +
                         "__", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File &apos;{0}&apos; does not have a sample. Cannot apply sample name pattern. Ignoring..
+        /// </summary>
+        public static string CommandLine_ApplySampleNameRegex_File___0___does_not_have_a_sample__Cannot_apply_sample_name_pattern__Ignoring_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ApplySampleNameRegex_File___0___does_not_have_a_sample__Cannot_apply_" +
+                        "sample_name_pattern__Ignoring_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sample name &apos;{0}&apos; does not match the pattern &apos;{1}&apos;. Ignoring {2}.
+        /// </summary>
+        public static string CommandLine_ApplySampleNameRegex_Sample_name___0___does_not_match_the_pattern___1____Ignoring__2_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ApplySampleNameRegex_Sample_name___0___does_not_match_the_pattern___1" +
+                        "____Ignoring__2_", resourceCulture);
             }
         }
         
@@ -5188,6 +5248,15 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No replicates left to import..
+        /// </summary>
+        public static string CommandLine_ImportResults_No_replicates_left_to_import_ {
+            get {
+                return ResourceManager.GetString("CommandLine_ImportResults_No_replicates_left_to_import_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} -&gt; {1}  Note: The file has already been imported. Ignoring....
         /// </summary>
         public static string CommandLine_ImportResultsFile__0______1___Note__The_file_has_already_been_imported__Ignoring___ {
@@ -5668,6 +5737,16 @@ namespace pwiz.Skyline.Properties {
         public static string CommandLine_LogNewEntries_Document_unchanged {
             get {
                 return ResourceManager.GetString("CommandLine_LogNewEntries_Document_unchanged", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replicate &apos;{0}&apos; already exists in the document, using &apos;{1}&apos; instead..
+        /// </summary>
+        public static string CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_document__using___1___instead_ {
+            get {
+                return ResourceManager.GetString("CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_docume" +
+                        "nt__using___1___instead_", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -10583,4 +10583,28 @@ Click 'Retry' to try building again with original spectrum files placed next to 
   <data name="ThermoMassListExporter_EnsureLibraries_Thermo_instrument_software_may_not_be_installed_correctly__The_library__0__could_not_be_found_" xml:space="preserve">
     <value>Thermo instrument software may not be installed correctly. The library {0} could not be found.</value>
   </data>
+  <data name="CommandLine_ImportResults_No_replicates_left_to_import_" xml:space="preserve">
+    <value>No replicates left to import.</value>
+  </data>
+  <data name="CommandArgs_ParseRegexArgument_Error__Regular_expression___0___for__1__cannot_be_parsed_" xml:space="preserve">
+    <value>Error: Regular expression '{0}' for {1} cannot be parsed.</value>
+  </data>
+  <data name="CommandLine_ApplySampleNameRegex_File___0___does_not_have_a_sample__Cannot_apply_sample_name_pattern__Ignoring_" xml:space="preserve">
+    <value>File '{0}' does not have a sample. Cannot apply sample name pattern. Ignoring.</value>
+  </data>
+  <data name="CommandLine_ApplyFileAndSampleNameRegex_No_files_match_the_file_name_pattern___0___" xml:space="preserve">
+    <value>No files match the file name pattern '{0}'.</value>
+  </data>
+  <data name="CommandLine_ApplyFileAndSampleNameRegex_No_files_match_the_sample_name_pattern___0___" xml:space="preserve">
+    <value>No files match the sample name pattern '{0}'.</value>
+  </data>
+  <data name="CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_document__using___1___instead_" xml:space="preserve">
+    <value>Replicate '{0}' already exists in the document, using '{1}' instead.</value>
+  </data>
+  <data name="CommandLine_ApplyFileNameRegex_File_name___0___does_not_match_the_pattern___1____Ignoring__2_" xml:space="preserve">
+    <value>File name '{0}' does not match the pattern '{1}'. Ignoring {2}</value>
+  </data>
+  <data name="CommandLine_ApplySampleNameRegex_Sample_name___0___does_not_match_the_pattern___1____Ignoring__2_" xml:space="preserve">
+    <value>Sample name '{0}' does not match the pattern '{1}'. Ignoring {2}</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/TestData/CommandLineWiffTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineWiffTest.cs
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Serialization;
@@ -23,6 +25,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Collections;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Results;
+using pwiz.Skyline.Properties;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTestData
@@ -111,6 +114,112 @@ namespace pwiz.SkylineTestData
                     Assert.AreEqual(i, msDataFilePath.SampleIndex);
                 }
             }
+        }
+
+        /// <summary>
+        /// Tests importing results from two .wiff files with different file names but same sample names.
+        /// </summary>
+        [TestMethod]
+        public void TestWiffCommandLineImportSameSampleName()
+        {
+            var testFilesDir = new TestFilesDir(TestContext, ZIP_PATH);
+            string docPath = testFilesDir.GetTestPath(DOC_NAME);
+            string rawPath = testFilesDir.GetTestPath(WIFF_NAME);
+
+            RunCommand("--in=" + docPath,
+                "--import-file=" + rawPath,
+                "--save");
+            CheckDocument(docPath, new[] { rawPath }, 1);
+
+            // Make a copy of the file, rename it and import it. The document should contain 8 replicates. 
+            // From the 1st file: "blank", "rfp9_after_h_1", "test", "rfp9_before_h_1"
+            // From the 2nd file: "blank2", "rfp9_after_h_12", "test2", "rfp9_before_h_12"
+            var wiffCopy = Path.Combine(testFilesDir.FullPath,
+                Path.GetFileNameWithoutExtension(rawPath) + "_copy.wiff");
+            File.Copy(rawPath, wiffCopy);
+            Assert.IsTrue(File.Exists(wiffCopy));
+            var msg = RunCommand("--in=" + docPath,
+                "--import-file=" + wiffCopy,
+                "--save");
+            CheckDocument(docPath, new[] { rawPath, wiffCopy }, 2);
+            foreach (var sample in SAMPLE_NAMES)
+            {
+                CheckRunCommandOutputContains(
+                    string.Format(
+                        Resources.CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_document__using___1___instead_,
+                        sample, sample+"2"), msg);
+            }          
+        }
+
+        /// <summary>
+        /// Tests importing results from wiff files in a directory where each file has multiple samples,
+        /// and sample names are the same.
+        /// </summary>
+        [TestMethod]
+        public void TestWiffsInDirCommandLineImport()
+        {
+            var testFilesDir = new TestFilesDir(TestContext, ZIP_PATH);
+            var docPath = testFilesDir.GetTestPath(DOC_NAME);
+            var testDir = testFilesDir.FullPath;
+            var rawPath = testFilesDir.GetTestPath(WIFF_NAME);
+            var rawPath2 = Path.Combine(testDir, Path.GetFileNameWithoutExtension(rawPath) + "_copy.wiff");
+            var rawPath3 = Path.Combine(testDir, Path.GetFileNameWithoutExtension(rawPath) + "_copy2.wiff");
+
+            File.Copy(rawPath, rawPath2);
+            Assert.IsTrue(File.Exists(rawPath2));
+            File.Copy(rawPath, rawPath3);
+            Assert.IsTrue(File.Exists(rawPath2));
+            RunCommand("--in=" + docPath,
+                "--import-all=" + testDir,
+                "--save");
+            var doc = ResultsUtil.DeserializeDocument(docPath);
+            Assert.IsTrue(doc.Settings.HasResults);
+            Assert.AreEqual(SAMPLE_NAMES.Count * 3, doc.Settings.MeasuredResults.Chromatograms.Count);
+
+            // Each file has samples named: "blank", "rfp9_after_h_1", "test", "rfp9_before_h_1"
+            // After the import we should have 3 replicates per sample name.
+            // From the 1st file: "blank", "rfp9_after_h_1", "test", "rfp9_before_h_1"
+            // From the 2nd file: "blank2", "rfp9_after_h_12", "test2", "rfp9_before_h_12"
+            // From the 3rd file: "blank3", "rfp9_after_h_13", "test3", "rfp9_before_h_13"
+            var expectedReplicates = new List<string>();
+            expectedReplicates.AddRange(SAMPLE_NAMES);
+            expectedReplicates.AddRange(SAMPLE_NAMES.Select(sample => sample + "2"));
+            expectedReplicates.AddRange(SAMPLE_NAMES.Select(sample => sample + "3"));
+            expectedReplicates.Sort();
+            var docReplicates = doc.MeasuredResults.Chromatograms.Select(chrom => chrom.Name).ToList();
+            docReplicates.Sort();
+            Assert.IsTrue(expectedReplicates.SequenceEqual(docReplicates));
+        }
+
+        private static void CheckDocument(string docPath, string[] rawPaths, int importCount)
+        {
+            var doc = ResultsUtil.DeserializeDocument(docPath);
+            Assert.IsTrue(doc.Settings.HasResults);
+            Assert.AreEqual(SAMPLE_NAMES.Count * importCount, doc.Settings.MeasuredResults.Chromatograms.Count);
+            for (int i = 0; i < SAMPLE_NAMES.Count; i++)
+            {
+                for (int j = 1; j <= importCount; j++)
+                {
+                    var chromIndex = i + SAMPLE_NAMES.Count * (j - 1);
+                    var chromatogramSet = doc.Settings.MeasuredResults.Chromatograms[chromIndex];
+
+                    var replicateName = SAMPLE_NAMES[i] + (j > 1 ? j.ToString() : "");
+                    Assert.AreEqual(replicateName, chromatogramSet.Name);
+
+                    Assert.AreEqual(1, chromatogramSet.MSDataFilePaths.Count());
+                    var msDataFilePath = chromatogramSet.MSDataFilePaths.First() as MsDataFilePath;
+                    Assert.IsNotNull(msDataFilePath);
+                    Assert.AreEqual(i, msDataFilePath.SampleIndex);
+                    Assert.AreEqual(SAMPLE_NAMES[i], msDataFilePath.SampleName);
+                    Assert.AreEqual(rawPaths[j - 1], msDataFilePath.FilePath);
+                }
+            }
+        }
+
+        private static void CheckRunCommandOutputContains(string expectedMessage, string actualMessage)
+        {
+            Assert.IsTrue(actualMessage.Contains(expectedMessage),
+                string.Format("Expected RunCommand result message containing \n\"{0}\",\ngot\n\"{1}\"\ninstead.", expectedMessage, actualMessage));
         }
     }
 }

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -1630,6 +1630,24 @@ namespace pwiz.Skyline.Util
             return 0;
         }
 
+        public static List<string> EnsureUniqueNames(List<string> names, HashSet<string> reservedNames = null)
+        {
+            var setUsedNames = reservedNames ?? new HashSet<string>();
+            var result = new List<string>();
+            for (int i = 0; i < names.Count; i++)
+            {
+                string baseName = names[i];
+                // Make sure the next name added is unique
+                string name = (baseName.Length != 0 ? baseName : @"1");
+                for (int suffix = 2; setUsedNames.Contains(name); suffix++)
+                    name = baseName + suffix;
+                result.Add(name);
+                // Add this name to the used set
+                setUsedNames.Add(name);
+            }
+            return result;
+        }
+
         /// <summary>
         /// Count the number of lines in the file specified.
         /// </summary>
@@ -1876,7 +1894,7 @@ namespace pwiz.Skyline.Util
 
         public static string NullableDoubleToString(double? d)
         {
-            return d.HasValue ? d.Value.ToString(LocalizationHelper.CurrentCulture) : string.Empty;
+            return d.HasValue ? d.Value.ToString(LocalizationHelper.CurrentCulture) : String.Empty;
         }
     }
 


### PR DESCRIPTION
- Added two new command-line options --import-filename-pattern and --import-samplename-pattern (issue 626)
- Import results from multi-injection wiff files that have the same sample names (issue 627)