### PR TITLE
Skyline would not load chromatogram files with fewer than 3 chromatog…

### DIFF
--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -995,11 +995,7 @@ namespace pwiz.ProteowizardWrapper
             get
             {
                 var len = ChromatogramCount;
-
-                // Many files have just one TIC chromatogram
-                if (len < 2)
-                    return false;
-
+                
                 for (var i = 0; i < len; i++)
                 {
                     int index;


### PR DESCRIPTION
…rams, apparently on the assumption that they were pure metadata. Now it actually looks at them to see if they are SIC chromatograms.

Reported by user egauth in https://skyline.ms/announcements/home/support/thread.view?rowId=47502