### PR TITLE
Triggered Acquisition: Make it so that truncated peaks get included for group comparisons an…

### DIFF
--- a/pwiz_tools/Skyline/Model/GroupComparison/NormalizationData.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/NormalizationData.cs
@@ -88,7 +88,7 @@ namespace pwiz.Skyline.Model.GroupComparison
                                         continue;
                                     }
                                     double? area = PeptideQuantifier.GetArea(treatMissingValuesAsZero, qValueCutoff,
-                                        transitionGroup, transition, iResult, chromInfo);
+                                        false, transitionGroup, transition, iResult, chromInfo);
                                     if (!area.HasValue)
                                     {
                                         continue;

--- a/pwiz_tools/Skyline/Model/GroupComparison/NormalizationMethod.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/NormalizationMethod.cs
@@ -125,9 +125,14 @@ namespace pwiz.Skyline.Model.GroupComparison
             {
                 result.Add(GLOBAL_STANDARDS);
             }
-            foreach (var isotopeLabelType in document.Settings.PeptideSettings.Modifications.InternalStandardTypes)
+
+            var modificationTypes = document.Settings.PeptideSettings.Modifications.GetModificationTypes().ToList();
+            if (modificationTypes.Count > 1)
             {
-                result.Add(GetNormalizationMethod(isotopeLabelType));
+                foreach (var isotopeLabelType in document.Settings.PeptideSettings.Modifications.InternalStandardTypes)
+                {
+                    result.Add(GetNormalizationMethod(isotopeLabelType));
+                }
             }
             return result.AsReadOnly();
         }

--- a/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
@@ -179,6 +179,10 @@ namespace pwiz.Skyline.SettingsUI
             FormUtil.RemoveTabPage(tabIntegration, helpTip);
             comboNormalizationMethod.Items.AddRange(
                 NormalizationMethod.ListNormalizationMethods(parent.DocumentUI).ToArray());
+            if (!comboNormalizationMethod.Items.Contains(_peptideSettings.Quantification.NormalizationMethod))
+            {
+                comboNormalizationMethod.Items.Add(_peptideSettings.Quantification.NormalizationMethod);
+            }
             comboNormalizationMethod.SelectedItem = _peptideSettings.Quantification.NormalizationMethod;
             comboWeighting.Items.AddRange(RegressionWeighting.All.Cast<object>().ToArray());
             comboWeighting.SelectedItem = _peptideSettings.Quantification.RegressionWeighting;


### PR DESCRIPTION
…d calibration curves if the Transition Instrument settings have "Triggered Acquisition" set.

Triggered Acquisition methods nearly always result in truncated peaks, so it does not do much good to exclude truncated peaks from quantification.

(Also, fix case where "Ratio to Heavy" would not be available as a normalization method if "Heavy" was not marked as an internal standard. Now all label types are available as normalization method)