### PR TITLE
- added sumMs1 option to scanSumming filter

### DIFF
--- a/pwiz/analysis/common/CwtPeakDetector.hpp
+++ b/pwiz/analysis/common/CwtPeakDetector.hpp
@@ -43,7 +43,7 @@ struct PWIZ_API_DECL CwtPeakDetector : public PeakDetector
     virtual void detect(const std::vector<double>& x, const std::vector<double>& y,
                         std::vector<double>& xPeakValues, std::vector<double>& yPeakValues,
                         std::vector<Peak>* peaks = NULL);
-
+    virtual const char* name() const { return "CantWait (continuous wavelet transform) peak picker"; }
     void getScales( const std::vector <double> &, const std::vector <double> &, std::vector <std::vector< std::vector<int> > > &, std::vector <double> &) const;
     void calcCorrelation( const std::vector <double> &, const std::vector <double> &, const std::vector <std::vector<std::vector<int> > > &, const std::vector <double> &, std::vector < std::vector <double> > &) const;
     void getPeakLines(const std::vector < std::vector <double> > &, const std::vector <double> &, std::vector <ridgeLine> &, std::vector <double> &) const;

--- a/pwiz/analysis/common/LocalMaximumPeakDetector.hpp
+++ b/pwiz/analysis/common/LocalMaximumPeakDetector.hpp
@@ -39,7 +39,7 @@ struct PWIZ_API_DECL LocalMaximumPeakDetector : public PeakDetector
     virtual void detect(const std::vector<double>& x, const std::vector<double>& y,
                         std::vector<double>& xPeakValues, std::vector<double>& yPeakValues,
                         std::vector<Peak>* peaks = NULL);
-
+    virtual const char* name() const { return "local maximum peak picker"; }
     private:
     size_t window_;
 };

--- a/pwiz/analysis/common/PeakDetector.hpp
+++ b/pwiz/analysis/common/PeakDetector.hpp
@@ -50,7 +50,7 @@ struct PWIZ_API_DECL PeakDetector
     virtual void detect(const std::vector<double>& x, const std::vector<double>& y,
                         std::vector<double>& xPeakValues, std::vector<double>& yPeakValues,
                         std::vector<Peak>* peaks = NULL) = 0;
-
+    virtual const char* name() const = 0;
     virtual ~PeakDetector() {}
 };
 

