### PR TITLE
Skyline: completing yesterday's fix to ion-mobility-filtered 2D Full …

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/MsDataFileScanHelper.cs
+++ b/pwiz_tools/Skyline/Model/Results/MsDataFileScanHelper.cs
@@ -90,14 +90,24 @@ namespace pwiz.Skyline.Model.Results
             return SourceNames[(int) source];
         }
 
-        public MsDataSpectrum[] GetFilteredScans()
+        public MsDataSpectrum[] GetFilteredScans(out double minIonMobilityVal, out double maxIonMobilityVal)
         {
             var fullScans = MsDataSpectra;
             double minIonMobility, maxIonMobility;
             if (Settings.Default.FilterIonMobilityFullScan && GetIonMobilityRange(out minIonMobility, out maxIonMobility, Source))
+            {
                 fullScans = fullScans.Where(s => minIonMobility <= s.IonMobility.Mobility && s.IonMobility.Mobility <= maxIonMobility // im-per-scan case
                                                  || minIonMobility <= s.MaxIonMobility && maxIonMobility >= s.MinIonMobility // 3-array case
                 ).ToArray();
+            }
+            else
+            {
+                minIonMobility = double.MinValue;
+                maxIonMobility = double.MaxValue;
+            }
+
+            minIonMobilityVal = minIonMobility;
+            maxIonMobilityVal = maxIonMobility;
             return fullScans;
         }
 


### PR DESCRIPTION
…Scan graphs - the previous fix restored the ability to view the scan but did not actually apply ion mobility filtering to the view.
![image](https://user-images.githubusercontent.com/1200761/89337642-1d912280-d650-11ea-9668-02b1335bc836.png)
![image](https://user-images.githubusercontent.com/1200761/89337673-2c77d500-d650-11ea-9624-061fcedd414a.png)
