### PR TITLE
Change ExceptionUtil.GetStackTraceText so that it just uses "exception.ToString()"

### DIFF
--- a/pwiz_tools/Skyline/Alerts/ReportErrorDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/ReportErrorDlg.cs
@@ -60,7 +60,7 @@ namespace pwiz.Skyline.Alerts
 
         public ReportErrorDlg(Exception e, StackTrace stackTraceExceptionCaughtAt)
         {
-            Init(e.GetType().Name, e.Message, ExceptionUtil.GetStackTraceText(e, stackTraceExceptionCaughtAt));
+            Init(e.GetType().Name, e.Message, ExceptionUtil.GetExceptionText(e, stackTraceExceptionCaughtAt));
 
             Install.InstallType installType = Install.Type;
 

--- a/pwiz_tools/Skyline/Alerts/ReportShutdownDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/ReportShutdownDlg.cs
@@ -94,7 +94,7 @@ namespace pwiz.Skyline.Alerts
                 var exceptionInfo2 = new StringBuilder();
                 exceptionInfo2.AppendLine(exception.GetType().FullName);
                 exceptionInfo2.AppendLine(exception.Message);
-                exceptionInfo2.AppendLine(ExceptionUtil.GetStackTraceText(exception));
+                exceptionInfo2.AppendLine(ExceptionUtil.GetExceptionText(exception, null));
                 File.WriteAllText(GetExceptionFile(), exceptionInfo2.ToString());
             }
         }

--- a/pwiz_tools/Skyline/Controls/Graphs/FileProgressControl.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/FileProgressControl.cs
@@ -142,7 +142,7 @@ namespace pwiz.Skyline.Controls.Graphs
                             _errorExceptions.RemoveAt(2);
                         }
                         _errorLog.Insert(0, Error);
-                        _errorExceptions.Insert(0, ExceptionUtil.GetStackTraceText(status.ErrorException, null, false));
+                        _errorExceptions.Insert(0, status.ErrorException.ToString());
                         btnRetry.Text = Resources.FileProgressControl_SetStatus_Retry;
                         btnRetry.Visible = true;
                         ShowWarningIcon(Resources.FileProgressControl_SetStatus_failed);

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -211,7 +211,7 @@ namespace pwiz.SkylineTestUtil
                 return;
 
             Fail(TextUtil.LineSeparate(exceptions.Count == 1 ? "Unexpected exception:" : "Unexpected exceptions:",
-                TextUtil.LineSeparate(exceptions.Select(x => TextUtil.LineSeparate(x.Message, ExceptionUtil.GetStackTraceText(x, null, false), string.Empty)))));
+                TextUtil.LineSeparate(exceptions.Select(x => x.ToString()))));
         }
 
         public static void Contains(string value, params string[] parts)

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -2113,30 +2113,20 @@ namespace pwiz.Skyline.Util
             return ex.Message;
         }
 
-        public static string GetStackTraceText(Exception exception, StackTrace stackTraceExceptionCaughtAt = null, bool showMessage = true)
+        /// <summary>
+        /// Returns text to be used when reporting an unhandled exception to the Skyline.ms.
+        /// </summary>
+        public static string GetExceptionText(Exception exception, StackTrace stackTraceExceptionCaughtAt)
         {
-            StringBuilder stackTrace = new StringBuilder();
-            if (showMessage)
-                stackTrace.AppendLine(@"Stack trace:").AppendLine();
-
-            stackTrace.AppendLine(exception.StackTrace).AppendLine();
-
-            for (var x = exception.InnerException; x != null; x = x.InnerException)
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine(exception.ToString());
+            if (stackTraceExceptionCaughtAt != null)
             {
-                if (ReferenceEquals(x, exception.InnerException))
-                    stackTrace.AppendLine(@"Inner exceptions:");
-                else
-                    stackTrace.AppendLine(@"---------------------------------------------------------------");
-                stackTrace.Append(@"Exception type: ").Append(x.GetType().FullName).AppendLine();
-                stackTrace.Append(@"Error message: ").AppendLine(x.Message);
-                stackTrace.AppendLine(x.Message).AppendLine(x.StackTrace);
+                stringBuilder.AppendLine(@"Exception caught at: ");
+                stringBuilder.AppendLine(stackTraceExceptionCaughtAt.ToString());
             }
-            if (null != stackTraceExceptionCaughtAt)
-            {
-                stackTrace.AppendLine(@"Exception caught at: ");
-                stackTrace.AppendLine(stackTraceExceptionCaughtAt.ToString());
-            }
-            return stackTrace.ToString();
+
+            return stringBuilder.ToString();
         }
     }
 


### PR DESCRIPTION
It used to walk up the chain of InnerException objects, but would lose information for some exception types such as AggregateException.
(also, rename that method to "GetExceptionText")