### PR TITLE
Skyline/work/20200331 debugger option on assert ex failure

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -57,7 +58,7 @@ namespace pwiz.SkylineTestFunctional
         public void TestLibraryBuild()
         {
             TestFilesZip = @"TestFunctional\LibraryBuildTest.zip";
-using (new Assume.DebugOnFail("BSPRATT-UW3")) // If any AsertEx or Assume fails on BSPRATT-UW3, invoke debugger instead of failing  TODO(bspratt) remove this once debugged
+using (new Assume.DebugOnFail(Environment.MachineName.Contains("BSPRATT-UW3"))) // If any AsertEx or Assume fails on BSPRATT-UW3, invoke debugger instead of failing  TODO(bspratt) remove this once debugged
                 RunFunctionalTest();
         }
 
@@ -149,7 +150,7 @@ using (new Assume.DebugOnFail("BSPRATT-UW3")) // If any AsertEx or Assume fails 
             BuildLibraryValid("heavy_adduct.ssl", true, false, false, 1);
             // Make sure explorer handles this adduct type
             var viewLibUI = ShowDialog<ViewLibraryDlg>(SkylineWindow.ViewSpectralLibraries);
-            RunUI(() => Assume.IsTrue(viewLibUI.GraphItem.IonLabels.Any()));
+            RunUI(() => AssertEx.IsTrue(viewLibUI.GraphItem.IonLabels.Any()));
             RunUI(viewLibUI.CancelDialog);
 
             // Barbara added code to ProteoWizard to rebuild a missing or invalid mzXML index

--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -57,7 +57,8 @@ namespace pwiz.SkylineTestFunctional
         public void TestLibraryBuild()
         {
             TestFilesZip = @"TestFunctional\LibraryBuildTest.zip";
-            RunFunctionalTest();
+using (new Assume.DebugOnFail("BSPRATT-UW3")) // If any AsertEx or Assume fails on BSPRATT-UW3, invoke debugger instead of failing  TODO(bspratt) remove this once debugged
+                RunFunctionalTest();
         }
 
         protected override void DoTest()

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -37,17 +37,128 @@ using pwiz.Skyline.Util.Extensions;
 
 namespace pwiz.SkylineTestUtil
 {
+    /// <summary>
+    /// AssertEx provides an extended set of Assert functions, such as collection equality, as well as
+    /// new implementations of common Assert functions such as Assert.IsTrue.
+    /// 
+    /// These implementations give two advantages over standard Assert.* functions:
+    ///    Easier to set breakpoints while debugging
+    ///    Tests can optionally invoke a debugger instead of quitting, using the <see cref="Assume.DebugOnFail"/> mechanism.
+    /// </summary>
     public static class AssertEx
     {
         public static void AreEqualDeep<TItem>(IList<TItem> l1, IList<TItem> l2)
         {
-            Assert.AreEqual(l1.Count, l2.Count);
+            AreEqual(l1.Count, l2.Count);
             for (int i = 0; i < l1.Count; i++)
             {
                 if (!Equals(l1[i], l2[i]))
-                    Assert.AreEqual(l1[i], l2[i]);  // For setting breakpoint
+                {
+                    AreEqual(l1[i], l2[i]);  // For setting breakpoint
+                }
             }
         }
+
+        public static void AreEqual<T>(T expected, T actual, string message = null)
+        {
+            if (!Equals(expected, actual))
+            {
+                if (Assume.InvokeDebuggerOnFail)
+                {
+                    Assume.Fail(message); // Handles the debugger launch
+                }
+                Assert.AreEqual(expected, actual, message);
+            }
+        }
+
+        public static void AreNotEqual<T>(T expected, T actual, string message)
+        {
+            if (Equals(expected, actual))
+            {
+                if (Assume.InvokeDebuggerOnFail)
+                {
+                    Assume.Fail(message); // Handles the debugger launch
+                }
+                Assert.AreNotEqual(expected, actual, message);
+            }
+        }
+
+        public static void AreNotSame(object expected, object actual)
+        {
+            if (!ReferenceEquals(expected, actual))
+            {
+                if (Assume.InvokeDebuggerOnFail)
+                {
+                    Assume.Fail(); // Handles the debugger launch
+                }
+                Assert.AreNotSame(expected, actual);
+            }
+        }
+
+        public static void Fail(string message = null)
+        {
+            if (Assume.InvokeDebuggerOnFail)
+            {
+                Assume.Fail(message); // Handles the debugger launch
+            }
+            Assert.Fail(message);
+        }
+
+        public static void Fail(string message, params object[] parameters)
+        {
+            if (Assume.InvokeDebuggerOnFail)
+            {
+                Assume.Fail(message); // Handles the debugger launch
+            }
+            Assert.Fail(message, parameters);
+        }
+
+        public static void AreEqual(double expected, double actual, double tolerance, string message = null)
+        {
+            if (!Equals(expected, actual))
+            {
+                if (Math.Abs(expected - actual) > tolerance)
+                {
+                    AreEqual(expected, actual, message);
+                }
+            }
+        }
+
+        public static void AreEqual(double? expected, double? actual, double tolerance, string message = null)
+        {
+            if (!Equals(expected, actual))
+            {
+                if (expected.HasValue && actual.HasValue)
+                {
+                    AreEqual(expected.Value, actual.Value, tolerance, message);
+                }
+                else
+                {
+                    AreEqual(expected, actual, message);
+                }
+            }
+        }
+
+        public static void IsTrue(bool expected, string message = null)
+        {
+            AreEqual(expected, true, message);
+        }
+
+        public static void IsFalse(bool expected, string message = null)
+        {
+            AreEqual(expected, false, message);
+        }
+
+        public static void IsNull(object obj, string message = null)
+        {
+            AreEqual(null, obj, message);
+        }
+
+        public static void IsNotNull(object obj, string message = null)
+        {
+            AreNotEqual(null, obj, message);
+        }
+
 
         public static void ThrowsException<TEx>(Action throwEx, string message = null)
             where TEx : Exception
@@ -71,7 +182,7 @@ namespace pwiz.SkylineTestUtil
             }
             // Assert that an exception was thrown. We do this outside of the catch block
             // so that the AssertFailedException will not get caught if TEx is Exception.
-            Assert.IsTrue(exceptionThrown, "Exception expected");
+            IsTrue(exceptionThrown, "Exception expected");
         }
 
 
