### PR TITLE
Skyline: Uniprot now just drops the connection when presented with a …

### DIFF
--- a/pwiz_tools/Shared/ProteomeDb/Fasta/WebEnabledFastaImporter.cs
+++ b/pwiz_tools/Shared/ProteomeDb/Fasta/WebEnabledFastaImporter.cs
@@ -1305,6 +1305,10 @@ namespace pwiz.ProteomeDatabase.Fasta
                                 return URL_TOO_LONG; // Probably asked for too many at once, caller will go into batch reduction mode
                         }
                     }
+                    else if (ex.Status == WebExceptionStatus.ConnectionClosed && searchType == UNIPROTKB_TAG) // Uniprot just drops the connection on too-large searches as of Sept 2019
+                    {
+                        return URL_TOO_LONG; // Probably asked for too many at once, caller will go into batch reduction mode
+                    }
                     caught = true;
                 }
                 catch


### PR DESCRIPTION
…too-long search query, so treat that as a cue to back off on protein metadata search batch size