### PR TITLE
Skyline: Display underlying error if an exception occurs while getting a list of folders from a Panorama server

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
@@ -112,7 +112,7 @@ namespace pwiz.Skyline.FileUI
         {
             if (PanoramaPublishClient == null)
                 PanoramaPublishClient = new WebPanoramaPublishClient();
-            var listErrorServers = new List<Server>();
+            var listErrorServers = new List<Tuple<Server, string>>();
             foreach (var server in _panoramaServers)
             {
                 JToken folders = null;
@@ -124,7 +124,17 @@ namespace pwiz.Skyline.FileUI
                 {
                     if (ex is WebException || ex is PanoramaServerException)
                     {
-                        listErrorServers.Add(server);
+                        var error = ex.Message;
+                        if (Resources
+                            .EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server
+                            .Equals(error))
+                        {
+                            error += Environment.NewLine + Resources
+                                         .PublishDocumentDlg_PublishDocumentDlgLoad_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password_;
+
+                        }
+
+                        listErrorServers.Add(new Tuple<Server, string>(server, error));
                     }
                     else
                     {
@@ -142,9 +152,9 @@ namespace pwiz.Skyline.FileUI
             }
         }
 
-        private string ServersToString(IEnumerable<Server> servers)
+        private string ServersToString(IEnumerable<Tuple<Server, string>> servers)
         {
-            return TextUtil.LineSeparate(servers.Select(s => s.URI.ToString()));
+            return TextUtil.LineSeparate(servers.Select(t => string.Join(Environment.NewLine, t.Item1.URI.ToString(), t.Item2)));
         }
 
         private TreeViewStateRestorer ServerTreeStateRestorer { get; set; }

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
@@ -129,8 +129,8 @@ namespace pwiz.Skyline.FileUI
                             .EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server
                             .Equals(error))
                         {
-                            error += Environment.NewLine + Resources
-                                         .PublishDocumentDlg_PublishDocumentDlgLoad_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password_;
+                            error = TextUtil.LineSeparate(error, Resources
+                                .PublishDocumentDlg_PublishDocumentDlgLoad_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password_);
 
                         }
 
@@ -154,7 +154,7 @@ namespace pwiz.Skyline.FileUI
 
         private string ServersToString(IEnumerable<Tuple<Server, string>> servers)
         {
-            return TextUtil.LineSeparate(servers.Select(t => string.Join(Environment.NewLine, t.Item1.URI.ToString(), t.Item2)));
+            return TextUtil.LineSeparate(servers.Select(t => TextUtil.LineSeparate(t.Item1.URI.ToString(), t.Item2)));
         }
 
         private TreeViewStateRestorer ServerTreeStateRestorer { get; set; }

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -22171,6 +22171,16 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Go to Tools &gt; Options &gt; Panorama tab to update the username and password..
+        /// </summary>
+        public static string PublishDocumentDlg_PublishDocumentDlgLoad_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password_ {
+            get {
+                return ResourceManager.GetString("PublishDocumentDlg_PublishDocumentDlgLoad_Go_to_Tools___Options___Panorama_tab_to" +
+                        "_update_the_username_and_password_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The selected server does not support version {0} of the skyd file format. 
         ///Please contact the Panorama server administrator to upgrade the server..
         /// </summary>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -10947,4 +10947,7 @@ Invalid peptide sequence at position 18
   <data name="EditStaticModDlg_SetModification___0___is_not_a_recognized_Unimod_name_" xml:space="preserve">
     <value>'{0}' is not a recognized Unimod name.</value>
   </data>
+  <data name="PublishDocumentDlg_PublishDocumentDlgLoad_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password_" xml:space="preserve">
+    <value>Go to Tools &gt; Options &gt; Panorama tab to update the username and password.</value>
+  </data>
 </root>


### PR DESCRIPTION
PublishDocumentDlg displays a list of configured Panorama servers along with a tree view of the folders on each server where the user can upload Skyline documents.  If an error occurs while querying the list for folders on a server (e.g. the user could not be authenticated with the saved username and password) the underlying error is not displayed to the user. 