### PR TITLE
- fixed stack overflow in Reader_Agilent_Test built under debug mode

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -726,14 +726,14 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Thermo::spectrum(size_t index, DetailLeve
             {
                 result->swapMZIntensityArrays(massList->mzArray, massList->intensityArray, MS_number_of_detector_counts);
             }
-        }
 
-        if (msLevel < maxMsLevel_ && detailLevel >= DetailLevel_FullMetadata)
-        {
-            // insert into cache if there is a higher ms level
-            // NB: even FullMetadata level will have binary arrays (because they have to be retrieved to get defaultArrayLength)
-            boost::lock_guard<boost::mutex> lock(readMutex);
-            precursorCache_.insert(CacheEntry(index, make_pair(result->getMZArray()->data, result->getIntensityArray()->data)));
+            if (msLevel < maxMsLevel_)
+            {
+                // insert into cache if there is a higher ms level
+                // NB: even FullMetadata level will have binary arrays (because they have to be retrieved to get defaultArrayLength)
+                boost::lock_guard<boost::mutex> lock(readMutex);
+                precursorCache_.insert(CacheEntry(index, make_pair(result->getMZArray()->data, result->getIntensityArray()->data)));
+            }
         }
 
         return result;
@@ -942,20 +942,21 @@ PWIZ_API_DECL double SpectrumList_Thermo::getPrecursorIntensity(int precursorSpe
 {
     const PrecursorBinaryData* precursorBinaryData = nullptr;
 
-    {
-        boost::lock_guard<boost::mutex> lock(readMutex);
-        auto findItr = precursorCache_.find(precursorSpectrumIndex);
-        if (findItr != precursorCache_.end())
-            precursorBinaryData = &findItr->binaryData;
-    }
+    boost::lock_guard<boost::mutex> lock(readMutex);
+    auto findItr = precursorCache_.find(precursorSpectrumIndex);
+    if (findItr != precursorCache_.end())
+        precursorBinaryData = &findItr->binaryData;
 
     // CONSIDER: is it worth it to keep separate caches for centroid and profile spectra?
     if (!precursorBinaryData)
     {
-        spectrum(precursorSpectrumIndex, true, msLevelsToCentroid);
+        const IndexEntry& precursorIndexEntry = index_[precursorSpectrumIndex];
+        auto raw = rawfile_->getRawByThread(std::hash<std::thread::id>()(std::this_thread::get_id()));
+        bool doCentroid = msLevelsToCentroid.contains((int)precursorIndexEntry.msOrder);
+        MassListPtr massList = raw->getMassList(precursorIndexEntry.scan, "", Cutoff_None, 0, 0, doCentroid);
+        precursorCache_.insert(CacheEntry(precursorSpectrumIndex, make_pair(massList->mzArray, massList->intensityArray)));
         precursorBinaryData = &precursorCache_.find(precursorSpectrumIndex)->binaryData;
     }
-
 
     const auto& mz = precursorBinaryData->first;
     const auto& intensity = precursorBinaryData->second;


### PR DESCRIPTION
- fixed stack overflow in Reader_Agilent_Test built under debug mode (caused by an assert in automation_vector destructor throwing in CrtReportHook which caused another assert, and so on)
* fixed a thread safety issue with Thermo precursorCache_

I found the Thermo thread safety issue while working on the FAIMS test failure but I doubt it fixes that failure because Skyline isn't using multi-threaded calls to a single SpectrumList.