@@ -90,7 +201,7 @@ namespace pwiz.SkylineTestUtil
             }
             catch (TEx x)
             {
-                Assert.Fail(TextUtil.LineSeparate(string.Format("Unexpected exception: {0}", x.Message), x.StackTrace));
+                Fail(TextUtil.LineSeparate(string.Format("Unexpected exception: {0}", x.Message), x.StackTrace));
             }
         }
 
@@ -99,31 +210,31 @@ namespace pwiz.SkylineTestUtil
             if (exceptions.Count == 0)
                 return;
 
-            Assert.Fail(TextUtil.LineSeparate(exceptions.Count == 1 ? "Unexpected exception:" : "Unexpected exceptions:",
+            Fail(TextUtil.LineSeparate(exceptions.Count == 1 ? "Unexpected exception:" : "Unexpected exceptions:",
                 TextUtil.LineSeparate(exceptions.Select(x => TextUtil.LineSeparate(x.Message, ExceptionUtil.GetStackTraceText(x, null, false), string.Empty)))));
         }
 
         public static void Contains(string value, params string[] parts)
         {
-            Assert.IsNotNull(value, "No message found");
-            Assert.AreNotEqual(0, parts.Length, "Must have at least one thing contained");
+            IsNotNull(value, "No message found");
+            AreNotEqual(0, parts.Length, "Must have at least one thing contained");
             foreach (string part in parts)
             {
                 if (!string.IsNullOrEmpty(part) && !value.Contains(part))
-                    Assert.Fail("The text '{0}' does not contain '{1}'", value, part);
+                    Fail("The text '{0}' does not contain '{1}'", value, part);
             }
         }
 
         public static void FileExists(string filePath, string message = null)
         {
             if (!File.Exists(filePath))
-                Assert.Fail(TextUtil.LineSeparate(string.Format("Missing file {0}", filePath), message ?? string.Empty));
+                Fail(TextUtil.LineSeparate(string.Format("Missing file {0}", filePath), message ?? string.Empty));
         }
 
         public static void FileNotExists(string filePath, string message = null)
         {
             if (File.Exists(filePath))
-                Assert.Fail(TextUtil.LineSeparate(string.Format("Unexpected file exists {0}", filePath), message ?? string.Empty));
+                Fail(TextUtil.LineSeparate(string.Format("Unexpected file exists {0}", filePath), message ?? string.Empty));
         }
 
         public static TObj Deserialize<TObj>(string s)
@@ -184,7 +295,7 @@ namespace pwiz.SkylineTestUtil
                     if (deserializeType == DeserializeType.error)
                     {
                         // Fail if deserialization succeeds.
-                        Assert.Fail("Expected error deserializing {0}:\r\n{1}", typeof(TObj).Name, s);
+                        Fail("Expected error deserializing {0}:\r\n{1}", typeof(TObj).Name, s);
                     }
 
                     if (deserializeType == DeserializeType.roundtrip)
@@ -201,7 +312,7 @@ namespace pwiz.SkylineTestUtil
                     }
                     else
                     {
-                        Assert.Fail("Unexpected exception {0} - {1}:\r\n{2}", typeof(TEx), message, x.StackTrace);
+                        Fail("Unexpected exception {0} - {1}:\r\n{2}", typeof(TEx), message, x.StackTrace);
                     }
                 }
                 catch (TEx x)
