### PR TITLE
Change "psi-ms.obo" and "unimod.obo" to be "links" in Skyline.csproj …

### DIFF
--- a/pwiz_tools/Skyline/Jamfile.jam
+++ b/pwiz_tools/Skyline/Jamfile.jam
@@ -222,9 +222,6 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
         ) > "$(<)"
     }
 
-    make unimod.obo : ../../pwiz/data/common/unimod.obo : @common.copy : <location>$(SKYLINE_PATH) ;
-    make psi-ms.obo : ../../pwiz/data/common/psi-ms.obo : @common.copy : <location>$(SKYLINE_PATH) ;
-
     rule build-location ( properties * )
     {
         local result ;
@@ -280,8 +277,6 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
             <dependency>../../pwiz_tools/BiblioSpec/src//BlibBuild/<location>$(BIBLIO_SPEC_PATH)/obj/$(PLATFORM)
             <dependency>../../pwiz_tools/BiblioSpec/src//BlibFilter/<location>$(BIBLIO_SPEC_PATH)/obj/$(PLATFORM)
             <dependency>../../pwiz_tools/BiblioSpec/src//BlibToMs2/<location>$(BIBLIO_SPEC_PATH)/obj/$(PLATFORM)
-            <dependency>unimod.obo
-            <dependency>psi-ms.obo
     ;
 
     make InspectCode

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -3071,9 +3071,6 @@
     <EmbeddedResource Include="Resources\StartPage\WizardPeptideSearchPRM.png" />
     <EmbeddedResource Include="Resources\Ions_fragments.bmp" />
     <EmbeddedResource Include="Resources\Edit_Undo_Multiple.bmp" />
-    <Content Include="unimod.obo">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Protobuf Include="ProtocolBuffers\model.proto" />
     <Protobuf Include="ProtocolBuffers\predict.proto" />
     <Protobuf Include="ProtocolBuffers\prediction_service.proto" />
@@ -3084,11 +3081,16 @@
     <EmbeddedResource Include="Model\Prosit\Config\PrositConfig.xml">
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <None Include="Model\Prosit\Config\PrositConfig_development.xml" />
-    <None Include="Model\Prosit\Config\UpdatePrositConfiguration.bat" />
-    <Content Include="psi-ms.obo">
+    <Content Include="..\..\pwiz\data\common\psi-ms.obo">
+      <Link>psi-ms.obo</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\pwiz\data\common\unimod.obo">
+      <Link>unimod.obo</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <None Include="Model\Prosit\Config\PrositConfig_development.xml" />
+    <None Include="Model\Prosit\Config\UpdatePrositConfiguration.bat" />
     <None Include="Resources\Locked.bmp" />
     <EmbeddedResource Include="Resources\MoleculeLib.bmp" />
     <None Include="Resources\MoleculeStandard.bmp" />


### PR DESCRIPTION
…so they do not need to be copied by the jamfile.

I noticed that the files "unimod.obo" and "psi-ms.obo" always show up in pwiz_tools\Skyline source tree as new files.

This change makes it so that Skyline.csproj references those files in "..\..\pwiz\data\common" as Visual Studio project linked files, so they do not need to be copied.

I think this fix works perfectly, but if it turns out that there really is some reason they need to get copied then we should update .gitignore.