### PR TITLE
Fixes a problem with performing chromatogram extraction with ion mobi…

### DIFF
--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/Hela_QC_PASEF_Slot1-first-6-frames-combineIMS-ms1.mzML
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/Hela_QC_PASEF_Slot1-first-6-frames-combineIMS-ms1.mzML
@@ -34,7 +34,7 @@
     <software id="micrOTOFcontrol" version="5.0.2.528-10700-vc110">
       <cvParam cvRef="MS" accession="MS:1000726" name="micrOTOFcontrol" value=""/>
     </software>
-    <software id="pwiz_Reader_Bruker" version="3.0.20071">
+    <software id="pwiz_Reader_Bruker" version="3.0.20168">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -79,6 +79,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="22754.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="2.3340182e07"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.5321323114365826" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.6354718404441517" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="1">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan>

--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/Hela_QC_PASEF_Slot1-first-6-frames-combineIMS-ms2.mzML
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/Hela_QC_PASEF_Slot1-first-6-frames-combineIMS-ms2.mzML
@@ -34,7 +34,7 @@
     <software id="micrOTOFcontrol" version="5.0.2.528-10700-vc110">
       <cvParam cvRef="MS" accession="MS:1000726" name="micrOTOFcontrol" value=""/>
     </software>
-    <software id="pwiz_Reader_Bruker" version="3.0.20071">
+    <software id="pwiz_Reader_Bruker" version="3.0.20168">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -79,6 +79,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="1321.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.57401e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3710551562242919" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3961843052800458" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=1 scan=229">
@@ -187,6 +189,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="1321.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.57401e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=1 scan=297">
@@ -295,6 +299,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="777.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.7477e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3909498649959178" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.416071343992563" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=2 scan=210">
@@ -402,6 +408,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="777.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.7477e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3480115875740128" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3731496221401176" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=2 scan=251">
@@ -510,6 +518,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="777.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.7477e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=2 scan=297">
@@ -618,6 +628,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="540.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.89068e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3909498649959178" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.416071343992563" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=3 scan=210">
@@ -725,6 +737,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="540.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.89068e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3480115875740128" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3731496221401176" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=3 scan=251">
@@ -833,6 +847,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="540.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.89068e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=3 scan=297">
@@ -941,6 +957,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="469.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.77207e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3909498649959178" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.416071343992563" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=4 scan=210">
@@ -1048,6 +1066,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="469.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.77207e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3480115875740128" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3731496221401176" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=4 scan=251">
@@ -1156,6 +1176,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="469.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.77207e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=4 scan=297">
@@ -1264,6 +1286,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="275.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="2.27079e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3909498649959178" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.416071343992563" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=5 scan=210">
@@ -1371,6 +1395,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="275.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="2.27079e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3480115875740128" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3731496221401176" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=5 scan=251">
@@ -1479,6 +1505,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="275.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="2.27079e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=5 scan=297">

--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/Hela_QC_PASEF_Slot1-first-6-frames-combineIMS.mzML
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/Hela_QC_PASEF_Slot1-first-6-frames-combineIMS.mzML
@@ -35,7 +35,7 @@
     <software id="micrOTOFcontrol" version="5.0.2.528-10700-vc110">
       <cvParam cvRef="MS" accession="MS:1000726" name="micrOTOFcontrol" value=""/>
     </software>
-    <software id="pwiz_Reader_Bruker" version="3.0.20071">
+    <software id="pwiz_Reader_Bruker" version="3.0.20168">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -80,6 +80,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="1321.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.57401e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3710551562242919" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3961843052800458" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=1 scan=229">
@@ -188,6 +190,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="1321.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.57401e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=1 scan=297">
@@ -296,6 +300,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="777.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.7477e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3909498649959178" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.416071343992563" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=2 scan=210">
@@ -403,6 +409,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="777.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.7477e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3480115875740128" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3731496221401176" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=2 scan=251">
@@ -511,6 +519,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="777.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="5.7477e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=2 scan=297">
@@ -619,6 +629,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="540.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.89068e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3909498649959178" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.416071343992563" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=3 scan=210">
@@ -726,6 +738,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="540.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.89068e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3480115875740128" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3731496221401176" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=3 scan=251">
@@ -834,6 +848,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="540.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.89068e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=3 scan=297">
@@ -942,6 +958,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="469.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.77207e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3909498649959178" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.416071343992563" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=4 scan=210">
@@ -1049,6 +1067,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="469.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.77207e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3480115875740128" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3731496221401176" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=4 scan=251">
@@ -1157,6 +1177,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="469.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="4.77207e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=4 scan=297">
@@ -1265,6 +1287,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="275.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="2.27079e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3909498649959178" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.416071343992563" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=5 scan=210">
@@ -1372,6 +1396,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="275.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="2.27079e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.3480115875740128" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3731496221401176" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=5 scan=251">
@@ -1480,6 +1506,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="275.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="2.27079e05"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.2998032407592823" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.3249598693553066" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="25">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan spectrumRef="frame=5 scan=297">
@@ -1588,6 +1616,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="22754.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="2.3340182e07"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.5321323114365826" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.6354718404441517" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="1">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan>

