### PR TITLE
Fix intermittent failure in TestManageResults

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -470,14 +470,11 @@ namespace pwiz.Skyline.Controls.Graphs
                 progressControl.ShowGraph += (sender, args) => ShowGraph();
                 progressControl.ShowLog += (sender, args) => ShowLog();
                 controlsToAdd.Add(progressControl);
+                _fileProgressControls.Add(filePath.GetLocation(), progressControl);
                 first = false;
             }
 
             flowFileStatus.Controls.AddRange(controlsToAdd.ToArray());
-            foreach (var control in controlsToAdd)
-            {
-                _fileProgressControls.Add(control.FilePath.GetLocation(), control);
-            }
         }
 
         private void CancelMissingFiles(MultiProgressStatus status)


### PR DESCRIPTION
I believe that this change will fix the intermittent failure in TestManageResults.
If two status updates come in at the same time for the same file, then we would create two FileProgress controls. Also, we would throw a "item with the same key already added" exception, and that would get displayed as an import failure error.

(This error was made possible between the work I did to make the AllChromatogramsGraph a little faster when importing thousands of files at once: the controls get added to flowFileStatus with one "AddRange" call instead of one at a time. The fact that I moved the adding to "_fileProgressControls" made it possible to create controls for the same URI more than once, but it could only happen if we were processing two statuses for the same URI in the same batch, which I think only became possible to happen because of this 3array work)