### PR TITLE
ShowDialog timeout set to 3000 to avoid intermittent test failure.

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/AuditLogValidationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AuditLogValidationTest.cs
@@ -48,7 +48,7 @@ namespace pwiz.SkylineTestFunctional
 
             try
             {
-                ShowDialog<MessageDlg>(() => SkylineWindow.OpenFile(documentFile), 200);
+                ShowDialog<MessageDlg>(() => SkylineWindow.OpenFile(documentFile), 3000);
                 Assert.Fail("Failed to open a well-formed document with normal audit log.");
             }
             catch (AssertFailedException)
@@ -80,7 +80,7 @@ namespace pwiz.SkylineTestFunctional
 
             var documentFile = TestFilesDir.GetTestPath(fileName);
             //if no dialog is opened the method will fail on timeout
-            var messageDialog = ShowDialog<MessageDlg>(() => SkylineWindow.OpenFile(documentFile), 200);
+            var messageDialog = ShowDialog<MessageDlg>(() => SkylineWindow.OpenFile(documentFile), 3000);
             //making sure we get the expected error message
             string dialogMessage = "(none)";
             RunUI(() => dialogMessage = messageDialog.Message);


### PR DESCRIPTION
https://skyline.ms/testresults/home/development/Nightly%20x64/showFailures.view?end=09/30/2019&failedTest=TestAuditLogValidation