### PR TITLE
(WIP) Add C++ stacktraces

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -357,9 +357,12 @@ project pwiz
         <threading>multi
 
         # change boost debug assertions to exceptions by force including Exception.hpp
-        <variant>debug,<toolset>msvc:<cxxflags>/FIpwiz/utility/misc/Exception.hpp
-        <variant>debug,<toolset>gcc:<cxxflags>"-include pwiz/utility/misc/Exception.hpp"
-        <variant>debug,<toolset>darwin:<cxxflags>"-include pwiz/utility/misc/Exception.hpp"
+        <toolset>msvc:<cxxflags>/FIpwiz/utility/misc/Exception.hpp
+        <toolset>gcc:<cxxflags>"-include pwiz/utility/misc/Exception.hpp"
+        <toolset>darwin:<cxxflags>"-include pwiz/utility/misc/Exception.hpp"
+
+        <toolset>msvc,<variant>release:<cxxflags>"/Gy /Gw /Zo- /FS"
+        <toolset>msvc:<define>_WINSOCKAPI_
 
         <toolset>msvc,<debug-symbols>on:<preserve-test-targets>off # save space on debug builds by deleting test artifacts which run successfully
 
@@ -377,6 +380,8 @@ project pwiz
         #<warnings-as-errors>on
         <warnings>all
         <threading>multi
+        <debug-symbols>on
+        <debug-store>database
     ;
 
 

--- a/libraries/ext-boost.jam
+++ b/libraries/ext-boost.jam
@@ -563,6 +563,39 @@ rule init ( version : location : options * )
                 <link>static:<define>BOOST_SYSTEM_STATIC_LINK=1
             ;
 
+
+        local stacktrace_sources ;
+        if [ modules.peek : NT ]
+        {
+          stacktrace_sources = windbg ;
+          stacktrace_link = "<define>BOOST_STACKTRACE_USE_WINDBG" ;
+        } else
+        {
+          stacktrace_sources = basic ;
+        }
+        lib dl ;
+        lib ole32 ;
+        lib Dbgeng ;
+
+        lib stacktrace
+            :   $(location)/libs/stacktrace/src/$(stacktrace_sources).cpp
+            :   $(requirements)
+                <location-prefix>stacktrace-$(version-tokens:J=_)
+                <use>boost
+                <target-os>linux:<library>dl
+                <target-os>windows:<library>Dbgeng
+                <target-os>windows:<library>ole32
+                <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+                <define>BOOST_STACKTRACE_LINK
+                <define>BOOST_STACKTRACE_INTERNAL_BUILD_LIBS
+                <visibility>hidden
+            :
+            :   <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+                <define>BOOST_STACKTRACE_LINK
+                $(stacktrace_link)
+            ;
+
+
         lib atomic
             :   $(location)/libs/atomic/src/lockpool.cpp
             :   $(requirements)

--- a/pwiz/Jamfile.jam
+++ b/pwiz/Jamfile.jam
@@ -25,6 +25,10 @@ build-project-if-exists utility ;
 build-project-if-exists data ;
 build-project-if-exists analysis ;
 
+project pwiz_core
+    : requirements
+        <library>/ext/boost//stacktrace
+    ;
 
 lib pwiz_version 
     : # sources

