### PR TITLE
Fix error message when Sciex .wiff.scan file is missing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,8 @@
 version: '{build}.{branch}'
+branches:
+  only:
+  - /master/
+  - /pull\/.*/head
 skip_branch_with_pr: true
 image:
 - Visual Studio 2017

--- a/pwiz/data/vendor_readers/ABI/ChromatogramList_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/ChromatogramList_ABI.cpp
@@ -114,29 +114,22 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_ABI::chromatogram(size_t index, D
 
             map<double, double> fullFileTIC;
 
-            try
+            int periodCount = wifffile_->getPeriodCount(ie.sample);
+            for (int ii=1; ii <= periodCount; ++ii)
             {
-                int periodCount = wifffile_->getPeriodCount(ie.sample);
-                for (int ii=1; ii <= periodCount; ++ii)
+                //Console::WriteLine("Sample {0}, Period {1}", i, ii);
+
+                int experimentCount = wifffile_->getExperimentCount(ie.sample, ii);
+                for (int iii=1; iii <= experimentCount; ++iii)
                 {
-                    //Console::WriteLine("Sample {0}, Period {1}", i, ii);
+                    ExperimentPtr msExperiment = experimentsMap_.find(pair<int, int>(ii, iii))->second;
 
-                    int experimentCount = wifffile_->getExperimentCount(ie.sample, ii);
-                    for (int iii=1; iii <= experimentCount; ++iii)
-                    {
-                        ExperimentPtr msExperiment = experimentsMap_.find(pair<int, int>(ii, iii))->second;
-
-                        // add current experiment TIC to full file TIC
-                        vector<double> times, intensities;
-                        msExperiment->getTIC(times, intensities);
-                        for (int iiii = 0, end = intensities.size(); iiii < end; ++iiii)
-                            fullFileTIC[times[iiii]] += intensities[iiii];
-                    }
+                    // add current experiment TIC to full file TIC
+                    vector<double> times, intensities;
+                    msExperiment->getTIC(times, intensities);
+                    for (int iiii = 0, end = intensities.size(); iiii < end; ++iiii)
+                        fullFileTIC[times[iiii]] += intensities[iiii];
                 }
-            }
-            catch (exception&)
-            {
-                // TODO: log warning
             }
 
             result->setTimeIntensityArrays(std::vector<double>(), std::vector<double>(), UO_minute, MS_number_of_detector_counts);
@@ -168,29 +161,22 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_ABI::chromatogram(size_t index, D
 
             map<double, double> fullFileBPC;
 
-            try
+            int periodCount = wifffile_->getPeriodCount(ie.sample);
+            for (int ii = 1; ii <= periodCount; ++ii)
             {
-                int periodCount = wifffile_->getPeriodCount(ie.sample);
-                for (int ii = 1; ii <= periodCount; ++ii)
+                //Console::WriteLine("Sample {0}, Period {1}", i, ii);
+
+                int experimentCount = wifffile_->getExperimentCount(ie.sample, ii);
+                for (int iii = 1; iii <= experimentCount; ++iii)
                 {
-                    //Console::WriteLine("Sample {0}, Period {1}", i, ii);
+                    ExperimentPtr msExperiment = experimentsMap_.find(pair<int, int>(ii, iii))->second;
 
-                    int experimentCount = wifffile_->getExperimentCount(ie.sample, ii);
-                    for (int iii = 1; iii <= experimentCount; ++iii)
-                    {
-                        ExperimentPtr msExperiment = experimentsMap_.find(pair<int, int>(ii, iii))->second;
-
-                        // add current experiment TIC to full file TIC
-                        vector<double> times, intensities;
-                        msExperiment->getBPC(times, intensities);
-                        for (int iiii = 0, end = intensities.size(); iiii < end; ++iiii)
-                            fullFileBPC[times[iiii]] += intensities[iiii];
-                    }
+                    // add current experiment TIC to full file TIC
+                    vector<double> times, intensities;
+                    msExperiment->getBPC(times, intensities);
+                    for (int iiii = 0, end = intensities.size(); iiii < end; ++iiii)
+                        fullFileBPC[times[iiii]] += intensities[iiii];
                 }
-            }
-            catch (exception&)
-            {
-                // TODO: log warning
             }
 
             result->setTimeIntensityArrays(std::vector<double>(), std::vector<double>(), UO_minute, MS_number_of_detector_counts);

--- a/pwiz/utility/misc/cpp_cli_utilities.hpp
+++ b/pwiz/utility/misc/cpp_cli_utilities.hpp
@@ -245,6 +245,19 @@ std::string trimFunctionMacro(const char* function, const T& param)
     return what;
 }
 
+std::string flattenInnerExceptions(System::Exception^ e)
+{
+    auto what = e->Message;
+    while (e->InnerException != nullptr)
+    {
+        e = e->InnerException;
+        auto newWhat = e->Message;
+        if (!what->Contains(newWhat))
+            what += "\r\n" + newWhat;
+    }
+    return pwiz::util::ToStdString(what);
+}
+
 } // namespace
 
 
@@ -256,7 +269,7 @@ std::string trimFunctionMacro(const char* function, const T& param)
     catch (_com_error& e) {throw std::runtime_error(std::string("COM error: ") + e.ErrorMessage());} \
     /*catch (CException* e) {std::auto_ptr<CException> exceptionDeleter(e); char message[1024]; e->GetErrorMessage(message, 1024); throw std::runtime_error(string("MFC error: ") + message);}*/ \
     catch (System::AggregateException^ e) { throw std::runtime_error(trimFunctionMacro(__FUNCTION__, (param)) + pwiz::util::ToStdString(e->ToString())); } \
-    catch (System::Exception^ e) { throw std::runtime_error(trimFunctionMacro(__FUNCTION__, (param)) + pwiz::util::ToStdString(e->Message)); }
+    catch (System::Exception^ e) { throw std::runtime_error(trimFunctionMacro(__FUNCTION__, (param)) + flattenInnerExceptions(e)); }
 
 #define CATCH_AND_FORWARD CATCH_AND_FORWARD_EX("")
 


### PR DESCRIPTION
- fixed error message about missing .scan file not being shown if error is triggered during chromatogram retrieval
* removed exception handling around Sciex BPC/TIC retrieval because it was only needed when ALL samples were being aggregated and some samples might cause errors