### PR TITLE
Fix problems associated with manually adjusted peak boundaries in Tri…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/ChromGraphItem.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ChromGraphItem.cs
@@ -81,7 +81,7 @@ namespace pwiz.Skyline.Controls.Graphs
                               TransitionDocNode transition,
                               ChromatogramInfo chromatogram,
                               TransitionChromInfo tranPeakInfo,
-                              IRegressionFunction timeRegressionFunction,
+                              RegressionLine timeRegressionFunction,
                               bool[] annotatePeaks,
                               double[] dotProducts,
                               double bestProduct,
@@ -162,7 +162,7 @@ namespace pwiz.Skyline.Controls.Graphs
         public TransitionDocNode TransitionNode { get; private set; }
         public ChromatogramInfo Chromatogram { get; private set; }
         public TransitionChromInfo TransitionChromInfo { get; private set; }
-        public IRegressionFunction TimeRegressionFunction { get; private set; }
+        public RegressionLine TimeRegressionFunction { get; private set; }
         public ScaledRetentionTime ScaleRetentionTime(double measuredTime)
         {
             return new ScaledRetentionTime(measuredTime, MeasuredTimeToDisplayTime(measuredTime));
@@ -902,24 +902,20 @@ namespace pwiz.Skyline.Controls.Graphs
             return TimeRegressionFunction.GetY(time);
         }
 
-        public ScaledRetentionTime GetNearestDisplayTime(double displayTime)
+        public ScaledRetentionTime GetValidPeakBoundaryTime(double displayTime)
         {
-            int index = NearestIndex(_displayTimes, displayTime);
-            if (index < 0)
+            double measuredTime = TimeRegressionFunction == null
+                ? displayTime
+                : TimeRegressionFunction.GetX(displayTime);
+            var chromatogramInfo = Chromatogram;
+            if (chromatogramInfo.TimeIntervals != null)
             {
-                return ScaledRetentionTime.ZERO;
+                return ScaleRetentionTime(measuredTime);
             }
-            return new ScaledRetentionTime(_measuredTimes[index], _displayTimes[index]);
-        }
 
-        public ScaledRetentionTime GetNearestMeasuredTime(double measuredTime)
-        {
-            int index = GetNearestMeasuredIndex(measuredTime);
-            if (index < 0)
-            {
-                return ScaledRetentionTime.ZERO;
-            }
-            return new ScaledRetentionTime(_measuredTimes[index], _displayTimes[index]);
+            var interpolatedTimeIntensities = chromatogramInfo.GetInterpolatedTimeIntensities();
+            int index = interpolatedTimeIntensities.IndexOfNearestTime((float)displayTime);
+            return ScaleRetentionTime(interpolatedTimeIntensities.Times[index]);
         }
 
         public int GetNearestMeasuredIndex(double measuredTime)

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphValues.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphValues.cs
@@ -139,7 +139,7 @@ namespace pwiz.Skyline.Controls.Graphs
             /// If successful, then this method returns true, and the regressionFunction is set 
             /// appropriately.
             /// </summary>
-            bool TryGetRegressionFunction(ChromFileInfoId chromFileInfoId, out IRegressionFunction regressionFunction);
+            bool TryGetRegressionFunction(ChromFileInfoId chromFileInfoId, out RegressionLine regressionFunction);
         }
 
         public class RegressionUnconversion : IRetentionTimeTransformOp
@@ -160,7 +160,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 return string.Format(Resources.RegressionUnconversion_CalculatorScoreValueFormat, calculatorName, ToLocalizedString(rtPeptideValue));
             }
 
