### PR TITLE
Fix Bruker BAF returning empty spectra

### DIFF
--- a/pwiz/analysis/common/ExtraZeroSamplesFilter.cpp
+++ b/pwiz/analysis/common/ExtraZeroSamplesFilter.cpp
@@ -91,5 +91,41 @@ void ExtraZeroSamplesFilter::remove_zeros(const vector<double>& x, const vector<
 }
 
 
+int ExtraZeroSamplesFilter::count_non_zeros(const vector<double>& x, const vector<double>& y, bool preserveFlankingZeros)
+{
+    if (x.size() != y.size())
+        throw runtime_error("[ExtraZeroSamplesFilter::count_zeros()] x and y arrays must be the same size");
+
+    int count = 0;
+
+    if (preserveFlankingZeros)
+    {
+        if (y.size() > 3)
+        {
+            // leave flanking zeros around non-zero data points
+            int i, end = y.size() - 1;
+            for (i = 0; i < end; ++i)
+            {
+                if (y[i] || y[i + 1] || (i && y[i - 1]))
+                    ++count;
+            }
+
+            if (y[i] || y[i - 1])
+                ++count;
+        }
+        else
+        {
+            count = x.size();
+        }
+    }
+    else
+    {
+        count = std::count_if(y.begin(), y.end(), [](const double& v) { return v != 0; });
+    }
+
+    return count;
+}
+
+
 } // namespace analysis
 } // namespace pwiz

--- a/pwiz/analysis/common/ExtraZeroSamplesFilter.hpp
+++ b/pwiz/analysis/common/ExtraZeroSamplesFilter.hpp
@@ -39,6 +39,9 @@ struct PWIZ_API_DECL ExtraZeroSamplesFilter
     static void remove_zeros(const std::vector<double>& x, const std::vector<double>& y,
                              std::vector<double>& xProcessed, std::vector<double>& yProcessed,
                              bool preserveFlankingZeros);
+
+    /// return the count of datapoints after removing excess zero samples
+    static int count_non_zeros(const std::vector<double>& x, const std::vector<double>& y, bool preserveFlankingZeros);
 };
 
 

--- a/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
+++ b/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
@@ -35,6 +35,7 @@
 #include "pwiz/utility/misc/IntegerSet.hpp"
 #include "pwiz/utility/misc/SHA1Calculator.hpp"
 #include "pwiz/utility/minimxml/XMLWriter.hpp"
+#include "pwiz/analysis/common/ExtraZeroSamplesFilter.hpp"
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/spirit/include/karma.hpp>
 
