### PR TITLE
Display Skyline document import progress

### DIFF
--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -3428,12 +3428,21 @@ namespace pwiz.Skyline
                     }
                     else
                     {
-                        _statusWriter.WriteLine(
-                            Resources.PanoramaPublishHelper_PublishDocToPanorama_An_error_occurred_on_the_Panorama_server___0___importing_the_file_, 
-                            panoramaEx.ServerUrl);
-                        _statusWriter.WriteLine(
-                            Resources.PanoramaPublishHelper_PublishDocToPanorama_Error_details_can_be_found_at__0_,
-                            panoramaEx.JobUrl);
+                        if (panoramaEx.JobCancelled)
+                        {
+                            _statusWriter.WriteLine(Resources.PanoramaPublishHelper_PublishDocToPanorama_Document_import_was_cancelled_on_the_Panorama_server__0__, panoramaEx.ServerUrl);
+                            _statusWriter.WriteLine(Resources.PanoramaPublishHelper_PublishDocToPanorama_Job_details_can_be_found_at__0__, panoramaEx.JobUrl);
+                        }
+                        else
+                        {
+                            _statusWriter.WriteLine(
+                                Resources
+                                    .PanoramaPublishHelper_PublishDocToPanorama_An_error_occurred_on_the_Panorama_server___0___importing_the_file_,
+                                panoramaEx.ServerUrl);
+                            _statusWriter.WriteLine(
+                                Resources.PanoramaPublishHelper_PublishDocToPanorama_Error_details_can_be_found_at__0_,
+                                panoramaEx.JobUrl);
+                        }
                     }
                 }
             }

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -329,6 +329,16 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Document import was cancelled on the server. Would you like to go to Panorama?.
+        /// </summary>
+        public static string AbstractPanoramaPublishClient_UploadSharedZipFile_Document_import_was_cancelled_on_the_server__Would_you_like_to_go_to_Panorama_ {
+            get {
+                return ResourceManager.GetString("AbstractPanoramaPublishClient_UploadSharedZipFile_Document_import_was_cancelled_o" +
+                        "n_the_server__Would_you_like_to_go_to_Panorama_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Upload succeeded, would you like to view the file in Panorama?.
         /// </summary>
         public static string AbstractPanoramaPublishClient_UploadSharedZipFile_Upload_succeeded__would_you_like_to_view_the_file_in_Panorama_ {
@@ -18973,11 +18983,30 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Document import was cancelled on the Panorama server {0}..
+        /// </summary>
+        public static string PanoramaPublishHelper_PublishDocToPanorama_Document_import_was_cancelled_on_the_Panorama_server__0__ {
+            get {
+                return ResourceManager.GetString("PanoramaPublishHelper_PublishDocToPanorama_Document_import_was_cancelled_on_the_P" +
+                        "anorama_server__0__", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error details can be found at {0}.
         /// </summary>
         public static string PanoramaPublishHelper_PublishDocToPanorama_Error_details_can_be_found_at__0_ {
             get {
                 return ResourceManager.GetString("PanoramaPublishHelper_PublishDocToPanorama_Error_details_can_be_found_at__0_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Job details can be found at {0}..
+        /// </summary>
+        public static string PanoramaPublishHelper_PublishDocToPanorama_Job_details_can_be_found_at__0__ {
+            get {
+                return ResourceManager.GetString("PanoramaPublishHelper_PublishDocToPanorama_Job_details_can_be_found_at__0__", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -25594,6 +25594,26 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Opening a document inside a ZIP file is not supported..
+        /// </summary>
+        public static string SkylineWindow_HasFileToOpen_Opening_a_document_inside_a_ZIP_file_is_not_supported_ {
+            get {
+                return ResourceManager.GetString("SkylineWindow_HasFileToOpen_Opening_a_document_inside_a_ZIP_file_is_not_supported" +
+                        "_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unzip the file {0} first and then open the extracted file {1}..
+        /// </summary>
+        public static string SkylineWindow_HasFileToOpen_Unzip_the_file__0__first_and_then_open_the_extracted_file__1__ {
+            get {
+                return ResourceManager.GetString("SkylineWindow_HasFileToOpen_Unzip_the_file__0__first_and_then_open_the_extracted_" +
+                        "file__1__", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Import Annotations.
         /// </summary>
         public static string SkylineWindow_ImportAnnotations_Import_Annotations {

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -10883,4 +10883,13 @@ Click 'Retry' to try building again with original spectrum files placed next to 
   <data name="SkylineWindow_HasFileToOpen_Opening_a_document_inside_a_ZIP_file_is_not_supported_" xml:space="preserve">
     <value>Opening a document inside a ZIP file is not supported.</value>
   </data>
+  <data name="PanoramaPublishHelper_PublishDocToPanorama_Document_import_was_cancelled_on_the_Panorama_server__0__" xml:space="preserve">
+    <value>Document import was cancelled on the Panorama server {0}.</value>
+  </data>
+  <data name="PanoramaPublishHelper_PublishDocToPanorama_Job_details_can_be_found_at__0__" xml:space="preserve">
+    <value>Job details can be found at {0}.</value>
+  </data>
+  <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_Document_import_was_cancelled_on_the_server__Would_you_like_to_go_to_Panorama_" xml:space="preserve">
+    <value>Document import was cancelled on the server. Would you like to go to Panorama?</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -10877,4 +10877,10 @@ Click 'Retry' to try building again with original spectrum files placed next to 
   <data name="SkylineWindow_ImportResults_Are_you_sure__Peak_scoring_models_trained_with_non_matching_targets_and_decoys_may_produce_incorrect_results_" xml:space="preserve">
     <value>Are you sure? Peak scoring models trained with non-matching targets and decoys may produce incorrect results.</value>
   </data>
+  <data name="SkylineWindow_HasFileToOpen_Unzip_the_file__0__first_and_then_open_the_extracted_file__1__" xml:space="preserve">
+    <value>Unzip the file {0} first and then open the extracted file {1}.</value>
+  </data>
+  <data name="SkylineWindow_HasFileToOpen_Opening_a_document_inside_a_ZIP_file_is_not_supported_" xml:space="preserve">
+    <value>Opening a document inside a ZIP file is not supported.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -273,7 +273,7 @@ namespace pwiz.Skyline
         {
             base.OnShown(e);
 
-            if (_fileToOpen != null)
+            if (HasFileToOpen())
             {
                 try
                 {
@@ -281,12 +281,31 @@ namespace pwiz.Skyline
                 }
                 catch (UriFormatException)
                 {
-                    MessageBox.Show(this, Resources.SkylineWindow_SkylineWindow_Invalid_file_specified, Program.Name);
+                    MessageDlg.Show(this, Resources.SkylineWindow_SkylineWindow_Invalid_file_specified);
                 }
-                _fileToOpen = null;
             }
+            _fileToOpen = null;
 
             EnsureUIModeSet();
+        }
+
+        private bool HasFileToOpen()
+        {
+            if (_fileToOpen == null)
+                return false;
+
+            string parentDir = Path.GetDirectoryName(_fileToOpen);
+            // If the parent directory ends with .zip and lives in AppData\Local\Temp
+            // then the user has double-clicked a file in Windows Explorer inside a ZIP file
+            if (parentDir != null && PathEx.HasExtension(parentDir, @".zip") &&
+                parentDir.ToLower().Contains(@"appdata\local\temp"))
+            {
+                MessageDlg.Show(this, TextUtil.LineSeparate(Resources.SkylineWindow_HasFileToOpen_Opening_a_document_inside_a_ZIP_file_is_not_supported_,
+                    string.Format(Resources.SkylineWindow_HasFileToOpen_Unzip_the_file__0__first_and_then_open_the_extracted_file__1__, Path.GetFileName(parentDir), Path.GetFileName(_fileToOpen))));
+                return false;
+            }
+
+            return true;
         }
 
         public void OpenPasteFileDlg(PasteFormat pf)

--- a/pwiz_tools/Skyline/Util/PanoramaUtil.cs
+++ b/pwiz_tools/Skyline/Util/PanoramaUtil.cs
@@ -65,7 +65,7 @@ namespace pwiz.Skyline.Util
         {
             const string https = "https://";
             const string http = "http://";
-
+            
             var httpsIndex = serverName.IndexOf(https, StringComparison.Ordinal);
             var httpIndex = serverName.IndexOf(http, StringComparison.Ordinal);
 
@@ -107,7 +107,7 @@ namespace pwiz.Skyline.Util
         public static UserState ValidateServerAndUser(ref Uri serverUri, string username, string password)
         {
             var pServer = new PanoramaServer(serverUri, username, password);
-
+           
             try
             {
                 var userState = EnsureLogin(pServer);
@@ -313,7 +313,7 @@ namespace pwiz.Skyline.Util
         {
             byte[] authBytes = Encoding.UTF8.GetBytes(String.Format(@"{0}:{1}", username, password));
             var authHeader = @"Basic " + Convert.ToBase64String(authBytes);
-            return authHeader;
+            return authHeader;   
         }
 
         #region Implementation of IXmlSerializable
@@ -448,7 +448,7 @@ namespace pwiz.Skyline.Util
 
         public WebPanoramaClient(Uri server)
         {
-            ServerUri = server;
+            ServerUri = server;       
         }
 
         public ServerState GetServerState()
@@ -488,7 +488,7 @@ namespace pwiz.Skyline.Util
         private bool TryNewProtocol(Func<bool> testFunc)
         {
             Uri currentUri = ServerUri;
-
+            
             // try again using https
             if (ServerUri.Scheme.Equals(@"http"))
             {
@@ -550,7 +550,7 @@ namespace pwiz.Skyline.Util
                 return PanoramaState.unknown;
             }
 
-            return PanoramaState.unknown;
+            return PanoramaState.unknown;  
         }
 
         public UserState IsValidUser(string username, string password)
@@ -566,7 +566,7 @@ namespace pwiz.Skyline.Util
 
         public FolderState IsValidFolder(string folderPath, string username, string password)
         {
-            try
+           try
             {
                 var uri = PanoramaUtil.GetContainersUri(ServerUri, folderPath, false);
 
@@ -596,7 +596,7 @@ namespace pwiz.Skyline.Util
                 }
                 else throw;
             }
-            return FolderState.valid;
+           return FolderState.valid;
         }
     }
 
@@ -642,7 +642,7 @@ namespace pwiz.Skyline.Util
         public ShareType DecideShareType(FolderInformation folderInfo, SrmDocument document)
         {
             ShareType shareType = ShareType.DEFAULT;
-
+            
             var settings = document.Settings;
             Assume.IsTrue(document.IsLoaded);
             var cacheVersion = settings.HasResults ? settings.MeasuredResults.CacheVersion : null;
@@ -750,7 +750,7 @@ namespace pwiz.Skyline.Util
                     throw new PanoramaServerException(Resources.EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server);
                 case UserState.unknown:
                     throw new PanoramaServerException(string.Format(Resources.EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__, refServerUri.AbsoluteUri));
-            }
+            } 
         }
 
         public override JToken GetInfoForFolders(Server server, string folder)
@@ -834,12 +834,12 @@ namespace pwiz.Skyline.Util
 
                 // Need to tell server which uploaded file to import.
                 var dataImportInformation = new NameValueCollection
-                {
-                    // For now, we only have one root that user can upload to
-                    {@"path", @"./"},
-                    {@"file", zipFileName}
-                };
-
+                                                {
+                                                    // For now, we only have one root that user can upload to
+                                                    {@"path", @"./"},
+                                                    {@"file", zipFileName}
+                                                };
+                
                 JToken importResponse = _webClient.Post(importUrl, dataImportInformation);
 
                 // ID to check import status.
@@ -1149,7 +1149,7 @@ namespace pwiz.Skyline.Util
             Headers.Add(HttpRequestHeader.Authorization, Server.GetBasicAuthHeader(username, password));
             _serverUri = serverUri;
         }
-
+        
         public JObject Post(Uri uri, NameValueCollection postData)
         {
             if (string.IsNullOrEmpty(_csrfToken))
@@ -1226,7 +1226,7 @@ namespace pwiz.Skyline.Util
             Password = password;
 
             var path = serverUri.AbsolutePath;
-
+            
             if (path.Length > 1)
             {
                 // Get the context path (e.g. /labkey) from the path


### PR DESCRIPTION
Display Skyline document import progress percent, if reported by Panorama server.  Reduce frequency of pipeline job status check requests to the server. 