### PR TITLE
Add SpectrumList::find() id mismatch warning message

### DIFF
--- a/pwiz/data/msdata/SpectrumList_BTDX.cpp
+++ b/pwiz/data/msdata/SpectrumList_BTDX.cpp
@@ -89,7 +89,7 @@ const SpectrumIdentity& SpectrumList_BTDXImpl::spectrumIdentity(size_t index) co
 size_t SpectrumList_BTDXImpl::find(const string& id) const
 {
     map<string,size_t>::const_iterator it=idToIndex_.find(id);
-    return it!=idToIndex_.end() ? it->second : size();
+    return it!=idToIndex_.end() ? it->second : checkNativeIdFindResult(size(), id);
 }
 
 

--- a/pwiz/data/msdata/SpectrumList_MGF.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF.cpp
@@ -60,7 +60,7 @@ class SpectrumList_MGFImpl : public SpectrumList_MGF
     size_t find(const string& id) const
     {
         map<string, size_t>::const_iterator it = idToIndex_.find(id);
-        return it != idToIndex_.end() ? it->second : size();
+        return it != idToIndex_.end() ? it->second : checkNativeIdFindResult(size(), id);
     }
 
     size_t findNative(const string& nativeID) const

--- a/pwiz/data/msdata/SpectrumList_MSn.cpp
+++ b/pwiz/data/msdata/SpectrumList_MSn.cpp
@@ -144,7 +144,7 @@ class SpectrumList_MSnImpl : public SpectrumList_MSn
   size_t find(const string& id) const
   {
     map<string, size_t>::const_iterator it = idToIndex_.find(id);
-    return it != idToIndex_.end() ? it->second : size();
+    return it != idToIndex_.end() ? it->second : checkNativeIdFindResult(size(), id);
   }
   
   size_t findNative(const string& nativeID) const

--- a/pwiz/data/msdata/SpectrumList_mz5.cpp
+++ b/pwiz/data/msdata/SpectrumList_mz5.cpp
@@ -230,7 +230,7 @@ size_t SpectrumList_mz5Impl::find(const std::string& id) const
 {
     initSpectra();
     std::map<std::string, size_t>::const_iterator it = idMap_.find(id);
-    return it != idMap_.end() ? it->second : size();
+    return it != idMap_.end() ? it->second : checkNativeIdFindResult(size(), id);
 }
 
 IndexList SpectrumList_mz5Impl::findSpotID(const std::string& spotID) const

--- a/pwiz/data/msdata/SpectrumList_mzML.cpp
+++ b/pwiz/data/msdata/SpectrumList_mzML.cpp
@@ -98,7 +98,7 @@ const SpectrumIdentity& SpectrumList_mzMLImpl::spectrumIdentity(size_t index) co
 size_t SpectrumList_mzMLImpl::find(const string& id) const
 {
     //boost::call_once(indexInitialized_.flag, boost::bind(&SpectrumList_mzMLImpl::createIndex, this));
-    return index_->findSpectrumId(id);
+    return checkNativeIdFindResult(index_->findSpectrumId(id), id);
 }
 
 

--- a/pwiz/data/msdata/SpectrumList_mzXML.cpp
+++ b/pwiz/data/msdata/SpectrumList_mzXML.cpp
@@ -106,7 +106,7 @@ const SpectrumIdentity& SpectrumList_mzXMLImpl::spectrumIdentity(size_t index) c
 size_t SpectrumList_mzXMLImpl::find(const string& id) const
 {
     map<string,size_t>::const_iterator it=idToIndex_.find(id);
-    return it!=idToIndex_.end() ? it->second : size();
+    return it!=idToIndex_.end() ? it->second : checkNativeIdFindResult(size(), id);
 }
 
 

--- a/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
@@ -78,7 +78,7 @@ PWIZ_API_DECL size_t SpectrumList_ABI::find(const string& id) const
 
     map<string, size_t>::const_iterator scanItr = idToIndexMap_.find(id);
     if (scanItr == idToIndexMap_.end())
-        return size_;
+        return checkNativeIdFindResult(size_, id);
     return scanItr->second;
 }
 

--- a/pwiz/data/vendor_readers/Agilent/SpectrumList_Agilent.cpp
+++ b/pwiz/data/vendor_readers/Agilent/SpectrumList_Agilent.cpp
@@ -85,11 +85,11 @@ PWIZ_API_DECL size_t SpectrumList_Agilent::find(const string& id) const
     {
         map<string, size_t>::const_iterator scanItr = idToIndexMap_.find(id);
         if (scanItr == idToIndexMap_.end())
-            return size_;
+            return checkNativeIdFindResult(size_, id);
         return scanItr->second;
     }
 
-    return size();
+    return checkNativeIdFindResult(size_, id);
 }
 
 

--- a/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
+++ b/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
@@ -99,8 +99,8 @@ PWIZ_API_DECL size_t SpectrumList_Bruker::find(const string& id) const
                 // fall through and return size_ (id not found)
             }
         }