--- a/pwiz/analysis/chromatogram_processing/ChromatogramListFactoryTest.cpp
+++ b/pwiz/analysis/chromatogram_processing/ChromatogramListFactoryTest.cpp
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/chromatogram_processing/ChromatogramListWrapperTest.cpp
+++ b/pwiz/analysis/chromatogram_processing/ChromatogramListWrapperTest.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/chromatogram_processing/ChromatogramList_FilterTest.cpp
+++ b/pwiz/analysis/chromatogram_processing/ChromatogramList_FilterTest.cpp
@@ -217,7 +217,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/chromatogram_processing/ChromatogramList_LockmassRefinerTest.cpp
+++ b/pwiz/analysis/chromatogram_processing/ChromatogramList_LockmassRefinerTest.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/chromatogram_processing/SavitzkyGolaySmootherTest.cpp
+++ b/pwiz/analysis/chromatogram_processing/SavitzkyGolaySmootherTest.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/common/CwtPeakDetectorTest.cpp
+++ b/pwiz/analysis/common/CwtPeakDetectorTest.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/common/ExtraZeroSamplesFilterTest.cpp
+++ b/pwiz/analysis/common/ExtraZeroSamplesFilterTest.cpp
@@ -141,7 +141,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/common/LocalMaximumPeakDetectorTest.cpp
+++ b/pwiz/analysis/common/LocalMaximumPeakDetectorTest.cpp
@@ -124,7 +124,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/common/SavitzkyGolaySmootherTest.cpp
+++ b/pwiz/analysis/common/SavitzkyGolaySmootherTest.cpp
@@ -244,7 +244,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/common/WhittakerSmootherTest.cpp
+++ b/pwiz/analysis/common/WhittakerSmootherTest.cpp
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/common/ZeroSampleFillerTest.cpp
+++ b/pwiz/analysis/common/ZeroSampleFillerTest.cpp
@@ -238,7 +238,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/demux/CubicHermiteSplineTest.cpp
+++ b/pwiz/analysis/demux/CubicHermiteSplineTest.cpp
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/demux/DemuxDebugReadWriteTest.cpp
+++ b/pwiz/analysis/demux/DemuxDebugReadWriteTest.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/demux/DemuxHelpersTest.cpp
+++ b/pwiz/analysis/demux/DemuxHelpersTest.cpp
@@ -402,7 +402,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/demux/DemuxSolverTest.cpp
+++ b/pwiz/analysis/demux/DemuxSolverTest.cpp
@@ -153,7 +153,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/demux/MatrixIOTest.cpp
+++ b/pwiz/analysis/demux/MatrixIOTest.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/demux/PrecursorMaskCodecTest.cpp
+++ b/pwiz/analysis/demux/PrecursorMaskCodecTest.cpp
@@ -257,7 +257,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/demux/SpectrumPeakExtractorTest.cpp
+++ b/pwiz/analysis/demux/SpectrumPeakExtractorTest.cpp
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/frequency/FrequencyEstimatorPhysicalModelTest.cpp
+++ b/pwiz/analysis/frequency/FrequencyEstimatorPhysicalModelTest.cpp
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/frequency/FrequencyEstimatorSimpleTest.cpp
+++ b/pwiz/analysis/frequency/FrequencyEstimatorSimpleTest.cpp
@@ -294,7 +294,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/frequency/MagnitudeLorentzianTest.cpp
+++ b/pwiz/analysis/frequency/MagnitudeLorentzianTest.cpp
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/frequency/ParametrizedFunctionTest.cpp
+++ b/pwiz/analysis/frequency/ParametrizedFunctionTest.cpp
@@ -238,7 +238,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/frequency/PeakDetectorMatchedFilterTest.cpp
+++ b/pwiz/analysis/frequency/PeakDetectorMatchedFilterTest.cpp
@@ -179,7 +179,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/frequency/PeakDetectorNaiveTest.cpp
+++ b/pwiz/analysis/frequency/PeakDetectorNaiveTest.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/frequency/TruncatedLorentzianParametersTest.cpp
+++ b/pwiz/analysis/frequency/TruncatedLorentzianParametersTest.cpp
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/passive/MSDataAnalyzerTest.cpp
+++ b/pwiz/analysis/passive/MSDataAnalyzerTest.cpp
@@ -189,7 +189,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/passive/MSDataCacheTest.cpp
+++ b/pwiz/analysis/passive/MSDataCacheTest.cpp
@@ -297,7 +297,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/passive/RegionAnalyzerTest.cpp
+++ b/pwiz/analysis/passive/RegionAnalyzerTest.cpp
@@ -306,7 +306,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/FeatureDetectorPeakelTest.cpp
+++ b/pwiz/analysis/peakdetect/FeatureDetectorPeakelTest.cpp
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/FeatureDetectorSimpleTest.cpp
+++ b/pwiz/analysis/peakdetect/FeatureDetectorSimpleTest.cpp
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/FeatureDetectorTuningTest.cpp
+++ b/pwiz/analysis/peakdetect/FeatureDetectorTuningTest.cpp
@@ -258,7 +258,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/FeatureModelerTest.cpp
+++ b/pwiz/analysis/peakdetect/FeatureModelerTest.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/MZRTFieldTest.cpp
+++ b/pwiz/analysis/peakdetect/MZRTFieldTest.cpp
@@ -301,7 +301,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/NoiseTest.cpp
+++ b/pwiz/analysis/peakdetect/NoiseTest.cpp
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/PeakExtractorTest.cpp
+++ b/pwiz/analysis/peakdetect/PeakExtractorTest.cpp
@@ -214,7 +214,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/PeakFamilyDetectorFTTest.cpp
+++ b/pwiz/analysis/peakdetect/PeakFamilyDetectorFTTest.cpp
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/PeakFinderTest.cpp
+++ b/pwiz/analysis/peakdetect/PeakFinderTest.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/PeakFitterTest.cpp
+++ b/pwiz/analysis/peakdetect/PeakFitterTest.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/PeakelGrowerTest.cpp
+++ b/pwiz/analysis/peakdetect/PeakelGrowerTest.cpp
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peakdetect/PeakelPickerTest.cpp
+++ b/pwiz/analysis/peakdetect/PeakelPickerTest.cpp
@@ -144,7 +144,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peptideid/PeptideIDMapTest.cpp
+++ b/pwiz/analysis/peptideid/PeptideIDMapTest.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peptideid/PeptideID_flatTest.cpp
+++ b/pwiz/analysis/peptideid/PeptideID_flatTest.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/peptideid/PeptideID_pepXMLTest.cpp
+++ b/pwiz/analysis/peptideid/PeptideID_pepXMLTest.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/proteome_processing/ProteinListFactoryTest.cpp
+++ b/pwiz/analysis/proteome_processing/ProteinListFactoryTest.cpp
@@ -80,7 +80,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/proteome_processing/ProteinList_DecoyGeneratorTest.cpp
+++ b/pwiz/analysis/proteome_processing/ProteinList_DecoyGeneratorTest.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/proteome_processing/ProteinList_FilterTest.cpp
+++ b/pwiz/analysis/proteome_processing/ProteinList_FilterTest.cpp
@@ -183,7 +183,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/MS2DeisotoperTest.cpp
+++ b/pwiz/analysis/spectrum_processing/MS2DeisotoperTest.cpp
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/PrecursorRecalculatorDefaultTest.cpp
+++ b/pwiz/analysis/spectrum_processing/PrecursorRecalculatorDefaultTest.cpp
@@ -641,7 +641,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumListFactoryTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactoryTest.cpp
@@ -711,7 +711,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_3D_Test.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_3D_Test.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ChargeFromIsotopeTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ChargeFromIsotopeTest.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ChargeStateCalculatorTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ChargeStateCalculatorTest.cpp
@@ -362,7 +362,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_DemuxTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_DemuxTest.cpp
@@ -467,7 +467,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_FilterTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_FilterTest.cpp
@@ -797,7 +797,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_IonMobility_Test.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_IonMobility_Test.cpp
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_LockmassRefinerTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_LockmassRefinerTest.cpp
@@ -105,7 +105,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_MZRefinerTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_MZRefinerTest.cpp
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_MZWindowTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_MZWindowTest.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_MetadataFixerTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_MetadataFixerTest.cpp
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_PeakFilterTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_PeakFilterTest.cpp
@@ -785,7 +785,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_PrecursorRecalculatorTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_PrecursorRecalculatorTest.cpp
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_PrecursorRefineTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_PrecursorRefineTest.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummerTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummerTest.cpp
@@ -226,7 +226,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/analysis/spectrum_processing/SpectrumList_SorterTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_SorterTest.cpp
@@ -248,7 +248,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/common/BinaryIndexStreamTest.cpp
+++ b/pwiz/data/common/BinaryIndexStreamTest.cpp
@@ -220,7 +220,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/common/CVTranslatorTest.cpp
+++ b/pwiz/data/common/CVTranslatorTest.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/common/MemoryIndexTest.cpp
+++ b/pwiz/data/common/MemoryIndexTest.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/common/ParamTypesTest.cpp
+++ b/pwiz/data/common/ParamTypesTest.cpp
@@ -279,7 +279,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/common/UnimodTest.cpp
+++ b/pwiz/data/common/UnimodTest.cpp
@@ -194,7 +194,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/common/cvtest.cpp
+++ b/pwiz/data/common/cvtest.cpp
@@ -189,7 +189,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/common/diff_std_test.cpp
+++ b/pwiz/data/common/diff_std_test.cpp
@@ -312,7 +312,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/common/obotest.cpp
+++ b/pwiz/data/common/obotest.cpp
@@ -240,7 +240,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/DiffTest.cpp
+++ b/pwiz/data/identdata/DiffTest.cpp
@@ -1379,7 +1379,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/ExtendedReadTest.cpp
+++ b/pwiz/data/identdata/ExtendedReadTest.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/IOTest.cpp
+++ b/pwiz/data/identdata/IOTest.cpp
@@ -919,7 +919,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/IdentDataTest.cpp
+++ b/pwiz/data/identdata/IdentDataTest.cpp
@@ -423,7 +423,7 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/KwCVMapTest.cpp
+++ b/pwiz/data/identdata/KwCVMapTest.cpp
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/MascotReaderTest.cpp
+++ b/pwiz/data/identdata/MascotReaderTest.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/ReaderTest.cpp
+++ b/pwiz/data/identdata/ReaderTest.cpp
@@ -202,7 +202,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/ReferencesTest.cpp
+++ b/pwiz/data/identdata/ReferencesTest.cpp
@@ -229,7 +229,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/Serializer_Text_Test.cpp
+++ b/pwiz/data/identdata/Serializer_Text_Test.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/Serializer_mzid_Test.cpp
+++ b/pwiz/data/identdata/Serializer_mzid_Test.cpp
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/Serializer_pepXML_Test.cpp
+++ b/pwiz/data/identdata/Serializer_pepXML_Test.cpp
@@ -440,7 +440,7 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/identdata/Serializer_protXML_Test.cpp
+++ b/pwiz/data/identdata/Serializer_protXML_Test.cpp
@@ -108,7 +108,7 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/misc/CalibrationParametersTest.cpp
+++ b/pwiz/data/misc/CalibrationParametersTest.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/misc/FrequencyDataTest.cpp
+++ b/pwiz/data/misc/FrequencyDataTest.cpp
@@ -266,7 +266,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/misc/MinimumPepXMLTest.cpp
+++ b/pwiz/data/misc/MinimumPepXMLTest.cpp
@@ -761,7 +761,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/misc/PeakDataTest.cpp
+++ b/pwiz/data/misc/PeakDataTest.cpp
@@ -468,7 +468,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/misc/SampleDatumTest.cpp
+++ b/pwiz/data/misc/SampleDatumTest.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/BinaryDataEncoderTest.cpp
+++ b/pwiz/data/msdata/BinaryDataEncoderTest.cpp
@@ -374,7 +374,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/ChromatogramListBaseTest.cpp
+++ b/pwiz/data/msdata/ChromatogramListBaseTest.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/ChromatogramList_mz5_Test.cpp
+++ b/pwiz/data/msdata/ChromatogramList_mz5_Test.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/ChromatogramList_mzML_Test.cpp
+++ b/pwiz/data/msdata/ChromatogramList_mzML_Test.cpp
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/DiffTest.cpp
+++ b/pwiz/data/msdata/DiffTest.cpp
@@ -1348,7 +1348,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/IOTest.cpp
+++ b/pwiz/data/msdata/IOTest.cpp
@@ -1311,7 +1311,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/LegacyAdapterTest.cpp
+++ b/pwiz/data/msdata/LegacyAdapterTest.cpp
@@ -226,7 +226,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/MSDataFileTest.cpp
+++ b/pwiz/data/msdata/MSDataFileTest.cpp
@@ -408,7 +408,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/MSDataMergerTest.cpp
+++ b/pwiz/data/msdata/MSDataMergerTest.cpp
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/MSDataTest.cpp
+++ b/pwiz/data/msdata/MSDataTest.cpp
@@ -280,7 +280,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/MSnReaderTest.cpp
+++ b/pwiz/data/msdata/MSnReaderTest.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/RAMPAdapterTest.cpp
+++ b/pwiz/data/msdata/RAMPAdapterTest.cpp
@@ -302,7 +302,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/ReaderTest.cpp
+++ b/pwiz/data/msdata/ReaderTest.cpp
@@ -316,7 +316,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/ReferencesTest.cpp
+++ b/pwiz/data/msdata/ReferencesTest.cpp
@@ -532,7 +532,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/Serializer_MGF_Test.cpp
+++ b/pwiz/data/msdata/Serializer_MGF_Test.cpp
@@ -195,7 +195,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/Serializer_MSn_Test.cpp
+++ b/pwiz/data/msdata/Serializer_MSn_Test.cpp
@@ -290,7 +290,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/Serializer_mz5_Test.cpp
+++ b/pwiz/data/msdata/Serializer_mz5_Test.cpp
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/Serializer_mzML_Test.cpp
+++ b/pwiz/data/msdata/Serializer_mzML_Test.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/Serializer_mzXML_Test.cpp
+++ b/pwiz/data/msdata/Serializer_mzXML_Test.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumInfoTest.cpp
+++ b/pwiz/data/msdata/SpectrumInfoTest.cpp
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumIteratorTest.cpp
+++ b/pwiz/data/msdata/SpectrumIteratorTest.cpp
@@ -275,7 +275,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumListBaseTest.cpp
+++ b/pwiz/data/msdata/SpectrumListBaseTest.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumListCacheTest.cpp
+++ b/pwiz/data/msdata/SpectrumListCacheTest.cpp
@@ -454,7 +454,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumListWrapperTest.cpp
+++ b/pwiz/data/msdata/SpectrumListWrapperTest.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumList_MGF_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF_Test.cpp
@@ -218,7 +218,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumList_MSn_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_MSn_Test.cpp
@@ -961,7 +961,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumList_mz5_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_mz5_Test.cpp
@@ -179,7 +179,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumList_mzML_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_mzML_Test.cpp
@@ -191,7 +191,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/SpectrumList_mzXML_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_mzXML_Test.cpp
@@ -247,7 +247,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/msdata/mz5/Jamfile.jam
+++ b/pwiz/data/msdata/mz5/Jamfile.jam
@@ -55,11 +55,11 @@ lib pwiz_data_msdata_mz5
         Translator_mz5.cpp
     : # requirements
         <link>static
