### PR TITLE
Skyline: correcting some inconsistent user-facing nomenclature around…

### DIFF
--- a/pwiz_tools/Skyline/Alerts/NoModeUIDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Alerts/NoModeUIDlg.Designer.cs
@@ -58,8 +58,8 @@ namespace pwiz.Skyline.Alerts
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NoModeUIDlg));
             this.imageListModeUI = new System.Windows.Forms.ImageList(this.components);
             this.listBoxModeUI = new pwiz.Skyline.Controls.ImageListBox();
-            this.imageListBoxItemProteomic = new pwiz.Skyline.Controls.ImageListBoxItem();
-            this.imageListBoxItemMolecules = new pwiz.Skyline.Controls.ImageListBoxItem();
+            this.imageListBoxItemProteomics = new pwiz.Skyline.Controls.ImageListBoxItem();
+            this.imageListBoxItemMolecule = new pwiz.Skyline.Controls.ImageListBoxItem();
             this.imageListBoxItemMixed = new pwiz.Skyline.Controls.ImageListBoxItem();
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
@@ -82,19 +82,19 @@ namespace pwiz.Skyline.Alerts
             resources.ApplyResources(this.listBoxModeUI, "listBoxModeUI");
             this.listBoxModeUI.ImageList = this.imageListModeUI;
             this.listBoxModeUI.Items.AddRange(new pwiz.Skyline.Controls.ImageListBoxItem[] {
-            this.imageListBoxItemProteomic,
-            this.imageListBoxItemMolecules,
+            this.imageListBoxItemProteomics,
+            this.imageListBoxItemMolecule,
             this.imageListBoxItemMixed});
             this.listBoxModeUI.Name = "listBoxModeUI";
             this.modeUIHandler.SetUIMode(this.listBoxModeUI, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.invariant);
             // 
             // imageListBoxItemProteomic
             // 
-            resources.ApplyResources(this.imageListBoxItemProteomic, "imageListBoxItemProteomic");
+            resources.ApplyResources(this.imageListBoxItemProteomics, "imageListBoxItemProteomics");
             // 
             // imageListBoxItemMolecules
             // 
-            resources.ApplyResources(this.imageListBoxItemMolecules, "imageListBoxItemMolecules");
+            resources.ApplyResources(this.imageListBoxItemMolecule, "imageListBoxItemMolecule");
             // 
             // imageListBoxItemMixed
             // 
@@ -139,8 +139,8 @@ namespace pwiz.Skyline.Alerts
         #endregion
         private pwiz.Skyline.Controls.ImageListBox listBoxModeUI;
         private System.Windows.Forms.ImageList imageListModeUI;
-        private Controls.ImageListBoxItem imageListBoxItemProteomic;
-        private Controls.ImageListBoxItem imageListBoxItemMolecules;
+        private Controls.ImageListBoxItem imageListBoxItemProteomics;
+        private Controls.ImageListBoxItem imageListBoxItemMolecule;
         private Controls.ImageListBoxItem imageListBoxItemMixed;
         private Label label2;
         private Label label1;

--- a/pwiz_tools/Skyline/Alerts/NoModeUIDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/NoModeUIDlg.cs
@@ -36,8 +36,8 @@ namespace pwiz.Skyline.Alerts
 
             // N.B. the Imagelist we use here is all blanks, which we then replace here in the ctor. This is done
             // so that if we ever update the proteomic/molecules/mixed bitmaps we don't have to remake this ImageList.
-            imageListBoxItemProteomic.ImageList.Images[imageListBoxItemProteomic.ImageIndex] = new Bitmap(Resources.UIModeProteomic);
-            imageListBoxItemMolecules.ImageList.Images[imageListBoxItemMolecules.ImageIndex] = new Bitmap(Resources.UIModeSmallMolecules);
+            imageListBoxItemProteomics.ImageList.Images[imageListBoxItemProteomics.ImageIndex] = new Bitmap(Resources.UIModeProteomic);
+            imageListBoxItemMolecule.ImageList.Images[imageListBoxItemMolecule.ImageIndex] = new Bitmap(Resources.UIModeSmallMolecules);
             imageListBoxItemMixed.ImageList.Images[imageListBoxItemMixed.ImageIndex] = new Bitmap(Resources.UIModeMixed);
 
             SelectModeUI(SrmDocument.DOCUMENT_TYPE.proteomic); // Make a guess at proteomic

--- a/pwiz_tools/Skyline/Alerts/NoModeUIDlg.ja.resx
+++ b/pwiz_tools/Skyline/Alerts/NoModeUIDlg.ja.resx
@@ -169,16 +169,16 @@
   <data name="listBoxModeUI.ItemHeight" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
-  <data name="imageListBoxItemProteomic.ImageIndex" type="System.Int32, mscorlib">
+  <data name="imageListBoxItemProteomics.ImageIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="imageListBoxItemProteomic.Text" xml:space="preserve">
+  <data name="imageListBoxItemProteomics.Text" xml:space="preserve">
     <value>プロテオミクス</value>
   </data>
-  <data name="imageListBoxItemMolecules.ImageIndex" type="System.Int32, mscorlib">
+  <data name="imageListBoxItemMolecule.ImageIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="imageListBoxItemMolecules.Text" xml:space="preserve">
+  <data name="imageListBoxItemMolecule.Text" xml:space="preserve">
     <value>分子</value>
   </data>
   <data name="imageListBoxItemMixed.ImageIndex" type="System.Int32, mscorlib">
@@ -319,16 +319,16 @@
   <data name="&gt;&gt;imageListModeUI.Type" xml:space="preserve">
     <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemProteomic.Name" xml:space="preserve">
