### PR TITLE
BiblioSpec: fix spectrumNativeID issue for iProphet and 2H element for MaxQuant

### DIFF
--- a/pwiz_tools/BiblioSpec/src/MaxQuantModReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantModReader.cpp
@@ -44,7 +44,7 @@ MaxQuantModReader::MaxQuantModReader(const char* xmlfilename,
     elementMasses_["S"] = 31.97207069;
     elementMasses_["Na"] = 22.98976967;
     // heavy masses
-    elementMasses_["Hx"] = 2.014101778;
+    elementMasses_["Hx"] = elementMasses_["2H"] = 2.014101778;
     elementMasses_["Ox"] = 16.9991315;
     elementMasses_["Cx"] = elementMasses_["13C"] = 13.0033548378;
     elementMasses_["Nx"] = 15.0001088984;

--- a/pwiz_tools/BiblioSpec/src/PepXMLreader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PepXMLreader.cpp
@@ -238,7 +238,8 @@ void PepXMLreader::startElement(const XML_Char* name, const XML_Char** attr)
            scanNumber = getIntRequiredAttrValue("start_scan", attr);
            if (lookUpBy_ == NAME_ID) {
                spectrumName = getRequiredAttrValue("spectrumNativeID", attr);
-           } else if (psms_.empty() && !(spectrumName = getAttrValue("spectrumNativeID", attr)).empty()) {
+           } else if (psms_.empty() && analysisType_ != INTER_PROPHET_ANALYSIS &&
+                      !(spectrumName = getAttrValue("spectrumNativeID", attr)).empty()) {
                // if the file has spectrumNativeIDs, use those for spectrum lookups
                lookUpBy_ = NAME_ID;
            }


### PR DESCRIPTION
BiblioSpec:
- disabled parsing spectrumNativeID attribute for iProphet pepXML
- added support for '2H' element in MaxQuant modifications.xml compositions