-        <library>/ext/hdf5//hdf5pp
+        <library>/ext/hdf5//hdf5pp/<debug-symbols>off
         <conditional>@usage-requirements
     : # default-build
     : # usage-requirements
         <include>.
-        <library>/ext/hdf5//hdf5pp
+        <library>/ext/hdf5//hdf5pp/<debug-symbols>off
         <conditional>@usage-requirements
     ;

--- a/pwiz/data/proteome/AminoAcidTest.cpp
+++ b/pwiz/data/proteome/AminoAcidTest.cpp
@@ -233,7 +233,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/DiffTest.cpp
+++ b/pwiz/data/proteome/DiffTest.cpp
@@ -181,7 +181,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/DigestionTest.cpp
+++ b/pwiz/data/proteome/DigestionTest.cpp
@@ -736,7 +736,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/PeptideTest.cpp
+++ b/pwiz/data/proteome/PeptideTest.cpp
@@ -880,7 +880,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/ProteinListCacheTest.cpp
+++ b/pwiz/data/proteome/ProteinListCacheTest.cpp
@@ -267,7 +267,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/ProteinListWrapperTest.cpp
+++ b/pwiz/data/proteome/ProteinListWrapperTest.cpp
@@ -113,7 +113,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/ProteomeDataFileTest.cpp
+++ b/pwiz/data/proteome/ProteomeDataFileTest.cpp
@@ -259,7 +259,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/ProteomeDataTest.cpp
+++ b/pwiz/data/proteome/ProteomeDataTest.cpp
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/ReaderTest.cpp
+++ b/pwiz/data/proteome/ReaderTest.cpp
@@ -199,7 +199,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/proteome/Serializer_FASTA_Test.cpp
+++ b/pwiz/data/proteome/Serializer_FASTA_Test.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/tradata/DiffTest.cpp
+++ b/pwiz/data/tradata/DiffTest.cpp
@@ -474,7 +474,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/tradata/IOTest.cpp
+++ b/pwiz/data/tradata/IOTest.cpp
@@ -217,7 +217,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/tradata/ReaderTest.cpp
+++ b/pwiz/data/tradata/ReaderTest.cpp
@@ -202,7 +202,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/tradata/ReferencesTest.cpp
+++ b/pwiz/data/tradata/ReferencesTest.cpp
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/tradata/Serializer_traML_Test.cpp
+++ b/pwiz/data/tradata/Serializer_traML_Test.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/tradata/TraDataFileTest.cpp
+++ b/pwiz/data/tradata/TraDataFileTest.cpp
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/tradata/TraDataTest.cpp
+++ b/pwiz/data/tradata/TraDataTest.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/vendor_readers/ABI/Reader_ABI_Test.cpp
+++ b/pwiz/data/vendor_readers/ABI/Reader_ABI_Test.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/vendor_readers/ABI/T2D/Reader_ABI_T2D_Test.cpp
+++ b/pwiz/data/vendor_readers/ABI/T2D/Reader_ABI_T2D_Test.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/vendor_readers/Agilent/Reader_Agilent_Test.cpp
+++ b/pwiz/data/vendor_readers/Agilent/Reader_Agilent_Test.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.cpp
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.cpp
+++ b/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.cpp
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.cpp
@@ -202,7 +202,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/vendor_readers/UIMF/Reader_UIMF_Test.cpp
+++ b/pwiz/data/vendor_readers/UIMF/Reader_UIMF_Test.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/data/vendor_readers/Waters/Reader_Waters.cpp
+++ b/pwiz/data/vendor_readers/Waters/Reader_Waters.cpp
@@ -182,12 +182,23 @@ void Reader_Waters::read(const string& filename,
         throw ReaderFail(string("[Reader_Waters::read()] Waters API does not support Unicode in filepaths ('") + utf8CharAsString(unicodeCharItr, filename.end()) + "')");
     }
 
