### PR TITLE
Fix exception viewing spectral library from Pecan.

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -690,7 +690,7 @@ namespace pwiz.Skyline.SettingsUI
                                                                           types,
                                                                           rankCharges,
                                                                           rankTypes,
-                                                                          spectrumInfo.SpectrumHeaderInfo is BiblioSpecSpectrumHeaderInfo bibliospecInfo ? bibliospecInfo.Score : null);
+                                                                          (spectrumInfo?.SpectrumHeaderInfo as BiblioSpecSpectrumHeaderInfo)?.Score);
                         LibraryChromGroup libraryChromGroup = null;
                         if (spectrumInfo != null && _showChromatograms)
                         {


### PR DESCRIPTION
(reported by Tomas)

The RetentionTimes table in a Pecan library always has zero in the "BestSpectrum" column. Because of this, GetSpectra(...,best) always returns null.
We used to handle this gracefully, but recent changes caused this to be a NullReferenceException.