### PR TITLE
Ion mobility filtering values can be shown in a report either at the …

### DIFF
--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Chromatogram.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Chromatogram.cs
@@ -64,9 +64,9 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             {
                 return _chromatogramInfo.Value == null ? null : _chromatogramInfo.Value.ExtractionWidth;
             } }
-        [Format(NullValue = TextUtil.EXCEL_NA)]
+        [Format(Formats.RETENTION_TIME, NullValue = TextUtil.EXCEL_NA)]
         public double? ChromatogramIonMobility { get { return _chromatogramInfo.Value == null ? null : _chromatogramInfo.Value.IonMobility; } }
-        [Format(NullValue = TextUtil.EXCEL_NA)]
+        [Format(Formats.RETENTION_TIME, NullValue = TextUtil.EXCEL_NA)]
         public double? ChromatogramIonMobilityExtractionWidth { get { return _chromatogramInfo.Value == null ? null : _chromatogramInfo.Value.IonMobilityExtractionWidth; } }
         [Format(NullValue = TextUtil.EXCEL_NA)]
         public string ChromatogramIonMobilityUnits

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/PrecursorResult.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/PrecursorResult.cs
@@ -20,7 +20,6 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
-using pwiz.Common.Chemistry;
 using pwiz.Common.DataBinding;
 using pwiz.Common.DataBinding.Attributes;
 using pwiz.Skyline.Model.DocSettings;
@@ -164,7 +163,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         public double? IonMobilityWindow { get { return ChromInfo.IonMobilityInfo.IonMobilityWindow; } }
 
         [Format(NullValue = TextUtil.EXCEL_NA)]
-        public string IonMobilityUnits { get { return IonMobilityValue.GetUnitsString(ChromInfo.IonMobilityInfo.IonMobilityUnits); } }
+        public string IonMobilityUnits { get { return IonMobilityFilter.IonMobilityUnitsL10NString(ChromInfo.IonMobilityInfo.IonMobilityUnits); } }
 
         [ChildDisplayName("Precursor{0}")]
         public LinkValue<QuantificationResult> PrecursorQuantification


### PR DESCRIPTION
…Precursor Results or Chromatogram level, but they were not formatted the same. Both now limit the digits of precision displayed, and both show ion mobility units in local language.