--- a/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
@@ -247,10 +247,11 @@ SpectrumListPtr filterCreator_scanSummer(const MSData& msd, const string& carg, 
     double precursorTol = parseKeyValuePair<double>(arg, "precursorTol=", 0.05); // m/z
     double scanTimeTol = parseKeyValuePair<double>(arg, "scanTimeTol=", 10); // seconds
     double ionMobilityTol = parseKeyValuePair<double>(arg, "ionMobilityTol=", 0.01); // ms for drift time or vs/cm^2 for TIMS
+    bool sumMs1 = parseKeyValuePair<bool>(arg, "sumMs1", false);
     if (bal::icontains(arg, "="))
-        throw user_error("[SpectrumList_ScanSummer] unused argument (key=value) in " + arg);
+        throw user_error("[SpectrumList_ScanSummer] unused argument (key=value) in " + arg + "; supported arguments are precursorTol, scanTimeTol, ionMobilityTol, and sumMs1");
 
-    return SpectrumListPtr(new SpectrumList_ScanSummer(msd.run.spectrumListPtr, precursorTol, scanTimeTol, ionMobilityTol, ilr));
+    return SpectrumListPtr(new SpectrumList_ScanSummer(msd.run.spectrumListPtr, precursorTol, scanTimeTol, ionMobilityTol, sumMs1, ilr));
 }
 UsageInfo usage_scanSummer = {"[precursorTol=<precursor tolerance>] [scanTimeTol=<scan time tolerance in seconds>] [ionMobilityTol=<ion mobility tolerance>]",
     "This filter sums MS2 sub-scans whose precursors are within <precursor tolerance> (default: 0.05 m/z)"

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ChargeFromIsotope.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ChargeFromIsotope.cpp
@@ -713,10 +713,11 @@ void SpectrumList_ChargeFromIsotope::simulateKL(const double finalRetentionTime,
                         elementsForDeletion.push_back( w ); // remove if element equal to min or 
                 }
     
-                for (int w=0, wend = elementsForDeletion.size(); w < wend; ++w )
+                sort(elementsForDeletion.rbegin(), elementsForDeletion.rend());
+                for (int elementToDelete : elementsForDeletion)
                 {
-                    windowIntensity.erase( windowIntensity.begin() + elementsForDeletion[w] - w );
-                    windowMZ.erase( windowMZ.begin() + elementsForDeletion[w] - w );
+                    windowIntensity.erase( windowIntensity.begin() + elementToDelete );
+                    windowMZ.erase( windowMZ.begin() + elementToDelete );
                 }
 
                 peaksInWindow = windowIntensity.size();
@@ -882,32 +883,34 @@ void SpectrumList_ChargeFromIsotope::getParentPeaks(const SpectrumPtr s,const ve
                     elementsForDeletion.push_back( j );
             }
     
-            for (int j=0, jend = elementsForDeletion.size(); j < jend; ++j )
+            sort(elementsForDeletion.rbegin(), elementsForDeletion.rend());
+            for (int elementToDelete : elementsForDeletion)
             {
-                peakIntensities.erase( peakIntensities.begin() + elementsForDeletion[j] - j );
-                peakMZs.erase( peakMZs.begin() + elementsForDeletion[j] - j );
+                peakIntensities.erase( peakIntensities.begin() + elementToDelete );
+                peakMZs.erase( peakMZs.begin() + elementToDelete );
             }
 
             /**
             Reduce number of peaks in window to maxNumberPeaks if needed 
             **/
             int peaksInWindow = peakIntensities.size();
-            elementsForDeletion.clear();
             while ( peaksInWindow > maxNumberPeaks ) 
             {
 
                 BinaryData<double>::iterator minIt = min_element( peakIntensities.begin(), peakIntensities.end() );
 
+                elementsForDeletion.clear();
                 for (int w=0, wend = peakIntensities.size(); w < wend; ++w)
                 {
                     if ( peakIntensities[w] == *minIt )
                         elementsForDeletion.push_back( w ); 
                 }
     
-                for (int w=0, wend = elementsForDeletion.size(); w < wend; ++w )
+                sort(elementsForDeletion.rbegin(), elementsForDeletion.rend());
+                for (int elementToDelete : elementsForDeletion)
                 {
-                    peakIntensities.erase( peakIntensities.begin() + elementsForDeletion[w] - w );
-                    peakMZs.erase( peakMZs.begin() + elementsForDeletion[w] - w );
+                    peakIntensities.erase( peakIntensities.begin() + elementToDelete );
+                    peakMZs.erase( peakMZs.begin() + elementToDelete );
                 }
 
                 peaksInWindow = peakIntensities.size();
@@ -938,33 +941,35 @@ void SpectrumList_ChargeFromIsotope::getParentPeaks(const SpectrumPtr s,const ve
                 else if ( peakIntensities[j] == *minIt )
                     elementsForDeletion.push_back( j ); // remove if element equal to min or 
             }
-    
-            for (int j=0, jend = elementsForDeletion.size(); j < jend; ++j )
+
+            sort(elementsForDeletion.rbegin(), elementsForDeletion.rend());
+            for (int elementToDelete : elementsForDeletion)
             {
-                peakIntensities.erase( peakIntensities.begin() + elementsForDeletion[j] - j );
-                peakMZs.erase( peakMZs.begin() + elementsForDeletion[j] - j );
+                peakIntensities.erase( peakIntensities.begin() + elementToDelete);
+                peakMZs.erase( peakMZs.begin() + elementToDelete);
             }
 
             /**
             Reduce number of peaks in window to maxNumberPeaks if needed 
             **/
             int peaksInWindow = peakIntensities.size();
-            elementsForDeletion.clear();
             while ( peaksInWindow > maxNumberPeaks ) 
             {
 
                 BinaryData<double>::iterator minIt = min_element( peakIntensities.begin(), peakIntensities.end() );
 
+                elementsForDeletion.clear();
                 for (int w=0, wend = peakIntensities.size(); w < wend; ++w)
                 {
                     if ( peakIntensities[w] == *minIt )
                         elementsForDeletion.push_back( w ); 
                 }
     
-                for (int w=0, wend = elementsForDeletion.size(); w < wend; ++w )
+                sort(elementsForDeletion.rbegin(), elementsForDeletion.rend());
+                for (int elementToDelete : elementsForDeletion)
                 {
-                    peakIntensities.erase( peakIntensities.begin() + elementsForDeletion[w] - w );
-                    peakMZs.erase( peakMZs.begin() + elementsForDeletion[w] - w );
+                    peakIntensities.erase( peakIntensities.begin() + elementToDelete );
+                    peakMZs.erase( peakMZs.begin() + elementToDelete);
                 }
 
                 peaksInWindow = peakIntensities.size();

--- a/pwiz/analysis/spectrum_processing/SpectrumList_PeakPicker.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_PeakPicker.cpp
@@ -129,8 +129,12 @@ SpectrumList_PeakPicker::SpectrumList_PeakPicker(
         method.userParams.push_back(UserParam("Waters/MassLynx peak picking"));
     else if (mode_ == 7)
         method.userParams.push_back(UserParam("Shimadzu peak picking"));
-    //else
-    //    method.userParams.push_back(algorithm->name());
+    else if (algorithm != NULL)
+        method.userParams.emplace_back(algorithm->name());
+
+    if (algorithm_)
+        noVendorCentroidingWarningMessage_ = string("[SpectrumList_PeakPicker]: vendor centroiding requested but not available for this data; falling back to ") + algorithm_->name();
+
     if (preferVendorPeakPicking && !mode_ && (algorithm_ != NULL)) // VendorOnlyPeakPicker sets algorithm null, we deal with this at get binary data time
     {
         cerr << "Warning: vendor peakPicking was requested, but is unavailable";
@@ -283,6 +287,9 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_PeakPicker::spectrum(size_t index, bool g
     {
         if (algorithm_ == NULL) // As with VendorOnlyPeakPicker
             throw NoVendorPeakPickingException();
+        if (mode_)
+            warn_once(noVendorCentroidingWarningMessage_.c_str());
+
         BinaryData<double>& mzs = s->getMZArray()->data;
         BinaryData<double>& intensities = s->getIntensityArray()->data;
         if (mzs.empty())

--- a/pwiz/analysis/spectrum_processing/SpectrumList_PeakPicker.hpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_PeakPicker.hpp
@@ -58,6 +58,7 @@ class PWIZ_API_DECL SpectrumList_PeakPicker : public msdata::SpectrumListWrapper
     private:
     PeakDetectorPtr algorithm_;
     const util::IntegerSet msLevelsToPeakPick_;
+    std::string noVendorCentroidingWarningMessage_;
     int mode_;
 };
 

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummer.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummer.cpp
@@ -170,7 +170,6 @@ double SpectrumList_ScanSummer::getPrecursorMz(const msdata::Spectrum& spectrum)
 // SpectrumList_ScanSummer
 //
 
-
 void SpectrumList_ScanSummer::sumSubScansNaive( BinaryData<double> & x, BinaryData<double> & y, const precursorGroupPtr& precursorGroupPtr, DetailLevel detailLevel ) const
 {
     if (x.size() != y.size())
@@ -178,6 +177,8 @@ void SpectrumList_ScanSummer::sumSubScansNaive( BinaryData<double> & x, BinaryDa
 
     BinaryData<double>& summedMZ = x;
     BinaryData<double>& summedIntensity = y;
+
+    sort_together(summedMZ, vector<boost::iterator_range<BinaryData<double>::iterator>> { summedIntensity });
 
     vector<double> binnedMZ; binnedMZ.reserve(summedMZ.size());
     vector<double> binnedIntensity; binnedIntensity.reserve(summedMZ.size());
@@ -204,6 +205,10 @@ void SpectrumList_ScanSummer::sumSubScansNaive( BinaryData<double> & x, BinaryDa
         swap(summedMZ, binnedMZ);
         swap(summedIntensity, binnedIntensity);
     }
+
+    if (!precursorGroupPtr)
+        return;
+
     vector<int>::const_iterator InitialIt = precursorGroupPtr->indexList.begin()+1;
     for( vector<int>::const_iterator listIt = InitialIt; listIt != precursorGroupPtr->indexList.end(); ++listIt)
     {
@@ -239,8 +244,8 @@ void SpectrumList_ScanSummer::sumSubScansNaive( BinaryData<double> & x, BinaryDa
 
 
 
-PWIZ_API_DECL SpectrumList_ScanSummer::SpectrumList_ScanSummer(const SpectrumListPtr& original, double precursorTol, double rTimeTol, double mobilityTol, IterationListenerRegistry* ilr)
-:   SpectrumListWrapper(original), precursorTol_(precursorTol), rTimeTol_(rTimeTol), mobilityTol_(mobilityTol)
+PWIZ_API_DECL SpectrumList_ScanSummer::SpectrumList_ScanSummer(const SpectrumListPtr& original, double precursorTol, double rTimeTol, double mobilityTol, bool sumMs1, IterationListenerRegistry* ilr)
+:   SpectrumListWrapper(original), precursorTol_(precursorTol), rTimeTol_(rTimeTol), mobilityTol_(mobilityTol), sumMs1_(sumMs1)
 {
     if (!inner_.get()) throw runtime_error("[SpectrumList_ScanSummer] Null pointer");
 
@@ -253,7 +258,7 @@ PWIZ_API_DECL SpectrumList_ScanSummer::SpectrumList_ScanSummer(const SpectrumLis
             SpectrumPtr s = inner_->spectrum(i, false);
             double precursorMZ = getPrecursorMz(*s);
 
-            if (precursorMZ == 0.0) // ms1 scans do not need summing
+            if (precursorMZ == 0.0) // ms1 scans do not need grouping
             {
                 pushSpectrum(spectrumIdentity);
                 precursorMap.push_back(precursorGroupPtr());
@@ -348,30 +353,35 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_ScanSummer::spectrum(size_t index, Detail
 
     size_t summedScanIndex = indexMap.at(index);
     SpectrumPtr summedSpectrum = inner_->spectrum(summedScanIndex, true);
-    
-    if (summedSpectrum->cvParam(MS_ms_level).valueAs<int>() > 1) // MS/MS scan
+
+    int msLevel = summedSpectrum->cvParam(MS_ms_level).valueAs<int>();
+    if (msLevel > 1 || sumMs1_)
     {
         try
         {
-            auto precursorGroupPtr = precursorMap.at(index);
-            if (!precursorGroupPtr)
-                throw runtime_error("ms2 index points to null precursorGroupPtr");
+            precursorGroupPtr precursorGroupPtr;
+            if (msLevel > 1)
+            {
+                precursorGroupPtr = precursorMap.at(index);
+                if (!precursorGroupPtr)
+                    throw runtime_error("ms2 index points to null precursorGroupPtr");
 
-            // output ms2 spectra by retention time, grab the appropriate spectrum
-            int newIndex = precursorGroupPtr->indexList[0];
-            summedSpectrum = inner_->spectrum(newIndex, true);
+                // output ms2 spectra by retention time, grab the appropriate spectrum
+                int newIndex = precursorGroupPtr->indexList[0];
+                summedSpectrum = inner_->spectrum(newIndex, true);
 
-            for (auto& cvParam : summedSpectrum->scanList.scans[0].cvParams)
-                if (cvParam.cvid == MS_scan_start_time)
-                    cvParam.value = lexical_cast<string>(median(precursorGroupPtr->scanTimes));
-                else if (cvParam.cvid == MS_inverse_reduced_ion_mobility)
-                    cvParam.value = lexical_cast<string>(median(precursorGroupPtr->ionMobilities));
-            for (auto& cvParam : summedSpectrum->precursors[0].selectedIons[0].cvParams)
-                if (cvParam.cvid == MS_selected_ion_m_z)
-                    cvParam.value = lexical_cast<string>(median(precursorGroupPtr->precursorMZs));
+                for (auto& cvParam : summedSpectrum->scanList.scans[0].cvParams)
+                    if (cvParam.cvid == MS_scan_start_time)
+                        cvParam.value = lexical_cast<string>(median(precursorGroupPtr->scanTimes));
+                    else if (cvParam.cvid == MS_inverse_reduced_ion_mobility)
+                        cvParam.value = lexical_cast<string>(median(precursorGroupPtr->ionMobilities));
+                for (auto& cvParam : summedSpectrum->precursors[0].selectedIons[0].cvParams)
+                    if (cvParam.cvid == MS_selected_ion_m_z)
+                        cvParam.value = lexical_cast<string>(median(precursorGroupPtr->precursorMZs));
 
-            // keep only first scan
-            summedSpectrum->scanList.scans.erase(summedSpectrum->scanList.scans.begin() + 1, summedSpectrum->scanList.scans.end());
+                // keep only first scan
+                summedSpectrum->scanList.scans.erase(summedSpectrum->scanList.scans.begin() + 1, summedSpectrum->scanList.scans.end());
+            }
 
             BinaryData<double>& mzs = summedSpectrum->getMZArray()->data;
             BinaryData<double>& intensities = summedSpectrum->getIntensityArray()->data;

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummer.hpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummer.hpp
@@ -56,7 +56,7 @@ class PWIZ_API_DECL SpectrumList_ScanSummer : public msdata::SpectrumListWrapper
 {
     public:
 
-    SpectrumList_ScanSummer(const msdata::SpectrumListPtr& inner, double precursorTol, double rTimeTol, double mobilityTol = 0, pwiz::util::IterationListenerRegistry* ilr = 0);
+    SpectrumList_ScanSummer(const msdata::SpectrumListPtr& inner, double precursorTol, double rTimeTol, double mobilityTol = 0, bool sumMs1 = false, pwiz::util::IterationListenerRegistry* ilr = 0);
     void pushSpectrum(const msdata::SpectrumIdentity&);
     double getPrecursorMz(const msdata::Spectrum&) const;
     //void sumSubScansResample( std::vector<double> &, std::vector<double> &, size_t, msdata::DetailLevel) const;
@@ -74,6 +74,7 @@ class PWIZ_API_DECL SpectrumList_ScanSummer : public msdata::SpectrumListWrapper
     double precursorTol_;
     double rTimeTol_;
     double mobilityTol_;
+    bool sumMs1_;
 
     std::vector<msdata::SpectrumIdentity> spectrumIdentities; // local cache, with fixed up index fields
     std::vector<size_t> indexMap; // maps index -> original index

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummerTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummerTest.cpp
@@ -50,68 +50,104 @@ struct TestScanSummerCalculator
     double inputPrecursorMZ;
     double rTime;
     double ionMobility;
+    int msLevel;
 };
 
 TestScanSummerCalculator testScanSummerCalculators[] =
 {
+    { "112 112.0000001 112.1 120 121 123 124 128 129 112 112.0000001 112.1 120 121 123 124 128 129",
+      "  3           2     6   0   1   4   2   1   7   3           2     6   0   1   4   2   1   7",
+      0,
+      20.0,
+      0.0,
+      1},
+
+    { "112.0001 119 120 121 122 123 124 127 128 129",
+      "       1   4   5   6   7   8   9  10  11  12",
+      0,
+      20.1,
+      0.0,
+      1},
 
     { "112 112.0000001 112.1 120 121 123 124 128 129",
       "  3           2     5   0   1   4   2   1   7",
       120.0,
       20.0,
-      0.0},
+      0.0,
+      2},
 
     { "112.0001 119 120 121 122 123 124 127 128 129",
       "       1   4   5   6   7   8   9  10  11  12",
       120.01,
       20.1,
-      0.0},
+      0.0,
+      2},
 
     { "200 200.1 200.2 200.9 202",
       "1.0 3.0 1.0 0.0 3.0",
       401.23,
       21.1,
-      1.0},
+      1.0,
+      2},
 
     { "120 126 127",
       "7 7 7",
       119.96,
       21.05,
-      0.0},
+      0.0,
+      2},
 
     { "200.1 200.2 200.3 200.8 200.9",
       "1.0 3.0 1.0 1.0 4.0",
       401.19,
       21.2,
-      1.01},
+      1.01,
+      2},
 
     { "200.1 200.2 200.3 200.8 200.9",
       "1.0 3.0 1.0 1.0 4.0",
       401.21,
       21.3,
-      2.0},
+      2.0,
+      2},
 };
 
 TestScanSummerCalculator goldStandard[] =
 {
+    { "112 112.1 120 121 123 124 128 129",
+      " 10    12   0   2   8   4   2  14",
+      0,
+      20.0,
+      0.0,
+      1},
+
+    { "112.0001 119 120 121 122 123 124 127 128 129",
+      "       1   4   5   6   7   8   9  10  11  12",
+      0,
+      20.1,
+      0.0,
+      1},
 
     { "112 112.1 119 120 121 122 123 124 126 127 128 129",
       "6       5   4  12   7   7  12  11   7  17  12  19",
       120.0,
       20.1, // median of 20 20.1 21.05
-      0.0},
+      0.0,
+      2},
 
     { "200 200.1 200.2 200.3 200.8 200.9 202",
       "1.0 4.0 4.0 1.0 1.0 4.0 3.0",
       401.21, // median of 401.19 401.23
       21.15, // median of 21.1 21.2
-      1.005}, // median of 1 1.01
+      1.005, // median of 1 1.01
+      2},
 
     { "200.1 200.2 200.3 200.8 200.9",
       "1.0 3.0 1.0 1.0 4.0",
       401.21,
       21.3,
-      2.0},
+      2.0,
+      2},
 };
 
 const size_t testScanSummerSize = sizeof(testScanSummerCalculators) / sizeof(TestScanSummerCalculator);
@@ -142,14 +178,16 @@ int test()
         TestScanSummerCalculator& t = testScanSummerCalculators[i];
         SpectrumPtr s(new Spectrum);
         s->set(MS_MSn_spectrum);
-        s->set(MS_ms_level,2);
-        s->index = i;
+        s->set(MS_ms_level, t.msLevel);
+        s->index = sl->spectra.size();
         s->scanList.scans.push_back(Scan());
         Scan& scanRef = s->scanList.scans[0];
         scanRef.set(MS_scan_start_time,t.rTime,UO_second);
         if (t.ionMobility > 0)
             scanRef.set(MS_inverse_reduced_ion_mobility, t.ionMobility, MS_volt_second_per_square_centimeter);
-        s->precursors.push_back(Precursor(t.inputPrecursorMZ));
+
+        if (t.msLevel > 1)
+            s->precursors.push_back(Precursor(t.inputPrecursorMZ));
         
         vector<double> inputMZArray = parseDoubleArray(t.inputMZArray);
         vector<double> inputIntensityArray = parseDoubleArray(t.inputIntensityArray);
@@ -176,16 +214,13 @@ int test()
     try
     {
 
-        SpectrumListPtr calculator(new SpectrumList_ScanSummer(originalList, 0.05, 10, 0.5));
+        SpectrumListPtr calculator(new SpectrumList_ScanSummer(originalList, 0.05, 10, 0.5, true));
 
         for (size_t i=0; i < calculator->size(); ++i) 
         {
             SpectrumPtr s = calculator->spectrum(i,true);
             BinaryData<double>& mzs = s->getMZArray()->data;
             BinaryData<double>& intensities = s->getIntensityArray()->data;
-            Precursor& precursor = s->precursors[0];
-            SelectedIon& selectedIon = precursor.selectedIons[0];
-            double precursorMZ = selectedIon.cvParam(MS_selected_ion_m_z).valueAs<double>();
             double rTime = s->scanList.scans[0].cvParam(MS_scan_start_time).timeInSeconds();
             double ionMobility = s->scanList.scans[0].cvParamValueOrDefault(MS_inverse_reduced_ion_mobility, 0.0);
 
@@ -195,9 +230,16 @@ int test()
             unit_assert_operator_equal(2, s->binaryDataArrayPtrs.size()); // mobility array dropped
             unit_assert_operator_equal(goldMZArray.size(), mzs.size());
             unit_assert_operator_equal(goldIntensityArray.size(), intensities.size());
-            unit_assert_equal(goldStandard[i].inputPrecursorMZ, precursorMZ, 1e-8);
             unit_assert_equal(goldStandard[i].rTime, rTime, 1e-8);
             unit_assert_equal(goldStandard[i].ionMobility, ionMobility, 1e-8);
+
+            if (goldStandard[i].msLevel > 1)
+            {
+                Precursor& precursor = s->precursors[0];
+                SelectedIon& selectedIon = precursor.selectedIons[0];
+                double precursorMZ = selectedIon.cvParam(MS_selected_ion_m_z).valueAs<double>();
+                unit_assert_equal(goldStandard[i].inputPrecursorMZ, precursorMZ, 1e-8);
+            }
 
             for (size_t j=0; j < mzs.size(); ++j)
             {

--- a/pwiz/data/msdata/Jamfile.jam
+++ b/pwiz/data/msdata/Jamfile.jam
@@ -68,6 +68,7 @@ lib pwiz_data_msdata
         SpectrumList_MSn.cpp
         SpectrumList_BTDX.cpp
         [ mz5-build SpectrumList_mz5.cpp ]
+        SpectrumListBase.cpp
         SpectrumListCache.cpp
         RAMPAdapter.cpp
         Reader.cpp

--- a/pwiz/data/msdata/SpectrumListBase.cpp
+++ b/pwiz/data/msdata/SpectrumListBase.cpp
@@ -1,0 +1,77 @@
+//
+// $Id$
+//
+//
+// Original author: Matt Chambers <matt.chambers <a.t> vanderbilt.edu>
+//
+// Copyright 2020 Matt Chambers
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+//
+
+
+#define PWIZ_SOURCE
+
+#include "SpectrumListBase.hpp"
+#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/mutex.hpp>
+
+
+namespace {
+    boost::mutex m;
+}
+
+PWIZ_API_DECL void pwiz::msdata::SpectrumListBase::warn_once(const char * msg) const
+{
+    boost::lock_guard<boost::mutex> g(m);
+    if (warn_msg_hashes_.insert(hash_(msg)).second) // .second is true iff value is new
+        std::cerr << msg << std::endl;
+}
+
+
+PWIZ_API_DECL size_t pwiz::msdata::SpectrumListBase::checkNativeIdFindResult(size_t result, const std::string& id) const
+{
+    if (result < size() || size() == 0)
+        return result;
+
+    boost::lock_guard<boost::mutex> g(m);
+
+    // early exit if warning already issued, to avoid potentially doing these calculations for thousands of ids
+    if (!warn_msg_hashes_.insert(spectrum_id_mismatch_hash_).second)
+        return size();
+
+    try
+    {
+        const auto& firstId = spectrumIdentity(0).id;
+        auto actualId = pwiz::msdata::id::parse(firstId);
+        auto actualIdKeys = actualId | boost::adaptors::map_keys;
+        auto actualIdKeySet = std::set<std::string>(actualIdKeys.begin(), actualIdKeys.end());
+
+        auto expectedId = pwiz::msdata::id::parse(id);
+        auto expectedIdKeys = expectedId | boost::adaptors::map_keys;
+        auto expectedIdKeySet = std::set<std::string>(expectedIdKeys.begin(), expectedIdKeys.end());
+
+        std::vector<std::string> missingIdKeys;
+        std::set_symmetric_difference(expectedIdKeySet.begin(), expectedIdKeySet.end(),
+            actualIdKeySet.begin(), actualIdKeySet.end(),
+            std::back_inserter(missingIdKeys));
+        if (!missingIdKeys.empty())
+            warn_once(("[SpectrumList::find]: mismatch between spectrum id format of the file (" + firstId + ") and the looked-up id (" + id + ")").c_str());
+        return size();
+    }
+    catch (std::exception& e)
+    {
+        warn_once(e.what()); // TODO: log exception
+        return size();
+    }
+}

--- a/pwiz/data/msdata/SpectrumListBase.hpp
+++ b/pwiz/data/msdata/SpectrumListBase.hpp
@@ -50,51 +50,12 @@ class PWIZ_API_DECL SpectrumListBase : public SpectrumList
     virtual void setDataProcessingPtr(DataProcessingPtr dp) { dp_ = dp; }
 
     /// issues a warning once per SpectrumList instance (based on string hash)
-    virtual void warn_once(const char* msg) const
-    {
-        if (warn_msg_hashes_.insert(hash_(msg)).second) // .second is true iff value is new
-        {
-            std::cerr << msg << std::endl;
-        }
-    }
+    virtual void warn_once(const char* msg) const;
 
     protected:
 
     // when find() fails to find a spectrum id, check whether the id fields of the input id and the spectrum list are matching
-    size_t checkNativeIdFindResult(size_t result, const std::string& id) const
-    {
-        if (result < size() || size() == 0)
-            return result;
-
-        // early exit if warning already issued, to avoid potentially doing these calculations for thousands of ids
-        if (!warn_msg_hashes_.insert(spectrum_id_mismatch_hash_).second)
-            return size();
-
-        try
-        {
-            const auto& firstId = spectrumIdentity(0).id;
-            auto actualId = pwiz::msdata::id::parse(firstId);
-            auto actualIdKeys = actualId | boost::adaptors::map_keys;
-            auto actualIdKeySet = std::set<std::string>(actualIdKeys.begin(), actualIdKeys.end());
-
-            auto expectedId = pwiz::msdata::id::parse(id);
-            auto expectedIdKeys = expectedId | boost::adaptors::map_keys;
-            auto expectedIdKeySet = std::set<std::string>(expectedIdKeys.begin(), expectedIdKeys.end());
-
-            std::vector<std::string> missingIdKeys;
-            std::set_symmetric_difference(expectedIdKeySet.begin(), expectedIdKeySet.end(),
-                                          actualIdKeySet.begin(), actualIdKeySet.end(),
-                                          std::back_inserter(missingIdKeys));
-            if (!missingIdKeys.empty())
-                warn_once(("[SpectrumList::find]: mismatch between spectrum id format of the file (" + firstId + ") and the looked-up id (" + id + ")").c_str());
-            return size();
-        }
-        catch (std::exception& e)
-        {
-            warn_once(e.what()); // TODO: log exception
-            return size();
-        }
-    }
+    size_t checkNativeIdFindResult(size_t result, const std::string& id) const;
 
     DataProcessingPtr dp_;
 

--- a/pwiz/data/vendor_readers/Agilent/ChromatogramList_Agilent.cpp
+++ b/pwiz/data/vendor_readers/Agilent/ChromatogramList_Agilent.cpp
@@ -140,15 +140,14 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Agilent::chromatogram(size_t inde
             {
                 result->setTimeIntensityArrays(vector<double>(), vector<double>(), UO_minute, MS_number_of_detector_counts);
 
-                automation_vector<double> xArray;
-                chromatogramPtr->getXArray(xArray);
-                result->getTimeArray()->data.assign(xArray.begin(), xArray.end());
+                auto& timeArray = result->getTimeArray()->data;
+                chromatogramPtr->getXArray(timeArray);
 
-                automation_vector<float> yArray;
+                pwiz::util::BinaryData<float> yArray;
                 chromatogramPtr->getYArray(yArray);
                 result->getIntensityArray()->data.assign(yArray.begin(), yArray.end());
 
-                result->defaultArrayLength = xArray.size();
+                result->defaultArrayLength = timeArray.size();
             }
             else
                 result->defaultArrayLength = chromatogramPtr->getTotalDataPoints();
@@ -171,15 +170,14 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Agilent::chromatogram(size_t inde
             {
                 result->setTimeIntensityArrays(vector<double>(), vector<double>(), UO_minute, MS_number_of_detector_counts);
 
-                automation_vector<double> xArray;
-                chromatogramPtr->getXArray(xArray);
-                result->getTimeArray()->data.assign(xArray.begin(), xArray.end());
+                auto& timeArray = result->getTimeArray()->data;
+                chromatogramPtr->getXArray(timeArray);
 
-                automation_vector<float> yArray;
+                pwiz::util::BinaryData<float> yArray;
                 chromatogramPtr->getYArray(yArray);
                 result->getIntensityArray()->data.assign(yArray.begin(), yArray.end());
 
-                result->defaultArrayLength = xArray.size();
+                result->defaultArrayLength = timeArray.size();
             }
             else
                 result->defaultArrayLength = chromatogramPtr->getTotalDataPoints();

--- a/pwiz/utility/misc/BinaryDataTest.cpp
+++ b/pwiz/utility/misc/BinaryDataTest.cpp
@@ -198,6 +198,60 @@ void test()
         unit_assert(equals(*vStd.rbegin(), vStd.back()));
     }
 
+    // test sort_together
+    {
+        std::vector<T> expectedV1{ 3,  2,  5,  1,  6,  4 };
+        std::vector<T> expectedV2{ 5, 10, 15, 20, 30, 50 };
+
+        {
+            std::vector<T> v1 = {  1,  2, 3,  4,  5,  6 };
+            std::vector<T> v2 = { 20, 10, 5, 50, 15, 30 };
+
+            vector<boost::iterator_range<typename std::vector<T>::iterator>> cov = { v1 };
+            pwiz::util::sort_together(v2, cov.begin(), cov.end());
+
+            for (size_t i = 0; i < v1.size(); ++i)
+            {
+                unit_assert_operator_equal(expectedV1[i], v1[i]);
+                unit_assert_operator_equal(expectedV2[i], v2[i]);
+            }
+        }
+
+        {
+            std::vector<T> v1 = {  1,  2, 3,  4,  5,  6 };
+            std::vector<T> v2 = { 20, 10, 5, 50, 15, 30 };
+            std::vector<T> v3 = {  6,  5, 4,  3,  2,  1 };
+
+            vector<boost::iterator_range<typename std::vector<T>::iterator>> cov = { v1, v3 };
+            pwiz::util::sort_together(v2, cov.begin(), cov.end());
+
+            std::vector<T> expectedV3{ 4, 5, 2, 6, 1, 3 };
+            for (size_t i = 0; i < v1.size(); ++i)
+            {
+                unit_assert_operator_equal(expectedV1[i], v1[i]);
+                unit_assert_operator_equal(expectedV2[i], v2[i]);
+                unit_assert_operator_equal(expectedV3[i], v3[i]);
+            }
+        }
+
+        {
+            std::vector<T> v1 = {  1,  2, 3,  4,  5,  6 };
+            std::vector<T> v2 = { 20, 10, 5, 50, 15, 30 };
+            std::vector<T> v3 = {  6,  5, 4,  3,  2,  1 };
+
+            vector<boost::iterator_range<typename std::vector<T>::iterator>> cov = { v1, v3 };
+            pwiz::util::sort_together(v2, cov);
+
+            std::vector<T> expectedV3{ 4, 5, 2, 6, 1, 3 };
+            for (size_t i = 0; i < v1.size(); ++i)
+            {
+                unit_assert_operator_equal(expectedV1[i], v1[i]);
+                unit_assert_operator_equal(expectedV2[i], v2[i]);
+                unit_assert_operator_equal(expectedV3[i], v3[i]);
+            }
+        }
+    }
+
 #ifdef __cplusplus_cli
     // test swap with std::vector<T> with managed array
     {

--- a/pwiz/utility/misc/Container.hpp
+++ b/pwiz/utility/misc/Container.hpp
@@ -35,6 +35,7 @@
 #include <numeric>
 #include <utility>
 #include <boost/foreach.hpp>
+#include <boost/iterator.hpp>
 
 using std::vector;
 using std::list;
@@ -76,6 +77,66 @@ using std::equal_range;
 using std::lower_bound;
 using std::upper_bound;
 
+
+namespace pwiz {
+namespace util {
+
+    template<typename T>
+    struct SortByOther
+    {
+        T begin_;
+
+        SortByOther(T sortValuesBegin) :
+            begin_(sortValuesBegin) {}
+
+        bool operator()(int i1, int i2) const
+        {
+            return *(begin_ + i1) < *(begin_ + i2);
+        }
+    };
+
+    template<typename ContainerT, typename ContainerOfContainerTIterator>
+    void sort_together(ContainerT& sortValues, ContainerOfContainerTIterator cosortValuesItrRangeBegin, ContainerOfContainerTIterator cosortValuesItrRangeEnd)
+    {
+        size_t size = sortValues.size();
+        vector<size_t> indices(size);
+        for (size_t i = 0; i < size; ++i)
+            indices[i] = i;
+        std::sort(indices.begin(), indices.end(), SortByOther<typename ContainerT::iterator>(sortValues.begin()));
+
+        ContainerT tmpSortValues(size);
+        size_t numRanges = cosortValuesItrRangeEnd - cosortValuesItrRangeBegin;
+        vector<ContainerT> tmpValuesRanges(numRanges);
+        for (auto& tmpValues : tmpValuesRanges)
+            tmpValues.resize(size);
+
+        for (size_t i = 0; i < size; ++i)
+        {
+            tmpSortValues[i] = sortValues[indices[i]];
+            for (size_t j = 0; j < numRanges; ++j)
+            {
+                auto& tmpValues = tmpValuesRanges[j];
+                auto& cosortValuesItr = *(cosortValuesItrRangeBegin + j);
+                tmpValues[i] = *(cosortValuesItr.begin() + indices[i]);
+            }
+        }
+        std::swap(tmpSortValues, sortValues);
+        for (size_t j = 0; j < numRanges; ++j)
+        {
+            auto& tmpCosortValues = *(cosortValuesItrRangeBegin + j);
+            for (size_t i = 0; i < size; ++i)
+                std::iter_swap(tmpValuesRanges[j].begin() + i, tmpCosortValues.begin() + i);
+        }
+    }
+
+    template<typename ContainerT, typename ContainerOfContainerT>
+    void sort_together(ContainerT& sortValues, ContainerOfContainerT cosortValuesItrRange)
+    {
+        sort_together(sortValues, std::begin(cosortValuesItrRange), std::end(cosortValuesItrRange));
+    }
+
+} // namespace util
+} // namespace pwiz
 
 #ifndef PWIZ_CONFIG_NO_CONTAINER_OUTPUT_OPERATORS
 

--- a/pwiz_aux/msrc/utility/vendor_api/Agilent/MassHunterData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Agilent/MassHunterData.cpp
@@ -182,10 +182,10 @@ class MassHunterDataImpl : public MassHunterData
     virtual const set<Transition>& getTransitions() const;
     virtual ChromatogramPtr getChromatogram(const Transition& transition) const;
 
-    virtual const automation_vector<double>& getTicTimes(bool ms1Only) const;
-    virtual const automation_vector<double>& getBpcTimes(bool ms1Only) const;
-    virtual const automation_vector<float>& getTicIntensities(bool ms1Only) const;
-    virtual const automation_vector<float>& getBpcIntensities(bool ms1Only) const;
+    virtual const BinaryData<double>& getTicTimes(bool ms1Only) const;
+    virtual const BinaryData<double>& getBpcTimes(bool ms1Only) const;
+    virtual const BinaryData<float>& getTicIntensities(bool ms1Only) const;
+    virtual const BinaryData<float>& getBpcIntensities(bool ms1Only) const;
 
     virtual ScanRecordPtr getScanRecord(int row) const;
     virtual SpectrumPtr getProfileSpectrumByRow(int row) const;
@@ -198,8 +198,8 @@ class MassHunterDataImpl : public MassHunterData
     gcroot<MHDAC::IMsdrDataReader^> reader_;
     gcroot<MIDAC::IMidacImsReader^> imsReader_;
     gcroot<MHDAC::IBDAMSScanFileInformation^> scanFileInfo_;
-    automation_vector<double> ticTimes_, ticTimesMs1_, bpcTimes_, bpcTimesMs1_;
-    automation_vector<float> ticIntensities_, ticIntensitiesMs1_, bpcIntensities_, bpcIntensitiesMs1_;
+    BinaryData<double> ticTimes_, ticTimesMs1_, bpcTimes_, bpcTimesMs1_;
+    BinaryData<float> ticIntensities_, ticIntensitiesMs1_, bpcIntensities_, bpcIntensitiesMs1_;
     set<Transition> transitions_;
     map<Transition, int> transitionToChromatogramIndexMap_;
 
@@ -275,8 +275,8 @@ struct ChromatogramImpl : public Chromatogram
 
     virtual double getCollisionEnergy() const;
     virtual int getTotalDataPoints() const;
-    virtual void getXArray(automation_vector<double>& x) const;
-    virtual void getYArray(automation_vector<float>& y) const;
+    virtual void getXArray(BinaryData<double>& x) const;
+    virtual void getYArray(BinaryData<float>& y) const;
     virtual IonPolarity getIonPolarity() const;
 
     private:
@@ -354,26 +354,26 @@ MassHunterDataImpl::MassHunterDataImpl(const std::string& path)
         // set filter for TIC
         filter->ChromatogramType = MHDAC::ChromType::TotalIon;
         MHDAC::IBDAChromData^ tic = reader_->GetChromatogram(filter)[0];
-        ToAutomationVector(tic->XArray, ticTimes_);
-        ToAutomationVector(tic->YArray, ticIntensities_);
+        ToBinaryData(tic->XArray, ticTimes_);
+        ToBinaryData(tic->YArray, ticIntensities_);
 
         // set filter for BPC
         filter->ChromatogramType = MHDAC::ChromType::BasePeak;
         MHDAC::IBDAChromData^ bpc = reader_->GetChromatogram(filter)[0];
-        ToAutomationVector(bpc->XArray, bpcTimes_);
-        ToAutomationVector(bpc->YArray, bpcIntensities_);
+        ToBinaryData(bpc->XArray, bpcTimes_);
+        ToBinaryData(bpc->YArray, bpcIntensities_);
 
         filter->MSLevelFilter = MHDAC::MSLevel::MS;
         filter->ChromatogramType = MHDAC::ChromType::TotalIon;
         tic = reader_->GetChromatogram(filter)[0];
-        ToAutomationVector(tic->XArray, ticTimesMs1_);
-        ToAutomationVector(tic->YArray, ticIntensitiesMs1_);
+        ToBinaryData(tic->XArray, ticTimesMs1_);
+        ToBinaryData(tic->YArray, ticIntensitiesMs1_);
 
         // set filter for BPC
         filter->ChromatogramType = MHDAC::ChromType::BasePeak;
         bpc = reader_->GetChromatogram(filter)[0];
-        ToAutomationVector(bpc->XArray, bpcTimesMs1_);
-        ToAutomationVector(bpc->YArray, bpcIntensitiesMs1_);
+        ToBinaryData(bpc->XArray, bpcTimesMs1_);
+        ToBinaryData(bpc->YArray, bpcIntensitiesMs1_);
 
         // chromatograms are always read completely into memory, and failing
         // to store them on this object after reading cost a 50x performance
@@ -564,22 +564,22 @@ const set<Transition>& MassHunterDataImpl::getTransitions() const
     return transitions_;
 }
 
-const automation_vector<double>& MassHunterDataImpl::getTicTimes(bool ms1Only) const
+const BinaryData<double>& MassHunterDataImpl::getTicTimes(bool ms1Only) const
 {
     return ms1Only ? ticTimesMs1_ : ticTimes_;
 }
 
-const automation_vector<double>& MassHunterDataImpl::getBpcTimes(bool ms1Only) const
+const BinaryData<double>& MassHunterDataImpl::getBpcTimes(bool ms1Only) const
 {
     return ms1Only ? bpcTimesMs1_ : bpcTimes_;
 }
 
-const automation_vector<float>& MassHunterDataImpl::getTicIntensities(bool ms1Only) const
+const BinaryData<float>& MassHunterDataImpl::getTicIntensities(bool ms1Only) const
 {
     return ms1Only ? ticIntensitiesMs1_ : ticIntensities_;
 }
 
-const automation_vector<float>& MassHunterDataImpl::getBpcIntensities(bool ms1Only) const
+const BinaryData<float>& MassHunterDataImpl::getBpcIntensities(bool ms1Only) const
 {
     return ms1Only ? bpcIntensitiesMs1_ : bpcIntensities_;
 }
@@ -784,14 +784,14 @@ int ChromatogramImpl::getTotalDataPoints() const
     try {return chromData_->TotalDataPoints;} CATCH_AND_FORWARD
 }
 
-void ChromatogramImpl::getXArray(automation_vector<double>& x) const
+void ChromatogramImpl::getXArray(BinaryData<double>& x) const
 {
-    try {return ToAutomationVector(chromData_->XArray, x);} CATCH_AND_FORWARD
+    try {return ToBinaryData(chromData_->XArray, x);} CATCH_AND_FORWARD
 }
 
-void ChromatogramImpl::getYArray(automation_vector<float>& y) const
+void ChromatogramImpl::getYArray(BinaryData<float>& y) const
 {
-    try {return ToAutomationVector(chromData_->YArray, y);} CATCH_AND_FORWARD
+    try {return ToBinaryData(chromData_->YArray, y);} CATCH_AND_FORWARD
 }
 
 IonPolarity ChromatogramImpl::getIonPolarity() const

--- a/pwiz_aux/msrc/utility/vendor_api/Agilent/MassHunterData.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Agilent/MassHunterData.hpp
@@ -30,7 +30,6 @@
 
 
 #include "pwiz/utility/misc/Export.hpp"
-#include "pwiz/utility/misc/automation_vector.h"
 #include "pwiz/utility/misc/BinaryData.hpp"
 #include "pwiz/utility/chemistry/MzMobilityWindow.hpp"
 #include <string>
@@ -177,8 +176,8 @@ struct PWIZ_API_DECL Chromatogram
 {
     virtual double getCollisionEnergy() const = 0;
     virtual int getTotalDataPoints() const = 0;
-    virtual void getXArray(automation_vector<double>& x) const = 0;
-    virtual void getYArray(automation_vector<float>& y) const = 0;
+    virtual void getXArray(pwiz::util::BinaryData<double>& x) const = 0;
+    virtual void getYArray(pwiz::util::BinaryData<float>& y) const = 0;
     virtual IonPolarity getIonPolarity() const = 0;
 
     virtual ~Chromatogram() {}
@@ -309,10 +308,10 @@ class PWIZ_API_DECL MassHunterData
     virtual const std::set<Transition>& getTransitions() const = 0;
     virtual ChromatogramPtr getChromatogram(const Transition& transition) const = 0;
 
-    virtual const automation_vector<double>& getTicTimes(bool ms1Only = false) const = 0;
-    virtual const automation_vector<double>& getBpcTimes(bool ms1Only = false) const = 0;
-    virtual const automation_vector<float>& getTicIntensities(bool ms1Only = false) const = 0;
-    virtual const automation_vector<float>& getBpcIntensities(bool ms1Only = false) const = 0;
+    virtual const pwiz::util::BinaryData<double>& getTicTimes(bool ms1Only = false) const = 0;
+    virtual const pwiz::util::BinaryData<double>& getBpcTimes(bool ms1Only = false) const = 0;
+    virtual const pwiz::util::BinaryData<float>& getTicIntensities(bool ms1Only = false) const = 0;
+    virtual const pwiz::util::BinaryData<float>& getBpcIntensities(bool ms1Only = false) const = 0;
 
     /// rowNumber is a 0-based index
     virtual ScanRecordPtr getScanRecord(int rowNumber) const = 0;

--- a/pwiz_aux/msrc/utility/vendor_api/Agilent/MidacData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Agilent/MidacData.cpp
@@ -287,22 +287,22 @@ const set<Transition>& MidacDataImpl::getTransitions() const
     return transitions_;
 }
 
-const automation_vector<double>& MidacDataImpl::getTicTimes(bool ms1Only) const
+const BinaryData<double>& MidacDataImpl::getTicTimes(bool ms1Only) const
 {
     return ms1Only ? ticTimesMs1_ : ticTimes_;
 }
 
-const automation_vector<double>& MidacDataImpl::getBpcTimes(bool ms1Only) const
+const BinaryData<double>& MidacDataImpl::getBpcTimes(bool ms1Only) const
 {
     return ms1Only ? bpcTimesMs1_ : bpcTimes_;
 }
 
-const automation_vector<float>& MidacDataImpl::getTicIntensities(bool ms1Only) const
+const BinaryData<float>& MidacDataImpl::getTicIntensities(bool ms1Only) const
 {
     return ms1Only ? ticIntensitiesMs1_ : ticIntensities_;
 }
 
-const automation_vector<float>& MidacDataImpl::getBpcIntensities(bool ms1Only) const
+const BinaryData<float>& MidacDataImpl::getBpcIntensities(bool ms1Only) const
 {
     return ms1Only ? bpcIntensitiesMs1_ : bpcIntensities_;
 }

--- a/pwiz_aux/msrc/utility/vendor_api/Agilent/MidacData.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Agilent/MidacData.hpp
@@ -78,10 +78,10 @@ class MidacDataImpl : public MassHunterData
     virtual const std::set<Transition>& getTransitions() const;
     virtual ChromatogramPtr getChromatogram(const Transition& transition) const;
 
-    virtual const automation_vector<double>& getTicTimes(bool ms1Only) const;
-    virtual const automation_vector<double>& getBpcTimes(bool ms1Only) const;
-    virtual const automation_vector<float>& getTicIntensities(bool ms1Only) const;
-    virtual const automation_vector<float>& getBpcIntensities(bool ms1Only) const;
+    virtual const BinaryData<double>& getTicTimes(bool ms1Only) const;
+    virtual const BinaryData<double>& getBpcTimes(bool ms1Only) const;
+    virtual const BinaryData<float>& getTicIntensities(bool ms1Only) const;
+    virtual const BinaryData<float>& getBpcIntensities(bool ms1Only) const;
 
     virtual ScanRecordPtr getScanRecord(int row) const;
     virtual SpectrumPtr getProfileSpectrumByRow(int row) const;
@@ -94,8 +94,8 @@ class MidacDataImpl : public MassHunterData
     gcroot<MIDAC::IMidacImsReader^> imsReader_;
     gcroot<MIDAC::IImsCcsInfoReader^> imsCcsReader_;
     gcroot<MHDAC::IBDAMSScanFileInformation^> scanFileInfo_;
-    automation_vector<double> ticTimes_, ticTimesMs1_, bpcTimes_, bpcTimesMs1_;
-    automation_vector<float> ticIntensities_, ticIntensitiesMs1_, bpcIntensities_, bpcIntensitiesMs1_;
+    BinaryData<double> ticTimes_, ticTimesMs1_, bpcTimes_, bpcTimesMs1_;
+    BinaryData<float> ticIntensities_, ticIntensitiesMs1_, bpcIntensities_, bpcIntensitiesMs1_;
     set<Transition> transitions_;
     map<Transition, int> transitionToChromatogramIndexMap_;
 

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.cpp
@@ -725,21 +725,6 @@ double TimsSpectrum::oneOverK0() const
     }
 }
 
-namespace {
-    template<typename T>
-    struct SortByOther
-    {
-        const vector<T> & value_vector;
-
-        SortByOther(const vector<T> & val_vec) :
-            value_vector(val_vec) {}
-
-        bool operator()(int i1, int i2) const
-        {
-            return value_vector[i1] < value_vector[i2];
-        }
-    };
-}
 
 void TimsSpectrum::getCombinedSpectrumData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities, pwiz::util::BinaryData<double>& mobilities, bool sortAndJitter) const
 {
@@ -778,21 +763,7 @@ void TimsSpectrum::getCombinedSpectrumData(pwiz::util::BinaryData<double>& mz, p
     if (!sortAndJitter)
         return;
 
-    // sort an array of indices by m/z; these indices are used to reorder all 3 arrays
-    vector<int> indices(mz.size());
-    for (int i = 0; i < mz.size(); ++i)
-        indices[i] = i;
-    std::sort(indices.begin(), indices.end(), SortByOther<double>(mz));
-    pwiz::util::BinaryData<double> mzTmp(mz.size()), intensityTmp(mz.size()), mobilityTmp(mz.size());
-    for (int i = 0; i < mz.size(); ++i)
-    {
-        mzTmp[i] = mz[indices[i]];
-        intensityTmp[i] = intensities[indices[i]];
-        mobilityTmp[i] = mobilities[indices[i]];
-    }
-    swap(mzTmp, mz);
-    swap(intensityTmp, intensities);
-    swap(mobilityTmp, mobilities);
+    sort_together(mz, vector<boost::iterator_range<BinaryData<double>::iterator>> { intensities, mobilities });
 
     // add jitter to identical m/z values (which come from different mobility bins)
     for (size_t i = 1; i < mz.size(); ++i)

--- a/pwiz_tools/MSConvertGUI/MainForm.Designer.cs
+++ b/pwiz_tools/MSConvertGUI/MainForm.Designer.cs
@@ -64,6 +64,10 @@ namespace MSConvertGUI
             this.StartButton = new System.Windows.Forms.Button();
             this.FilterGB = new System.Windows.Forms.GroupBox();
             this.SubsetPanel = new System.Windows.Forms.Panel();
+            this.PolarityBox = new System.Windows.Forms.ComboBox();
+            this.PolarityLabel = new System.Windows.Forms.Label();
+            this.AnalyzerTypeBox = new System.Windows.Forms.ComboBox();
+            this.AnalyzerTypeLabel = new System.Windows.Forms.Label();
             this.MSLevelsLabel = new System.Windows.Forms.Label();
             this.ActivationTypeBox = new System.Windows.Forms.ComboBox();
             this.MSLabelSeperator = new System.Windows.Forms.Label();
@@ -191,10 +195,7 @@ namespace MSConvertGUI
             this.networkResourceComboBox = new System.Windows.Forms.ComboBox();
             this.label3 = new System.Windows.Forms.Label();
             this.presetComboBox = new System.Windows.Forms.ComboBox();
-            this.AnalyzerTypeBox = new System.Windows.Forms.ComboBox();
-            this.AnalyzerTypeLabel = new System.Windows.Forms.Label();
-            this.PolarityBox = new System.Windows.Forms.ComboBox();
-            this.PolarityLabel = new System.Windows.Forms.Label();
+            this.ScanSummingSumMs1Checkbox = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.FilterDGV)).BeginInit();
             this.FilterGB.SuspendLayout();
             this.SubsetPanel.SuspendLayout();
@@ -318,8 +319,8 @@ namespace MSConvertGUI
             // 
             this.FilterGB.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.FilterGB.Controls.Add(this.SubsetPanel);
             this.FilterGB.Controls.Add(this.ScanSummingPanel);
+            this.FilterGB.Controls.Add(this.SubsetPanel);
             this.FilterGB.Controls.Add(this.LockmassRefinerPanel);
             this.FilterGB.Controls.Add(this.DemultiplexPanel);
             this.FilterGB.Controls.Add(this.FilterBox);
@@ -376,6 +377,57 @@ namespace MSConvertGUI
             this.SubsetPanel.Size = new System.Drawing.Size(500, 145);
             this.SubsetPanel.TabIndex = 6;
             this.SubsetPanel.Visible = false;
+            // 
+            // PolarityBox
+            // 
+            this.PolarityBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.PolarityBox.FormattingEnabled = true;
+            this.PolarityBox.Items.AddRange(new object[] {
+            "Any",
+            "Negative",
+            "Positive"});
+            this.PolarityBox.Location = new System.Drawing.Point(135, 112);
+            this.PolarityBox.MaxDropDownItems = 16;
+            this.PolarityBox.Name = "PolarityBox";
+            this.PolarityBox.Size = new System.Drawing.Size(93, 21);
+            this.PolarityBox.Sorted = true;
+            this.PolarityBox.TabIndex = 32;
+            // 
+            // PolarityLabel
+            // 
+            this.PolarityLabel.AutoSize = true;
+            this.PolarityLabel.Location = new System.Drawing.Point(56, 116);
+            this.PolarityLabel.Name = "PolarityLabel";
+            this.PolarityLabel.Size = new System.Drawing.Size(71, 13);
+            this.PolarityLabel.TabIndex = 33;
+            this.PolarityLabel.Text = "Scan polarity:";
+            // 
+            // AnalyzerTypeBox
+            // 
+            this.AnalyzerTypeBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.AnalyzerTypeBox.FormattingEnabled = true;
+            this.AnalyzerTypeBox.Items.AddRange(new object[] {
+            "Any",
+            "FT",
+            "IT",
+            "orbi",
+            "quad",
+            "TOF"});
+            this.AnalyzerTypeBox.Location = new System.Drawing.Point(372, 86);
+            this.AnalyzerTypeBox.MaxDropDownItems = 16;
+            this.AnalyzerTypeBox.Name = "AnalyzerTypeBox";
+            this.AnalyzerTypeBox.Size = new System.Drawing.Size(93, 21);
+            this.AnalyzerTypeBox.Sorted = true;
+            this.AnalyzerTypeBox.TabIndex = 30;
+            // 
+            // AnalyzerTypeLabel
+            // 
+            this.AnalyzerTypeLabel.AutoSize = true;
+            this.AnalyzerTypeLabel.Location = new System.Drawing.Point(293, 90);
+            this.AnalyzerTypeLabel.Name = "AnalyzerTypeLabel";
+            this.AnalyzerTypeLabel.Size = new System.Drawing.Size(73, 13);
+            this.AnalyzerTypeLabel.TabIndex = 31;
+            this.AnalyzerTypeLabel.Text = "Analyzer type:";
             // 
             // MSLevelsLabel
             // 
@@ -646,6 +698,7 @@ namespace MSConvertGUI
             // 
             // ScanSummingPanel
             // 
+            this.ScanSummingPanel.Controls.Add(this.ScanSummingSumMs1Checkbox);
             this.ScanSummingPanel.Controls.Add(this.label7);
             this.ScanSummingPanel.Controls.Add(this.label8);
             this.ScanSummingPanel.Controls.Add(this.label9);
@@ -657,7 +710,7 @@ namespace MSConvertGUI
             this.ScanSummingPanel.Controls.Add(this.ScanSummingPrecursorToleranceTextBox);
             this.ScanSummingPanel.Location = new System.Drawing.Point(24, 47);
             this.ScanSummingPanel.Name = "ScanSummingPanel";
-            this.ScanSummingPanel.Size = new System.Drawing.Size(283, 91);
+            this.ScanSummingPanel.Size = new System.Drawing.Size(283, 112);
             this.ScanSummingPanel.TabIndex = 18;
             this.ScanSummingPanel.Visible = false;
             // 
@@ -1687,56 +1740,16 @@ namespace MSConvertGUI
             this.presetComboBox.TabIndex = 35;
             this.presetComboBox.SelectedIndexChanged += new System.EventHandler(this.presetComboBox_SelectedIndexChanged);
             // 
-            // AnalyzerTypeBox
+            // ScanSummingSumMs1Checkbox
             // 
-            this.AnalyzerTypeBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.AnalyzerTypeBox.FormattingEnabled = true;
-            this.AnalyzerTypeBox.Items.AddRange(new object[] {
-            "Any",
-            "FT",
-            "IT",
-            "orbi",
-            "quad",
-            "TOF"});
-            this.AnalyzerTypeBox.Location = new System.Drawing.Point(372, 86);
-            this.AnalyzerTypeBox.MaxDropDownItems = 16;
-            this.AnalyzerTypeBox.Name = "AnalyzerTypeBox";
-            this.AnalyzerTypeBox.Size = new System.Drawing.Size(93, 21);
-            this.AnalyzerTypeBox.Sorted = true;
-            this.AnalyzerTypeBox.TabIndex = 30;
-            // 
-            // AnalyzerTypeLabel
-            // 
-            this.AnalyzerTypeLabel.AutoSize = true;
-            this.AnalyzerTypeLabel.Location = new System.Drawing.Point(293, 90);
-            this.AnalyzerTypeLabel.Name = "AnalyzerTypeLabel";
-            this.AnalyzerTypeLabel.Size = new System.Drawing.Size(73, 13);
-            this.AnalyzerTypeLabel.TabIndex = 31;
-            this.AnalyzerTypeLabel.Text = "Analyzer type:";
-            // 
-            // PolarityBox
-            // 
-            this.PolarityBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.PolarityBox.FormattingEnabled = true;
-            this.PolarityBox.Items.AddRange(new object[] {
-            "Any",
-            "Negative",
-            "Positive"});
-            this.PolarityBox.Location = new System.Drawing.Point(135, 112);
-            this.PolarityBox.MaxDropDownItems = 16;
-            this.PolarityBox.Name = "PolarityBox";
-            this.PolarityBox.Size = new System.Drawing.Size(93, 21);
-            this.PolarityBox.Sorted = true;
-            this.PolarityBox.TabIndex = 32;
-            // 
-            // PolarityLabel
-            // 
-            this.PolarityLabel.AutoSize = true;
-            this.PolarityLabel.Location = new System.Drawing.Point(56, 116);
-            this.PolarityLabel.Name = "PolarityLabel";
-            this.PolarityLabel.Size = new System.Drawing.Size(71, 13);
-            this.PolarityLabel.TabIndex = 33;
-            this.PolarityLabel.Text = "Scan polarity:";
+            this.ScanSummingSumMs1Checkbox.AutoSize = true;
+            this.ScanSummingSumMs1Checkbox.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.ScanSummingSumMs1Checkbox.Location = new System.Drawing.Point(14, 87);
+            this.ScanSummingSumMs1Checkbox.Name = "ScanSummingSumMs1Checkbox";
+            this.ScanSummingSumMs1Checkbox.Size = new System.Drawing.Size(128, 17);
+            this.ScanSummingSumMs1Checkbox.TabIndex = 19;
+            this.ScanSummingSumMs1Checkbox.Text = "Sum MS1 scans also:";
+            this.ScanSummingSumMs1Checkbox.UseVisualStyleBackColor = true;
             // 
             // MainForm
             // 
@@ -1943,6 +1956,7 @@ namespace MSConvertGUI
         private System.Windows.Forms.Label AnalyzerTypeLabel;
         private System.Windows.Forms.ComboBox PolarityBox;
         private System.Windows.Forms.Label PolarityLabel;
+        private System.Windows.Forms.CheckBox ScanSummingSumMs1Checkbox;
     }
 }
 

--- a/pwiz_tools/MSConvertGUI/MainForm.cs
+++ b/pwiz_tools/MSConvertGUI/MainForm.cs
@@ -651,7 +651,7 @@ namespace MSConvertGUI
                     FilterDGV.Rows.Add(new[] { "lockmassRefiner", $"mz={LockmassMz.Text} tol={LockmassTolerance.Text}" });
                     break;
                 case "Scan Summing":
-                    FilterDGV.Rows.Add(new[] { "scanSumming", $"precursorTol={ScanSummingPrecursorToleranceTextBox.Text} scanTimeTol={ScanSummingScanTimeToleranceTextBox.Text} ionMobilityTol={ScanSummingIonMobilityToleranceTextBox.Text}" });
+                    FilterDGV.Rows.Add(new[] { "scanSumming", $"precursorTol={ScanSummingPrecursorToleranceTextBox.Text} scanTimeTol={ScanSummingScanTimeToleranceTextBox.Text} ionMobilityTol={ScanSummingIonMobilityToleranceTextBox.Text} sumMs1={(ScanSummingSumMs1Checkbox.Checked ? 1 : 0)}" });
                     break;
             }
         }
@@ -1191,6 +1191,7 @@ namespace MSConvertGUI
             setToolTip(this.ScanSummingPrecursorToleranceTextBox, "Specify how similar two MS2 spectra's precursors must be to be considered for summing.");
             setToolTip(this.ScanSummingScanTimeToleranceTextBox, "Specify how similar two MS2 spectra's scan times must be to be considered for summing. A value of 0 specifies that a similar scan time is not required for summing.");
             setToolTip(this.ScanSummingIonMobilityToleranceTextBox, "Specify how similar two MS2 spectra's ion mobilities must be to be considered for summing. A value of 0 specifies that a similar ion mobility is not required for summing.");
+            setToolTip(this.ScanSummingSumMs1Checkbox, "Specify whether to sum MS1 scans as well as MS2s. Currently the tolerances are ignored: points are only summed within MS1 spectra, not between them.");
         }
 
         private void AboutButtonClick(object sender, EventArgs e)

--- a/pwiz_tools/MSConvertGUI/MainForm.resx
+++ b/pwiz_tools/MSConvertGUI/MainForm.resx
@@ -126,12 +126,6 @@
   <metadata name="ValueTab.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="OptionTab.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ValueTab.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="presetSaveButtonMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>142, 18</value>
   </metadata>


### PR DESCRIPTION
- added sumMs1 option to scanSumming filter, useful for getting Agilent and Waters data with combineIonMobilitySpectra back to the pre-3-array state (mobility array is dropped, near-identical m/z values at different mobilities have their intensities summed)

- added warning message when vendor centroiding requested but not available
* added PeakDetector::name() to allow implementations a descriptive string which SpectrumList_PeakPicker will now put in a UserParam
* fixed SpectrumListBase::warn_once() to be thread-safe
* refactored places still using automation_vector in Agilent readers to use BinaryData
* factored out TimsData::getCombinedSpectrumData()'s SortByOther to pwiz::util::sort_together(), also used by SpectrumList_ScanSummer (CONSIDER: an internal Spectrum property that tracks how the binary data is sorted, so functions that required data sorted a certain way can avoid sorting if it's already sorted the way they want)