@@ -209,14 +320,14 @@ namespace pwiz.SkylineTestUtil
                     message = GetMessageStack(x, null);
                     if (deserializeType != DeserializeType.error)
                     {
-                        Assert.Fail("Unexpected exception {0} - {1}:\r\n{2}", typeof(TEx), message, x.StackTrace);
+                        Fail("Unexpected exception {0} - {1}:\r\n{2}", typeof(TEx), message, x.StackTrace);
                     }
                 }
                 if (expectedExceptionText != null)
                 {
                     if ((message == null) || !message.Contains(expectedExceptionText))
                     {
-                        Assert.Fail("Unexpected exception message for {0}: expected to contain\r\n{1}\r\nactual\r\n{2}", typeof(TEx), expectedExceptionText, message ?? "<none>");
+                        Fail("Unexpected exception message for {0}: expected to contain\r\n{1}\r\nactual\r\n{2}", typeof(TEx), expectedExceptionText, message ?? "<none>");
                     }
                 }
             }
@@ -269,22 +380,22 @@ namespace pwiz.SkylineTestUtil
             {
                 var peptideModifiedSequence =
                     ModifiedSequence.GetModifiedSequence(doc.Settings, peptide, IsotopeLabelType.light);
-                Assert.IsNotNull(peptideModifiedSequence);
+                IsNotNull(peptideModifiedSequence);
                 if (peptide.ModifiedSequenceDisplay != peptideModifiedSequence.ToString())
                 {
-                    Assert.AreEqual(peptide.ModifiedSequenceDisplay, peptideModifiedSequence.ToString());
+                    AreEqual(peptide.ModifiedSequenceDisplay, peptideModifiedSequence.ToString());
                 }
                 foreach (var precursor in peptide.TransitionGroups)
                 {
                     var modifiedSequence = ModifiedSequence.GetModifiedSequence(doc.Settings, peptide,
                         precursor.TransitionGroup.LabelType);
-                    Assert.IsNotNull(modifiedSequence);
+                    IsNotNull(modifiedSequence);
                     var expectedModifiedSequence = doc.Settings.GetPrecursorCalc(
                             precursor.TransitionGroup.LabelType, peptide.ExplicitMods)
                         .GetModifiedSequence(peptide.Peptide.Target, true).ToString();
                     if (expectedModifiedSequence != modifiedSequence.ToString())
                     {
-                        Assert.AreEqual(expectedModifiedSequence, modifiedSequence.ToString());
+                        AreEqual(expectedModifiedSequence, modifiedSequence.ToString());
                     }
                 }
             }
@@ -319,7 +430,8 @@ namespace pwiz.SkylineTestUtil
                         var assembly = Assembly.GetAssembly(typeof(AssertEx));
                         var xsdName = typeof(AssertEx).Namespace + String.Format(CultureInfo.InvariantCulture, ".Schemas.Skyline_{0}.xsd", SrmDocument.FORMAT_VERSION);
                         var schemaStream = assembly.GetManifestResourceStream(xsdName);
-                        Assert.IsNotNull(schemaStream, string.Format("Schema {0} not found in TestUtil assembly", xsdName));
+                        IsNotNull(schemaStream, string.Format("Schema {0} not found in TestUtil assembly", xsdName));
+                        // ReSharper disable once AssignNullToNotNullAttribute
                         var schemaText = (new StreamReader(schemaStream)).ReadToEnd();
                         var xd = new XmlDocument();
                         xd.Load(new MemoryStream(Encoding.UTF8.GetBytes(schemaText)));
@@ -346,7 +458,8 @@ namespace pwiz.SkylineTestUtil
                                     {
                                         // Don't enter a redundant definition
                                         targetXML = xml;
-                                        Assert.IsNotNull(xd.DocumentElement);
+                                        IsNotNull(xd.DocumentElement);
+                                        // ReSharper disable once PossibleNullReferenceException
                                         xd.DocumentElement.AppendChild(nodes[i]);
                                     }
                                 }