@@ -392,12 +393,11 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Bruker::spectrum(size_t index, DetailLeve
             bool getLineData = msLevelsToCentroid.contains(msLevel);
 
             result->setMZIntensityArrays(vector<double>(), vector<double>(), MS_number_of_detector_counts);
+            auto& mz = result->getMZArray()->data;
+            auto& intensity = result->getIntensityArray()->data;
 
-            if (config_.combineIonMobilitySpectra)
+            if (config_.combineIonMobilitySpectra && format_ == Reader_Bruker_Format_TDF)
             {
-                auto& mz = result->getMZArray()->data;
-                auto& intensity = result->getIntensityArray()->data;
-
                 result->set(MS_centroid_spectrum); // TIMS is always centroided
 
                 BinaryDataArrayPtr mobility(new BinaryDataArray);
@@ -407,37 +407,43 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Bruker::spectrum(size_t index, DetailLeve
                 mobility->cvParams.emplace_back(arrayType);
 
                 spectrum->getCombinedSpectrumData(mz, intensity, mobility->data, config_.sortAndJitter);
-                result->defaultArrayLength = mz.size();
             }
             else
             {
-                automation_vector<double> mzArray, intensityArray;
                 if (!getLineData)
                 {
-                    spectrum->getProfileData(mzArray, intensityArray);
-                    if (mzArray.size() == 0)
+                    spectrum->getProfileData(mz, intensity);
+                    if (mz.size() == 0)
                         getLineData = true;  // We preferred profile, but there isn't any - try centroided
                     else
+                    {
+                        /*if (!config_.ignoreZeroIntensityPoints)
+                        {
+                            vector<double> mzProfile, intensityProfile;
+                            pwiz::analysis::ExtraZeroSamplesFilter::remove_zeros(mz, intensity, mzProfile, intensityProfile, true);
+                            swap(mz, mzProfile);
+                            swap(intensity, intensityProfile);
+                        }*/
+
                         result->set(MS_profile_spectrum);
+                    }
                 }
 
                 if (getLineData)
                 {
                     result->set(MS_centroid_spectrum); // Declare this as centroided data even if scan is empty
-                    spectrum->getLineData(mzArray, intensityArray);
-                    if (mzArray.size() > 0 && msLevelsToCentroid.contains(msLevel))
+                    spectrum->getLineData(mz, intensity);
+                    if (mz.size() > 0 && msLevelsToCentroid.contains(msLevel))
                     {
                         result->set(MS_profile_spectrum); // let SpectrumList_PeakPicker know this was probably also a profile spectrum, but doesn't need conversion (actually checking for profile data is crazy slow)
                     }
                 }
-                result->getMZArray()->data.assign(mzArray.begin(), mzArray.end());
-                result->getIntensityArray()->data.assign(intensityArray.begin(), intensityArray.end());
-                result->defaultArrayLength = mzArray.size();
             }
+            result->defaultArrayLength = mz.size();
         }
         else if (detailLevel == DetailLevel_FullMetadata)
         {
-            if (config_.combineIonMobilitySpectra)
+            if (config_.combineIonMobilitySpectra && format_ == Reader_Bruker_Format_TDF)
             {
                 result->defaultArrayLength = spectrum->getCombinedSpectrumDataSize();
                 result->set(MS_centroid_spectrum); // TIMS is always centroided
@@ -445,13 +451,19 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Bruker::spectrum(size_t index, DetailLeve
             else
             {
                 // N.B.: just getting the data size from the Bruker API is quite expensive.
-                if (msLevelsToCentroid.contains(msLevel) || ((result->defaultArrayLength = spectrum->getProfileDataSize())==0))
+                if (msLevelsToCentroid.contains(msLevel) || (result->defaultArrayLength = spectrum->getProfileDataSize())==0)
                 {
                     result->defaultArrayLength = spectrum->getLineDataSize();
                     result->set(MS_centroid_spectrum);
                 }
                 else
                 {
+                    /*if (!config_.ignoreZeroIntensityPoints)
+                    {
+                        BinaryData<double> mzProfile, intensityProfile;
+                        spectrum->getProfileData(mzProfile, intensityProfile);
+                        result->defaultArrayLength = pwiz::analysis::ExtraZeroSamplesFilter::count_non_zeros(mzProfile, intensityProfile, true);
+                    }*/
                     result->set(MS_profile_spectrum);
                 }
             }

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/Baf2Sql.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/Baf2Sql.cpp
@@ -281,13 +281,13 @@ bool Baf2SqlSpectrum::hasProfileData() const { return getProfileDataSize() > 0; 
 size_t Baf2SqlSpectrum::getLineDataSize() const { return lineIntensityArrayId_.is_initialized() ? storage_->getArrayNumElements(lineIntensityArrayId_.get()) : 0; }
 size_t Baf2SqlSpectrum::getProfileDataSize() const { return profileIntensityArrayId_.is_initialized() ? storage_->getArrayNumElements(profileIntensityArrayId_.get()) : 0; }
 
-void Baf2SqlSpectrum::readArray(uint64_t id, automation_vector<double> & result) const
+void Baf2SqlSpectrum::readArray(uint64_t id, pwiz::util::BinaryData<double> & result) const
 {
     size_t n = static_cast<size_t>(storage_->getArrayNumElements(id));
     readArray(id, result, n);
 }
 
-void Baf2SqlSpectrum::readArray(uint64_t id, automation_vector<double> & result, size_t n) const
+void Baf2SqlSpectrum::readArray(uint64_t id, pwiz::util::BinaryData<double> & result, size_t n) const
 {
 
     if (n > std::numeric_limits<size_t>::max())
@@ -295,7 +295,7 @@ void Baf2SqlSpectrum::readArray(uint64_t id, automation_vector<double> & result,
         BOOST_THROW_EXCEPTION(std::runtime_error("Array too large."));
     }
 
-    result.resize_no_initialize(n);
+    result.resize(n);
     if ((n>0) && (baf2sql_array_read_double(storage_->getHandle(), id, &result[0]) == 0))
     {
         baf2sql::throwLastBaf2SqlError();
@@ -303,7 +303,7 @@ void Baf2SqlSpectrum::readArray(uint64_t id, automation_vector<double> & result,
 }
 
 
-void Baf2SqlSpectrum::getLineData(automation_vector<double>& mz, automation_vector<double>& intensities) const
+void Baf2SqlSpectrum::getLineData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const
 {
     if (!lineIntensityArrayId_.is_initialized())
     {
@@ -321,7 +321,7 @@ void Baf2SqlSpectrum::getLineData(automation_vector<double>& mz, automation_vect
     readArray(lineMzArrayId_.get(), mz, n);  // Assume mz and intensity arrays are same length, for best read speed
 }
 
-void Baf2SqlSpectrum::getProfileData(automation_vector<double>& mz, automation_vector<double>& intensities) const
+void Baf2SqlSpectrum::getProfileData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const
 {
     if (!profileIntensityArrayId_.is_initialized())
     {

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/Baf2Sql.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/Baf2Sql.hpp
@@ -67,8 +67,8 @@ struct PWIZ_API_DECL Baf2SqlSpectrum : public MSSpectrum
     virtual bool hasProfileData() const;
     virtual size_t getLineDataSize() const;
     virtual size_t getProfileDataSize() const;
-    virtual void getLineData(automation_vector<double>& mz, automation_vector<double>& intensities) const;
-    virtual void getProfileData(automation_vector<double>& mz, automation_vector<double>& intensities) const;
+    virtual void getLineData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const;
+    virtual void getProfileData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const;
 
     virtual double getTIC() const { return tic_; }
     virtual double getBPI() const { return bpi_; }
@@ -87,8 +87,8 @@ struct PWIZ_API_DECL Baf2SqlSpectrum : public MSSpectrum
 
     private:
     virtual void handleAllIons(); // Deal with all-ions MS1 data by presenting it as MS2 with a wide isolation window
-    virtual void readArray(uint64_t id, automation_vector<double> & result) const;
-    virtual void readArray(uint64_t id, automation_vector<double> & result, size_t n) const; // For use when the id's array size is known, as when reading mz after reading intensity
+    virtual void readArray(uint64_t id, pwiz::util::BinaryData<double> & result) const;
+    virtual void readArray(uint64_t id, pwiz::util::BinaryData<double> & result, size_t n) const; // For use when the id's array size is known, as when reading mz after reading intensity
 
     int index_;
     int msLevel_;

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/CompassData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/CompassData.cpp
@@ -283,7 +283,7 @@ struct MSSpectrumImpl : public MSSpectrum
     virtual size_t getLineDataSize() const {return lineDataSize_;}
     virtual size_t getProfileDataSize() const {return profileDataSize_;}
 
-    virtual void getLineData(automation_vector<double>& mz, automation_vector<double>& intensities) const
+    virtual void getLineData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const
     {
         try
         {
@@ -305,8 +305,8 @@ struct MSSpectrumImpl : public MSSpectrum
             }
 
             // we always get a copy of the arrays because they can be modified by the client
-            ToAutomationVector((cli::array<double>^) lineMzArray_, mz);
-            ToAutomationVector((cli::array<double>^) lineIntensityArray_, intensities);
+            ToBinaryData((cli::array<double>^) lineMzArray_, mz);
+            ToBinaryData((cli::array<double>^) lineIntensityArray_, intensities);
 
             // the automation vectors now own the arrays, so nullify the cached versions
             lineMzArray_ = nullptr;
@@ -315,7 +315,7 @@ struct MSSpectrumImpl : public MSSpectrum
         CATCH_AND_FORWARD
     }
 
-    virtual void getProfileData(automation_vector<double>& mz, automation_vector<double>& intensities) const
+    virtual void getProfileData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const
     {
         try
         {
@@ -337,8 +337,8 @@ struct MSSpectrumImpl : public MSSpectrum
             }
 
             // we always get a copy of the arrays because they can be modified by the client
-            ToAutomationVector((cli::array<double>^) profileMzArray_, mz);
-            ToAutomationVector((cli::array<double>^) profileIntensityArray_, intensities);
+            ToBinaryData((cli::array<double>^) profileMzArray_, mz);
+            ToBinaryData((cli::array<double>^) profileIntensityArray_, intensities);
 
             // the automation vectors now own the arrays, so nullify the cached versions
             profileMzArray_ = nullptr;

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/CompassData.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/CompassData.hpp
@@ -27,7 +27,6 @@
 
 #include "pwiz/utility/misc/Export.hpp"
 #include "pwiz/utility/misc/BinaryData.hpp"
-#include "pwiz/utility/misc/automation_vector.h"
 #include "pwiz/utility/misc/IntegerSet.hpp"
 #include "pwiz/utility/chemistry/MzMobilityWindow.hpp"
 #include <string>
@@ -195,8 +194,8 @@ struct PWIZ_API_DECL MSSpectrum
     virtual bool hasProfileData() const = 0;
     virtual size_t getLineDataSize() const = 0;
     virtual size_t getProfileDataSize() const = 0;
-    virtual void getLineData(automation_vector<double>& mz, automation_vector<double>& intensities) const = 0;
-    virtual void getProfileData(automation_vector<double>& mz, automation_vector<double>& intensities) const = 0;
+    virtual void getLineData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const = 0;
+    virtual void getProfileData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const = 0;
 
     virtual double getTIC() const = 0;
     virtual double getBPI() const = 0;

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.cpp
@@ -668,7 +668,7 @@ bool TimsSpectrum::hasProfileData() const { return false; }
 size_t TimsSpectrum::getLineDataSize() const { return frame_.timsDataImpl_.readFrame(frame_.frameId_).getNbrPeaks(scanBegin_); }
 size_t TimsSpectrum::getProfileDataSize() const { return 0; }
 
-void TimsSpectrum::getLineData(automation_vector<double>& mz, automation_vector<double>& intensities) const
+void TimsSpectrum::getLineData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const
 {
     auto& storage = frame_.timsDataImpl_;
     const auto& frameProxy = storage.readFrame(frame_.frameId_);
@@ -684,8 +684,8 @@ void TimsSpectrum::getLineData(automation_vector<double>& mz, automation_vector<
     }
 
     auto scanMZs = frameProxy.getScanMZs(scanBegin_);
-    intensities.resize_no_initialize(intensityCounts.size());
-    mz.resize_no_initialize(intensityCounts.size());
+    intensities.resize(intensityCounts.size());
+    mz.resize(intensityCounts.size());
 
     double *m = &mz[0];
     double *inten = &intensities[0];
@@ -696,7 +696,7 @@ void TimsSpectrum::getLineData(automation_vector<double>& mz, automation_vector<
     }
 }
 
-void TimsSpectrum::getProfileData(automation_vector<double>& mz, automation_vector<double>& intensities) const
+void TimsSpectrum::getProfileData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const
 {
     // TDF does not support profile data
     mz.clear();

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.hpp
@@ -68,9 +68,10 @@ struct DiaPasefIsolationInfo
 enum class MsMsType
 {
     MS1 = 0,
-    MRM =2,
+    MRM = 2,
     DDA_PASEF = 8,
-    DIA_PASEF = 9
+    DIA_PASEF = 9,
+    PRM_PASEF = 10
 };
 
 struct PWIZ_API_DECL TimsFrame
@@ -139,8 +140,8 @@ public:
     virtual bool hasProfileData() const;
     virtual size_t getLineDataSize() const;
     virtual size_t getProfileDataSize() const;
-    virtual void getLineData(automation_vector<double>& mz, automation_vector<double>& intensities) const;
-    virtual void getProfileData(automation_vector<double>& mz, automation_vector<double>& intensities) const;
+    virtual void getLineData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const;
+    virtual void getProfileData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities) const;
 
     virtual double getTIC() const { return frame_.tic_; }
     virtual double getBPI() const { return frame_.bpi_; }


### PR DESCRIPTION
- fixed Bruker BAF returning empty spectra when combineIonMobilitySpectra is on (the default mode in Skyline and SeeMS)
* added ExtraZeroSamplesFilter::count_non_zeros(); tried using it (along with remove_zeros()) for Bruker profile spectra when config_.ignoreZeroIntensityPoints is off, but it didn't help as much as I expected due to lack of baseline removal in Bruker profile spectra
* refactored Bruker reader to use BinaryData instead of automation_vector which will avoid an extra copy of the unmanaged arrays

Sorry about this dropping off the radar @nickshulman .

@brendanx67 This certainly needs to be cherry picked over to 20.1, I'll do that as soon as tests pass.