### PR TITLE
- added "--help-filter" option to msconvert

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
@@ -1683,6 +1683,29 @@ string SpectrumListFactory::usage(bool detailedHelp, const char *morehelp_prompt
 }
 
 
+string SpectrumListFactory::usage(const std::string& detailedHelpForFilter)
+{
+    ostringstream oss;
+
+    for (JumpTableEntry* it = jumpTable_; it != jumpTableEnd_; ++it)
+    {
+        if (it->command == detailedHelpForFilter)
+        {
+            oss << it->command << " " << it->usage[0] << endl << it->usage[1] << endl;
+            return oss.str();
+        }
+    }
+
+    oss << "Invalid filter name: " << detailedHelpForFilter << endl << endl
+        << "Supported filters are:" << endl;
+
+    for (JumpTableEntry* it = jumpTable_; it != jumpTableEnd_; ++it)
+        oss << it->command << endl;
+
+    return oss.str();
+}
+
+
 } // namespace analysis 
 } // namespace pwiz
 

--- a/pwiz/analysis/spectrum_processing/SpectrumListFactory.hpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactory.hpp
@@ -49,6 +49,9 @@ class PWIZ_API_DECL SpectrumListFactory
 
     /// user-friendly documentation, with option of less or more detail
     static std::string usage(bool detailedHelp = true, const char* morehelp_prompt = NULL, int maxLineLength = 80);
+
+    /// user-friendly documentation for a specified filter
+    static std::string usage(const std::string& detailedHelpForFilter);
 };
 
 

--- a/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
+++ b/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
@@ -276,6 +276,7 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Bruker::spectrum(size_t index, DetailLeve
                      frameScanPair.first, *scanNumbers.begin());
 
             vector<Scan>& scans = result->scanList.scans;
+            scans.reserve(scanNumbers.size());
             for (auto itr = ++scanNumbers.begin(); itr != scanNumbers.end(); ++itr)
             {
                 scans.push_back(Scan());


### PR DESCRIPTION
- added "--help-filter" option to msconvert which will show detailed help for a single named filter (and if the user types a filter name wrong, it will list the available filters)
* added a reserve() call for Bruker scanList when creating list of merged PASEF scans