### PR TITLE
Fix DecoysMatchTest.

### DIFF
--- a/pwiz_tools/Skyline/TestPerf/PerfDecoysMatchTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfDecoysMatchTest.cs
@@ -20,8 +20,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline.Controls.Graphs;
+using pwiz.Skyline.Controls.SeqNode;
 using pwiz.Skyline.EditUI;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Results;
@@ -132,7 +134,7 @@ namespace TestPerf
                 SkylineWindow.SaveDocument();
                 SkylineWindow.ArrangeGraphsTiled();
                 SkylineWindow.ShowOtherRunPeptideIDTimes(true);
-                SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SequenceTree.SelectedNode.FirstNode;
+                SkylineWindow.SequenceTree.SelectedNode = SkipInvalidNodes(SkylineWindow.SequenceTree.SelectedNode.FirstNode);
             });
             for (int i = 0; i < 6; i++)
             {
@@ -147,7 +149,8 @@ namespace TestPerf
                         Assert.AreNotEqual(0, graphChromatogram.UnalignedRetentionMsMs.Length);
                         ValidateTimeRange(graphChromatogram, graphChromatogram.UnalignedRetentionMsMs, 8, 120);
                     }
-                    SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SequenceTree.SelectedNode.NextNode;
+
+                    SkylineWindow.SequenceTree.SelectedNode = SkipInvalidNodes(SkylineWindow.SequenceTree.SelectedNode.NextNode);
                 });
             }
 
@@ -167,7 +170,7 @@ namespace TestPerf
             RunUI(() =>
             {
                 SkylineWindow.SaveDocument();
-                SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SequenceTree.SelectedNode.FirstNode;
+                SkylineWindow.SequenceTree.SelectedNode = SkipInvalidNodes(SkylineWindow.SequenceTree.SelectedNode.FirstNode);
             });
 
             for (int i = 0; i < 6; i++)
@@ -183,8 +186,29 @@ namespace TestPerf
                         Assert.IsTrue(graphChromatogram.PredictedRT.HasValue);
                         ValidateTimeRange(graphChromatogram, new []{graphChromatogram.PredictedRT.Value}, 8, 135);
                     }
-                    SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SequenceTree.SelectedNode.NextNode;
+                    SkylineWindow.SequenceTree.SelectedNode = SkipInvalidNodes(SkylineWindow.SequenceTree.SelectedNode.NextNode);
                 });
+            }
+        }
+        /// <summary>
+        /// If the PeptideDocNode has a precursor m/z that is greater than 900 then return its first
+        /// sibling that matches the criteria.
+        /// The spectra only had a scan range up to 900, so larger peptides will be missing chromatograms.
+        /// </summary>
+        private PeptideTreeNode SkipInvalidNodes(TreeNode treeNode)
+        {
+            Assert.IsInstanceOfType(treeNode, typeof(PeptideTreeNode));
+            var peptideTreeNode = treeNode as PeptideTreeNode;
+            Assert.IsNotNull(peptideTreeNode);
+            while (true)
+            {
+                if (peptideTreeNode.DocNode.TransitionGroups.All(tg => tg.PrecursorMz < 900))
+                {
+                    return peptideTreeNode;
+                }
+
+                peptideTreeNode = (PeptideTreeNode)peptideTreeNode.NextNode;
+                Assert.IsNotNull(peptideTreeNode);
             }
         }
 


### PR DESCRIPTION
When verifying that the decoy chromatograms are correct, skip over any peptides whose precursor m/z is greater than 900, since those peptides will no longer have any chromatograms since the spectra are now being treated as SIM scans.