-
-        return size_;
+        
+        return checkNativeIdFindResult(size_, id);
     }
     return scanItr->second;
 }

--- a/pwiz/data/vendor_readers/Shimadzu/SpectrumList_Shimadzu.cpp
+++ b/pwiz/data/vendor_readers/Shimadzu/SpectrumList_Shimadzu.cpp
@@ -73,7 +73,7 @@ PWIZ_API_DECL size_t SpectrumList_Shimadzu::find(const string& id) const
 
     map<string, size_t>::const_iterator scanItr = idToIndexMap_.find(id);
     if (scanItr == idToIndexMap_.end())
-        return size_;
+        return checkNativeIdFindResult(size_, id);
     return scanItr->second;
 }
 

--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -113,11 +113,11 @@ PWIZ_API_DECL size_t SpectrumList_Thermo::find(const string& id) const
     {
         map<string, size_t>::const_iterator scanItr = idToIndexMap_.find(id);
         if (scanItr == idToIndexMap_.end())
-            return size_;
+            return checkNativeIdFindResult(size_, id);
         return scanItr->second;
     }
 
-    return size();
+    return checkNativeIdFindResult(size_, id);
 }
 
 

--- a/pwiz/data/vendor_readers/UIMF/SpectrumList_UIMF.cpp
+++ b/pwiz/data/vendor_readers/UIMF/SpectrumList_UIMF.cpp
@@ -73,7 +73,7 @@ PWIZ_API_DECL size_t SpectrumList_UIMF::find(const string& id) const
 
     map<string, size_t>::const_iterator scanItr = idToIndexMap_.find(id);
     if (scanItr == idToIndexMap_.end())
-        return size_;
+        return checkNativeIdFindResult(size_, id);
     return scanItr->second;
 }
 

--- a/pwiz/data/vendor_readers/UNIFI/SpectrumList_UNIFI.cpp
+++ b/pwiz/data/vendor_readers/UNIFI/SpectrumList_UNIFI.cpp
@@ -74,7 +74,7 @@ PWIZ_API_DECL size_t SpectrumList_UNIFI::find(const string& id) const
 
     map<string, size_t>::const_iterator scanItr = idToIndexMap_.find(id);
     if (scanItr == idToIndexMap_.end())
-        return size_;
+        return checkNativeIdFindResult(size_, id);
     return scanItr->second;
 }
 

--- a/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
+++ b/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
@@ -66,7 +66,7 @@ PWIZ_API_DECL size_t SpectrumList_Waters::find(const string& id) const
 {
     map<string, size_t>::const_iterator scanItr = idToIndexMap_.find(id);
     if (scanItr == idToIndexMap_.end())
-        return size_;
+        return checkNativeIdFindResult(size_, id);
     return scanItr->second;
 }
 

--- a/pwiz_tools/BiblioSpec/src/BlibUtils.cpp
+++ b/pwiz_tools/BiblioSpec/src/BlibUtils.cpp
@@ -100,6 +100,22 @@ const char* scoreTypeToProbabilityTypeString(PSM_SCORE_TYPE scoreType){
 }
 
 
