### PR TITLE
Fix calculation of TIC Area 

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -77,12 +77,11 @@ namespace pwiz.Skyline.Controls.Graphs
         public void RemoveAsync()
         {
             // Avoid closing the ACG during CreateHandle()
-            var closeThread = new Thread(() =>
+            ActionUtil.RunAsync(() =>
             {
                 _windowCreatedEvent.WaitOne();
                 Invoke((Action)Close);
-            });
-            closeThread.Start();
+            }, @"Close AllChromatogramsGraph");
         }
 
         protected override void OnLoad(EventArgs e)

--- a/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
@@ -135,7 +135,7 @@ namespace pwiz.Skyline.Model.Results
         /// </summary>
         public int IndexOffset { get; set; }
 
-        public int? TicChromatogramIndex { get; }
+        public int? TicChromatogramIndex { get; set; }
         public int? BpcChromatogramIndex { get; }
 
         public IList<int> GlobalChromatogramIndexes
@@ -174,6 +174,39 @@ namespace pwiz.Skyline.Model.Results
             else
             {
                 times = intensities = null;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the TIC chromatogram present in the .raw file can be relied on
+        /// for the calculation of total MS1 ion current.
+        /// </summary>
+        public bool IsTicChromatogramUsable()
+        {
+            if (!TicChromatogramIndex.HasValue)
+            {
+                return false;
+            }
+
+            float[] times;
+            if (!GetChromatogram(TicChromatogramIndex.Value, out times, out _))
+            {
+                return false;
+            }
+
+            if (times.Length == 0)
+            {
+                return false;
+            }
+
+            // If the number of points in the chromatogram is more than a quarter of the total
+            // spectra, then this chromatogram probably includes MS2 scans, and should not 
+            // be used for calculating TIC Area.
+            if (times.Length >= _dataFile.SpectrumCount / 4)
+            {
                 return false;
             }
 

--- a/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
@@ -202,10 +202,10 @@ namespace pwiz.Skyline.Model.Results
                 return false;
             }
 
-            // If the number of points in the chromatogram is more than a quarter of the total
+            // If the number of points in the chromatogram is more than half of the total
             // spectra, then this chromatogram probably includes MS2 scans, and should not 
             // be used for calculating TIC Area.
-            if (times.Length >= _dataFile.SpectrumCount / 4)
+            if (times.Length > _dataFile.SpectrumCount / 2)
             {
                 return false;
             }

--- a/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
@@ -204,8 +204,9 @@ namespace pwiz.Skyline.Model.Results
 
             // If the number of points in the chromatogram is more than half of the total
             // spectra, then this chromatogram probably includes MS2 scans, and should not 
-            // be used for calculating TIC Area.
-            if (times.Length > _dataFile.SpectrumCount / 2)
+            // be used for calculating TIC Area. (Actually, we compare it to a number which is a
+            // little more than half, because of the possibility of Waters lockmass scans).
+            if (times.Length > _dataFile.SpectrumCount / 1.9)
             {
                 return false;
             }

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -145,19 +145,23 @@ namespace pwiz.Skyline.Model.Results
                     _isHighAccMsFilter = !Equals(_fullScan.PrecursorMassAnalyzer,
                         FullScanMassAnalyzerType.qit);
 
-                    /*
-                     Leaving this here in case we ever decide to fall back to our own BPC+TIC extraction in cases where data
-                     file doesn't have them ready to go, as in mzXML
                     if (!firstPass && !_isIonMobilityFiltered)
                     {
-                        var key = TIC_KEY;
-                        dictPrecursorMzToFilter.Add(key, new SpectrumFilterPair(key, PeptideDocNode.UNKNOWN_COLOR, dictPrecursorMzToFilter.Count,
-                            _instrument.MinTime, _instrument.MaxTime, _isHighAccMsFilter, _isHighAccProductFilter));
-                        key = BPC_KEY;
-                        dictPrecursorMzToFilter.Add(key, new SpectrumFilterPair(key, PeptideDocNode.UNKNOWN_COLOR, dictPrecursorMzToFilter.Count,
-                            _instrument.MinTime, _instrument.MaxTime, _isHighAccMsFilter, _isHighAccProductFilter));
+                        if (gce?.TicChromatogramIndex == null)
+                        {
+                            var key = TIC_KEY;
+                            dictPrecursorMzToFilter.Add(key, new SpectrumFilterPair(key, PeptideDocNode.UNKNOWN_COLOR, dictPrecursorMzToFilter.Count,
+                                _instrument.MinTime, _instrument.MaxTime, _isHighAccMsFilter, _isHighAccProductFilter));
+                            /*
+                             Leaving this here in case we ever decide to fall back to our own BPC extraction in cases where data
+                             file doesn't have them ready to go, as in mzXML
+                            key = BPC_KEY;
+                            dictPrecursorMzToFilter.Add(key, new SpectrumFilterPair(key, PeptideDocNode.UNKNOWN_COLOR, dictPrecursorMzToFilter.Count,
+                                _instrument.MinTime, _instrument.MaxTime, _isHighAccMsFilter, _isHighAccProductFilter));
+                            */
+                        }
                     }
