### PR TITLE
Fix intermittent "ArgumentOutOfRangeException" in LongWaitDlg.timerUp…

### DIFF
--- a/pwiz_tools/Skyline/Controls/LongWaitDlg.cs
+++ b/pwiz_tools/Skyline/Controls/LongWaitDlg.cs
@@ -292,7 +292,8 @@ namespace pwiz.Skyline.Controls
 
         private void timerUpdate_Tick(object sender, EventArgs e)
         {
-            if (_progressValue == -1)
+            var progressValue = _progressValue;
+            if (progressValue == -1)
             {
                 progressBar.Style = ProgressBarStyle.Marquee;
                 UpdateTaskbarProgress(TaskbarProgress.TaskbarStates.Indeterminate, null);
@@ -300,7 +301,7 @@ namespace pwiz.Skyline.Controls
             else
             {
                 progressBar.Style = ProgressBarStyle.Continuous;
-                progressBar.Value = _progressValue;
+                progressBar.Value = progressValue;
                 UpdateTaskbarProgress(TaskbarProgress.TaskbarStates.Normal, progressBar.Value);
             }
 


### PR DESCRIPTION
…date_Tick

I think there is a threading issue where it's possible for us to try to set the ProgressBar.Value to -1 even though we checked the value of _progressValue right before that.

Someone submitted this exception report. I figure this is safe enough to fix in 19.1, even though this is the first time anyone ran into this bug.