### PR TITLE
Disable PWIZ_MANAGED_PASSTHROUGH

### DIFF
--- a/pwiz/utility/misc/cpp_cli_utilities.hpp
+++ b/pwiz/utility/misc/cpp_cli_utilities.hpp
@@ -44,7 +44,7 @@
 #include "BinaryData.hpp"
 
 #ifdef __cplusplus_cli
-#define PWIZ_MANAGED_PASSTHROUGH
+//#define PWIZ_MANAGED_PASSTHROUGH
 #endif
 
 namespace pwiz {


### PR DESCRIPTION
to allow Skyline nightly tests to check whether that fixes the TestMs1Tutorial "leak"

@brendanx67 This seems to have changed the memory usage profile in my local testing, but I still don't think it was/is a real leak. PWIZ_MANAGED_PASSTHROUGH certainly changes how the core code uses managed memory instead of native for several of the vendor readers, so I can easily see it breaking the previously acceptable 300kb heuristic. But it is really WEIRD how non-deterministic it is. Makes it seem garbage-collection related. If this fixes the "leak", what then? I don't think I ever did a performance comparison with the passthrough vs without. I should do that in any case.