### PR TITLE
Move QualitativeIonRatio to the PrecursorResult.

### DIFF
--- a/pwiz_tools/Skyline/Model/Databinding/Entities/PeptideResult.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/PeptideResult.cs
@@ -39,7 +39,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
     public class PeptideResult : Result
     {
         private readonly CachedValue<PeptideChromInfo> _chromInfo;
-        private readonly CachedValue<PeptideQuantificationResult> _quantificationResult;
+        private readonly CachedValue<QuantificationResult> _quantificationResult;
         private readonly CachedValue<CalibrationCurveFitter> _calibrationCurveFitter;
 
         public PeptideResult(Peptide peptide, ResultFile file) : base(peptide, file)
@@ -189,11 +189,11 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             }
         }
 
-        public LinkValue<PeptideQuantificationResult> Quantification
+        public LinkValue<QuantificationResult> Quantification
         {
             get
             {
-                return new LinkValue<PeptideQuantificationResult>(_quantificationResult.Value, (sender, args) =>
+                return new LinkValue<QuantificationResult>(_quantificationResult.Value, (sender, args) =>
                 {
                     SkylineWindow skylineWindow = DataSchema.SkylineWindow;
                     if (skylineWindow != null)
@@ -206,7 +206,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             }
         }
 
-        private PeptideQuantificationResult GetQuantification()
+        private QuantificationResult GetQuantification()
         {
             return _calibrationCurveFitter.Value.GetPeptideQuantificationResult(ResultFile.Replicate.ReplicateIndex);
         }

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
@@ -543,6 +543,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             }
         }
 
+        [Format(Formats.PEAK_AREA_NORMALIZED)]
         public double? TargetQualitativeIonRatio
         {
             get

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
@@ -543,6 +543,15 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             }
         }
 
+        public double? TargetQualitativeIonRatio
+        {
+            get
+            {
+                var calibrationCurveFitter = Peptide.GetCalibrationCurveFitter();
+                return calibrationCurveFitter.GetTargetIonRatio(DocNode);
+            }
+        }
+
         [InvariantDisplayName("PrecursorLocator")]
         public string Locator { get { return GetLocator(); } }
 

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
@@ -543,7 +543,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             }
         }
 
