### PR TITLE
Turn on optimization on Skyline-Daily.exe in Release.

### DIFF
--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -90,7 +90,7 @@
     <OutputPath>bin\x64\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>


### PR DESCRIPTION
This option was (presumably accidentally) turned off on 20180904.
Turning off optimization results in a .exe which is 790KB larger (5.4%) and a .pdb which is 2.1MB larger (12%).