### PR TITLE
* changed CheckUShort to avoid choking on higher point counts from TICs

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -251,7 +251,7 @@ namespace pwiz.Skyline.Model.Results
             _startPeakIndex = startPeakIndex;
             _startScoreIndex = startScoreIndex;
             _maxPeakIndex = maxPeakIndex != -1 ? CheckByte(maxPeakIndex, byte.MaxValue - 1) : NO_MAX_PEAK;
-            _numPoints = CheckUShort(numPoints);
+            _numPoints = numPoints;
             _compressedSize = compressedSize;
             _uncompressedSize = uncompressedSize;
             _locationPoints = location;

--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -251,7 +251,7 @@ namespace pwiz.Skyline.Model.Results
             _startPeakIndex = startPeakIndex;
             _startScoreIndex = startScoreIndex;
             _maxPeakIndex = maxPeakIndex != -1 ? CheckByte(maxPeakIndex, byte.MaxValue - 1) : NO_MAX_PEAK;
-            _numPoints = numPoints;
+            _numPoints = precursor == SignedMz.ZERO ? 0 : CheckUShort(numPoints);
             _compressedSize = compressedSize;
             _uncompressedSize = uncompressedSize;
             _locationPoints = location;


### PR DESCRIPTION
Related email thread:


On 7/26/2019 12:08 PM, Matt Chambers wrote:
The data I were testing were Agilent MRM PerfTest data. I suspect this is the TIC of MS1 only or TIC of all MS levels issue that Brian noted earlier. These large MRM files do have over 100,000 points in their pwiz TIC chromatogram (which in this case it's just reading from the vendor API), which is what the CheckUShort is testing against. There's no precursor or peaks so there's nothing to filter down and interpolate on. In this case, there are also no MS1s. Even if I were able to filter down to just the MS1s (which I'm not able to do for all vendors without enumerating all spectra at InstantMetadata level), this code would assume that either:
1. The TIC is not included in the ChromGroupHeaderInfos
or
2. That all files will have less than 65k MS1s.

I defer to you all whether assumption 1 is valid, and if not (i.e. TIC should be included), assert that assumption 2 is not sustainable (i.e. it won't be long before we see files with 65k+ MS1s if they aren't already out there).

I'm working on the Bruker PerfTest failure now, though it's likely to be along the same lines.


On 7/25/2019 6:02 PM, Brendan MacLean wrote:
> Any good reason it should have 65,535 points in the chromatogram? Seems like something may be wrong with the chromatogram and we are getting a separate point for every IMS frame, rather than every true retention time. Each IMS frame should for a MS1 spectrum should have the same RT and it makes no sense to have a bunch of intensities at a single RT. We should either be getting a separate chromatogram per IMS value or just one with all frames summed.
>
> On Thu, Jul 25, 2019 at 2:44 PM Nick Shulman <nicksh@proteinms.net> wrote:
>
>     That number is the number of points after Skyline has done its interpolation. Skyline always chooses a time interval so that there are not more than 65535 points. This happens in the function PeptideChromDataSets.EnsureMinDelta.
>
>     We have had bugs in the past where that CheckUShort was failing. In one case, I think it was because I was passing in the raw number of points, and I should have instead been passing in the interpolated number of points. Do we think that that is where the failure is happening?
>
>     That num of points stored in the ChromGroupHeaderInfo probably does not get used anywhere, unless the user is saving the Skyline document in a much older format.
>     More recent versions of Skyline all write out the chromatograms in a protocol buffer "ChromatogramGroupData", and it's the number in there "interpolatedNumPoints" that is important.
>
>     -- Nick
>
>
>     On Thu, Jul 25, 2019 at 2:34 PM Brian Pratt <bspratt@proteinms.net> wrote:
>
>         I believe it plans to store it as a ushort?
>
>         On Thu, Jul 25, 2019 at 2:30 PM Chambers, Matthew <matt.chambers42@gmail.com> wrote:
>
>             Huh. Why does ChromGroupHeaderInfo::ctor do this:
>             _numPoints = CheckUShort(numPoints);
>             when _numPoints is an int?