### PR TITLE
Fix problem where changing the uniqueness constraint in the Peptide S…

### DIFF
--- a/pwiz_tools/Skyline/Model/AuditLog/EnumNames.Designer.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/EnumNames.Designer.cs
@@ -763,6 +763,42 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to gene.
+        /// </summary>
+        public static string PeptideUniquenessConstraint_gene {
+            get {
+                return ResourceManager.GetString("PeptideUniquenessConstraint_gene", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to none.
+        /// </summary>
+        public static string PeptideUniquenessConstraint_none {
+            get {
+                return ResourceManager.GetString("PeptideUniquenessConstraint_none", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to protein.
+        /// </summary>
+        public static string PeptideUniquenessConstraint_protein {
+            get {
+                return ResourceManager.GetString("PeptideUniquenessConstraint_protein", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to species.
+        /// </summary>
+        public static string PeptideUniquenessConstraint_species {
+            get {
+                return ResourceManager.GetString("PeptideUniquenessConstraint_species", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Large.
         /// </summary>
         public static string PointSize_large {

--- a/pwiz_tools/Skyline/Model/AuditLog/EnumNames.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/EnumNames.resx
@@ -504,4 +504,16 @@
   <data name="MzFragmentFinder__m_z__gt__precursor___plus__2" xml:space="preserve">
     <value>(m/z &gt; precursor) + 2</value>
   </data>
+  <data name="PeptideUniquenessConstraint_none" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="PeptideUniquenessConstraint_protein" xml:space="preserve">
+    <value>protein</value>
+  </data>
+  <data name="PeptideUniquenessConstraint_gene" xml:space="preserve">
+    <value>gene</value>
+  </data>
+  <data name="PeptideUniquenessConstraint_species" xml:space="preserve">
+    <value>species</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.Designer.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.Designer.cs
@@ -2158,6 +2158,15 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Peptide Uniqueness.
+        /// </summary>
+        public static string PeptideFilter_PeptideUniqueness {
+            get {
+                return ResourceManager.GetString("PeptideFilter_PeptideUniqueness", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sequence.
         /// </summary>
         public static string PeptideGroupDocNode_Sequence {

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.resx
@@ -1415,4 +1415,7 @@
   <data name="RefinementSettings_MaxPrecursorPeakOnly" xml:space="preserve">
     <value>Max precursor peak only</value>
   </data>
+  <data name="PeptideFilter_PeptideUniqueness" xml:space="preserve">
+    <value>Peptide Uniqueness</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/PeptideSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/PeptideSettings.cs
@@ -864,6 +864,7 @@ namespace pwiz.Skyline.Model.DocSettings
             }
         }
 
+        [Track]
         public PeptideUniquenessConstraint PeptideUniqueness { get; private set; }
 
         #region Property change methods


### PR DESCRIPTION
…ettings dialog does not result in a new Undo record being created.

This was because the "PeptideUniqueness" property was not being tracked by the audit log, and only operations that result in an audit log entry being created also get an undo record.