### PR TITLE
* fixed publish category for enzymes.xml and Instruments.xml

### DIFF
--- a/pwiz_tools/Skyline/Executables/Installer/SkylineInstaller/Product.wxs
+++ b/pwiz_tools/Skyline/Executables/Installer/SkylineInstaller/Product.wxs
@@ -361,6 +361,18 @@
       <Component Id="DualProbeInterfaceParametersCS.dll">
         <File Source="$(var.Skyline.TargetDir)/DualProbeInterfaceParametersCS.dll" KeyPath="yes"/>
       </Component>
+      <Component Id="enzymes.xml">
+        <File Source="$(var.Skyline.TargetDir)/enzymes.xml" KeyPath="yes"/>
+      </Component>
+      <Component Id="FHOOE_IMP.MSAmanda.Core.dll">
+        <File Source="$(var.Skyline.TargetDir)/FHOOE_IMP.MSAmanda.Core.dll" KeyPath="yes"/>
+      </Component>
+      <Component Id="FHOOE_IMP.MSAmanda.InOutput.dll">
+        <File Source="$(var.Skyline.TargetDir)/FHOOE_IMP.MSAmanda.InOutput.dll" KeyPath="yes"/>
+      </Component>
+      <Component Id="FHOOE_IMP.MSAmanda.Utils.dll">
+        <File Source="$(var.Skyline.TargetDir)/FHOOE_IMP.MSAmanda.Utils.dll" KeyPath="yes"/>
+      </Component>
       <?if $(sys.BUILDARCH) != x64 ?>
       <Component Id="fileio.dll">
         <File Source="$(var.Skyline.TargetDir)/fileio.dll" KeyPath="yes"/>
@@ -389,6 +401,9 @@
       </Component>
       <Component Id="Iesi.Collections.dll">
         <File Source="$(var.Skyline.TargetDir)/Iesi.Collections.dll" KeyPath="yes"/>
+      </Component>
+      <Component Id="Instruments.xml">
+        <File Source="$(var.Skyline.TargetDir)/Instruments.xml" KeyPath="yes"/>
       </Component>
       <?if $(sys.BUILDARCH) != x64 ?>
       <Component Id="Interop.DataExplorer.dll">

--- a/pwiz_tools/Skyline/Executables/Installer/SkylineInstaller/Product.wxs
+++ b/pwiz_tools/Skyline/Executables/Installer/SkylineInstaller/Product.wxs
@@ -909,9 +909,6 @@
       <Component Id="Method_Bruker_BDal.Submethod.Wrapper.dll">
         <File Source="$(var.Skyline.TargetDir)/Method\Bruker\BDal.Submethod.Wrapper.dll" KeyPath="yes"/>
       </Component>
-      <Component Id="Method_Bruker_BDal.Submethod.Wrapper.xml">
-        <File Source="$(var.Skyline.TargetDir)/Method\Bruker\BDal.Submethod.Wrapper.xml" KeyPath="yes"/>
-      </Component>
       <Component Id="Method_Bruker_BdalRetentionTimeMassList.dll">
         <File Source="$(var.Skyline.TargetDir)/Method\Bruker\BdalRetentionTimeMassList.dll" KeyPath="yes"/>
       </Component>

--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -226,7 +226,7 @@ namespace pwiz.Skyline.Model.DdaSearch
                         finally
                         {
                             SearchEngine.Dispose();
-                            amandaInputParser.Dispose();
+                            amandaInputParser?.Dispose();
                             amandaInputParser = null;
                         }
                     }

--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -108,8 +108,12 @@ namespace pwiz.Skyline.Model.DdaSearch
 
         private void Helper_SearchProgressChanged(string message)
         {
-            int percentProgress = CurrentFile * 100 / TotalFiles;
-            percentProgress += amandaInputParser.CurrentSpectrum * 100 / amandaInputParser.TotalSpectra / TotalFiles;
+            int percentProgress = 0;
+            if (amandaInputParser != null)
+            {
+                percentProgress = CurrentFile * 100 / TotalFiles;
+                percentProgress += amandaInputParser.CurrentSpectrum * 100 / amandaInputParser.TotalSpectra / TotalFiles;
+            }
             SearchProgressChanged?.Invoke(this, new ProgressStatus(message).ChangePercentComplete(percentProgress));
         }
 
@@ -223,6 +227,7 @@ namespace pwiz.Skyline.Model.DdaSearch
                         {
                             SearchEngine.Dispose();
                             amandaInputParser.Dispose();
+                            amandaInputParser = null;
                         }
                     }
                 }

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -4718,9 +4718,6 @@
     <Content Include="Method\Bruker\BDal.Submethod.Wrapper.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Method\Bruker\BDal.Submethod.Wrapper.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="Method\Bruker\BdalRetentionTimeMassList.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -5103,6 +5100,26 @@
   </ItemGroup>
   <ItemGroup>
     <PublishFile Include="BiblioSpec.pdb">
+      <Visible>False</Visible>
+      <Group>
+      </Group>
+      <TargetPath>
+      </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
+      <FileType>File</FileType>
+    </PublishFile>
+    <PublishFile Include="enzymes.xml">
+      <Visible>False</Visible>
+      <Group>
+      </Group>
+      <TargetPath>
+      </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
+      <FileType>File</FileType>
+    </PublishFile>
+    <PublishFile Include="Instruments.xml">
       <Visible>False</Visible>
       <Group>
       </Group>

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -39,6 +39,11 @@ namespace pwiz.SkylineTestFunctional
         public void TestDdaSearch()
         {
             TestFilesZip = @"TestFunctional\DdaSearchTest.zip";
+
+            // test error parsing an MSAmanda installed file (enzymes.xml)
+            //var skylineDir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            //File.Move(System.IO.Path.Combine(skylineDir, "enzymes.xml"), System.IO.Path.Combine(skylineDir, "not-the-enzymes-you-are-looking-for.xml"));
+
             RunFunctionalTest();
         }
 
@@ -65,7 +70,7 @@ namespace pwiz.SkylineTestFunctional
         }
 
         /// <summary>
-        /// Test that the "Match Modifications" page of the Import Peptide Search wizard gets skipped.
+        /// Quick test that DDA search works with MSAmanda.
         /// </summary>
         private void TestAmandaSearch()
         {

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -40,7 +40,8 @@ namespace pwiz.SkylineTestFunctional
         {
             TestFilesZip = @"TestFunctional\DdaSearchTest.zip";
 
-            // test error parsing an MSAmanda installed file (enzymes.xml)
+            // Test that correct error is issued when MSAmanda tries to parse a missing file (enzymes.xml)
+            // Automating this test turned out to be more difficult than I thought and not worth the effort.
             //var skylineDir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
             //File.Move(System.IO.Path.Combine(skylineDir, "enzymes.xml"), System.IO.Path.Combine(skylineDir, "not-the-enzymes-you-are-looking-for.xml"));
 


### PR DESCRIPTION
* fixed publish category for enzymes.xml and Instruments.xml (defaulted to Data File, overrode them to Include)
* fixed missing MSAmanda dependencies giving NRE instead of sensible error message
* removed Method\Bruker\BDal.Submethod.Wrapper.xml from Skyline project since it's an XMLDOC file for the corresponding assembly
