### PR TITLE
Skyline/work/20200823 autoqc

### DIFF
--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/App.config
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/App.config
@@ -46,7 +46,7 @@
     </startup>
     <userSettings>
         <AutoQC.Properties.Settings>
-            <setting name="SkylineCmdLineExePath" serializeAs="String">
+            <setting name="SkylineInstallDir" serializeAs="String">
                 <value />
             </setting>
             <setting name="SkylineType" serializeAs="String">

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/MainForm.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/MainForm.cs
@@ -74,26 +74,26 @@ namespace AutoQC
         
         private void UpdateSkylineTypeAndInstallPathControls()
         {
+            if (!SkylineSettings.IsInitialized())
+            {
+                return;
+            }
+
             radioButtonUseSkyline.Checked = SkylineSettings.UseSkyline;
             radioButtonUseSkylineDaily.Checked = !SkylineSettings.UseSkyline;
-            
-            if (SkylineSettings.UseClickOnceInstaller)
-            {
-                radioButtonWebBasedSkyline.Checked = true;
-                textBoxSkylinePath.Text = string.Empty;
-            }
-            else
-            {
-                radioButtonSpecifySkylinePath.Checked = true;
-                textBoxSkylinePath.Text = SkylineSettings.GetSkylineCmdExeDir;
-                textBoxSkylinePath.Enabled = true;
-                buttonFileDialogSkylineInstall.Enabled = true;
-            }
+
+            var useClickOnce = SkylineSettings.UseClickOnceInstall;
+            radioButtonWebBasedSkyline.Checked = useClickOnce;
+            radioButtonSpecifySkylinePath.Checked = !useClickOnce;
+            textBoxSkylinePath.Text = SkylineSettings.SkylineInstallDir;
+
+            textBoxSkylinePath.Enabled = !useClickOnce;
+            buttonFileDialogSkylineInstall.Enabled = !useClickOnce;
         }
 
         public static string GetExePath()
         {
-            return SkylineSettings.GetSkylineCmdExePath;
+            return SkylineSettings.GetSkylineCmdLineExePath;
         }
 
         private void ReadSavedConfigurations()
@@ -1009,13 +1009,14 @@ namespace AutoQC
             Settings.Default.Save();
         }
 
-        private void ApplyChangesToSkylineSettings()
+        private bool ApplyChangesToSkylineSettings()
         {
             if (!SkylineSettings.UpdateSettings(radioButtonUseSkyline.Checked, radioButtonWebBasedSkyline.Checked,
                 textBoxSkylinePath.Text, out var errors))
             {
                 ShowWarningDialog("Cannot Update Skyline Settings", errors);
-                UpdateSkylineTypeAndInstallPathControls();
+                UpdateSkylineTypeAndInstallPathControls(); // Reset controls to saved settings
+                return false;
             }
             else
             {
@@ -1025,6 +1026,8 @@ namespace AutoQC
                 }
                 ShowInfoDialog("Skyline Settings Updated", "Skyline settings were updated successfully!");
             }
+
+            return true;
         }
 
         private void buttonFileDialogSkylineInstall_click(object sender, EventArgs e)
@@ -1068,6 +1071,7 @@ namespace AutoQC
                     ShowErrorDialog("Skyline Settings Not Initialized", 
                         "An installation of Skyline or Skyline-daily is required to use AutoQC Loader. Please select Skyline installation details to continue.");
                     e.Cancel = true;
+                    return;
                 }
                 if (SkylineSettings.SettingsChanged(radioButtonUseSkyline.Checked, radioButtonWebBasedSkyline.Checked,
                     textBoxSkylinePath.Text))
@@ -1076,7 +1080,10 @@ namespace AutoQC
                         "Unsaved Skyline Settings", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                     if (result == DialogResult.Yes)
                     {
-                        ApplyChangesToSkylineSettings();
+                        if (!ApplyChangesToSkylineSettings())
+                        {
+                            e.Cancel = true;
+                        };
                     }
                     else
                     {

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/MainForm.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/MainForm.cs
@@ -774,6 +774,7 @@ namespace AutoQC
             if (SkylineSettings.IsInitialized())
             {
                 UpdateSkylineTypeAndInstallPathControls();
+                Program.LogInfo(new StringBuilder("Skyline settings are: ").Append(SkylineSettings.GetSkylineSettingsStr()).ToString());
             }
             else
             {

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/Program.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/Program.cs
@@ -78,8 +78,15 @@ namespace AutoQC
                 // Initialize log4net -- global application logging
                 XmlConfigurator.Configure();
 
-//                var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
-//                Console.WriteLine("Local user config path: {0}", config.FilePath);
+                try
+                {
+                    var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
+                    LogInfo(string.Format("user.config path: {0}", config.FilePath));
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
 
                 InitSkylineSettings();
 

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AutoQC.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -26,12 +26,12 @@ namespace AutoQC.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string SkylineCmdLineExePath {
+        public string SkylineInstallDir {
             get {
-                return ((string)(this["SkylineCmdLineExePath"]));
+                return ((string)(this["SkylineInstallDir"]));
             }
             set {
-                this["SkylineCmdLineExePath"] = value;
+                this["SkylineInstallDir"] = value;
             }
         }
         

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/Properties/Settings.settings
@@ -2,11 +2,11 @@
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="AutoQC.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
-    <Setting Name="SkylineCmdLineExePath" Type="System.String" Scope="User">
-      <Value Profile="(Default)"> </Value>
+    <Setting Name="SkylineInstallDir" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
     </Setting>
     <Setting Name="SkylineType" Type="System.String" Scope="User">
-      <Value Profile="(Default)"> </Value>
+      <Value Profile="(Default)" />
     </Setting>
   </Settings>
 </SettingsFile>

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/SkylineSettings.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/SkylineSettings.cs
@@ -130,6 +130,13 @@ namespace AutoQC
             Settings.Default.SkylineType = skylineType;
             Settings.Default.SkylineCmdLineExePath = skylineCmdLineExePath;
             Settings.Default.Save();
+            Program.LogInfo(new StringBuilder("Skyline settings changed. ").Append(GetSkylineSettingsStr()).ToString());
+        }
+
+        public static string GetSkylineSettingsStr()
+        {
+            return new StringBuilder().Append($"Skyline type: {Settings.Default.SkylineType}; ")
+                .Append($"Skyline command-line exe: {Settings.Default.SkylineCmdLineExePath}").ToString();
         }
 
         public static bool UpdateSettings(bool useSkyline, bool useClickOnceInstaller, string installDir,


### PR DESCRIPTION
- save path to Skyline install directory, if the ClickOnce install will not be used, instead of path to SkylineCmd.exe or SkylineRunner.exe. SkylineRunner path will change across program upgrades
- stay on the Settings tab if user tries to switch to another tab without saving and Skyline settings entered are not valid.
- logging updates