### PR TITLE
When we show filenames in load failure messages, remove the decoratio…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -736,11 +736,11 @@ namespace pwiz.Skyline.Controls.Graphs
                     if (ReferenceEquals(SelectedControl, control))
                         sb.Append(@"-> ");
                     if (control.Error != null)
-                        sb.AppendLine(string.Format(@"{0}: Error - {1}", control.FilePath, control.Error));
+                        sb.AppendLine(string.Format(@"{0}: Error - {1}", control.FilePath.GetLocation(), control.Error));
                     else if (control.IsCanceled)
-                        sb.AppendLine(string.Format(@"{0}: Canceled", control.FilePath));
+                        sb.AppendLine(string.Format(@"{0}: Canceled", control.FilePath.GetLocation()));
                     else
-                        sb.AppendLine(string.Format(@"{0}: {1}%", control.FilePath, control.Progress));
+                        sb.AppendLine(string.Format(@"{0}: {1}%", control.FilePath.GetLocation(), control.Progress));
                 }
                 return TextUtil.LineSeparate(sb.ToString(), string.Format(@"Total complete: {0}%", ProgressTotalPercent));
             }

--- a/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
+++ b/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
@@ -397,7 +397,7 @@ namespace pwiz.Skyline.Model.Results
 
         public string IsLoadedExplained() // For test and debug purposes, gives a descriptive string for IsLoaded failure
         {
-            return IsLoaded ? string.Empty : @"No ChromFileInfo.FileWriteTime for " + string.Join(@",", MSDataFileInfos.Where(info => !info.FileWriteTime.HasValue).Select(f => f.FilePath.GetFilePath()));
+            return IsLoaded ? string.Empty : @"No ChromFileInfo.FileWriteTime for " + string.Join(@",", MSDataFileInfos.Where(info => !info.FileWriteTime.HasValue).Select(f => f.FilePath.GetLocation().GetFilePath()));
         }
 
         public Annotations Annotations { get; private set; }


### PR DESCRIPTION
…ns concerning centroiding, combined ion mobility etc