### PR TITLE
Skyline: Attempt fix for ACG.RemoveAsync() causing leak in TestGroupedStudies1Tutorial

### DIFF
--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -5234,7 +5234,7 @@ namespace pwiz.Skyline
                 Assume.IsFalse(multiStatus.IsEmpty);    // Should never be starting results window with empty status
                 ImportingResultsWindow = new AllChromatogramsGraph { Owner = this, ChromatogramManager = _chromatogramManager };
                 if (Settings.Default.AutoShowAllChromatogramsGraph)
-                    ImportingResultsWindow.Show(this);
+                    ImportingResultsWindow.ShowSafe(this);
             }
             if (ImportingResultsWindow != null)
                 ImportingResultsWindow.UpdateStatus(multiStatus);
@@ -5247,7 +5247,7 @@ namespace pwiz.Skyline
                 if (ImportingResultsWindow.Visible)
                     ImportingResultsWindow.Activate();
                 else
-                    ImportingResultsWindow.Show(this);
+                    ImportingResultsWindow.ShowSafe(this);
                 UpdateProgressUI(); // Sets selected control
             }
         }

--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -603,8 +603,9 @@ namespace pwiz.Skyline
             }
             if (ImportingResultsWindow != null)
             {
-                ImportingResultsWindow.RemoveAsync();
+                var importingResultsWindowTemp = ImportingResultsWindow;
                 ImportingResultsWindow = null;
+                importingResultsWindowTemp.RemoveAsync();
 
                 // Reset progress for the current document
                 _chromatogramManager.ResetProgress(Document);


### PR DESCRIPTION
Sometimes we new ACG but never show it, which means no HWND ever gets created. In the prior code that lead to WaitOne() waiting forever and leaking the thread and the ACG.