### PR TITLE
CLI binding UserParam improvements

### DIFF
--- a/pwiz/utility/bindings/CLI/common/ParamTypes.hpp
+++ b/pwiz/utility/bindings/CLI/common/ParamTypes.hpp
@@ -133,9 +133,9 @@ namespace data {
 using namespace cv;
 
 #undef CATCH_AND_FORWARD_CAST
-#define CATCH_AND_FORWARD_CAST(value, typeName) \
+#define CATCH_AND_FORWARD_CAST(value, paramType, typeName) \
     catch (boost::bad_lexical_cast &) { throw gcnew System::InvalidCastException( \
-    System::String::Format("Failed to cast CVParam value '{0}' to " + typeName + ".", value->ToString())); } \
+    System::String::Format("Failed to cast " paramType " value '{0}' to " typeName ".", value->ToString())); }
 
 /// <summary>
 /// A convenient variant type for casting to non-string types
@@ -154,22 +154,22 @@ public ref class CVParamValue
     static explicit operator float(CVParamValue^ value)
     {
         try { return (*value->base_)->valueAs<float>(); }
-        CATCH_AND_FORWARD_CAST(value, "float")
+        CATCH_AND_FORWARD_CAST(value, "CVParam", "float")
     }
     static operator double(CVParamValue^ value)
     {
         try { return (*value->base_)->valueAs<double>(); }
-        CATCH_AND_FORWARD_CAST(value, "double")
+        CATCH_AND_FORWARD_CAST(value, "CVParam", "double")
     }
     static explicit operator int(CVParamValue^ value)
     {
         try { return (*value->base_)->valueAs<int>(); }
-        CATCH_AND_FORWARD_CAST(value, "int")
+        CATCH_AND_FORWARD_CAST(value, "CVParam", "int")
     }
     static explicit operator System::UInt64(CVParamValue^ value)
     {
         try { return (System::UInt64) (*value->base_)->valueAs<size_t>(); }
-        CATCH_AND_FORWARD_CAST(value, "uint-64")
+        CATCH_AND_FORWARD_CAST(value, "CVParam", "uint-64")
     }
     static explicit operator bool(CVParamValue^ value) {return (*value->base_)->value == "true";}
     CVParamValue^ operator=(System::String^ value) {(*base_)->value = ToStdString(value); return this;} 
@@ -285,11 +285,29 @@ public ref class UserParamValue
 
     public:
     virtual System::String^ ToString() override {return (System::String^) this;}
-    static operator System::String^(UserParamValue^ value) {return gcnew System::String((*value->base_)->value.c_str());};
-    static explicit operator float(UserParamValue^ value) {return (*value->base_)->valueAs<float>();}
-    static operator double(UserParamValue^ value) {return (*value->base_)->valueAs<double>();}
-    static explicit operator int(UserParamValue^ value) {return (*value->base_)->valueAs<int>();}
-    static explicit operator System::UInt64(UserParamValue^ value) {return (System::UInt64) (*value->base_)->valueAs<size_t>();}
+    static operator System::String^(UserParamValue^ value) {return gcnew System::String((*value->base_)->value.c_str());}
+
+    static explicit operator float(UserParamValue^ value)
+    {
+        try { return (*value->base_)->valueAs<float>(); }
+        CATCH_AND_FORWARD_CAST(value, "UserParam", "float")
+    }
+    static operator double(UserParamValue^ value)
+    {
+        try { return (*value->base_)->valueAs<double>(); }
+        CATCH_AND_FORWARD_CAST(value, "UserParam", "double")
+    }
+    static explicit operator int(UserParamValue^ value)
+    {
+        try { return (*value->base_)->valueAs<int>(); }
+        CATCH_AND_FORWARD_CAST(value, "UserParam", "int")
+    }
+    static explicit operator System::UInt64(UserParamValue^ value)
+    {
+        try { return (System::UInt64) (*value->base_)->valueAs<size_t>(); }
+        CATCH_AND_FORWARD_CAST(value, "UserParam", "uint-64")
+    }
+
     static explicit operator bool(UserParamValue^ value) {return (*value->base_)->value == "true";}
     UserParamValue^ operator=(System::String^ value) {(*base_)->value = ToStdString(value); return this;} 
 };

