### PR TITLE
Various pwiz core fixes

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
@@ -210,11 +210,15 @@ SpectrumListPtr filterCreator_scanTime(const MSData& msd, const string& arg, pwi
 {
     double scanTimeLow = 0;
     double scanTimeHigh = 0;
+    LocaleBool assumeSorted = true;
 
     istringstream iss(arg);
     char open='\0', comma='\0', close='\0';
     iss >> open >> scanTimeLow >> comma >> scanTimeHigh >> close;
-
+    
+    if (iss.good())
+        iss >> assumeSorted;
+    cout << assumeSorted << endl;
     if (open!='[' || comma!=',' || close!=']')
     {
         cerr << "scanTime filter argument does not have form \"[\"<startTime>,<endTime>\"]\", ignored." << endl;
@@ -223,7 +227,7 @@ SpectrumListPtr filterCreator_scanTime(const MSData& msd, const string& arg, pwi
 
     return SpectrumListPtr(new
         SpectrumList_Filter(msd.run.spectrumListPtr, 
-                            SpectrumList_FilterPredicate_ScanTimeRange(scanTimeLow, scanTimeHigh)));
+                            SpectrumList_FilterPredicate_ScanTimeRange(scanTimeLow, scanTimeHigh, assumeSorted)));
 }
 UsageInfo usage_scanTime = {"<scan_time_range>",
     "This filter selects only spectra within a given time range.\n"

--- a/pwiz/analysis/spectrum_processing/SpectrumListFactoryTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactoryTest.cpp
@@ -90,20 +90,38 @@ void testWrap()
 
 void testWrapScanTimeRange()
 {
-    MSData msd;
-    examples::initializeTiny(msd);
+    {
+        MSData msd;
+        examples::initializeTiny(msd);
 
-    SpectrumListPtr& sl = msd.run.spectrumListPtr;
-    unit_assert(sl.get());
-    unit_assert(sl->size() > 2);
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert(sl.get());
+        unit_assert(sl->size() > 2);
 
-    double timeHighInSeconds = 5.9 * 60; // between first and second scan
-    ostringstream oss;
-    oss << "scanTime [0," << timeHighInSeconds << "]";
-    SpectrumListFactory::wrap(msd, oss.str());
-    unit_assert(sl->size() == 2);
-    unit_assert(sl->spectrumIdentity(0).id == "scan=19");
-    unit_assert(sl->spectrumIdentity(1).id == "sample=1 period=1 cycle=23 experiment=1"); // not in scan time order (42 seconds)
+        double timeHighInSeconds = 5.9 * 60; // between first and second scan
+        ostringstream oss;
+        oss << "scanTime [0," << timeHighInSeconds << "]";
+        SpectrumListFactory::wrap(msd, oss.str());
+        unit_assert(sl->size() == 1);
+        unit_assert(sl->spectrumIdentity(0).id == "scan=19");
+    }
+
+    {
+        MSData msd;
+        examples::initializeTiny(msd);
+
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert(sl.get());
+        unit_assert(sl->size() > 2);
+
+        double timeHighInSeconds = 5.9 * 60; // between first and second scan
+        ostringstream oss;
+        oss << "scanTime [0," << timeHighInSeconds << "] false";
+        SpectrumListFactory::wrap(msd, oss.str());
+        unit_assert(sl->size() == 2);
+        unit_assert(sl->spectrumIdentity(0).id == "scan=19");
+        unit_assert(sl->spectrumIdentity(1).id == "sample=1 period=1 cycle=23 experiment=1"); // not in scan time order (42 seconds)
+    }
 }
 
 

--- a/pwiz/analysis/spectrum_processing/SpectrumList_Filter.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_Filter.cpp
@@ -271,8 +271,8 @@ PWIZ_API_DECL boost::logic::tribool SpectrumList_FilterPredicate_ScanEventSet::a
 //
 
 
-PWIZ_API_DECL SpectrumList_FilterPredicate_ScanTimeRange::SpectrumList_FilterPredicate_ScanTimeRange(double scanTimeLow, double scanTimeHigh)
-:   scanTimeLow_(scanTimeLow), scanTimeHigh_(scanTimeHigh)
+PWIZ_API_DECL SpectrumList_FilterPredicate_ScanTimeRange::SpectrumList_FilterPredicate_ScanTimeRange(double scanTimeLow, double scanTimeHigh, bool assumeSorted)
+:   scanTimeLow_(scanTimeLow), scanTimeHigh_(scanTimeHigh), eos_(false), assumeSorted_(assumeSorted)
 {}
 
 
@@ -291,7 +291,14 @@ PWIZ_API_DECL boost::logic::tribool SpectrumList_FilterPredicate_ScanTimeRange::
     if (param.cvid == CVID_Unknown) return boost::logic::indeterminate;
     double time = param.timeInSeconds();
 
+    eos_ = assumeSorted_ && time > scanTimeHigh_;
     return (time>=scanTimeLow_ && time<=scanTimeHigh_);
+}
+
+
+PWIZ_API_DECL bool SpectrumList_FilterPredicate_ScanTimeRange::done() const
+{
+    return eos_; // end of set
 }
 
 

--- a/pwiz/analysis/spectrum_processing/SpectrumList_Filter.hpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_Filter.hpp
@@ -161,14 +161,17 @@ class PWIZ_API_DECL SpectrumList_FilterPredicate_ScanEventSet : public SpectrumL
 class PWIZ_API_DECL SpectrumList_FilterPredicate_ScanTimeRange : public SpectrumList_Filter::Predicate
 {
     public:
-    SpectrumList_FilterPredicate_ScanTimeRange(double scanTimeLow, double scanTimeHigh);
+    SpectrumList_FilterPredicate_ScanTimeRange(double scanTimeLow, double scanTimeHigh, bool assumeSorted = true);
     virtual boost::logic::tribool accept(const msdata::SpectrumIdentity& spectrumIdentity) const;
     virtual boost::logic::tribool accept(const msdata::Spectrum& spectrum) const;
+    virtual bool done() const;
     virtual std::string describe() const { return "scan time range"; }
 
     private:
     double scanTimeLow_;
     double scanTimeHigh_;
+    mutable bool eos_;
+    bool assumeSorted_;
 };
 
 

--- a/pwiz/analysis/spectrum_processing/ThresholdFilter.cpp
+++ b/pwiz/analysis/spectrum_processing/ThresholdFilter.cpp
@@ -125,6 +125,13 @@ void setXYPlusPairs(Spectrum& s, XYPlusPair* input, size_t size, CVID yUnits, co
 
     double* bdX = &x[0];
     double* bdY = &y[0];
+    vector<double*> bdExtra(extraArrays.size());
+    for (size_t i = 0; i < extraArrays.size(); ++i)
+    {
+        extraArrays[i]->resize(size);
+        bdExtra[i] = &(*extraArrays[i])[0];
+    }
+
     for (const XYPlusPair& pair : boost::iterator_range<XYPlusPair*>(input, input+size))
     {
         *bdX++ = pair.x;
@@ -132,7 +139,7 @@ void setXYPlusPairs(Spectrum& s, XYPlusPair* input, size_t size, CVID yUnits, co
         if (pair.extra.size() != end)
             throw runtime_error("[setXYPlusPairs] pair has mismatched number of extra values");
         for (size_t i = 0; i < end; ++i)
-            extraArrays[i]->push_back(pair.extra[i]);
+            (*bdExtra[i] = pair.extra[i])++;
     }
 
     s.defaultArrayLength = size;

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -563,9 +563,11 @@ struct double3_policy : boost::spirit::karma::real_policies<T>
     static bool trailing_zeros(T) { return false; }
 
     template <typename OutputIterator>
-    static bool dot(OutputIterator&, T, unsigned int precision)
+    static bool dot(OutputIterator& sink, T n, unsigned int precision)
     {
-        return precision > 0;
+        if (precision == 0)
+            return false;
+        return boost::spirit::karma::real_policies<T>::dot(sink, n, precision);
     }
 };
 

--- a/pwiz/utility/misc/FilesystemTest.cpp
+++ b/pwiz/utility/misc/FilesystemTest.cpp
@@ -238,6 +238,10 @@ void testAbbreviateByteSize()
     unit_assert_operator_equal("1 MB", abbreviate_byte_size(1000000));
     unit_assert_operator_equal("999 MB", abbreviate_byte_size(999000000));
     unit_assert_operator_equal("1 GB", abbreviate_byte_size(1000000000));
+    unit_assert_operator_equal("100 GB", abbreviate_byte_size(100000000000));
+    unit_assert_operator_equal("1.23 KB", abbreviate_byte_size(1230));
+    unit_assert_operator_equal("12.3 KB", abbreviate_byte_size(12300));
+    unit_assert_operator_equal("123 KB", abbreviate_byte_size(123000));
 
     unit_assert_operator_equal("1 B", abbreviate_byte_size(1, ByteSizeAbbreviation_IEC));
     unit_assert_operator_equal("1023 B", abbreviate_byte_size(1023, ByteSizeAbbreviation_IEC));

--- a/pwiz/utility/misc/SHA1.cpp
+++ b/pwiz/utility/misc/SHA1.cpp
@@ -21,7 +21,7 @@
 #include <boost/interprocess/mapped_region.hpp>
 
 #ifdef SHA1_UTILITY_FUNCTIONS
-#define SHA1_MAX_FILE_BUFFER 8000
+#define SHA1_MAX_FILE_BUFFER (32 * 20 * 820)
 #endif
 
 // Rotate x bits to the left
@@ -156,7 +156,7 @@ bool CSHA1::HashFile(const TCHAR* tszFileName)
 		const INT_64 fileSize = (INT_64)boost::filesystem::file_size(tszFileName);
 
 		// don't use a 32-bit process's entire address space, but 64-bit processes can just use the file size
-		const INT_64 maxRegionSize = sizeof(void*) == 8 ? fileSize : (1 << 30);
+        const INT_64 maxRegionSize = std::min(fileSize, (1ll << 30));
 		const INT_64 lMaxBuf = SHA1_MAX_FILE_BUFFER;
 
 		using namespace boost::interprocess;

--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
@@ -374,6 +374,12 @@ class ShimadzuReaderImpl : public ShimadzuReader
 
         System::DateTime acquisitionTime = dataObject_->SampleInfo->AnalysisDate.ToUniversalTime();
 
+        // these are Boost.DateTime restrictions enforced because one of the test files had a corrupt date
+        if (acquisitionTime.Year > 10000)
+            acquisitionTime = acquisitionTime.AddYears(10000 - acquisitionTime.Year);
+        else if (acquisitionTime.Year < 1400)
+            acquisitionTime = acquisitionTime.AddYears(1400 - acquisitionTime.Year);
+
         bpt::ptime pt(boost::gregorian::date(acquisitionTime.Year, boost::gregorian::greg_month(acquisitionTime.Month), acquisitionTime.Day),
                       bpt::time_duration(acquisitionTime.Hour, acquisitionTime.Minute, acquisitionTime.Second, bpt::millisec(acquisitionTime.Millisecond).fractional_seconds()));
 


### PR DESCRIPTION
- changed ScanTime filter to stop enumerating by default after the upper end of the time range is reached; new assumeSorted parameter can disable that optimization, but it's not yet accessible in msconvert(GUI)
- fixed excessive memory usage of 64-bit SHA1 calculation
- fixed abbreviate_byte_size not printing decimal dot (used by msbenchmark to report memory usage for example)
- optimized performance of thresholding filter for 3-array ion mobility data
- fixed Shimadzu reader for files with invalid date (apologies if you collected your data in the middle ages or after the year 10000)

@brendanx67 I expect this will be merged to master today or tomorrow. It's been sitting on my drive for weeks. Shouldn't affect Skyline.