### PR TITLE
- fixed scan summer filter to drop extra binary arrays

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummer.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummer.cpp
@@ -375,6 +375,12 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_ScanSummer::spectrum(size_t index, Detail
 
             BinaryData<double>& mzs = summedSpectrum->getMZArray()->data;
             BinaryData<double>& intensities = summedSpectrum->getIntensityArray()->data;
+
+            // remove extra arrays that are the same length as the m/z array because the summing will not preserve the one-to-one correspondence
+            for (size_t i = 2; i < summedSpectrum->binaryDataArrayPtrs.size(); ++i)
+                if (summedSpectrum->binaryDataArrayPtrs[i]->data.size() == mzs.size())
+                    summedSpectrum->binaryDataArrayPtrs.erase(summedSpectrum->binaryDataArrayPtrs.begin() + (i--));
+
             sumSubScansNaive(mzs, intensities, precursorGroupPtr, DetailLevel_FullData);
             summedSpectrum->defaultArrayLength = mzs.size();
 

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummerTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummerTest.cpp
@@ -156,6 +156,11 @@ int test()
         s->setMZIntensityArrays(inputMZArray, inputIntensityArray, MS_number_of_detector_counts);
         s->defaultArrayLength = inputMZArray.size();
 
+        auto mobilityArray = boost::make_shared<BinaryDataArray>();
+        mobilityArray->data.resize(inputMZArray.size(), 0);
+        mobilityArray->set(MS_raw_ion_mobility_array);
+        s->binaryDataArrayPtrs.push_back(mobilityArray);
+
         scanRef.scanWindows.push_back(ScanWindow());
         scanRef.scanWindows[0].set(MS_scan_window_lower_limit,inputMZArray[0]);
         scanRef.scanWindows[0].set(MS_scan_window_upper_limit,inputMZArray[inputMZArray.size()-1]);
@@ -187,6 +192,7 @@ int test()
             vector<double> goldMZArray = parseDoubleArray(goldStandard[i].inputMZArray);
             vector<double> goldIntensityArray = parseDoubleArray(goldStandard[i].inputIntensityArray);
 
+            unit_assert_operator_equal(2, s->binaryDataArrayPtrs.size()); // mobility array dropped
             unit_assert_operator_equal(goldMZArray.size(), mzs.size());
             unit_assert_operator_equal(goldIntensityArray.size(), intensities.size());
             unit_assert_equal(goldStandard[i].inputPrecursorMZ, precursorMZ, 1e-8);


### PR DESCRIPTION
- fixed scan summer filter to drop extra binary arrays with the same size as the default arrays (we assume that the extra array is supposed to have a one-to-one correspondence which would no longer be valid after summing)