--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/ThyroglobMRM000003-combineIMS-ms1.mzML
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/ThyroglobMRM000003-combineIMS-ms1.mzML
@@ -33,7 +33,7 @@
     <software id="micrOTOFcontrol" version="5.0.71.422-9346-vc110">
       <cvParam cvRef="MS" accession="MS:1000726" name="micrOTOFcontrol" value=""/>
     </software>
-    <software id="pwiz_Reader_Bruker" version="3.0.20071">
+    <software id="pwiz_Reader_Bruker" version="3.0.20168">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>

--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/ThyroglobMRM000003-combineIMS-ms2.mzML
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/ThyroglobMRM000003-combineIMS-ms2.mzML
@@ -34,7 +34,7 @@
     <software id="micrOTOFcontrol" version="5.0.71.422-9346-vc110">
       <cvParam cvRef="MS" accession="MS:1000726" name="micrOTOFcontrol" value=""/>
     </software>
-    <software id="pwiz_Reader_Bruker" version="3.0.20071">
+    <software id="pwiz_Reader_Bruker" version="3.0.20168">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -79,6 +79,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="148.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10513.0"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.4602232906378299" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.555768150531077" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="1">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan>
@@ -137,6 +139,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="3657.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="1.68258e07"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.4602232906378299" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.555768150531077" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="1">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan>

--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/ThyroglobMRM000003-combineIMS.mzML
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/ThyroglobMRM000003-combineIMS.mzML
@@ -34,7 +34,7 @@
     <software id="micrOTOFcontrol" version="5.0.71.422-9346-vc110">
       <cvParam cvRef="MS" accession="MS:1000726" name="micrOTOFcontrol" value=""/>
     </software>
-    <software id="pwiz_Reader_Bruker" version="3.0.20071">
+    <software id="pwiz_Reader_Bruker" version="3.0.20168">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -79,6 +79,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="148.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10513.0"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.4602232906378299" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.555768150531077" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="1">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan>
@@ -137,6 +139,8 @@
         <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="3657.0"/>
         <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="1.68258e07"/>
         <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+        <userParam name="ion mobility lower limit" value="1.4602232906378299" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+        <userParam name="ion mobility upper limit" value="1.555768150531077" type="xsd:double" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
         <scanList count="1">
           <cvParam cvRef="MS" accession="MS:1000571" name="sum of spectra" value=""/>
           <scan>

--- a/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
+++ b/pwiz/data/vendor_readers/Bruker/SpectrumList_Bruker.cpp
@@ -353,6 +353,11 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Bruker::spectrum(size_t index, DetailLeve
         IntegerSet scanNumbers = spectrum->getMergedScanNumbers();
         if (config_.combineIonMobilitySpectra && format_ == Reader_Bruker_Format_TDF)
         {
+            // Note the measured range
+            auto imRange = spectrum->getIonMobilityRange();
+            result->userParams.emplace_back("ion mobility lower limit", lexical_cast<string>(imRange.first), "xsd:double", MS_Vs_cm_2);
+            result->userParams.emplace_back("ion mobility upper limit", lexical_cast<string>(imRange.second), "xsd:double", MS_Vs_cm_2);
+
             result->scanList.set(MS_sum_of_spectra);
             if (scanNumbers.size() < 100)
             {

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/CompassData.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/CompassData.hpp
@@ -213,6 +213,7 @@ struct PWIZ_API_DECL MSSpectrum
 
     virtual bool isIonMobilitySpectrum() const { return false; }
     virtual double oneOverK0() const { return 0.0; }
+    virtual std::pair<double, double> getIonMobilityRange() const { return std::pair<double, double>(0, 0); }
 	virtual int getWindowGroup() const { return 0; } // for diaPASEF data
 
     virtual void getCombinedSpectrumData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities, pwiz::util::BinaryData<double>& mobilities, bool sortAndJitter) const { }

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.cpp
@@ -762,6 +762,19 @@ double TimsSpectrum::oneOverK0() const
     }
 }
 
