### PR TITLE
Fix BiblioSpec ProteinPilot group.xml progress indication

### DIFF
--- a/libraries/expat.jam
+++ b/libraries/expat.jam
@@ -109,6 +109,7 @@ rule init ( version ? : location : options * )
             <toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE
             <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
             <define>HAVE_EXPAT_CONFIG_H
+            <define>XML_LARGE_SIZE
             <implicit-dependency>expat_config.h
             <dependency>expat_config.h
             #~ <link>shared:<define>EXPAT_EXPORTS
@@ -118,6 +119,7 @@ rule init ( version ? : location : options * )
         :
         :   <include>$(location)/lib
             <define>HAVE_EXPAT_CONFIG_H
+            <define>XML_LARGE_SIZE
             <implicit-dependency>expat_config.h
             <dependency>expat_config.h
             <link>static:<define>XML_STATIC

--- a/pwiz_tools/BiblioSpec/src/BuildParser.cpp
+++ b/pwiz_tools/BiblioSpec/src/BuildParser.cpp
@@ -530,7 +530,7 @@ void BuildParser::insertSpectrum(PSM* psm,
         map<const Protein*, sqlite3_int64>::const_iterator j = proteins.find(*i);
         sqlite3_int64 proteinId = (j == proteins.end()) ? insertProtein(*i) : j->second;
         sprintf(sql_statement_buf,
-                "INSERT INTO RefSpectraProteins (RefSpectraId, ProteinId) VALUES (%d, %d)",
+                "INSERT INTO RefSpectraProteins (RefSpectraId, ProteinId) VALUES (%d, %lld)",
                 libSpecId, proteinId);
         blibMaker_.sql_stmt(sql_statement_buf);
         sql_statement_buf[0] = '\0';

--- a/pwiz_tools/BiblioSpec/src/Jamfile.jam
+++ b/pwiz_tools/BiblioSpec/src/Jamfile.jam
@@ -119,6 +119,19 @@ project
 ;
 
 
+# all the pwiz and boost libraries required
+pwiz-boost-libraries = <library>/ext/boost//program_options
+                       <library>/ext/boost//filesystem
+                       <library>/ext/boost//thread
+                       <library>/ext/boost//iostreams
+                       <library>/ext/boost//system
+                       <library>/ext/expat//expat
+                       <library>$(PWIZ_ROOT_PATH)/pwiz/data/msdata//pwiz_data_msdata
+                       <library>$(PWIZ_ROOT_PATH)/pwiz/data/identdata//pwiz_data_identdata
+                       <library>$(PWIZ_ROOT_PATH)/pwiz/utility/minimxml//pwiz_utility_minimxml
+                       <library>$(PWIZ_ROOT_PATH)/pwiz/utility/misc//pwiz_utility_misc ;
+
+
 # the main BiblioSpec library
 lib blibbuild
   : # sources
@@ -151,6 +164,7 @@ lib blibbuild
     <conditional>@mascot-api-requirements
     <conditional>@waters-define
     <library>$(PWIZ_ROOT_PATH)/libraries/SQLite//sqlite3
+    $(pwiz-boost-libraries)
     <dependency>modifications.xml # required file for running BlibBuild with MaxQuant support
     <dependency>unimod.xml # required file for running BlibBuild with OpenSWATH support
   : # default-build
@@ -158,6 +172,7 @@ lib blibbuild
     <conditional>@mascot-api-usage-requirements
     <conditional>@waters-api-usage-requirements
     <library>$(PWIZ_ROOT_PATH)/libraries/SQLite//sqlite3
+    $(pwiz-boost-libraries)
     <dependency>unimod.xml
     <dependency>modifications.xml
  ;
@@ -186,26 +201,12 @@ lib blib
   : # requirements
     <link>static
     <library>$(PWIZ_ROOT_PATH)/libraries/SQLite//sqlite3
-    <library>pwiz-boost-libraries
+    $(pwiz-boost-libraries)
   : # default-build
   : # usage-requirements
     <library>$(PWIZ_ROOT_PATH)/libraries/SQLite//sqlite3
-    <library>pwiz-boost-libraries
+    $(pwiz-boost-libraries)
  ;
-
-# all the pwiz and boost libraries required
-alias pwiz-boost-libraries 
-  : /ext/boost//program_options
-    /ext/boost//filesystem
-    /ext/boost//thread
-    /ext/boost//iostreams
-    /ext/boost//system
-    /ext/expat//expat
-    $(PWIZ_ROOT_PATH)/pwiz/data/msdata//pwiz_data_msdata
-    $(PWIZ_ROOT_PATH)/pwiz/data/identdata//pwiz_data_identdata
-    $(PWIZ_ROOT_PATH)/pwiz/utility/minimxml//pwiz_utility_minimxml
-    $(PWIZ_ROOT_PATH)/pwiz/utility/misc//pwiz_utility_misc
-;
 
 
  
@@ -229,27 +230,27 @@ exe BlibFilter
   : # sources
     BlibFilter.cpp
     blib
-    pwiz-boost-libraries
   : # requirements
     <link>static  
+    $(pwiz-boost-libraries)
 ;
 
 exe BlibSearch
   : # sources
     BlibSearch.cpp
     blib
-    pwiz-boost-libraries
   : # requirements
-    <link>static  
+    <link>static
+    $(pwiz-boost-libraries)
 ;
 
 exe BlibToMs2
   : # sources
     BlibToMs2.cpp
     blib
-    pwiz-boost-libraries
   : # requirements
-    <link>static  
+    <link>static
+    $(pwiz-boost-libraries)
 ;
 
 # code from BiblioSpec version 1 for converter

--- a/pwiz_tools/BiblioSpec/src/PepXMLreader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PepXMLreader.cpp
@@ -84,12 +84,10 @@ void PepXMLreader::startElement(const XML_Char* name, const XML_Char** attr)
        
        if (analysis.find("interprophet") == 0) {
            analysisType_ = INTER_PROPHET_ANALYSIS;
-           // Unfortunately, there is no way to get a file count
-           // from this element.
-           struct stat filestatus;
-           stat(getFileName().c_str(), &filestatus);
+           // Unfortunately, there is no way to get a file count from this element.
+
            // work in bytes / 1000 to avoid overflow
-           initSpecFileProgress(filestatus.st_size / 1000);
+           initSpecFileProgress(bfs::file_size(getFileName()) / 1000);
        }
    } else if(state == STATE_PROPHET_SUMMARY && isElement("inputfile",name)) {
       // Count files for use in reporting percent complete

--- a/pwiz_tools/BiblioSpec/src/ProteinPilotReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/ProteinPilotReader.cpp
@@ -51,7 +51,8 @@ ProteinPilotReader::ProteinPilotReader(
   probCutOff_(getScoreThreshold(PROT_PILOT)),
   skipMods_(true),
   skipNTermMods_(false),
-  skipCTermMods_(false)
+  skipCTermMods_(false),
+  lastFilePosition_(0)
 {
     this->setFileName(xmlFileName); // this is done for the saxhandler
     curPSM_ = NULL;
@@ -61,6 +62,8 @@ ProteinPilotReader::ProteinPilotReader(
     // point to self as spec reader
     delete specReader_;
     specReader_ = this;
+
+    initReadAddProgress();
 }
 
 ProteinPilotReader::~ProteinPilotReader()
@@ -80,8 +83,12 @@ bool ProteinPilotReader::parseFile()
 {
     string filename = getFileName();
     setSpecFileName(filename.c_str());
-    Verbosity::debug("ProteinPilotReader is parsing %s.", filename.c_str());
+    int filesize = bfs::file_size(filename) / 1000ull;
+    readSpecProgress_ = new ProgressIndicator(filesize);
+
+    Verbosity::debug("ProteinPilotReader is parsing %s (%d kb).", filename.c_str(), filesize);
     bool success = parse();
+    Verbosity::debug("ProteinPilotReader finished parsing %s.", filename.c_str());
 
     if( ! success ){
         return success;
@@ -184,6 +191,12 @@ void ProteinPilotReader::endElement(const XML_Char* name)
         //cerr << "ending spectrum" << endl;
         saveMatch();
         state_ = ROOT_STATE;
+
+        int position = getCurrentByteIndex() / 1000ull;
+        int progress = position - lastFilePosition_;
+        lastFilePosition_ = position;
+        readSpecProgress_->add(progress);
+
     } else if (isElement("MATCH", name)) {
         //cerr << "ending match" << endl;
         state_ = SPECTRUM_STATE;
@@ -200,6 +213,7 @@ void ProteinPilotReader::parseSearchID(const XML_Char** attr){
 
 void ProteinPilotReader::parseSpectrumFilename(const XML_Char** attr){
     string filename = getRequiredAttrValue("originalfilename", attr);
+
     searchIdFileMap_[curSearchID_] = filename;
 }
 

--- a/pwiz_tools/BiblioSpec/src/ProteinPilotReader.h
+++ b/pwiz_tools/BiblioSpec/src/ProteinPilotReader.h
@@ -76,6 +76,9 @@ namespace BiblioSpec {
         vector<PEAK_T> curPeaks_;
         string peaksStr_;
         size_t expectedNumPeaks_;
+        int totalSpectrumCount_;
+        int lastFilePosition_;
+        ProgressIndicator* readSpecProgress_; // each spec read from file
         double curSpecMz_;
         double probCutOff_;
         bool skipMods_;

--- a/pwiz_tools/BiblioSpec/src/ProteinPilotReader.h
+++ b/pwiz_tools/BiblioSpec/src/ProteinPilotReader.h
@@ -76,7 +76,6 @@ namespace BiblioSpec {
         vector<PEAK_T> curPeaks_;
         string peaksStr_;
         size_t expectedNumPeaks_;
-        int totalSpectrumCount_;
         int lastFilePosition_;
         ProgressIndicator* readSpecProgress_; // each spec read from file
         double curSpecMz_;

--- a/pwiz_tools/BiblioSpec/src/saxhandler.cpp
+++ b/pwiz_tools/BiblioSpec/src/saxhandler.cpp
@@ -137,6 +137,10 @@ bool SAXHandler::parse()
     return true;
 }
 
+boost::int64_t SAXHandler::getCurrentByteIndex() {
+    return XML_GetCurrentByteIndex(m_parser_);
+}
+
 string SAXHandler::generateError(const string& message) {
     stringstream ss;
     ss << m_strFileName_

--- a/pwiz_tools/BiblioSpec/src/saxhandler.h
+++ b/pwiz_tools/BiblioSpec/src/saxhandler.h
@@ -218,9 +218,7 @@ public:
     /**
      * Returns the current position in the file in bytes.
      */
-    int getCurrentByteIndex(){
-        return XML_GetCurrentByteIndex(m_parser_);
-    }
+    boost::int64_t getCurrentByteIndex();
 
 protected:
     XML_Parser m_parser_;
@@ -236,6 +234,7 @@ protected:
      * Sax parsers can throw this error to be caught in parse() where
      * filename and line number info is added.
      */
+    [[ noreturn ]]
     void throwParseError(const char* format, ...)
     {
         va_list args;


### PR DESCRIPTION
- fixed progress indication when reading large ProteinPilot group.xml files
* fixed saxhandler::getCurrentByteIndex() for large file sizes
* fixed some compile warnings in BiblioSpec