### PR TITLE
Fix implementation of QuantificationResult.ToString().

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
@@ -77,7 +77,7 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         {
             if (CalculatedConcentration.HasValue)
             {
-                FormatCalculatedConcentration(CalculatedConcentration.Value, Units);
+                return FormatCalculatedConcentration(CalculatedConcentration.Value, Units);
             }
             else if (NormalizedArea.HasValue)
             {

--- a/pwiz_tools/Skyline/TestFunctional/SingleReplicateResponseCurveTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SingleReplicateResponseCurveTest.cs
@@ -30,6 +30,8 @@ using System.Linq;
 using System.Windows.Forms;
 using pwiz.Skyline.Model.Databinding.Entities;
 using pwiz.Skyline.Model.DocSettings.AbsoluteQuantification;
+using pwiz.Skyline.Model.Hibernate;
+using pwiz.Skyline.Util.Extensions;
 
 namespace pwiz.SkylineTestFunctional
 {
@@ -206,6 +208,9 @@ namespace pwiz.SkylineTestFunctional
                     var expectedConcentration = precursorResult.Precursor.PrecursorConcentration;
                     var accuracy = calculatedConcentration / expectedConcentration;
                     Assert.AreEqual(accuracy.Value, quantificationResult.Value.Accuracy.Value, .0001);
+                    Assert.AreEqual(
+                        TextUtil.SpaceSeparate(calculatedConcentration.Value.ToString(Formats.Concentration), "fmol"),
+                        quantificationResult.ToString());
                 }
             });
 


### PR DESCRIPTION
It was showing up as #N/A.
Reported by Brendan
Also fixed in 20.1 branch.