### PR TITLE
Fix Issue 746: Retention time alignment makes mouse act out of phase …

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/ChromGraphItem.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ChromGraphItem.cs
@@ -934,7 +934,7 @@ namespace pwiz.Skyline.Controls.Graphs
             }
 
             var interpolatedTimeIntensities = chromatogramInfo.GetInterpolatedTimeIntensities();
-            int index = interpolatedTimeIntensities.IndexOfNearestTime((float)displayTime);
+            int index = interpolatedTimeIntensities.IndexOfNearestTime((float)measuredTime);
             return ScaleRetentionTime(interpolatedTimeIntensities.Times[index]);
         }
 


### PR DESCRIPTION
…on aligned replicate graphs

When retention times are aligned to a different replicate on the chromatogram graph, clicking on the graph to bring up the Full Scan Spectrum Viewer would bring up the wrong scan.
(Reported by Matt Chambers)