+// Get the measured ion mobility range
+std::pair<double, double> TimsSpectrum::getIonMobilityRange() const
+{
+    if (!isCombinedScans())
+    {
+        return make_pair(frame_.oneOverK0_[scanBegin_], frame_.oneOverK0_[scanBegin_]);
+    }
+    else
+    {
+        return make_pair(frame_.oneOverK0_[scanEnd()], frame_.oneOverK0_[scanBegin_]);
+    }
+}
+
 
 void TimsSpectrum::getCombinedSpectrumData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities, pwiz::util::BinaryData<double>& mobilities, bool sortAndJitter) const
 {

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.hpp
@@ -159,6 +159,7 @@ public:
 
     virtual bool isIonMobilitySpectrum() const { return oneOverK0() > 0; }
     virtual double oneOverK0() const;
+    virtual std::pair<double, double> getIonMobilityRange() const; // Gets the measured IM range
 
     void getCombinedSpectrumData(pwiz::util::BinaryData<double>& mz, pwiz::util::BinaryData<double>& intensities, pwiz::util::BinaryData<double>& mobilities, bool sortAndJitter) const;
     size_t getCombinedSpectrumDataSize() const;

--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -931,6 +931,19 @@ namespace pwiz.ProteowizardWrapper
                 var param = spectrum.scanList.scans[0].userParam(@"windowGroup"); // For Bruker diaPASEF
                 msDataSpectrum.WindowGroup = param.empty() ? 0 : int.Parse(param.value);
             }
+
+            if (expectIonMobilityValue)
+            {
+                // Note the range actually measured (for zero vs missing value determination)
+                var param = spectrum.userParam(@"ion mobility lower limit");
+                if (!param.empty())
+                {
+                    msDataSpectrum.IonMobilityMeasurementRangeLow = param.value;
+                    param = spectrum.userParam(@"ion mobility upper limit");
+                    msDataSpectrum.IonMobilityMeasurementRangeHigh = param.value;
+                }
+            }
+
             if (spectrum.binaryDataArrays.Count <= 1)
             {
                 msDataSpectrum.Mzs = new double[0];
@@ -1544,6 +1557,12 @@ namespace pwiz.ProteowizardWrapper
             get { return _ionMobility ?? IonMobilityValue.EMPTY; }
             set { _ionMobility = value; }
         }
