### PR TITLE
Fix MaxQuantReader bug 

### DIFF
--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
@@ -531,7 +531,7 @@ void MaxQuantReader::parseHeader(string& line)
     }
     
     // check that all required columns were in the file
-    for (size_t i = 0; i < targetColumns_.size(); i++)
+    for (int i = targetColumns_.size() - 1; i >= 0; i--)
     {
         if (targetColumns_[i].position_ < 0)
         {
@@ -541,7 +541,6 @@ void MaxQuantReader::parseHeader(string& line)
             {
                 optionalColumns_.erase(j);
                 targetColumns_.erase(targetColumns_.begin() + i);
-                break;
             }
             else
             {


### PR DESCRIPTION
Fix bug where MaxQuantReader fails to parse file if it is missing both optional columns "Labeling State" and "Evidence ID".
(Reported by marie locard-paulet)
https://skyline.ms/announcements/home/support/thread.view?rowId=46588

The code was exiting the loop as soon as it found the first missing optional column, and so a column remained in the list whose position was "-1".