### PR TITLE
Skyline/bugfix/20190908 managed mem leaks

### DIFF
--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -313,6 +313,7 @@ namespace pwiz.Skyline
             }
 
             MainWindow = null;
+            SystemEvents.DisplaySettingsChanged -= SystemEventsOnDisplaySettingsChanged;
             return EXIT_CODE_SUCCESS;
         }
 

--- a/pwiz_tools/Skyline/Util/FormEx.cs
+++ b/pwiz_tools/Skyline/Util/FormEx.cs
@@ -77,6 +77,12 @@ namespace pwiz.Skyline.Util
             return _modeUIHelper.Format(format, args);
         }
 
+        protected override void OnHandleDestroyed(EventArgs e)
+        {
+            _modeUIHelper.Dispose();
+            base.OnHandleDestroyed(e);
+        }
+
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public SrmDocument.DOCUMENT_TYPE ModeUI

--- a/pwiz_tools/Skyline/Util/ModeUIAwareForm.cs
+++ b/pwiz_tools/Skyline/Util/ModeUIAwareForm.cs
@@ -113,7 +113,7 @@ namespace pwiz.Skyline.Util
             }
         }
 
-        public class ModeUIAwareFormHelper // Assists in adapting the UI from its traditional proteomic language to small molecule language
+        public class ModeUIAwareFormHelper : IDisposable // Assists in adapting the UI from its traditional proteomic language to small molecule language
         {
             public static ModeUIAwareFormHelper DEFAULT = new ModeUIAwareFormHelper(null);
 
@@ -153,6 +153,15 @@ namespace pwiz.Skyline.Util
             }
 
             #endregion
+
+            public void Dispose()
+            {
+                if (_modeUIToolBarDropDownButton != null)
+                {
+                    _modeUIToolBarDropDownButton.DropDown.Dispose();
+                    _modeUIToolBarDropDownButton = null;
+                }
+            }
 
             public void SetModeUIToolStripButtons(ToolStripDropDownButton modeUIToolBarDropDownButton, Action<SrmDocument.DOCUMENT_TYPE> handler)
             {


### PR DESCRIPTION
Fix newish (in 3.5 and 19.1) leaks in managed memory during FunctionalTests