### PR TITLE
Fix AssayLibraryImportTest

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
@@ -1118,10 +1118,10 @@ namespace pwiz.SkylineTestFunctional
 
             // Undo import
             RunUI(SkylineWindow.Undo);
-            doc = WaitForDocumentChange(doc);
+            WaitForDocumentChange(doc);
 
             // Import assay library and choose a file
-            AllowAllIonTypes();
+            doc = AllowAllIonTypes();
             var irtCsvFile = TestFilesDir.GetTestPath("OpenSWATH_SM4_iRT.csv");
             var overwriteDlg = ShowDialog<MultiButtonMsgDlg>(() => SkylineWindow.ImportAssayLibrary(csvFile));
             var chooseIrt2 = ShowDialog<ChooseIrtStandardPeptidesDlg>(overwriteDlg.BtnYesClick);


### PR DESCRIPTION
I think the test might be failing because AllowAllIonTypes was changing the document without updating the doc variable, so the next WaitForDocumentChange call always completed immediately? What do you think?