### PR TITLE
Fixed issue with non-SPS spectra

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -1334,6 +1334,7 @@ void ScanInfoImpl::initialize()
         {
             // append SPS masses to precursors parsed from filter string
             string spsMassesStr = rawfile_->getTrailerExtraValue(scanNumber_, "SPS Masses:") + rawfile_->getTrailerExtraValue(scanNumber_, "SPS Masses Continued:");
+            bal::trim(spsMassesStr);
             if (!spsMassesStr.empty())
             {
                 vector<string> tokens;


### PR DESCRIPTION
- fixed issue with non-SPS spectra being treated as having multiple precursors, which disabled utilization of the monoisotopic m/z