### PR TITLE
Skyline: Fixes motivated by issues found in May Institute webinars

### DIFF
--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -505,7 +505,6 @@ namespace pwiz.Skyline
             Dependencies =
             {
                 { ARG_DECOYS_ADD_COUNT, ARG_DECOYS_ADD },
-                { ARG_DECOYS_DISCARD, ARG_DECOYS_ADD },
             }
         };
 
@@ -754,7 +753,7 @@ namespace pwiz.Skyline
             (c, p) => c.Refinement.UseBestResult = true);
         // Refinement consistency tab
         public static readonly Argument ARG_REFINE_CV_REMOVE_ABOVE_CUTOFF = new RefineArgument(@"refine-cv-remove-above-cutoff", NUM_VALUE,
-            (c,p) => c.Refinement.CVCutoff = p.ValueDouble);
+            (c,p) => c.Refinement.CVCutoff = p.ValueDouble >= 1 ? p.ValueDouble : p.ValueDouble * 100);  // If a value like 0.2, interpret as 20%
         public static readonly Argument ARG_REFINE_CV_GLOBAL_NORMALIZE = new RefineArgument(@"refine-cv-global-normalize",
             new[] { NormalizationMethod.GLOBAL_STANDARDS.Name, NormalizationMethod.EQUALIZE_MEDIANS.Name },
             (c, p) =>

--- a/pwiz_tools/Skyline/Model/DocNode.cs
+++ b/pwiz_tools/Skyline/Model/DocNode.cs
@@ -1068,13 +1068,13 @@ namespace pwiz.Skyline.Model
                 AddCounts(childNew, nodeCountStack);
             }
 
-            // If no children changed, then just return this node
-            if (ArrayUtil.ReferencesEqual(Children, childrenNew))
-                return this;
-
             // If this is a level below which empty nodes are removed, return null if empty
             if (levelRemoveEmpty.HasValue && levelRemoveEmpty.Value < 0 && childrenNew.Count == 0)
                 return null;
+
+            // If no children changed, then just return this node
+            if (ArrayUtil.ReferencesEqual(Children, childrenNew))
+                return this;
 
             return ChangeChildren(childrenNew, nodeCountStack).ChangeAutoManageChildren(false);
         }

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -4679,6 +4679,15 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Decoys discarded.
+        /// </summary>
+        public static string CommandLine_AddDecoys_Decoys_discarded {
+            get {
+                return ResourceManager.GetString("CommandLine_AddDecoys_Decoys_discarded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error: Attempting to add decoys to document with decoys..
         /// </summary>
         public static string CommandLine_AddDecoys_Error__Attempting_to_add_decoys_to_document_with_decoys_ {

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -10980,4 +10980,7 @@ There might be something wrong with default web browser on this computer.</value
   <data name="FastaImporter_Import__0__proteins_and__1__peptides_added" xml:space="preserve">
     <value>{0} proteins and {1} peptides added</value>
   </data>
+  <data name="CommandLine_AddDecoys_Decoys_discarded" xml:space="preserve">
+    <value>Decoys discarded</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -421,6 +421,14 @@ namespace pwiz.SkylineTestData
                                        "--decoys-add");
             AssertEx.Contains(output, Resources.CommandLine_AddDecoys_Error__Attempting_to_add_decoys_to_document_with_decoys_);
 
+            output = RunCommand("--in=" + outPath, "--decoys-discard");
+            AssertEx.Contains(output, Resources.CommandLine_AddDecoys_Decoys_discarded);
+
+            output = RunCommand("--in=" + outPath, "--decoys-add", "--decoys-discard");
+            AssertEx.Contains(output, Resources.CommandLine_AddDecoys_Decoys_discarded);
+            AssertEx.Contains(output, string.Format(Resources.CommandLine_AddDecoys_Added__0__decoy_peptides_using___1___method,
+                expectedPeptides, DecoyGeneration.REVERSE_SEQUENCE));
+
             int tooManyPeptides = expectedPeptides + 1;
             output = RunCommand("--in=" + docPath,
                                        "--decoys-add",


### PR DESCRIPTION
- CommandLine support for --decoys-discard
- CommandLine support for --refine-cv-remove-above-cutoff with decimal percent <1
- Remove based on CV cutoff removes empty peptides
- Refinement based on CV and GC can still remove proteins based on remaining peptide count