-    <value>imageListBoxItemProteomic</value>
+  <data name="&gt;&gt;imageListBoxItemProteomics.Name" xml:space="preserve">
+    <value>imageListBoxItemProteomics</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemProteomic.Type" xml:space="preserve">
+  <data name="&gt;&gt;imageListBoxItemProteomics.Type" xml:space="preserve">
     <value>pwiz.Skyline.Controls.ImageListBoxItem, Skyline-daily, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemMolecules.Name" xml:space="preserve">
-    <value>imageListBoxItemMolecules</value>
+  <data name="&gt;&gt;imageListBoxItemMolecule.Name" xml:space="preserve">
+    <value>imageListBoxItemMolecule</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemMolecules.Type" xml:space="preserve">
+  <data name="&gt;&gt;imageListBoxItemMolecule.Type" xml:space="preserve">
     <value>pwiz.Skyline.Controls.ImageListBoxItem, Skyline-daily, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;imageListBoxItemMixed.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Alerts/NoModeUIDlg.resx
+++ b/pwiz_tools/Skyline/Alerts/NoModeUIDlg.resx
@@ -169,17 +169,17 @@
   <data name="listBoxModeUI.ItemHeight" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
-  <data name="imageListBoxItemProteomic.ImageIndex" type="System.Int32, mscorlib">
+  <data name="imageListBoxItemProteomics.ImageIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="imageListBoxItemProteomic.Text" xml:space="preserve">
-    <value>Proteomic</value>
+  <data name="imageListBoxItemProteomics.Text" xml:space="preserve">
+    <value>Proteomics</value>
   </data>
-  <data name="imageListBoxItemMolecules.ImageIndex" type="System.Int32, mscorlib">
+  <data name="imageListBoxItemMolecule.ImageIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="imageListBoxItemMolecules.Text" xml:space="preserve">
-    <value>Molecules</value>
+  <data name="imageListBoxItemMolecule.Text" xml:space="preserve">
+    <value>Molecule</value>
   </data>
   <data name="imageListBoxItemMixed.ImageIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -319,16 +319,16 @@ created Skyline documents.</value>
   <data name="&gt;&gt;imageListModeUI.Type" xml:space="preserve">
     <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemProteomic.Name" xml:space="preserve">
-    <value>imageListBoxItemProteomic</value>
+  <data name="&gt;&gt;imageListBoxItemProteomics.Name" xml:space="preserve">
+    <value>imageListBoxItemProteomics</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemProteomic.Type" xml:space="preserve">
+  <data name="&gt;&gt;imageListBoxItemProteomics.Type" xml:space="preserve">
     <value>pwiz.Skyline.Controls.ImageListBoxItem, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemMolecules.Name" xml:space="preserve">
-    <value>imageListBoxItemMolecules</value>
+  <data name="&gt;&gt;imageListBoxItemMolecule.Name" xml:space="preserve">
+    <value>imageListBoxItemMolecule</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemMolecules.Type" xml:space="preserve">
+  <data name="&gt;&gt;imageListBoxItemMolecule.Type" xml:space="preserve">
     <value>pwiz.Skyline.Controls.ImageListBoxItem, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;imageListBoxItemMixed.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Alerts/NoModeUIDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Alerts/NoModeUIDlg.zh-CHS.resx
@@ -169,16 +169,16 @@
   <data name="listBoxModeUI.ItemHeight" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
-  <data name="imageListBoxItemProteomic.ImageIndex" type="System.Int32, mscorlib">
+  <data name="imageListBoxItemProteomics.ImageIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="imageListBoxItemProteomic.Text" xml:space="preserve">
+  <data name="imageListBoxItemProteomics.Text" xml:space="preserve">
     <value>蛋白质组学</value>
   </data>
-  <data name="imageListBoxItemMolecules.ImageIndex" type="System.Int32, mscorlib">
+  <data name="imageListBoxItemMolecule.ImageIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="imageListBoxItemMolecules.Text" xml:space="preserve">
+  <data name="imageListBoxItemMolecule.Text" xml:space="preserve">
     <value>分子学</value>
   </data>
   <data name="imageListBoxItemMixed.ImageIndex" type="System.Int32, mscorlib">
@@ -319,16 +319,16 @@
   <data name="&gt;&gt;imageListModeUI.Type" xml:space="preserve">
     <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemProteomic.Name" xml:space="preserve">
-    <value>imageListBoxItemProteomic</value>
+  <data name="&gt;&gt;imageListBoxItemProteomics.Name" xml:space="preserve">
+    <value>imageListBoxItemProteomics</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemProteomic.Type" xml:space="preserve">
+  <data name="&gt;&gt;imageListBoxItemProteomics.Type" xml:space="preserve">
     <value>pwiz.Skyline.Controls.ImageListBoxItem, Skyline-daily, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemMolecules.Name" xml:space="preserve">
-    <value>imageListBoxItemMolecules</value>
+  <data name="&gt;&gt;imageListBoxItemMolecule.Name" xml:space="preserve">
+    <value>imageListBoxItemMolecule</value>
   </data>
-  <data name="&gt;&gt;imageListBoxItemMolecules.Type" xml:space="preserve">
+  <data name="&gt;&gt;imageListBoxItemMolecule.Type" xml:space="preserve">
     <value>pwiz.Skyline.Controls.ImageListBoxItem, Skyline-daily, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;imageListBoxItemMixed.Name" xml:space="preserve">


### PR DESCRIPTION
… UI modes - in the one-time never-yet-selected-a-UI-mode dialog I had it as "proteomics" and "molecule" but in the rest of Skyline it's "proteomic" and "molecules".