### PR TITLE
Fixes related to invalid crosslinked peptides

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -1307,6 +1307,10 @@ namespace pwiz.Skyline.Model.Results
             int labelMassDelta = 0;
 
             var lightSequence = ModifiedSequence.GetModifiedSequence(settings, peptideDocNode, IsotopeLabelType.light);
+            if (lightSequence == null)
+            {
+                return null;
+            }
             var lightModificationNames = lightSequence.GetModifications().Select(mod => mod.Name).ToHashSet();
             foreach (var labelType in settings.PeptideSettings.Modifications.GetHeavyModificationTypes())
             {

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -1930,11 +1930,6 @@ namespace pwiz.Skyline.SettingsUI
             {
                 sequence = peptideLibraryKey.ModifiedSequence;
             }
-            else if (pep.Key.LibraryKey is CrosslinkLibraryKey crosslinkLibraryKey)
-            {
-                sequence = string.Join(string.Empty,
-                    crosslinkLibraryKey.PeptideLibraryKeys.Select(key => key.ModifiedSequence));
-            }
             else
             {
                 return modList;

--- a/pwiz_tools/Skyline/Test/CrosslinkSequenceParserTest.cs
+++ b/pwiz_tools/Skyline/Test/CrosslinkSequenceParserTest.cs
@@ -60,11 +60,14 @@ namespace pwiz.SkylineTest
         public void TestCrosslinkIsSupportedBySkyline()
         {
             VerifySupported("YGPPCPPCPAPEFLGGPSVFLFPPKPK-YGPPCPPCPAPEFLGGPSVFLFPPKPK-[-2.01565@5,5]", true);
+            // Two crosslinks between the same pair of peptides
             VerifySupported("YGPPCPPCPAPEFLGGPSVFLFPPKPK-YGPPCPPCPAPEFLGGPSVFLFPPKPK-[-2.01565@5,5][-2.01565@8,8]", false);
             VerifySupported("YGPPCPPCPAPEFLGGPSVFLFPPKPK-YGPPCPPCPAPEFLGGPSVFLFPPKPK-[-2.01565@8-5,*][-2.01565@5,5]", true);
             VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,2,*][-2@*,2,3]", true);
+            // Crosslinks forming a ring that cannot be represented as a tree
             VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,2,*][-2@2,*,3][-2@*,2,3]", false);
             VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,2,*][-2@2,*,3]", true);
+            // One peptide that is not connected to the rest of the peptides.
             VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,*,3]", false);
         }
 

--- a/pwiz_tools/Skyline/Test/CrosslinkSequenceParserTest.cs
+++ b/pwiz_tools/Skyline/Test/CrosslinkSequenceParserTest.cs
@@ -55,5 +55,23 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(ImmutableList.Singleton(4), libKey.Crosslinks[0].Positions[0]);
             Assert.AreEqual(ImmutableList.Singleton(2), libKey.Crosslinks[0].Positions[1]);
         }
+
+        [TestMethod]
+        public void TestCrosslinkIsSupportedBySkyline()
+        {
+            VerifySupported("YGPPCPPCPAPEFLGGPSVFLFPPKPK-YGPPCPPCPAPEFLGGPSVFLFPPKPK-[-2.01565@5,5]", true);
+            VerifySupported("YGPPCPPCPAPEFLGGPSVFLFPPKPK-YGPPCPPCPAPEFLGGPSVFLFPPKPK-[-2.01565@5,5][-2.01565@8,8]", false);
+            VerifySupported("YGPPCPPCPAPEFLGGPSVFLFPPKPK-YGPPCPPCPAPEFLGGPSVFLFPPKPK-[-2.01565@8-5,*][-2.01565@5,5]", true);
+            VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,2,*][-2@*,2,3]", true);
+            VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,2,*][-2@2,*,3][-2@*,2,3]", false);
+            VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,2,*][-2@2,*,3]", true);
+            VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,*,3]", false);
+        }
+
+        private static void VerifySupported(string libKeyString, bool expectedSupported)
+        {
+            var libKey = CrosslinkSequenceParser.ParseCrosslinkLibraryKey(libKeyString, 1);
+            Assert.AreEqual(expectedSupported, libKey.IsSupportedBySkyline());
+        }
     }
 }


### PR DESCRIPTION
Fix some problems with invalid peptide crosslink sequences:
1. If there are more than one crosslink between a pair of peptides, make sure that Skyline reports that as not supported (reported by Yu)
2. Fix exceptions that happen hovering over crosslinked peptides with unmatched modifications in Spectral Library viewer.
Also:
3. Fix NullReferenceException using Triggered Acquisition in small molecule document (reported by jrenders)