@@ -376,14 +489,14 @@ namespace pwiz.SkylineTestUtil
                                 }
                                 catch (Exception e)
                                 {
-                                    Assert.Fail(e.Message + "  XML text:\r\n" + xmlText);
+                                    Fail(e.Message + "  XML text:\r\n" + xmlText);
                                 }
                             }
                         }
                     }
                     catch (Exception e)
                     {
-                        Assert.Fail(e.ToString());
+                        Fail(e.ToString());
                     }
                 }
             }
@@ -415,7 +528,7 @@ namespace pwiz.SkylineTestUtil
 
             string version = "0";
             if (documentHashIndex < 0)
-                Assert.Fail("Invalid Audit Log. No audit_log tag found");
+                Fail("Invalid Audit Log. No audit_log tag found");
             if (formatVersionIndex > 0 && formatVersionIndex < documentHashIndex)
             {
                 version = xmlText.Substring(formatVersionIndex + 16,
@@ -438,7 +551,8 @@ namespace pwiz.SkylineTestUtil
             var assembly = Assembly.GetAssembly(typeof(AssertEx));
             var schemaFileName = typeof(AssertEx).Namespace + String.Format(CultureInfo.InvariantCulture, @".Schemas.{0}.xsd", xsdName);
             var schemaFile = assembly.GetManifestResourceStream(schemaFileName);
-            Assert.IsNotNull(schemaFile, "could not locate a schema file called " + schemaFileName);
+            IsNotNull(schemaFile, "could not locate a schema file called " + schemaFileName);
+            // ReSharper disable once AssignNullToNotNullAttribute
             using (var schemaReader = new XmlTextReader(schemaFile))
             {
                 var schema = XmlSchema.Read(schemaReader, OldSchemaValidationCallBack);
@@ -462,7 +576,7 @@ namespace pwiz.SkylineTestUtil
                     }
                     catch (Exception e)
                     {
-                        Assert.Fail(e.Message + "  XML text:\r\n" + xmlText);
+                        Fail(e.Message + "  XML text:\r\n" + xmlText);
                     }
                 }
             }
@@ -511,7 +625,7 @@ namespace pwiz.SkylineTestUtil
                 }
                 catch (Exception e)
                 {
-                    Assert.Fail(e.ToString());
+                    Fail(e.ToString());
                 }
             }
 
@@ -591,16 +705,18 @@ namespace pwiz.SkylineTestUtil
                     if (lineTarget == null && lineActual == null)
                         return;
                     if (lineTarget == null)
-                        Assert.Fail(GetEarlyEndingMessage(helpMsg, "Expected", count-1, lineEqualLast, lineActual, readerActual));
+                        Fail(GetEarlyEndingMessage(helpMsg, "Expected", count-1, lineEqualLast, lineActual, readerActual));
                     if (lineActual == null)
-                        Assert.Fail(GetEarlyEndingMessage(helpMsg, "Actual", count-1, lineEqualLast, lineTarget, readerTarget));
+                        Fail(GetEarlyEndingMessage(helpMsg, "Actual", count-1, lineEqualLast, lineTarget, readerTarget));
                     if (lineTarget != lineActual)
                     {
                         bool failed = true;
                         if (columnTolerances != null)
                         {
+                            // ReSharper disable PossibleNullReferenceException
                             var colsActual = lineActual.Split('\t');
                             var colsTarget = lineTarget.Split('\t');
+                            // ReSharper restore PossibleNullReferenceException
                             if (colsTarget.Length == colsActual.Length)
                             {
                                 failed = false; // May yet be saved by tolerance check
@@ -623,7 +739,7 @@ namespace pwiz.SkylineTestUtil
                         }
 
                         if (failed)
-                            Assert.Fail(helpMsg + "Diff found at line {0}:\r\n{1}\r\n>\r\n{2}", count, lineTarget, lineActual);
+                            Fail(helpMsg + "Diff found at line {0}:\r\n{1}\r\n>\r\n{2}", count, lineTarget, lineActual);
                     }
 
                     lineEqualLast = lineTarget;
@@ -691,11 +807,11 @@ namespace pwiz.SkylineTestUtil
                         allowedExtraLinesInActual--;
                     }
                     if (lineActual != null)
-                        Assert.Fail("Target stops at line {0}.", count);
+                        Fail("Target stops at line {0}.", count);
                 }
                 else if (lineActual == null)
                 {
-                    Assert.Fail("Actual stops at line {0}.", count);
+                    Fail("Actual stops at line {0}.", count);
                 }
                 else if (lineTarget != lineActual)
                 {
@@ -708,7 +824,7 @@ namespace pwiz.SkylineTestUtil
                         countFields = Math.Max(fieldsTarget.Length, fieldsActual.Length);
                     }
                     if (fieldsTarget.Length < countFields || fieldsActual.Length < countFields)
