### PR TITLE
- fixed product m/z values for OpenSWATH assay input to BiblioSpec

### DIFF
--- a/pwiz_tools/BiblioSpec/src/TSVReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/TSVReader.cpp
@@ -313,7 +313,7 @@ namespace {
             {"PrecursorCharge", -1, TSVLine::insertCharge},
             {"PrecursorMz", -1, TSVLine::insertMz},
             {"Decoy", -1, TSVLine::insertDecoy},
-            {"ProductMz", -1, TSVLine::insertLeftWidth},
+            {"ProductMz", -1, TSVLine::insertProductMz}, // populates leftWidth field
             {"LibraryIntensity", -1, TSVLine::insertPeakArea},
             {"FragmentType", -1, TSVLine::insertFragmentAnnotation},
             {"FragmentSeriesNumber", -1, TSVLine::insertFragmentSeriesNumber}

--- a/pwiz_tools/BiblioSpec/src/TSVReader.h
+++ b/pwiz_tools/BiblioSpec/src/TSVReader.h
@@ -98,6 +98,9 @@ public:
     static void insertRightWidth(TSVLine& line, const std::string& value) {
         line.rightWidth = value.empty() ? 0 : lexical_cast<double>(value) / 60;
     }
+    static void insertProductMz(TSVLine& line, const std::string& value) {
+        line.leftWidth = value.empty() ? 0 : lexical_cast<double>(value);
+    }
     static void insertPeakArea(TSVLine& line, const std::string& value) {
         line.peakArea = value;
     }


### PR DESCRIPTION
Tested in Skyline, looks good.