### PR TITLE
Skyline: clean up some code inspection warnings from latest ReSharper…

### DIFF
--- a/pwiz_tools/Shared/Common/PeakFinding/ChromSmoother.cs
+++ b/pwiz_tools/Shared/Common/PeakFinding/ChromSmoother.cs
@@ -97,7 +97,7 @@ namespace pwiz.Common.PeakFinding
                         newWeights[hw - i] = tmp;
                     }
                 }
-                else if (derivative > 3)
+                else // if (derivative > 3) N.B. this causes an inspection warning
                 {
                     throw new Exception(@"gaussian derivative of greater than 3rd order not supported");
                 }

--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -1644,8 +1644,7 @@ namespace pwiz.ProteowizardWrapper
         {
             unchecked
             {
-                int result = 0;
-                result = (result * 397) ^ (Model != null ? Model.GetHashCode() : 0);
+                int result = Model != null ? Model.GetHashCode() : 0; // N.B. generated code starts with result = 0, which causes an inspection warning
                 result = (result * 397) ^ (Ionization != null ? Ionization.GetHashCode() : 0);
                 result = (result * 397) ^ (Analyzer != null ? Analyzer.GetHashCode() : 0);
                 result = (result * 397) ^ (Detector != null ? Detector.GetHashCode() : 0);

--- a/pwiz_tools/Skyline/Controls/Graphs/SummaryPeptideGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SummaryPeptideGraphPane.cs
@@ -72,7 +72,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
         protected override IdentityPath GetIdentityPath(CurveItem curveItem, int barIndex)
         {
-            if (0 <= barIndex || barIndex < _graphData.XScalePaths.Length)
+            if (0 <= barIndex && barIndex < _graphData.XScalePaths.Length)
                 return _graphData.XScalePaths[barIndex];
             return null;
         }

--- a/pwiz_tools/Skyline/Model/AbstractMassListExporter.cs
+++ b/pwiz_tools/Skyline/Model/AbstractMassListExporter.cs
@@ -620,8 +620,11 @@ namespace pwiz.Skyline.Model
 
             protected override void InsertItem(int index, PeptideSchedule item)
             {
-                TransitionCount += item.TransitionCount;
-                base.InsertItem(index, item);
+                if (item != null)
+                {
+                    TransitionCount += item.TransitionCount;
+                    base.InsertItem(index, item);
+                }
             }
 
             protected override void RemoveItem(int index)
@@ -632,8 +635,11 @@ namespace pwiz.Skyline.Model
 
             protected override void SetItem(int index, PeptideSchedule item)
             {
-                TransitionCount += item.TransitionCount - this[index].TransitionCount;
-                base.SetItem(index, item);
+                if (item != null)
+                {
+                    TransitionCount += item.TransitionCount - this[index].TransitionCount;
+                    base.SetItem(index, item);
+                }
             }
         }
 

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -769,6 +769,7 @@ namespace pwiz.Skyline.Model
         private bool ValidateCharge(int? charge, bool getPrecursorColumns, out string errMessage)
         {
             var absCharge = Math.Abs(charge ?? 0);
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse (in case we ever set min charge > 1)
             if (getPrecursorColumns && absCharge != 0 && (absCharge < TransitionGroup.MIN_PRECURSOR_CHARGE ||
                                                           absCharge > TransitionGroup.MAX_PRECURSOR_CHARGE))
             {
@@ -778,6 +779,7 @@ namespace pwiz.Skyline.Model
                 return false;
             }
             else if (!getPrecursorColumns && absCharge != 0 &&
+                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse (in case we ever set min charge > 1)
                      (absCharge < Transition.MIN_PRODUCT_CHARGE || absCharge > Transition.MAX_PRODUCT_CHARGE))
             {
                 errMessage = String.Format(

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -426,6 +426,7 @@ namespace pwiz.Skyline
             int numTools = toolList.Count;
             const int endValue = 100;
             int progressValue = 0;
+            // ReSharper disable once UselessBinaryOperation (in case we decide to start at progress>0 for display purposes)
             int increment = (endValue - progressValue)/(numTools +1);
 
             foreach (var tool in toolList)

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -1278,7 +1278,7 @@ namespace pwiz.Skyline.Util
                         {
                             resultDict[unlabeledSymbol] = unlabeledCount; // Number of remaining non-label atoms
                         }
-                        else if (unlabeledCount < 0) // Can't remove that which is not there
+                        else // Can't remove that which is not there
                         {
                             throw new InvalidOperationException(
                                 string.Format(Resources.Adduct_ApplyToMolecule_Adduct___0___calls_for_labeling_more__1__atoms_than_are_found_in_the_molecule__2_,


### PR DESCRIPTION
…, including one in SummaryPeptideGraphPane.cs that was an actual bug