### PR TITLE
Wine fixes

### DIFF
--- a/pwiz/data/msdata/SpectrumWorkerThreads.cpp
+++ b/pwiz/data/msdata/SpectrumWorkerThreads.cpp
@@ -22,6 +22,7 @@
 #define PWIZ_SOURCE
 
 #include "pwiz/utility/misc/Std.hpp"
+#include "pwiz/utility/misc/Filesystem.hpp"
 #include "pwiz/data/msdata/SpectrumWorkerThreads.hpp"
 #include "pwiz/data/msdata/SpectrumListWrapper.hpp"
 #include "pwiz/analysis/spectrum_processing/SpectrumList_Demux.hpp"
@@ -58,6 +59,7 @@ class SpectrumWorkerThreads::Impl
 
         bool isBruker = icPtr.get() && icPtr->hasCVParamChild(MS_Bruker_Daltonics_instrument_model);
         bool isShimadzu = icPtr.get() && icPtr->hasCVParamChild(MS_Shimadzu_instrument_model);
+        bool isThermoOnWine = icPtr.get() && icPtr->hasCVParamChild(MS_Thermo_Fisher_Scientific_instrument_model) && running_on_wine();
 
         bool isDemultiplexed = false;
         const boost::shared_ptr<const DataProcessing> dp = sl.dataProcessingPtr();
@@ -77,8 +79,7 @@ class SpectrumWorkerThreads::Impl
             }
         }
 
-        useThreads_ = useWorkerThreads && !(isBruker || isShimadzu || isDemultiplexed); // Bruker library is not thread-friendly
-        //useThreads_ = !(isBruker); // Bruker library is not thread-friendly
+        useThreads_ = useWorkerThreads && !(isBruker || isShimadzu || isThermoOnWine || isDemultiplexed); // some libraries/platforms are not thread-friendly
 
         if (sl.size() > 0 && useThreads_)
         {

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -237,11 +237,20 @@ namespace pwiz {
 namespace util {
 
 
+PWIZ_API_DECL bool running_on_wine()
+{
+#ifdef WIN32
+    return GetLibraryProcAddress("ntdll.dll", "wine_get_version") != NULL;
+#else
+    return false;
+#endif
+}
+
+
 PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, bool closeMemoryMappedSections) noexcept(true)
 {
 #ifdef WIN32
-    bool runningUnderWine = GetLibraryProcAddress("ntdll.dll", "wine_get_version") != NULL;
-    if (runningUnderWine)
+    if (running_on_wine())
         return;
 
     _NtQuerySystemInformation NtQuerySystemInformation = (_NtQuerySystemInformation)GetLibraryProcAddress("ntdll.dll", "NtQuerySystemInformation");

--- a/pwiz/utility/misc/Filesystem.hpp
+++ b/pwiz/utility/misc/Filesystem.hpp
@@ -71,6 +71,10 @@ namespace pwiz {
 namespace util {
 
 
+/// returns true iff process is Windows executable running under Wine
+PWIZ_API_DECL bool running_on_wine();
+
+
 /// on Windows, closes all file handles and memory mapped sections relating to the given filepath
 PWIZ_API_DECL void force_close_handles_to_filepath(const std::string& filepath, bool closeMemoryMappedSections = false) noexcept(true);
 

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -948,6 +948,8 @@ int go(const Config& config)
         failedFileCount = mergeFiles(config.filenames, config, readers);
     else
     {
+        if (config.filenames.size() > 1 && running_on_wine())
+            *os_ << "Warning: when running on Wine it is recommended to only process one file at a time" << endl;
 
         for (vector<string>::const_iterator it=config.filenames.begin(); 
              it!=config.filenames.end(); ++it)


### PR DESCRIPTION
- disabled multi-thread spectrum reading for msconvert on Wine
- added warning in msconvert about converting multiple files at a time on Wine
* created running_on_wine() function