### PR TITLE
Move the Settings.Default.Reset to either before the SkylineWindow ha…

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/UpgradeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/UpgradeTest.cs
@@ -52,10 +52,15 @@ namespace pwiz.SkylineTestFunctional
         [TestMethod]
         public void UpgradeBasicFunctionalTest()
         {
-            UpgradeManager.CheckAtStartup = true;
             _deployment = CreateDeployment();
 
             RunFunctionalTest();
+        }
+
+        protected override void InitializeSkylineSettings()
+        {
+            base.InitializeSkylineSettings();
+            UpgradeManager.CheckAtStartup = true;
         }
 
         protected override void DoTest()
@@ -90,10 +95,15 @@ namespace pwiz.SkylineTestFunctional
         [TestMethod]
         public void UpgradeCancelFunctionalTest()
         {
-            UpgradeManager.CheckAtStartup = true;
             _deployment = UpgradeBasicTest.CreateDeployment();
 
             RunFunctionalTest();
+        }
+
+        protected override void InitializeSkylineSettings()
+        {
+            base.InitializeSkylineSettings();
+            UpgradeManager.CheckAtStartup = true;
         }
 
         protected override void DoTest()
@@ -132,10 +142,15 @@ namespace pwiz.SkylineTestFunctional
         [TestMethod]
         public void UpgradeErrorsFunctionalTest()
         {
-            UpgradeManager.CheckAtStartup = false;
             _deployment = UpgradeBasicTest.CreateDeployment();
 
             RunFunctionalTest();
+        }
+
+        protected override void InitializeSkylineSettings()
+        {
+            base.InitializeSkylineSettings();
+            UpgradeManager.CheckAtStartup = false;
         }
 
         private const string errorText = "Update error text";

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1145,20 +1145,7 @@ namespace pwiz.SkylineTestUtil
 
                 // Run test in new thread (Skyline on main thread).
                 Program.Init();
-                Settings.Default.Reset();
-                Settings.Default.ImportResultsAutoCloseWindow = true;
-                Settings.Default.ImportResultsSimultaneousFiles = (int)MultiFileLoader.ImportResultsSimultaneousFileOptions.many;    // use maximum threads for multiple file import
-                Settings.Default.SrmSettingsList[0] = SrmSettingsList.GetDefault();
-                // Reset defaults with names from resources for testing different languages
-                Settings.Default.BackgroundProteomeList[0] = BackgroundProteomeList.GetDefault();
-                Settings.Default.DeclusterPotentialList[0] = DeclusterPotentialList.GetDefault();
-                Settings.Default.RetentionTimeList[0] = RetentionTimeList.GetDefault();
-                Settings.Default.ShowStartupForm = ShowStartPage;
-                Settings.Default.MruList = SetMru;
-                // For automated demos, start with the main window maximized
-                if (IsDemoMode)
-                    Settings.Default.MainWindowMaximized = true;
-
+                InitializeSkylineSettings();
                 if (Program.PauseSeconds != 0)
                 {
                     ForceMzml = false;
@@ -1216,6 +1203,29 @@ namespace pwiz.SkylineTestUtil
                 //Log<AbstractFunctionalTest>.Fail(@"Functional test did not complete");
                 Assert.Fail("Functional test did not complete");
             }
+        }
+
+        /// <summary>
+        /// Reset the settings for the Skyline application before starting a test.
+        /// Tests can override this method if they have have any settings that need to
+        /// be set before the test's DoTest method gets called (i.e. before the SkylineWindow is created).
+        /// </summary>
+        protected virtual void InitializeSkylineSettings()
+        {
+            Settings.Default.Reset();
+            Settings.Default.ImportResultsAutoCloseWindow = true;
+            Settings.Default.ImportResultsSimultaneousFiles = (int)MultiFileLoader.ImportResultsSimultaneousFileOptions.many;    // use maximum threads for multiple file import
+            Settings.Default.SrmSettingsList[0] = SrmSettingsList.GetDefault();
+            // Reset defaults with names from resources for testing different languages
+            Settings.Default.BackgroundProteomeList[0] = BackgroundProteomeList.GetDefault();
+            Settings.Default.DeclusterPotentialList[0] = DeclusterPotentialList.GetDefault();
+            Settings.Default.RetentionTimeList[0] = RetentionTimeList.GetDefault();
+            Settings.Default.ShowStartupForm = ShowStartPage;
+            Settings.Default.MruList = SetMru;
+            // For automated demos, start with the main window maximized
+            if (IsDemoMode)
+                Settings.Default.MainWindowMaximized = true;
+
         }
 
         private void BeginAuditLogging()

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1145,6 +1145,9 @@ namespace pwiz.SkylineTestUtil
 
                 // Run test in new thread (Skyline on main thread).
                 Program.Init();
+                Settings.Default.Reset();
+                Settings.Default.ImportResultsAutoCloseWindow = true;
+                Settings.Default.ImportResultsSimultaneousFiles = (int)MultiFileLoader.ImportResultsSimultaneousFileOptions.many;    // use maximum threads for multiple file import
                 Settings.Default.SrmSettingsList[0] = SrmSettingsList.GetDefault();
                 // Reset defaults with names from resources for testing different languages
                 Settings.Default.BackgroundProteomeList[0] = BackgroundProteomeList.GetDefault();
@@ -1393,9 +1396,6 @@ namespace pwiz.SkylineTestUtil
                     Assert.IsTrue(Program.MainWindow != null && Program.MainWindow.IsHandleCreated,
                     @"Timeout {0} seconds exceeded in WaitForSkyline", waitCycles * SLEEP_INTERVAL / 1000);
                 }
-                Settings.Default.Reset();
-                Settings.Default.ImportResultsAutoCloseWindow = true;
-                Settings.Default.ImportResultsSimultaneousFiles = (int)MultiFileLoader.ImportResultsSimultaneousFileOptions.many;    // use maximum threads for multiple file import
                 BeginAuditLogging();
                 RunTest();
                 EndAuditLogging();
@@ -1406,8 +1406,8 @@ namespace pwiz.SkylineTestUtil
                 Program.AddTestException(x);
             }
 
-            Settings.Default.Reset();
             EndTest();
+            Settings.Default.Reset();
         }
 
         private void RunTest()


### PR DESCRIPTION
Attempt to fix intermittent failures in SettingsPropertyValueCollection.get_Item (called from TreeViewMS.OnPaint).

My theory is that the Settings.Default.Reset() call in WaitForSkyline is happening right as the SkylineWindow is being created on a different thread.

This change moves the Settings.Default.Reset() call so that it happens before we call Program.Main.

I had to change UpgradeTest.cs because they were counting on the fact that the Settings.Default.Reset call usually happened in WaitForSkyline after the SkylineWindow had already been created.