+
+        /// <summary>
+        /// The range of ion mobilities that were scanned (for zero vs missing value determination)
+        /// </summary>
+        public double? IonMobilityMeasurementRangeLow { get; set; }
+        public double? IonMobilityMeasurementRangeHigh { get; set; }
 
         public ImmutableList<MsPrecursor> GetPrecursorsByMsLevel(int level)
         {

--- a/pwiz_tools/Skyline/TestPerf/PerfImportPrmPasefTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportPrmPasefTest.cs
@@ -140,14 +140,14 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                 Resources.ReportSpecList_GetDefaults_Peptide_RT_Results,
                 210, null);
             var rts = new double?[] {
-                12.45, 21.48, 16.93, 22.93, 13.63, 19.12, 28.97, 14.88, 14.22, 27.25, 14.97, 14.26, 25.7, 15.06, 11.93, 26.37, 12.89, 15.88,
-                18.34, 11.16, 10.46, 10.98, 28.02, 24.01, 11.15, 18.97, 23.33, 26.56, 11.94, 19, 24.2, 23.42, 26.1, 27.86, 27.76, 20.99, 26.15,
+                12.45, 21.48, 16.93, 22.93, 13.63, 19.12, 28.97, 14.88, 14.24, 27.25, 14.97, 14.26, 25.7, 15.06, 11.93, 26.37, 12.89, 15.88,
+                18.34, 11.16, 10.46, 10.98, 28, 24.01, 11.15, 18.97, 23.33, 26.56, 11.94, 19, 24.2, 23.42, 26.1, 27.86, 27.76, 20.99, 26.15,
                 21.16, 25.99, 14.29, 26.04, 15.04, 24.07, 28.15, 20.1, 26.03, 15.07, 19.78, 27.2, 21.26, 25.39, 25.04, 11.71, 21.1, 20.51,
                 14.71, 25.24, 24.9, 28.57, 21.13, 17.19, 15.39, 18.08, 16.06, 26.11, 10.26, 13.11, 9.46, 10.78, 14.42, 25.16, 26.36, 17.21,
                 24.79, 13.9, 20.63, 19.7, 22.5, 13.97, 19.34, 19.05, 18.45, 13.96, 6.59, 26.12, 17.76, 28.31, 24.27, 29.25, 27.56, 23.72,
                 12.09, 8.92, 18.39, 20.23, 26.42, 28.45, 22.17, 15.17, 24.73, 28.22, 17.16, 9.59, 13.84, 22.91, 17.14, 19.92, 24.24, 27.82,
-                null, 10.41, 12.27, 21.21, 18.69, 12.68, 21.09, 22.11, 21.43, 14.51, 17.31, 21.92, 22.43, 19.53, 25.24, 25.31, 11.61, 25.79,
-                10.07, 24.29, 23.28, 15.83, 14.87, 28.53, 14.85, 28.5, 22.49, 19.35, 24.81, 24.75, 24.63, 24.36, 15.46, 22.7, 19.85, 22.56,
+                null, 10.41, 12.27, 21.21, 18.69, 12.68, 21.09, 22.11, 21.43, 14.51, 17.31, 21.92, 22.43, 19.53, 25.24, 25.31, 11.61, 24.37,
+                10.07, 24.29, 23.28, 15.83, 14.87, 28.53, 14.85, 28.5, 22.49, 19.35, 24.81, 24.57, 24.63, 24.36, 15.46, 22.7, 19.85, 22.56,
                 21.91, 15.97, 20.82, 13.62, 19.52, 15.55, 23.71, 30.35, 19.57, 13.57, 29.08, 15.56, 21.73, 16.05, 13.95, 25.39, 14.3, 25.3,
                 15.72, 10.48, 9.88, 21.31, 9.92, 26.56, 27.89, 29.85, 22.12, 25.06, 21.53, 15.25, 21.13, 22.81, 20.44, 18.23, 11.49, 25.59,
                 20.13, 16.32, 13.19, 9.63, 12.11, 21.84, 10.83, 12.49, 16.99, 18.83, 11.71, 12.84, 17.31, 11.13, 12.88, 24.35, 16.83, 15.26,
@@ -156,10 +156,6 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             for (row = 0; row < rts.Length; row++)
             {
                 var rt = rts[row];
-
-                // CONSIDER: No idea why these differ in uncombined mode, but they do
-                if (MsDataFileImpl.ForceUncombinedIonMobility && (rt == 28.02 || rt == 22.81))
-                    continue;
 
                 CheckFieldByName(documentGrid, "PeptideRetentionTime", row, rt, msg, true);
             }
@@ -177,9 +173,11 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             {
                 // By checking the 1th row we check both the single file and two file cases
                 var val = documentGrid.DataGridView.Rows[row].Cells[col.Index].Value as double?;
-                Assert.AreEqual(expected.HasValue, val.HasValue, name + (msg ?? string.Empty));
                 if (!IsRecordMode || !recordValues)
+                {
+                    Assert.AreEqual(expected.HasValue, val.HasValue, name + (msg ?? string.Empty));
                     Assert.AreEqual(expected ?? 0, val ?? 0, 0.005, name + (msg ?? string.Empty));
+                }
                 else
                 {
                     Console.Write(@"{0:0.##}, ", val);


### PR DESCRIPTION
…lity filtering where there was not a proper distinction between failure to detect signal because a scan simply has none in a given IM filter range (zero value) versus an IM filter range being outside the measurement range of the instrument (no value). The pwiz CLI API has been modified to provide this instrument IM range metadata when available (currently only Bruker TDF has this).

This clears up a mystery around subtle differences in Skyline peakpicking results between 2-array and 3-array representations of IMS data, as seen in BrukerPrmPasefImportTest. A zero intensity chromatogram time point leads to slightly different RT peak placement than a missing time point does, and in the extreme can mean a red dot vs no dot chromatogram quality indicator in the Targets tree.

NOTE this is a copy of a previous PR that wound up with some strange line ending changes, just making a fresh branch for a clean merge. No need for review, thanks