### PR TITLE
The "Filter Ion Mobility" button in the Full Scan viewer was broken w…

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/MsDataFileScanHelper.cs
+++ b/pwiz_tools/Skyline/Model/Results/MsDataFileScanHelper.cs
@@ -95,7 +95,9 @@ namespace pwiz.Skyline.Model.Results
             var fullScans = MsDataSpectra;
             double minIonMobility, maxIonMobility;
             if (Settings.Default.FilterIonMobilityFullScan && GetIonMobilityRange(out minIonMobility, out maxIonMobility, Source))
-                fullScans = fullScans.Where(s => minIonMobility <= s.IonMobility.Mobility && s.IonMobility.Mobility <= maxIonMobility).ToArray();
+                fullScans = fullScans.Where(s => minIonMobility <= s.IonMobility.Mobility && s.IonMobility.Mobility <= maxIonMobility // im-per-scan case
+                                                 || minIonMobility <= s.MaxIonMobility && maxIonMobility >= s.MinIonMobility // 3-array case
+                ).ToArray();
             return fullScans;
         }
 


### PR DESCRIPTION
…hen used in combination with  the newer 3-array representation of ion mobility scans. When engaged, it prevented the display of such scans altogether. Credit to Nick for the fix.

reported by Brad Williams in https://skyline.ms/announcements/home/support/thread.view?rowId=45440