-            public bool TryGetRegressionFunction(ChromFileInfoId chromFileInfoId, out IRegressionFunction regressionFunction)
+            public bool TryGetRegressionFunction(ChromFileInfoId chromFileInfoId, out RegressionLine regressionFunction)
             {
                 regressionFunction = _retentionTimeRegression.GetUnconversion(chromFileInfoId);
                 return regressionFunction != null;
@@ -221,7 +221,7 @@ namespace pwiz.Skyline.Controls.Graphs
             public ChromatogramSet ChromatogramSet { get; private set; }
             public ChromFileInfo ChromFileInfo { get; private set; }
             public FileRetentionTimeAlignments FileRetentionTimeAlignments { get; private set; }
-            public bool TryGetRegressionFunction(ChromFileInfoId chromFileInfoId, out IRegressionFunction regressionFunction)
+            public bool TryGetRegressionFunction(ChromFileInfoId chromFileInfoId, out RegressionLine regressionFunction)
             {
                 if (ReferenceEquals(chromFileInfoId, ChromFileInfo.Id))
                 {

--- a/pwiz_tools/Skyline/Controls/Graphs/RTReplicateGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTReplicateGraphPane.cs
@@ -364,7 +364,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 }
                 Assume.IsNotNull(chromInfoData, @"chromInfoData");
                 Assume.IsNotNull(chromInfoData.ChromFileInfo, @"chromInfoData.ChromFileInfo");
-                IRegressionFunction regressionFunction;
+                RegressionLine regressionFunction;
                 return !RetentionTimeTransform.RtTransformOp.TryGetRegressionFunction(chromInfoData.ChromFileInfo.FileId, out regressionFunction);
             }
 
@@ -383,7 +383,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 foreach (var chromInfoData in chromInfoDatas)
                 {
                     var retentionTimeValues = getRetentionTimeValues(chromInfoData).GetValueOrDefault();
-                    IRegressionFunction regressionFunction = null;
+                    RegressionLine regressionFunction = null;
                     if (null != RetentionTimeTransform.RtTransformOp)
                     {
                         RetentionTimeTransform.RtTransformOp.TryGetRegressionFunction(chromInfoData.ChromFileInfo.FileId, out regressionFunction);

--- a/pwiz_tools/Skyline/Controls/Graphs/SummaryPeptideGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SummaryPeptideGraphPane.cs
@@ -600,7 +600,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 {
                     return retentionTimeValues;
                 }
-                IRegressionFunction regressionFunction;
+                RegressionLine regressionFunction;
                 if (!RetentionTimeTransformOp.TryGetRegressionFunction(chromFileInfoId, out regressionFunction))
                 {
                     return null;

--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -57,6 +57,11 @@ namespace pwiz.Skyline.Model.DocSettings
         void GetCurve(RetentionTimeStatistics statistics, out double[] hyrdoScores, out double[] predictions);
     }
 
+    public interface IInvertibleRegressionFunction : IRegressionFunction
+    {
+
+    }
+
     /// <summary>
     /// Describes a slope and intercept for converting from a
     /// hydrophobicity factor to a predicted retention time in minutes.
@@ -276,7 +281,7 @@ namespace pwiz.Skyline.Model.DocSettings
             return GetRegressionFunction(fileId) ?? Conversion;
         }
 
-        public IRegressionFunction GetUnconversion(ChromFileInfoId fileId)
+        public RegressionLine GetUnconversion(ChromFileInfoId fileId)
         {
             double slope, intercept;
             var regressionLineFromFile = GetRegressionFunction(fileId);

--- a/pwiz_tools/Skyline/Model/Results/ChromDataSet.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataSet.cs
@@ -697,7 +697,8 @@ namespace pwiz.Skyline.Model.Results
                             flags |= ChromPeak.FlagValues.peak_truncated;
                         }
                     }
-                    peak.CalcChromPeak(peakMax, flags, TimeIntervals);
+
+                    peak.CalcChromPeak(peakMax, flags, timeIntervals);
 
                     if (timeIntervals != null)
                     {

--- a/pwiz_tools/Skyline/Model/Results/PeakIntegrator.cs
+++ b/pwiz_tools/Skyline/Model/Results/PeakIntegrator.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using pwiz.Common.PeakFinding;
+using pwiz.Skyline.Util;
+
+namespace pwiz.Skyline.Model.Results
+{
+    public class PeakIntegrator
+    {
+        public PeakIntegrator(TimeIntensities interpolatedTimeIntensities)
+            : this(interpolatedTimeIntensities, CreatePeakFinder(interpolatedTimeIntensities))
+        {
+        }
+
+        public PeakIntegrator(TimeIntensities interpolatedTimeIntensities, IPeakFinder peakFinder)
+        {
+            InterpolatedTimeIntensities = interpolatedTimeIntensities;
+            PeakFinder = peakFinder;
+        }
+
+        public IPeakFinder PeakFinder { get; private set; }
+        public TimeIntensities InterpolatedTimeIntensities { get; private set; }
+        public TimeIntensities RawTimeIntensities { get; set; }
+        public TimeIntervals TimeIntervals { get; set; }
+
+        public ChromPeak IntegratePeak(float startTime, float endTime, ChromPeak.FlagValues flags)
+        {
+            if (TimeIntervals != null)
+            {
+                return IntegratePeakWithoutBackground(startTime, endTime, flags);
+            }
+            if (PeakFinder == null)
+            {
+                PeakFinder = CreatePeakFinder(InterpolatedTimeIntensities);
+            }
+
+            int startIndex = InterpolatedTimeIntensities.IndexOfNearestTime(startTime);
+            int endIndex = InterpolatedTimeIntensities.IndexOfNearestTime(endTime);
+            if (startIndex == endIndex)
+            {
+                return ChromPeak.EMPTY;
+            }
+            var foundPeak = PeakFinder.GetPeak(startIndex, endIndex);
+            return new ChromPeak(PeakFinder, foundPeak, flags, InterpolatedTimeIntensities, RawTimeIntensities?.Times);
+        }
+
+        public Tuple<ChromPeak, IFoundPeak> IntegrateFoundPeak(IFoundPeak peakMax, ChromPeak.FlagValues flags)
+        {
+            Assume.IsNotNull(PeakFinder);
+            var interpolatedPeak = PeakFinder.GetPeak(peakMax.StartIndex, peakMax.EndIndex);
+            if ((flags & ChromPeak.FlagValues.forced_integration) != 0 && ChromData.AreCoeluting(peakMax, interpolatedPeak))
+                flags &= ~ChromPeak.FlagValues.forced_integration;
+
+            var chromPeak = new ChromPeak(PeakFinder, interpolatedPeak, flags, InterpolatedTimeIntensities, RawTimeIntensities?.Times);
+            if (TimeIntervals != null)
+            {
+                chromPeak = IntegratePeakWithoutBackground(InterpolatedTimeIntensities.Times[peakMax.StartIndex], InterpolatedTimeIntensities.Times[peakMax.EndIndex], flags);
+            }
+
+            return Tuple.Create(chromPeak, interpolatedPeak);
+        }
+
+        private ChromPeak IntegratePeakWithoutBackground(float startTime, float endTime, ChromPeak.FlagValues flags)
+        {
+            if (TimeIntervals != null)
+            {
+                var intervalIndex = TimeIntervals.IndexOfIntervalEndingAfter(startTime);
+                if (intervalIndex >= 0 && intervalIndex < TimeIntervals.Count)
+                {
+                    startTime = Math.Max(startTime, TimeIntervals.Starts[intervalIndex]);
+                    endTime = Math.Min(endTime, TimeIntervals.Ends[intervalIndex]);
+                }
+            }
+            return new ChromPeak(RawTimeIntensities ?? InterpolatedTimeIntensities, startTime, endTime, flags);
+        }
+
+        public static IPeakFinder CreatePeakFinder(TimeIntensities interpolatedTimeIntensities)
+        {
+            var peakFinder = PeakFinders.NewDefaultPeakFinder();
+            peakFinder.SetChromatogram(interpolatedTimeIntensities.Times, interpolatedTimeIntensities.Intensities);
+            return peakFinder;
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -1495,12 +1495,10 @@ namespace pwiz.Skyline.Model
             {
                 return ChromPeak.EMPTY;
             }
-            int startIndex = info.IndexOfNearestTime(chromInfoBest.StartRetentionTime);
-            int endIndex = info.IndexOfNearestTime(chromInfoBest.EndRetentionTime);
             ChromPeak.FlagValues flags = 0;
             if (settingsNew.MeasuredResults.IsTimeNormalArea)
                 flags = ChromPeak.FlagValues.time_normalized;
-            return info.CalcPeak(startIndex, endIndex, flags);
+            return info.CalcPeak(chromInfoBest.StartRetentionTime, chromInfoBest.EndRetentionTime, flags);
         }
 
         private static ChromPeak CalcMatchingPeak(SrmSettings settingsNew,
@@ -1510,12 +1508,10 @@ namespace pwiz.Skyline.Model
                                                   double qcutoff, 
                                                   ref UserSet userSet)
         {
-            int startIndex = info.IndexOfNearestTime(chromGroupInfoMatch.StartRetentionTime.Value);
-            int endIndex = info.IndexOfNearestTime(chromGroupInfoMatch.EndRetentionTime.Value);
             ChromPeak.FlagValues flags = 0;
             if (settingsNew.MeasuredResults.IsTimeNormalArea)
                 flags = ChromPeak.FlagValues.time_normalized;
-            var peak = info.CalcPeak(startIndex, endIndex, flags);
+            var peak = info.CalcPeak(chromGroupInfoMatch.StartRetentionTime.Value, chromGroupInfoMatch.EndRetentionTime.Value, flags);
             userSet = UserSet.MATCHED;
             var userSetBest = UserSet.FALSE;
             int bestIndex = GetBestIndex(info, reintegratePeak, qcutoff, ref userSetBest);
@@ -2704,18 +2700,16 @@ namespace pwiz.Skyline.Model
                     listChildrenNew.Add(nodeTran.RemovePeak(indexSet, fileId, userSet));
                 else
                 {
-                    // CONSIDER: Do this more efficiently?  Only when there is opimization
+                    // CONSIDER: Do this more efficiently?  Only when there is optimization
                     //           data will the loop execute more than once.
                     int numSteps = listChromInfo.Count / 2;
                     var nodeTranNew = nodeTran;
                     for (int i = 0; i < listChromInfo.Count; i++)
                     {
                         var chromInfo = listChromInfo[i];
-                        int startIndex = chromInfo.IndexOfNearestTime((float)startTime);
-                        int endIndex = chromInfo.IndexOfNearestTime((float)endTime);
                         int step = i - numSteps;
                         nodeTranNew = (TransitionDocNode) nodeTranNew.ChangePeak(indexSet, fileId, step,
-                                                                                    chromInfo.CalcPeak(startIndex, endIndex, flags),
+                                                                                    chromInfo.CalcPeak((float) startTime, (float) endTime, flags),
                                                                                     chromInfo.GetIonMobilityFilter(),
                                                                                     ratioCount, userSet);
                     }

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -465,6 +465,7 @@
       <DependentUpon>PrositResources.resx</DependentUpon>
     </Compile>
     <Compile Include="Model\Prosit\PrositRetentionScoreCalculator.cs" />
+    <Compile Include="Model\Results\PeakIntegrator.cs" />
     <Compile Include="Model\Results\RemoteApi\RemoteAccountList.cs" />
     <Compile Include="Model\Results\RemoteApi\RemoteAccount.cs" />
     <Compile Include="Model\Results\RemoteApi\RemoteAccountType.cs" />

--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -3035,7 +3035,7 @@ namespace pwiz.Skyline
 
         public void CloseAllChromatograms()
         {
-            foreach (var graphChromatogram in _listGraphChrom)
+            foreach (var graphChromatogram in _listGraphChrom.ToList())
             {
                 graphChromatogram.Hide();
             }

--- a/pwiz_tools/Skyline/TestFunctional/ChromUITest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ChromUITest.cs
@@ -149,8 +149,8 @@ namespace pwiz.SkylineTestFunctional
                         null,
                         graphChrom.NameSet,
                         graphChrom.ChromGroupInfos[0].FilePath,
-                        graphChrom.GraphItems.First().GetNearestDisplayTime(40.0),
-                        graphChrom.GraphItems.First().GetNearestDisplayTime(42.0),
+                        graphChrom.GraphItems.First().GetValidPeakBoundaryTime(40.0),
+                        graphChrom.GraphItems.First().GetValidPeakBoundaryTime(42.0),
                         PeakIdentification.ALIGNED,
                         PeakBoundsChangeType.both)
                 };

--- a/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
@@ -765,8 +765,8 @@ namespace pwiz.SkylineTestTutorial
                         null,
                         graphChrom.NameSet,
                         graphChrom.ChromGroupInfos[0].FilePath,
-                        graphChrom.GraphItems.First().GetNearestDisplayTime(startDisplayTime),
-                        graphChrom.GraphItems.First().GetNearestDisplayTime(endDisplayTime),
+                        graphChrom.GraphItems.First().GetValidPeakBoundaryTime(startDisplayTime),
+                        graphChrom.GraphItems.First().GetValidPeakBoundaryTime(endDisplayTime),
                         PeakIdentification.ALIGNED,
                         PeakBoundsChangeType.both)
                 };

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -284,8 +284,8 @@ namespace pwiz.SkylineTestUtil
                         null,
                         graphChrom.NameSet,
                         graphChrom.ChromGroupInfos[0].FilePath,
-                        graphChrom.GraphItems.First().GetNearestDisplayTime(startDisplayTime),
-                        graphChrom.GraphItems.First().GetNearestDisplayTime(endDisplayTime),
+                        graphChrom.GraphItems.First().GetValidPeakBoundaryTime(startDisplayTime),
+                        graphChrom.GraphItems.First().GetValidPeakBoundaryTime(endDisplayTime),
                         PeakIdentification.ALIGNED,
                         PeakBoundsChangeType.both)
                 };


### PR DESCRIPTION
…ggered Acquisition (SureQuant) data.

If it is Triggered Acquisition then we allow the user to set peak boundaries to any number they want, unconstrained by what the times are in the interpolated chromatograms.

Also fix it so that in GraphChromatogram the feedback that the user sees is always exactly where the peak boundary is going to be placed. Previously the steps would depend on whether you were looking at the Raw or Interpolated chromatogram, even though when you released the mouse the peak boundary would always snap to an interpolated ("evenly spaced") time.