### PR TITLE
Skyline: Fix IsPanorama() server check

### DIFF
--- a/pwiz_tools/Skyline/Util/PanoramaUtil.cs
+++ b/pwiz_tools/Skyline/Util/PanoramaUtil.cs
@@ -565,7 +565,7 @@ namespace pwiz.Skyline.Util
         {
             try
             {
-                // Use the LabKey AdminController.HealthCheckAction instead of Project.GetContainersAction which does not return the expected
+                // Use the LabKey AdminController.HealthCheckAction instead of ProjectController.GetContainersAction which does not return the expected
                 // JSON key if the "Home" container on the LabKey Server is not public.
                 // (https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=20686)
                 Uri uri = new Uri(ServerUri, @"admin/home/healthCheck.view");

--- a/pwiz_tools/Skyline/Util/PanoramaUtil.cs
+++ b/pwiz_tools/Skyline/Util/PanoramaUtil.cs
@@ -565,19 +565,17 @@ namespace pwiz.Skyline.Util
         {
             try
             {
-                Uri uri = new Uri(ServerUri, @"project/home/getContainers.view");
+                // Use the LabKey AdminController.HealthCheckAction instead of Project.GetContainersAction which does not return the expected
+                // JSON key if the "Home" container on the LabKey Server is not public.
+                // (https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=20686)
+                Uri uri = new Uri(ServerUri, @"admin/home/healthCheck.view");
                 using (var webClient = new UTF8WebClient())
                 {
                     JObject jsonResponse = webClient.Get(uri);
-                    string type = (string)jsonResponse[@"type"];
-                    if (string.Equals(type, @"project"))
-                    {
-                        return PanoramaState.panorama;
-                    }
-                    else
-                    {
-                        return PanoramaState.other;
-                    }
+                    var panoramaState = jsonResponse.ContainsKey(@"healthy")
+                        ? PanoramaState.panorama
+                        : PanoramaState.other;
+                    return panoramaState;
                 }
             }
             catch (WebException ex)


### PR DESCRIPTION
Call LabKey's AdminController.HealthCheckAction instead of ProjectController.GetContainersAction which does not return the expected JSON key if the "Home" container on the server is not public (https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=20686). 