### PR TITLE
Skyline: Set PeptideLibraries.HasDocument library to false if the document library is removed

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
@@ -513,9 +513,14 @@ namespace pwiz.Skyline.SettingsUI
                     {
                         librarySpecs = Libraries.LibrarySpecs;
                         librariesLoaded = Libraries.Libraries;
+                        documentLibrary = Libraries.HasDocumentLibrary;
+                    }
+                    else
+                    {
+                        // Set to true only if one of the selected libraries is a document library.
+                        documentLibrary = librarySpecs.Any(libSpec => libSpec != null && libSpec.IsDocumentLibrary);
                     }
 
-                    documentLibrary = Libraries.HasDocumentLibrary;
                     // Otherwise, leave the list of loaded libraries empty,
                     // and let the LibraryManager refill it.  This ensures a
                     // clean save of library specs only in the user config, rather


### PR DESCRIPTION
If multiple libraries are selected for a document, un-checking or removing the document library does not set PeptideLibraries.HasDocumentLibrary to false. If the document is then saved and opened again Skyline looks for the document library and adds it back.  If the document is saved as a shared .zip file opening the .zip results in an error about the missing document library and chromatograms are not loaded. 