-                        Assert.Fail("Diff found at line {0}:\r\n{1}\r\n>\r\n{2}", count, lineTarget, lineActual);
+                        Fail("Diff found at line {0}:\r\n{1}\r\n>\r\n{2}", count, lineTarget, lineActual);
                     for (int i = 0; i < countFields; i++)
                     {
                         if (exceptIndex.HasValue && exceptIndex.Value == i)
@@ -731,7 +847,7 @@ namespace pwiz.SkylineTestUtil
                                 if (Math.Abs(dTarget - dActual) <= toler)
                                     continue;
                             }
-                            Assert.Fail("Diff found at line {0}:\r\n{1}\r\n>\r\n{2}", count, lineTarget, lineActual);
+                            Fail("Diff found at line {0}:\r\n{1}\r\n>\r\n{2}", count, lineTarget, lineActual);
                         }
                     }
                 }
@@ -749,7 +865,7 @@ namespace pwiz.SkylineTestUtil
                 string actualXML = null;
                 RoundTrip(actual, ref actualXML); // Just for the XML output
                 NoDiff(expectedXML, actualXML, "AssertEx.DocsEqual failed.  Expressing as XML to aid in debugging:");  // This should throw
-                Assert.AreEqual(expected, actual);  // In case NoDiff doesn't throw (as when problem is actually in XML read or write)
+                AreEqual(expected, actual);  // In case NoDiff doesn't throw (as when problem is actually in XML read or write)
             }
         }
 
@@ -758,7 +874,7 @@ namespace pwiz.SkylineTestUtil
             DocsEqual(expected, actual);
             if (ReferenceEquals(expected, actual))
             {
-                Assert.AreNotSame(expected, actual);
+                AreNotSame(expected, actual);
             }
         }
 
@@ -770,11 +886,11 @@ namespace pwiz.SkylineTestUtil
         {
             if (!Equals(expected, actual))
             {
-                Assert.AreEqual(expected, actual);
+                AreEqual(expected, actual);
             }
             if (ReferenceEquals(expected, actual) && !ReferenceEquals(actual, def))
             {
-                Assert.AreNotSame(expected, actual);
+                AreNotSame(expected, actual);
             }
         }
 
@@ -782,7 +898,7 @@ namespace pwiz.SkylineTestUtil
         {
             string message = GetMessageStack(x, t);
             if (message != null)
-                Assert.Fail("Expected exception type {0} not found:\r\n{1}", t.Name, message);
+                Fail("Expected exception type {0} not found:\r\n{1}", t.Name, message);
         }
 
         private static string GetMessageStack(Exception x, Type t)
