### PR TITLE
* fixed BiblioSpec tests building in parallel when debug-symbols=on

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -361,8 +361,6 @@ project pwiz
         <variant>debug,<toolset>gcc:<cxxflags>"-include pwiz/utility/misc/Exception.hpp"
         <variant>debug,<toolset>darwin:<cxxflags>"-include pwiz/utility/misc/Exception.hpp"
 
-        <toolset>msvc,<debug-symbols>on:<preserve-test-targets>off # save space on debug builds by deleting test artifacts which run successfully
-
         <conditional>@msvc-runtime-dlls
 
         $(TEAMCITY_TEST_DECORATION)

--- a/pwiz_tools/BiblioSpec/tests/Jamfile.jam
+++ b/pwiz_tools/BiblioSpec/tests/Jamfile.jam
@@ -28,6 +28,7 @@ import sequence ;
 project 
   : requirements
       <link>static
+      <preserve-test-targets>on # necessary because ExecuteBlib.obj is shared between tests
 ;
 
 # extract the input files for the tests


### PR DESCRIPTION
preserve-test-targets=off was deleting the ExecuteBlib.obj file which is shared between all the tests (although I'm not quite sure why it's not renaming the .obj file based on each test's unique name; may want to revisit this later because the pdb files still take up a lot of space after running tests); <preserve-test-targets>off in Jamroot.jam will be moved to TC build commands (--remove-test-targets)