### PR TITLE
Revert "[mz5] fixed typo in data set ChromatogramTime"

### DIFF
--- a/pwiz/data/msdata/ChromatogramList_mz5.cpp
+++ b/pwiz/data/msdata/ChromatogramList_mz5.cpp
@@ -258,7 +258,7 @@ ChromatogramPtr ChromatogramList_mz5Impl::chromatogram(size_t index, bool getBin
         {
             if (!binaryParamList_[index].empty()) {
                 std::vector<double> time, inten;
-                conn_->getData(time, Configuration_mz5::ChromatogramTime, start, end);
+                conn_->getData(time, Configuration_mz5::ChomatogramTime, start, end);
                 conn_->getData(inten, Configuration_mz5::ChromatogramIntensity, start, end);
                 ptr->setTimeIntensityArrays(time, inten, CVID_Unknown, CVID_Unknown);
                 // time and intensity unit will be set by the following command

--- a/pwiz/data/msdata/mz5/Configuration_mz5.cpp
+++ b/pwiz/data/msdata/mz5/Configuration_mz5.cpp
@@ -117,8 +117,8 @@ void Configuration_mz5::init(const bool deltamz,
             "SpectrumMZ"));
     variableNames_.insert(std::pair<MZ5DataSets, std::string>(
             SpectrumIntensity, "SpectrumIntensity"));
-    variableNames_.insert(std::pair<MZ5DataSets, std::string>(ChromatogramTime,
-            "ChromatogramTime"));
+    variableNames_.insert(std::pair<MZ5DataSets, std::string>(ChomatogramTime,
+            "ChomatogramTime"));
     variableNames_.insert(std::pair<MZ5DataSets, std::string>(
             ChromatogramIntensity, "ChromatogramIntensity"));
     variableNames_.insert(std::pair<MZ5DataSets, std::string>(FileInformation,
@@ -237,12 +237,12 @@ void Configuration_mz5::init(const bool deltamz,
 
     if (timeprec == pwiz::msdata::BinaryDataEncoder::Precision_64)
     {
-        variableTypes_.insert(std::pair<MZ5DataSets, DataType>(ChromatogramTime,
+        variableTypes_.insert(std::pair<MZ5DataSets, DataType>(ChomatogramTime,
                 PredType::NATIVE_DOUBLE));
     }
     else if (timeprec == pwiz::msdata::BinaryDataEncoder::Precision_32)
     {
-        variableTypes_.insert(std::pair<MZ5DataSets, DataType>(ChromatogramTime,
+        variableTypes_.insert(std::pair<MZ5DataSets, DataType>(ChomatogramTime,
                 PredType::NATIVE_FLOAT));
     }
     else
@@ -269,7 +269,7 @@ void Configuration_mz5::init(const bool deltamz,
             spectrumChunkSize));
     variableChunkSizes_.insert(std::pair<MZ5DataSets, hsize_t>(
             SpectrumIntensity, spectrumChunkSize));
-    variableChunkSizes_.insert(std::pair<MZ5DataSets, hsize_t>(ChromatogramTime,
+    variableChunkSizes_.insert(std::pair<MZ5DataSets, hsize_t>(ChomatogramTime,
             chromatogramChunkSize));
     variableChunkSizes_.insert(std::pair<MZ5DataSets, hsize_t>(
             ChromatogramIntensity, chromatogramChunkSize));
@@ -289,7 +289,7 @@ void Configuration_mz5::init(const bool deltamz,
             spectrumBufferSize));
     variableBufferSizes_.insert(std::pair<MZ5DataSets, size_t>(
             SpectrumIntensity, spectrumBufferSize));
-    variableBufferSizes_.insert(std::pair<MZ5DataSets, size_t>(ChromatogramTime,
+    variableBufferSizes_.insert(std::pair<MZ5DataSets, size_t>(ChomatogramTime,
             chromatogramBufferSize));
     variableBufferSizes_.insert(std::pair<MZ5DataSets, size_t>(
             ChromatogramIntensity, chromatogramBufferSize));
@@ -342,13 +342,6 @@ Configuration_mz5::MZ5DataSets Configuration_mz5::getVariableFor(
     {
         return variableVariables_.find(name)->second;
     }
-
-    //spelling error - backward compatibility
-    if (name == "ChomatogramTime")
-    {
-        return variableVariables_.find("ChromatogramTime")->second;
-    }
-
     throw std::out_of_range("[Configurator_mz5::getVariableFor]: out of range");
 }
 

--- a/pwiz/data/msdata/mz5/Configuration_mz5.hpp
+++ b/pwiz/data/msdata/mz5/Configuration_mz5.hpp
@@ -176,7 +176,7 @@ public:
         /**
          * Dataset containing all time values.
          */
-        ChromatogramTime,
+        ChomatogramTime,
         /**
          * Dataset containing all chromatogram intensities.
          */

--- a/pwiz/data/msdata/mz5/ReferenceWrite_mz5.cpp
+++ b/pwiz/data/msdata/mz5/ReferenceWrite_mz5.cpp
@@ -455,7 +455,7 @@ pwiz::util::IterationListener::Status ReferenceWrite_mz5::readAndWriteChromatogr
                         {
                             accIndex += (unsigned long)inten.size();
                             connection.extendData(time,
-                                    Configuration_mz5::ChromatogramTime);
+                                    Configuration_mz5::ChomatogramTime);
                             connection.extendData(inten,
                                     Configuration_mz5::ChromatogramIntensity);
                         }


### PR DESCRIPTION
Reverts ProteoWizard/pwiz#643

The backward compatibility bit isn't enough. It causes an error in old files:
```
[10:15]   1.0   zzzNativeVsMz5_ThermoDdaVChromatogramPerformanceTest (en) HDF5-DIAG: Error detected in HDF5 (1.8.7) thread 10508:
  #000: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5D.c line 334 in H5Dopen2(): not found
    major: Dataset
    minor: Object not found
  #001: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5Gloc.c line 430 in H5G_loc_find(): can't find object
    major: Symbol table
    minor: Object not found
  #002: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5Gtraverse.c line 905 in H5G_traverse(): internal path traversal failed
    major: Symbol table
    minor: Object not found
  #003: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5Gtraverse.c line 688 in H5G_traverse_real(): traversal operator failed
    major: Symbol table
    minor: Callback failed
  #004: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5Gloc.c line 385 in H5G_loc_find_cb(): object 'ChromatogramTime' doesn't exist
    major: Symbol table
    minor: Object not found
HDF5-DIAG: Error detected in HDF5 (1.8.7) thread 10508:
  #000: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5D.c line 334 in H5Dopen2(): not found
    major: Dataset
    minor: Object not found
  #001: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5Gloc.c line 430 in H5G_loc_find(): can't find object
    major: Symbol table
    minor: Object not found
  #002: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5Gtraverse.c line 905 in H5G_traverse(): internal path traversal failed
    major: Symbol table
    minor: Object not found
  #003: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5Gtraverse.c line 688 in H5G_traverse_real(): traversal operator failed
    major: Symbol table
    minor: Callback failed
  #004: C:\pwiz.git\pwiz\libraries\hdf5-1.8.7\src\H5Gloc.c line 385 in H5G_loc_find_cb(): object 'ChromatogramTime' doesn't exist
    major: Symbol table
```
Any ideas @jeleclaire ? If not I can look at it later. When recommitting this we'll need a test to make sure it works on old mz5s (most of our pwiz serialization tests work by first writing out the file with the current code then making sure we can read it back in and get the same result). We caught this with the Skyline perf tests zzzNativeVsMz5_* which I decided not run on TeamCity because the mz5s are too big. I may revisit that decision...