### PR TITLE
Change all TestFunctional.cs uses of Assert.* to AssertEx.* so we can…

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -174,7 +174,7 @@ namespace pwiz.SkylineTestUtil
             {
                 var messageDlg = existingDialog as MessageDlg;
                 if (messageDlg == null)
-                    Assert.IsNull(existingDialog, typeof(TDlg) + " is already open");
+                    AssertEx.IsNull(existingDialog, typeof(TDlg) + " is already open");
                 else
                     Assert.Fail(typeof(TDlg) + " is already open with the message: " + messageDlg.Message);
             }


### PR DESCRIPTION
… catch more overnight failures in a debugger before reaching an actual Assert.