### PR TITLE
MSAmanda fixes

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/DDASearchControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/DDASearchControl.cs
@@ -91,11 +91,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         public async void RunSearch()
         {
-            if (string.IsNullOrEmpty(txtSearchProgress.Text))
-            {
-                //search for first time
-                ImportPeptideSearch.SearchEngine.SearchProgressChanged += SearchEngine_MessageNotificationEvent;
-            }
+            ImportPeptideSearch.SearchEngine.SearchProgressChanged += SearchEngine_MessageNotificationEvent;
             txtSearchProgress.Text = string.Empty;
             _progressTextItems.Clear();
             btnCancel.Enabled = true;
@@ -123,6 +119,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             UpdateTaskbarProgress(TaskbarProgress.TaskbarStates.NoProgress, 0);
             btnCancel.Enabled = false;
             OnSearchFinished?.Invoke(t.Result);
+            ImportPeptideSearch.SearchEngine.SearchProgressChanged -= SearchEngine_MessageNotificationEvent;
         }
 
         private void SearchEngine_MessageNotificationEvent(object sender, IProgressStatus status)
@@ -133,10 +130,15 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             }
         }
 
-        private void btnCancel_Click(object sender, EventArgs e)
+        public void Cancel()
         {
             cancelToken.Cancel();
             btnCancel.Enabled = false;
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            Cancel();
         }
 
         private void showTimestampsCheckbox_CheckedChanged(object sender, EventArgs e)

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -469,6 +469,8 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                         }
                         else
                         {
+                            ImportPeptideSearch.SpectrumSourceFiles.Clear();
+
                             // in PerformDDA mode, set SpectrumSourceFiles and offer to remove prefix
                             for (int i = 0; i < BuildPepSearchLibControl.DdaSearchDataSources.Length; ++i)
                             {

--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -299,7 +299,7 @@ namespace pwiz.Skyline.Model.DdaSearch
         private Modification GenerateNewModification(StaticMod mod, char a)
         {
             return new Modification(mod.ShortName ?? mod.Name, mod.Name, mod.MonoisotopicMass ?? 0.0,
-                mod.AverageMass ?? 0.0, a, !mod.IsVariable, mod.Losses?.Select(l => l.MonoisotopicMass)?.ToArray() ?? new double[0],
+                mod.AverageMass ?? 0.0, a, !mod.IsVariable, mod.Losses?.Select(l => l.MonoisotopicMass).ToArray() ?? new double[0],
                 mod.Terminus.HasValue && mod.Terminus.Value == ModTerminus.N,
                 mod.Terminus.HasValue && mod.Terminus.Value == ModTerminus.C,
                 mod.UnimodId ?? 0, false);

--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -298,8 +298,8 @@ namespace pwiz.Skyline.Model.DdaSearch
 
         private Modification GenerateNewModification(StaticMod mod, char a)
         {
-            return new Modification(mod.ShortName, mod.Name, mod.MonoisotopicMass ?? 0.0,
-                mod.AverageMass ?? 0.0, a, !mod.IsVariable, mod.Losses.Select(l => l.MonoisotopicMass).ToArray(),
+            return new Modification(mod.ShortName ?? mod.Name, mod.Name, mod.MonoisotopicMass ?? 0.0,
+                mod.AverageMass ?? 0.0, a, !mod.IsVariable, mod.Losses?.Select(l => l.MonoisotopicMass)?.ToArray() ?? new double[0],
                 mod.Terminus.HasValue && mod.Terminus.Value == ModTerminus.N,
                 mod.Terminus.HasValue && mod.Terminus.Value == ModTerminus.C,
                 mod.UnimodId ?? 0, false);


### PR DESCRIPTION
- fixed non-Unimod mods causing errors in MSAmanda
- fixed error caused by going back from DDA settings page to spectra page, changing input files, and forward again
* fixed search engine UIUpdate not connecting after the first time the DDASearchControl is shown
* added test for canceling search, adding another spectrum file, and starting search again

@brendanx67 I assume you'll want these in 20.2 as well?