### PR TITLE
* fixed error extracting SkylineTester.zip

### DIFF
--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -475,9 +475,9 @@ namespace SkylineNightly
                     Log("Unzip SkylineTester");
                     zipFile.ExtractAll(skylineTesterDir, ExtractExistingFileAction.OverwriteSilently);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
-                    Log("Error attempting to unzip SkylineTester");
+                    Log("Error attempting to unzip SkylineTester: " + e.ToString());
                     return false;
                 }
             }

--- a/pwiz_tools/Skyline/SkylineTester/CreateZipInstallerWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CreateZipInstallerWindow.cs
@@ -96,6 +96,8 @@ namespace SkylineTester
                 // DotNetZip has a _bug_ which causes an extraction error without this
                 // (see http://stackoverflow.com/questions/15337186/dotnetzip-badreadexception-on-extract)
                 zipFile.ParallelDeflateThreshold = -1;
+                zipFile.AlternateEncodingUsage = ZipOption.Always;
+                zipFile.AlternateEncoding = System.Text.Encoding.UTF8;
 
                 if ((String.Empty + Path.GetFileName(zipPath)).ToLower() == "skylinenightly.zip")
                 {


### PR DESCRIPTION
* fixed error extracting SkylineTester.zip since adding Reader_Shimadzu_Test's file with Japanese characters in the filename; **tested manually with SkylineNightly (after some fiddling to make it use a local copy of the zip file)**

If you approve Brendan I'll cherry pick over to 19.2 as well.