-    RawDataPtr rawdata = RawDataPtr(new RawData(filename, config.iterationListenerRegistry));
+    try
+    {
+        RawDataPtr rawdata = RawDataPtr(new RawData(filename, config.iterationListenerRegistry));
 
-    result.run.spectrumListPtr = SpectrumListPtr(new SpectrumList_Waters(result, rawdata, config));
-    result.run.chromatogramListPtr = ChromatogramListPtr(new ChromatogramList_Waters(rawdata));
+        result.run.spectrumListPtr = SpectrumListPtr(new SpectrumList_Waters(result, rawdata, config));
+        result.run.chromatogramListPtr = ChromatogramListPtr(new ChromatogramList_Waters(rawdata));
 
-    fillInMetadata(filename, rawdata, result);
+        fillInMetadata(filename, rawdata, result);
+    }
+    catch (exception& e)
+    {
+        throw_with_trace(e);
+    }
+    catch (...)
+    {
+        throw_with_trace(exception("unknown error opening Waters RAW"));
+    }
 }
 
 

--- a/pwiz/data/vendor_readers/Waters/Reader_Waters_Test.cpp
+++ b/pwiz/data/vendor_readers/Waters/Reader_Waters_Test.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/chemistry/ChemistryTest.cpp
+++ b/pwiz/utility/chemistry/ChemistryTest.cpp
@@ -269,7 +269,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/chemistry/IsotopeCalculatorTest.cpp
+++ b/pwiz/utility/chemistry/IsotopeCalculatorTest.cpp
@@ -187,7 +187,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/chemistry/IsotopeEnvelopeEstimatorTest.cpp
+++ b/pwiz/utility/chemistry/IsotopeEnvelopeEstimatorTest.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/chemistry/IsotopeTableTest.cpp
+++ b/pwiz/utility/chemistry/IsotopeTableTest.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/chemistry/MZToleranceTest.cpp
+++ b/pwiz/utility/chemistry/MZToleranceTest.cpp
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/math/LinearLeastSquaresTest.cpp
+++ b/pwiz/utility/math/LinearLeastSquaresTest.cpp
@@ -195,7 +195,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/math/LinearSolverTest.cpp
+++ b/pwiz/utility/math/LinearSolverTest.cpp
@@ -263,7 +263,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/math/MatchedFilterTest.cpp
+++ b/pwiz/utility/math/MatchedFilterTest.cpp
@@ -222,7 +222,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/math/OrderedPairTest.cpp
+++ b/pwiz/utility/math/OrderedPairTest.cpp
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/math/ParabolaTest.cpp
+++ b/pwiz/utility/math/ParabolaTest.cpp
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/math/StatsTest.cpp
+++ b/pwiz/utility/math/StatsTest.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/math/erfTest.cpp
+++ b/pwiz/utility/math/erfTest.cpp
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/minimxml/SAXParserTest.cpp
+++ b/pwiz/utility/minimxml/SAXParserTest.cpp
@@ -601,7 +601,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/minimxml/XMLWriterTest.cpp
+++ b/pwiz/utility/minimxml/XMLWriterTest.cpp
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/Base64Test.cpp
+++ b/pwiz/utility/misc/Base64Test.cpp
@@ -141,7 +141,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/BinaryDataTest.cpp
+++ b/pwiz/utility/misc/BinaryDataTest.cpp
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/COMInitializerTest.cpp
+++ b/pwiz/utility/misc/COMInitializerTest.cpp
@@ -66,7 +66,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/ClickwrapPrompterTest.cpp
+++ b/pwiz/utility/misc/ClickwrapPrompterTest.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/DateTimeTest.cpp
+++ b/pwiz/utility/misc/DateTimeTest.cpp
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/ExceptionTest.cpp
+++ b/pwiz/utility/misc/ExceptionTest.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/FilesystemTest.cpp
+++ b/pwiz/utility/misc/FilesystemTest.cpp
@@ -268,7 +268,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/IntegerSetTest.cpp
+++ b/pwiz/utility/misc/IntegerSetTest.cpp
@@ -257,7 +257,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
 
     TEST_EPILOG

