### PR TITLE
Audit logging for Import Peptide|Molecule Search library build step wa…

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.cs
@@ -83,7 +83,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
             public BuildPeptideSearchLibrarySettings(BuildPeptideSearchLibraryControl control) : this(control.CutOffScore,
                 control.SearchFilenames, control.IrtStandards, control.IncludeAmbiguousMatches,
-                control.FilterForDocumentPeptides, control.WorkflowType, control.DocumentContainer.Document.DocumentType)
+                control.FilterForDocumentPeptides, control.WorkflowType, control.ModeUI)
             {
             }
 
@@ -98,7 +98,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                 IncludeAmbiguousMatches = includeAmbiguousMatches;
                 FilterForDocumentPeptides = filterForDocumentPeptides;
                 WorkFlow = workFlow;
-                _docType = SrmDocument.DOCUMENT_TYPE.none;
+                _docType = docType;
             }
 
             [Track(ignoreDefaultParent: true)]
@@ -130,6 +130,8 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         private IModifyDocumentContainer DocumentContainer { get; set; }
         private LibraryManager LibraryManager { get; set; }
         public ImportPeptideSearch ImportPeptideSearch { get; set; }
+
+        private SrmDocument.DOCUMENT_TYPE ModeUI => (WizardForm is FormEx parent) ? parent.ModeUI : SrmDocument.DOCUMENT_TYPE.none;
 
         private Form WizardForm
         {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
@@ -169,9 +169,9 @@ Search files =
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT standard peptides = None,
+iRT standard molecules = None,
 Include ambiguous matches = False,
-Filter for document peptides = True,
+Filter for document molecules = True,
 Workflow = "PRM"
 
 Undo Redo : Imported a molecule search

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorialAsSmallMolecules.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorialAsSmallMolecules.log
@@ -323,9 +323,9 @@ Search files =
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT standard peptides = None,
+iRT standard molecules = None,
 Include ambiguous matches = False,
-Filter for document peptides = True,
+Filter for document molecules = True,
 Workflow = "PRM"
 
 Undo Redo : Imported a molecule search

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
@@ -169,9 +169,9 @@ Search files =
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT standard peptides = None,
+iRT standard molecules = None,
 Include ambiguous matches = False,
-Filter for document peptides = True,
+Filter for document molecules = True,
 Workflow = "PRM"
 
 Undo Redo : Imported a molecule search

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorialAsSmallMolecules.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorialAsSmallMolecules.log
@@ -323,9 +323,9 @@ Search files =
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT standard peptides = None,
+iRT standard molecules = None,
 Include ambiguous matches = False,
-Filter for document peptides = True,
+Filter for document molecules = True,
 Workflow = "PRM"
 
 Undo Redo : Imported a molecule search

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/ja/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/ja/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
@@ -169,9 +169,9 @@ Extra Info: カットオフスコア = "0.99",
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT標準ペプチド = なし,
+iRT標準分子 = なし,
 曖昧な一致を含める = 偽,
-ドキュメント内のペプチドをフィルタリング = 真,
+ドキュメント内の分子をフィルタリング = 真,
 ワークフロー = "PRM"
 
 Undo Redo : 分子検索がインポートされました

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/ja/TestTargetedMSMSTutorialAsSmallMolecules.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/ja/TestTargetedMSMSTutorialAsSmallMolecules.log
@@ -323,9 +323,9 @@ Extra Info: カットオフスコア = "0.99",
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT標準ペプチド = なし,
+iRT標準分子 = なし,
 曖昧な一致を含める = 偽,
-ドキュメント内のペプチドをフィルタリング = 真,
+ドキュメント内の分子をフィルタリング = 真,
 ワークフロー = "PRM"
 
 Undo Redo : 分子検索がインポートされました

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
@@ -169,9 +169,9 @@ Search files =
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT standard peptides = None,
+iRT standard molecules = None,
 Include ambiguous matches = False,
-Filter for document peptides = True,
+Filter for document molecules = True,
 Workflow = "PRM"
 
 Undo Redo : Imported a molecule search

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorialAsSmallMolecules.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorialAsSmallMolecules.log
@@ -323,9 +323,9 @@ Search files =
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT standard peptides = None,
+iRT standard molecules = None,
 Include ambiguous matches = False,
-Filter for document peptides = True,
+Filter for document molecules = True,
 Workflow = "PRM"
 
 Undo Redo : Imported a molecule search

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/zh/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/zh/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
@@ -169,9 +169,9 @@ Extra Info: 阈值 = "0.99",
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT 标准肽段 = 无,
+iRT 标准分子 = 无,
 包含不明确匹配项 = 假,
-文档肽段筛选器 = 真,
+文档分子筛选器 = 真,
 工作流程 = "PRM（并行反应离子监测）"
 
 Undo Redo : 已导入分子搜索

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/zh/TestTargetedMSMSTutorialAsSmallMolecules.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/zh/TestTargetedMSMSTutorialAsSmallMolecules.log
@@ -323,9 +323,9 @@ Extra Info: 阈值 = "0.99",
     "klc_20100329v_Protea_Peptide_Curve_20fmol_uL_tech1.perc.xml",
     "klc_20100329v_Protea_Peptide_Curve_80fmol_uL_tech1.perc.xml"
 ],
-iRT 标准肽段 = 无,
+iRT 标准分子 = 无,
 包含不明确匹配项 = 假,
-文档肽段筛选器 = 真,
+文档分子筛选器 = 真,
 工作流程 = "PRM（并行反应离子监测）"
 
 Undo Redo : 已导入分子搜索


### PR DESCRIPTION
…s ignoring UI mode, which made for inconsistent "peptide" vs "molecule" usage in some log messages