@@ -847,14 +963,14 @@ namespace pwiz.SkylineTestUtil
         {
             var errmsg = DocumentStateTestResultString(document, revision, groups, peptides, tranGroups, transitions);
             if (errmsg.Length > 0)
-                Assert.Fail((hint??string.Empty) + errmsg);
+                Fail((hint??string.Empty) + errmsg);
 
             // Verify that no two nodes in the document tree have the same global index
             var setIndexes = new HashSet<int>();
             var nodeDuplicate = FindFirstDuplicateGlobalIndex(document, setIndexes);
             if (nodeDuplicate != null)
             {
-                Assert.Fail((hint??string.Empty) + "Duplicate global index {0} found in node {1}",
+                Fail((hint??string.Empty) + "Duplicate global index {0} found in node {1}",
                     nodeDuplicate.Id.GlobalIndex, nodeDuplicate);
             }
         }
@@ -892,7 +1008,7 @@ namespace pwiz.SkylineTestUtil
             File.WriteAllText(tmpSky, xmlSaved);
             using (var cmd = new Skyline.CommandLine())
             {
-                Assert.IsTrue(cmd.OpenSkyFile(tmpSky)); // Handles any path shifts in database files, like our .imdb file
+                IsTrue(cmd.OpenSkyFile(tmpSky)); // Handles any path shifts in database files, like our .imdb file
                 var docLoad = cmd.Document;
                 using (var docContainer = new ResultsTestDocumentContainer(null, tmpSky))
                 {
@@ -959,12 +1075,12 @@ namespace pwiz.SkylineTestUtil
             Cloned(target.DataSettings.GroupComparisonDefs, copy.DataSettings.GroupComparisonDefs, defData.GroupComparisonDefs);
             Cloned(target.DataSettings.Lists, copy.DataSettings.Lists, defData.Lists);
             Cloned(target.DataSettings.ViewSpecList, copy.DataSettings.ViewSpecList, defData.ViewSpecList);
-            Assert.AreEqual(target.DataSettings, copy.DataSettings);  // Might both by DataSettings.DEFAULT
+            AreEqual(target.DataSettings, copy.DataSettings);  // Might both by DataSettings.DEFAULT
             if (!DataSettings.DEFAULT.Equals(target.DataSettings))
-                Assert.AreNotSame(target.DataSettings, copy.DataSettings);
-            Assert.AreEqual(target.MeasuredResults, copy.MeasuredResults);
+                AreNotSame(target.DataSettings, copy.DataSettings);
+            AreEqual(target.MeasuredResults, copy.MeasuredResults);
             if (target.MeasuredResults != null)
-                Assert.AreNotSame(target.MeasuredResults, copy.MeasuredResults);
+                AreNotSame(target.MeasuredResults, copy.MeasuredResults);
             Cloned(target, copy);
         }
 
@@ -974,16 +1090,16 @@ namespace pwiz.SkylineTestUtil
             string[] expectedParts = Regex.Split(expected,@"{\d}");
             if (replacements.HasValue)
             {
-                Assert.AreEqual(replacements, expectedParts.Length - 1,
-                    "Expected {0} replacements in string resource '{1}'", replacements, expected);
+                AreEqual(replacements, expectedParts.Length - 1,
+                    string.Format("Expected {0} replacements in string resource '{1}'", replacements, expected));
             }
 
             int startIndex = 0;
             foreach (var expectedPart in expectedParts)
             {
                 int partIndex = actual.IndexOf(expectedPart, startIndex, StringComparison.Ordinal);
-                Assert.AreNotEqual(-1, partIndex,
-                    "Expected part '{0}' not found in the string '{1}'", expectedPart, actual);
+                AreNotEqual(-1, partIndex,
+                    string.Format("Expected part '{0}' not found in the string '{1}'", expectedPart, actual));
                 startIndex = partIndex + expectedPart.Length;
             }
         }
@@ -992,41 +1108,41 @@ namespace pwiz.SkylineTestUtil
         {
             if (num1 == null || num2 == null)
             {
-                Assert.IsTrue(num1 == null && num2 == null);
+                IsTrue(num1 == null && num2 == null);
             }
             else
             {
-                Assert.AreEqual(num1.Value, num2.Value, diff);
+                AreEqual(num1.Value, num2.Value, diff);
             }
         }
 
         public static void AreEqualLines(string expected, string actual)
         {
-            Assert.AreEqual(LineBracket(expected), LineBracket(actual));
+            AreEqual(LineBracket(expected), LineBracket(actual));
         }
 
         public static void IsLessThan<T>(T actual, T expectedBound) where T : IComparable<T>
         {
             if (actual.CompareTo(expectedBound) >= 0)
-                Assert.Fail("\"{0}\" is not less than \"{1}\"", actual, expectedBound);
+                Fail("\"{0}\" is not less than \"{1}\"", actual, expectedBound);
         }
 
         public static void IsLessThanOrEqual<T>(T actual, T expectedBound) where T : IComparable<T>
         {
             if (actual.CompareTo(expectedBound) > 0)
-                Assert.Fail("\"{0}\" is not less than or equal to \"{1}\"", actual, expectedBound);
+                Fail("\"{0}\" is not less than or equal to \"{1}\"", actual, expectedBound);
         }
 
         public static void IsGreaterThan<T>(T actual, T expectedBound) where T : IComparable<T>
         {
             if (actual.CompareTo(expectedBound) <= 0)
-                Assert.Fail("\"{0}\" is not greater than \"{1}\"", actual, expectedBound);
+                Fail("\"{0}\" is not greater than \"{1}\"", actual, expectedBound);
         }
 
         public static void IsGreaterThanOrEqual<T>(T actual, T expectedBound) where T : IComparable<T>
         {
             if (actual.CompareTo(expectedBound) < 0)
-                Assert.Fail("\"{0}\" is not greater than or equal to \"{1}\"", actual, expectedBound);
+                Fail("\"{0}\" is not greater than or equal to \"{1}\"", actual, expectedBound);
         }
 
         /// <summary>
@@ -1055,7 +1171,7 @@ namespace pwiz.SkylineTestUtil
                     convertedMoleculeGroupsIterator.MoveNext();
                     ConvertedSmallMoleculePeptideGroupIsSimilar(convertedMoleculeGroupsIterator.Current, peptideGroupDocNode, conversionMode);
                 }
-                Assert.IsFalse(convertedMoleculeGroupsIterator.MoveNext());
+                IsFalse(convertedMoleculeGroupsIterator.MoveNext());
             }
         }
 