--- a/pwiz/utility/misc/IterationListenerTest.cpp
+++ b/pwiz/utility/misc/IterationListenerTest.cpp
@@ -264,7 +264,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/SHA1CalculatorTest.cpp
+++ b/pwiz/utility/misc/SHA1CalculatorTest.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/SHA1_ostream_test.cpp
+++ b/pwiz/utility/misc/SHA1_ostream_test.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/TabReaderTest.cpp
+++ b/pwiz/utility/misc/TabReaderTest.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/almost_equal_test.cpp
+++ b/pwiz/utility/misc/almost_equal_test.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/automation_vector_test.cpp
+++ b/pwiz/utility/misc/automation_vector_test.cpp
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/endian_test.cpp
+++ b/pwiz/utility/misc/endian_test.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/misc/mru_list_test.cpp
+++ b/pwiz/utility/misc/mru_list_test.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz/utility/proteome/IPIFASTADatabaseTest.cpp
+++ b/pwiz/utility/proteome/IPIFASTADatabaseTest.cpp
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_aux/Jamfile.jam
+++ b/pwiz_aux/Jamfile.jam
@@ -24,3 +24,7 @@
 build-project-if-exists sfcap ;
 build-project-if-exists msrc ;
 
+project pwiz_aux
+    : requirements
+        <library>/ext/boost//stacktrace
+    ;

