### PR TITLE
Fix "Refine > Advanced" max peptide peak rank when there are peptides…

### DIFF
--- a/pwiz_tools/Skyline/EditUI/RefineDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/RefineDlg.cs
@@ -218,7 +218,7 @@ namespace pwiz.Skyline.EditUI
             if (!string.IsNullOrEmpty(textMaxPepPeakRank.Text))
             {
                 int maxVal;
-                if (!helper.ValidateNumberTextBox(textMaxPepPeakRank, 1, 10, out maxVal))
+                if (!helper.ValidateNumberTextBox(textMaxPepPeakRank, 1, 20, out maxVal))
                     return;
                 maxPepPeakRank = maxVal;
             }
@@ -227,7 +227,7 @@ namespace pwiz.Skyline.EditUI
             if (!string.IsNullOrEmpty(textMaxPeakRank.Text))
             {
                 int maxVal;
-                if (!helper.ValidateNumberTextBox(textMaxPeakRank, 1, 10, out maxVal))
+                if (!helper.ValidateNumberTextBox(textMaxPeakRank, 1, 20, out maxVal))
                     return;
                 maxPeakRank = maxVal;
             }

--- a/pwiz_tools/Skyline/Model/RefinementSettings.cs
+++ b/pwiz_tools/Skyline/Model/RefinementSettings.cs
@@ -416,13 +416,21 @@ namespace pwiz.Skyline.Model
                 int countPeps = listPeptides.Count;
                 var listAreaIndexes = new List<PepAreaSortInfo>();
                 var internalStandardTypes = document.Settings.PeptideSettings.Modifications.InternalStandardTypes;
+                var unrankedPeptides = new List<PeptideDocNode>();
                 for (int i = 0; i < countPeps; i++)
                 {
                     var nodePep = listPeptides[i];
                     // Only peptides with children can possible be ranked by area
                     // Those without should be removed by this operation
                     if (nodePep.Children.Count == 0)
-                        continue;                    
+                        continue;     
+                    if (nodePep.GlobalStandardType != null 
+                        || nodePep.TransitionGroups.All(tranGroup=>internalStandardTypes.Contains(tranGroup.LabelType)))
+                    {
+                        // Peptides which are internal standards get added back no matter what
+                        unrankedPeptides.Add(nodePep);
+                        continue;
+                    }
                     int bestResultIndex = (UseBestResult ? nodePep.BestResult : -1);
                     var sortInfo = new PepAreaSortInfo(nodePep, internalStandardTypes, bestResultIndex, listAreaIndexes.Count);
                     listAreaIndexes.Add(sortInfo);
@@ -441,6 +449,7 @@ namespace pwiz.Skyline.Model
 
                 // Add back all peptides with low enough rank.
                 listPeptides.Clear();
+                listPeptides.AddRange(unrankedPeptides);
                 foreach (var areaIndex in arrayAreaIndexes)
                 {
                     if (areaIndex.Area == 0 || areaIndex.Rank > MaxPepPeakRank.Value)


### PR DESCRIPTION
… that only have internal standard precursors.

Increase maximum peptide peak rank from 10 to 20.
(Reported by Lilian).