### PR TITLE
Add diagnostics to AsynchChromatogramsGraph2.CreateHandle and Dispose…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -157,7 +157,7 @@ namespace pwiz.Skyline.Controls.Graphs
             Assume.IsFalse(_inCreateHandle);
             if (Program.FunctionalTest && Program.MainWindow != null && Program.MainWindow.InvokeRequired)
             {
-                throw new ApplicationException(@"CreateHandle called on wrong thread");
+                throw new ApplicationException(@"AllChromatogramsGraph.CreateHandle called on wrong thread");
             }
 
             try

--- a/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.Designer.cs
@@ -7,19 +7,6 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary> 
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Component Designer generated code
 
         /// <summary> 

--- a/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.cs
@@ -19,9 +19,13 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Security;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Properties;
+using pwiz.Skyline.Util;
 using ZedGraph;
 
 namespace pwiz.Skyline.Controls.Graphs
@@ -560,5 +564,63 @@ namespace pwiz.Skyline.Controls.Graphs
                 }
             }
         }
+
+        private bool _inCreateHandle;
+        /// <summary>
+        /// Override CreateHandle in order to try to track down intermittent test failures.
+        /// "HandleProcessCorruptedStateExceptions" just in case a type of exception is getting thrown
+        /// that cannot be caught by ordinary C# code.
+        /// TODO(nicksh): Remove this override once the intermittent failure is figured out
+        /// </summary>
+        [HandleProcessCorruptedStateExceptions]
+        [SecurityCritical]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        protected override void CreateHandle()
+        {
+            Assume.IsFalse(_inCreateHandle);
+            if (Program.FunctionalTest && Program.MainWindow != null && Program.MainWindow.InvokeRequired)
+            {
+                throw new ApplicationException(@"AsynchChromatogramsGraph2.CreateHandle called on wrong thread");
+            }
+
+            try
+            {
+                _inCreateHandle = true;
+                base.CreateHandle();
+            }
+            catch (Exception e)
+            {
+                Console.Out.WriteLine(@"Exception in AsynchChromatogramsGraph2 CreateHandle {0}", e);
+                throw new Exception(@"Exception in AsynchChromatogramsGraph2", e);
+            }
+            finally
+            {
+                _inCreateHandle = false;
+            }
+        }
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// Also, check "_inCreateHandle" in the hopes of tracking down intermittent test failures.
+        /// TODO(nicksh): Move this function back to AsyncChromatogramsGraph2.Designer.cs once the
+        /// test failures are figured out.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        protected override void Dispose(bool disposing)
+        {
+            if (_inCreateHandle)
+            {
+                Console.Out.WriteLine(@"AsyncChromatogramsGraph2 _inCreateHandle is {0}", _inCreateHandle);
+            }
+
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+
     }
 }


### PR DESCRIPTION
… in order to track down intermittent test failure.