### PR TITLE
Improve Thermo finding precursor spectrum heuristic and enable using Master Scan

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -627,7 +627,7 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Thermo::spectrum(size_t index, DetailLeve
                         // to last isolation m/z of the current scan;
                         // i.e. MS3 with filter "234.56@cid30.00 123.45@cid30.00" matches to MS2 with filter "234.56@cid30.00"
                         double precursorIsolationMz = i > 0 ? scanInfo->precursorMZ(i - 1, false) : 0;
-                        size_t precursorScanIndex = findPrecursorSpectrumIndex(raw, msLevel - 1, precursorIsolationMz, index);
+                        size_t precursorScanIndex = findPrecursorSpectrumIndex(raw, msLevel - 1, isolationMz, precursorIsolationMz, index);
                         if (precursorScanIndex < index_.size())
                         {
                             precursor.spectrumID = index_[precursorScanIndex].id;
@@ -923,11 +923,13 @@ PWIZ_API_DECL void SpectrumList_Thermo::createIndex()
 }
 
 
-PWIZ_API_DECL size_t SpectrumList_Thermo::findPrecursorSpectrumIndex(RawFile* raw, int precursorMsLevel, double precursorIsolationMz, size_t index) const
+PWIZ_API_DECL size_t SpectrumList_Thermo::findPrecursorSpectrumIndex(RawFile* raw, int precursorMsLevel, double isolationMz, double precursorIsolationMz, size_t index) const
 {
     // exit early if the precursor MS level doesn't exist (i.e. targeted MSn runs)
     if (numSpectraOfMSOrder(static_cast<MSOrder>(precursorMsLevel)) == 0)
         return size_;
+
+    long masterScan = raw->getTrailerExtraValueLong(index, "Master Scan:", -1);
 
     // return first scan with MSn-1 that matches the precursor isolation m/z
 
@@ -938,23 +940,40 @@ PWIZ_API_DECL size_t SpectrumList_Thermo::findPrecursorSpectrumIndex(RawFile* ra
         if (ie.msOrder < MSOrder_MS)
             continue;
 
+        if (masterScan > -1)
+        {
+            if (masterScan == ie.scan)
+                return index;
+
+            // master scan not in index (i.e. SIM scan without simAsSpectra)
+            if (masterScan > ie.scan)
+                return size_;
+        }
+
         if (static_cast<int>(ie.msOrder) == precursorMsLevel &&
             (precursorIsolationMz == 0 ||
              precursorIsolationMz == ie.isolationMz))
         {
-            // if potential precursor scan is a zoom scan, make sure the precursorIsolationMz is in the scan window
-            if (ie.scanType == ScanType_Zoom)
+            // make sure the precursorIsolationMz (for zoom scans) or isolationMz (for other MSn scans) is in the scan window
+            double isolationMzToFind = ie.scanType == ScanType_Zoom ? precursorIsolationMz : isolationMz;
+            bool mzInRange = false;
+            auto scanInfo = raw->getScanInfo(ie.scan);
+            size_t scanRangeCount = scanInfo->scanRangeCount();
+            if ((ie.scanType == ScanType_SIM || ie.scanType == ScanType_SRM) && scanRangeCount > 1)
             {
-                auto zoomScanInfo = raw->getScanInfo(ie.scan);
-                bool mzInRange = false;
-                for (size_t i = 0, end = zoomScanInfo->scanRangeCount(); i < end && !mzInRange; ++i)
+                for (size_t i = 0; i < scanRangeCount && !mzInRange; ++i)
                 {
-                    auto scanRange = zoomScanInfo->scanRange(i);
-                    mzInRange = precursorIsolationMz >= scanRange.first && precursorIsolationMz <= scanRange.second;
+                    const pair<double, double>& scanRange = scanInfo->scanRange(i);
+                    mzInRange = isolationMzToFind >= scanRange.first && isolationMzToFind <= scanRange.second;
                 }
-                if (!mzInRange)
-                    continue;
             }
+            else
+            {
+                mzInRange = isolationMzToFind >= scanInfo->lowMass() && isolationMzToFind <= scanInfo->highMass();
+            }
+
+            if (!mzInRange)
+                continue;
 
             return index;
         }

--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.hpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.hpp
@@ -92,6 +92,9 @@ class PWIZ_API_DECL SpectrumList_Thermo : public SpectrumListIonMobilityBase
         pwiz::vendor_api::Thermo::ScanType scanType;
         pwiz::vendor_api::Thermo::MSOrder msOrder;
         double isolationMz;
+
+        // TODO: store this here, but need a way to get it quickly in createIndex()
+        //std::vector<double> scanWindowLowMz, scanWindowHighMz;
     };
 
     vector<IndexEntry> index_;
@@ -111,7 +114,7 @@ class PWIZ_API_DECL SpectrumList_Thermo : public SpectrumListIonMobilityBase
     typedef MemoryMRUCache<CacheEntry, BOOST_MULTI_INDEX_MEMBER(CacheEntry, size_t, index) > CacheType;
     mutable CacheType precursorCache_;
 
-    size_t findPrecursorSpectrumIndex(RawFile* raw, int precursorMsLevel, double precursorIsolationMz, size_t index) const;
+    size_t findPrecursorSpectrumIndex(RawFile* raw, int precursorMsLevel, double isolationMz, double precursorIsolationMz, size_t index) const;
     double getPrecursorIntensity(int precursorSpectrumIndex, double isolationMz, double isolationHalfWidth, const pwiz::util::IntegerSet& msLevelsToCentroid) const;
     pwiz::vendor_api::Thermo::ScanInfoPtr findPrecursorZoomScan(RawFile* raw, int precursorMsLevel, double precursorIsolationMz, size_t index) const;
     InstrumentConfigurationPtr findInstrumentConfiguration(const MSData& msd, CVID massAnalyzerType) const;

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -138,9 +138,9 @@ class RawFileImpl : public RawFile
     virtual const vector<DetectorType>& getDetectors() const;
 
     virtual std::string getSampleID() const;
-    virtual std::string getTrailerExtraValue(long scanNumber, const std::string& name) const;
-    virtual double getTrailerExtraValueDouble(long scanNumber, const std::string& name) const;
-    virtual long getTrailerExtraValueLong(long scanNumber, const std::string& name) const;
+    virtual std::string getTrailerExtraValue(long scanNumber, const std::string& name, string valueIfMissing = "") const;
+    virtual double getTrailerExtraValueDouble(long scanNumber, const std::string& name, double valueIfMissing = 0) const;
+    virtual long getTrailerExtraValueLong(long scanNumber, const std::string& name, long valueIfMissing = 0) const;
 
     virtual ChromatogramDataPtr
     getChromatogramData(ChromatogramType traceType,
@@ -250,9 +250,9 @@ class RawFileThreadImpl : public RawFile
     virtual const vector<DetectorType>& getDetectors() const;
 
     virtual std::string getSampleID() const;
-    virtual std::string getTrailerExtraValue(long scanNumber, const std::string& name) const;
-    virtual double getTrailerExtraValueDouble(long scanNumber, const std::string& name) const;
-    virtual long getTrailerExtraValueLong(long scanNumber, const std::string& name) const;
+    virtual std::string getTrailerExtraValue(long scanNumber, const std::string& name, std::string valueIfMissing = "") const;
+    virtual double getTrailerExtraValueDouble(long scanNumber, const std::string& name, double valueIfMissing = 0) const;
+    virtual long getTrailerExtraValueLong(long scanNumber, const std::string& name, long valueIfMissing = 0) const;
 
     virtual ChromatogramDataPtr
         getChromatogramData(ChromatogramType traceType,
@@ -717,7 +717,7 @@ std::string RawFileImpl::getSampleID() const
 }
 
 
-std::string RawFileImpl::getTrailerExtraValue(long scanNumber, const string& name) const
+std::string RawFileImpl::getTrailerExtraValue(long scanNumber, const string& name, string valueIfMissing) const
 {
 #ifndef _WIN64
     try
@@ -730,7 +730,7 @@ std::string RawFileImpl::getTrailerExtraValue(long scanNumber, const string& nam
         }
         catch (invalid_argument&)
         {
-            return "";
+            return valueIfMissing;
         }
 
         switch (v.vt)
@@ -756,7 +756,7 @@ std::string RawFileImpl::getTrailerExtraValue(long scanNumber, const string& nam
 #endif
 }
 
-double RawFileImpl::getTrailerExtraValueDouble(long scanNumber, const string& name) const
+double RawFileImpl::getTrailerExtraValueDouble(long scanNumber, const string& name, double valueIfMissing) const
 {
 #ifndef _WIN64
     try
@@ -769,7 +769,7 @@ double RawFileImpl::getTrailerExtraValueDouble(long scanNumber, const string& na
         }
         catch (invalid_argument&)
         {
-            return 0.0;
+            return valueIfMissing;
         }
 
         switch (v.vt)
@@ -787,7 +787,7 @@ double RawFileImpl::getTrailerExtraValueDouble(long scanNumber, const string& na
 }
 
 
-long RawFileImpl::getTrailerExtraValueLong(long scanNumber, const string& name) const
+long RawFileImpl::getTrailerExtraValueLong(long scanNumber, const string& name, long valueIfMissing) const
 {
 #ifndef _WIN64
     try
@@ -800,7 +800,7 @@ long RawFileImpl::getTrailerExtraValueLong(long scanNumber, const string& name) 
         }
         catch (invalid_argument&)
         {
-            return 0;
+            return valueIfMissing;
         }
 
         switch (v.vt)
@@ -2546,7 +2546,7 @@ std::string RawFileThreadImpl::getSampleID() const
 }
 
 
-std::string RawFileThreadImpl::getTrailerExtraValue(long scanNumber, const string& name) const
+std::string RawFileThreadImpl::getTrailerExtraValue(long scanNumber, const string& name, string valueIfMissing) const
 {
     if (currentControllerType_ != Controller_MS)
         return "";
@@ -2563,36 +2563,36 @@ std::string RawFileThreadImpl::getTrailerExtraValue(long scanNumber, const strin
     CATCH_AND_FORWARD_EX(name)
 }
 
-double RawFileThreadImpl::getTrailerExtraValueDouble(long scanNumber, const string& name) const
+double RawFileThreadImpl::getTrailerExtraValueDouble(long scanNumber, const string& name, double valueIfMissing) const
 {
     if (currentControllerType_ != Controller_MS)
-        return 0.0;
+        return valueIfMissing;
 
     try
     {
         auto findItr = rawFile_->trailerExtraIndexByName.find(name);
         if (findItr == rawFile_->trailerExtraIndexByName.end())
-            return 0.0;
+            return valueIfMissing;
         System::Object^ result = raw_->GetTrailerExtraValue(scanNumber, findItr->second);
-        return result == nullptr ? 0.0 : System::Convert::ToDouble(result);
+        return result == nullptr ? valueIfMissing : System::Convert::ToDouble(result);
     }
     CATCH_AND_FORWARD_EX(name)
 }
 
 
-long RawFileThreadImpl::getTrailerExtraValueLong(long scanNumber, const string& name) const
+long RawFileThreadImpl::getTrailerExtraValueLong(long scanNumber, const string& name, long valueIfMissing) const
 {
     if (currentControllerType_ != Controller_MS)
-        return 0;
+        return valueIfMissing;
 
     try
     {
         auto findItr = rawFile_->trailerExtraIndexByName.find(name);
         if (findItr == rawFile_->trailerExtraIndexByName.end())
-            return 0;
+            return valueIfMissing;
 
         System::Object^ result = raw_->GetTrailerExtraValue(scanNumber, findItr->second);
-        return result == nullptr ? 0 : System::Convert::ToInt32(result);
+        return result == nullptr ? valueIfMissing : System::Convert::ToInt32(result);
     }
     CATCH_AND_FORWARD_EX(name)
 }

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.h
@@ -456,9 +456,9 @@ class PWIZ_API_DECL RawFile
     virtual const std::vector<DetectorType>& getDetectors() const = 0;
 
     virtual std::string getSampleID() const = 0;
-    virtual std::string getTrailerExtraValue(long scanNumber, const std::string& name) const = 0;
-    virtual double getTrailerExtraValueDouble(long scanNumber, const std::string& name) const = 0;
-    virtual long getTrailerExtraValueLong(long scanNumber, const std::string& name) const = 0;
+    virtual std::string getTrailerExtraValue(long scanNumber, const std::string& name, std::string valueIfMissing = "") const = 0;
+    virtual double getTrailerExtraValueDouble(long scanNumber, const std::string& name, double valueIfMissing = 0) const = 0;
+    virtual long getTrailerExtraValueLong(long scanNumber, const std::string& name, long valueIfMissing = 0) const = 0;
 
     virtual ChromatogramDataPtr
     getChromatogramData(ChromatogramType traceType,

--- a/pwiz_tools/examples/msbenchmark.cpp
+++ b/pwiz_tools/examples/msbenchmark.cpp
@@ -423,6 +423,16 @@ int main(int argc, char* argv[])
                 readerConfig.acceptZeroLengthSpectra = true;
                 --i;
             }
+            else if (argv[i] == string("--simAsSpectra"))
+            {
+                readerConfig.simAsSpectra = true;
+                --i;
+            }
+            else if (argv[i] == string("--srmAsSpectra"))
+            {
+                readerConfig.srmAsSpectra = true;
+                --i;
+            }
             else if (argv[i] == string("--loop"))
             {
                 loop = true;


### PR DESCRIPTION
- added support for assigning precursor spectrum by checking the "Master Scan" header item
- fixed precursor spectrum heuristic to check that isolation m/z is within the precursor spectrum's scan window(s)
- added simAsSpectra and srmAsSpectra options to msbenchmark
* added valueIfMissing parameters for RawFile::getTrailerExtraValue*() functions; will switch to use these instead of try/catch later