### PR TITLE
- fixed precursorList for Thermo MS3 data with "SPS Masses" 

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -37,7 +37,7 @@ namespace {
     std::vector<double> getMultiFillTimes(const string& multiFill)
     {
         std::vector<double> fillTimes;
-        if (multiFill.empty())
+        if (multiFill.empty() || bal::trim_copy(multiFill).empty())
         {
             // This parameter is not specified, return an empty set of fill times
             return fillTimes;
@@ -419,7 +419,7 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Thermo::spectrum(size_t index, DetailLeve
 
         if (scanInfo->hasMultiplePrecursors())
         {
-            vector<double> isolationWidths = rawfile_->getIsolationWidths(ie.scan);
+            vector<double> isolationWidths = scanInfo->getIsolationWidths();
             if (precursorCount != (long) isolationWidths.size())
             {
                 throw runtime_error("precursor count does not match isolation width count");
@@ -443,6 +443,9 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Thermo::spectrum(size_t index, DetailLeve
                 precursor.isolationWindow.set(MS_isolation_window_target_m_z, isolationMz, MS_m_z);
                 precursor.isolationWindow.set(MS_isolation_window_lower_offset, isolationWidth, MS_m_z);
                 precursor.isolationWindow.set(MS_isolation_window_upper_offset, isolationWidth, MS_m_z);
+
+                int msLevel = scanInfo->isSPS() && i == 0 ? 1 : 2;
+                precursor.userParams.push_back(UserParam("ms level", lexical_cast<string>(msLevel)));
 
                 ActivationType activationType = scanInfo->activationType();
                 if (activationType == ActivationType_Unknown)

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
@@ -266,6 +266,8 @@ class PWIZ_API_DECL ScanInfo
     virtual double precursorMZ(long index, bool preferMonoisotope = true) const = 0;
     virtual double precursorActivationEnergy(long index) const = 0;
 
+    virtual std::vector<double> getIsolationWidths() const = 0;
+
     virtual ActivationType supplementalActivationType() const = 0;
     virtual double supplementalActivationEnergy() const = 0;
 
@@ -429,7 +431,6 @@ class PWIZ_API_DECL RawFile
     virtual ScanFilterMassAnalyzerType getMassAnalyzerType(long scanNumber) const = 0;
     virtual ActivationType getActivationType(long scanNumber) const = 0;
     // getDetectorType is obsolete?
-    virtual std::vector<double> getIsolationWidths(long scanNumber) const = 0;
     virtual double getIsolationWidth(int scanSegment, int scanEvent) const = 0;
     virtual double getDefaultIsolationWidth(int scanSegment, int msLevel)const = 0;
 


### PR DESCRIPTION
The first precursor is the MS1 precursor and the rest are MS2 precursors; the ms level is indicated by an "ms level" userParam in the <Precursor> element but will later switch to a standardized representation