### PR TITLE
* fixed logging crash in TestRunner from PR #900

### DIFF
--- a/pwiz_tools/Skyline/Jamfile.jam
+++ b/pwiz_tools/Skyline/Jamfile.jam
@@ -151,7 +151,7 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
         echo Building Skyline Test Data in $(CONFIGURATION:L) configuration...
         msbuild $(SKYLINE_PATH)/Skyline.sln /p:Configuration=$(CONFIGURATION);Platform=$(PLATFORM);OutDir=$(OUTPUT_PATH) /t:TestData /nologo /verbosity:minimal
         echo Testing subset of Skyline's leak checking (pass1) in $(CONFIGURATION:L) configuration...
-        $(OUTPUT_PATH)/TestRunner.exe pass1=on pass2=off test=TestInstrumentInfo,TestQcTraces,TestTicChromatogram $(.teamcity-test-decoration)
+        $(OUTPUT_PATH)/TestRunner.exe buildcheck=1 pass1=on pass2=off test=TestInstrumentInfo,TestQcTraces,TestTicChromatogram $(.teamcity-test-decoration)
         set status=%ERRORLEVEL%
         exit %status%
     }

--- a/pwiz_tools/Skyline/Jamfile.jam
+++ b/pwiz_tools/Skyline/Jamfile.jam
@@ -140,6 +140,22 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
         exit %status%
     }
     
+    rule do_skyline_test_pass1_subset ( targets + : sources * : properties * )
+    {
+        return [ build-properties $(targets) : $(sources) : $(properties) ] ;
+    }
+
+    actions do_skyline_test_pass1_subset
+    {
+        $(MSVC_CURRENT_SETUP_SCRIPT)
+        echo Building Skyline Test Data in $(CONFIGURATION:L) configuration...
+        msbuild $(SKYLINE_PATH)/Skyline.sln /p:Configuration=$(CONFIGURATION);Platform=$(PLATFORM);OutDir=$(OUTPUT_PATH) /t:TestData /nologo /verbosity:minimal
+        echo Testing subset of Skyline's leak checking (pass1) in $(CONFIGURATION:L) configuration...
+        $(OUTPUT_PATH)/TestRunner.exe pass1=on pass2=off test=TestInstrumentInfo,TestQcTraces,TestTicChromatogram $(.teamcity-test-decoration)
+        set status=%ERRORLEVEL%
+        exit %status%
+    }
+    
     rule do_skyline_test_functional ( targets + : sources * : properties * )
     {
         return [ build-properties $(targets) : $(sources) : $(properties) ] ;
@@ -296,6 +312,18 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
         : # sources
         : # actions
             @do_skyline_test_a
+        : # requirements
+            <link>shared:<build>no
+            <conditional>@no-express-requirement
+            <conditional>@msvc-dotnet-requirement
+            <conditional>@build-location
+            <dependency>Skyline.exe
+        ;
+    
+    make TestPass1Subset
+        : # sources
+        : # actions
+            @do_skyline_test_pass1_subset
         : # requirements
             <link>shared:<build>no
             <conditional>@no-express-requirement

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -76,7 +76,8 @@ namespace TestRunner
         // These tests get extra runs to meet the leak thresholds
         private static Dictionary<string, ExpandedLeakCheck> LeakCheckIterationsOverrideByTestName = new Dictionary<string, ExpandedLeakCheck>
         {
-            {"TestGroupedStudiesTutorial", new ExpandedLeakCheck(LeakCheckIterations * 4, true)}
+            {"TestGroupedStudiesTutorial", new ExpandedLeakCheck(LeakCheckIterations * 4, true)},
+            {"TestInstrumentInfo", new ExpandedLeakCheck(LeakCheckIterations * 2, true)}
         };
 
         // These tests are allowed to fail the total memory leak threshold, and extra iterations are not done to stabilize a spiky total memory distribution
@@ -670,7 +671,8 @@ namespace TestRunner
                         if (!GetLeakCheckReportEarly(test))
                         {
                             leakMessage = minDeltas.Value.GetLeakMessage(LeakThresholds, test.TestMethod.Name);
-                            runTests.Log(leakMessage);
+                            if (leakMessage != null)
+                                runTests.Log(leakMessage);
                         }
 
                         if (leakMessage != null)


### PR DESCRIPTION
* added TestPass1Subset test in Skyline's Jamfile so pass1 gets some testing on TeamCity
* made TestInstrumentInfo, one of the TestPass1Subset tests, a ReportLeakEarly test so that code path gets tested on TeamCity

@brendanx67 Adding TestInstrumentInfo to the LeakCheckIterationsOverrideByTestName dictionary with ReportLeakEarly changes behavior a bit (if that test starts leaking), but I figure this is acceptable for the benefit of getting some pass1 testing on TeamCity?