### PR TITLE
Fix looking up of ion mobilities in libraries

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/Midas/MidasBlibBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Lib/Midas/MidasBlibBuilder.cs
@@ -77,7 +77,7 @@ namespace pwiz.Skyline.Model.Lib.Midas
                             SourceFile = bestSpectrum.ResultsFile.FilePath,
                             PrecursorMz = bestSpectrum.PrecursorMz,
                             SpectrumPeaks = _library.LoadSpectrum(bestSpectrum),
-                            Key = nodeTranGroup.GetLibKey(nodePep),
+                            Key = nodeTranGroup.GetLibKey(_doc.Settings, nodePep),
                             RetentionTimes = new[] { new SpectrumMzInfo.IonMobilityAndRT(bestSpectrum.ResultsFile.FilePath, IonMobilityAndCCS.EMPTY, bestSpectrum.RetentionTime, true) }.ToList()
                         });
                     }

--- a/pwiz_tools/Skyline/Model/Results/IonMobilityFinder.cs
+++ b/pwiz_tools/Skyline/Model/Results/IonMobilityFinder.cs
@@ -177,7 +177,7 @@ namespace pwiz.Skyline.Model.Results
             {
                 var nodePep = pair.NodePep;
                 var nodeGroup = pair.NodeGroup;
-                var libKey = nodeGroup.GetLibKey(nodePep);
+                var libKey = nodeGroup.GetLibKey(_document.Settings, nodePep);
                 if (key.Equals(libKey))
                 {
                     return nodeGroup.PrecursorMz;
@@ -202,7 +202,7 @@ namespace pwiz.Skyline.Model.Results
             {
                 var nodePep = pair.NodePep;
                 var nodeGroup = pair.NodeGroup;
-                var libKey = nodeGroup.GetLibKey(nodePep);
+                var libKey = nodeGroup.GetLibKey(_document.Settings, nodePep);
                 // Across all replicates for this precursor, note the ion mobility at max intensity for this mz
                 for (var i = 0; i < results.Chromatograms.Count; i++)
                 {

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -110,7 +110,7 @@ namespace pwiz.Skyline.Model.Results
             // TODO(bspratt): Should be queried out of the libraries as needed, as with RT not bulk copied all at once
             var libraryIonMobilityInfo = document.Settings.PeptideSettings.Prediction.UseLibraryIonMobilityValues
                 ? document.Settings.GetIonMobilities(moleculesThisPass.SelectMany(
-                    node => node.TransitionGroups.Select(nodeGroup => nodeGroup.GetLibKey(node))).ToArray(), msDataFileUri)
+                    node => node.TransitionGroups.Select(nodeGroup => nodeGroup.GetLibKey(document.Settings, node))).ToArray(), msDataFileUri)
                 : null;
             var ionMobilityMax = maxObservedIonMobilityValue ?? 0;
 

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -516,7 +516,7 @@ namespace pwiz.Skyline.Model
             get
             {
                 return Molecules.SelectMany(
-                    node => node.TransitionGroups.Select(nodeGroup => nodeGroup.GetLibKey(node)));
+                    node => node.TransitionGroups.Select(nodeGroup => nodeGroup.GetLibKey(Settings, node)));
             }
         }
 

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -181,11 +181,18 @@ namespace pwiz.Skyline.Model
             get { return TransitionGroup.CustomMolecule;  }
         }
 
-        public LibKey GetLibKey(PeptideDocNode nodePeptideDocNode)
+        public LibKey GetLibKey(SrmSettings settings, PeptideDocNode nodePep)
         {
-            return IsCustomIon
-                ? new LibKey(nodePeptideDocNode.CustomMolecule.GetSmallMoleculeLibraryAttributes(), PrecursorAdduct)
-                : new LibKey(nodePeptideDocNode.ModifiedSequence, PrecursorAdduct.AdductCharge);
+            if (IsCustomIon)
+            {
+                return new LibKey(nodePep.CustomMolecule.GetSmallMoleculeLibraryAttributes(),
+                    PrecursorAdduct);
+            }
+
+            var modifiedSequence = settings
+                .GetPrecursorCalc(TransitionGroup.LabelType, nodePep.ExplicitMods)
+                .GetModifiedSequence(nodePep.Peptide.Target, SequenceModFormatType.full_precision, false).ToString();
+            return new LibKey(modifiedSequence, PrecursorAdduct.AdductCharge);
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/TestFunctional/PrositSkylineIntegrationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PrositSkylineIntegrationTest.cs
@@ -1409,7 +1409,7 @@ namespace pwiz.SkylineTestFunctional
                 var precursors = peptides[i].TransitionGroups.ToArray();
                 for (var j = 0; j < precursors.Length; ++j)
                 {
-                    var libKey = precursors[j].GetLibKey(peptides[i]);
+                    var libKey = precursors[j].GetLibKey(SkylineWindow.Document.Settings, peptides[i]);
                     var spectra = prositLib.GetSpectra(libKey, precursors[j].LabelType, LibraryRedundancy.all).ToArray();
                     if (spectra.Length == 0)
                     {


### PR DESCRIPTION
Fix looking up of ion mobilities in libraries when the precursor has heavy modifications.