### PR TITLE
MSn format nativeID and scan number fix

### DIFF
--- a/pwiz/data/msdata/Serializer_MSn.cpp
+++ b/pwiz/data/msdata/Serializer_MSn.cpp
@@ -138,10 +138,10 @@ namespace
         return (int)(charges.size() - startingChargesCount);
     }
     
-    int getScanNumber(SpectrumPtr s)
+    int getScanNumber(const SpectrumPtr& s, CVID nativeIdFormat)
     {
-        string scanNumber = id::translateNativeIDToScanNumber(MS_scan_number_only_nativeID_format, s->id);
-        int scanNum = 0;
+        string scanNumber = id::translateNativeIDToScanNumber(nativeIdFormat, s->id);
+        int scanNum = s->index + 1;
         if (!scanNumber.empty())
         {
             scanNum = lexical_cast<int>(scanNumber);
@@ -150,14 +150,14 @@ namespace
         return scanNum;
     }
 
-    void writeSpectrumText(SpectrumPtr s, ostream& os)
+    void writeSpectrumText(const SpectrumPtr& s, ostream& os, CVID nativeIdFormat)
     {
         os << std::setprecision(7); // 123.4567
         bool ms1File = s->cvParam(MS_ms_level).valueAs<int>() == 1;
         
         // Write the scan numbers 
         os << "S\t";
-        int scanNum = getScanNumber(s);
+        int scanNum = getScanNumber(s, nativeIdFormat);
         os << scanNum <<  "\t" << scanNum;
 
         if (!ms1File)
@@ -168,7 +168,9 @@ namespace
             os << "\t" << mz;
         }
         os << "\n";
-        
+
+        os << "I\tNativeID\t" << s->id << "\n";
+
         // Write the scan time, if available
         if( !(s->scanList.empty()) && s->scanList.scans[0].cvParam(MS_scan_start_time).timeInSeconds() )
           os << "I\tRTime\t" << s->scanList.scans[0].cvParam(MS_scan_start_time).timeInSeconds()/60 << "\n";
@@ -237,7 +239,7 @@ namespace
         }
     }
 
-    void writeCompressedPeaks(SpectrumPtr s, ostream& os)
+    void writeCompressedPeaks(const SpectrumPtr& s, ostream& os)
     {
         // Build arrays to hold peaks prior to compression
         int numPeaks = (int) s->defaultArrayLength;
@@ -293,11 +295,11 @@ namespace
         }
     }
 
-    void writeSpectrumBinary(SpectrumPtr s, int version, bool compress, ostream& os)
+    void writeSpectrumBinary(const SpectrumPtr& s, int version, bool compress, ostream& os, CVID nativeIdFormat)
     {
         bool ms1File = s->cvParam(MS_ms_level).valueAs<int>() == 1;
 
-        int scanNum = getScanNumber(s);
+        int scanNum = getScanNumber(s, nativeIdFormat);
         os.write(reinterpret_cast<char *>(&scanNum), sizeIntMSn);
         os.write(reinterpret_cast<char *>(&scanNum), sizeIntMSn); // Yes, there are two
 
@@ -423,6 +425,8 @@ void Serializer_MSn::Impl::write(ostream& os, const MSData& msd,
     const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
     bool useWorkerThreads) const
 {
+    CVID nativeIdFormat = id::getDefaultNativeIDFormat(msd);
+
     // Write the header
     if ((MSn_Type_BMS1 == _filetype) ||
         (MSn_Type_CMS1 == _filetype) ||
@@ -452,22 +456,22 @@ void Serializer_MSn::Impl::write(ostream& os, const MSData& msd,
             switch (_filetype)
             {
             case MSn_Type_MS1:
-                writeSpectrumText(s, os);
+                writeSpectrumText(s, os, nativeIdFormat);
                 break;
             case MSn_Type_CMS1:
-                writeSpectrumBinary(s, 3 /* version */, true, os);
+                writeSpectrumBinary(s, 3 /* version */, true, os, nativeIdFormat);
                 break;
             case MSn_Type_BMS1:
-                writeSpectrumBinary(s, 3 /* version */, false, os);
+                writeSpectrumBinary(s, 3 /* version */, false, os, nativeIdFormat);
                 break;
             case MSn_Type_MS2:
-                writeSpectrumText(s, os);
+                writeSpectrumText(s, os, nativeIdFormat);
                 break;
             case MSn_Type_CMS2:
-                writeSpectrumBinary(s, 3 /* version */, true, os);
+                writeSpectrumBinary(s, 3 /* version */, true, os, nativeIdFormat);
                 break;
             case MSn_Type_BMS2:
-                writeSpectrumBinary(s, 3 /* version */, false, os);
+                writeSpectrumBinary(s, 3 /* version */, false, os, nativeIdFormat);
                 break;
             case MSn_Type_UNKNOWN:
                 throw runtime_error("[SpectrumList_MSn::Impl::write] Cannot create unknown MSn file type.");


### PR DESCRIPTION
- added nativeID field (as an 'I' entry) for ms1 and ms2 formats
- fixed ms1/ms2 format scan numbers defaulting to 0 instead of index for nativeID formats that can't translate to scan numbers