### PR TITLE
Skyline: Make closing the AllChromatogramsGraph asynchronous…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -22,6 +22,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Windows.Forms;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.AuditLog;
@@ -39,6 +40,7 @@ namespace pwiz.Skyline.Controls.Graphs
     public partial class AllChromatogramsGraph : FormEx
     {
         private readonly Stopwatch _stopwatch;
+        private readonly ManualResetEvent _windowCreatedEvent;
         private int _selected = -1;
         private bool _selectionIsSticky;
         private readonly int _multiFileWindowWidth;
@@ -58,9 +60,29 @@ namespace pwiz.Skyline.Controls.Graphs
         public AllChromatogramsGraph()
         {
             InitializeComponent();
+
+            _windowCreatedEvent = new ManualResetEvent(false);
+            HandleCreated += Notification_HandleCreated;
+
             toolStrip1.Renderer = new CustomToolStripProfessionalRenderer();
             _stopwatch = new Stopwatch();
             _multiFileWindowWidth = Size.Width;
+        }
+
+        private void Notification_HandleCreated(object sender, EventArgs e)
+        {
+            _windowCreatedEvent.Set();
+        }
+
+        public void RemoveAsync()
+        {
+            // Avoid closing the ACG during CreateHandle()
+            var closeThread = new Thread(() =>
+            {
+                _windowCreatedEvent.WaitOne();
+                Invoke((Action)Close);
+            });
+            closeThread.Start();
         }
 
         protected override void OnLoad(EventArgs e)

--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -603,7 +603,7 @@ namespace pwiz.Skyline
             }
             if (ImportingResultsWindow != null)
             {
-                ImportingResultsWindow.Close();
+                ImportingResultsWindow.RemoveAsync();
                 ImportingResultsWindow = null;
 
                 // Reset progress for the current document


### PR DESCRIPTION
… and dependent on CreateHandle() having completed successfully

- Trying to fix the Dispose() in CreateHandle() errors happening in nightly test runs