-                    //*/
+
                 }
                 if (EnabledMsMs)
                 {

--- a/pwiz_tools/Skyline/TestPerf/PerfTicAreaTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfTicAreaTest.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2020 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline.Model.Results;
+using pwiz.SkylineTestUtil;
+
+namespace TestPerf
+{
+    [TestClass]
+    public class PerfTicAreaTest : AbstractFunctionalTest
+    {
+        /// <summary>
+        /// Tests that the Total Ion Current area is calculated correctly in various types of files.
+        /// <see cref="GlobalChromatogramExtractor.IsTicChromatogramUsable"/> is responsible for deciding whether
+        /// the TIC chromatogram that is present in the data file can be used to calculate the TicArea. If that chromatogram
+        /// is not usable, then Skyline falls back to the technique of summing the spectrum intensities in each MS1 spectrum.
+        /// </summary>
+        [TestMethod]
+        public void TestPerfTicArea()
+        {
+            TestFilesZipPaths = new[]
+            {
+                "https://skyline.gs.washington.edu/perftests/PerfTicAreaTest.zip"
+            };
+            RunFunctionalTest();
+        }
+
+        protected override void DoTest()
+        {
+            var ticAreas = new Dictionary<string, double>();
+
+            // TIC chromatogram includes MS2 scans
+            ticAreas.Add("DemuxedMzML.mzML", 231215169536);
+            // TIC chromatogram has zero points because MS1 scans were marked as SIM
+            ticAreas.Add("SIMRawFile.raw", 231215169536);
+            // TIC chromatogram is usable
+            ticAreas.Add("XlinkRawFile.raw", 1021147086848);
+            // TIC chromatogram includes MS2 scans, but is otherwise the same as XlinkRawFile.raw
+            ticAreas.Add("XlinkRawFile.mzML", 1007182479360);
+
+            RunUI(()=>SkylineWindow.OpenFile(TestFilesDir.GetTestPath("PerfTicAreaTest.sky")));
+            ImportResultsFiles(ticAreas.Keys.Select(fileName=> new MsDataFilePath(TestFilesDir.GetTestPath(fileName))).ToArray());
+
+            Assert.IsNotNull(SkylineWindow.Document.Settings.MeasuredResults);
+            foreach (var chromatogramSet in SkylineWindow.Document.Settings.MeasuredResults.Chromatograms)
+            {
+                foreach (var msDataFileInfo in chromatogramSet.MSDataFileInfos)
+                {
+                    string filename = msDataFileInfo.FilePath.GetFileName();
+                    Assert.IsNotNull(msDataFileInfo.TicArea, filename);
+                    double expectedTicArea;
+                    Assert.IsTrue(ticAreas.TryGetValue(filename, out expectedTicArea), filename);
+                    Assert.AreEqual(expectedTicArea, msDataFileInfo.TicArea.Value, 1.0, filename);
+                }
+            }
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
+++ b/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
@@ -164,6 +164,7 @@
     <Compile Include="PerfPeakTest.cs" />
     <Compile Include="PerfPeakViewConvert.cs" />
     <Compile Include="PerfThermoFAIMSTest.cs" />
+    <Compile Include="PerfTicAreaTest.cs" />
     <Compile Include="PerfUniquePeptidesTest.cs" />
     <Compile Include="SmallMolDriftTimePredictorTest.cs" />
   </ItemGroup>


### PR DESCRIPTION
Make it so that Skyline falls back to the old way of extracting the Total Ion Current chromatogram and calculating the TIC Area if the Tic Chromatogram that is present in the data file is not usable.

It might not be usable if:
1. The chromatogram contains MS2 scans. We don't know for sure whether it contains MS2 scans, but the heuristic is that if the point count in the TIC chromatogram is more than 1/2 (number chosen because of typical MSe data) as large as the total spectrum count, we don't use it.
2. The chromatogram has zero points in it. This can happen if all of the spectra in the .raw file were marked as SIM spectra.

The logic for this is in GlobalChromatogramExtractor.IsTicChromatogramUsable