### PR TITLE
Fix TestMs1Tutorial.

### DIFF
--- a/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
@@ -508,7 +508,7 @@ namespace pwiz.SkylineTestTutorial
             {
                 SkylineWindow.SynchronizeZooming(true);
                 SkylineWindow.LockYChrom(false);
-                SkylineWindow.AlignToFile = SkylineWindow.GraphChromatograms.ToArray()[TIP3].GetChromFileInfoId(); // align to Tip3
+                SkylineWindow.AlignToFile = GetGraphChromatogram(TIP3).GetChromFileInfoId(); // align to Tip3
             });
             ZoomBoth(36.5, 39.5, 1600); // simulate the wheel scroll described in tutorial
             RunUI(() => SkylineWindow.ShowChromatogramLegends(false));
@@ -631,6 +631,12 @@ namespace pwiz.SkylineTestTutorial
             RunUI(SkylineWindow.NewDocument);
         }
 
+        private GraphChromatogram GetGraphChromatogram(int chromIndex)
+        {
+            string replicateName = SkylineWindow.Document.Settings.MeasuredResults.Chromatograms[chromIndex].Name;
+            return SkylineWindow.GraphChromatograms.FirstOrDefault(chrom => chrom.NameSet == replicateName);
+        }
+
         private void VerifyLib(string[] expectedPaths, int expectedSpectra, string[] foundPaths, int foundSpectra,
             string sourceMessage, string buildArgs, string buildOutput)
         {
@@ -652,7 +658,7 @@ namespace pwiz.SkylineTestTutorial
 
         private void ZoomSingle(int index, double startTime, double endTime, double? y = null)
         {
-            RunUI(() => SkylineWindow.GraphChromatograms.ToArray()[index].ZoomTo(startTime, endTime, y));
+            RunUI(() => GetGraphChromatogram(index).ZoomTo(startTime, endTime, y));
             WaitForGraphs();            
         }
 
@@ -687,7 +693,7 @@ namespace pwiz.SkylineTestTutorial
             {
                 var pathPep = SkylineWindow.DocumentUI.GetPathTo((int) SrmDocument.Level.Molecules, pepIndex);
                 SkylineWindow.SelectedPath = pathPep;
-                var graphChrom = SkylineWindow.GraphChromatograms.ToArray()[chromIndex];
+                var graphChrom = GetGraphChromatogram(chromIndex);
                 // ToArray in RunUI() to avoid trying to enumerate off the UI thread
                 result = graphChrom.GetAnnotationLabelStrings().ToArray();
             });
@@ -703,7 +709,7 @@ namespace pwiz.SkylineTestTutorial
                 var nodeTran = nodeGroup.Transitions.First();
                 for (int i = 0; i < 2; i++)
                 {
-                    var graph = SkylineWindow.GraphChromatograms.ToArray()[i];
+                    var graph = GetGraphChromatogram(i);
                     var approxRT = ((i == 1) ? rt1 : rt0);
                     TransitionGroupDocNode nodeGroupGraph;
                     TransitionDocNode nodeTranGraph;
@@ -751,7 +757,7 @@ namespace pwiz.SkylineTestTutorial
                 SkylineWindow.SelectedPath = pathPep;
 
                 var nodeGroup = SkylineWindow.DocumentUI.Peptides.ElementAt(pepIndex).TransitionGroups.First();
-                var graphChrom = SkylineWindow.GraphChromatograms.ToArray()[chromIndex];
+                var graphChrom = GetGraphChromatogram(chromIndex);
 
                 var listChanges = new List<ChangedPeakBoundsEventArgs>
                 {


### PR DESCRIPTION
The order of the items in SkylineWindow.GraphChromatograms changed because of recent "MRU chromatogram" change.