### PR TITLE
Fix reading Thermo RAW w/ PDA from an unknown MS instrument model 

### DIFF
--- a/pwiz/data/msdata/SpectrumListBase.cpp
+++ b/pwiz/data/msdata/SpectrumListBase.cpp
@@ -34,7 +34,7 @@ namespace {
 PWIZ_API_DECL void pwiz::msdata::SpectrumListBase::warn_once(const char * msg) const
 {
     boost::lock_guard<boost::mutex> g(m);
-    if (warn_msg_hashes_.insert(hash_(msg)).second) // .second is true iff value is new
+    if (warn_msg_hashes_.insert(hash(msg)).second) // .second is true iff value is new
         std::cerr << msg << std::endl;
 }
 
@@ -77,4 +77,9 @@ PWIZ_API_DECL size_t pwiz::msdata::SpectrumListBase::checkNativeIdFindResult(siz
         warn_once(e.what()); // TODO: log exception
         return size();
     }
+}
+
+size_t pwiz::msdata::SpectrumListBase::hash(const char* msg) const
+{
+    return boost::hash_range(msg, msg + strlen(msg));
 }

--- a/pwiz/data/msdata/SpectrumListBase.hpp
+++ b/pwiz/data/msdata/SpectrumListBase.hpp
@@ -41,7 +41,7 @@ namespace msdata {
 class PWIZ_API_DECL SpectrumListBase : public SpectrumList
 {
     public:
-    SpectrumListBase() : MSLevelsNone(), hash_(), spectrum_id_mismatch_hash_(hash_("spectrum id mismatch")) {};
+    SpectrumListBase() : MSLevelsNone(), /*hash_(),*/ spectrum_id_mismatch_hash_(hash("spectrum id mismatch")) {};
 
     /// implementation of SpectrumList
     virtual const boost::shared_ptr<const DataProcessing> dataProcessingPtr() const {return dp_;}
@@ -64,8 +64,9 @@ class PWIZ_API_DECL SpectrumListBase : public SpectrumList
 
     private:
 
+    size_t hash(const char*) const;
     mutable std::set<size_t> warn_msg_hashes_; // for warn_once use
-    boost::hash<const char*> hash_;
+    //boost::hash<const char*> hash_;
     size_t spectrum_id_mismatch_hash_;
 };
 

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo.cpp
@@ -235,7 +235,8 @@ void fillInMetadata(const string& filename, RawFile& rawfile, MSData& msd, const
     initializeInstrumentConfigurationPtrs(msd, rawfile, softwareXcalibur, instData);
     if (!msd.instrumentConfigurationPtrs.empty())
         msd.run.defaultInstrumentConfigurationPtr = msd.instrumentConfigurationPtrs[0];
-    else if (!instData.Model.empty() && !instData.Name.empty())
+
+    if (!instData.Model.empty() && !instData.Name.empty() && rawfile.getInstrumentModel() == InstrumentModelType_Unknown)
     {
         if (config.unknownInstrumentIsError)
             throw runtime_error("[Reader_Thermo::fillInMetadata] unable to parse instrument model; please report this error to the ProteoWizard developers with this information: model(" + instData.Model + ") name(" + instData.Name + "); if want to convert the file anyway, use the ignoreUnknownInstrumentError flag");

--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -124,7 +124,7 @@ PWIZ_API_DECL size_t SpectrumList_Thermo::find(const string& id) const
 }
 
 
-InstrumentConfigurationPtr findInstrumentConfiguration(const MSData& msd, CVID massAnalyzerType)
+InstrumentConfigurationPtr SpectrumList_Thermo::findInstrumentConfiguration(const MSData& msd, CVID massAnalyzerType) const
 {
     if (msd.instrumentConfigurationPtrs.empty())
         return InstrumentConfigurationPtr();
@@ -133,11 +133,19 @@ InstrumentConfigurationPtr findInstrumentConfiguration(const MSData& msd, CVID m
     {
         size_t analyzerCount = boost::range::count_if(icPtr->componentList, [](const auto& component) { return component.type == ComponentType_Analyzer; });
 
-        if (icPtr->componentList.analyzer(analyzerCount-1).hasCVParam(massAnalyzerType))
-            return icPtr;
+        try
+        {
+            if (icPtr->componentList.analyzer(analyzerCount - 1).hasCVParam(massAnalyzerType))
+                return icPtr;
+        }
+        catch (out_of_range&)
+        {
+            continue;
+        }
     }
 
-    throw runtime_error("no matching instrument configuration for analyzer type " + cvTermInfo(massAnalyzerType).shortName());
+    warn_once(("no matching instrument configuration for analyzer type " + cvTermInfo(massAnalyzerType).shortName()).c_str());
+    return InstrumentConfigurationPtr();
 }
 
 inline boost::optional<double> getElectronvoltActivationEnergy(const ScanInfo& scanInfo)
@@ -493,7 +501,7 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Thermo::spectrum(size_t index, DetailLeve
 
                 if (addMultiFill)
                 {
-                    precursor.userParams.push_back(UserParam("MultiFillTime", lexical_cast<string>(*fillTimeItr), "xsd:double"));
+                    scan.userParams.push_back(UserParam("MultiFillTime", lexical_cast<string>(*fillTimeItr), "xsd:double"));
                     ++fillTimeItr;
                 }
                 result->precursors.push_back(precursor);

--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.hpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.hpp
@@ -114,6 +114,7 @@ class PWIZ_API_DECL SpectrumList_Thermo : public SpectrumListIonMobilityBase
     size_t findPrecursorSpectrumIndex(RawFile* raw, int precursorMsLevel, double precursorIsolationMz, size_t index) const;
     double getPrecursorIntensity(int precursorSpectrumIndex, double isolationMz, double isolationHalfWidth, const pwiz::util::IntegerSet& msLevelsToCentroid) const;
     pwiz::vendor_api::Thermo::ScanInfoPtr findPrecursorZoomScan(RawFile* raw, int precursorMsLevel, double precursorIsolationMz, size_t index) const;
+    InstrumentConfigurationPtr findInstrumentConfiguration(const MSData& msd, CVID massAnalyzerType) const;
 
 #endif // PWIZ_READER_THERMO
 };

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -2507,19 +2507,26 @@ std::string RawFileThreadImpl::getSampleID() const
 
 std::string RawFileThreadImpl::getTrailerExtraValue(long scanNumber, const string& name) const
 {
+    if (rawFile_->getCurrentController().type != Controller_MS)
+        return "";
+
     try
     {
         auto findItr = rawFile_->trailerExtraIndexByName.find(name);
         if (findItr == rawFile_->trailerExtraIndexByName.end())
             return "";
 
-        return ToStdString(raw_->GetTrailerExtraValue(scanNumber, findItr->second)->ToString());
+        auto result = raw_->GetTrailerExtraValue(scanNumber, findItr->second);
+        return result == nullptr ? "" : ToStdString(result->ToString());
     }
     CATCH_AND_FORWARD_EX(name)
 }
 
 double RawFileThreadImpl::getTrailerExtraValueDouble(long scanNumber, const string& name) const
 {
+    if (rawFile_->getCurrentController().type != Controller_MS)
+        return 0.0;
+
     try
     {
         auto findItr = rawFile_->trailerExtraIndexByName.find(name);
@@ -2534,6 +2541,9 @@ double RawFileThreadImpl::getTrailerExtraValueDouble(long scanNumber, const stri
 
 long RawFileThreadImpl::getTrailerExtraValueLong(long scanNumber, const string& name) const
 {
+    if (rawFile_->getCurrentController().type != Controller_MS)
+        return 0;
+
     try
     {
         auto findItr = rawFile_->trailerExtraIndexByName.find(name);


### PR DESCRIPTION
- fixed reading Thermo RAW from an unknown MS instrument model and a PDA detector (the PDA instrumentConfiguration was being picked as the default)
- fixed errors reading Thermo RAW when calling GetTrailerExtraValue on non-MS controllers
* changed warn_once to hash string contents instead of pointer
* moved MultiFill userParam from Precursor to Scan element