### PR TITLE
SkylineNightly: extend duration if hang detected

### DIFF
--- a/pwiz_tools/Skyline/SkylineNightly/LogFileMonitor.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/LogFileMonitor.cs
@@ -72,7 +72,7 @@ namespace SkylineNightly
         {
             lock (_lock)
             {
-                _logChecker.Enabled = true;
+                _logChecker.Start();
             }
         }
 
@@ -81,7 +81,19 @@ namespace SkylineNightly
             lock (_lock)
             {
                 _fileStream?.Dispose();
-                _logChecker.Enabled = false;
+                _logChecker.Stop();
+            }
+        }
+
+        public bool IsHanging()
+        {
+            try
+            {
+                return File.GetLastWriteTime(_testerLog).Equals(_lastReportedHang);
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -437,8 +437,9 @@ namespace SkylineNightly
                     {
                         if (logMonitor.IsHanging())
                         {
-                            // extend the end time until 12pm
-                            var newEndTime = new DateTime(endTime.Year, endTime.Month, endTime.Hour < 12 ? endTime.Day : endTime.Day + 1, 12, 0, 0);
+                            // extend the end time until 12pm to give us more time to attach a debugger
+                            var newEndTime = originalEndTime.AddHours(16);
+                            newEndTime = new DateTime(newEndTime.Year, newEndTime.Month, newEndTime.Day, 12, 0, 0);
                             if (SetEndTime(newEndTime))
                                 endTime = newEndTime;
                         }
@@ -1156,6 +1157,7 @@ namespace SkylineNightly
         private static readonly ChannelFactory<IEndTimeSetter> END_TIME_SETTER_FACTORY =
             new ChannelFactory<IEndTimeSetter>(new NetNamedPipeBinding(), new EndpointAddress("net.pipe://localhost/Nightly/SetEndTime"));
 
+        // Set the end time of an already running nightly run (e.g. if there is a hang and we want to give more time for someone to attach a debugger)
         public bool SetEndTime(DateTime endTime)
         {
             try
@@ -1169,6 +1171,7 @@ namespace SkylineNightly
             }
         }
 
+        // Allows SkylineNightly to change the stop time of a nightly run via IPC
         [ServiceContract]
         public interface IEndTimeSetter
         {

--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -27,6 +27,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.ServiceModel;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -349,7 +350,7 @@ namespace SkylineNightly
             // Create ".skytr" file to execute nightly build in SkylineTester.
             var assembly = Assembly.GetExecutingAssembly();
             const string resourceName = "SkylineNightly.SkylineNightly.skytr";
-            int durationSeconds;
+            double durationHours;
             using (var stream = assembly.GetManifestResourceStream(resourceName))
             {
                 if (stream == null)
@@ -375,8 +376,7 @@ namespace SkylineNightly
                         Log("Testing branch at " + branchUrl);
                     }
                     skylineTester.Save(skylineNightlySkytr);
-                    var durationHours = double.Parse(skylineTester.GetChild("nightlyDuration").Value);
-                    durationSeconds = (int) (durationHours*60*60) + 30*60;  // 30 minutes grace before we kill SkylineTester
+                    durationHours = double.Parse(skylineTester.GetChild("nightlyDuration").Value);
                 }
             }
 
@@ -394,8 +394,6 @@ namespace SkylineNightly
                 WorkingDirectory = Path.GetDirectoryName(skylineTesterExe) ?? ""
             };
 
-            var startTime = DateTime.Now;
-
             bool retryTester;
             const int maxRetryMinutes = 60;
 
@@ -412,24 +410,48 @@ namespace SkylineNightly
                     return result;
                 }
                 Log("SkylineTester started");
-                if (!skylineTesterProcess.WaitForExit(durationSeconds * 1000))
+
+                var endTime = skylineTesterProcess.StartTime.AddHours(durationHours);
+                var originalEndTime = endTime;
+                for (;; Thread.Sleep(1000))
                 {
-                    SaveErrorScreenshot();
-                    Log(result = "SkylineTester has exceeded its " + durationSeconds +
-                                 " second WaitForExit timeout.  You should investigate.");
-                }
-                else if (skylineTesterProcess.ExitCode == 0xDEAD)
-                {
-                    // User killed, don't post
-                    Log(result = SkylineTesterStoppedByUser);
-                    return result;
-                }
-                else
-                {
-                    Log("SkylineTester finished");
+                    if (skylineTesterProcess.HasExited)
+                    {
+                        if (skylineTesterProcess.ExitCode == 0xDEAD)
+                        {
+                            // User killed, don't post
+                            Log(result = SkylineTesterStoppedByUser);
+                            return result;
+                        }
+                        Log("SkylineTester finished");
+                        break;
+                    }
+                    else if (DateTime.Now > endTime.AddMinutes(30)) // 30 minutes grace before we kill SkylineTester
+                    {
+                        SaveErrorScreenshot();
+                        Log(result = "SkylineTester has exceeded its " + durationHours + " hour runtime.  You should investigate.");
+                        break;
+                    }
+
+                    if (endTime == originalEndTime)
+                    {
+                        if (logMonitor.IsHanging())
+                        {
+                            // extend the end time until 12pm
+                            var newEndTime = new DateTime(endTime.Year, endTime.Month, endTime.Hour < 12 ? endTime.Day : endTime.Day + 1, 12, 0, 0);
+                            if (SetEndTime(newEndTime))
+                                endTime = newEndTime;
+                        }
+                    }
+                    else if (!logMonitor.IsHanging())
+                    {
+                        // was hanging but not anymore
+                        if (SetEndTime(originalEndTime))
+                            endTime = originalEndTime;
+                    }
                 }
 
