### PR TITLE
Skyline/bugfix/20191202 corrected bruker ccs calc

### DIFF
--- a/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
+++ b/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
@@ -731,8 +731,9 @@ PWIZ_API_DECL bool SpectrumList_Bruker::hasCombinedIonMobility() const
 
 // Per email thread Aug 22 2017 bpratt, mattc, Bruker's SvenB:
 // The gas is nitrogen(14.0067 AMU) and the temperature is(according to Sven) assumed to be 305K.
+// Turns out it's N2, actually, which seems obvious in retrospect (bpratt Dec 2 2019)
 static const double ccs_conversion_factor = 18509.863216340458;
-static const double MolWeightGas = 14.0067;
+static const double MolWeightGas = 28.0134; // 2* 14.0067
 static const double Temperature = 305;
 
 PWIZ_API_DECL double SpectrumList_Bruker::ionMobilityToCCS(double inverseK0, double mz, int charge) const

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -470,14 +470,11 @@ namespace pwiz.Skyline.Controls.Graphs
                 progressControl.ShowGraph += (sender, args) => ShowGraph();
                 progressControl.ShowLog += (sender, args) => ShowLog();
                 controlsToAdd.Add(progressControl);
+                _fileProgressControls.Add(filePath.GetLocation(), progressControl);
                 first = false;
             }
 
             flowFileStatus.Controls.AddRange(controlsToAdd.ToArray());
-            foreach (var control in controlsToAdd)
-            {
-                _fileProgressControls.Add(control.FilePath.GetLocation(), control);
-            }
         }
 
         private void CancelMissingFiles(MultiProgressStatus status)

--- a/pwiz_tools/Skyline/TestPerf/PerfImportDiaPasefTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportDiaPasefTest.cs
@@ -150,7 +150,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             CheckFieldByName(documentGrid, "PrecursorResult.IonMobilityFragment", row, 1.1732, msg); 
             CheckFieldByName(documentGrid, "PrecursorResult.IonMobilityUnits", row, IonMobilityValue.GetUnitsString(eIonMobilityUnits.inverse_K0_Vsec_per_cm2), msg);
             CheckFieldByName(documentGrid, "PrecursorResult.IonMobilityWindow", row, 0.12, msg);
-            CheckFieldByName(documentGrid, "PrecursorResult.CollisionalCrossSection", row, 666.9175, msg);
+            CheckFieldByName(documentGrid, "PrecursorResult.CollisionalCrossSection", row, 473.2742, msg);
             EnableDocumentGridColumns(documentGrid,
                 Resources.ReportSpecList_GetDefaults_Peptide_RT_Results,
                 doc1.PeptideCount * doc1.MeasuredResults.Chromatograms.Count, null);

--- a/pwiz_tools/Skyline/TestPerf/PerfImportPasefMascotTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportPasefMascotTest.cs
@@ -272,7 +272,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             CheckFieldByName(documentGrid, "IonMobilityFragment", row, (double?)null, msg); // Document is all precursor
             CheckFieldByName(documentGrid, "IonMobilityUnits", row, IonMobilityValue.GetUnitsString(eIonMobilityUnits.inverse_K0_Vsec_per_cm2), msg);
             CheckFieldByName(documentGrid, "IonMobilityWindow", row, 0.04, msg);
-            CheckFieldByName(documentGrid, "CollisionalCrossSection", row, 474.26, msg);
+            CheckFieldByName(documentGrid, "CollisionalCrossSection", row, 337.4821, msg);
             // And clean up after ourselves
             RunUI(() => documentGrid.Close());
         }


### PR DESCRIPTION
This changes the Bruker CCS calculation to use mass N2 instead of mass N.