### PR TITLE
Thermo centroiding of profile ITMS fix

### DIFF
--- a/pwiz/utility/misc/cpp_cli_utilities.hpp
+++ b/pwiz/utility/misc/cpp_cli_utilities.hpp
@@ -170,6 +170,12 @@ void ToBinaryData(cli::array<managed_value_type>^ managedArray, BinaryData<nativ
 {
     typedef System::Runtime::InteropServices::GCHandle GCHandle;
 
+    if (managedArray->Length == 0)
+    {
+        binaryData.clear();
+        return;
+    }
+
 #ifdef PWIZ_MANAGED_PASSTHROUGH
     GCHandle handle = GCHandle::Alloc(managedArray);
     binaryData = ((System::IntPtr)handle).ToPointer();


### PR DESCRIPTION
- fixed crash in Thermo 64-bit reader when asking for centroids on an empty profile ITMS scan (the scan could have data points but they were all zero)

@brendanx67 This could theoretically affect Skyline, if anybody uses ITMS for quant in Skyline. :) Want it in 19.2?