@@ -1069,19 +1185,20 @@ namespace pwiz.SkylineTestUtil
                     convertedMoleculesIterator.MoveNext();
                     var convertedMol = convertedMoleculesIterator.Current;
                     Assert.IsNotNull(convertedMol);
+                    // ReSharper disable once PossibleNullReferenceException
                     if (convertedMol.Note != null)
-                        Assert.AreEqual(mol.Note ?? string.Empty,
+                        AreEqual(mol.Note ?? string.Empty,
                             convertedMol.Note.Replace(RefinementSettings.TestingConvertedFromProteomic, string.Empty));
                     else
-                        Assert.Fail(@"unexpected empty note"); 
-                    Assert.AreEqual(mol.SourceKey, convertedMol.SourceKey);
-                    Assert.AreEqual(mol.Rank, convertedMol.Rank);
-                    Assert.AreEqual(mol.Results, convertedMol.Results);
-                    Assert.AreEqual(mol.ExplicitRetentionTime, convertedMol.ExplicitRetentionTime);
-                    Assert.AreEqual(mol.BestResult, convertedMol.BestResult);
+                        Fail(@"unexpected empty note"); 
+                    AreEqual(mol.SourceKey, convertedMol.SourceKey);
+                    AreEqual(mol.Rank, convertedMol.Rank);
+                    AreEqual(mol.Results, convertedMol.Results);
+                    AreEqual(mol.ExplicitRetentionTime, convertedMol.ExplicitRetentionTime);
+                    AreEqual(mol.BestResult, convertedMol.BestResult);
                     ConvertedSmallMoleculeIsSimilar(convertedMol, mol, conversionMode);
                 }
-                Assert.IsFalse(convertedMoleculesIterator.MoveNext());
+                IsFalse(convertedMoleculesIterator.MoveNext());
             }
         }
 
@@ -1109,7 +1226,7 @@ namespace pwiz.SkylineTestUtil
                 return;
             }
             if (!Equals(group.Results, convertedGroup.Results))
-                Assert.AreEqual(group.Results, convertedGroup.Results, group + " vs " + convertedGroup);
+                AreEqual(group.Results, convertedGroup.Results, group + " vs " + convertedGroup);
         }
 
         private static void ConvertedSmallMoleculeIsSimilar(PeptideDocNode convertedMol, PeptideDocNode mol, RefinementSettings.ConvertToSmallMoleculesMode conversionMode)
@@ -1121,21 +1238,22 @@ namespace pwiz.SkylineTestUtil
                     convertedTransitionGroupIterator.MoveNext();
                     var convertedTransitionGroupDocNode = convertedTransitionGroupIterator.Current;
                     ConvertedSmallMoleculePrecursorIsSimilar(convertedTransitionGroupDocNode, transitionGroupDocNode, conversionMode);
