### PR TITLE
Skyline: Attempt to fix command-line deadlocks in MemoryDocumentContainer

### DIFF
--- a/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
+++ b/pwiz_tools/Skyline/Model/MemoryDocumentContainer.cs
@@ -72,10 +72,9 @@ namespace pwiz.Skyline.Model
 
                     if (wait)
                     {
-                        while (!IsFinal(Document))
-                            Monitor.Wait(CHANGE_EVENT_LOCK);    // Wait for completing document changed event
+                        WaitForComplete();
                     }
-                    else if (IsFinal(docNew))
+                    else if (IsFinal(Document))
                     {
                         Monitor.Pulse(CHANGE_EVENT_LOCK);
                     }
@@ -89,8 +88,9 @@ namespace pwiz.Skyline.Model
         {
             lock (CHANGE_EVENT_LOCK)
             {
+                // Wait for completing document changed event
                 while (!IsFinal(Document))
-                    Monitor.Wait(CHANGE_EVENT_LOCK);    // Wait until next DocumentChangedEvent
+                    Monitor.Wait(CHANGE_EVENT_LOCK, 1000);  // Check ever second or risk deadlock
             }
         }
 
@@ -109,25 +109,36 @@ namespace pwiz.Skyline.Model
 
         private void UpdateProgress(object sender, ProgressUpdateEventArgs e)
         {
+            var status = e.Progress;
+            if (ProgressMonitor != null)
+                ProgressMonitor.UpdateProgress(status);
+
             // Unblock the waiting thread, if there was a cancel or error
             lock (CHANGE_EVENT_LOCK)
             {
                 // Keep track of last progress, but do not overwrite an error, unless
                 // this is a MultiProgressStatus, where useful information may be added
                 // even after the first error.
-                var multiProgress = e.Progress as MultiProgressStatus;
-                if (multiProgress != null || LastProgress == null || !LastProgress.IsError)
+                if (status is MultiProgressStatus)
                 {
-                    // Keep MultiProgressStatus around, even when it is completed
-                    LastProgress = multiProgress != null || !e.Progress.IsComplete
-                        ? e.Progress : null;
+                    // But avoid overwriting a final progress with a non-final progress for the same operation
+                    if (IsProgressIdChanging(status) || !LastProgress.IsFinal)
+                        LastProgress = status;
                 }
-                if (e.Progress.IsCanceled || e.Progress.IsError)
+                else
+                {
+                    if (IsProgressIdChanging(status) || !LastProgress.IsError)
+                        LastProgress = !status.IsComplete ? status : null;
+                }
+
+                if (status.IsCanceled || status.IsError)
                     Monitor.Pulse(CHANGE_EVENT_LOCK);
             }
+        }
 
-            if (ProgressMonitor != null)
-                ProgressMonitor.UpdateProgress(e.Progress);
+        private bool IsProgressIdChanging(IProgressStatus status)
+        {
+            return LastProgress == null || !ReferenceEquals(LastProgress.Id, status.Id);
         }
 
         public void Register(BackgroundLoader loader)


### PR DESCRIPTION
This code succeeded in running command-line tests that hung usually within a few hundred test runs for over 2500 runs. The primary cause seemed to be overwriting a final multi-status with a non-final multi-status, leaving MemoryDocumentContainer.LastProgress with a different idea of the current status than ChromatogramManager.MultiFileLoader.Status.

Other improvements in getting to this solution included never waiting indefinitely to check whether the status was final and a re-ordering in UpdateProgress.