### PR TITLE
Calibration curve fixes to make ImCal demo (Isotopolog Calibration Cu…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/Calibration/CalibrationForm.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/Calibration/CalibrationForm.cs
@@ -198,23 +198,19 @@ namespace pwiz.Skyline.Controls.Graphs.Calibration
             double minY = double.MaxValue;
             _scatterPlots = new CurveList();
 
-            var sampleTypes = curveFitter.IsotopologResponseCurve
-                ? new[] {SampleType.STANDARD}
-                : SampleType.ListSampleTypes().Where(Options.DisplaySampleType);
+            IEnumerable<SampleType> sampleTypes = SampleType.ListSampleTypes()
+                .Where(Options.DisplaySampleType);
             foreach (var sampleType in sampleTypes)
             {
                 PointPairList pointPairList = new PointPairList();
                 PointPairList pointPairListExcluded = new PointPairList();
                 foreach (var standardIdentifier in curveFitter.EnumerateCalibrationPoints())
                 {
-                    if (null == standardIdentifier.LabelType)
+                    if (!Equals(sampleType, curveFitter.GetSampleType(standardIdentifier)))
                     {
-                        ChromatogramSet chromatogramSet = document.Settings.MeasuredResults.Chromatograms[standardIdentifier.ReplicateIndex];
-                        if (!Equals(sampleType, chromatogramSet.SampleType))
-                        {
-                            continue;
-                        }
+                        continue;
                     }
+
                     double? y = curveFitter.GetYValue(standardIdentifier);
                     double? xCalculated = curveFitter.GetCalculatedXValue(CalibrationCurve, standardIdentifier);
                     double? x = curveFitter.GetSpecifiedXValue(standardIdentifier)
@@ -407,13 +403,24 @@ namespace pwiz.Skyline.Controls.Graphs.Calibration
                     }
                 }
 
-                var quantificationResult = curveFitter.GetQuantificationResult(_skylineWindow.SelectedResultsIndex);
-                if (quantificationResult.CalculatedConcentration.HasValue)
+                QuantificationResult quantificationResult = null;
+                double? calculatedConcentration;
+                if (curveFitter.IsotopologResponseCurve)
+                {
+                    calculatedConcentration =
+                        curveFitter.GetCalculatedConcentration(CalibrationCurve, selectionIdentifier.Value);
+                }
+                else
+                {
+                    quantificationResult = curveFitter.GetQuantificationResult(selectionIdentifier.Value.ReplicateIndex);
+                    calculatedConcentration = quantificationResult?.CalculatedConcentration;
+                }
+                if (calculatedConcentration.HasValue)
                 {
                     labelLines.Add(string.Format(@"{0} = {1}",
-                        QuantificationStrings.Calculated_Concentration, quantificationResult));
+                        QuantificationStrings.Calculated_Concentration, calculatedConcentration));
                 }
-                else if (!quantificationResult.NormalizedArea.HasValue)
+                else if (quantificationResult != null && !quantificationResult.NormalizedArea.HasValue)
                 {
                     labelLines.Add(QuantificationStrings.CalibrationForm_DisplayCalibrationCurve_The_selected_replicate_has_missing_or_truncated_transitions);
                 }
@@ -587,12 +594,10 @@ namespace pwiz.Skyline.Controls.Graphs.Calibration
             if (IsEnableIsotopologResponseCurve())
             {
                 singleBatchContextMenuItem.Visible = true;
-                showSampleTypesContextMenuItem.Visible = false;
             }
             else
             {
                 singleBatchContextMenuItem.Visible = CalibrationCurveFitter.AnyBatchNames(_skylineWindow.Document.Settings);
-                showSampleTypesContextMenuItem.Visible = true;
             }
             var replicateIndexFromPoint = ReplicateIndexFromPoint(mousePt);
             if (replicateIndexFromPoint.HasValue && null == replicateIndexFromPoint.Value.LabelType)

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/PrecursorResult.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/PrecursorResult.cs
@@ -248,12 +248,11 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         }
         private QuantificationResult GetQuantification()
         {
-            if (!Precursor.PrecursorConcentration.HasValue)
+            var calibrationCurveFitter = PeptideResult.GetCalibrationCurveFitter();
+            if (!calibrationCurveFitter.IsotopologResponseCurve)
             {
                 return null;
             }
-
-            var calibrationCurveFitter = PeptideResult.GetCalibrationCurveFitter();
             return calibrationCurveFitter.GetPrecursorQuantificationResult(GetResultFile().Replicate.ReplicateIndex,
                 Precursor.DocNode);
         }

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/CalibrationCurveFitter.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/CalibrationCurveFitter.cs
@@ -127,8 +127,8 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
             {
                 return new IsotopeLabelType[] {null};
             }
-            return PeptideQuantifier.PeptideDocNode.TransitionGroups.Where(tg => tg.PrecursorConcentration.HasValue)
-                .Select(tg => tg.LabelType).Distinct().OrderBy(labelType=>labelType);
+            return PeptideQuantifier.PeptideDocNode.TransitionGroups.Select(tg => tg.LabelType)
+                .Distinct().OrderBy(labelType=>labelType);
         }
 
         public IEnumerable<int> EnumerateReplicates()
@@ -443,6 +443,17 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
                 return PeakAreaRatioText(PeptideQuantifier.MeasuredLabelTypes, PeptideQuantifier.RatioLabelType);
             }
             return QuantificationStrings.CalibrationCurveFitter_GetYAxisTitle_Normalized_Peak_Area;
+        }
+
+        public SampleType GetSampleType(CalibrationPoint calibrationPoint)
+        {
+            if (null == calibrationPoint.LabelType)
+            {
+                ChromatogramSet chromatogramSet = SrmSettings.MeasuredResults.Chromatograms[calibrationPoint.ReplicateIndex];
+                return chromatogramSet.SampleType;
+            }
+
+            return GetSpecifiedXValue(calibrationPoint).HasValue ? SampleType.STANDARD : SampleType.UNKNOWN;
         }
 
         public double? GetSpecifiedXValue(CalibrationPoint calibrationPoint)


### PR DESCRIPTION
…rves) work:

1. On CalibrationForm, display points as either "Standard" or "Unknown" depending on whether the PrecursorConcentration has been set.
2. Make the CalculatedConcentration on the CalibrationForm reflect the currently selected TransitionGroupTreeNode.
3. If the PrecursorConcentration has been specified for any Precursor within a Peptide, then calculate the PrecursorConcentration for all precursors regardless of whether the PrecursorConcentration has been specified for that particular precursor.