### PR TITLE
Fix exception in Import Peptide Search if regression has failed

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -1534,7 +1534,12 @@ namespace pwiz.Skyline.Model.Lib
                 }
                 var alignedTime = measuredTime.RetentionTime;
                 if (fileAlignment != null)
-                    alignedTime = fileAlignment.RegressionRefined.Conversion.GetY(alignedTime);
+                {
+                    if (fileAlignment.RegressionRefined != null)
+                    {
+                        alignedTime = fileAlignment.RegressionRefined.Conversion.GetY(alignedTime);
+                    }
+                }
                 peptideTimes.Add(alignedTime);
             }
         }


### PR DESCRIPTION
A user reported an exception (in Skyline 20.1) where they were getting a NullReferenceException in BiblioSpecLiteLibrary.AddAlignedRetentionTimes.
https://skyline.ms/announcements/home/issues/exceptions/thread.view?rowId=48174  
The files necessary to reproduce this bug are here:
/net/maccoss/vol6/home/nicksh/bugs/AddIrtsNullReference

This seems to happen if Skyline successfully gets a retention time alignment between two runs, but then Skyline is unable to refine the regression enough to get past the R-squared threshold.

I believe the correct fix is to not try to align the retention times in this case, and just use the original times.

I could imagine that the fix might be to use fileAlignments.Regression if fileAlignments.RegressionRefined is null, but that's probably not a good thing do do.

I will port this fix to the 20.2 branch after I commit it to master.