+const char* specIdTypeToString(SPEC_ID_TYPE specIdType)
+{
+    switch (specIdType)
+    {
+        case SCAN_NUM_ID:
+            return "scan number";
+        case INDEX_ID:
+            return "index";
+        case NAME_ID:
+            return "nativeID";
+        default:
+            throw BlibException(true, "unknown specIdType");
+    }
+}
+
+
 const char* ionMobilityTypeToString(IONMOBILITY_TYPE ionMobilityType)
 {
     switch (ionMobilityType)

--- a/pwiz_tools/BiblioSpec/src/BlibUtils.h
+++ b/pwiz_tools/BiblioSpec/src/BlibUtils.h
@@ -63,6 +63,7 @@ namespace BiblioSpec {
  * files and spectrum files.  
  */
 enum SPEC_ID_TYPE { SCAN_NUM_ID, INDEX_ID, NAME_ID };
+const char* specIdTypeToString(SPEC_ID_TYPE specIdType);
 
 /**
  * Different kinds of ion mobility are supported.

--- a/pwiz_tools/BiblioSpec/src/BuildParser.cpp
+++ b/pwiz_tools/BiblioSpec/src/BuildParser.cpp
@@ -357,6 +357,8 @@ void BuildParser::buildTables(PSM_SCORE_TYPE scoreType, string specFilename, boo
         fileId = insertSpectrumFilename(specFilename, true); // insert as is
     }
 
+    BiblioSpec::Verbosity::debug("BuildParser lookup method is %s", specIdTypeToString(lookUpBy_));
+
     // for each psm
     map<const Protein*, sqlite3_int64> proteinIds;
     for(unsigned int i=0; i<psms_.size(); i++) {

--- a/pwiz_tools/BiblioSpec/src/PwizReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PwizReader.cpp
@@ -73,7 +73,7 @@ void PwizReader::openFile(const char* filename, bool mzSort){
             nativeIdFormat_ = MS_scan_number_only_nativeID_format;
         
         const auto& nativeIdFormatInfo = cvTermInfo(nativeIdFormat_);
-        BiblioSpec::Verbosity::debug("PwizReader lookup method is %s, nativeIdFormat is %s", specIdTypeToString(idType_), nativeIdFormatInfo.shortName());
+        BiblioSpec::Verbosity::debug("PwizReader lookup method is %s, nativeIdFormat is %s", specIdTypeToString(idType_), nativeIdFormatInfo.shortName().c_str());
 
         // HACK!  Without this block, I get an index out of bounds
         // error in getSpectrum(1, data, INDEX_ID)
@@ -222,7 +222,7 @@ bool PwizReader::getSpectrum(string identifier,
                              BiblioSpec::SpecData& returnData, 
                              bool getPeaks){
     int foundIndex = getSpecIndex(identifier);
-    BiblioSpec::Verbosity::comment(BiblioSpec::V_DETAIL, "PwizReader looking for id %s.", identifier);
+    BiblioSpec::Verbosity::comment(BiblioSpec::V_DETAIL, "PwizReader looking for id %s.", identifier.c_str());
     return getSpectrum(foundIndex, returnData, BiblioSpec::INDEX_ID, getPeaks);
 }
 

--- a/pwiz_tools/BiblioSpec/src/PwizReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PwizReader.cpp
@@ -72,6 +72,9 @@ void PwizReader::openFile(const char* filename, bool mzSort){
         if (nativeIdFormat_ == MS_no_nativeID_format)   // This never works
             nativeIdFormat_ = MS_scan_number_only_nativeID_format;
         
+        const auto& nativeIdFormatInfo = cvTermInfo(nativeIdFormat_);
+        BiblioSpec::Verbosity::debug("PwizReader lookup method is %s, nativeIdFormat is %s", specIdTypeToString(idType_), nativeIdFormatInfo.shortName());
+
         // HACK!  Without this block, I get an index out of bounds
         // error in getSpectrum(1, data, INDEX_ID)
         // With this block, I get errors for getSpectrum(n,data,SCAN_NUM_ID)
@@ -136,10 +139,7 @@ bool PwizReader::getSpectrum(int identifier,
                              BiblioSpec::SPEC_ID_TYPE findBy,
                              bool getPeaks)
 {
-    BiblioSpec::Verbosity::comment(BiblioSpec::V_DETAIL, 
-                                   "PwizReader looking for %s %d.",
-                    (findBy == BiblioSpec::INDEX_ID ? "index" : "scan number" ),
-                                   identifier);
+    BiblioSpec::Verbosity::comment(BiblioSpec::V_DETAIL, "PwizReader looking for %s %d.", specIdTypeToString(findBy), identifier);
     
     size_t foundIndex = getSpecIndex(identifier, findBy);
     
@@ -181,10 +181,15 @@ int PwizReader::getSpecIndex(string identifier){
     while( timesLooked < 2 && foundIndex == -1 ){
         switch(lookUpByNative){
         case(1):
-            foundIndex = allSpectra_->find(identifier);
-            if( foundIndex == (int)allSpectra_->size() ){// not found
+            if (identifier.find('=') == string::npos){
                 foundIndex = -1;
                 lookUpByNative = !lookUpByNative; // try other method
+            } else {
+                foundIndex = allSpectra_->find(identifier);
+                if (foundIndex == (int)allSpectra_->size()) {// not found
+                    foundIndex = -1;
+                    lookUpByNative = !lookUpByNative; // try other method
+                }
             }
             timesLooked++;
             break;
@@ -217,6 +222,7 @@ bool PwizReader::getSpectrum(string identifier,
                              BiblioSpec::SpecData& returnData, 
                              bool getPeaks){
     int foundIndex = getSpecIndex(identifier);
+    BiblioSpec::Verbosity::comment(BiblioSpec::V_DETAIL, "PwizReader looking for id %s.", identifier);
     return getSpectrum(foundIndex, returnData, BiblioSpec::INDEX_ID, getPeaks);
 }
 
@@ -263,10 +269,7 @@ bool PwizReader::getSpectrum(int identifier,
                                      BiblioSpec::SPEC_ID_TYPE findBy,
                                      bool getPeaks)
 {
-    BiblioSpec::Verbosity::comment(BiblioSpec::V_DETAIL,
-                                   "PwizReader looking for %s %d.",
-                 (findBy == BiblioSpec::INDEX_ID ? "index" : "scan number" ),
-                                   identifier);
+    BiblioSpec::Verbosity::comment(BiblioSpec::V_DETAIL, "PwizReader looking for %s %d.", specIdTypeToString(findBy), identifier);
     
     size_t foundIndex = getSpecIndex(identifier, findBy);
     


### PR DESCRIPTION
* added helpful warning when call to SpectrumList::find() fails because the SpectrumList format and query format do not match (e.g. "scan=123" vs. "function=1 process=0 scan=123")

This is particularly useful when trying to match mzIdentML ids to MSData ids.