### PR TITLE
Ongoing investigation of "Dispose cannot be called during CreateHandl…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -22,8 +22,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
-using System.Security;
 using System.Text;
 using System.Windows.Forms;
 using pwiz.Skyline.Model;

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -109,12 +109,8 @@ namespace pwiz.Skyline.Controls.Graphs
         private bool _inCreateHandle;
         /// <summary>
         /// Override CreateHandle in order to try to track down intermittent test failures.
-        /// "HandleProcessCorruptedStateExceptions" just in case a type of exception is getting thrown
-        /// that cannot be caught by ordinary C# code.
         /// TODO(nicksh): Remove this override once the intermittent failure is figured out
         /// </summary>
-        [HandleProcessCorruptedStateExceptions]
-        [SecurityCritical]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         protected override void CreateHandle()
         {

--- a/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.cs
@@ -20,8 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
-using System.Security;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Properties;

--- a/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.cs
@@ -568,12 +568,8 @@ namespace pwiz.Skyline.Controls.Graphs
         private bool _inCreateHandle;
         /// <summary>
         /// Override CreateHandle in order to try to track down intermittent test failures.
-        /// "HandleProcessCorruptedStateExceptions" just in case a type of exception is getting thrown
-        /// that cannot be caught by ordinary C# code.
         /// TODO(nicksh): Remove this override once the intermittent failure is figured out
         /// </summary>
-        [HandleProcessCorruptedStateExceptions]
-        [SecurityCritical]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         protected override void CreateHandle()
         {


### PR DESCRIPTION
…e" intermittent failures that used to happen.

See whether removing "[HandleProcessCorruptedStateExceptions]" and "[SecurityCritical]" attributes cause intermittent failure to start happening again.