### PR TITLE
- fixed Thermo reader isolation width

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -528,7 +528,7 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Thermo::spectrum(size_t index, DetailLeve
                 {
                     // isolationWindow
 
-                    double isolationWidth = 0;
+                    double isolationWidth = precursorInfo.isolationWidth / 2;
 
                     try
                     {

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -1875,6 +1875,7 @@ void RawFileImpl::parseInstrumentMethod()
     sregex scanEventIsoWRegex = sregex::compile("\\s*MS.*:.*\\s+IsoW\\s+(\\S+)\\s*");
     sregex repeatedEventRegex = sregex::compile("\\s*Scan Event (\\d+) repeated for top (\\d+)\\s*");
     sregex defaultIsolationWidthRegex = sregex::compile("\\s*MS(\\d+) Isolation Width:\\s*(\\S+)\\s*");
+    sregex defaultIsolationWindowRegex = sregex::compile("\\s*Isolation Window \\(m/z\\) =\\s*(\\S+)\\s*");
     sregex isolationMzOffsetRegex = sregex::compile("\\s*Isolation m/z Offset =\\s*(\\S+)\\s*");
     sregex scanDescriptionRegex = sregex::compile("\\s*Scan Description =\\s*(\\S+)\\s*");
 
@@ -1933,7 +1934,7 @@ void RawFileImpl::parseInstrumentMethod()
         }
 
         // Data Dependent Settings:
-        if (bal::icontains(line, "Data Dependent Settings"))
+        if (bal::icontains(line, "Data Dependent Settings") || bal::icontains(line, "Scan DIAScan"))
         {
             dataDependentSettings = true;
             continue;
@@ -1947,6 +1948,13 @@ void RawFileImpl::parseInstrumentMethod()
                 int msLevel = lexical_cast<int>(what[1]);
                 double isolationWidth = lexical_cast<double>(what[2]);
                 defaultIsolationWidthBySegmentAndMsLevel[scanSegment][msLevel] = isolationWidth;
+                continue;
+            }
+            
+            if (regex_match(line, what, defaultIsolationWindowRegex))
+            {
+                double isolationWidth = lexical_cast<double>(what[1]);
+                defaultIsolationWidthBySegmentAndMsLevel[scanSegment][2] = isolationWidth;
                 continue;
             }
 


### PR DESCRIPTION
- fixed Thermo reader to use isolation width from RawFile's precursor info (previously it was only using trailer extra value or default isolation width from instrument method)
- added support for capturing default isolation width from instrument method variable like "Isolation Window (m/z) = "