### PR TITLE
Skyp: add Panorama server and open

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/SkypTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SkypTest.cs
@@ -52,13 +52,13 @@ namespace pwiz.SkylineTestFunctional
                 DownloadClient = downloadClient
             };
 
-            var errDlg = ShowDialog<MessageDlg>(() => skypSupport.Open(skypPath, null));
+            var errDlg = ShowDialog<AlertDlg>(() => skypSupport.Open(skypPath, null));
             Assert.IsTrue(errDlg.Message.Contains(string.Format(
                 Resources
                     .SkypSupport_Download_You_may_have_to_add__0__as_a_Panorama_server_from_the_Tools___Options_menu_in_Skyline_,
                 skyp.SkylineDocUri.Host)));
 
-            RunUI(() => { errDlg.ClickOk();});
+            RunUI(() => { errDlg.ClickCancel();});
             WaitForClosedForm(errDlg);
 
             skypSupport.DownloadClient = new TestDownladClient(skyZipPath, skyp.DownloadPath);

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.cs
@@ -283,7 +283,7 @@ namespace pwiz.Skyline.ToolsUI
                     Settings.Default.ShowStartupForm = checkBoxShowWizard.Checked;
                     Settings.Default.DisplayLanguage = displayLanguageItem.Key;
                     Settings.Default.UsePowerOfTen = powerOfTenCheckBox.Checked;
-                    Program.MainWindow.UpdateGraphPanes();
+                    Program.MainWindow?.UpdateGraphPanes();
                 }
                 CompactFormatOption compactFormatOption = comboCompactFormatOption.SelectedItem as CompactFormatOption;
                 if (null != compactFormatOption)
@@ -390,7 +390,7 @@ namespace pwiz.Skyline.ToolsUI
             if (newColorScheme != null)
             {
                 Settings.Default.CurrentColorScheme = newColorScheme.Name;
-                Program.MainWindow.ChangeColorScheme();
+                Program.MainWindow?.ChangeColorScheme();
             }
             _driverColorSchemes.SelectedIndexChangedEvent(sender, e);
         }


### PR DESCRIPTION
If the skyline document that a skyp file points to requires login on the Panorama server, and the server is not configured in Skyline, let the user add the Panorama server and try to download and open the file again.