### PR TITLE
Skyline: Make charge state suffix parsing more flexible to handle the…

### DIFF
--- a/pwiz_tools/Skyline/Test/AdductTest.cs
+++ b/pwiz_tools/Skyline/Test/AdductTest.cs
@@ -19,7 +19,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model;
@@ -488,6 +490,42 @@ namespace pwiz.SkylineTest
                     }
                 }
             }
+        }
+
+        [TestMethod]
+        public void ChargeStateTextTest()
+        {
+            int min = Transition.MIN_PRODUCT_CHARGE, max = Transition.MAX_PRODUCT_CHARGE;
+            for (int i = min; i < max; i++)
+            {
+                ValidateChargeText(i, Transition.GetChargeIndicator(Adduct.FromChargeProtonated(i)));
+                ValidateChargeText(-i, Transition.GetChargeIndicator(Adduct.FromChargeProtonated(-i)));
+                ValidateChargeText(i, Transition.GetChargeIndicator(Adduct.FromChargeProtonated(i), CultureInfo.InvariantCulture));
+                ValidateChargeText(-i, Transition.GetChargeIndicator(Adduct.FromChargeProtonated(-i), CultureInfo.InvariantCulture));
+                ValidateChargeText(i, GetLongFormChargeIndicator(i));
+                ValidateChargeText(-i, GetLongFormChargeIndicator(-i));
+            }
+        }
+
+        private static void ValidateChargeText(int charge, string chargeText)
+        {
+            const string pepText = "PEPTIDER";
+            int min = Transition.MIN_PRODUCT_CHARGE, max = Transition.MAX_PRODUCT_CHARGE;
+            Assert.AreEqual(pepText, Transition.StripChargeIndicators(pepText + chargeText, min, max),
+                "Unable to round trip charge text " + chargeText);
+            Assert.AreEqual(Adduct.FromChargeProtonated(charge), Transition.GetChargeFromIndicator(chargeText, min, max));
+
+            // If the charge indicator contains a space, make sure it is not necessary to be interpreted correctly
+            if (chargeText.Contains(' '))
+                ValidateChargeText(charge, chargeText.Replace(" ", string.Empty));
+        }
+
+        private string GetLongFormChargeIndicator(int i)
+        {
+            char c = i > 0 ? '+' : '-';
+            var sb = new StringBuilder();
+            sb.Append(c, Math.Abs(i));
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
… following cases

- A series of + or - symbols however long (used to stop at ++++ for positive and -- for negative)
- Use CultureInfo.TextInfo.ListSeparator (semi-colon in Europe) "; +5" instead of CultureInfo.NumberFormat.NumberGroupSeparator (period, space or apostrophe in Europe) ". +5", "  +5", or "' +5"
- Allow invariant form always ", +5" even when current culture indicates "; +5"
- Allow the absence of the space in charge states with numbers, i.e. ",+5" or ";+5"