-                _duration = DateTime.Now - startTime;
+                _duration = DateTime.Now - skylineTesterProcess.StartTime;
                 retryTester = _duration.TotalMinutes < maxRetryMinutes;
                 if (retryTester)
                 {
@@ -1129,6 +1151,29 @@ namespace SkylineNightly
             {
                 Log(logFileName, $@"Error establishing a session and getting a CSRF token: {e}");
             }
+        }
+
+        private static readonly ChannelFactory<IEndTimeSetter> END_TIME_SETTER_FACTORY =
+            new ChannelFactory<IEndTimeSetter>(new NetNamedPipeBinding(), new EndpointAddress("net.pipe://localhost/Nightly/SetEndTime"));
+
+        public bool SetEndTime(DateTime endTime)
+        {
+            try
+            {
+                END_TIME_SETTER_FACTORY.CreateChannel().SetEndTime(endTime);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        [ServiceContract]
+        public interface IEndTimeSetter
+        {
+            [OperationContract]
+            void SetEndTime(DateTime endTime);
         }
     }
 

--- a/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.csproj
+++ b/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.csproj
@@ -74,6 +74,7 @@
     <Reference Include="System.Net.Http">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTester.csproj
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTester.csproj
@@ -118,6 +118,7 @@
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/pwiz_tools/Skyline/SkylineTester/TabNightly.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabNightly.cs
@@ -734,6 +734,7 @@ namespace SkylineTester
 
         BackgroundWorker SkylineTesterWindow.IMemoryGraphContainer.UpdateWorker { get; set; }
 
+        // Facilitates IPC so that we can receive signals from SkylineNightly
         [ServiceBehavior(InstanceContextMode = InstanceContextMode.Single)]
         public class NightlyListener: IEndTimeSetter
         {
@@ -773,6 +774,7 @@ namespace SkylineTester
             }
         }
 
+        // Allows SkylineNightly to change the stop time of a nightly run via IPC
         [ServiceContract]
         public interface IEndTimeSetter
         {

--- a/pwiz_tools/Skyline/SkylineTester/TabNightly.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabNightly.cs
@@ -25,9 +25,11 @@ using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.ServiceModel;
 using System.Windows.Forms;
 using Microsoft.Win32.TaskScheduler;
 using ZedGraph;
+using Timer = System.Windows.Forms.Timer;
 
 namespace SkylineTester
 {
@@ -37,6 +39,7 @@ namespace SkylineTester
 
         private const int MINUTES_PER_INCREMENT = 60; // 1 hour
 
+        private NightlyListener _nightlyListener;
         private Timer _updateTimer;
         private Timer _stopTimer;
         private string _revision;
@@ -247,6 +250,12 @@ namespace SkylineTester
 
         public override void Cancel()
         {
+            if (_nightlyListener != null)
+            {
+                _nightlyListener.Stop();
+                _nightlyListener = null;
+            }
+
             bool runAgain = MainWindow.NightlyRunIndefinitely.Checked;
             if (Math.Abs(MainWindow.RunElapsedTime.TotalMinutes - (int) MainWindow.NightlyDuration.Value * MINUTES_PER_INCREMENT) > 5)
                 runAgain = false;
@@ -377,6 +386,8 @@ namespace SkylineTester
                 _updateTimer.Start();
             if (_stopTimer != null)
                 _stopTimer.Start();
+
+            _nightlyListener = new NightlyListener(_stopTimer);
         }
 
         private int _architecture;
@@ -722,5 +733,51 @@ namespace SkylineTester
         }
 
         BackgroundWorker SkylineTesterWindow.IMemoryGraphContainer.UpdateWorker { get; set; }
+
+        [ServiceBehavior(InstanceContextMode = InstanceContextMode.Single)]
+        public class NightlyListener: IEndTimeSetter
+        {
+            private readonly ServiceHost _host;
+            private readonly Timer _stopTimer;
+
+            public NightlyListener(Timer stopTimer)
+            {
+                _host = new ServiceHost(this, new Uri("net.pipe://localhost/Nightly"));
+                _host.AddServiceEndpoint(typeof(IEndTimeSetter), new NetNamedPipeBinding(), "SetEndTime");
+                _host.Open();
+
+                _stopTimer = stopTimer;
+            }
+
+            public void Stop()
+            {
+                _host.Close();
+            }
+
+            public void SetEndTime(DateTime endTime)
+            {
+                if (_stopTimer == null)
+                    return;
+
+                _stopTimer.Stop();
+
+                var now = DateTime.Now;
+                if (endTime <= now)
+                {
+                    MainWindow.StopByTimer();
+                    return;
+                }
+
+                _stopTimer.Interval = endTime.Subtract(now).Milliseconds;
+                _stopTimer.Start();
+            }
+        }
+
+        [ServiceContract]
+        public interface IEndTimeSetter
+        {
+            [OperationContract]
+            void SetEndTime(DateTime endTime);
+        }
     }
 }


### PR DESCRIPTION
If SkylineNightly detects a hang, it will change SkylineTester's end time to 12pm to allow extra time for someone to debug.