### PR TITLE
Preserve the original exception if an exception occurs while trying t…

### DIFF
--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -545,10 +545,19 @@ namespace pwiz.Skyline
 
         private static void ReportExceptionUI(Exception exception, StackTrace stackTrace)
         {
-            using (var reportForm = new ReportErrorDlg(exception, stackTrace))
+            try
             {
-                reportForm.ShowDialog(MainWindow);
-            }         
+                using (var reportForm = new ReportErrorDlg(exception, stackTrace))
+                {
+                    reportForm.ShowDialog(MainWindow);
+                }
+            }
+            catch (Exception e2)
+            {
+                // We had an error trying to bring up the ReportErrorDlg.
+                // Skyline is going to shut down, but we want to preserve the original exception.
+                throw new AggregateException(exception, e2);
+            }
         }
 
         public static void AddTestException(Exception exception)

--- a/pwiz_tools/Skyline/TestFunctional/DuplicateTransitionGroupTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DuplicateTransitionGroupTest.cs
@@ -46,20 +46,24 @@ namespace pwiz.SkylineTestFunctional
                 Tuple.Create("ExtraHeavy", (double?) 1),
             };
             var dataGridView = documentGrid.DataGridView;
-            Assert.AreEqual(expectedResults.Length, dataGridView.RowCount);
-            for (int iRow = 0; iRow < expectedResults.Length; iRow++)
+            RunUI(() =>
             {
-                Assert.AreEqual(expectedResults[iRow].Item1, dataGridView.Rows[iRow].Cells[0].Value);
-                if (expectedResults[iRow].Item2 == null)
+                Assert.AreEqual(expectedResults.Length, dataGridView.RowCount);
+                for (int iRow = 0; iRow < expectedResults.Length; iRow++)
                 {
-                    Assert.IsNull(dataGridView.Rows[iRow].Cells[1].Value);
+                    Assert.AreEqual(expectedResults[iRow].Item1, dataGridView.Rows[iRow].Cells[0].Value);
+                    if (expectedResults[iRow].Item2 == null)
+                    {
+                        Assert.IsNull(dataGridView.Rows[iRow].Cells[1].Value);
+                    }
+                    else
+                    {
+                        Assert.IsInstanceOfType(dataGridView.Rows[iRow].Cells[1].Value, typeof(double));
+                        Assert.AreEqual(expectedResults[iRow].Item2.Value,
+                            (double) dataGridView.Rows[iRow].Cells[1].Value, .001);
+                    }
                 }
-                else
-                {
-                    Assert.IsInstanceOfType(dataGridView.Rows[iRow].Cells[1].Value, typeof(double));
-                    Assert.AreEqual(expectedResults[iRow].Item2.Value, (double) dataGridView.Rows[iRow].Cells[1].Value, .001);
-                }
-            }
+            });
         }
     }
 }


### PR DESCRIPTION
…o bring up the ReportErrorDlg.

This will give us better information when dealing with errors such as "current process used too many windows handles"