### PR TITLE
Skyline: Fixes to Prosit integration (#989)

### DIFF
--- a/pwiz_tools/Skyline/Controls/PrositUIHelpers.cs
+++ b/pwiz_tools/Skyline/Controls/PrositUIHelpers.cs
@@ -32,9 +32,8 @@ namespace pwiz.Skyline.Controls
             {
                 using (var dlg = new AlertDlg(PrositResources.BuildLibraryDlg_dataSourceFilesRadioButton_CheckedChanged_Some_Prosit_settings_are_not_set__Would_you_like_to_set_them_now_, MessageBoxButtons.YesNo))
                 {
-                    dlg.ShowDialog(owner);
-                    if (dlg.DialogResult == DialogResult.Yes)
-                        skylineWindow.ShowToolOptionsUI(dlg, ToolOptionsUI.TABS.Prosit);
+                    if (dlg.ShowDialog(owner) == DialogResult.Yes)
+                        skylineWindow.ShowToolOptionsUI(owner, ToolOptionsUI.TABS.Prosit);
                 }
             }
         }

--- a/pwiz_tools/Skyline/Model/Lib/Library.cs
+++ b/pwiz_tools/Skyline/Model/Lib/Library.cs
@@ -2318,7 +2318,7 @@ namespace pwiz.Skyline.Model.Lib
         public SpectrumInfoLibrary(Library library, IsotopeLabelType labelType, string filePath,
             double? retentionTime, IonMobilityAndCCS ionMobilityInfo, bool isBest, object spectrumKey) :
                 base(labelType, true)