--- a/pwiz_aux/msrc/utility/vendor_api/UIMF/Jamfile.jam
+++ b/pwiz_aux/msrc/utility/vendor_api/UIMF/Jamfile.jam
@@ -66,12 +66,12 @@ rule vendor-api-usage-requirements ( properties * )
         if <link>shared in $(properties) || "link=shared" in [ modules.peek : ARGV ]
         {
             result += <library>$(PWIZ_ROOT_PATH)/pwiz/utility/misc//pwiz_utility_misc/<link>shared ;
-            result += <library>$(PWIZ_LIBRARIES_PATH)/SQLite//sqlite3pp/<link>shared ;
+            result += <library>$(PWIZ_LIBRARIES_PATH)/SQLite//sqlite3pp/<link>shared/<debug-symbols>off ;
         }
         else
         {
             result += <library>$(PWIZ_ROOT_PATH)/pwiz/utility/misc//pwiz_utility_misc ;
-            result += <library>$(PWIZ_LIBRARIES_PATH)/SQLite//sqlite3pp ;
+            result += <library>$(PWIZ_LIBRARIES_PATH)/SQLite//sqlite3pp/<debug-symbols>off ;
         }
 
         result += <assembly>$(.dll-location)/UIMFLibrary.dll ;

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/ScanFilterTest.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/ScanFilterTest.cpp
@@ -547,7 +547,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/BiblioSpec/src/BlibBuild.cpp
+++ b/pwiz_tools/BiblioSpec/src/BlibBuild.cpp
@@ -203,6 +203,8 @@ int main(int argc, char* argv[])
             WriteErrorLines(e.what());
             cerr << "ERROR: reading file " << inFiles.at(i) << endl;
             success = false;
