### PR TITLE
- IDPicker: fixed IndexOutOfRange error when expanding row

### DIFF
--- a/pwiz_tools/Bumbershoot/idpicker/Forms/IDPickerForm.cs
+++ b/pwiz_tools/Bumbershoot/idpicker/Forms/IDPickerForm.cs
@@ -480,9 +480,14 @@ namespace IDPicker
                                 result = sourcePath;
                                 break;
                             }
-                            catch
+                            catch (ArgumentException e)
                             {
                                 // couldn't find the source in that directory; prompt user again
+                                MessageBox.Show(e.Message);
+                            }
+                            catch(Exception e)
+                            {
+                                Program.HandleException(e);
                             }
                         }
                     }));

--- a/pwiz_tools/Bumbershoot/idpicker/Forms/NewVersionForm.Designer.cs
+++ b/pwiz_tools/Bumbershoot/idpicker/Forms/NewVersionForm.Designer.cs
@@ -58,6 +58,7 @@ namespace IDPicker.Forms
             this.noButton = new System.Windows.Forms.Button();
             this.showChangeLogCheckbox = new System.Windows.Forms.CheckBox();
             this.splitContainer = new System.Windows.Forms.SplitContainer();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
             this.splitContainer.Panel1.SuspendLayout();
             this.splitContainer.Panel2.SuspendLayout();
             this.splitContainer.SuspendLayout();
@@ -71,13 +72,13 @@ namespace IDPicker.Forms
             this.textTemplate.Size = new System.Drawing.Size(200, 65);
             this.textTemplate.TabIndex = 0;
             this.textTemplate.Text = "There is a newer version of {0} available.\r\nYou are using version {1}.\r\nThe lates" +
-                "t version is {2}.\r\n\r\nDownload it now?";
+    "t version is {2}.\r\n\r\nDownload it now?";
             // 
             // changelogTextBox
             // 
-            this.changelogTextBox.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.changelogTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.changelogTextBox.BackColor = System.Drawing.SystemColors.Window;
             this.changelogTextBox.Location = new System.Drawing.Point(12, 3);
             this.changelogTextBox.Multiline = true;
@@ -109,7 +110,7 @@ namespace IDPicker.Forms
             // 
             // showChangeLogCheckbox
             // 
-            this.showChangeLogCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.showChangeLogCheckbox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.showChangeLogCheckbox.Appearance = System.Windows.Forms.Appearance.Button;
             this.showChangeLogCheckbox.AutoSize = true;
             this.showChangeLogCheckbox.Checked = true;
@@ -120,6 +121,7 @@ namespace IDPicker.Forms
             this.showChangeLogCheckbox.TabIndex = 4;
             this.showChangeLogCheckbox.Text = "Show Change Log";
             this.showChangeLogCheckbox.UseVisualStyleBackColor = true;
+            this.showChangeLogCheckbox.Visible = false;
             this.showChangeLogCheckbox.CheckedChanged += new System.EventHandler(this.showChangeLogCheckbox_CheckedChanged);
             // 
             // splitContainer
@@ -163,6 +165,7 @@ namespace IDPicker.Forms
             this.splitContainer.Panel1.PerformLayout();
             this.splitContainer.Panel2.ResumeLayout(false);
             this.splitContainer.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).EndInit();
             this.splitContainer.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/pwiz_tools/Bumbershoot/idpicker/Forms/NewVersionForm.resx
+++ b/pwiz_tools/Bumbershoot/idpicker/Forms/NewVersionForm.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/pwiz_tools/Bumbershoot/idpicker/Forms/SpectrumTableForm.cs
+++ b/pwiz_tools/Bumbershoot/idpicker/Forms/SpectrumTableForm.cs
@@ -260,15 +260,18 @@ namespace IDPicker.Forms
 
             public static NHibernate.IQuery GetQuery(NHibernate.ISession session, DataFilter dataFilter)
             {
-                if (dataFilter.Spectrum != null && dataFilter.Spectrum.Count == 1 ||
-                    dataFilter.Peptide != null && dataFilter.Peptide.Count == 1 ||
-                    dataFilter.DistinctMatchKey != null && dataFilter.DistinctMatchKey.Count == 1)
+                if (dataFilter.Spectrum?.Count == 1 ||
+                    dataFilter.Peptide?.Count == 1 ||
+                    dataFilter.DistinctMatchKey?.Count == 1)
                 {
                     var basicFilter = new DataFilter(dataFilter)
                     {
                         AminoAcidOffset = null,
                         Cluster = null,
-                        Protein = null
+                        Protein = null,
+                        ProteinGroup = null,
+                        Gene = null,
+                        GeneGroup = null
                     };
 
                     if (dataFilter.Spectrum != null)

--- a/pwiz_tools/Bumbershoot/idpicker/Util/Path.cs
+++ b/pwiz_tools/Bumbershoot/idpicker/Util/Path.cs
@@ -107,7 +107,8 @@ namespace IDPicker
 
             if (matches.Length == 0)
                 throw new ArgumentException("Cannot find source file corresponding to \"" +
-                                            source + "\"\r\n\r\n" +
+                                            source + "\"\r\nin these directories:\r\n" +
+                                            String.Join("\r\n", paths) + "\r\n\r\n" +
                                             "Check that this source file can be " +
                                             "found in the source search paths " +
                                             "(configured in Tools/Options) with one of the " +


### PR DESCRIPTION
- IDPicker: fixed IndexOutOfRange error when expanding row in spectrum view to PSM list when data filter includes protein group, gene, or gene group
- IDPicker: improved error feedback in LocateSpectrumSource
* IDPicker: hid Show Change Log button since it's not currently working