### PR TITLE
Add practical support for running perf and tutorial tests on TeamCity

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
@@ -162,6 +162,11 @@ namespace pwiz.SkylineTestUtil
                             if (!Directory.Exists(targetFolder))
                                 Directory.CreateDirectory(targetFolder);
 
+                            bool downloadFromS3 = Environment.GetEnvironmentVariable("SKYLINE_DOWNLOAD_FROM_S3") == "1";
+                            string s3hostname = @"skyline-perftest.s3-us-west-2.amazonaws.com";
+                            if (downloadFromS3)
+                                zipPath = zipPath.Replace(@"skyline.gs.washington.edu", s3hostname).Replace(@"skyline.ms", s3hostname);
+
                             WebClient webClient = new WebClient();
                             using (var fs = new FileSaver(zipFilePath))
                             {

--- a/scripts/misc/tc-perftests.bat
+++ b/scripts/misc/tc-perftests.bat
@@ -1,0 +1,13 @@
+@echo off
+set SKYLINE_DOWNLOAD_PATH=z:\download
+
+REM Remove C++ build artifacts to free up space
+rmdir /s /q build-nt-x86
+
+pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe test=TestTutorial.dll loop=1 language=en perftests=on teamcitytestdecoration=on
+rmdir /s /q %SKYLINE_DOWNLOAD_PATH%
+
+FOR %%I IN (AgilentIMSImportTest,AgilentSpectrumMillRampedIMSImportTest,AgilentSpectrumMillSpectralLibTest,BrukerPasefMascotImportTest,ElectronIonizationAllIonsPerfTest,ImportResultsHugeTest,MeasuredDriftValuesPerfTest,MeasuredInverseK0ValuesPerfTest,NegativeIonDIATest,PeakSortingTest,TestAreaCVHistogramQValuesAndRatios,TestDriftTimePredictorSmallMolecules,TestDriftTimePredictorTutorial,TestHiResMetabolomicsTutorial,TestImportMassOnlyMolecules,TestMinimizeResultsPerformance,TestMs3Chromatograms,TestThermoFAIMS,UniquePeptides0PerfTest,UniquePeptides1PerfTest,UniquePeptides2PerfTest,UniquePeptides3PerfTest,UniquePeptides4PerfTest,UniquePeptides5PerfTest,WatersIMSImportTest,WatersLockmassCmdlinePerfTest,WatersLockmassPerfTest) DO (
+pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe test=%%I loop=1 language=en perftests=on teamcitytestdecoration=on
+rmdir /s /q %SKYLINE_DOWNLOAD_PATH%
+)


### PR DESCRIPTION
* added SKYLINE_DOWNLOAD_FROM_S3 logic to replace perftest and tutorial urls with S3 ones, which download extremely fast on AWS EC2 agents
* added script to run Skyline perf tests one at a time on TC