### PR TITLE
Added CAD chromatogram for Thermo

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.cpp
@@ -345,7 +345,7 @@ PWIZ_API_DECL void ChromatogramList_Thermo::createIndex() const
 
                                 for (size_t j=0, jc=scanInfo->scanRangeCount(); j < jc; ++j)
                                 {
-                                    double q1 = scanInfo->precursorMZ(0);
+                                    double q1 = (scanInfo->scanRange(j).first + scanInfo->scanRange(j).second) / 2.0;
                                     auto polarityType = translate(scanInfo->polarityType());
                                     string polarity = polarityStringForFilter(polarityType);
                                     string id = (format("%sSIM SIC %.10g", std::locale::classic())

--- a/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.hpp
+++ b/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.hpp
@@ -88,6 +88,7 @@ public:
     mutable map<string, size_t> idMap_;
 
     void createIndex() const;
+    IndexEntry& addChromatogram(const string& id, ControllerType controllerType, int controllerNumber, CVID chromatogramType, const string& filter) const;
 #endif // PWIZ_READER_THERMO
 };
 

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
@@ -333,7 +333,7 @@ enum PWIZ_API_DECL ChromatogramType
     Type_ECD = Type_MassRange
 #else
     Type_ECD = 31, // TraceType.ChannelA
-    Type_TotalScan = 23 // TraceType.SpectrumMax
+    Type_TotalScan = 22 // TraceType.TotalAbsorbance
 #endif
 };
 


### PR DESCRIPTION
- added CAD chromatogram for Thermo (treating it as a kind of TIC)
* fixed enumeration of PDA chromatograms on 64-bit (really need a unit test file for this...)
* refactored repeated code out of ChromatogramList_Thermo::createIndex() into new private addChromatogram() function