### PR TITLE
SkylineRunner: Increase wait timeout for connecting to Skyline

### DIFF
--- a/pwiz_tools/Skyline/Executables/SkylineRunner/Program.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineRunner/Program.cs
@@ -127,14 +127,13 @@ namespace pwiz.SkylineRunner
             }
         }
 
-
         private bool WaitForConnection(NamedPipeServerStream serverStream, string inPipeName)
         {
             Thread connector = new Thread(() =>
             {
                 serverStream.WaitForConnection();
                 lock (SERVER_CONNECTION_LOCK)
-                {         
+                {
                     _connected = true;
                     Monitor.Pulse(SERVER_CONNECTION_LOCK);
                 }

--- a/pwiz_tools/Skyline/Executables/SkylineRunner/Program.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineRunner/Program.cs
@@ -127,13 +127,14 @@ namespace pwiz.SkylineRunner
             }
         }
 
+
         private bool WaitForConnection(NamedPipeServerStream serverStream, string inPipeName)
         {
             Thread connector = new Thread(() =>
             {
                 serverStream.WaitForConnection();
                 lock (SERVER_CONNECTION_LOCK)
-                {
+                {         
                     _connected = true;
                     Monitor.Pulse(SERVER_CONNECTION_LOCK);
                 }
@@ -142,10 +143,36 @@ namespace pwiz.SkylineRunner
             connector.Start();
 
             bool connected;
+            var wait = 5;
             lock (SERVER_CONNECTION_LOCK)
             {
-                Monitor.Wait(SERVER_CONNECTION_LOCK, 5 * 1000);
+                Monitor.Wait(SERVER_CONNECTION_LOCK, wait * 1000);
                 connected = _connected;
+            }
+
+            if (!connected)
+            {
+                // Wait another 10 seconds for a total of 15 seconds.
+                Console.Write(Resources.Program_WaitForConnection_Waiting_for_Skyline);
+
+                wait++;
+                var timer = new System.Timers.Timer(1000);
+                timer.Elapsed += (sender, e) =>
+                {
+                    Console.Write(@".");
+                    wait++;
+                };
+                timer.Start();
+                lock (SERVER_CONNECTION_LOCK)
+                {
+                    Monitor.Wait(SERVER_CONNECTION_LOCK, 10 * 1000);
+                    connected = _connected;
+                } 
+                timer.Stop();
+                timer.Dispose();
+
+                Console.Write($@" {wait}s");
+                Console.WriteLine();
             }
 
             if (!connected)

--- a/pwiz_tools/Skyline/Executables/SkylineRunner/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineRunner/Properties/Resources.Designer.cs
@@ -87,5 +87,14 @@ namespace pwiz.SkylineRunner.Properties {
                 return ResourceManager.GetString("Program_Program_Make_sure_you_have_a_valid__0__installation_", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Waiting for Skyline.
+        /// </summary>
+        internal static string Program_WaitForConnection_Waiting_for_Skyline {
+            get {
+                return ResourceManager.GetString("Program_WaitForConnection_Waiting_for_Skyline", resourceCulture);
+            }
+        }
     }
 }

--- a/pwiz_tools/Skyline/Executables/SkylineRunner/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Executables/SkylineRunner/Properties/Resources.resx
@@ -108,4 +108,7 @@
     <comment>Example: Make sure you have a valid Skyline installation.</comment>
     <value>Make sure you have a valid {0} installation.</value>
   </data>
+  <data name="Program_WaitForConnection_Waiting_for_Skyline" xml:space="preserve">
+    <value>Waiting for Skyline</value>
+  </data>
 </root>


### PR DESCRIPTION
Problem reported by Sonnet Davis.  Skyline was installed in the expected location but SkylineRunner (via AutoQC Loader) would exit with the following error:
Error: Could not connect to Skyline.
Make sure you have a valid Skyline installation.
SkylineRunner sometimes takes longer than 5s to connect to the named pipe in WaitForConnection().  Increasing the timeout fixed the problem.