-        [Format(Formats.PEAK_AREA_NORMALIZED)]
+        [Format(Formats.STANDARD_RATIO)]
         public double? TargetQualitativeIonRatio
         {
             get

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/PrecursorResult.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/PrecursorResult.cs
@@ -37,7 +37,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
     public class PrecursorResult : Result
     {
         private readonly CachedValue<TransitionGroupChromInfo> _chromInfo;
-        private readonly CachedValue<QuantificationResult> _quantificationResult;
+        private readonly CachedValue<PrecursorQuantificationResult> _quantificationResult;
         public PrecursorResult(Precursor precursor, ResultFile file) : base(precursor, file)
         {
             _chromInfo = CachedValue.Create(DataSchema, ()=>GetResultFile().FindChromInfo(precursor.DocNode.Results));
@@ -165,12 +165,11 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         [Format(NullValue = TextUtil.EXCEL_NA)]
         public string IonMobilityUnits { get { return IonMobilityFilter.IonMobilityUnitsL10NString(ChromInfo.IonMobilityInfo.IonMobilityUnits); } }
 
-        [ChildDisplayName("Precursor{0}")]
-        public LinkValue<QuantificationResult> PrecursorQuantification
+        public LinkValue<PrecursorQuantificationResult> PrecursorQuantification
         {
             get
             {
-                return new LinkValue<QuantificationResult>(_quantificationResult.Value, (sender, args) =>
+                return new LinkValue<PrecursorQuantificationResult>(_quantificationResult.Value, (sender, args) =>
                 {
                     SkylineWindow skylineWindow = DataSchema.SkylineWindow;
                     if (skylineWindow != null)
@@ -245,16 +244,11 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         {
             return !ChromInfo.RetentionTime.HasValue;
         }
-        private QuantificationResult GetQuantification()
+        private PrecursorQuantificationResult GetQuantification()
         {
             var calibrationCurveFitter = PeptideResult.GetCalibrationCurveFitter();
-            if (!calibrationCurveFitter.IsotopologResponseCurve)
-            {
-                return null;
-            }
             return calibrationCurveFitter.GetPrecursorQuantificationResult(GetResultFile().Replicate.ReplicateIndex,
                 Precursor.DocNode);
         }
-
     }
 }

--- a/pwiz_tools/Skyline/Model/Databinding/SkylineViewContext.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/SkylineViewContext.cs
@@ -523,6 +523,7 @@ namespace pwiz.Skyline.Model.Databinding
                     columnsToRemove.Add(PropertyPath.Root.Property("ExplicitCompensationVoltage"));
                     columnsToRemove.Add(PropertyPath.Root.Property("PrecursorConcentration"));
                     columnsToRemove.Add(PropertyPath.Root.Property(nameof(Precursor.AutoSelectTransitions)));
+                    columnsToRemove.Add(PropertyPath.Root.Property(nameof(Precursor.TargetQualitativeIonRatio)));
                     addRoot = true;
                 }
                 else if (columnDescriptor.PropertyType == typeof(Entities.Transition))

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/FiguresOfMerit.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/FiguresOfMerit.cs
@@ -37,9 +37,6 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         [Browsable(false)]
         public string Units { get; private set; }
 
-        [Format(Formats.STANDARD_RATIO, NullValue = TextUtil.EXCEL_NA)]
-        public double? TargetQualitativeIonRatio { get; private set; }
-
         public FiguresOfMerit ChangeLimitOfDetection(double? limitOfDetection)
         {
             return ChangeProp(ImClone(this), im => im.LimitOfDetection = limitOfDetection);
@@ -53,11 +50,6 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         public FiguresOfMerit ChangeUnits(string units)
         {
             return ChangeProp(ImClone(this), im => im.Units = units);
-        }
-
-        public FiguresOfMerit ChangeTargetQualitativeIonRatio(double? targetIonRatio)
-        {
-            return ChangeProp(ImClone(this), im => im.TargetQualitativeIonRatio = targetIonRatio);
         }
 
         public override string ToString()

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
@@ -98,35 +98,41 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         }
     }
 
-    public class PeptideQuantificationResult : QuantificationResult
+    public class PrecursorQuantificationResult : QuantificationResult
     {
         #region duplicate properties from base class to control the order they appear in Report Editor
         [Format(Formats.GLOBAL_STANDARD_RATIO, NullValue = TextUtil.EXCEL_NA)]
+        [InvariantDisplayName("PrecursorNormalizedArea")]
         public new double? NormalizedArea
         {
             get { return base.NormalizedArea; }
         }
 
         [Format(Formats.GLOBAL_STANDARD_RATIO, NullValue = TextUtil.EXCEL_NA)]
+        [InvariantDisplayName("PrecursorCalculatedConcentration")]
         public new double? CalculatedConcentration
         {
             get { return base.CalculatedConcentration; }
         }
 
         [Format(Formats.CV, NullValue = TextUtil.EXCEL_NA)]
+        [InvariantDisplayName("PrecursorAccuracy")]
         public new double? Accuracy
         {
             get { return base.Accuracy; }
         }
         #endregion
 
+        [InvariantDisplayName("BatchTargetQualitativeIonRatio")]
+        public double? TargetQualitativeIonRatio { get; private set; }
         public double? QualitativeIonRatio { get; private set; }
         public ValueStatus QualitativeIonRatioStatus { get; private set; }
 
-        public PeptideQuantificationResult ChangeIonRatio(double? ionRatio, ValueStatus ionRatioStatus)
+        public PrecursorQuantificationResult ChangeIonRatio(double? targetIonRatio, double? ionRatio, ValueStatus ionRatioStatus)
         {
             return ChangeProp(ImClone(this), im =>
             {
+                im.TargetQualitativeIonRatio = targetIonRatio;
                 im.QualitativeIonRatio = ionRatio;
                 im.QualitativeIonRatioStatus = ionRatioStatus;
             });

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
@@ -123,11 +123,11 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         }
         #endregion
 
-        [Format(Formats.PEAK_AREA_NORMALIZED)]
+        [Format(Formats.STANDARD_RATIO)]
         public double? QualitativeIonRatio { get; private set; }
         public ValueStatus QualitativeIonRatioStatus { get; private set; }
         [InvariantDisplayName("BatchTargetQualitativeIonRatio")]
-        [Format(Formats.PEAK_AREA_NORMALIZED)]
+        [Format(Formats.STANDARD_RATIO)]
         public double? TargetQualitativeIonRatio { get; private set; }
         public PrecursorQuantificationResult ChangeIonRatio(double? targetIonRatio, double? ionRatio, ValueStatus ionRatioStatus)
         {

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationResult.cs
@@ -123,11 +123,12 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         }
         #endregion
 
-        [InvariantDisplayName("BatchTargetQualitativeIonRatio")]
-        public double? TargetQualitativeIonRatio { get; private set; }
+        [Format(Formats.PEAK_AREA_NORMALIZED)]
         public double? QualitativeIonRatio { get; private set; }
         public ValueStatus QualitativeIonRatioStatus { get; private set; }
-
+        [InvariantDisplayName("BatchTargetQualitativeIonRatio")]
+        [Format(Formats.PEAK_AREA_NORMALIZED)]
+        public double? TargetQualitativeIonRatio { get; private set; }
         public PrecursorQuantificationResult ChangeIonRatio(double? targetIonRatio, double? ionRatio, ValueStatus ionRatioStatus)
         {
             return ChangeProp(ImClone(this), im =>

--- a/pwiz_tools/Skyline/Model/GroupComparison/PeptideQuantifier.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/PeptideQuantifier.cs
@@ -182,31 +182,28 @@ namespace pwiz.Skyline.Model.GroupComparison
             return totalArea;
         }
 
-        public double? GetQualitativeIonRatio(SrmSettings settings, int replicateIndex)
+        public double? GetQualitativeIonRatio(SrmSettings settings, TransitionGroupDocNode precursor, int replicateIndex)
         {
             double numerator = 0;
             int numeratorCount = 0;
             double denominator = 0;
             int denominatorCount = 0;
-            foreach (var precursor in PeptideDocNode.TransitionGroups)
+            foreach (var transition in precursor.Transitions)
             {
-                foreach (var transition in precursor.Transitions)
+                var quantity = GetTransitionQuantity(settings, null, NormalizationMethod.NONE, replicateIndex,
+                    precursor, transition, false);
+                if (quantity != null)
                 {
-                    var quantity = GetTransitionQuantity(settings, null, NormalizationMethod.NONE, replicateIndex,
-                        precursor, transition, false);
-                    if (quantity != null)
+                    double value = quantity.Intensity / quantity.Denominator;
+                    if (transition.ExplicitQuantitative)
                     {
-                        double value = quantity.Intensity / quantity.Denominator;
-                        if (transition.ExplicitQuantitative)
-                        {
-                            denominator += value;
-                            denominatorCount++;
-                        }
-                        else
-                        {
-                            numerator += value;
-                            numeratorCount++;
-                        }
+                        denominator += value;
+                        denominatorCount++;
+                    }
+                    else
+                    {
+                        numerator += value;
+                        numeratorCount++;
                     }
                 }
             }

--- a/pwiz_tools/Skyline/TestFunctional/QualitativeIonRatioTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/QualitativeIonRatioTest.cs
@@ -64,17 +64,18 @@ namespace pwiz.SkylineTestFunctional
                     .Property(nameof(Protein.Peptides)).LookupAllItems();
                 columnsTab.AddColumn(ppPeptides);
                 columnsTab.AddColumn(PropertyPath.Root.Property(nameof(SkylineDocument.Replicates)).LookupAllItems());
-                columnsTab.AddColumn(ppPeptides.Property(nameof(Peptide.FiguresOfMerit)).Property(nameof(FiguresOfMerit.TargetQualitativeIonRatio)));
-                PropertyPath ppPeptideResults =
-                    ppPeptides.Property(nameof(Peptide.Results)).DictionaryValues();
-                PropertyPath ppQuantification = ppPeptideResults.Property(nameof(PeptideResult.Quantification));
-                columnsTab.AddColumn(ppQuantification.Property(nameof(PeptideQuantificationResult.QualitativeIonRatio)));
-                columnsTab.AddColumn(ppQuantification.Property(nameof(PeptideQuantificationResult.QualitativeIonRatioStatus)));
+                PropertyPath ppPrecursors = ppPeptides.Property(nameof(Peptide.Precursors)).LookupAllItems();
+                columnsTab.AddColumn(ppPrecursors.Property(nameof(Precursor.TargetQualitativeIonRatio)));
+                PropertyPath ppPrecursorResults =
+                    ppPrecursors.Property(nameof(Precursor.Results)).DictionaryValues();
+                PropertyPath ppQuantification = ppPrecursorResults.Property(nameof(PrecursorResult.PrecursorQuantification));
+                columnsTab.AddColumn(ppQuantification.Property(nameof(PrecursorQuantificationResult.QualitativeIonRatio)));
+                columnsTab.AddColumn(ppQuantification.Property(nameof(PrecursorQuantificationResult.QualitativeIonRatioStatus)));
                 viewEditor.ViewName = "IonRatios";
                 viewEditor.OkDialog();
             });
             WaitForConditionUI(() => documentGrid.IsComplete);
-            PropertyPath ppTargetIonRatio = PropertyPath.Root.Property(nameof(Peptide.FiguresOfMerit)).Property(nameof(FiguresOfMerit.TargetQualitativeIonRatio));
+            PropertyPath ppTargetIonRatio = PropertyPath.Root.Property(nameof(Precursor.TargetQualitativeIonRatio));
             RunUI(() =>
             {
                 var colTargetIonRatio = documentGrid.FindColumn(ppTargetIonRatio);
@@ -105,15 +106,17 @@ namespace pwiz.SkylineTestFunctional
             });
             RunUI(() =>
             {
-                var ppPeptideResults = PropertyPath.Root.Property(nameof(Peptide.Results))
+                var ppPrecursorResults = PropertyPath.Root.Property(nameof(Precursor.Results))
                     .DictionaryValues();
-                var ppIonRatio = ppPeptideResults
-                    .Property(nameof(PeptideResult.Quantification))
-                    .Property(nameof(PeptideQuantificationResult.QualitativeIonRatio));
-                var ppReplicate = ppPeptideResults.Property(nameof(PeptideResult.ResultFile))
+                var ppIonRatio = ppPrecursorResults
+                    .Property(nameof(PrecursorResult.PrecursorQuantification))
+                    .Property(nameof(PrecursorQuantificationResult.QualitativeIonRatio));
+                var ppReplicate = ppPrecursorResults
+                    .Property(nameof(PrecursorResult.PeptideResult))
+                    .Property(nameof(PeptideResult.ResultFile))
                     .Property(nameof(ResultFile.Replicate));
                 var colIonRatio = documentGrid.DataboundGridControl.FindColumn(ppIonRatio);
-                var colPeptide = documentGrid.DataboundGridControl.FindColumn(PropertyPath.Root);
+                var colPeptide = documentGrid.DataboundGridControl.FindColumn(PropertyPath.Root.Property(nameof(Precursor.Peptide)));
                 var colReplicate = documentGrid.DataboundGridControl.FindColumn(ppReplicate);
                 for (int iRow = 0; iRow < documentGrid.RowCount; iRow++)
                 {

--- a/pwiz_tools/Skyline/TestFunctional/SingleReplicateResponseCurveTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SingleReplicateResponseCurveTest.cs
@@ -199,7 +199,7 @@ namespace pwiz.SkylineTestFunctional
                     var replicateCalibrationCurve =
                         (LinkValue<CalibrationCurve>) row.Cells[colReplicateCalibrationCurve.Index].Value;
                     var quantificationResult =
-                        (LinkValue<QuantificationResult>) row.Cells[colQuantificationResult.Index].Value;
+                        (LinkValue<PrecursorQuantificationResult>) row.Cells[colQuantificationResult.Index].Value;
                     var precursor = (Precursor) row.Cells[colPrecursor.Index].Value;
                     var precursorResult = (PrecursorResult) row.Cells[colPrecursorResult.Index].Value;
                     var totalArea = precursorResult.TotalArea;


### PR DESCRIPTION
It used to be on the PeptideResult, but based on user feedback, it needs to be a precursor level value.
(Reported by Jeffrey)