### PR TITLE
Skyline/work/20200207 cherry pick20 1

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.cs
@@ -420,6 +420,11 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                     string libraryName =
                         Helpers.GetUniqueName(Path.GetFileNameWithoutExtension(libraryPath), existingNames);
                     docLibSpec = LibrarySpec.CreateFromPath(libraryName, libraryPath);
+                    if (docLibSpec == null)
+                    {
+                        MessageDlg.Show(WizardForm, string.Format(Resources.EditLibraryDlg_OkDialog_The_file__0__is_not_a_supported_spectral_library_file_format, libraryPath));
+                        return false;
+                    }
                     Settings.Default.SpectralLibraryList.SetValue(docLibSpec);
                 }
             }


### PR DESCRIPTION
* Fix exception choosing an invalid library file when "Use Existing" import peptide search. (#903)
(Reported by exception web)

* Fix the Chinese (and Japanese) small molecule quantification tutorial so that they use a different concentrations.xlsx file which uses the localized names of sample types "Blank" etc. (#906)

I have already updated the .zip files at https://skyline.gs.washington.edu/tutorials/SmallMoleculeQuantification.zip and https://skyline.gs.washington.edu/tutorials/SmallMoleculeQuantification_mzML.zip so that they contain those new "concentrations_zh.xlsx" and "concentrations_ja.xlsx" files.

Also, the tutorial was always using mzML. I have changed that so that if PauseForScreenShots it uses raw files.

