### PR TITLE
Do not try to find a peak if no explicit peak was found in EnyclopeDI…

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -1215,6 +1215,7 @@ namespace pwiz.Skyline.Model.Lib
                 return null;
             }
             int fileId = _librarySourceFiles[iFile].Id;
+            bool anySequenceMatch = false;
             foreach (var item in LibraryEntriesWithSequences(peptideSequences))
             {
                 ExplicitPeakBounds peakBoundaries;
@@ -1222,6 +1223,19 @@ namespace pwiz.Skyline.Model.Lib
                 {
                     return peakBoundaries;
                 }
+
+                if (item.PeakBoundariesByFileId.Any())
+                {
+                    // If the library has peak boundaries for this sequence in some other file, assume
+                    // that the peptide was just not found in this file.
+                    anySequenceMatch = true;
+                }
+            }
+
+            if (anySequenceMatch)
+            {
+                // If the library has 
+                return ExplicitPeakBounds.EMPTY;
             }
             return null;
         }

--- a/pwiz_tools/Skyline/Model/Lib/EncylopeDiaLibrary.cs
+++ b/pwiz_tools/Skyline/Model/Lib/EncylopeDiaLibrary.cs
@@ -542,6 +542,8 @@ namespace pwiz.Skyline.Model.Lib
             {
                 return null;
             }
+
+            bool anyMatch = false;
             foreach (var entry in LibraryEntriesWithSequences(peptideSequences))
             {
                 FileData fileData;
@@ -549,6 +551,16 @@ namespace pwiz.Skyline.Model.Lib
                 {
                     return fileData.PeakBounds;
                 }
+
+                if (entry.FileDatas.Any())
+                {
+                    anyMatch = true;
+                }
+            }
+
+            if (anyMatch)
+            {
+                return ExplicitPeakBounds.EMPTY;
             }
             return null;
         }

--- a/pwiz_tools/Skyline/Model/Lib/ExplicitPeakBounds.cs
+++ b/pwiz_tools/Skyline/Model/Lib/ExplicitPeakBounds.cs
@@ -23,6 +23,7 @@ namespace pwiz.Skyline.Model.Lib
     public class ExplicitPeakBounds : Immutable
     {
         public const double UNKNOWN_SCORE = double.NaN;
+        public static readonly ExplicitPeakBounds EMPTY = new ExplicitPeakBounds(0, 0, UNKNOWN_SCORE);
 
         public ExplicitPeakBounds(double startTime, double endTime, double score)
         {
@@ -56,6 +57,11 @@ namespace pwiz.Skyline.Model.Lib
                 hashCode = (hashCode * 397) ^ Score.GetHashCode();
                 return hashCode;
             }
+        }
+
+        public bool IsEmpty
+        {
+            get { return StartTime == 0 && EndTime == 0; }
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/Results/ChromData.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromData.cs
@@ -150,7 +150,14 @@ namespace pwiz.Skyline.Model.Results
         {
             Finder = Crawdads.NewCrawdadPeakFinder();
             Finder.SetChromatogram(Times, Intensities);
-            RawPeaks = new [] {Finder.GetPeak(TimeToIndex(peakBounds.StartTime), TimeToIndex(peakBounds.EndTime))};
+            if (peakBounds.IsEmpty)
+            {
+                RawPeaks = new IFoundPeak[0];
+            }
+            else
+            {
+                RawPeaks = new[] { Finder.GetPeak(TimeToIndex(peakBounds.StartTime), TimeToIndex(peakBounds.EndTime)) };
+            }
         }
 
         private int[] TimesToIndices(double[] retentionTimes)

--- a/pwiz_tools/Skyline/Model/Results/ChromDataSet.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataSet.cs
@@ -429,9 +429,12 @@ namespace pwiz.Skyline.Model.Results
 
             }
             var firstChromData = _listChromData.First();
-            var firstPeak = new ChromDataPeak(firstChromData, firstChromData.RawPeaks.First());
-            ChromDataPeakList chromDataPeakList = new ChromDataPeakList(firstPeak, _listChromData);
-            _listPeakSets.Add(chromDataPeakList);
+            if (firstChromData.RawPeaks.Any())
+            {
+                var firstPeak = new ChromDataPeak(firstChromData, firstChromData.RawPeaks.First());
+                ChromDataPeakList chromDataPeakList = new ChromDataPeakList(firstPeak, _listChromData);
+                _listPeakSets.Add(chromDataPeakList);
+            }
         }
         
         /// <summary>

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -202,7 +202,7 @@ namespace pwiz.Skyline.Model.Results
                         if (_fullScan.RetentionTimeFilterType != RetentionTimeFilterType.none)
                         {
                             peakBoundaries = document.Settings.GetExplicitPeakBounds(nodePep, msDataFileUri);
-                            if (peakBoundaries != null)
+                            if (peakBoundaries != null && !peakBoundaries.IsEmpty)
                             {
                                 minTime = peakBoundaries.StartTime - _fullScan.RetentionTimeFilterLength;
                                 maxTime = peakBoundaries.EndTime + _fullScan.RetentionTimeFilterLength;


### PR DESCRIPTION
…A or other library.

If a library such as EncyclopeDIA has explicit peak information for a particular result file, and has explicit peak information for a peptide in other result files, but not the one being asked about, then conclude that the peptide was not found in that particular file.

It used to be that Skyline would then try to do its own peak finding if EncyclopeDIA said it couldn't find a peak for that peptide in that file.
Now what happens is Skyline does not choose a peak at all, and the chromatogram group gets an empty candidate peak list.