### PR TITLE
Fix some bugs in AreaCVHistogram:

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AreaCVToolbar.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AreaCVToolbar.cs
@@ -76,7 +76,7 @@ namespace pwiz.Skyline.Controls.Graphs
             }
             else
             {
-                Program.MainWindow.SetAreaCVAnnotation(toolStripComboGroup.Items[index].ToString(), false);
+                Program.MainWindow.SetAreaCVAnnotation(toolStripComboGroup.Items[index], false);
                 var document = _graphSummary.DocumentUIContainer.DocumentUI;
                 var groupByGroup =
                     ReplicateValue.FromPersistedString(document.Settings, AreaGraphController.GroupByGroup);
@@ -226,7 +226,10 @@ namespace pwiz.Skyline.Controls.Graphs
 
             if (groupsVisible)
             {
-                var annotations = new[] { Resources.GraphSummary_UpdateToolbar_All }.Concat(AnnotationHelper.GetPossibleAnnotations(document, ReplicateValue.FromPersistedString(document.Settings, AreaGraphController.GroupByGroup))).ToArray();
+                var annotations = new[] {Resources.GraphSummary_UpdateToolbar_All}.Concat(
+                    AnnotationHelper.GetPossibleAnnotations(document,
+                            ReplicateValue.FromPersistedString(document.Settings, AreaGraphController.GroupByGroup))
+                        .Except(new object[] {null})).ToArray();
 
                 toolStripComboGroup.Items.Clear();
                 // ReSharper disable once CoVariantArrayConversion
@@ -279,9 +282,9 @@ namespace pwiz.Skyline.Controls.Graphs
 
         public bool GroupsVisible { get { return toolStripLabel1.Visible && toolStripComboGroup.Visible; } }
 
-        public IEnumerable<string> Annotations
+        public IEnumerable<object> Annotations
         {
-            get { return toolStripComboGroup.Items.Cast<string>(); }
+            get { return toolStripComboGroup.Items.Cast<object>(); }
             set
             {
                 toolStripComboGroup.Items.Clear();

--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -4470,7 +4470,8 @@ namespace pwiz.Skyline
 
                 if (areaCVCountTransitionsToolStripMenuItem.DropDownItems.Count == 0)
                 {
-                    var maxTransCount = Document.PeptideTransitionGroups.Max(g => g.TransitionCount);
+                    var maxTransCount = Document.MoleculeTransitionGroups
+                        .Select(g => g.TransitionCount).Append(0).Max();
                     for (int i = 1; i <= maxTransCount; i++)
                     {
                         var tmp = new ToolStripMenuItem(i.ToString(), null,
@@ -4855,9 +4856,9 @@ namespace pwiz.Skyline
             UpdatePeakAreaGraph();
         }
 
-        public void SetAreaCVAnnotation(string annotation, bool update = true)
+        public void SetAreaCVAnnotation(object annotationValue, bool update = true)
         {
-            AreaGraphController.GroupByAnnotation = annotation;
+            AreaGraphController.GroupByAnnotation = annotationValue;
 
             if(update)
                 UpdatePeakAreaGraph();

--- a/pwiz_tools/Skyline/TestFunctional/AreaCVHistogramTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AreaCVHistogramTest.cs
@@ -234,7 +234,7 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() => SkylineWindow.SetAreaCVPointsType(PointsTypePeakArea.targets));
             WaitForGraphs();
 
-            string[] annotations = null;
+            object[] annotations = null;
             RunUI(() => annotations = toolbar.Annotations.ToArray());
 
             CollectionAssert.AreEqual(annotations,


### PR DESCRIPTION
1. ArgumentNullException if trying to group on a property where some of the replicates have null values.
2. Unable to group on values that are not strings.
3. InvalidOperationException if document contains zero PeptideTransitionGroups.