### PR TITLE
Add logging code to AllChromatogramsGraph.CreateHandle

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.Designer.cs
@@ -9,19 +9,6 @@ namespace pwiz.Skyline.Controls.Graphs
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -143,12 +143,18 @@ namespace pwiz.Skyline.Controls.Graphs
         }
 
         private bool _inCreateHandle;
+        /// <summary>
+        /// Override CreateHandle in order to try to track down intermittent test failures.
+        /// "HandleProcessCorruptedStateExceptions" just in case a type of exception is getting thrown
+        /// that cannot be caught by ordinary C# code.
+        /// TODO(nicksh): Remove this override once the intermittent failure is figured out
+        /// </summary>
         [HandleProcessCorruptedStateExceptions]
         [SecurityCritical]
         protected override void CreateHandle()
         {
             Assume.IsFalse(_inCreateHandle);
-            if (Program.MainWindow != null && Program.MainWindow.InvokeRequired)
+            if (Program.FunctionalTest && Program.MainWindow != null && Program.MainWindow.InvokeRequired)
             {
                 throw new ApplicationException(@"CreateHandle called on wrong thread");
             }
@@ -160,7 +166,7 @@ namespace pwiz.Skyline.Controls.Graphs
             }
             catch (Exception e)
             {
-                Trace.TraceWarning(@"Exception in AllChromatogramsGraph CreateHandle {0}", e);
+                Console.Out.WriteLine(@"Exception in AllChromatogramsGraph CreateHandle {0}", e);
                 throw new Exception(@"Exception in AllChromatogramsGraph", e);
             }
             finally
@@ -168,6 +174,28 @@ namespace pwiz.Skyline.Controls.Graphs
                 _inCreateHandle = false;
             }
         }
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// Also, check "_inCreateHandle" in the hopes of tracking down intermittent test failures.
+        /// TODO(nicksh): Move this function back to AllChromatogramsGraph.Designer.cs once the
+        /// test failures are figured out.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (_inCreateHandle)
+            {
+                Console.Out.WriteLine(@"AllChromatogramsGraph _inCreateHandle is {0}", _inCreateHandle);
+            }
+
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
 
         private void ElapsedTimer_Tick(object sender, EventArgs e)
         {

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -151,6 +151,7 @@ namespace pwiz.Skyline.Controls.Graphs
         /// </summary>
         [HandleProcessCorruptedStateExceptions]
         [SecurityCritical]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         protected override void CreateHandle()
         {
             Assume.IsFalse(_inCreateHandle);
@@ -182,6 +183,7 @@ namespace pwiz.Skyline.Controls.Graphs
         /// test failures are figured out.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         protected override void Dispose(bool disposing)
         {
             if (_inCreateHandle)


### PR DESCRIPTION
Trying to track down intermittent failures "Dispose" cannot be called during "CreateHandle".