### PR TITLE
Fix intermittent failure in PasteMoleculesTest.

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -719,7 +719,7 @@ namespace pwiz.SkylineTestFunctional
                     "Proteins!*.Peptides!*.HMDB",
                     "Proteins!*.Peptides!*.SMILES",
                     "Proteins!*.Peptides!*.CAS",
-                    "Proteins!*.Peptides!*.KEGG"});
+                    "Proteins!*.Peptides!*.KEGG"}, null, 32);
                 const double explicitCE2= 123.45;
                 var colCE = FindDocumentGridColumn(documentGrid, "ExplicitCollisionEnergy");
                 RunUI(() => documentGrid.DataGridView.Rows[0].Cells[colCE.Index].Value = explicitCE2);


### PR DESCRIPTION
The expected row count is 32 (since the view gets changed to include some Transition columns), but the test usually succeeds because the number of rows is initially 16, and never notices that the row count is wrong.
This test has been intermittently failing since April 2019.