--- a/pwiz/utility/bindings/CLI/common/ParamTypesTest.cpp
+++ b/pwiz/utility/bindings/CLI/common/ParamTypesTest.cpp
@@ -31,6 +31,7 @@ using System::String;
 void test()
 {
     CVParamList params;
+    UserParamList userParams;
 
     params.Add(gcnew CVParam(CVID::MS_lowest_observed_m_z, 420));
     params.Add(gcnew CVParam(CVID::MS_highest_observed_m_z, 2000.012345));
@@ -38,7 +39,10 @@ void test()
     params.Add(gcnew CVParam(CVID::MS_scan_start_time, 5.890500, CVID::UO_minute)); 
     params.Add(gcnew CVParam(CVID::MS_collision_energy, 35.00, CVID::UO_electronvolt)); 
     params.Add(gcnew CVParam(CVID::MS_deisotoping, true)); 
-    params.Add(gcnew CVParam(CVID::MS_peak_picking, false)); 
+    params.Add(gcnew CVParam(CVID::MS_peak_picking, false));
+
+    userParams.Add(gcnew UserParam("highest m/z", "2000.012345", "xsd:double"));
+    userParams.Add(gcnew UserParam("m/z", "goober", "xsd:string"));
 
     // verify simple things
     unit_assert(420 == (int) params[0]->value);
@@ -56,6 +60,12 @@ void test()
     unit_assert(CV::cvTermInfo("MS:1000447")->cvid == (gcnew CVTermInfo("MS:1000447"))->cvid);
     unit_assert(CV::cvIsA(CVID::MS_LTQ, CVID::MS_Thermo_Scientific_instrument_model));
     unit_assert(!CV::cvIsA(CVID::MS_QSTAR, CVID::MS_Thermo_Scientific_instrument_model));
+
+    unit_assert_throws_what((double) params[2]->value, System::InvalidCastException, "Failed to cast CVParam");
+
+    unit_assert(2000.012345 == (double) userParams[0]->value);
+    unit_assert("goober" == (String^) userParams[1]->value);
+    unit_assert_throws_what((double) userParams[1]->value, System::InvalidCastException, "Failed to cast UserParam");
 
     System::Collections::Generic::IList<CVID>^ cvids = CV::cvids();
     unit_assert(cvids->Count > 0);

--- a/pwiz/utility/bindings/CLI/common/unit.hpp
+++ b/pwiz/utility/bindings/CLI/common/unit.hpp
@@ -121,10 +121,10 @@ inline System::String^ unit_assert_exception_message(const char* filename, int l
         try { (x); } \
         catch (exception^ e) \
         { \
-        if (e->Message == gcnew System::String(whatStr)) \
+            if (e->Message->Contains(gcnew System::String(whatStr))) \
                 threw = true; \
             else \
-            throw gcnew System::Exception(unit_assert_exception_message(__FILE__, __LINE__, #x, System::String::Format("{0} {1}\nBut a different exception was thrown: {2}", gcnew System::String(#exception), gcnew System::String((whatStr)), e->Message))); \
+                throw gcnew System::Exception(unit_assert_exception_message(__FILE__, __LINE__, #x, System::String::Format("{0} {1}\nBut a different exception was thrown: {2}", gcnew System::String(#exception), gcnew System::String((whatStr)), e->Message))); \
         } \
         if (!threw) \
             throw gcnew System::Exception(unit_assert_exception_message(__FILE__, __LINE__, #x, System::String::Format("{0} {1}", gcnew System::String(#exception), gcnew System::String((whatStr))))); \


### PR DESCRIPTION
* added try/catch forwarding to UserParamValue casts to make its error handling as robust as CVParamValue's
* added UserParam and error handling tests in ParamTypesTest
* changed unit_assert_throws_what() to check for substring instead of exact string match