### PR TITLE
Disable the part of TestDdaSearch that is intermittently failing on 32 bit TeamCity.

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -170,15 +171,22 @@ namespace pwiz.SkylineTestFunctional
             {
                 int proteinCount, peptideCount, precursorCount, transitionCount;
                 emptyProteinsDlg.NewTargetsAll(out proteinCount, out peptideCount, out precursorCount, out transitionCount);
-                Assert.AreEqual(1131, proteinCount);
-                Assert.AreEqual(61, peptideCount);
-                Assert.AreEqual(61, precursorCount);
-                Assert.AreEqual(183, transitionCount);
+                if (Environment.Is64BitProcess)
+                {
+                    // TODO: reenable these checks for 32 bit once intermittent failures are debugged
+                    Assert.AreEqual(1131, proteinCount);
+                    Assert.AreEqual(61, peptideCount);
+                    Assert.AreEqual(61, precursorCount);
+                    Assert.AreEqual(183, transitionCount);
+                }
                 emptyProteinsDlg.NewTargetsFinalSync(out proteinCount, out peptideCount, out precursorCount, out transitionCount);
-                Assert.AreEqual(57, proteinCount);
-                Assert.AreEqual(61, peptideCount);
-                Assert.AreEqual(61, precursorCount);
-                Assert.AreEqual(183, transitionCount);
+                if (Environment.Is64BitProcess)
+                {
+                    Assert.AreEqual(57, proteinCount);
+                    Assert.AreEqual(61, peptideCount);
+                    Assert.AreEqual(61, precursorCount);
+                    Assert.AreEqual(183, transitionCount);
+                }
                 emptyProteinsDlg.OkDialog();
             });
 


### PR DESCRIPTION
This change disables the asserts that are failing in TestDdaSearch on 32 bit TeamCity.
The rest of the test still runs as normal.