### PR TITLE
Fix formatting of calculated concentration of CalibrationForm so that…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/Calibration/CalibrationForm.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/Calibration/CalibrationForm.cs
@@ -418,7 +418,9 @@ namespace pwiz.Skyline.Controls.Graphs.Calibration
                 if (calculatedConcentration.HasValue)
                 {
                     labelLines.Add(string.Format(@"{0} = {1}",
-                        QuantificationStrings.Calculated_Concentration, calculatedConcentration));
+                        QuantificationStrings.Calculated_Concentration,
+                        QuantificationResult.FormatCalculatedConcentration(calculatedConcentration.Value,
+                            curveFitter.QuantificationSettings.Units)));
                 }
                 else if (quantificationResult != null && !quantificationResult.NormalizedArea.HasValue)
                 {

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
@@ -77,11 +77,7 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         {
             if (CalculatedConcentration.HasValue)
             {
-                if (Units == null)
-                {
-                    return CalculatedConcentration.Value.ToString(Formats.CalibrationCurve);
-                }
-                return TextUtil.SpaceSeparate(CalculatedConcentration.Value.ToString(Formats.Concentration), Units);
+                FormatCalculatedConcentration(CalculatedConcentration.Value, Units);
             }
             else if (NormalizedArea.HasValue)
             {
@@ -89,6 +85,16 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
                     NormalizedArea.Value.ToString(Formats.CalibrationCurve));
             }
             return TextUtil.EXCEL_NA;
+        }
+
+        public static string FormatCalculatedConcentration(double calculatedConcentration, string units)
+        {
+            if (units == null)
+            {
+                return calculatedConcentration.ToString(Formats.CalibrationCurve);
+            }
+
+            return TextUtil.SpaceSeparate(calculatedConcentration.ToString(Formats.Concentration), units);
         }
     }
 }


### PR DESCRIPTION
… it displays the units and four decimal places.

(This fix was back-ported from master).