-                    Assert.IsNotNull(convertedTransitionGroupDocNode);
-                    Assert.AreEqual(transitionGroupDocNode.TransitionGroup.PrecursorCharge,
+                    IsNotNull(convertedTransitionGroupDocNode);
+                    // ReSharper disable once PossibleNullReferenceException
+                    AreEqual(transitionGroupDocNode.TransitionGroup.PrecursorCharge,
                         convertedTransitionGroupDocNode.TransitionGroup.PrecursorCharge);
-                    Assert.AreEqual(transitionGroupDocNode.TransitionGroup.LabelType,
+                    AreEqual(transitionGroupDocNode.TransitionGroup.LabelType,
                         convertedTransitionGroupDocNode.TransitionGroup.LabelType);
-                    Assert.AreEqual(transitionGroupDocNode.PrecursorMz, convertedTransitionGroupDocNode.PrecursorMz,
+                    AreEqual(transitionGroupDocNode.PrecursorMz, convertedTransitionGroupDocNode.PrecursorMz,
                         SequenceMassCalc.MassTolerance, "transitiongroup as small molecule");
                     ConvertedSmallMoleculeTransitionGroupResultIsSimilar(convertedTransitionGroupDocNode, transitionGroupDocNode, conversionMode);
-                    Assert.AreEqual(transitionGroupDocNode.TransitionGroup.PrecursorCharge,
+                    AreEqual(transitionGroupDocNode.TransitionGroup.PrecursorCharge,
                         convertedTransitionGroupDocNode.TransitionGroup.PrecursorCharge);
-                    Assert.AreEqual(transitionGroupDocNode.TransitionGroup.LabelType,
+                    AreEqual(transitionGroupDocNode.TransitionGroup.LabelType,
                         convertedTransitionGroupDocNode.TransitionGroup.LabelType);
 
                 }
-                Assert.IsFalse(convertedTransitionGroupIterator == null || convertedTransitionGroupIterator.MoveNext());
+                IsFalse(convertedTransitionGroupIterator.MoveNext());
             }
         }
 
@@ -1147,28 +1265,17 @@ namespace pwiz.SkylineTestUtil
                 {
                     convertedTransitionIterator.MoveNext();
                     var convertedTransition = convertedTransitionIterator.Current;
-                    Assert.IsNotNull(convertedTransition);
+                    IsNotNull(convertedTransition);
+                    // ReSharper disable once PossibleNullReferenceException
                     if (Math.Abs(transition.Mz - convertedTransition.Mz) > SequenceMassCalc.MassTolerance)
-                        Assert.AreEqual(transition.Mz, convertedTransition.Mz, "mz mismatch transition as small molecule");
-                    Assert.AreEqual(transition.IsotopeDistInfo, convertedTransition.IsotopeDistInfo);
+                        AreEqual(transition.Mz, convertedTransition.Mz, "mz mismatch transition as small molecule");
+                    AreEqual(transition.IsotopeDistInfo, convertedTransition.IsotopeDistInfo);
                     if (conversionMode == RefinementSettings.ConvertToSmallMoleculesMode.formulas && 
                         !Equals(transition.Results, convertedTransition.Results))
-                        Assert.AreEqual(transition.Results, convertedTransition.Results, "results mismatch transition as small molecule");
+                        AreEqual(transition.Results, convertedTransition.Results, "results mismatch transition as small molecule");
                 }
-                Assert.IsFalse(convertedTransitionIterator.MoveNext());
+                IsFalse(convertedTransitionIterator.MoveNext());
             }
-        }
-
-        /// <summary>
-        /// Just like regular Assert.Equals but easier to set a breakpoint on.
-        /// </summary>
-        public static void AreEqual<T>(T expected, T actual)
-        {
-            if (Equals(expected, actual))
-            {
-                return;
-            }
-            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -1967,34 +1967,22 @@ namespace pwiz.Skyline.Util
     public static class Assume
     {
 
-        private static string _machineNamePatternForInvokeDebuggerOnFail; // When set, if machine name contains this string we will invoke the debugger rather than fail.
+        public static bool InvokeDebuggerOnFail { get; private set; } // When set, we will invoke the debugger rather than fail.
         public class DebugOnFail : IDisposable
         {
-            private string _initialValue;
+            private bool _pushPopInvokeDebuggerOnFail;
 
-            public DebugOnFail(string machineNamePattern)
+            public DebugOnFail(bool invokeDebuggerOnFail = true)
             {
-                _initialValue = _machineNamePatternForInvokeDebuggerOnFail;
-                _machineNamePatternForInvokeDebuggerOnFail = machineNamePattern;
+                _pushPopInvokeDebuggerOnFail = InvokeDebuggerOnFail; // Push
+                InvokeDebuggerOnFail = invokeDebuggerOnFail;
             }
 
             public void Dispose()
             {
-                _machineNamePatternForInvokeDebuggerOnFail = _initialValue;
+                InvokeDebuggerOnFail = _pushPopInvokeDebuggerOnFail; // Pop
             }
         }
-
-        public static bool InvokeDebuggerOnFail
-        {
-            get
-            {
-                if (String.IsNullOrEmpty(_machineNamePatternForInvokeDebuggerOnFail))
-                    return false;
-                return (_machineNamePatternForInvokeDebuggerOnFail.Equals(@"*") ||
-                        Environment.MachineName.Contains(_machineNamePatternForInvokeDebuggerOnFail));
-            }
-        }
-
 
         public static void IsTrue(bool condition, string error = "")
         {

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -2033,7 +2033,7 @@ namespace pwiz.Skyline.Util
                 Console.WriteLine();
                 if (!string.IsNullOrEmpty(error))
                     Console.WriteLine(error);
-                Console.WriteLine(@"error encountered, launching debugger as indicated by Assume.MachineNamePatternForInvokeDebuggerOnFail");
+                Console.WriteLine(@"error encountered, launching debugger as requested by Assume.DebugOnFail");
                 Debugger.Launch();
             }
             throw new AssumptionException(error);


### PR DESCRIPTION
Skyline: when Assume.Fail (optionally) launches a debugger, first launch devenv with the proper .sln file so it's up and running when the system's list of debugger options is presented to the user. This allows for better code navigation than a generic debugger session.

We actually launch devenv with a copy of Skyline.sln called "USE THIS FOR ASSUME FAIL DEBUGGING.sln" so that it's obvious which one should be picked from the list. Many developer machines will present a whole list of running debuggers called "Skyline", but this one shows up as "USE THIS FOR ASSUME FAIL DEBUGGING".
