### PR TITLE
Fix a couple of typos in audit logging:

### DIFF
--- a/pwiz_tools/Skyline/Model/AuditLog/EnumNames.Designer.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/EnumNames.Designer.cs
@@ -1078,7 +1078,7 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use only scans withing time frame of MS/MS IDs.
+        ///   Looks up a localized string similar to Use only scans within time frame of MS/MS IDs.
         /// </summary>
         public static string RetentionTimeFilterType_ms2_ids {
             get {
@@ -1096,7 +1096,7 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use only scans withing time frame of predicted RT.
+        ///   Looks up a localized string similar to Use only scans within time frame of predicted RT.
         /// </summary>
         public static string RetentionTimeFilterType_scheduling_windows {
             get {

--- a/pwiz_tools/Skyline/Model/AuditLog/EnumNames.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/EnumNames.resx
@@ -322,13 +322,13 @@
     <value>None</value>
   </data>
   <data name="RetentionTimeFilterType_ms2_ids" xml:space="preserve">
-    <value>Use only scans withing time frame of MS/MS IDs</value>
+    <value>Use only scans within time frame of MS/MS IDs</value>
   </data>
   <data name="RetentionTimeFilterType_none" xml:space="preserve">
     <value>Include all matching scans</value>
   </data>
   <data name="RetentionTimeFilterType_scheduling_windows" xml:space="preserve">
-    <value>Use only scans withing time frame of predicted RT</value>
+    <value>Use only scans within time frame of predicted RT</value>
   </data>
   <data name="String1FullScanMassAnalyzerType_centroided" xml:space="preserve">
     <value>Centroided</value>

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDiaQeFullSearchTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDiaQeFullSearchTutorial.log
@@ -66,7 +66,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "999", End = "1219", Margin = "1" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "napedro_3mixed_human_yeast_ecoli_20140403_iRT_reverse.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -201,7 +201,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDiaQeTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDiaQeTutorial.log
@@ -66,7 +66,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "999", End = "1219", Margin = "1" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "target_protein_sequences.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -201,7 +201,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDiaTtofFullSearchTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDiaTtofFullSearchTutorial.log
@@ -111,7 +111,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "1110.1", End = "1200", Margin = "0.5" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "napedro_3mixed_human_yeast_ecoli_20140403_iRT_reverse.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -471,7 +471,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDiaTtofTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDiaTtofTutorial.log
@@ -111,7 +111,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "1110.1", End = "1200", Margin = "0.5" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "target_protein_sequences.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -471,7 +471,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDriftTimePredictorTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDriftTimePredictorTutorial.log
@@ -75,7 +75,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "3"
 
 Undo Redo : Imported results from "Yeast_0pt1ug_BSA_100nM_18May15_Fir_15-04-01.d"

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestHiResMetabolomicsTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestHiResMetabolomicsTutorial.log
@@ -31,7 +31,7 @@ Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed fr
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "70000"
 Settings > Transition Settings -- Full-Scan > Resolving power m/z changed from Missing to "200"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from 16 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorial.log
@@ -223,7 +223,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -244,7 +244,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
@@ -223,7 +223,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -244,7 +244,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorialAsSmallMolecules.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestTargetedMSMSTutorialAsSmallMolecules.log
@@ -377,7 +377,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -398,7 +398,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDiaQeFullSearchTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDiaQeFullSearchTutorial.log
@@ -66,7 +66,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "999", End = "1219", Margin = "1" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "napedro_3mixed_human_yeast_ecoli_20140403_iRT_reverse.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -201,7 +201,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDiaQeTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDiaQeTutorial.log
@@ -66,7 +66,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "999", End = "1219", Margin = "1" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "target_protein_sequences.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -201,7 +201,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDiaTtofFullSearchTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDiaTtofFullSearchTutorial.log
@@ -111,7 +111,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "1110,1", End = "1200", Margin = "0,5" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "napedro_3mixed_human_yeast_ecoli_20140403_iRT_reverse.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -471,7 +471,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDiaTtofTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDiaTtofTutorial.log
@@ -111,7 +111,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "1110,1", End = "1200", Margin = "0,5" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "target_protein_sequences.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -471,7 +471,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDriftTimePredictorTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestDriftTimePredictorTutorial.log
@@ -75,7 +75,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "3"
 
 Undo Redo : Imported results from "Yeast_0pt1ug_BSA_100nM_18May15_Fir_15-04-01.d"

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestHiResMetabolomicsTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestHiResMetabolomicsTutorial.log
@@ -31,7 +31,7 @@ Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed fr
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "70000"
 Settings > Transition Settings -- Full-Scan > Resolving power m/z changed from Missing to "200"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from 16 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorial.log
@@ -223,7 +223,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -244,7 +244,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
@@ -223,7 +223,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -244,7 +244,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorialAsSmallMolecules.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/fr/TestTargetedMSMSTutorialAsSmallMolecules.log
@@ -377,7 +377,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -398,7 +398,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDiaQeFullSearchTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDiaQeFullSearchTutorial.log
@@ -66,7 +66,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "999", End = "1219", Margin = "1" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "napedro_3mixed_human_yeast_ecoli_20140403_iRT_reverse.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -201,7 +201,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDiaQeTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDiaQeTutorial.log
@@ -66,7 +66,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "999", End = "1219", Margin = "1" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "target_protein_sequences.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -201,7 +201,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDiaTtofFullSearchTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDiaTtofFullSearchTutorial.log
@@ -111,7 +111,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "1110,1", End = "1200", Margin = "0,5" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "napedro_3mixed_human_yeast_ecoli_20140403_iRT_reverse.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -471,7 +471,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDiaTtofTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDiaTtofTutorial.log
@@ -111,7 +111,7 @@ Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespe
 Import Peptide Search > Configure Full-Scan Settings > Isolation scheme > Prespecified isolation windows : contains { Start = "1110,1", End = "1200", Margin = "0,5" }
 Import Peptide Search > Configure Full-Scan Settings > Product mass analyzer is "Centroided"
 Import Peptide Search > Configure Full-Scan Settings > Mass accuracy is "20"
-Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans withing time frame of predicted RT"
+Import Peptide Search > Configure Full-Scan Settings > Retention time filter type is "Use only scans within time frame of predicted RT"
 Import Peptide Search > Import FASTA > FASTA file is "target_protein_sequences.fasta"
 Import Peptide Search > Import FASTA > Decoy generation method is "Shuffle Sequence"
 Import Peptide Search > Import FASTA > Decoys per target is "1"
@@ -471,7 +471,7 @@ Configure Full-Scan Settings =
     },
     Product mass analyzer = "Centroided",
     Mass accuracy = "20",
-    Retention time filter type = "Use only scans withing time frame of predicted RT"
+    Retention time filter type = "Use only scans within time frame of predicted RT"
 },
 Import FASTA = 
 {

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDriftTimePredictorTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestDriftTimePredictorTutorial.log
@@ -75,7 +75,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "3"
 
 Undo Redo : Imported results from "Yeast_0pt1ug_BSA_100nM_18May15_Fir_15-04-01.d"

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestHiResMetabolomicsTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestHiResMetabolomicsTutorial.log
@@ -31,7 +31,7 @@ Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed fr
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "70000"
 Settings > Transition Settings -- Full-Scan > Resolving power m/z changed from Missing to "200"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from 16 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorial.log
@@ -223,7 +223,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -244,7 +244,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorialAsSmallMoleculeMasses.log
@@ -223,7 +223,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -244,7 +244,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorialAsSmallMolecules.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/tr/TestTargetedMSMSTutorialAsSmallMolecules.log
@@ -377,7 +377,7 @@ Settings > Transition Settings -- Full-Scan > Peaks changed from Missing to "3"
 Settings > Transition Settings -- Full-Scan > Precursor mass analyzer changed from "None" to "TOF"
 Settings > Transition Settings -- Full-Scan > Resolving power changed from Missing to "30000"
 Settings > Transition Settings -- Full-Scan > Isotope labeling enrichment changed from Missing to "Default"
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans withing time frame of MS/MS IDs" to "Include all matching scans"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Use only scans within time frame of MS/MS IDs" to "Include all matching scans"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "5" to "0"
 
 Undo Redo : Imported results from "6-BSA-500fmol.mzML"
@@ -398,7 +398,7 @@ Undo Redo : Transition Settings -- Full-Scan changed
 Summary   : Settings > Transition Settings -- Full-Scan changed
 All Info  :
 Transition Settings -- Full-Scan changed
-Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans withing time frame of predicted RT"
+Settings > Transition Settings -- Full-Scan > Retention time filter type changed from "Include all matching scans" to "Use only scans within time frame of predicted RT"
 Settings > Transition Settings -- Full-Scan > Retention time filter length changed from "0" to "1"
 
 Undo Redo : Imported results from 5 files


### PR DESCRIPTION
"Use only scans withing time frame of MS/MS IDs" -> "Use only scans within time frame of MS/MS IDs"
and
"Use only scans withing time frame of predicted RT" -> "Use only scans within time frame of predicted RT"