-    {
+        {
             _library = library;
             LabelType = labelType;
             SpectrumKey = spectrumKey;
@@ -2371,8 +2371,8 @@ namespace pwiz.Skyline.Model.Lib
 
         private SpectrumPeaksInfo _peaksInfo;
 
-        public SpectrumInfoProsit(PrositMS2Spectra ms2Spectrum, TransitionGroupDocNode precursor, int nce) : base(
-            IsotopeLabelType.light, true)
+        public SpectrumInfoProsit(PrositMS2Spectra ms2Spectrum, TransitionGroupDocNode precursor, IsotopeLabelType labelType, int nce)
+            : base(labelType, true)
         {
             _peaksInfo = ms2Spectrum?.GetSpectrum(precursor).SpectrumPeaks;
             Precursor = precursor;

--- a/pwiz_tools/Skyline/Model/Prosit/Models/PrositModel.cs
+++ b/pwiz_tools/Skyline/Model/Prosit/Models/PrositModel.cs
@@ -336,21 +336,23 @@ namespace pwiz.Skyline.Model.Prosit.Models
 
             public PrositRequest(PrositPredictionClient client, PrositIntensityModel intensityModel,
                 PrositRetentionTimeModel rtModel, SrmSettings settings,
-                PeptideDocNode peptide, TransitionGroupDocNode precursor, int nce, Action updateCallback)
+                PeptideDocNode peptide, TransitionGroupDocNode precursor, IsotopeLabelType labelType,
+                int nce, Action updateCallback)
             {
                 Client = client;
                 IntensityModel = intensityModel;
                 RTModel = rtModel;
                 Settings = settings;
                 Precursor = precursor;
+                LabelType = labelType;
                 Peptide = peptide;
                 NCE = nce;
                 _updateCallback = updateCallback;
             }
 
-            public PrositRequest(SrmSettings settings, PeptideDocNode peptide, TransitionGroupDocNode precursor, Action updateCallback) :
+            public PrositRequest(SrmSettings settings, PeptideDocNode peptide, TransitionGroupDocNode precursor, IsotopeLabelType labelType, Action updateCallback) :
                 this(PrositPredictionClient.Current, PrositIntensityModel.Instance, PrositRetentionTimeModel.Instance,
-                    settings, peptide, precursor, Properties.Settings.Default.PrositNCE, updateCallback)
+                    settings, peptide, precursor, labelType, Properties.Settings.Default.PrositNCE, updateCallback)
             {
             }
 
@@ -360,8 +362,9 @@ namespace pwiz.Skyline.Model.Prosit.Models
                 {
                     try
                     {
+                        var labelType = LabelType ?? Precursor.LabelType;
                         var skyIn = new PrositIntensityModel.PeptidePrecursorNCE(Peptide,
-                            Precursor, Precursor.LabelType, NCE);
+                            Precursor, labelType, NCE);
                         var massSpectrum = IntensityModel.PredictSingle(Client,
                             Settings, skyIn,
                             _tokenSource.Token);
@@ -369,8 +372,7 @@ namespace pwiz.Skyline.Model.Prosit.Models
                             Settings,
                             Peptide, _tokenSource.Token);
                         Spectrum = new SpectrumDisplayInfo(
-                            new SpectrumInfoProsit(massSpectrum, Precursor,
-                                NCE),
+                            new SpectrumInfoProsit(massSpectrum, Precursor, labelType, NCE),
                             // ReSharper disable once AssignNullToNotNullAttribute
                             Precursor,
                             iRT[Peptide]);
@@ -404,16 +406,17 @@ namespace pwiz.Skyline.Model.Prosit.Models
             public PrositIntensityModel IntensityModel { get; protected set; }
             public PrositRetentionTimeModel RTModel { get; protected set; }
             public SrmSettings Settings { get; protected set; }
-            public TransitionGroupDocNode Precursor { get; protected set; }
             public PeptideDocNode Peptide { get; protected set; }
+            public TransitionGroupDocNode Precursor { get; protected set; }
+            public IsotopeLabelType LabelType { get; protected set; }
             public int NCE { get; protected set; }
 
             protected bool Equals(PrositRequest other)
             {
                 return Client.Server == other.Client.Server && ReferenceEquals(IntensityModel, other.IntensityModel) &&
                        ReferenceEquals(RTModel, other.RTModel) && ReferenceEquals(Settings, other.Settings) &&
-                       ReferenceEquals(Precursor, other.Precursor) && ReferenceEquals(Peptide, other.Peptide) &&
-                       NCE == other.NCE;
+                       ReferenceEquals(Peptide, other.Peptide) && ReferenceEquals(Precursor, other.Precursor) &&
+                       ReferenceEquals(LabelType, other.LabelType) && NCE == other.NCE;
             }
 
             public override bool Equals(object obj)
@@ -432,8 +435,9 @@ namespace pwiz.Skyline.Model.Prosit.Models
                     hashCode = (hashCode * 397) ^ (IntensityModel != null ? IntensityModel.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ (RTModel != null ? RTModel.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ (Settings != null ? Settings.GetHashCode() : 0);
-                    hashCode = (hashCode * 397) ^ (Precursor != null ? Precursor.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ (Peptide != null ? Peptide.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Precursor != null ? Precursor.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (LabelType != null ? LabelType.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ NCE;
                     return hashCode;
                 }

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
@@ -121,7 +122,7 @@ namespace pwiz.Skyline.ToolsUI
         {
             public PrositPingRequest(string ms2Model, string rtModel, SrmSettings settings,
                 PeptideDocNode peptide, TransitionGroupDocNode precursor, int nce, Action updateCallback) : base(null,
-                null, null, settings, peptide, precursor, nce, updateCallback)
+                null, null, settings, peptide, precursor, null, nce, updateCallback)
             {
                 Client = PrositPredictionClient.CreateClient(PrositConfig.GetPrositConfig());
                 IntensityModel = PrositIntensityModel.GetInstance(ms2Model);
@@ -137,14 +138,15 @@ namespace pwiz.Skyline.ToolsUI
                 {
                     try
                     {
+                        var labelType = Precursor.LabelType;
                         var ms = IntensityModel.PredictSingle(Client, Settings,
-                            new PrositIntensityModel.PeptidePrecursorNCE(Peptide, Precursor, Precursor.LabelType, NCE), _tokenSource.Token);
+                            new PrositIntensityModel.PeptidePrecursorNCE(Peptide, Precursor, labelType, NCE), _tokenSource.Token);
 
                         var iRTMap = RTModel.PredictSingle(Client,
                             Settings,
                             Peptide, _tokenSource.Token);
 
-                        var spectrumInfo = new SpectrumInfoProsit(ms, Precursor, NCE);
+                        var spectrumInfo = new SpectrumInfoProsit(ms, Precursor, labelType, NCE);
                         var irt = iRTMap[Peptide];
                         Spectrum = new SpectrumDisplayInfo(
                             spectrumInfo, Precursor, irt);
@@ -271,10 +273,16 @@ namespace pwiz.Skyline.ToolsUI
             _driverRemoteAccounts.EditList();
         }
 
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            base.OnClosing(e);
+
+            if (!e.Cancel)
+                _pingRequest?.Cancel();
+        }
+
         protected override void OnClosed(EventArgs e)
         {
-            _pingRequest?.Cancel();
-
             if (DialogResult == DialogResult.OK)
             {
                 var displayLanguageItem = listBoxLanguages.SelectedItem as DisplayLanguageItem;


### PR DESCRIPTION
- Failure to annotate fragment ions in heavy labeled Prosit predicted spectra
- Failure to match m/z values between heavy labeled library spectra and Prosit mirror plot spectra
- Mistake in parenting ToolOptionsUI when shown as a result of CheckPrositSettings
- Fix canceling of PrositPingRequest during closing of ToolOptionsUI