### PR TITLE
Re-enable Thermo PDA and UV chromatograms

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
@@ -325,11 +325,16 @@ struct PWIZ_API_DECL ErrorLogItem
 enum PWIZ_API_DECL ChromatogramType
 {
     Type_MassRange,
-    Type_ECD = Type_MassRange,
     Type_TIC,
-    Type_TotalScan = Type_TIC,
     Type_BasePeak,
-    Type_NeutralFragment
+    Type_NeutralFragment,
+#ifndef _WIN64
+    Type_TotalScan = Type_TIC,
+    Type_ECD = Type_MassRange
+#else
+    Type_ECD = 31, // TraceType.ChannelA
+    Type_TotalScan = 23 // TraceType.SpectrumMax
+#endif
 };
 
 


### PR DESCRIPTION
- re-enabled Thermo PDA and UV chromatograms (disabled since upgrading to RawFileReader); added checks so that other chromatography traces (like pump pressure) are not interpreted as UV chromatograms