+            const boost::stacktrace::stacktrace* st = boost::get_error_info<pwiz::util::traced>(e);
+            if (st) cerr << "ERROR: Stacktrace:\nERROR: " << bal::replace_all_copy(pwiz::util::to_string_brief(*st), "\n", "\nERROR: ") << endl;
         } catch(string s){ // in case a throwParseError is not caught
             failureMessage = s;
             cerr << "ERROR: " << s << endl;

--- a/pwiz_tools/BiblioSpec/src/BuildParser.cpp
+++ b/pwiz_tools/BiblioSpec/src/BuildParser.cpp
@@ -43,7 +43,7 @@ BuildParser::BuildParser(BlibBuilder& maker,
     fileroot_ = getFileRoot(fullFilename_);
 
     preferEmbeddedSpectra_ = maker.preferEmbeddedSpectra().get_value_or(true);
-
+    pwiz::util::throw_with_trace(runtime_error("wtf"));
     this->parentProgress_ = parentProgress_;
     this->readAddProgress_ = NULL;
     this->fileProgress_ = NULL;

--- a/pwiz_tools/BiblioSpec/tests/ExecuteBlib.cpp
+++ b/pwiz_tools/BiblioSpec/tests/ExecuteBlib.cpp
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (const char* msg) {
         TEST_FAILED(msg);

--- a/pwiz_tools/Bumbershoot/freicore/AhoCorasickTrieTest.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/AhoCorasickTrieTest.cpp
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/Bumbershoot/freicore/SearchResultSetTest.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/SearchResultSetTest.cpp
@@ -381,7 +381,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/Bumbershoot/freicore/SharedTests.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/SharedTests.cpp
@@ -432,7 +432,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/Bumbershoot/freicore/percentile_test.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/percentile_test.cpp
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/EmbedderTest.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/EmbedderTest.cpp
@@ -509,7 +509,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/FilterTest.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/FilterTest.cpp
@@ -1459,7 +1459,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/LoggerTest.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/LoggerTest.cpp
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/QonverterTest.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/QonverterTest.cpp
@@ -960,7 +960,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/Jamfile.jam
+++ b/pwiz_tools/Jamfile.jam
@@ -30,3 +30,8 @@ build-project-if-exists BiblioSpec ;
 build-project-if-exists Skyline ;
 build-project-if-exists Topograph ;
 build-project-if-exists sld ;
+
+project pwiz_tools
+    : requirements
+        <library>/ext/boost//stacktrace
+    ;

--- a/pwiz_tools/common/MSDataAnalyzerApplicationTest.cpp
+++ b/pwiz_tools/common/MSDataAnalyzerApplicationTest.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
     }
     catch (exception& e)
     {
-        TEST_FAILED(e.what())
+        TEST_FAILED_EX(e)
     }
     catch (...)
     {

--- a/pwiz_tools/examples/msbenchmark.cpp
+++ b/pwiz_tools/examples/msbenchmark.cpp
@@ -402,6 +402,8 @@ int main(int argc, char* argv[])
     catch (exception& e)
     {
         cerr << e.what() << endl;
+        const boost::stacktrace::stacktrace* st = boost::get_error_info<pwiz::util::traced>(e);
+        if (st) cerr << "Stacktrace:\n" << pwiz::util::to_string_brief(*st) << endl;
     }
     catch (...)
     {


### PR DESCRIPTION
- added stacktraces to exception handlers for unit tests
* added boost::stacktrace lib target in ext-boost.jam
* added pwiz::util::throw_with_trace()
* changed most TEST_FAILED macros to TEST_FAILED_EX which just takes the exception instead of the message, and prints stacktrace if present
* changed a few global build settings for MSVC to make debug symbols leaner but always present; the PDB files are still really big though: probably too big to distribute to users, so I'm still not sure how to get stacktraces from users

@bspratt you might be interested in looking at this. I'm not really happy with the size of the PDBs so I don't see a way to redistribute this to users, but at least it works for developer builds (or rather, it would if I went through and replaced almost all the `throw XXX` calls with `throw_with_trace`).

Probably broken on Linux, let's see.