### PR TITLE
Disarm WIFF2 DayOfYear timebomb

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/ExtensionTestContext.cs
+++ b/pwiz_tools/Skyline/TestUtil/ExtensionTestContext.cs
@@ -157,10 +157,9 @@ namespace pwiz.SkylineTestUtil
             get
             {
                 // return false to import mzML
-                return (DateTime.UtcNow.DayOfYear > 240 /* start failing after 8 months into the new year */ ||
-                        (Environment.Is64BitProcess && !Program.SkylineOffscreen &&  /* wiff2 access leaks thread and event handles, so avoid it during nightly tests when offscreen */
-                         (CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator != "," || /* wiff2 access fails under french language settings */
-                          CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator != "\xA0")) /* no break space */ ) ;
+                return (Environment.Is64BitProcess && !Program.SkylineOffscreen &&  /* wiff2 access leaks thread and event handles, so avoid it during nightly tests when offscreen */
+                        (CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator != "," || /* wiff2 access fails under french language settings */
+                         CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator != "\xA0")) /* no break space */ ;
             }
         }
 


### PR DESCRIPTION
* removed WIFF2 DayOfYear timebomb (WIFF2 tests will be disabled for 32-bit or French-like language settings until new SDK is integrated)

@brendanx67 I assume you want this merged to release as well?