### PR TITLE
Trying to track down intermittent TestDdaSearch failure on TeamCity

### DIFF
--- a/pwiz_tools/Skyline/Alerts/PeptidesPerProteinDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/PeptidesPerProteinDlg.cs
@@ -87,7 +87,7 @@ namespace pwiz.Skyline.Alerts
         }
 
         private readonly SrmDocument _document;
-        private readonly List<PeptideGroupDocNode> _addedPeptideGroups;
+        public readonly List<PeptideGroupDocNode> _addedPeptideGroups;
 
         public bool DocumentFinalCalculated { get; private set; }
         public SrmDocument DocumentFinal { get; private set; }

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -180,6 +180,7 @@ namespace pwiz.SkylineTestFunctional
                     {
                         Console.Out.WriteLine("{0}, {1}", peptideGroup.Name, string.Join(",", peptideGroup.Molecules.Select(mol=>mol.ModifiedSequence)));
                     }
+
                     Assert.AreEqual(61, peptideCount);
                 }
                 Assert.AreEqual(61, precursorCount);

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -171,7 +172,15 @@ namespace pwiz.SkylineTestFunctional
                 int proteinCount, peptideCount, precursorCount, transitionCount;
                 emptyProteinsDlg.NewTargetsAll(out proteinCount, out peptideCount, out precursorCount, out transitionCount);
                 Assert.AreEqual(1131, proteinCount);
-                Assert.AreEqual(61, peptideCount);
+                if (61 != peptideCount)
+                {
+                    Console.Out.WriteLine("Incorrect peptide count");
+                    foreach (var peptideGroup in emptyProteinsDlg._addedPeptideGroups)
+                    {
+                        Console.Out.WriteLine("{0}: {1} peptides", peptideGroup.Name, peptideGroup.PeptideCount);
+                    }
+                    Assert.AreEqual(61, peptideCount);
+                }
                 Assert.AreEqual(61, precursorCount);
                 Assert.AreEqual(183, transitionCount);
                 emptyProteinsDlg.NewTargetsFinalSync(out proteinCount, out peptideCount, out precursorCount, out transitionCount);

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -175,6 +175,7 @@ namespace pwiz.SkylineTestFunctional
                 if (61 != peptideCount)
                 {
                     Console.Out.WriteLine("Incorrect peptide count");
+
                     foreach (var peptideGroup in emptyProteinsDlg._addedPeptideGroups)
                     {
                         Console.Out.WriteLine("{0}, {1}", peptideGroup.Name, string.Join(",", peptideGroup.Molecules.Select(mol=>mol.ModifiedSequence)));

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -177,7 +177,7 @@ namespace pwiz.SkylineTestFunctional
                     Console.Out.WriteLine("Incorrect peptide count");
                     foreach (var peptideGroup in emptyProteinsDlg._addedPeptideGroups)
                     {
-                        Console.Out.WriteLine("{0}: {1} peptides", peptideGroup.Name, peptideGroup.PeptideCount);
+                        Console.Out.WriteLine("{0}, {1}", peptideGroup.Name, string.Join(",", peptideGroup.Molecules.Select(mol=>mol.ModifiedSequence)));
                     }
                     Assert.AreEqual(61, peptideCount);
                 }


### PR DESCRIPTION
Added some instrumentation to TestDdaSearch to try to track down intermittent failure on TeamCity

This pull request is not intended to be committed to master.