### PR TITLE
Fix Shimadzu TIC chromatogram time values

### DIFF
--- a/pwiz/data/vendor_readers/Shimadzu/ChromatogramList_Shimadzu.cpp
+++ b/pwiz/data/vendor_readers/Shimadzu/ChromatogramList_Shimadzu.cpp
@@ -105,7 +105,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Shimadzu::chromatogram(size_t ind
             auto ticPtr = rawfile_->getTIC(config_.globalChromatogramsAreMs1Only);
             if (getBinaryData)
             {
-                result->setTimeIntensityArrays(vector<double>(), vector<double>(), UO_minute, MS_number_of_detector_counts);
+                result->setTimeIntensityArrays(vector<double>(), vector<double>(), UO_second, MS_number_of_detector_counts);
                 ticPtr->getXArray(result->getTimeArray()->data);
                 ticPtr->getYArray(result->getIntensityArray()->data);
             }

--- a/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/10nmol_Negative_MS_ID_ON_055-centroid.mzML
+++ b/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/10nmol_Negative_MS_ID_ON_055-centroid.mzML
@@ -20,7 +20,7 @@
     <software id="Shimadzu_x0020_software" version="4.0">
       <cvParam cvRef="MS" accession="MS:1001557" name="Shimadzu Corporation software" value=""/>
     </software>
-    <software id="pwiz" version="3.0.19326">
+    <software id="pwiz" version="3.0.20134">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -5316,11 +5316,11 @@
       <chromatogram index="0" id="TIC" defaultArrayLength="150">
         <cvParam cvRef="MS" accession="MS:1000235" name="total ion current chromatogram" value=""/>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="616">
+          <binaryDataArray encodedLength="480">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0F+EFWEYx/G30h9T+qPJVuqcalVna21lSlv2fZ9HN2cvujnddDM33czN3pwu9mbPzYoRibEsOSuRWYkYkRgROSuRORIxIjEicVYisxLR9+418zy/z89jjDFemc545bhNBvOWtx0WBe/aToR7HN/demfaDYvrLmvfcsy4vBG7iTBxK/0+/1PX8zNmchcmA+YKRwizlWvGI+ZrByF5Y6vctp6QKdWCLyv9Q3Ijbwj5sla3pOdPSRAEgiWrXSthck38rC24Eo86Yr2bstEKhQ4SRZE04zkp067QR2arBTFmkZ07ODF7d7HusXsfL2F/CXOZjAe4fXIeYj8i6zF+St4TOjwl8xk9MnKf0+UF2S/pk5P/ik6vMd5gDDDeYrzDeI9RYHzA+IjxCaPE+IzxBeMrRoXxDeM7xg+MEcZPjF8YvzFqjD8YfzH+YRjN2ps0TDarV25R7qZRtE39bLuu1TuUG2oz3qnDYpf2/N3KPbVM92o82qdBsF+5rSaDA2q9MV3vHFTurLPVYd1oHdHV7lHl5mrMMYzjGCcwxjFOYpzCOI3RwjiDcRZjEmMK4xzGeYwLGAHGRYxLGJcxpjGuYFzFmMGwGE7/A+rH8/4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzlFEXXEcB/A/McYexojYw4gYe4hDRDrniDHuwxgj9jDGIXqIiLGHO0vKkqWkczcpSzZlljuzlClNNjs3TZOypGyuZullT3vb5+37/Xx/D78QQqgVpc5aUXRW8qZYjkMox5U8j6OoqhdxltVZSGrFpcRNkmUtSRRFCWIl1s0y1s/K8hAf1SdsOZtlC2yJVdkKW2dbrGC77IAdszo7Y3/ZPxbSKGpIs+xCWskvpn5IQ7jMrrBG1sSusmusmbWw6+wGa2URa2PtrIMlrIvdZLdYid1md9hd1s3usfvsActYD+tlfayfDbCH7BEry4/5E33QNsSG2Qh7ykbZGHvGxtkEm2RTbJrl7Dl7wWbYLJtjL9k8W2Cv2Gu2yJbYG/aWLbMqe8fesw9sha2yNfaRrbMNtsk+sS32mX1hX1nBttkO+8Z22Xe2x/bZAfvBDtkRO2Yn7Cf7xerslP1mf9gZO0//A2Tu8QM=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="576">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>

--- a/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/10nmol_Negative_MS_ID_ON_055.mzML
+++ b/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/10nmol_Negative_MS_ID_ON_055.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="10nmol_Negative_MS_ID_ON_055" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.12" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -20,7 +20,7 @@
     <software id="Shimadzu_x0020_software" version="4.0">
       <cvParam cvRef="MS" accession="MS:1001557" name="Shimadzu Corporation software" value=""/>
     </software>
-    <software id="pwiz" version="3.0.18312">
+    <software id="pwiz" version="3.0.20134">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -5312,11 +5312,11 @@
       <chromatogram index="0" id="TIC" defaultArrayLength="150">
         <cvParam cvRef="MS" accession="MS:1000235" name="total ion current chromatogram" value=""/>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="616">
+          <binaryDataArray encodedLength="480">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0F+EFWEYx/G30h9T+qPJVuqcalVna21lSlv2fZ9HN2cvujnddDM33czN3pwu9mbPzYoRibEsOSuRWYkYkRgROSuRORIxIjEicVYisxLR9+418zy/z89jjDFemc545bhNBvOWtx0WBe/aToR7HN/demfaDYvrLmvfcsy4vBG7iTBxK/0+/1PX8zNmchcmA+YKRwizlWvGI+ZrByF5Y6vctp6QKdWCLyv9Q3Ijbwj5sla3pOdPSRAEgiWrXSthck38rC24Eo86Yr2bstEKhQ4SRZE04zkp067QR2arBTFmkZ07ODF7d7HusXsfL2F/CXOZjAe4fXIeYj8i6zF+St4TOjwl8xk9MnKf0+UF2S/pk5P/ik6vMd5gDDDeYrzDeI9RYHzA+IjxCaPE+IzxBeMrRoXxDeM7xg+MEcZPjF8YvzFqjD8YfzH+YRjN2ps0TDarV25R7qZRtE39bLuu1TuUG2oz3qnDYpf2/N3KPbVM92o82qdBsF+5rSaDA2q9MV3vHFTurLPVYd1oHdHV7lHl5mrMMYzjGCcwxjFOYpzCOI3RwjiDcRZjEmMK4xzGeYwLGAHGRYxLGJcxpjGuYFzFmMGwGE7/A+rH8/4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzlFEXXEcB/A/McYexojYw4gYe4hDRDrniDHuwxgj9jDGIXqIiLGHO0vKkqWkczcpSzZlljuzlClNNjs3TZOypGyuZullT3vb5+37/Xx/D78QQqgVpc5aUXRW8qZYjkMox5U8j6OoqhdxltVZSGrFpcRNkmUtSRRFCWIl1s0y1s/K8hAf1SdsOZtlC2yJVdkKW2dbrGC77IAdszo7Y3/ZPxbSKGpIs+xCWskvpn5IQ7jMrrBG1sSusmusmbWw6+wGa2URa2PtrIMlrIvdZLdYid1md9hd1s3usfvsActYD+tlfayfDbCH7BEry4/5E33QNsSG2Qh7ykbZGHvGxtkEm2RTbJrl7Dl7wWbYLJtjL9k8W2Cv2Gu2yJbYG/aWLbMqe8fesw9sha2yNfaRrbMNtsk+sS32mX1hX1nBttkO+8Z22Xe2x/bZAfvBDtkRO2Yn7Cf7xerslP1mf9gZO0//A2Tu8QM=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="576">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo.cpp
@@ -239,7 +239,7 @@ void fillInMetadata(const string& filename, RawFile& rawfile, MSData& msd, const
     if (!instData.Model.empty() && !instData.Name.empty() && rawfile.getInstrumentModel() == InstrumentModelType_Unknown)
     {
         if (config.unknownInstrumentIsError)
-            throw runtime_error("[Reader_Thermo::fillInMetadata] unable to parse instrument model; please report this error to the ProteoWizard developers with this information: model(" + instData.Model + ") name(" + instData.Name + "); if want to convert the file anyway, use the ignoreUnknownInstrumentError flag");
+            throw runtime_error("[Reader_Thermo::fillInMetadata] unable to parse instrument model; make sure you are using the latest version of ProteoWizard; if you are, please report this error to the ProteoWizard developers with this information: model(" + instData.Model + ") name(" + instData.Name + "); if want to convert the file anyway, use the ignoreUnknownInstrumentError flag");
         // TODO: else log warning
     }
 

--- a/pwiz/utility/minimxml/SAXParser.cpp
+++ b/pwiz/utility/minimxml/SAXParser.cpp
@@ -583,8 +583,7 @@ PWIZ_API_DECL void parse(istream& is, Handler& handler)
 
 string xml_root_element(const string& fileheader)
 {
-    // TODO: make this static again when we switch to a proper C++11 compiler (e.g. VC++ 2015)
-    const /*static*/ bxp::sregex e = bxp::sregex::compile("<\\?xml.*?>.*?<([^?!]\\S+?)[\\s>]");
+    const static bxp::sregex e = bxp::sregex::compile("<\\?xml.*?>.*?<([^?!]\\S+?)[\\s>]");
 
     // convert Unicode to ASCII
     string asciiheader;

--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
@@ -485,7 +485,7 @@ TICChromatogramImpl::TICChromatogramImpl(const ShimadzuReaderImpl& reader, DataO
     y_.reserve(fullFileTIC.size());
     for (const auto& kvp : fullFileTIC)
     {
-        x_.push_back((double) kvp.first / ShimadzuUtil::MASSNUMBER_UNIT);
+        x_.push_back((double) kvp.first / 1e3);
         y_.push_back((double) kvp.second);
     }
 }

--- a/pwiz_tools/SeeMS/Types.cs
+++ b/pwiz_tools/SeeMS/Types.cs
@@ -222,7 +222,7 @@ namespace seems
 
             if( IsChromatogram )
             {
-                axis.Title.Text = "Time";
+                axis.Title.Text = "Time " + (Properties.Settings.Default.TimeInMinutes ? "(min)" : "(sec)");
             } else
             {
                 axis.Title.Text = "m/z";
@@ -346,7 +346,17 @@ namespace seems
             {
                 using( pwiz.CLI.msdata.Chromatogram element = chromatogramList.chromatogram( index, true ) )
                 {
-                    return new ZedGraph.PointPairList( element.binaryDataArrays[0].data, element.binaryDataArrays[1].data );
+                    var timeArray = element.getTimeArray();
+                    var timeArrayData = timeArray.data;
+                    var timeArrayUnits = timeArray.cvParam(CVID.MS_time_array).units;
+                    if (timeArrayUnits == CVID.UO_second && Properties.Settings.Default.TimeInMinutes)
+                        for (int i = 0; i < timeArrayData.Count; ++i)
+                            timeArrayData[i] /= 60;
+                    else if (timeArrayUnits == CVID.UO_minute && !Properties.Settings.Default.TimeInMinutes)
+                        for (int i = 0; i < timeArrayData.Count; ++i)
+                            timeArrayData[i] *= 60;
+
+                    return new ZedGraph.PointPairList(timeArrayData, element.binaryDataArrays[1].data );
                 }
             }
 		}


### PR DESCRIPTION
- fixed Shimadzu TIC chromatogram time values being converted to frac…tions of seconds rather than seconds, and fixed the cvParam's units from minutes to seconds
- fixed thread safety issue with Thermo 64-bit reader which resulted in strange behavior for files with non-MS controllers
- fixed SeeMS chromatogram graphs to show time units and adjust based on the View/Time in Minutes option