### PR TITLE
Skyline: Add TextReader class that uses IEnumerator<char> as input

### DIFF
--- a/pwiz_tools/Shared/Common/CommonUtil.csproj
+++ b/pwiz_tools/Shared/Common/CommonUtil.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Collections\StructSerializer.cs" />
     <Compile Include="Collections\UniqueList.cs" />
     <Compile Include="SystemUtil\CenterWinDialog.cs" />
+    <Compile Include="SystemUtil\CharEnumeratorReader.cs" />
     <Compile Include="SystemUtil\CommonException.cs" />
     <Compile Include="SystemUtil\MemoryBlockingCollection.cs" />
     <Compile Include="SystemUtil\TrackAttribute.cs" />

--- a/pwiz_tools/Shared/Common/SystemUtil/CharEnumeratorReader.cs
+++ b/pwiz_tools/Shared/Common/SystemUtil/CharEnumeratorReader.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2019 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/pwiz_tools/Shared/Common/SystemUtil/CharEnumeratorReader.cs
+++ b/pwiz_tools/Shared/Common/SystemUtil/CharEnumeratorReader.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace pwiz.Common.SystemUtil
+{
+    public class CharEnumeratorReader : TextReader
+    {
+        private int? _nextChar;
+        private IEnumerator<char> _enumerator;
+        public CharEnumeratorReader(IEnumerator<char> enumerator)
+        {
+            _enumerator = enumerator;
+        }
+
+        public override int Peek()
+        {
+            _nextChar = Read();
+            return _nextChar.Value;
+        }
+
+        public override int Read()
+        {
+            if (_nextChar.HasValue)
+            {
+                var result = _nextChar.Value;
+                _nextChar = null;
+                return result;
+            }
+
+            if (!_enumerator.MoveNext())
+            {
+                return -1;
+            }
+
+            return _enumerator.Current;
+        }
+
+        public static CharEnumeratorReader FromLines(IEnumerable<string> lines)
+        {
+            var charEnumerator = lines.SelectMany(line => line + Environment.NewLine).GetEnumerator();
+            return new CharEnumeratorReader(charEnumerator);
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -318,8 +318,15 @@ namespace pwiz.Skyline.Model
 
         private IList<string> ReadLinesFromText()
         {
+            var inputLines = ReadLinesFromText(_inputText);
+            InitFormat(inputLines);
+            return inputLines;
+        }
+
+        public static IList<string> ReadLinesFromText(string text)
+        {
             var inputLines = new List<string>();
-            using (var readerLines = new StringReader(_inputText))
+            using (var readerLines = new StringReader(text))
             {
                 string line;
                 while ((line = readerLines.ReadLine()) != null)
@@ -331,7 +338,6 @@ namespace pwiz.Skyline.Model
             }
             if (inputLines.Count == 0)
                 throw new InvalidDataException(Resources.MassListImporter_Import_Empty_transition_list);
-            InitFormat(inputLines);
             return inputLines;
         }
 
@@ -421,6 +427,7 @@ namespace pwiz.Skyline.Model
 
         public static IEnumerable<string> IrtColumnNames { get { return new[] { @"irt", @"normalizedretentiontime", @"tr_recalibrated" }; } }
         public static IEnumerable<string> LibraryColumnNames { get { return new[] { @"libraryintensity", @"relativeintensity", @"relative_intensity", @"relativefragmentintensity", @"library_intensity" }; } }
+        public static IEnumerable<string> ProteinNames { get { return new [] {@"proteinname", @"protein", @"proteinid", @"uniprotid"}; } }
 
         public IEnumerable<PeptideGroupDocNode> Import(IProgressMonitor progressMonitor,
                                                        string sourceFile,
@@ -463,6 +470,7 @@ namespace pwiz.Skyline.Model
                 string[] headers = fields.All(field => GetColumnType(field.Trim(), FormatProvider) != typeof (double))
                                        ? fields
                                        : null;
+                int proteinColumn = -1;
                 int decoyColumn = -1;
                 int irtColumn = -1;
                 int libraryColumn = -1;
@@ -471,6 +479,8 @@ namespace pwiz.Skyline.Model
                 {
                     lines.RemoveAt(0);
                     linesSeen++;
+
+                    proteinColumn = headers.IndexOf(col => ProteinNames.Contains(col.ToLowerInvariant()));
                     decoyColumn = headers.IndexOf(col => decoyNames.Contains(col.ToLowerInvariant()));
                     irtColumn = headers.IndexOf(col => IrtColumnNames.Contains(col.ToLowerInvariant()));
                     libraryColumn = headers.IndexOf(col => LibraryColumnNames.Contains(col.ToLowerInvariant()));
@@ -484,14 +494,14 @@ namespace pwiz.Skyline.Model
                 _rowReader = ExPeptideRowReader.Create(lines, decoyColumn, FormatProvider, Separator, Settings, irtColumn, libraryColumn);
                 if (_rowReader == null)
                 {
-                    _rowReader = GeneralRowReader.Create(lines, headers, decoyColumn, FormatProvider, Separator, Settings, irtColumn, libraryColumn);
+                    _rowReader = GeneralRowReader.Create(lines, headers, proteinColumn, decoyColumn, FormatProvider, Separator, Settings, irtColumn, libraryColumn);
                     if (_rowReader == null && headers == null && lines.Count > 1)
                     {
                         // Check for a possible header row
                         headers = lines[0].Split(Separator);
                         lines.RemoveAt(0);
                         linesSeen++;
-                        _rowReader = GeneralRowReader.Create(lines, headers, decoyColumn, FormatProvider, Separator, Settings, irtColumn, libraryColumn);
+                        _rowReader = GeneralRowReader.Create(lines, headers, proteinColumn, decoyColumn, FormatProvider, Separator, Settings, irtColumn, libraryColumn);
                     }
                     if (_rowReader == null)
                         throw new LineColNumberedIoException(Resources.MassListImporter_Import_Failed_to_find_peptide_column, 1, -1);
@@ -1168,7 +1178,7 @@ namespace pwiz.Skyline.Model
                 public IList<TransitionExp> TransitionExps { get; private set; } 
             }
 
-            public static GeneralRowReader Create(IList<string> lines, IList<string> headers, int iDecoy,
+            public static GeneralRowReader Create(IList<string> lines, IList<string> headers, int iProt, int iDecoy,
                 IFormatProvider provider, char separator, SrmSettings settings, int iirt, int iLibrary)
             {
                 // Split the first line into fields.
@@ -1253,9 +1263,10 @@ namespace pwiz.Skyline.Model
                 if (iProduct == -1)
                     throw new MzMatchException(Resources.GeneralRowReader_Create_No_valid_product_m_z_column_found, 1, -1);
 
-                int iProtein = FindProtein(fieldsFirstRow, iSequence, lines, headers, provider, separator);
+                if (iProt == -1)
+                    iProt = FindProtein(fieldsFirstRow, iSequence, lines, headers, provider, separator);
 
-                var indices = new ColumnIndices(iProtein, iSequence, iPrecursor, iProduct, iLabelType, iDecoy, iirt, iLibrary);
+                var indices = new ColumnIndices(iProt, iSequence, iPrecursor, iProduct, iLabelType, iDecoy, iirt, iLibrary);
 
                 return new GeneralRowReader(provider, separator, indices, settings, lines);
             }

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -1579,34 +1579,24 @@ namespace pwiz.Skyline.Model
     {
         private readonly DsvFileReader _csvReader;
 
-        public SmallMoleculeTransitionListCSVReader(IEnumerable<string> csvText) : 
-            // ReSharper disable LocalizableElement
-            this(string.Join("\n", csvText))
-            // ReSharper restore LocalizableElement
-        {
-
-        }
-
-        public SmallMoleculeTransitionListCSVReader(string csvText)
+        public SmallMoleculeTransitionListCSVReader(IList<string> csvText)
         {
             // Accept either true CSV or currentculture equivalent
             Type[] columnTypes;
             IFormatProvider formatProvider;
             char separator;
+            var header = csvText[0];
             // Skip over header line to deduce decimal format
-            var endLine = csvText.IndexOf('\n');
-            var line = (endLine != -1 ? csvText.Substring(endLine+1) : csvText);
+            string line = csvText.Count > 1 ? csvText[1] : header;
             MassListImporter.IsColumnar(line, out formatProvider, out separator, out columnTypes);
             // Double check that separator - does it appear in header row, or was it just an unlucky hit in a text field?
-            var header = (endLine != -1 ? csvText.Substring(0, endLine) : csvText);
             if (!header.Contains(separator))
             {
                 // Try again, this time without the distraction of a plausible but clearly incorrect seperator
                 MassListImporter.IsColumnar(line.Replace(separator,'_'), out formatProvider, out separator, out columnTypes);
             }
             _cultureInfo = formatProvider;
-            var reader = new StringReader(csvText);
-            _csvReader = new DsvFileReader(reader, separator, SmallMoleculeTransitionListColumnHeaders.KnownHeaderSynonyms);
+            _csvReader = new DsvFileReader(new StringListReader(csvText), separator, SmallMoleculeTransitionListColumnHeaders.KnownHeaderSynonyms);
             // Do we recognize all the headers?
             var badHeaders =
                 _csvReader.FieldNames.Where(
@@ -1635,14 +1625,12 @@ namespace pwiz.Skyline.Model
             get { return Rows.Count; }
         }
 
-        public static bool IsPlausibleSmallMoleculeTransitionList(IEnumerable<string> csvText)
+        public static bool IsPlausibleSmallMoleculeTransitionList(string csvText)
         {
-            // ReSharper disable LocalizableElement
-            return IsPlausibleSmallMoleculeTransitionList(string.Join("\n", csvText));
-            // ReSharper restore LocalizableElement
+            return IsPlausibleSmallMoleculeTransitionList(MassListInputs.ReadLinesFromText(csvText));
         }
 
-        public static bool IsPlausibleSmallMoleculeTransitionList(string csvText)
+        public static bool IsPlausibleSmallMoleculeTransitionList(IList<string> csvText)
         {
             try
             {
@@ -1654,7 +1642,7 @@ namespace pwiz.Skyline.Model
             catch
             {
                 // Not a proper small molecule transition list, but was it trying to be one?
-                var header = csvText.Split('\n')[0];
+                var header = csvText.First();
                 if (header.ToLowerInvariant().Contains(@"peptide"))
                 {
                     return false;

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -1596,7 +1596,7 @@ namespace pwiz.Skyline.Model
                 MassListImporter.IsColumnar(line.Replace(separator,'_'), out formatProvider, out separator, out columnTypes);
             }
             _cultureInfo = formatProvider;
-            _csvReader = new DsvFileReader(new StringListReader(csvText), separator, SmallMoleculeTransitionListColumnHeaders.KnownHeaderSynonyms);
+            _csvReader = new DsvFileReader(CharEnumeratorReader.FromLines(csvText), separator, SmallMoleculeTransitionListColumnHeaders.KnownHeaderSynonyms);
             // Do we recognize all the headers?
             var badHeaders =
                 _csvReader.FieldNames.Where(

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -1759,7 +1759,7 @@ namespace pwiz.Skyline
                     selectPath = null;
                     using (var longWaitDlg = new LongWaitDlg(this) {Text = description})
                     {
-                        var smallMoleculeTransitionListReader = new SmallMoleculeTransitionListCSVReader(csvText);
+                        var smallMoleculeTransitionListReader = new SmallMoleculeTransitionListCSVReader(MassListInputs.ReadLinesFromText(csvText));
                         IdentityPath firstAdded;
                         longWaitDlg.PerformWork(this, 1000,
                             () => docNew = smallMoleculeTransitionListReader.CreateTargets(doc, null, out firstAdded));

--- a/pwiz_tools/Skyline/Util/UtilIO.cs
+++ b/pwiz_tools/Skyline/Util/UtilIO.cs
@@ -1031,6 +1031,24 @@ namespace pwiz.Skyline.Util
         }
     }
 
+    public sealed class StringListReader : TextReader
+    {
+        private readonly IList<string> _lines;
+        private int _currentLine;
+
+        public StringListReader(IList<string> lines)
+        {
+            _lines = lines;
+        }
+
+        public override string ReadLine()
+        {
+            if (_currentLine < _lines.Count)
+                return _lines[_currentLine++];
+            return null;
+        }
+    }
+
 
     public sealed class FileSaver : IDisposable
     {

--- a/pwiz_tools/Skyline/Util/UtilIO.cs
+++ b/pwiz_tools/Skyline/Util/UtilIO.cs
@@ -1031,24 +1031,6 @@ namespace pwiz.Skyline.Util
         }
     }
 
-    public sealed class StringListReader : TextReader
-    {
-        private readonly IList<string> _lines;
-        private int _currentLine;
-
-        public StringListReader(IList<string> lines)
-        {
-            _lines = lines;
-        }
-
-        public override string ReadLine()
-        {
-            if (_currentLine < _lines.Count)
-                return _lines[_currentLine++];
-            return null;
-        }
-    }
-
 
     public sealed class FileSaver : IDisposable
     {


### PR DESCRIPTION
Here's what I think we should do instead of #761 
A minimal implementation of TextReader should override Peak() and Read(). The base class implementations just return -1 indicating end of file.

I added a class called "CharEnumeratorReader" which implements a TextReader whose source is an IEnumerator<char>.

Where can I find the really big assay library text file so I can make sure this isn't too slow?