### PR TITLE
- replaced Shimadzu DataReader with IoModule for MRM files

### DIFF
--- a/pwiz/data/vendor_readers/Shimadzu/ChromatogramList_Shimadzu.cpp
+++ b/pwiz/data/vendor_readers/Shimadzu/ChromatogramList_Shimadzu.cpp
@@ -120,7 +120,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Shimadzu::chromatogram(size_t ind
             result->precursor.isolationWindow.set(MS_isolation_window_target_m_z, ci.transition.Q1, MS_m_z);
             result->precursor.activation.set(MS_CID);
             result->precursor.activation.set(MS_collision_energy, ci.transition.collisionEnergy, UO_electronvolt);
-            result->set(ci.transition.polarity != 1 ? MS_positive_scan : MS_negative_scan);
+            result->set(ci.transition.polarity == pwiz::vendor_api::Shimadzu::Positive ? MS_positive_scan : MS_negative_scan);
 
             result->product.isolationWindow.set(MS_isolation_window_target_m_z, ci.transition.Q3, MS_m_z);
             //result->product.isolationWindow.set(MS_isolation_window_lower_offset, ci.q3Offset, MS_m_z);
@@ -131,7 +131,7 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Shimadzu::chromatogram(size_t ind
 
             if (getBinaryData)
             {
-                result->setTimeIntensityArrays(vector<double>(), vector<double>(), UO_minute, MS_number_of_detector_counts);
+                result->setTimeIntensityArrays(vector<double>(), vector<double>(), UO_second, MS_number_of_detector_counts);
                 chromatogramPtr->getXArray(result->getTimeArray()->data);
                 chromatogramPtr->getYArray(result->getIntensityArray()->data);
                 result->defaultArrayLength = result->getTimeArray()->data.size();
@@ -150,16 +150,13 @@ PWIZ_API_DECL void ChromatogramList_Shimadzu::createIndex() const
 {
     const set<SRMTransition>& transitions = rawfile_->getTransitions();
 
-    if (transitions.empty()) // MRM file reading interface doesn't provide TIC
-    {
-        // support file-level TIC for all file types
-        index_.push_back(IndexEntry());
-        IndexEntry& ci = index_.back();
-        ci.index = index_.size() - 1;
-        ci.chromatogramType = MS_TIC_chromatogram;
-        ci.id = "TIC";
-        idMap_[ci.id] = ci.index;
-    }
+    // support file-level TIC for all file types
+    index_.push_back(IndexEntry());
+    IndexEntry& ci = index_.back();
+    ci.index = index_.size() - 1;
+    ci.chromatogramType = MS_TIC_chromatogram;
+    ci.id = "TIC";
+    idMap_[ci.id] = ci.index;
 
     for (const SRMTransition& transition : transitions)
     {

--- a/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/20140312_六mix_column_1 (scheduled) 一个试-centroid.mzML
+++ b/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/20140312_六mix_column_1 (scheduled) 一个试-centroid.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="20140312_六mix_column_1 (scheduled) 一个试" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.41" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -20,7 +20,7 @@
     <software id="Shimadzu_x0020_software" version="4.0">
       <cvParam cvRef="MS" accession="MS:1001557" name="Shimadzu Corporation software" value=""/>
     </software>
-    <software id="pwiz" version="3.0.19326">
+    <software id="pwiz" version="3.0.20255">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -59,9 +59,26 @@
       </processingMethod>
     </dataProcessing>
   </dataProcessingList>
-  <run id="_x0032_0140312__x00e5__x0085__x00ad_mix_column_1_x0020__x0028_scheduled_x0029__x0020__x00e4__x00b8__x0080__x00e4__x00b8__x00aa__x00e8__x00af__x0095_" defaultInstrumentConfigurationRef="IC1" defaultSourceFileRef="_x0032_0140312__x00e5__x0085__x00ad_mix_column_1_x0020__x0028_scheduled_x0029__x0020__x00e4__x00b8__x0080__x00e4__x00b8__x00aa__x00e8__x00af__x0095_.lcd">
-    <chromatogramList count="143" defaultDataProcessingRef="pwiz_Reader_Shimadzu_conversion">
-      <chromatogram index="0" id="SRM SIC Q1=1059 Q3=244.15 Channel=1 Event=1 Segment=1 CE=50.6" defaultArrayLength="238">
+  <run id="_x0032_0140312__x00e5__x0085__x00ad_mix_column_1_x0020__x0028_scheduled_x0029__x0020__x00e4__x00b8__x0080__x00e4__x00b8__x00aa__x00e8__x00af__x0095_" defaultInstrumentConfigurationRef="IC1" startTimeStamp="2014-03-12T06:03:16Z" defaultSourceFileRef="_x0032_0140312__x00e5__x0085__x00ad_mix_column_1_x0020__x0028_scheduled_x0029__x0020__x00e4__x00b8__x0080__x00e4__x00b8__x00aa__x00e8__x00af__x0095_.lcd">
+    <chromatogramList count="144" defaultDataProcessingRef="pwiz_Reader_Shimadzu_conversion">
+      <chromatogram index="0" id="TIC" defaultArrayLength="2605">
+        <cvParam cvRef="MS" accession="MS:1000235" name="total ion current chromatogram" value=""/>
+        <binaryDataArrayList count="2">
+          <binaryDataArray encodedLength="11508">
+            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNl3lYlIf5tWeGYRisNcbaGGuMtYZYP2KtMdYYa+D1PDHEGmOsodYYREREFBERURHZN9lklV32fZdNBJRNBEQEpMb4M8RYY22MsUZ2xO/8kSvXpckMPO/93ucclUqlMtGpPzTReX+4KriJ/1ablXy80GxVsGLW1LnLjH9u9ujtSP5ZupmLfTn/vMlsMr+Xf3fPzP/H//Hv1eaBrxmbP3r7VfONq+aa8/81n7ltibmL/XLzgWOrzfk55okJn5hP5n9ublX3T3N+pvmiO/vM/X90Nn84cdycn29uOcOfnxFsXvtmGD8n0nzeslh+VoK5h1kKPy/dfPCzbH5mvvk662J+brl51qEqfvYFc513Az+/ydw+so3f0WHeld7N7+k1X1oxwO+6bR7RfJffd8/8Wd8Dfucj8633f+L3/s+8+pchfveY+VztFL9fraydZqBYzjBUnGYZKfxdlLTf/UqpffPXSu8fXlH4eyka098o85b9VlmxYo7C31GxXTNP8TCbr8RhgcLfV2n/2yJl8DMTZfTvixX+7sqSHabKOuulynbbZQrvoIQcWKFkHVqp1B9ZpfAmypOTaxSd91plgb+Zwvsom8Og2Ed+pHjHfqzwVkpFyt+UrvRPlfvZnym8mzK75O/K0oovlPXV/1B4Q8Wt8UslovkrJe/KToX3VG5f360869ujTLu1V+FtlTWD+5Wt9x0Vx4dOCu+spP7solT/4qr0jLgpvLmiUp1U5mpP8R8vhfdXlut9eANfZcN0P97BX7GZGcBbBCrus4N4j2Al+vXTvEmIUvRGKO8SprT9Ppy3iVDuvnWG94lUhv8YxRtFKzOWxvBOscri5XG81VnFbGU875WgbFudyJslKc5rk3m3FCVYSeXtzikZH6XxfulK3ScZvGGm0v9pFu+YrTz+PIe3zFW0lnm8Z74yf3sBb1qorLQq4l2LlU02JbxtqWJnV8b7liueDhW88Xkl/mAl71yllB2u5q1rlI6jtbz3BeXeiTre/KIyfqqed29QZvk28vaXFNPAy7x/kyIhzXwGLcqOiFY+hzbFNfoKn0W7Enb2Kp9Hh5KT1Mln0qU0nrvG59Kt3Mq8zmfTozzNvcHn06voi/r4jPqVhWU3+ZwGlNWV/+KzuqVsqf2az+u24lD/DZ/ZHcX38v/xud1Vklu/5bMbVCqvfsfnd0/pvvY9n+F95cGNf/M5PlCmbv7AZ/lQmXP7P3yej5Rld//LZ/qjYnHvMZ/rT4r1gydKoKUVIh2tkOxnhZwkK5RVWKGuwwpt31mhZ8QKt2fsxH2TnXjy150Y/ftOaPbvxHSfnZiTsBMLy3bCtH0nVn67E2ZDO7FhujW2LrKG1QfWsP/cGi721qgMssZwnjVWdVhj3XfW2DhiDcsZu2BtsgsZH+3C/T27YBKwC8tSdmF15S5I1y5s+n4XIjQ26P2DDWbBBvO328DqhA20cTaYUWyDua02WHTHBrYTNsiZtxsP1+zGsy27scJlN26H78b97N14Ur8bo/27sfr5brjPtkX9e7Zo/5st9AdsURJoi9pUW7RU2aL7mi1m/GSLzb/eg8ile5Ase3DXdg98vfYg7OwexJfsQUbbHtx/sAcmOjvYvW0H57V2qPjKDtuO2yExwQ5ZZXYoabdD7bd2GJ+yw5oFe+FhtheBlnvRcXQvnKL28q57ede9vOte3nUvZr5ujy3v2yN6mz1SnewxGGEP/0J7tHfZo/d7e9wZs8eDmfuwePk+3nIfCpz38Zb7eMt9SG7dh7v/3oeHE/vwbJYDJpc4YO0GB3g6OKDptAO60h0wvdkBFXcd8PyFA6Zm74f+nf285X5s3b0fcb77cStzP+7V7ecd96NjeD+mzTmA2X86gAUfHcCSHQfgcPIAipIP8I4HeMcDvOMBDL7iiIV/doTpx45YaeUIM1dHeMc68o6O0P7LkXd05B0PYviPB7Hqk4NYZ30QG90OwjL8IO94ELevH8S8nw/yjk68oxOmr3PCJhsn3tEJNmec4JjrxDs64elDJyzXH+IdD/GOh7Doy0OwdT/EOx7C8fxD8L18iHc8BJ3aGRYLnXlHZ97RGauPOMM9xpl3dEZEszMSbzvzjs6Y/7vDZPIw73iYdzyMzWGHEVl8mEweJpOHyeRhMumC+D+54PYmF8xzciGTLrDLceEdXcijC+/owjse4R2P8I5HeMcjvOMR3vEI73iEdzzCOx7hHV1R9q4r6j5xRZu1K3rcXDEz3hVbal0R/bUrUn925R2Pwt/0KHk8Cse9R+F26ijveBQhRUfJ41He8Sjv6Ibtb7mRRzfe0Y08umFJshtWnHfD2k43WNxzQ7D6GLoWHuMdj2HOP4/xjscwFXMMZlXH8ODGMd7xGHk8Bu1rx7H+L8fJ43HyeBz9Yccxu+Q4eTyOyUfHkWF4AkVvnED1ihNo2nCC7/gJSMgJ3vEE73iCPJ6A29QJ1L7pzju6847ufLfd4eHpjsZz7lBdducd3XlHd4TNOYkVK07C9e8neceTvONJvtsn+W6fhPvNk6h/fpJ39OAdPbBhowee7vXA8iAP3tGDd/TA414PDP/HA6uMT+H4klO84yne8RR03qfI4ynyeIp3PMU7nkKezhMV8z3xfK0nefTkHT15R0/y6An7Xk8U/M+T/40Xls7y4n/nhVVLvLBttReOf+KFxH96YcEeLzLshVm+XlgR7QVduhefgRdm1nohrsUL1f1euHXfC6O/eMHjpRdSX/GG83xvesIbtmu88Wi9N5y2eOP5V96YfdAbK095k3Vv3EnwxmS+N3pqvPG03RstA958Xt7ofuyNLaPecNH7IPp1H1T+0Qer3/PBdvHB0i0+fBd8sPCQD3LcfWAa6IOyKB/0ZvjgWYUPZrX4IP66Dx3jg5DHPiia9IHnNF8+W18EL/TFjKW+WLbWF5s/9YXzV74YtvfFnOO+eBTgi2lnfXE3yxc2Zb54eNEXju2+CLvli5KHvnSRL7Ya+MH1N358l/xgv9wPa8z8yIEf1lv6oWuXHx47+9H5flga5YeKFD/0F/sh56IfXeXHd8wPCx74IeupH5ZM+jED/OHwhj9C3vHHzPf9sdzCH1pLf5jY+WPUxZ/M+EMT4o/AOH/k5fijo9ofj674w6nPHxHf+8PmqT98VQF8HwNwZ24AcyIAD/4cAJ0SgMWfB8BiVwC6DwTgyckAui4A9xIDUJkXQL4C0HgpgPkRANs7AfD/MQA5EwEwNQrExjmBWGASCLOVgXx3AxG/KZCZEoiMPYFocQ3Eff9AZksggtMDUVAeCI9LgUjtCYTz3UCyGAj354FQqYKwcGYQ1v0+CDZ/DmLmBEG/MQh3/hmEyX1BfM+DsNU3iPkTBKvEIHgWBCGtLghNnUFY/68g2P0QRIcGYbs2mDwGk8dg8hjMXArGXQnG1NZg8hiMrEPBaPMKRnx4MDMqmDwGk8dg8hiMeT3BWDMYjB0/B5PHYGh+dRqL5p2mb09jzurT5PE0pv3jNPPrNGwOncZD99NwDDzNHDuNktzT5PE0trachmv/afJ4Gvb/O401L09jxyshWDY/hDyGkMcQNJqFYPCzEKisQ8hjCHkMQXtICLMuBHX5IQirCaGnQ+A9EALdvRDyGIKZoyF0dii2vB4Klz+GYnRFKOZKKB5/HorpNqEYdAqFyiuU7gnFtoRQ8hhKHkPp8lBk3Qilz0Ox4XEoHCZDsXZaGKx+F4blfwyj28Ngsj6M3SMMHjvDmJVhaPQMY16GwTYpjI4Kw7YLYTjeEYaNt8Lg+DCMXSQMswzCET8jnM4Kx+0/haPor+Ho3hiOtO3haHIIR/SxcNgFhJPDcGzPCod7ZTg2NYeTw3C6LByzn4Rj5VQ49NMjsOSNCGZsBOZ/EIGnH0eg5YsI9pYIVLtE4JZvBAoiI+BxLgKppRFwbohAZHcEGYzAqkcR2DYWQQbPkMEzZPAMnr17hgyewYPNZ6DbdQa3D55B0ckz6A49g7TEM2gqOIPo2jOwu3IGgf86g+3/PkP+zmCTJpL8ReL5/EjmdCT5i6QbIxH2j0iU7I2Et2sk+YvE4shIWKRHYl5pJF0ZSf4ice+bSFT+JxKBw5HkL4p9KAqb/hDFLI+iO6Mwe1MUHn4Zhbp9UQhzi2I/iqJHo7A1MwqLy6Ng0RRF9qLw5P+i0PTfKNwbj0KlPhqBr0Uzo6Lh/l40Nq2LxsLN0XRhNF0YTfaiURccTfaiyV40vKuiyV40FvdGk71o9oBoPJmMRtO0GNz7XQzZi0HgX2Lowhi4b42hC2PIXgyee8RgdngMHibFkL0YshdD9mLIXgy23o/B4v/FwEIdi3mvxOLJG7Fo+n+xuPdBLCotYpl3sdhuGwv3I7HY5BOLhWdi8TwlltkXSw/GMv9i6cFYejAW3kOx9GAcFr8aRw/GYd6yOHbeOHowDve2x6HSPg6BR+Ow3S+OHSMOmzLi2H/j8LwhDrOvx+HhnTjUPYpj34hDidFZeP/2LDJMzsJ1xVlYKGeZmWexZudZzHA8i2UeZ+nAsxiIP8s+d5YOPMtOdxb1N8/SgWfpwLN0YDwdGE/24rHhnXiyF0/24jFzWzzZiyd78WQvnuzFk714shdP9uLpv3iyF0/24jFtJJ7sJTBvE9ilE8heAtrME+i/BNRaJSDkQAJ7dQI8TydgS3wCTHISsL46gf06gTmcgMbBBAz+nICKFwnw/1Uits1NhOniRGxclciemMjOnchsTkT8wUTUnkpESGgi3ZeI5XmJ0FYnwuRKIrtjIrruJTKvE+H8IhGRv06C7bwkui8J01Yl0X1JdF8Sem2S6L4kZngSNoQmwSE5CWsLkui+JNxvS2IWJzGLk5jpSXRfEvtRMt2XDDFNpvuS6b5k1G9NRoRNMsoOJ7MvJTOLk9mZkpnFyZhfl8wsTmYWJyPufjLdl8z+lEL3pdB9KdCYpmDg/RQMW6SgwzIFybYpcDqcgnVeKeymKViZmgJ9UQruXEghfynouZWCjAcpcP0lhfylkr9U9tVU5nAq+Uslf6nkLxV5dqnkL5X8pZK/VPKXSv5SyV8q+Uslf6mwfpBK/lLJ3znydw7jb55D9zvnyN858neO3fYc7OzOsd+eI3/nmMPnoEo7xxw+xxw+xxw+xxw+R/edo/vO0X1pWPGbNOgWptF9aXRfGjw3pNF9aextaVh/NA1z/dLwODIN0zPSMFiahoqGNPh3pWHb7TQcf5TGLpeGBYbp3BfpaPt9OjM4HbUfpiNkYzqstqdjuX06thxLZ79Lx2h0OjdHOhlMZwan03/pZDCdDKaTwXQymEEGM8hgBrL+nAG3DzPIYAYcdmRgrUMGZh7LYAZnMIMz2AMzmMEZzOAMbO7OYAZnQH7MwJyxDDzSZaJ+dibuvpXJjp0JX/NMWG7K5F7JxIYDmZh/IhNPAzPREpuJuMxMVJ/PRHBTJnb0ZGLZ3UxofszEoolMDOuz0PFaFpLfyoLTu1mIWJeFsi1Z8LXOguXBLCw5mYXJ4CzMT8wig1lkMIsMZpHBLATfyyKDWehSZ7MPZrMPZpPBbDKYzc2TjW3/zIbp3mxMHclGr082ss5koy0tGw/KslHbmI2Qa9mw+iYby/+TzS6YjVsGOSh4NYc9Pgepy3K4LXMgf8thn8/Bqn05qD+SgwifHHbBHPim5cCyJAdL6nMw2ZGD+d/kkMEcMpiDOINc2L+aSwZzyWAuGcyF5m+5ZDCXDswlg7lkMJcM5pLBXLQX5pLBXHbBXJgN5GLW/Vw8eJqL2qlchEzP4x7IY/7mQfuXPNxCHgo+z2P+5jF/87DIPQ/DQXnoiMtDclYenCryuBPy6ME8ejCPHsxD2EgerA3z6cF8cphPDvPJYT45zMeWbfnkMJ99MB9d3vlIjciHc0o+pDAfthfz2Qfz6cJ8ujCfLsxnDufThQXsgwUoWVwA75UF2IoC9sEC9sEC9sECpJ0ogEtQAdbHFWBuVgH7YAFZLCCLBWSxgCwWMIsLcFdbiLJZhfD9fSEs/1RIFgsx+Ukhev5RyD5YCFeXQu66QsyLKMST5ELmcSHzuBCVVwux+mYhpn9fSCcW0omF6P91EZ1YRCcWYeq9IvSuK6ITi+BmVUQei8hjEXks4v4rIo9FsC8vwppLRZjRXUQei5jJRczkImZyMTthMTO5GP1Li5GzppgbpRgb/1HMfViMZ4eL2QmL2QmL6cVidsJiMllMJovJZDGZLCaTxVj2opidsAQDr5cg7+0SdPylhLlcwlwuYS6XoH1/CXO5hJ2wBGaxJZiVWUIuS6BrKiGXJeSyhFyWQDtcwo1eSi5L4bGgFJuXlmLRmlJyWUo3ltKNpXRjKd1YSjeWMptLmc2lzOZSWLeVMptL2QtLcftJKXdKKXdKGdJ+VwaTt8vYC8vQpZQh9bMyNO4sg+wv404p404pQ31MGXthGXthGVY2lkF/rQx3bpdxo5bRj2X0Yzn9WE4/ljOfy5H2QTlcLMq5U8ox17acfixnNyxHZFg5u2E5VuWXsxuW425rOcr6yuH7XTksn5Rzy5Zj0rgCPXMqmNEVzOgKxKEC8z6rwJMdFeyHFeyHFagMqsDqmAo6soKOrKAjK9DfXUFHVsD0YQWmnlegV3OejjwPtzfPM6fPM6fPM6fPM6fPI273edg7n8caz/OYEXaeO/g8t8p5BFafx/bW81jadx6bvj+P/p/Oc6ucx3HjSvbESjgurmRWVzKrK+nJSnqyklldSU9W0pOVqI6u5FappCcrsayhEpquSgx8XYm8HyrRMVzJrljFrljFrliFdtMqdsUqOH5cBbMvqjBrdxUeHKrinq5iXlcxr6uY11XM6yrmdRUKeqvgMViFzT9V0ZVVkF9V05XVdGU1XVmNdebVsNlczb5Yzb5Yzb5YDWv/avbFau7natwuqUZRfTU8O6uR9k01TH6o5n6upi9r6MsaNC6ooS9r6Msa+rKGe6WGe6WGvqxhZtcws2vgllqDDUU1zOwarO2sYWbXMLNrUP1LDX1Zi9Hf1JLLWnJZS1/WIvLTWlR8VUtf1mKaWy23cy02nq2FY24tt3Mt2i7X4sGNWjJZy75YSyZryeQFMnmBffECXXkBdusvYPXWC3TlBbryApL9LtCVF+jKC8zrC+TxAiyvXyCPF9gXL3A3X8BTozrMfL0OcYvquJvrEKzU0ZN13Mx12OxYR0/WQULqyGIdd0odptXUkcU6TN2s42auY1bXoU11kTvlInfKRTryIsY/vEhHXqQjL9KRF8nhRXJ4kRxeJIcXsbTiInfKRe6Ui3h+9yLaf7yIhxMXuVPq2RXr6cd6+rEeGR/Vc6fUsyvWk8F6MliPHRH17Ir1zOl6LLpYj+Gr9Zhzu55urKcb6+nGBrqxgTndQP4auFMayF8D+Wsgfw3cKQ3cKQ3sig3sig3sig3cKQ3cKQ30YgO92MCd3Ej2GrmTG8leIxJXN3KnNHInN3InN3KnNHKnNMI1upFObGRGN9KJjXRiI53YSO4a2RMbmdGXyN0lPHr7EnviJZh+fIkZfYkZfYk98RJ9eAkPzlyiDy8xoy/Bqu4SmbtE5i6RuUtk7hLmai9j9ezL3CiXMbjsMirWXkb/p5fpwsvcKJeRePwyXXiZG+UyN8pl7uPL3CiXuVEuc6NcZke8zI7YhBm/buJGaWJHbKIHm+jBJnqwiR5sYj434a5fE6ZimpjPTcznJrg1NiH+ehNqv23C2v82cRs3cRs3cxs349aiZhQsb6YDm7mNm+H8VTMd2Axb92b4hzRj2tlmOrAZU5XNWNDWzG3cDLdvmxH/pJnZ3Mxt3ELmWpjNLdzGLczmFjLXQuZa8Ni5Bc4eLWSuhcy1kLkWMtdC5lrIXAuZayFzLczlVuZyK93XipaVrbj/USu0lq0wsWtlN2zlLm7lLm5FXk4rt0kr87gV02610nmt7IWtcDRqQ9icNrLWhp5VbfRdG33Xxk7Yxk7YxhxuQ3R8G13XhoHaNnLWRs7ayFkbOWuj564gce4V1C25gjurrzB/r2D+9ivsgle4R65wj1zhFr7C7L2Ce3VX6LcrWHTnCnvgFdhOXOEWaUfOvHby1U63tUO/sZ0dsJ2Z2w6Hk+30WjuKktvRXdTODdxOttrJVjvZaidb7dwgV1Ex/yqz9ir371Xu36tYaXWV3e8q98dV5uxV1KZepcuuYrzxKrfvVawZvIodP1/l9rhKj3XQYx1kqgMq8w7mawfWWXfA5lAHHdbBztfBztfBbO1gtnaQpw7y1EGeOshTJ3O1k32vE4+Xd2L6uk4s3dLJvdvJTO1k1+tk1+tEb0Yn3dWJWS2dWNHfya3byZ7XyZ7XherfdJGjLmZpF+ZKF73VRW910Vtd9FYXc7SLDHWRoS4y1MV+18WN0cUM7UKG4TW0/PYa7ptcY7e7BpP115if17gvrnHfXkNewDX2umt4lHON7FyDafs1bLx1jdviGjvdNW7bbuZmN54u7sbM97ux3KKbruqmq7rpqm66qpu7tpu7thtzLnRjVUc387Kbm6IbiWPdqDO+zh53HZNLrjMrr2PthuvcE9fh6XCdHe46mk5fx73E69AUXqejrnPPXmd/uw7/H68zI6+j/Vc9eDivB/p3erDkrz3YsLGHfuqhn3ropx76qYe9rQczinuYjT3cED3cED2I/KmHna2Hne0Gc/EGZv/pBlZ+eIP74Qb72g1u2BvcsDdwO/wGxlNvYF7pDXrpBrfDDebhDe7XG2h8eQODr/RC9fteLPxzL7Owl1nYSyf10km9dFIvndTLHOzF4vJeWDT1wr63l/2sl/2slxnYh8ev9mH6H/qw9N0+drM+OG3p42bt42bt417ow7OoPvayPqw430cX9cG1v4/Z18fs62P29TP7+jH3rX6sfq8f26Uf7lv76aF+eqifHuqnh/qxILsfZlX97GL97GL93Aj9aBnqx33Dm9C+dpM97CbW/+UmM+8m98FNbtSb6Dh6kx3sJv1zE6a5N7Gx5ia3wU3u05vMu5vMu5vMuwG6Z4DuGaB7Bti9BrhNB1BpP4CBYwPcBANke4jZPMRsHqIrh7inh+jKIf6MQ+R7iJ1xCLPDh9gZh9gZh9gZh/hzDpHxIebzEDvjEPN5iPk8TF8O82cdJufD9OUwO+MwfTlMXw6zMw7z5x0m68OIyBhmZxxmRg+zMw4zo4f5Mw+T92F2xhF2xhF2xhFu6hF2xhH+3CNkfoSdcYTOHGFnHGFnHKEzR9gZR8j9CJ05ws44ws44ws44giWTI+yMo2R/lN4cZWcchYUyys44ys44ys44Sv5H6c5RZvUos3qUnXGUnXGUu3qU78Ao/TnKzjjKzjiGrJlj7Ixj7IxjfA/G6NAx5vUYO+MY83qMeT3GzjjGd2GMHh1jZxxjZxxjZxyD6rsxdsYxvg9jdOk4O+M4FpiMM7PH2RnHmdnjfCfG6dNxdsZxdsZxdsZxdsZx7Cgd53sxTqeOszOOszOOw/35ODvjBHN7gu/GBL06wdyeYGecYGecYGecYGec4PsxQbdOsDNOsDNOsDNO4FbLBDvjBN+RCfp1gp1xgtk9yeyeZGecZGec5HsyScdOsjNOsjNOsjNOsjNOYkX0JN+VSXp2kp1xkvk9iS1fTzK/J5nfk3xfXtC1L7ixX7AzvmBnfIFH61+gfusLvjMv6NsXWHnqBfShL3An4QUz/AW8q17wvXlB577A+Lcv0P34BdLGX8BFP4X1r03x3Zmid6fQaDbF3jgF2y+n2Bun2Bun+P5M0b1TzPEp5vgUd/YUd/YUem5N8R2aon+nYKF+iXmvvMSTN16yO75E9Psv+R69pINfYrrNSww6vUSFx0tm+UtsS3jJd+klPfwSvc0vmeUvmeUvseHxS8wff4lRA5Xcm6aSrldVUvm6SlIXqCTwbZU4L1XJ9vdUImtUsnSdSuZ8ohLVZpU8slRJ/1cqqbdVSc5+lUQcVsnx4yqx8VLJxkCVrAxXyYJYleiTVfIsQyV38lXSVqaSkhqVxDeqxLtNJQ7XVLK1XyVrv1HJ4nsqmfkflYw/Ucn9IZV0T6qk2kAtadPUEvyqWlxeV8uOBWpZ/7Zali1Vy9z31KJZo5bHiloGLNTS+Jla8izVEvmVWtxt1WK7Xy2bDqtl1XG1LPRSy7RAtTwPU8vdGLW0J6mlLEMtiflq8S1Ti2ONWiwb1WLWppYl19Qyq18tk7fV8uA7tfQ8VEvtE7VkDKklZFItrgYasZqmEYtXNbL8dY3MW6AR7dsaefKORm6t0EjTBxopUDQSbaERj880Ymepkc1faWS1rUYW7dfI9MMaGT6mkUFPjXQEaKQiTCPJMRrxT9KIU4ZGtuVrZF2ZhrNEI7MbNTLVqpGHXRrp7dNI3W2NZH2nkbCHGnF7ohHrIY1smNTICgMDmT/NQHSvGsjTOQZy+00DaTExkKJ3DCRuhYF4fmAg9oqBbLEwkDWfGYiJpYHM+MpARncbyD0HA+lyNpDKYwaS6mkggQEG4hxmINtjDESSDGRphoHMyTcQVZmBPKo2kP4GA6lvNZCcLgOJ6DOQ47cNxOY7A9n40EBWPjGQBUMGop80kGcardwx1krbTK2UzNFK/Jta8TbRisM7Wtm6QitrP9DKYkUrMy20Mr5JK/e/0Er3Dq1U79ZKmoNWgp214nJMKzs8tbI+QCvLwrQyN0YrmiStPE7XykCeVhpLtZJXrZXIBq24t2rFtksrm/q0suq2VhZ+p5VpD7Xy/Cet3H2ulfYJrZRpDCXR2FB8ZxqK4xxDsXzTUMxMDGXJO4Yya4WhTK42lAfmhtLzsaHUbjKUjC8MJWSHobjuNhQrB0OxcDaU5ccMZZ6noWgDDOVJqKHcijaUpkRDKUg3lOg8Q/EoNRS7akPZ3GAoq1sNZVGXoUzvM5Thrw1lcNBQOn4wlIqfDCX5uaH4TxiKk0Yn24x1sm6mTkzn6GT2mzqZeksnD0110vuuTupW6yTLXCdhH+vEbZNOrL/QyYYdOlmxWyfzHXSic9bJUzed3D6lkxZ/nRSF6iQuWieeiTqxT9fJljydrCnViUm1TmY06GS0RSf3OnXS1auTyq91kjqok8AfdOL8k062P9eJTOhkqcZI5hgbiWqmkTx6zUj65xtJ/VtGkmNqJBHvGsnx1UZiY24kGz82kpWbjGTBF0ai32Ekz2yM5M4+I2k7ZCQlbkYSf8pIvP2NxCHUSLZGG8naRCNZnG4kM/OMZLzESO5XGUl3vZFUtxhJWqeRBPcaicvXRrJj0EjW/2Aky34ykrnPjUQzYSSP1XoZ0Oul8RW95L2ml8j5enF/Sy+2pnrZ9K5eVq3Wy0JzvUz7WC/PP9XL3a16af9SL2U2ekncpxffQ3pxdNOL5Sm9mPnrZUmoXmZF62UyQS8P0vTSk6uX2hK9ZFTpJaReL64terHq1ItFr16Wf62XeYN60f6glyeP9XLrF700jeulQG0s0Xpj8XjFWOxeM5bN841l9VvGssjUWKa/ayzD7xvLoJmxdKw3lopPjSV5q7H4f2ksTjbGsm2fsaw7ZCymbsYy+5Sx/H9VQ3De</binary>
+          </binaryDataArray>
+          <binaryDataArray encodedLength="2900">
+            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+            <binary>eJztWg+MFcUZ/5oAPQLIWY9wHqc+2mrxRERFpQnq3tt9u2jQvlOsp7XpO73Qo6I+DYnamDj88fq0J5wV4eSfz4TiVZE+BAOiJQtRS5XAxVBDI8Unag7/BC8Em4ux2O978627Ozv3bl9qqqE3yZdv5jffzszOzvfN980swFAaSt+VJAyAdCNAEclIAuSQ1iF1I3UhzUeagVSDBEhHUG4bkkCqpmeMb/kF/oeJ5onSrKTknzI/z5T8AubAvJPrLeZdzN9i3uDJa9LaMnW/KlPnpXxycJnTYrRzz+AyoiNGOySXjyn3ZDw5uC2m3MxvUO4AroHzY8i9nZQUR25EzH5bY87flphyf485L5Q+rkD25fiycddEKW2sQPZEBbIjrdiibn18WTE8viz8u4LxHqxA9pkKvkUF68FoqGDO5saXNX4bQ/aAtMNGNoYs66B7bQzZY1LWuCKGLNtXEUd2uJzXOGtH8PcSMXTI051YOuTtB2eUGUMibK/EdWVk+xTblioj216BrLpvlZNVxutOLyM7M2qLxUM4bxdWMBZKu010fco8c0zzTNYEY2aZZ3T7RMcgz/Q0RrFZFdgFSvfHkG8uI3NJmboqTd0YDTZOg9UPIFc0wljClL5oMF2HWHVgPnNYrvLLYjmWuwPPLA+3KxYofaeV8o+VsvpOnyrfcqNSJl9QXOmXF2O5EBhPHbY3NTBe8oUeCLSxT6l/yww9L8hvDLZ/hTK+E8p4xiv11yhldY20K+UlSvlBpXylUu4P9P9FID85IHe7nxcPB/K5QP73AfmnA/j+AD7M1x+3xs+LWn3e+FFA30w/nxF+vrgpIPNhWD+Nc1Jf57M9Mm9c62O178l8T7OPVR2Q+WrHxwp7ZD5zlo/ldst84nBgvPu4jyd8rP8dxiwfa+6VmDjuz03fEW57jo9lPmJsnv9d0h/4Y/BS1z+jmHEgitUeimLZ/ijWMdqOYBvqotgrE6PYl2dFsfpxUazme1GsXzNmY3MUO7JMIzcvihWnR7HM6CiW2B+165k/MBbQZWMKY0F9f4m/V3BP9b7hVA0WtC1zFF2kdJ4Ge0OzH7UOEMu0DYBnB8CXDYCrPoKXXh8khvJiJ7JLOl93BvtI5DPr4lR6ZnYSjGk4149r6v+MWE8S3DkWiHeUeto77sNn77DACNiakm1CHFoQGxH41hS3v5CUujkqgFPcWWOCOwH7+H4Ar5E4lPoN4NhGicg29gbG1NcoCfdP8aXmXRZi3zofCfdD4wHNmnw8ihUfjWLuPZo2L49iIfvqpbM17Wl8ap0v5E6JYqH589Lh6FwIHbZPgy3TzOMEDZbW+X0aH+1kSbp369Ng0zTzopM7mefqZEgF3TfTfFvdWdajGqwuqqeJjVGseoayf+LaaduqYEeT0H96eH8nvV3comBfmXB8aRhzL7Zg5R8V3wBtfe55RW6JBV0bwljmeQvuW688u8OCtXml360WjFgTxhIrLGhfFcaM2y3YpWCiyYLjTypj+bUFt6xQsAU4vk4Fm2vBjIcVbBKOeb7Sx7MmVDcp70F7iOpvoV+YP5aKYM0bFQxtYfdDCoa+SfYGBcM1lZ2iYBiLVY8MY8V3FT97b7icOBgui3+Fy4Ux4fYKE8Llvp+Ey/mzZbmT/e/CeMnTNeyr10uevYB9cvbde25k/CbJXfb9+wzJi9Mkz0/ici37+SO4HY4njB3M10pefETyzELG75Xc/SW/508lF6cx/4z17V32fT5nPtoK8a/rPb/IiwWfVe4tPN3PG/CdSAkej+fvFpgfUspefeJb2lu8ONw7X+jkcQxTxufxfq7PMP9/ulsbSpUlWlukj7RW6Dx8Mq6hDJ0tJWXskeY7W9LdxDdwT1t6HtvporXJd8Jt3Fcbl4dxfzmWo3HRWdwkJsr38N0xaMbk3UXTc9P4XdYiree7aPI36Mx32yDv5M0N9UNjwviudBe7AWkLt9fB80X91PJc0RjJ5tH5B8WjS/g+nN7xFpan8nbSV1OeBTaa8szMRpqCNBbpA6zfwTEayVIM+wZj67mNefw+FA/vSspzMYr1JiKdiXQq0jAmOg+9GmkB7skrzNJ5l1iDhPFqyXYvMeW5Jp39Eb4U+d1IhiljlVGmvOulWJ/OiOeijDDl2VoX8k3I/2GWYliDYtAGqxRbGegrCCzDGMxT/PmJlCudgW9F6kZaLcdBsbXAGFwsMkuxOI1BPIX5F5GTPJ3LvY18L9KrSLtMGW8dxbgX24dzsQ8b+2tFWmRBosuCYgHpTcz3Yv1XyNEvKI5NQXpcCjrrkCamoKcB+WVIuAf33Yx12RTkFqWgainKrkzBkWdS4KK/mN2Tgt29KWgbbsOWOhvExTbM+pkNk++04ec5G6avtmH+Zhu277Vh9lEbLhnpgHGGAwcvcuCRqxxwMw4cutcR9b9zYNtjjli1yhFPrXPE0g0OtG524JyXHNH7F0d073Tgtlcd6H3NEe8jnYL5611H/HW7I9agXN1zDjzxtCNaVjhif4cDFy10oOUuB16+GfuxHfgM+2tKODBqrAN7Ttiw8jD6YH+zwd5kQwP6hsfbbdj2GxuWXWND9aU2rP6hDelT8Z3Ahq5iCmp3pqCwDuejA/ndyJtSkL8U82ciVeGc4Fy6O3Fe0bcoCsyncW7PRz4e6Qf8vbFM91rCQUpa8hyqGqmI3+xP+M0WI7UgXY90A9IvTHkXT+dLtyI1IU1HqjXlfch21rc06xr9Q0J2gDjpcyvrt5uUukNn1LTugXXplaT/LwrpMv2nMpX1dTLrLNUtT8r/VrpZ32ezTSI74JKtYCLbQHtyotGnIuNU7+3bA9mRgfrIB57V2iWsN2gs/N7NbOPa2cbM5nei9nY3Sn8hzbZScNslYlucZlubZ8pp5IfSUPrv038AUfbRdQ==</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </chromatogram>
+      <chromatogram index="1" id="SRM SIC Q1=1059 Q3=244.15 Channel=1 Event=1 Segment=1 CE=50.647" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -70,7 +87,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="50.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="50.647" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -82,18 +99,18 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="64">
+          <binaryDataArray encodedLength="80">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYBgFo2CwggcODAwfHBkYCpwYGKY4QWgQf4MjhDaB8gscB9ql9AYAfGwKNw==</binary>
+            <binary>eJxjYBgFo2DQAQcgdmRgmAHELE4MDAZA7AHEDkCsAcQCQMwAxC+A8juAuAGIBYDYwWFgnU0/AADnyQfR</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="1" id="SRM SIC Q1=1059 Q3=359.2 Channel=2 Event=1 Segment=1 CE=38" defaultArrayLength="238">
+      <chromatogram index="2" id="SRM SIC Q1=1059 Q3=359.2 Channel=2 Event=1 Segment=1 CE=38" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -114,8 +131,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -125,7 +142,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="2" id="SRM SIC Q1=1059 Q3=529.3 Channel=3 Event=1 Segment=1 CE=48.6" defaultArrayLength="238">
+      <chromatogram index="3" id="SRM SIC Q1=1059 Q3=529.3 Channel=3 Event=1 Segment=1 CE=48.552" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -134,7 +151,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="48.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="48.552" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -146,8 +163,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -157,7 +174,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="3" id="SRM SIC Q1=1059 Q3=741.4 Channel=4 Event=1 Segment=1 CE=40.6" defaultArrayLength="238">
+      <chromatogram index="4" id="SRM SIC Q1=1059 Q3=741.4 Channel=4 Event=1 Segment=1 CE=40.647" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -166,7 +183,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.647" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -178,18 +195,18 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="44">
+          <binaryDataArray encodedLength="56">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYBgFo2CwgQJHBgYTJwaGKVAMYoPERgEMAABb2gP7</binary>
+            <binary>eJxjYBgFo2CwgAYHBoYARwaGC0Cs4MTA4ALFIDZIDCQHUjMKADN1BpU=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="4" id="SRM SIC Q1=1059 Q3=855.4 Channel=5 Event=1 Segment=1 CE=39" defaultArrayLength="238">
+      <chromatogram index="5" id="SRM SIC Q1=1059 Q3=855.4 Channel=5 Event=1 Segment=1 CE=39" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -210,8 +227,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -221,7 +238,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="5" id="SRM SIC Q1=1059 Q3=1041.5 Channel=6 Event=1 Segment=1 CE=38.6" defaultArrayLength="238">
+      <chromatogram index="6" id="SRM SIC Q1=1059 Q3=1041.5 Channel=6 Event=1 Segment=1 CE=38.558" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -230,7 +247,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.558" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -242,8 +259,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -253,7 +270,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="6" id="SRM SIC Q1=1059 Q3=1298.65 Channel=7 Event=1 Segment=1 CE=39" defaultArrayLength="238">
+      <chromatogram index="7" id="SRM SIC Q1=1059 Q3=1298.65 Channel=7 Event=1 Segment=1 CE=39" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -274,8 +291,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -285,7 +302,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="7" id="SRM SIC Q1=582.3 Q3=595.3 Channel=1 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="8" id="SRM SIC Q1=582.3 Q3=595.3 Channel=1 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -306,8 +323,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="124">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -317,7 +334,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="8" id="SRM SIC Q1=582.3 Q3=708.4 Channel=2 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="9" id="SRM SIC Q1=582.3 Q3=708.4 Channel=2 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -338,18 +355,18 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="116">
+          <binaryDataArray encodedLength="136">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYIABVmcGhjgoBrENnBgoBjccGRiuAc1hc4bgG04QMXT5T0C8AIj3ALEuUJ0CCDuhqhEGilkjyYHEPwBpPaiYHhR7OCPUMjpDzIbZz+YMADTaGTI=</binary>
+            <binary>eJxjYAhwZGDwcWJgeAPE2s4MDPpAzADEbUD+DqBcgwMD2eAGUP81oDlszhB8wwkihi7/CYgXAPEeINYFqlMAYSdUNcJAMWskOZD4ByCtBxXTg2IPZ4RaRmeI2TD72ZwBX94c3w==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="9" id="SRM SIC Q1=582.3 Q3=837.45 Channel=3 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="10" id="SRM SIC Q1=582.3 Q3=837.45 Channel=3 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -370,8 +387,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="68">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -381,7 +398,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="10" id="SRM SIC Q1=582.3 Q3=951.5 Channel=4 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="11" id="SRM SIC Q1=582.3 Q3=951.5 Channel=4 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -402,18 +419,18 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="184">
+          <binaryDataArray encodedLength="196">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAEApwYGISdGRhCgXgeEMcDcRtQbAEQf4LKWQOxBxrWdYaoueHIwLAHSCc7MzTMB+I7QPHdQDwZiBWhatiA4suA+CAQTwKKXQOKBQD1hQDpHmeGAxwuDA3KEHxAyIWB4TtQ3UuIerD9IPMLgPQJIF4OFL8KxEB2wxmomjtQ9S+dAUrvMag=</binary>
+            <binary>eJxjYMAFFjgwMFxwZGCY4MTAcAmItZwZGOYBcTwQtwH5C4D4ExALA/nWQOyBhnWdIWpuAM3YA6STnRka5gPxHaD4biCeDMSKUDVsQPFlQHwQiCcBxa4BxQKA+kKAdI8zwwEOF4YGZQg+IOTCwPAdqO4lRD3YfpD5BUD6BBAvB4pfBWIgu+EMVM0dqPqXzgCN6TRs</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="11" id="SRM SIC Q1=582.3 Q3=1050.55 Channel=5 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="12" id="SRM SIC Q1=582.3 Q3=1050.55 Channel=5 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -434,8 +451,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -445,7 +462,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="12" id="SRM SIC Q1=540.3 Q3=460.3 Channel=1 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="13" id="SRM SIC Q1=540.3 Q3=460.3 Channel=1 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -466,8 +483,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -477,7 +494,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="13" id="SRM SIC Q1=540.3 Q3=574.3 Channel=2 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="14" id="SRM SIC Q1=540.3 Q3=574.3 Channel=2 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -498,8 +515,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -509,7 +526,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="14" id="SRM SIC Q1=540.3 Q3=673.4 Channel=3 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="15" id="SRM SIC Q1=540.3 Q3=673.4 Channel=3 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -530,8 +547,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -541,7 +558,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="15" id="SRM SIC Q1=540.3 Q3=836.45 Channel=4 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="16" id="SRM SIC Q1=540.3 Q3=836.45 Channel=4 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -562,8 +579,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -573,7 +590,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="16" id="SRM SIC Q1=540.3 Q3=907.5 Channel=5 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="17" id="SRM SIC Q1=540.3 Q3=907.5 Channel=5 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -594,8 +611,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -605,7 +622,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="17" id="SRM SIC Q1=653.35 Q3=712.45 Channel=1 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="18" id="SRM SIC Q1=653.35 Q3=712.45 Channel=1 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -626,8 +643,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -637,7 +654,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="18" id="SRM SIC Q1=653.35 Q3=841.5 Channel=2 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="19" id="SRM SIC Q1=653.35 Q3=841.5 Channel=2 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -658,8 +675,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -669,7 +686,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="19" id="SRM SIC Q1=653.35 Q3=956.5 Channel=3 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="20" id="SRM SIC Q1=653.35 Q3=956.5 Channel=3 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -690,8 +707,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -701,7 +718,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="20" id="SRM SIC Q1=653.35 Q3=1055.55 Channel=4 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="21" id="SRM SIC Q1=653.35 Q3=1055.55 Channel=4 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -722,8 +739,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -733,7 +750,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="21" id="SRM SIC Q1=653.35 Q3=1168.65 Channel=5 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="22" id="SRM SIC Q1=653.35 Q3=1168.65 Channel=5 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -754,8 +771,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -765,7 +782,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="22" id="SRM SIC Q1=740.4 Q3=274.2 Channel=1 Event=5 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="23" id="SRM SIC Q1=740.4 Q3=274.2 Channel=1 Event=5 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -786,8 +803,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -797,7 +814,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="23" id="SRM SIC Q1=740.4 Q3=387.25 Channel=2 Event=5 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="24" id="SRM SIC Q1=740.4 Q3=387.25 Channel=2 Event=5 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -818,8 +835,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -829,7 +846,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="24" id="SRM SIC Q1=740.4 Q3=685.45 Channel=3 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="25" id="SRM SIC Q1=740.4 Q3=685.45 Channel=3 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -850,8 +867,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -861,7 +878,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="25" id="SRM SIC Q1=740.4 Q3=813.5 Channel=4 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="26" id="SRM SIC Q1=740.4 Q3=813.5 Channel=4 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -882,8 +899,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -893,7 +910,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="26" id="SRM SIC Q1=740.4 Q3=960.55 Channel=5 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="27" id="SRM SIC Q1=740.4 Q3=960.55 Channel=5 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -914,8 +931,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -925,7 +942,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="27" id="SRM SIC Q1=740.4 Q3=1017.6 Channel=6 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="28" id="SRM SIC Q1=740.4 Q3=1017.6 Channel=6 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -946,8 +963,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -957,7 +974,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="28" id="SRM SIC Q1=740.4 Q3=1180.65 Channel=7 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="29" id="SRM SIC Q1=740.4 Q3=1180.65 Channel=7 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -978,8 +995,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -989,7 +1006,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="29" id="SRM SIC Q1=858.9 Q3=628.3 Channel=1 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="30" id="SRM SIC Q1=858.9 Q3=628.3 Channel=1 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1010,8 +1027,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1021,7 +1038,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="30" id="SRM SIC Q1=858.9 Q3=687.3 Channel=2 Event=6 Segment=3 CE=31" defaultArrayLength="51">
+      <chromatogram index="31" id="SRM SIC Q1=858.9 Q3=687.3 Channel=2 Event=6 Segment=3 CE=31" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1042,8 +1059,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1053,7 +1070,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="31" id="SRM SIC Q1=858.9 Q3=816.3 Channel=3 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="32" id="SRM SIC Q1=858.9 Q3=816.3 Channel=3 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1074,8 +1091,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1085,7 +1102,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="32" id="SRM SIC Q1=858.9 Q3=929.4 Channel=4 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="33" id="SRM SIC Q1=858.9 Q3=929.4 Channel=4 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1106,8 +1123,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1117,7 +1134,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="33" id="SRM SIC Q1=858.9 Q3=1158.5 Channel=5 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="34" id="SRM SIC Q1=858.9 Q3=1158.5 Channel=5 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1138,8 +1155,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1149,7 +1166,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="34" id="SRM SIC Q1=858.9 Q3=1255.55 Channel=6 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="35" id="SRM SIC Q1=858.9 Q3=1255.55 Channel=6 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1170,8 +1187,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1181,7 +1198,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="35" id="SRM SIC Q1=858.9 Q3=1369.6 Channel=7 Event=6 Segment=3 CE=31" defaultArrayLength="51">
+      <chromatogram index="36" id="SRM SIC Q1=858.9 Q3=1369.6 Channel=7 Event=6 Segment=3 CE=31" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1202,8 +1219,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1213,7 +1230,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="36" id="SRM SIC Q1=533.3 Q3=310.2 Channel=1 Event=7 Segment=3 CE=19" defaultArrayLength="51">
+      <chromatogram index="37" id="SRM SIC Q1=533.3 Q3=310.2 Channel=1 Event=7 Segment=3 CE=19" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1234,8 +1251,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1245,7 +1262,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="37" id="SRM SIC Q1=533.3 Q3=425.2 Channel=2 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="38" id="SRM SIC Q1=533.3 Q3=425.2 Channel=2 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1266,8 +1283,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1277,7 +1294,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="38" id="SRM SIC Q1=533.3 Q3=526.25 Channel=3 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="39" id="SRM SIC Q1=533.3 Q3=526.25 Channel=3 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1298,8 +1315,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1309,7 +1326,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="39" id="SRM SIC Q1=533.3 Q3=641.3 Channel=4 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="40" id="SRM SIC Q1=533.3 Q3=641.3 Channel=4 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1330,8 +1347,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1341,7 +1358,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="40" id="SRM SIC Q1=533.3 Q3=754.35 Channel=5 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="41" id="SRM SIC Q1=533.3 Q3=754.35 Channel=5 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1362,8 +1379,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1373,7 +1390,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="41" id="SRM SIC Q1=533.3 Q3=853.45 Channel=6 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="42" id="SRM SIC Q1=533.3 Q3=853.45 Channel=6 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1394,8 +1411,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1405,7 +1422,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="42" id="SRM SIC Q1=533.3 Q3=966.5 Channel=7 Event=7 Segment=3 CE=19" defaultArrayLength="51">
+      <chromatogram index="43" id="SRM SIC Q1=533.3 Q3=966.5 Channel=7 Event=7 Segment=3 CE=19" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1426,8 +1443,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1437,7 +1454,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="43" id="SRM SIC Q1=621.3 Q3=676.35 Channel=1 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="44" id="SRM SIC Q1=621.3 Q3=676.35 Channel=1 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1458,8 +1475,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1469,7 +1486,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="44" id="SRM SIC Q1=621.3 Q3=775.4 Channel=2 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="45" id="SRM SIC Q1=621.3 Q3=775.4 Channel=2 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1490,8 +1507,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1501,7 +1518,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="45" id="SRM SIC Q1=621.3 Q3=890.45 Channel=3 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="46" id="SRM SIC Q1=621.3 Q3=890.45 Channel=3 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1522,8 +1539,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1533,7 +1550,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="46" id="SRM SIC Q1=621.3 Q3=991.5 Channel=4 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="47" id="SRM SIC Q1=621.3 Q3=991.5 Channel=4 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1554,8 +1571,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1565,7 +1582,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="47" id="SRM SIC Q1=621.3 Q3=1078.55 Channel=5 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="48" id="SRM SIC Q1=621.3 Q3=1078.55 Channel=5 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1586,8 +1603,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1597,7 +1614,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="48" id="SRM SIC Q1=710.85 Q3=308.15 Channel=1 Event=9 Segment=5 CE=25" defaultArrayLength="52">
+      <chromatogram index="49" id="SRM SIC Q1=710.85 Q3=308.15 Channel=1 Event=9 Segment=5 CE=25" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1618,8 +1635,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1629,7 +1646,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="49" id="SRM SIC Q1=710.85 Q3=610.8 Channel=2 Event=9 Segment=5 CE=25" defaultArrayLength="52">
+      <chromatogram index="50" id="SRM SIC Q1=710.85 Q3=610.8 Channel=2 Event=9 Segment=5 CE=25" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1650,8 +1667,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="52">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1661,7 +1678,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="50" id="SRM SIC Q1=710.85 Q3=722.3 Channel=3 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="51" id="SRM SIC Q1=710.85 Q3=722.3 Channel=3 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1682,8 +1699,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1693,7 +1710,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="51" id="SRM SIC Q1=710.85 Q3=869.35 Channel=4 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="52" id="SRM SIC Q1=710.85 Q3=869.35 Channel=4 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1714,8 +1731,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1725,7 +1742,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="52" id="SRM SIC Q1=710.85 Q3=982.45 Channel=5 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="53" id="SRM SIC Q1=710.85 Q3=982.45 Channel=5 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1746,8 +1763,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1757,7 +1774,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="53" id="SRM SIC Q1=710.85 Q3=1083.5 Channel=6 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="54" id="SRM SIC Q1=710.85 Q3=1083.5 Channel=6 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1778,8 +1795,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1789,7 +1806,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="54" id="SRM SIC Q1=710.85 Q3=1220.55 Channel=7 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="55" id="SRM SIC Q1=710.85 Q3=1220.55 Channel=7 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1810,8 +1827,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1821,7 +1838,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="55" id="SRM SIC Q1=875.35 Q3=751.3 Channel=1 Event=10 Segment=5 CE=33" defaultArrayLength="52">
+      <chromatogram index="56" id="SRM SIC Q1=875.35 Q3=751.3 Channel=1 Event=10 Segment=5 CE=33" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1842,8 +1859,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1853,7 +1870,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="56" id="SRM SIC Q1=875.35 Q3=912.3 Channel=2 Event=10 Segment=5 CE=37.7" defaultArrayLength="52">
+      <chromatogram index="57" id="SRM SIC Q1=875.35 Q3=912.3 Channel=2 Event=10 Segment=5 CE=37.678" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1862,7 +1879,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.7" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.678" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -1874,8 +1891,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1885,7 +1902,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="57" id="SRM SIC Q1=875.35 Q3=1041.35 Channel=3 Event=10 Segment=5 CE=33" defaultArrayLength="52">
+      <chromatogram index="58" id="SRM SIC Q1=875.35 Q3=1041.35 Channel=3 Event=10 Segment=5 CE=33" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1906,8 +1923,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1917,7 +1934,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="58" id="SRM SIC Q1=875.35 Q3=1169.4 Channel=4 Event=10 Segment=5 CE=33" defaultArrayLength="52">
+      <chromatogram index="59" id="SRM SIC Q1=875.35 Q3=1169.4 Channel=4 Event=10 Segment=5 CE=33" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1938,8 +1955,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1949,7 +1966,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="59" id="SRM SIC Q1=875.35 Q3=1316.5 Channel=5 Event=10 Segment=5 CE=33" defaultArrayLength="52">
+      <chromatogram index="60" id="SRM SIC Q1=875.35 Q3=1316.5 Channel=5 Event=10 Segment=5 CE=33" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1970,8 +1987,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1981,7 +1998,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="60" id="SRM SIC Q1=875.35 Q3=1472.55 Channel=6 Event=10 Segment=5 CE=31" defaultArrayLength="52">
+      <chromatogram index="61" id="SRM SIC Q1=875.35 Q3=1472.55 Channel=6 Event=10 Segment=5 CE=31" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2002,8 +2019,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2013,7 +2030,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="61" id="SRM SIC Q1=471.25 Q3=175.1 Channel=1 Event=11 Segment=6 CE=16" defaultArrayLength="54">
+      <chromatogram index="62" id="SRM SIC Q1=471.25 Q3=175.1 Channel=1 Event=11 Segment=6 CE=16" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2034,8 +2051,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="32">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2045,7 +2062,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="62" id="SRM SIC Q1=471.25 Q3=274.2 Channel=2 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="63" id="SRM SIC Q1=471.25 Q3=274.2 Channel=2 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2066,8 +2083,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="32">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2077,7 +2094,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="63" id="SRM SIC Q1=471.25 Q3=387.25 Channel=3 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="64" id="SRM SIC Q1=471.25 Q3=387.25 Channel=3 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2098,8 +2115,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2109,7 +2126,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="64" id="SRM SIC Q1=471.25 Q3=484.3 Channel=4 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="65" id="SRM SIC Q1=471.25 Q3=484.3 Channel=4 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2130,8 +2147,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="56">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2141,7 +2158,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="65" id="SRM SIC Q1=471.25 Q3=599.35 Channel=5 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="66" id="SRM SIC Q1=471.25 Q3=599.35 Channel=5 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2162,8 +2179,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2173,7 +2190,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="66" id="SRM SIC Q1=471.25 Q3=712.45 Channel=6 Event=11 Segment=6 CE=16" defaultArrayLength="54">
+      <chromatogram index="67" id="SRM SIC Q1=471.25 Q3=712.45 Channel=6 Event=11 Segment=6 CE=16" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2194,8 +2211,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2205,7 +2222,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="67" id="SRM SIC Q1=471.25 Q3=769.45 Channel=7 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="68" id="SRM SIC Q1=471.25 Q3=769.45 Channel=7 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2226,8 +2243,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2237,7 +2254,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="68" id="SRM SIC Q1=497.75 Q3=244.15 Channel=1 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="69" id="SRM SIC Q1=497.75 Q3=244.15 Channel=1 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2255,11 +2272,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2269,7 +2286,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="69" id="SRM SIC Q1=497.75 Q3=372.2 Channel=2 Event=12 Segment=7 CE=17" defaultArrayLength="69">
+      <chromatogram index="70" id="SRM SIC Q1=497.75 Q3=372.2 Channel=2 Event=12 Segment=7 CE=17" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2287,11 +2304,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2301,7 +2318,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="70" id="SRM SIC Q1=497.75 Q3=459.25 Channel=3 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="71" id="SRM SIC Q1=497.75 Q3=459.25 Channel=3 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2319,11 +2336,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2333,7 +2350,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="71" id="SRM SIC Q1=497.75 Q3=572.35 Channel=4 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="72" id="SRM SIC Q1=497.75 Q3=572.35 Channel=4 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2351,11 +2368,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2365,7 +2382,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="72" id="SRM SIC Q1=497.75 Q3=629.35 Channel=5 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="73" id="SRM SIC Q1=497.75 Q3=629.35 Channel=5 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2383,11 +2400,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2397,7 +2414,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="73" id="SRM SIC Q1=497.75 Q3=790.4 Channel=6 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="74" id="SRM SIC Q1=497.75 Q3=790.4 Channel=6 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2415,11 +2432,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2429,7 +2446,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="74" id="SRM SIC Q1=692.85 Q3=351.2 Channel=1 Event=13 Segment=8 CE=25" defaultArrayLength="104">
+      <chromatogram index="75" id="SRM SIC Q1=692.85 Q3=351.2 Channel=1 Event=13 Segment=8 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2447,11 +2464,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2461,7 +2478,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="75" id="SRM SIC Q1=692.85 Q3=460.75 Channel=2 Event=13 Segment=8 CE=25" defaultArrayLength="104">
+      <chromatogram index="76" id="SRM SIC Q1=692.85 Q3=460.75 Channel=2 Event=13 Segment=8 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2479,11 +2496,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2493,7 +2510,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="76" id="SRM SIC Q1=692.85 Q3=676.35 Channel=3 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="77" id="SRM SIC Q1=692.85 Q3=676.35 Channel=3 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2511,11 +2528,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2525,7 +2542,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="77" id="SRM SIC Q1=692.85 Q3=823.45 Channel=4 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="78" id="SRM SIC Q1=692.85 Q3=823.45 Channel=4 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2543,11 +2560,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2557,7 +2574,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="78" id="SRM SIC Q1=692.85 Q3=920.5 Channel=5 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="79" id="SRM SIC Q1=692.85 Q3=920.5 Channel=5 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2575,11 +2592,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2589,7 +2606,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="79" id="SRM SIC Q1=692.85 Q3=991.5 Channel=6 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="80" id="SRM SIC Q1=692.85 Q3=991.5 Channel=6 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2607,11 +2624,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2621,7 +2638,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="80" id="SRM SIC Q1=692.85 Q3=1090.6 Channel=7 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="81" id="SRM SIC Q1=692.85 Q3=1090.6 Channel=7 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2639,11 +2656,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2653,7 +2670,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="81" id="SRM SIC Q1=487.3 Q3=347.25 Channel=1 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="82" id="SRM SIC Q1=487.3 Q3=347.25 Channel=1 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2674,18 +2691,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="116">
+          <binaryDataArray encodedLength="128">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAELjgyMJg4MTC0AbEBEG9wJKiFJqAAaO8HIC5wQmAwH4d7QOIBQDU3gFjCmYHBFog9gNgIiFmdIf4ByecA8SYo/YHKfgOFlQHFYQcAGS8Wdg==</binary>
+            <binary>eJxjYCAELjgyMJg4MTC0AbEBEG9wJKiF6sDBgYGhAGQv0P4IIC6A0iA+WNwBXQMDwwygeAxQ/hIQ8zozMNgCsQcQGwExqzPEPwFAnAPEm6D0Byr7DRRWBhSHHQA1fBWL</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="82" id="SRM SIC Q1=487.3 Q3=462.25 Channel=2 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="83" id="SRM SIC Q1=487.3 Q3=462.25 Channel=2 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2706,18 +2723,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="88">
+          <binaryDataArray encodedLength="104">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYBhM4IMjA8MmJwYGEWcIXgdk33CEyBU4QuRNnCB0gSPx5oLMWALUpw40MwCILYH4HZAf4ESaOQMDACnCDwI=</binary>
+            <binary>eJxjYBg0wAGInRgYNgExvzMDAx8QrwOyLzgyMDwAyhUA6Q9ALOMEoUF8sB4CYAFQzQKg2iVAfepAMwOA2BKI3wH5AU5QcwY1AAAY9BAw</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="83" id="SRM SIC Q1=487.3 Q3=575.35 Channel=3 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="84" id="SRM SIC Q1=487.3 Q3=575.35 Channel=3 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2738,18 +2755,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="76">
+          <binaryDataArray encodedLength="84">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAHXHBkYJjhxMDwB4h5nRkY7gHpACAucCTLOKqBBw4MDBuAbhBxgmAQW2CA3UQ5AABXrwnc</binary>
+            <binary>eJxjYCAHXHBkYJjhxMDwD4g5nRkYbgDpECBuAIo32JNlJMUAbC/Q/g1AzOEEwSC2ABAzOAyMm6gDAGehCq8=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="84" id="SRM SIC Q1=487.3 Q3=646.4 Channel=4 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="85" id="SRM SIC Q1=487.3 Q3=646.4 Channel=4 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2770,18 +2787,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="104">
+          <binaryDataArray encodedLength="132">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYKA3KHBkYDBxYmCYAsUgNkgMWW4TEF8A4nVArALECY6kmfcBKJYDpN8BsY4zA4MDELsAsTIQiwLxH6j5bVC1Dxzo4nUyAQBCphcX</binary>
+            <binary>eJxjYKAnaLAHYkcGBgMnBoY+KAaxQWIMDhDaAshfA8SngHgFEMsAcQFUHgMAxTqg5nVAsQ0QSwBxExC/AmJVZwYGayB2AWJlIBYF4j9A8QtA3AbEH4D6H2Aze9AAAFxpF98=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="85" id="SRM SIC Q1=487.3 Q3=761.4 Channel=5 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="86" id="SRM SIC Q1=487.3 Q3=761.4 Channel=5 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2802,18 +2819,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="236">
+          <binaryDataArray encodedLength="248">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjaGh1ZmA4AcQFQNwDxD5AXAnEEUBsCsR3nBgYDgDxEiB+AMT/gJjNGYL5gVgZiB2BOABKg/i8QPwOqG4TEJtAMYhtBFUHokF8ESgGsVmdIRgm/sCBgWGCI9A9QPYxJ4iZIH2WUNoDiDshbm/4AsSsLnB8gM+FwUERiN2A7HogvQWIP7kwMEi6MjQouTI4AOkF/10YHux1YVjQBNSjBZS7DjUzB2jX4AIA/l411w==</binary>
+            <binary>eJzNzS8PQVEYx/GfGQqbSDMkIyK6nGMzf4okioKgandGM1kUbJqJik0QvANF8AIE8wLwvbv3RTjbZ7/nec6zc+QujHTFBEt0McUAZdwb0hlbPPBB1PiSyKGGXpBen8CTvT2cwBEl5h3jp9fnAweEjM+rU8jUpTVG1FfEuSuigir6WOGCl5ETtnIjVk6MTFqd81ZqWw3nVo8d8zd9uik325RDbr7MT1abGfsF7m6808KYv/7r/ADanDSi</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="86" id="SRM SIC Q1=487.3 Q3=874.5 Channel=6 Event=14 Segment=9 CE=17" defaultArrayLength="105">
+      <chromatogram index="87" id="SRM SIC Q1=487.3 Q3=874.5 Channel=6 Event=14 Segment=9 CE=17" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2834,18 +2851,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="108">
+          <binaryDataArray encodedLength="124">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYKAHKHBkYMhxYmBgc2Zg8ADiACCWAeIpQDERIDZxgrCnQNkg9dSydwLQPFmgXfVAvBCIlzszNEwA0uFA/A5q3wMH6thHGwAAAAgQwQ==</binary>
+            <binary>eJxjYKA1aLBnYOhwZGAocWJgYHVmYHAGYm8glgTiWUAxBSC2AOI+KDYA4gZHiD6KgAMDww5HiB2cQLvqgXghEC93ZmiYAKTDgfgdUM4EiB84UMGjNAMASIAS5Q==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="87" id="SRM SIC Q1=869.45 Q3=565.25 Channel=1 Event=15 Segment=10 CE=43.9" defaultArrayLength="109">
+      <chromatogram index="88" id="SRM SIC Q1=869.45 Q3=565.25 Channel=1 Event=15 Segment=10 CE=43.881" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2854,7 +2871,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="43.9" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="43.881" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2863,11 +2880,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2877,7 +2894,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="88" id="SRM SIC Q1=869.45 Q3=963.45 Channel=2 Event=15 Segment=10 CE=36.6" defaultArrayLength="109">
+      <chromatogram index="89" id="SRM SIC Q1=869.45 Q3=963.45 Channel=2 Event=15 Segment=10 CE=36.626" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2886,7 +2903,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="36.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="36.626" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2895,11 +2912,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2909,7 +2926,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="89" id="SRM SIC Q1=869.45 Q3=1062.5 Channel=3 Event=15 Segment=10 CE=29" defaultArrayLength="109">
+      <chromatogram index="90" id="SRM SIC Q1=869.45 Q3=1062.5 Channel=3 Event=15 Segment=10 CE=29.049" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2918,7 +2935,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="29.0" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="29.049" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2927,11 +2944,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2941,7 +2958,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="90" id="SRM SIC Q1=869.45 Q3=1175.6 Channel=4 Event=15 Segment=10 CE=38.1" defaultArrayLength="109">
+      <chromatogram index="91" id="SRM SIC Q1=869.45 Q3=1175.6 Channel=4 Event=15 Segment=10 CE=38.073" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2950,7 +2967,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.1" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.073" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2959,11 +2976,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2973,7 +2990,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="91" id="SRM SIC Q1=869.45 Q3=1272.65 Channel=5 Event=15 Segment=10 CE=33.2" defaultArrayLength="109">
+      <chromatogram index="92" id="SRM SIC Q1=869.45 Q3=1272.65 Channel=5 Event=15 Segment=10 CE=33.247" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2982,7 +2999,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="33.2" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="33.247" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2991,21 +3008,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="60">
+          <binaryDataArray encodedLength="72">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAEHjgwMOxwZGAQcILgDY4QMXwApMYAqLbNCUKD+KOAWgAAGu4IXQ==</binary>
+            <binary>eJxjYCAEHjgwMOxwZGAQcGJg4ADiFY4QMVygwZ6BYQNQjQFQbY0ThAbxQeKjgBoAAPM3CcE=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="92" id="SRM SIC Q1=869.45 Q3=1385.75 Channel=6 Event=15 Segment=10 CE=40" defaultArrayLength="109">
+      <chromatogram index="93" id="SRM SIC Q1=869.45 Q3=1385.75 Channel=6 Event=15 Segment=10 CE=40.009" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3014,7 +3031,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.0" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.009" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -3023,11 +3040,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3037,7 +3054,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="93" id="SRM SIC Q1=634.35 Q3=288.2 Channel=1 Event=16 Segment=11 CE=22" defaultArrayLength="104">
+      <chromatogram index="94" id="SRM SIC Q1=634.35 Q3=288.2 Channel=1 Event=16 Segment=11 CE=22" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3055,11 +3072,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3069,7 +3086,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="94" id="SRM SIC Q1=634.35 Q3=658.4 Channel=2 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="95" id="SRM SIC Q1=634.35 Q3=658.4 Channel=2 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3087,11 +3104,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3101,7 +3118,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="95" id="SRM SIC Q1=634.35 Q3=771.45 Channel=3 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="96" id="SRM SIC Q1=634.35 Q3=771.45 Channel=3 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3119,11 +3136,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3133,7 +3150,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="96" id="SRM SIC Q1=634.35 Q3=934.55 Channel=4 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="97" id="SRM SIC Q1=634.35 Q3=934.55 Channel=4 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3151,11 +3168,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3165,7 +3182,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="97" id="SRM SIC Q1=634.35 Q3=991.55 Channel=5 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="98" id="SRM SIC Q1=634.35 Q3=991.55 Channel=5 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3183,11 +3200,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3197,7 +3214,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="98" id="SRM SIC Q1=634.35 Q3=1104.65 Channel=6 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="99" id="SRM SIC Q1=634.35 Q3=1104.65 Channel=6 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3215,11 +3232,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3229,7 +3246,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="99" id="SRM SIC Q1=610.8 Q3=332.2 Channel=1 Event=17 Segment=12 CE=22" defaultArrayLength="103">
+      <chromatogram index="100" id="SRM SIC Q1=610.8 Q3=332.2 Channel=1 Event=17 Segment=12 CE=22" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3247,11 +3264,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="200">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3261,7 +3278,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="100" id="SRM SIC Q1=610.8 Q3=576.3 Channel=2 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="101" id="SRM SIC Q1=610.8 Q3=576.3 Channel=2 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3279,11 +3296,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="220">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3293,7 +3310,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="101" id="SRM SIC Q1=610.8 Q3=675.4 Channel=3 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="102" id="SRM SIC Q1=610.8 Q3=675.4 Channel=3 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3311,11 +3328,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="128">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3325,7 +3342,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="102" id="SRM SIC Q1=610.8 Q3=790.4 Channel=4 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="103" id="SRM SIC Q1=610.8 Q3=790.4 Channel=4 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3343,11 +3360,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="144">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3357,7 +3374,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="103" id="SRM SIC Q1=610.8 Q3=889.5 Channel=5 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="104" id="SRM SIC Q1=610.8 Q3=889.5 Channel=5 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3375,11 +3392,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="180">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3389,7 +3406,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="104" id="SRM SIC Q1=610.8 Q3=988.55 Channel=6 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="105" id="SRM SIC Q1=610.8 Q3=988.55 Channel=6 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3407,11 +3424,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="100">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3421,7 +3438,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="105" id="SRM SIC Q1=860.45 Q3=645.35 Channel=1 Event=18 Segment=13 CE=31" defaultArrayLength="102">
+      <chromatogram index="106" id="SRM SIC Q1=860.45 Q3=645.35 Channel=1 Event=18 Segment=13 CE=31" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3442,8 +3459,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="40">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3453,7 +3470,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="106" id="SRM SIC Q1=860.45 Q3=801.4 Channel=2 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="107" id="SRM SIC Q1=860.45 Q3=801.4 Channel=2 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3474,8 +3491,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3485,7 +3502,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="107" id="SRM SIC Q1=860.45 Q3=930.45 Channel=3 Event=18 Segment=13 CE=31" defaultArrayLength="102">
+      <chromatogram index="108" id="SRM SIC Q1=860.45 Q3=930.45 Channel=3 Event=18 Segment=13 CE=31" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3506,8 +3523,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3517,7 +3534,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="108" id="SRM SIC Q1=860.45 Q3=1059.5 Channel=4 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="109" id="SRM SIC Q1=860.45 Q3=1059.5 Channel=4 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3538,8 +3555,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3549,7 +3566,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="109" id="SRM SIC Q1=860.45 Q3=1174.55 Channel=5 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="110" id="SRM SIC Q1=860.45 Q3=1174.55 Channel=5 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3570,8 +3587,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3581,7 +3598,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="110" id="SRM SIC Q1=860.45 Q3=1287.6 Channel=6 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="111" id="SRM SIC Q1=860.45 Q3=1287.6 Channel=6 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3602,8 +3619,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3613,7 +3630,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="111" id="SRM SIC Q1=860.45 Q3=1507.7 Channel=7 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="112" id="SRM SIC Q1=860.45 Q3=1507.7 Channel=7 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3634,8 +3651,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3645,7 +3662,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="112" id="SRM SIC Q1=482.25 Q3=400.75 Channel=1 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="113" id="SRM SIC Q1=482.25 Q3=400.75 Channel=1 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3663,11 +3680,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3677,7 +3694,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="113" id="SRM SIC Q1=482.25 Q3=516.3 Channel=2 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="114" id="SRM SIC Q1=482.25 Q3=516.3 Channel=2 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3695,11 +3712,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="48">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3709,7 +3726,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="114" id="SRM SIC Q1=482.25 Q3=573.35 Channel=3 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="115" id="SRM SIC Q1=482.25 Q3=573.35 Channel=3 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3727,11 +3744,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="64">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3741,7 +3758,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="115" id="SRM SIC Q1=482.25 Q3=686.4 Channel=4 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="116" id="SRM SIC Q1=482.25 Q3=686.4 Channel=4 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3759,11 +3776,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="68">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3773,7 +3790,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="116" id="SRM SIC Q1=482.25 Q3=800.45 Channel=5 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="117" id="SRM SIC Q1=482.25 Q3=800.45 Channel=5 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3791,11 +3808,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="40">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3805,7 +3822,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="117" id="SRM SIC Q1=713.3 Q3=395.2 Channel=1 Event=20 Segment=15 CE=25" defaultArrayLength="105">
+      <chromatogram index="118" id="SRM SIC Q1=713.3 Q3=395.2 Channel=1 Event=20 Segment=15 CE=25" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3823,11 +3840,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="104">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3837,7 +3854,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="118" id="SRM SIC Q1=713.3 Q3=524.25 Channel=2 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="119" id="SRM SIC Q1=713.3 Q3=524.25 Channel=2 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3855,11 +3872,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="92">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3869,7 +3886,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="119" id="SRM SIC Q1=713.3 Q3=637.35 Channel=3 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="120" id="SRM SIC Q1=713.3 Q3=637.35 Channel=3 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3887,11 +3904,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="116">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3901,7 +3918,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="120" id="SRM SIC Q1=713.3 Q3=736.4 Channel=4 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="121" id="SRM SIC Q1=713.3 Q3=736.4 Channel=4 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3919,11 +3936,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="104">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3933,7 +3950,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="121" id="SRM SIC Q1=713.3 Q3=865.45 Channel=5 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="122" id="SRM SIC Q1=713.3 Q3=865.45 Channel=5 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3951,11 +3968,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="100">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3965,7 +3982,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="122" id="SRM SIC Q1=713.3 Q3=1051.5 Channel=6 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="123" id="SRM SIC Q1=713.3 Q3=1051.5 Channel=6 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3983,11 +4000,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="72">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3997,7 +4014,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="123" id="SRM SIC Q1=734.4 Q3=530.3 Channel=1 Event=21 Segment=16 CE=26" defaultArrayLength="183">
+      <chromatogram index="124" id="SRM SIC Q1=734.4 Q3=530.3 Channel=1 Event=21 Segment=16 CE=26" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4015,11 +4032,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4029,7 +4046,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="124" id="SRM SIC Q1=734.4 Q3=643.4 Channel=2 Event=21 Segment=16 CE=26" defaultArrayLength="183">
+      <chromatogram index="125" id="SRM SIC Q1=734.4 Q3=643.4 Channel=2 Event=21 Segment=16 CE=26" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4047,11 +4064,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4061,7 +4078,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="125" id="SRM SIC Q1=734.4 Q3=714.45 Channel=3 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="126" id="SRM SIC Q1=734.4 Q3=714.45 Channel=3 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4079,11 +4096,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="88">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4093,7 +4110,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="126" id="SRM SIC Q1=734.4 Q3=785.45 Channel=4 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="127" id="SRM SIC Q1=734.4 Q3=785.45 Channel=4 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4111,11 +4128,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="92">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4125,7 +4142,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="127" id="SRM SIC Q1=734.4 Q3=898.55 Channel=5 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="128" id="SRM SIC Q1=734.4 Q3=898.55 Channel=5 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4143,11 +4160,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="84">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4157,7 +4174,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="128" id="SRM SIC Q1=734.4 Q3=1013.55 Channel=6 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="129" id="SRM SIC Q1=734.4 Q3=1013.55 Channel=6 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4175,11 +4192,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="64">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4189,7 +4206,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="129" id="SRM SIC Q1=734.4 Q3=1217.65 Channel=7 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="130" id="SRM SIC Q1=734.4 Q3=1217.65 Channel=7 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4207,11 +4224,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="116">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4221,7 +4238,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="130" id="SRM SIC Q1=489.95 Q3=416.25 Channel=1 Event=22 Segment=17 CE=16" defaultArrayLength="188">
+      <chromatogram index="131" id="SRM SIC Q1=489.95 Q3=416.25 Channel=1 Event=22 Segment=17 CE=16" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4239,21 +4256,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="232">
+          <binaryDataArray encodedLength="240">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAEDJwYGEScGRj2OjMcMHRheNDtwqCwy4WB4SoQP3JhaHjhwuDww4VBgNmVoQGIHb67MCTcBao5DpTbClGbcASo5hIQA+kHG4B4ugvDgQYg3w1I8wHN+ePM4MAGVP/PmaHhMNCucCC+B7R3ExAfAuIlQKwDxAGOCHcVANkfgLgAKD4FiC8A8QMoBqkPAOINQPkHDph+guk1cYKa4YipZhQMRwAATXk3MA==</binary>
+            <binary>eJztzzEKwjAYhuEPFEdx6AE8gIOewNhGJ68g5CjZPYDg5OABXHRQlA4FHUVwUyhOxQvoIOJbiji6iz99+JvkS9JK36oZSkEkrSPFLat0aFVfWumIi5XPrMzdqlbqysPcrNyZzJa1eZF1CZkD6OkMI6vYM+7Rq5zziGQq5J+R/Iq7Brhy7wIbTNCA6fBBhgeO9zJzDmMkOGGPKfrY5Xn49ud/3nszBGHR83E+/69frxecVjdl</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="131" id="SRM SIC Q1=489.95 Q3=530.3 Channel=2 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="132" id="SRM SIC Q1=489.95 Q3=530.3 Channel=2 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4271,21 +4288,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="220">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYEAHDxwYGD44MjC0OTEwvANiK2eGhi/ODAxdLgwMXK4MBpGuDCumuzJo7HJl6LjiyqDwACj2CCh2x5XhxHVXhglA/OMekP3KleHDRyB+58oQcdeVoeKoK8ON5a4ML7pcGQRCXBkcJIF6LwPNXOzC4NAGxLFAtqwLQ8M7oF17gXYuA+JWIDsOiB2BWAaIDwHd4wHEBY4Yzh4Fo4AIAAAlDDJS</binary>
+            <binary>eJztzqEKAlEQheE/m6wKgtFoNl3dnWY0aBBfw2i6yCabdhHNRotJsCtoUFlMsmFZwWD0ZA2+wB74uMPA3Bn4Tuwga4JvQSqNgNErgCiEglHvGaupUdsY46NRjdW7q3cx9idjIu+b6sTInpIa3asx3BnnpfGIjGLHcCXNHvTnPMR56auuSKJdW+1c6PUyECdlWeuetsx0n3M/p+fJ8ycfG1Ux6g==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="132" id="SRM SIC Q1=489.95 Q3=643.4 Channel=3 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="133" id="SRM SIC Q1=489.95 Q3=643.4 Channel=3 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4303,21 +4320,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="176">
+          <binaryDataArray encodedLength="196">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYEAHBY4MDB+A2MQJQoP4BkB2uDPDAR4XBoUOF4YDp4H4LxCzuTJMYHJlOPDHhWHBfwgfhBNYXRk2MLgyFLBA2BeAeAFQXcNXFwaHe0AzdrkwPJgOVJ8K5Iu4MDTMdmZgOAW044EjhnNGARnggQMk3kScIPEYgBSXIxsAAPwBKII=</binary>
+            <binary>eJxjYEAHBY4MDB+A2MQJQoP4BkB2uDPDAR4XBoUOF4YDp4H4LxCzuTJMYHJlOPDHhWHBfwgfhBNYXRk2MLgyFLBA2BeAeAFQXcNXFwaHe0AzdrkwPJgOVJ8K5Iu4MDTMdmZgOAW044EjhnNGAYmgwR4Yjg4MDBOAYcniBIk7EP4B5CcAsYPDQLtwIAEANDoppQ==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="133" id="SRM SIC Q1=489.95 Q3=683.35 Channel=4 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="134" id="SRM SIC Q1=489.95 Q3=683.35 Channel=4 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4335,21 +4352,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="280">
+          <binaryDataArray encodedLength="296">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAWBDgxMOQ6MzQIuDAcaHBhWLDFhSHhDpD+7MLw4DeQ/gQUv+7CoHDMhcHhIlDsjwuDAL8rwwcBV4YANleGhG9AsUdAOaD8gxkuDA2+QPwfaN55IH7qzMDA6MLA8AdIPwPyXwJpTqB5akAxayBtB6EdNIBscSDmA+qVBYp5AHE+xD0N9VDcDDS/CyjWA1TfDuSXAOkEiFoHHSBmBbIvA81fDrSnE0h7AjEvEB8C+q8NiAuA+AIQywDFHIGYzRki/sCB6KAaBYMWAAA3oEdA</binary>
+            <binary>eJxjYCAWBDgxMOQ6MzQIuDAcaHBhWLDFhSHhDpD+7MLw4DeQ/gQUv+7CoHDMhcHhIlDsjwuDAL8rwwcBV4YANleGhG9AsUdAOaD8gxkuDA2+QPwfaN55IH7qzMDA6MLA8AdIPwPy3zgzHOAEmqcKVGMJFLcDsoF0A5B/QAJIiwDNUQGKuwP5mUB2DZCuB7oB6K6EFqB8J9COLiC7FSheCpSPh6h10ATSHED5q0A7VgFxO9A+HyAWAOITQP9NgOJLQCwBFNMEYhYg7gDyFzgyMDTYEx1co2BQAgBxsEo5</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="134" id="SRM SIC Q1=489.95 Q3=714.45 Channel=5 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="135" id="SRM SIC Q1=489.95 Q3=714.45 Channel=5 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4367,21 +4384,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="168">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYMAHNjgyMCxxYmAwcmZg2OTM0CDkwuBQ5sKgsMuF4QOzK4OCoitDgLYrQ4OSK0OCoCvDAxag2A8XBoa3QPzQheHAdReGhAtA9kmIngeLXRgWNALFHVwYGn4AzVwMxFZAfA9ohw8QrwDa98ABr5NGwSigAAAAZxEf5Q==</binary>
+            <binary>eJxjYMAHNjgyMCxxYmAwcmZg2OTM0CDkwuBQ5sKgsMuF4QOzK4OCoitDgLYrQ4OSK0OCoCvDAxag2A8XBoa3QPzQheHAdReGhAtA9kmIngeLXRgWNALFHVwYGn4AzVwMxFZAfA9ohw8QrwDad8ABr5NGwSigAAAAG1EfxQ==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="135" id="SRM SIC Q1=489.95 Q3=754.4 Channel=6 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="136" id="SRM SIC Q1=489.95 Q3=754.4 Channel=6 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4399,21 +4416,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="280">
+          <binaryDataArray encodedLength="284">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYMAHNjgyMGxyYmAIdwbSzgwNP5wZHBRdGBpKXBgO7HdhuMDjytCg6cpQoOXK8EDQleHAR6D4DQh2uOfCwPDQhUHhAZB/yoXhwQYXhgWNQL1RLmAzHOSBmB2CG24BzV4CtMMFiLmB+B3EzoZVID5QjR5QTRAQRwLNDAXSDkAz1YC0FhD7A+XbgfZMBbInQN0WBhRzgaozhNrHCtT7CGjmVqCZU4A4DYgtgVgGiHmBmA2I/wHtfeAE8XMbEJs4QcLggQPeYBoFQwYAAE2rREo=</binary>
+            <binary>eJzt0DFLw0AYxvFnMgRE8AuYOuog2llJmrxH1y4S0q/QxaGD4ymODg5+gA6dJThlM7OTo5RS0o/QrXTqX7NnF3zhx10e7t7LndRV5UB6T6U8Y8zkt5mSU5OfmuoP09ehkz9zujt3ao6d6g35dytZmbQ29Rq+P01NaZo9sHdsvz2SCEHLL+g95wxDCKHAG+eFrLmg14h1ORgVg6zu4xaP5C9kz7hnXpANccPeK5yQBz//Q88Kr5jgGhGOcIAdd12m7Z2fcImKNxB83PlU//Unag/8N0Fr</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="136" id="SRM SIC Q1=489.95 Q3=825.45 Channel=7 Event=22 Segment=17 CE=16" defaultArrayLength="188">
+      <chromatogram index="137" id="SRM SIC Q1=489.95 Q3=825.45 Channel=7 Event=22 Segment=17 CE=16" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4431,21 +4448,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="300">
+          <binaryDataArray encodedLength="328">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztkD8LQWEUxh+DQVksNuVPme9qUNz7vrIxKiUSJYPJprySxXQHKYPYbNIdlTIafQL5EGwGD0eZbGxO/XrOOZ2eczrAp9hkAc8G8g7MwgECCtURuSpkUhrHusa5o+E2NVAWTE3DamtsKtScRjSmUQ1xjpi41MUgZw8K57Git8I+SXzMt9wz454V9ST7ECYJkuZMQ8H05QYzZK9HbQnLAesp8zlxpd7XSelxK3sRcqHnTvzhvXbcCNQzN2syYt2lTqhrmTcutUBOtvzDsuU33wrr5et33v7/+FXcAU+MTRc=</binary>
+            <binary>eJztkLFLQlEUxj+nCFxaWlxUwtnVBjHfvRG0CI5CKIYIQe5Nt8RFHCwaatKpxchHo9NbBMfmBvGfMBz7PW6r4OLWgR/fdw7nnnM50rYIz6TPsnQRyI0C6dCo3oO1Ualg9dW0WnWshi0r1TyuYZW/sQqv0HOrdMaqfkQfuKzPK0l6F0arvmG2UZSDBH7Gnlf2vMMyUHRA7RhOoGjkrlFnNO7iH/B3cMvbDn+iFj2hL9SG6D15m74q+SmaQjfMncM08Lu+YQ0/3itEB9DFP8MEPuARLiEBb9zDlP1txqWtp9s50szJx/Ng+adxHtf/Yx/xC7QVTeA=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="137" id="SRM SIC Q1=585.35 Q3=232.15 Channel=1 Event=23 Segment=18 CE=21" defaultArrayLength="555">
+      <chromatogram index="138" id="SRM SIC Q1=585.35 Q3=232.15 Channel=1 Event=23 Segment=18 CE=21" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4463,21 +4480,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="532">
+          <binaryDataArray encodedLength="620">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztkz1IQlEUx/99KBYpDQYuUdQSRSAhTQ1+vPMIanjQ4hS1FzgUSEO45GZERGMYNEQEiQWNhQRJDblEERKOuYRDLQ3R//auFIFFSw164Mc597x77j0f9wEN+RuphIBsGPBGbJStfPUoqu451v+ocbIfBW0rrXoTIDHdH6VVTED37LNf+XZITscpe4MkVa/DH3HZGmdXJROyY+41SR1b0X4V+0rczHWIWGSeTJMQ6YrY+as8SmSE61QEiTNSJi0GTj0GEt3UAwa/U08YCC4ZmNmiP0ddNmB1CDr7BBgVBEWQiQpKi4KHlKB3W+A6oD4WxE8EhQt+vxb4bgSxK0EiL4iec8+lwLoT+J95TruJosfEZJsJX6uJI4eJoMuEv4kUBbuHgvw69y4zfpaM86wxrod5Rg/vcPC+FwNrzbzLzZycgvQt895nDZsG0qvMe4X5L9AXt3m3p6gHyRNr39O96tc9qs7iu3n8RkpBe35ePXNlK58ipv3qDuvL+/npjdbj/1qrlw1pyP/KG+eel10=</binary>
+            <binary>eJzt0z9oFEEUx/Ef5BRBEMEUKYKepBOEKyyCBG6i+w6DFikUUlhcIRi0CWJxnUsKOYzKgSIHNmeqi9UVgsFCrwoSNQZECKS5SqKNAVMp/vk+80ALC5sgagY+zO6+t7PzZmal7bY1LS9LrUQ/KhWOSafRQDs04pnHPOd7bvlPz3prmteVJ2mcOpdR8ppxHwtYCc/RibWZwCDWyH+K+Z90Rzef9xNPuIybaOI2rqGGyeDX08HvR2Ldfaw2VlCMb+bxfh1XY9zZmOcG9h2XDuEoEkZQwkEMYD+GcR638BCr+Iw9GfFM3VKmfAwXM1WvZ+q16Re5f59parepe8C0fsTUOmmaOmdKV0ztG6bOXdOuOdPaA3Iem4YXTMVnpvyFqbpkWn5J7JWpuYo3vPfBNP7VNFio6NTOijZ2VKS+iqofTQNvTXvJnXxkmr9nqs2Qf8nUOMM3y4x1eHMeeb+px5w6BeKfMhXfMdfX1PGEec9x38QMc5/OlGq4QGyCGsv0Q/R9xBap/Q7OYghfWMel2H9f4xOxH032QUjp98+U5/u5qsdedqJvxbWflR7Wg58l/07JY/5++jHe//q//motW6EezzzmOf9Kzdvtb2vfAIQUswo=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="138" id="SRM SIC Q1=585.35 Q3=619.3 Channel=2 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="139" id="SRM SIC Q1=585.35 Q3=619.3 Channel=2 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4495,21 +4512,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="584">
+          <binaryDataArray encodedLength="672">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztk00ohFEUht8UjcxI+UlRlKIUSUrT+Jvx3dMki0kpsjALpPxnM6TMhmyssEJZKKVM09iwUEPIRimRhcXsxEKzluS9uVMfZUdR89bTOfeee797zvnuBdL6X0q0AVEvMOoDtkmMBHwfc9+tTzK2aNbqPQ1k0vsR01bvTY1/W/ocff6qIZWLXVGTb2Y7UE3qSSlxkSzybKu7wEbU1JDqUcDUmyBvvs979blJk8uJiRWauN6jz4/r73KugriJvx3hBdplskP/mrbIAjzEbyHeQltLW0lK6OcQ0M+10OamP2GhfM3C1j7HZ/TPLYRPOH9L36GwVaMQDCjEBxQCkwqORYW6Tc4f0d4r5L0onDoFr6WC8lpBolkQ7BAcdAmcPYLhPoE/KNgeIlOCZEiwNMfYjCA8LbgfFwyMCApGBXODguJewV0r11bR5guaXILObMFVhuDiSSF0o9BzTCLMZUUhPKuQ7GYeHuZYxhydCnhhDQ+s6ZI17bHWeY4bSR7remWPHskhibBXGyRGf5es0+83PY/Z7oGmztZ79hxjZMjcg5j5b2n9DaXe2tc3mFZaP6t3qvianw==</binary>
+            <binary>eJzt1D9oFEEUx/EfVkdM5ESLFMEswUDIaThEwULMnjczVQIB/6AQ4YwpgoVKSJHCYokgp9WBh6QQOYjIYUCDhYiFrBDiCUFCUEiTECGNYBHFIqCF382Otc0VKe7Bh515M3v7ZmZvpVbs/YgGEUr5grSAzDnpJIa8YxBqjAWoMTfGCO0YWcbOYMTPz6MdDcYqhXRect9mmN6rMH1msyJMfpPfj7Di6+nzkvYaubonX+cTfE7WVZQO4CDasOPzL/AAFxBgp5CuJ7GNo+QmMIu3WMYnxHju81X/nFdYwmpSi7eBn9jPM3swiGtFRfe4zuED7e2iwg4jdRtF/RgwinP0e43CI+ii38P1FLnzjE/TrpCbMyq9Ntr8iK/0ZVU5bLWSs1qwVhqzakRW2YdWtbpV/b3V7Dpjv63GO5waXU7jOaf6aadO41QddoouOo2OOsVjmHAKbjr1TTpdnnIq4xft5VtOWze4Xndau8Ic7hs6S27AKR84lQ7RzzD2x6r0zar8xepNbBXN45FV5i41UlveWAX9VjE1395HvVtGtUXW9swouM96rrLeE6w3ix/s1SresV8vwd5FVfozuIRefGefn+IOpvHYn3Gb3/vjfl57MT2j5Nw7UfbvejPf1Vb8P/59j+S/Hbvn4JV9bvf/HrbOphXNir8iga5A</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="139" id="SRM SIC Q1=585.35 Q3=690.35 Channel=3 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="140" id="SRM SIC Q1=585.35 Q3=690.35 Channel=3 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4527,21 +4544,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="808">
+          <binaryDataArray encodedLength="968">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztlE1oE0EUx/8HrQpVIwQVqRJtDoVeiuRgxUja3XnrsQhiT7Uo0h4Ug+QgpcIWaQSpYktugkYoVItITQ/WgxBERIuH+lFEqiEXUQ+W4KF4EPE/7FsIOSyIih468OPNvnnzvmZmgT85sl1AqhsoKHZudf9y/E5OM7TL0/472egAFcqev1RTNRP4rSmnNN9ydzCvRcQMayyRBZX22+Yf+oxr7j0Na9m6eMtkL+s8RFqdwFeH1mvzs3ubqD9GTjuBbUl95nV/C3XtTmA3qbnbGuJOQEl1pQZdKsjdH+X3Gwf+Z8qHlCOUXRrLyqOkj3Q6QbyC+mrSuEknOKuq6gt1TGqeeY2X0lzs+dKvXyB3SZl8IDEXmU4X/oCL8mXOi+SGi+olFzhD3QlylpwPdHbNf0T5gnKJ8qWL/vfBHF9cJDYZ9KcN/JxBbMyg95pB4p7BuUWD7DeDwQ2CwS2CRKug96Bg7qTg9QXBlXHB8aLAnRWszAuGlgTvPnF9RTC/1sPbzR5ubvWQ2+HhwE4PzQkPmT0eJpIebpNFzj9Sf3Gbh1naptd5ePxD0Fyjn6pgzSvBnSeCW3OC4pRgO+PlhgRtRwSxtGBfuyC5S9hX2nxlrs8MqtMGbeOcj7CWAYOOw6xlP9lN1htkKqz9PrlOJtijMcpR9mGYfemjTFPGbV/Y5wc8L/YewwH+VTJNnvL7OZnSsw/v9rK+xxa9p3F9m3a9ondhQc95Ru9u1Nux9z+r9qU6svru6vdH/U+sbeO9jnq34ZsP32JUnuH41RhRI/y/VZSwX6tjdfx/4ydbPfif</binary>
+            <binary>eJzt1E9IFFEcB/CvZX/8U1ppSUu2GxISHhI8bBG4u8686R+ykIiHgiU0IjKkOnRQGE0oRWj7g0ilbWrhQUJEw0PFQNIhKhY0WaLDEiEGEkvdQqjvc37SHuq00cmBz77fzLx5897b+f2ATI9AgD9BwKY4FYaAcqHjuNzTfZb7/ocjkznZPA/zeoKq2NemAXpMfdRCXprifW+Ga7Kr3ecdCnCsGKWojOMfppPUQH7Kp7Gg9Au489Tz79Pr4L1DdJZa6TLVhdz5l8iaCyUukrH0M9myJ+dlfQlaorU1wDe2rylGPdRLLyhFm3i/mApoDS3yWpI+h9w4Ja0+/0CzYk7Mpvko7yzlOMeoje7QA+qvgR0lm3Ej1VI1VZKPtlA2gbIk1vR48/SGJmhQ5q/X0UkdEo/SAu3mM/V8TzfbJ2zn9DgGbB+F6LSBQJsB7zUDyS4DuM6404DTTlepm3rpEftO8v5L9n9HCfabZ7tkIFpgorDchGOZiDWbKOkxERky4X9mIj5nIvzdxP0chQWPQkOlQtFRBf8Zhd4OhfzbCtuHFS5MKqReKdQmFC5+UdjzQyF3nYXj+Rb6tlqI77Cw6LEwX2rhudfCOZ+FcbZNPL+008K2Ygs3N1s4tYF9fyosphT2feL7ZhT2TiuUTSjUD7G9pWC3K1Q1KpQcURjlfCK72D9XIcZ5js2YSD2lfhP7u6iFazlhInqAa/OZaMkzkfzKfXhrIDLO9Q/QDe5PBzXzeh33yc/YwziL3nO/J+gh3eP+83/HoLhLXdREB8lDebSeNlKOxPobSMn3NE3DkgsVku9hyRsIR/J8SuqDzrcr1C3fhs77sOSMrgUjQTf/kmn1pCKtNSTv9Hc2IqKShzrPdL1x0t6v55IMuDVkRTLwe466NqzUiOV8D7rj1Mm4f3tHLO3ZP9YcqTVO0K1jDbJPrRLra47UGTuD2rZ6rB7/9vgFu9oQXg==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="140" id="SRM SIC Q1=585.35 Q3=803.45 Channel=4 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="141" id="SRM SIC Q1=585.35 Q3=803.45 Channel=4 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4559,21 +4576,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="708">
+          <binaryDataArray encodedLength="820">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztlE9IVFEUxr9FlosJCmZnwkARSlEiQyoRzMx791Di4i2C3OVKEpQkXLQoeBgqMxA0NLQYsgYaTERksKSEoMGFtHwqLUKZhllEYEhEhAsXftd3H81KRnB2c+DHuefdd8+fe857wHHKaBz4TaIJX2u7XjJq4iwSz2ht1zPmcUst93XYO9rWdXdagGP5WtvhxP9zAdoux2rPS8fLGKJV/rT/S4xz08Qr0R4medJD+yV5Q+6aXI5Sk857LwF3woK7QOboY5Ccs/weeybWsOl32PJZNH50fYFv7cvR8U1uJXNP9Kf9Y4TEyUmyw73TpqakX4O7TJa4/mL0BvVfC8UWG7HLNtwuG+jg+grXfOa2+hrXbRQf2CjnbUQ2aO/YGPjHvZ9cf+XeZ55Zow4peL0KzmOSVOieUiikFCKvFJpXFDr+KOydFdjtglCCDAii44LmtMCZFiy85d47wcwnQduqIO8J7m0JPlYEWdL3XdBP+/2mIEJC3wQX13mO785/EJTmBFuvBetZQea5YDYlCI8Jum8Lfl0T5C4IzoQFJ5oE2FbIeQrFJYXdF8x7SKF8Q8G9qvAsqhDrZL4R5n+KzzZZ3zLJse40637C9UPWfp819/t3hwrv8ym5Re6QcYO+f/b/oB+OP0duifoHNfuAR6ZfwdxUz6hjCObiPGkik7QLNf4TgvkpHPF7aUhDGlJv2QfPTdJx</binary>
+            <binary>eJzt009IVEEcB/Bv/yMMLAtEOiy00mIFYkKHjN7uvvm1BIGQhz1IbUkZedkuoSD1MpMIpCgi2w5ttIl0kC0WklhisYjAEJE0+kd7KywWD10qiL7j+wUW0UWIDjvw4Tdv3ryZ+c3MAxZcHCBNgTDgUZqyGu2zbS84fr8FT2XH4HgDhAjQREepU6N9tu1z78Pa/38rzt/3q17XDq3P7zOksWjfMc8+ytMH+kolemrzpxaqpAn9Pqnj2bOw++Lt+m1Zjj+nnc9+Y7/dQo6O1U1pHd/OszgKrKBVVEUbaTsZClOIvrNfJuKvNa13YX5OI5pLUHOZphp+F6PD1EFxHXctzej8D6mgcppvkho15woKUYJSdg8i/lprqUnHF9pJ26iBHGql01F4lxlvU471R/ScPvJ5iQtnjYvCBgrSJhdeyAXqGBv4TtjWzvp51jOMeRfpcReBl+zzzkXiPdu+MK42qK81KIQNkgcMLnYbeP0GQzcMqu+zbcrA+WawdJ1g5VbBm92CfJvg0ylBql9wMiXoGxRM3xW05gWVTwSD4zQl6HklqHsrKFGIKl4Lzr0QHJoUtIwJBkYFwyOCI8OCmoxg9prgxAXBsV72Py74HBe4YYG3WYBqwePljCWuacIgnjPoTBnMnuHa2yhmkG3k2oMGzeuZxzKDxAzzHWP+WcbrzJ974XXxeT/3xqEA64u4H8+4pze5p2epnfbRHtpLB6mH76/QLT2Lq9RFO6L+3bvHM+3Vc7d38xLdoVGa1DN/oO2xiH/Pmu3dc36993P/gf6TRf0vfypqO/7wv5RLuZTLvyw/AN7v4p8=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="141" id="SRM SIC Q1=585.35 Q3=916.55 Channel=5 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="142" id="SRM SIC Q1=585.35 Q3=916.55 Channel=5 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4591,21 +4608,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="408">
+          <binaryDataArray encodedLength="472">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztkqFLA2EYxh+QJctAwQXDZMW4YBFk7LbvjcpMqyuC0WBUPBSHTcGJUR3KVETGlmZSLEabYBhXBC1ywT/A37FLSwORlXvgx/Ps/d5v3/vdnZQo0aja8KSFktSIiXJU+28FxcE50/GZFQi90c6OesJ47lH3DO+P9nbgO6YzdPc2Xud3qix5Zfn7+D28kb/gndyBXajCFrVbvI//xEw4Ke/k7+Btp2LfqZYyFadMrxlTmIMlU37NVNk2peumA6gcsn5CPjPVLkzzl6aXa9Nn15R5Mq0/s/5gat/Rc0U/nLfITZOOTf4m/7VCLpmyy/Su0lMwBTP0fTBHj5lunLJNp+CUvMd8VciR06zPOT0W8EVqk9R63KXB3VqDZ+Af4bPlwTsbl/76DSRKlGjc+gVC0GnP</binary>
+            <binary>eJztkrEvQ1EUxj+JUWiCxNZO0piwiMmj7wiTDoYmBpUYJAb/gbxBREjoIpGQppWGJiIpikEknTAYukgspKNJjEa/yxsMWBgM70t+7zv33XvOPfe+J0WK9JM8j8ewFEAdYiNSMsTF9XDOrXlf+0cKhj7qNSBN7QLcw0vIDWxBL9Tcvp/3Ji5AIuzN5VZCd+PEVzlfnNnVb+GMk7AKOyEungUPfFiCK+hISROwDEWophRcwDnxIb4LeeISfoLf4s8peW2+gj5fmvFVW/flHflK3PlqvOKtpkbcVOmHUVMwZUovmGqBqbBiym2YtjZNc9smr2jK7Jt6D03JY+JTU9cZXmV9xfRyYNKeqZwnl5zEGmPqxObZI0P+OD4ISeY7qd1kyj7Q2yV9lOgvB4v0mIUx4gHoYT4O7bxrxp840zWUYY0zTkM3PHI/wcjHt3P3/93d/5l++Q9EihTpP+kN9LF+MQ==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="142" id="SRM SIC Q1=585.35 Q3=1070.6 Channel=6 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="143" id="SRM SIC Q1=585.35 Q3=1070.6 Channel=6 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4623,17 +4640,17 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="328">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztkDFKQ0EURY+WFpJC0lhEBMVGiFnBz595INgIYmeRDQhmB7/RRhAFsU6nWEj4KxhttLS1kb8AkSxA0DvMR+vUzoXDffO485h5kJX1X9UUMB3CSpmIdezNcyeyL2rRiFdxJmbDv+x1zDkYuOR1m3kqU+9WfDnCqqfoesKyvOfh0DO58Kw9iGfVb/IP+bfnZMmga1TrRmfLmG6mutgwJttGGBj96D1j1lFW+ctFo/lMs6o7zb/xjK48zbn8VOex+kfyXb1hL1EcJK9K+Y5cbwwLyrw4qvsEj+73zLF4b/cSd1C3f4+Edlfz7DsrKysLfgBwy1TG</binary>
+            <binary>eJzt0DFLA0EQhuEPsTGt0UJSHCga0NrWizcLIgqCjVhICgXLgK3FJdWJEiwES69RRBvLYGFSC0JMkTqIhYj4C0R8D64R8g+yAw87Ozu3e7uSDx+jFPEKQpKKtIUEaS7Ja9la1pP1Dvsm6/1AsCpt4BhNXOAsn+/jEAlu8Yw3fOMXUxHboYH7SHE/UihTp2gKl7BuUs1UbZrSG1PQNnrIv0xdOZ0XnMJJxhmnIMCcU3feqVZ2SqEFzLJeok5fPEHPD3u8s9cLWqbBNeMlZ51ybp3xiPEAu5y9Te8m1qhXqC1TKzOfJh8n/+SfX9HGA664xwn2sIgx9LhnB094xF3+TjsoosUbVoe8tw8fPnz8jz8Dz1w6</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>

--- a/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/20140312_六mix_column_1 (scheduled) 一个试.mzML
+++ b/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/20140312_六mix_column_1 (scheduled) 一个试.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="20140312_六mix_column_1 (scheduled) 一个试" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.1" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.41" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -20,7 +20,7 @@
     <software id="Shimadzu_x0020_software" version="4.0">
       <cvParam cvRef="MS" accession="MS:1001557" name="Shimadzu Corporation software" value=""/>
     </software>
-    <software id="pwiz" version="3.0.18206">
+    <software id="pwiz" version="3.0.20255">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -55,9 +55,26 @@
       </processingMethod>
     </dataProcessing>
   </dataProcessingList>
-  <run id="_x0032_0140312__x00e5__x0085__x00ad_mix_column_1_x0020__x0028_scheduled_x0029__x0020__x00e4__x00b8__x0080__x00e4__x00b8__x00aa__x00e8__x00af__x0095_" defaultInstrumentConfigurationRef="IC1" defaultSourceFileRef="_x0032_0140312__x00e5__x0085__x00ad_mix_column_1_x0020__x0028_scheduled_x0029__x0020__x00e4__x00b8__x0080__x00e4__x00b8__x00aa__x00e8__x00af__x0095_.lcd">
-    <chromatogramList count="143" defaultDataProcessingRef="pwiz_Reader_Shimadzu_conversion">
-      <chromatogram index="0" id="SRM SIC Q1=1059 Q3=244.15 Channel=1 Event=1 Segment=1 CE=50.6" defaultArrayLength="238">
+  <run id="_x0032_0140312__x00e5__x0085__x00ad_mix_column_1_x0020__x0028_scheduled_x0029__x0020__x00e4__x00b8__x0080__x00e4__x00b8__x00aa__x00e8__x00af__x0095_" defaultInstrumentConfigurationRef="IC1" startTimeStamp="2014-03-12T06:03:16Z" defaultSourceFileRef="_x0032_0140312__x00e5__x0085__x00ad_mix_column_1_x0020__x0028_scheduled_x0029__x0020__x00e4__x00b8__x0080__x00e4__x00b8__x00aa__x00e8__x00af__x0095_.lcd">
+    <chromatogramList count="144" defaultDataProcessingRef="pwiz_Reader_Shimadzu_conversion">
+      <chromatogram index="0" id="TIC" defaultArrayLength="2605">
+        <cvParam cvRef="MS" accession="MS:1000235" name="total ion current chromatogram" value=""/>
+        <binaryDataArrayList count="2">
+          <binaryDataArray encodedLength="11508">
+            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNl3lYlIf5tWeGYRisNcbaGGuMtYZYP2KtMdYYa+D1PDHEGmOsodYYREREFBERURHZN9lklV32fZdNBJRNBEQEpMb4M8RYY22MsUZ2xO/8kSvXpckMPO/93ucclUqlMtGpPzTReX+4KriJ/1ablXy80GxVsGLW1LnLjH9u9ujtSP5ZupmLfTn/vMlsMr+Xf3fPzP/H//Hv1eaBrxmbP3r7VfONq+aa8/81n7ltibmL/XLzgWOrzfk55okJn5hP5n9ublX3T3N+pvmiO/vM/X90Nn84cdycn29uOcOfnxFsXvtmGD8n0nzeslh+VoK5h1kKPy/dfPCzbH5mvvk662J+brl51qEqfvYFc513Az+/ydw+so3f0WHeld7N7+k1X1oxwO+6bR7RfJffd8/8Wd8Dfucj8633f+L3/s+8+pchfveY+VztFL9fraydZqBYzjBUnGYZKfxdlLTf/UqpffPXSu8fXlH4eyka098o85b9VlmxYo7C31GxXTNP8TCbr8RhgcLfV2n/2yJl8DMTZfTvixX+7sqSHabKOuulynbbZQrvoIQcWKFkHVqp1B9ZpfAmypOTaxSd91plgb+Zwvsom8Og2Ed+pHjHfqzwVkpFyt+UrvRPlfvZnym8mzK75O/K0oovlPXV/1B4Q8Wt8UslovkrJe/KToX3VG5f360869ujTLu1V+FtlTWD+5Wt9x0Vx4dOCu+spP7solT/4qr0jLgpvLmiUp1U5mpP8R8vhfdXlut9eANfZcN0P97BX7GZGcBbBCrus4N4j2Al+vXTvEmIUvRGKO8SprT9Ppy3iVDuvnWG94lUhv8YxRtFKzOWxvBOscri5XG81VnFbGU875WgbFudyJslKc5rk3m3FCVYSeXtzikZH6XxfulK3ScZvGGm0v9pFu+YrTz+PIe3zFW0lnm8Z74yf3sBb1qorLQq4l2LlU02JbxtqWJnV8b7liueDhW88Xkl/mAl71yllB2u5q1rlI6jtbz3BeXeiTre/KIyfqqed29QZvk28vaXFNPAy7x/kyIhzXwGLcqOiFY+hzbFNfoKn0W7Enb2Kp9Hh5KT1Mln0qU0nrvG59Kt3Mq8zmfTozzNvcHn06voi/r4jPqVhWU3+ZwGlNWV/+KzuqVsqf2az+u24lD/DZ/ZHcX38v/xud1Vklu/5bMbVCqvfsfnd0/pvvY9n+F95cGNf/M5PlCmbv7AZ/lQmXP7P3yej5Rld//LZ/qjYnHvMZ/rT4r1gydKoKUVIh2tkOxnhZwkK5RVWKGuwwpt31mhZ8QKt2fsxH2TnXjy150Y/ftOaPbvxHSfnZiTsBMLy3bCtH0nVn67E2ZDO7FhujW2LrKG1QfWsP/cGi721qgMssZwnjVWdVhj3XfW2DhiDcsZu2BtsgsZH+3C/T27YBKwC8tSdmF15S5I1y5s+n4XIjQ26P2DDWbBBvO328DqhA20cTaYUWyDua02WHTHBrYTNsiZtxsP1+zGsy27scJlN26H78b97N14Ur8bo/27sfr5brjPtkX9e7Zo/5st9AdsURJoi9pUW7RU2aL7mi1m/GSLzb/eg8ile5Ase3DXdg98vfYg7OwexJfsQUbbHtx/sAcmOjvYvW0H57V2qPjKDtuO2yExwQ5ZZXYoabdD7bd2GJ+yw5oFe+FhtheBlnvRcXQvnKL28q57ede9vOte3nUvZr5ujy3v2yN6mz1SnewxGGEP/0J7tHfZo/d7e9wZs8eDmfuwePk+3nIfCpz38Zb7eMt9SG7dh7v/3oeHE/vwbJYDJpc4YO0GB3g6OKDptAO60h0wvdkBFXcd8PyFA6Zm74f+nf285X5s3b0fcb77cStzP+7V7ecd96NjeD+mzTmA2X86gAUfHcCSHQfgcPIAipIP8I4HeMcDvOMBDL7iiIV/doTpx45YaeUIM1dHeMc68o6O0P7LkXd05B0PYviPB7Hqk4NYZ30QG90OwjL8IO94ELevH8S8nw/yjk68oxOmr3PCJhsn3tEJNmec4JjrxDs64elDJyzXH+IdD/GOh7Doy0OwdT/EOx7C8fxD8L18iHc8BJ3aGRYLnXlHZ97RGauPOMM9xpl3dEZEszMSbzvzjs6Y/7vDZPIw73iYdzyMzWGHEVl8mEweJpOHyeRhMumC+D+54PYmF8xzciGTLrDLceEdXcijC+/owjse4R2P8I5HeMcjvOMR3vEI73iEdzzCOx7hHV1R9q4r6j5xRZu1K3rcXDEz3hVbal0R/bUrUn925R2Pwt/0KHk8Cse9R+F26ijveBQhRUfJ41He8Sjv6Ibtb7mRRzfe0Y08umFJshtWnHfD2k43WNxzQ7D6GLoWHuMdj2HOP4/xjscwFXMMZlXH8ODGMd7xGHk8Bu1rx7H+L8fJ43HyeBz9Yccxu+Q4eTyOyUfHkWF4AkVvnED1ihNo2nCC7/gJSMgJ3vEE73iCPJ6A29QJ1L7pzju6847ufLfd4eHpjsZz7lBdducd3XlHd4TNOYkVK07C9e8neceTvONJvtsn+W6fhPvNk6h/fpJ39OAdPbBhowee7vXA8iAP3tGDd/TA414PDP/HA6uMT+H4klO84yne8RR03qfI4ynyeIp3PMU7nkKezhMV8z3xfK0nefTkHT15R0/y6An7Xk8U/M+T/40Xls7y4n/nhVVLvLBttReOf+KFxH96YcEeLzLshVm+XlgR7QVduhefgRdm1nohrsUL1f1euHXfC6O/eMHjpRdSX/GG83xvesIbtmu88Wi9N5y2eOP5V96YfdAbK095k3Vv3EnwxmS+N3pqvPG03RstA958Xt7ofuyNLaPecNH7IPp1H1T+0Qer3/PBdvHB0i0+fBd8sPCQD3LcfWAa6IOyKB/0ZvjgWYUPZrX4IP66Dx3jg5DHPiia9IHnNF8+W18EL/TFjKW+WLbWF5s/9YXzV74YtvfFnOO+eBTgi2lnfXE3yxc2Zb54eNEXju2+CLvli5KHvnSRL7Ya+MH1N358l/xgv9wPa8z8yIEf1lv6oWuXHx47+9H5flga5YeKFD/0F/sh56IfXeXHd8wPCx74IeupH5ZM+jED/OHwhj9C3vHHzPf9sdzCH1pLf5jY+WPUxZ/M+EMT4o/AOH/k5fijo9ofj674w6nPHxHf+8PmqT98VQF8HwNwZ24AcyIAD/4cAJ0SgMWfB8BiVwC6DwTgyckAui4A9xIDUJkXQL4C0HgpgPkRANs7AfD/MQA5EwEwNQrExjmBWGASCLOVgXx3AxG/KZCZEoiMPYFocQ3Eff9AZksggtMDUVAeCI9LgUjtCYTz3UCyGAj354FQqYKwcGYQ1v0+CDZ/DmLmBEG/MQh3/hmEyX1BfM+DsNU3iPkTBKvEIHgWBCGtLghNnUFY/68g2P0QRIcGYbs2mDwGk8dg8hjMXArGXQnG1NZg8hiMrEPBaPMKRnx4MDMqmDwGk8dg8hiMeT3BWDMYjB0/B5PHYGh+dRqL5p2mb09jzurT5PE0pv3jNPPrNGwOncZD99NwDDzNHDuNktzT5PE0trachmv/afJ4Gvb/O401L09jxyshWDY/hDyGkMcQNJqFYPCzEKisQ8hjCHkMQXtICLMuBHX5IQirCaGnQ+A9EALdvRDyGIKZoyF0dii2vB4Klz+GYnRFKOZKKB5/HorpNqEYdAqFyiuU7gnFtoRQ8hhKHkPp8lBk3Qilz0Ox4XEoHCZDsXZaGKx+F4blfwyj28Ngsj6M3SMMHjvDmJVhaPQMY16GwTYpjI4Kw7YLYTjeEYaNt8Lg+DCMXSQMswzCET8jnM4Kx+0/haPor+Ho3hiOtO3haHIIR/SxcNgFhJPDcGzPCod7ZTg2NYeTw3C6LByzn4Rj5VQ49NMjsOSNCGZsBOZ/EIGnH0eg5YsI9pYIVLtE4JZvBAoiI+BxLgKppRFwbohAZHcEGYzAqkcR2DYWQQbPkMEzZPAMnr17hgyewYPNZ6DbdQa3D55B0ckz6A49g7TEM2gqOIPo2jOwu3IGgf86g+3/PkP+zmCTJpL8ReL5/EjmdCT5i6QbIxH2j0iU7I2Et2sk+YvE4shIWKRHYl5pJF0ZSf4ice+bSFT+JxKBw5HkL4p9KAqb/hDFLI+iO6Mwe1MUHn4Zhbp9UQhzi2I/iqJHo7A1MwqLy6Ng0RRF9qLw5P+i0PTfKNwbj0KlPhqBr0Uzo6Lh/l40Nq2LxsLN0XRhNF0YTfaiURccTfaiyV40vKuiyV40FvdGk71o9oBoPJmMRtO0GNz7XQzZi0HgX2Lowhi4b42hC2PIXgyee8RgdngMHibFkL0YshdD9mLIXgy23o/B4v/FwEIdi3mvxOLJG7Fo+n+xuPdBLCotYpl3sdhuGwv3I7HY5BOLhWdi8TwlltkXSw/GMv9i6cFYejAW3kOx9GAcFr8aRw/GYd6yOHbeOHowDve2x6HSPg6BR+Ow3S+OHSMOmzLi2H/j8LwhDrOvx+HhnTjUPYpj34hDidFZeP/2LDJMzsJ1xVlYKGeZmWexZudZzHA8i2UeZ+nAsxiIP8s+d5YOPMtOdxb1N8/SgWfpwLN0YDwdGE/24rHhnXiyF0/24jFzWzzZiyd78WQvnuzFk714shdP9uLpv3iyF0/24jFtJJ7sJTBvE9ilE8heAtrME+i/BNRaJSDkQAJ7dQI8TydgS3wCTHISsL46gf06gTmcgMbBBAz+nICKFwnw/1Uits1NhOniRGxclciemMjOnchsTkT8wUTUnkpESGgi3ZeI5XmJ0FYnwuRKIrtjIrruJTKvE+H8IhGRv06C7bwkui8J01Yl0X1JdF8Sem2S6L4kZngSNoQmwSE5CWsLkui+JNxvS2IWJzGLk5jpSXRfEvtRMt2XDDFNpvuS6b5k1G9NRoRNMsoOJ7MvJTOLk9mZkpnFyZhfl8wsTmYWJyPufjLdl8z+lEL3pdB9KdCYpmDg/RQMW6SgwzIFybYpcDqcgnVeKeymKViZmgJ9UQruXEghfynouZWCjAcpcP0lhfylkr9U9tVU5nAq+Uslf6nkLxV5dqnkL5X8pZK/VPKXSv5SyV8q+Uslf6mwfpBK/lLJ3znydw7jb55D9zvnyN858neO3fYc7OzOsd+eI3/nmMPnoEo7xxw+xxw+xxw+xxw+R/edo/vO0X1pWPGbNOgWptF9aXRfGjw3pNF9aextaVh/NA1z/dLwODIN0zPSMFiahoqGNPh3pWHb7TQcf5TGLpeGBYbp3BfpaPt9OjM4HbUfpiNkYzqstqdjuX06thxLZ79Lx2h0OjdHOhlMZwan03/pZDCdDKaTwXQymEEGM8hgBrL+nAG3DzPIYAYcdmRgrUMGZh7LYAZnMIMz2AMzmMEZzOAMbO7OYAZnQH7MwJyxDDzSZaJ+dibuvpXJjp0JX/NMWG7K5F7JxIYDmZh/IhNPAzPREpuJuMxMVJ/PRHBTJnb0ZGLZ3UxofszEoolMDOuz0PFaFpLfyoLTu1mIWJeFsi1Z8LXOguXBLCw5mYXJ4CzMT8wig1lkMIsMZpHBLATfyyKDWehSZ7MPZrMPZpPBbDKYzc2TjW3/zIbp3mxMHclGr082ss5koy0tGw/KslHbmI2Qa9mw+iYby/+TzS6YjVsGOSh4NYc9Pgepy3K4LXMgf8thn8/Bqn05qD+SgwifHHbBHPim5cCyJAdL6nMw2ZGD+d/kkMEcMpiDOINc2L+aSwZzyWAuGcyF5m+5ZDCXDswlg7lkMJcM5pLBXLQX5pLBXHbBXJgN5GLW/Vw8eJqL2qlchEzP4x7IY/7mQfuXPNxCHgo+z2P+5jF/87DIPQ/DQXnoiMtDclYenCryuBPy6ME8ejCPHsxD2EgerA3z6cF8cphPDvPJYT45zMeWbfnkMJ99MB9d3vlIjciHc0o+pDAfthfz2Qfz6cJ8ujCfLsxnDufThQXsgwUoWVwA75UF2IoC9sEC9sEC9sECpJ0ogEtQAdbHFWBuVgH7YAFZLCCLBWSxgCwWMIsLcFdbiLJZhfD9fSEs/1RIFgsx+Ukhev5RyD5YCFeXQu66QsyLKMST5ELmcSHzuBCVVwux+mYhpn9fSCcW0omF6P91EZ1YRCcWYeq9IvSuK6ITi+BmVUQei8hjEXks4v4rIo9FsC8vwppLRZjRXUQei5jJRczkImZyMTthMTO5GP1Li5GzppgbpRgb/1HMfViMZ4eL2QmL2QmL6cVidsJiMllMJovJZDGZLCaTxVj2opidsAQDr5cg7+0SdPylhLlcwlwuYS6XoH1/CXO5hJ2wBGaxJZiVWUIuS6BrKiGXJeSyhFyWQDtcwo1eSi5L4bGgFJuXlmLRmlJyWUo3ltKNpXRjKd1YSjeWMptLmc2lzOZSWLeVMptL2QtLcftJKXdKKXdKGdJ+VwaTt8vYC8vQpZQh9bMyNO4sg+wv404p404pQ31MGXthGXthGVY2lkF/rQx3bpdxo5bRj2X0Yzn9WE4/ljOfy5H2QTlcLMq5U8ox17acfixnNyxHZFg5u2E5VuWXsxuW425rOcr6yuH7XTksn5Rzy5Zj0rgCPXMqmNEVzOgKxKEC8z6rwJMdFeyHFeyHFagMqsDqmAo6soKOrKAjK9DfXUFHVsD0YQWmnlegV3OejjwPtzfPM6fPM6fPM6fPM6fPI273edg7n8caz/OYEXaeO/g8t8p5BFafx/bW81jadx6bvj+P/p/Oc6ucx3HjSvbESjgurmRWVzKrK+nJSnqyklldSU9W0pOVqI6u5FappCcrsayhEpquSgx8XYm8HyrRMVzJrljFrljFrliFdtMqdsUqOH5cBbMvqjBrdxUeHKrinq5iXlcxr6uY11XM6yrmdRUKeqvgMViFzT9V0ZVVkF9V05XVdGU1XVmNdebVsNlczb5Yzb5Yzb5YDWv/avbFau7natwuqUZRfTU8O6uR9k01TH6o5n6upi9r6MsaNC6ooS9r6Msa+rKGe6WGe6WGvqxhZtcws2vgllqDDUU1zOwarO2sYWbXMLNrUP1LDX1Zi9Hf1JLLWnJZS1/WIvLTWlR8VUtf1mKaWy23cy02nq2FY24tt3Mt2i7X4sGNWjJZy75YSyZryeQFMnmBffECXXkBdusvYPXWC3TlBbryApL9LtCVF+jKC8zrC+TxAiyvXyCPF9gXL3A3X8BTozrMfL0OcYvquJvrEKzU0ZN13Mx12OxYR0/WQULqyGIdd0odptXUkcU6TN2s42auY1bXoU11kTvlInfKRTryIsY/vEhHXqQjL9KRF8nhRXJ4kRxeJIcXsbTiInfKRe6Ui3h+9yLaf7yIhxMXuVPq2RXr6cd6+rEeGR/Vc6fUsyvWk8F6MliPHRH17Ir1zOl6LLpYj+Gr9Zhzu55urKcb6+nGBrqxgTndQP4auFMayF8D+Wsgfw3cKQ3cKQ3sig3sig3sig3cKQ3cKQ30YgO92MCd3Ej2GrmTG8leIxJXN3KnNHInN3InN3KnNHKnNMI1upFObGRGN9KJjXRiI53YSO4a2RMbmdGXyN0lPHr7EnviJZh+fIkZfYkZfYk98RJ9eAkPzlyiDy8xoy/Bqu4SmbtE5i6RuUtk7hLmai9j9ezL3CiXMbjsMirWXkb/p5fpwsvcKJeRePwyXXiZG+UyN8pl7uPL3CiXuVEuc6NcZke8zI7YhBm/buJGaWJHbKIHm+jBJnqwiR5sYj434a5fE6ZimpjPTcznJrg1NiH+ehNqv23C2v82cRs3cRs3cxs349aiZhQsb6YDm7mNm+H8VTMd2Axb92b4hzRj2tlmOrAZU5XNWNDWzG3cDLdvmxH/pJnZ3Mxt3ELmWpjNLdzGLczmFjLXQuZa8Ni5Bc4eLWSuhcy1kLkWMtdC5lrIXAuZayFzLczlVuZyK93XipaVrbj/USu0lq0wsWtlN2zlLm7lLm5FXk4rt0kr87gV02610nmt7IWtcDRqQ9icNrLWhp5VbfRdG33Xxk7Yxk7YxhxuQ3R8G13XhoHaNnLWRs7ayFkbOWuj564gce4V1C25gjurrzB/r2D+9ivsgle4R65wj1zhFr7C7L2Ce3VX6LcrWHTnCnvgFdhOXOEWaUfOvHby1U63tUO/sZ0dsJ2Z2w6Hk+30WjuKktvRXdTODdxOttrJVjvZaidb7dwgV1Ex/yqz9ir371Xu36tYaXWV3e8q98dV5uxV1KZepcuuYrzxKrfvVawZvIodP1/l9rhKj3XQYx1kqgMq8w7mawfWWXfA5lAHHdbBztfBztfBbO1gtnaQpw7y1EGeOshTJ3O1k32vE4+Xd2L6uk4s3dLJvdvJTO1k1+tk1+tEb0Yn3dWJWS2dWNHfya3byZ7XyZ7XherfdJGjLmZpF+ZKF73VRW910Vtd9FYXc7SLDHWRoS4y1MV+18WN0cUM7UKG4TW0/PYa7ptcY7e7BpP115if17gvrnHfXkNewDX2umt4lHON7FyDafs1bLx1jdviGjvdNW7bbuZmN54u7sbM97ux3KKbruqmq7rpqm66qpu7tpu7thtzLnRjVUc387Kbm6IbiWPdqDO+zh53HZNLrjMrr2PthuvcE9fh6XCdHe46mk5fx73E69AUXqejrnPPXmd/uw7/H68zI6+j/Vc9eDivB/p3erDkrz3YsLGHfuqhn3ropx76qYe9rQczinuYjT3cED3cED2I/KmHna2Hne0Gc/EGZv/pBlZ+eIP74Qb72g1u2BvcsDdwO/wGxlNvYF7pDXrpBrfDDebhDe7XG2h8eQODr/RC9fteLPxzL7Owl1nYSyf10km9dFIvndTLHOzF4vJeWDT1wr63l/2sl/2slxnYh8ev9mH6H/qw9N0+drM+OG3p42bt42bt417ow7OoPvayPqw430cX9cG1v4/Z18fs62P29TP7+jH3rX6sfq8f26Uf7lv76aF+eqifHuqnh/qxILsfZlX97GL97GL93Aj9aBnqx33Dm9C+dpM97CbW/+UmM+8m98FNbtSb6Dh6kx3sJv1zE6a5N7Gx5ia3wU3u05vMu5vMu5vMuwG6Z4DuGaB7Bti9BrhNB1BpP4CBYwPcBANke4jZPMRsHqIrh7inh+jKIf6MQ+R7iJ1xCLPDh9gZh9gZh9gZh/hzDpHxIebzEDvjEPN5iPk8TF8O82cdJufD9OUwO+MwfTlMXw6zMw7z5x0m68OIyBhmZxxmRg+zMw4zo4f5Mw+T92F2xhF2xhF2xhFu6hF2xhH+3CNkfoSdcYTOHGFnHGFnHKEzR9gZR8j9CJ05ws44ws44ws44giWTI+yMo2R/lN4cZWcchYUyys44ys44ys44Sv5H6c5RZvUos3qUnXGUnXGUu3qU78Ao/TnKzjjKzjiGrJlj7Ixj7IxjfA/G6NAx5vUYO+MY83qMeT3GzjjGd2GMHh1jZxxjZxxjZxyD6rsxdsYxvg9jdOk4O+M4FpiMM7PH2RnHmdnjfCfG6dNxdsZxdsZxdsZxdsZx7Cgd53sxTqeOszOOszOOw/35ODvjBHN7gu/GBL06wdyeYGecYGecYGecYGec4PsxQbdOsDNOsDNOsDNO4FbLBDvjBN+RCfp1gp1xgtk9yeyeZGecZGec5HsyScdOsjNOsjNOsjNOsjNOYkX0JN+VSXp2kp1xkvk9iS1fTzK/J5nfk3xfXtC1L7ixX7AzvmBnfIFH61+gfusLvjMv6NsXWHnqBfShL3An4QUz/AW8q17wvXlB577A+Lcv0P34BdLGX8BFP4X1r03x3Zmid6fQaDbF3jgF2y+n2Bun2Bun+P5M0b1TzPEp5vgUd/YUd/YUem5N8R2aon+nYKF+iXmvvMSTN16yO75E9Psv+R69pINfYrrNSww6vUSFx0tm+UtsS3jJd+klPfwSvc0vmeUvmeUvseHxS8wff4lRA5Xcm6aSrldVUvm6SlIXqCTwbZU4L1XJ9vdUImtUsnSdSuZ8ohLVZpU8slRJ/1cqqbdVSc5+lUQcVsnx4yqx8VLJxkCVrAxXyYJYleiTVfIsQyV38lXSVqaSkhqVxDeqxLtNJQ7XVLK1XyVrv1HJ4nsqmfkflYw/Ucn9IZV0T6qk2kAtadPUEvyqWlxeV8uOBWpZ/7Zali1Vy9z31KJZo5bHiloGLNTS+Jla8izVEvmVWtxt1WK7Xy2bDqtl1XG1LPRSy7RAtTwPU8vdGLW0J6mlLEMtiflq8S1Ti2ONWiwb1WLWppYl19Qyq18tk7fV8uA7tfQ8VEvtE7VkDKklZFItrgYasZqmEYtXNbL8dY3MW6AR7dsaefKORm6t0EjTBxopUDQSbaERj880Ymepkc1faWS1rUYW7dfI9MMaGT6mkUFPjXQEaKQiTCPJMRrxT9KIU4ZGtuVrZF2ZhrNEI7MbNTLVqpGHXRrp7dNI3W2NZH2nkbCHGnF7ohHrIY1smNTICgMDmT/NQHSvGsjTOQZy+00DaTExkKJ3DCRuhYF4fmAg9oqBbLEwkDWfGYiJpYHM+MpARncbyD0HA+lyNpDKYwaS6mkggQEG4hxmINtjDESSDGRphoHMyTcQVZmBPKo2kP4GA6lvNZCcLgOJ6DOQ47cNxOY7A9n40EBWPjGQBUMGop80kGcardwx1krbTK2UzNFK/Jta8TbRisM7Wtm6QitrP9DKYkUrMy20Mr5JK/e/0Er3Dq1U79ZKmoNWgp214nJMKzs8tbI+QCvLwrQyN0YrmiStPE7XykCeVhpLtZJXrZXIBq24t2rFtksrm/q0suq2VhZ+p5VpD7Xy/Cet3H2ulfYJrZRpDCXR2FB8ZxqK4xxDsXzTUMxMDGXJO4Yya4WhTK42lAfmhtLzsaHUbjKUjC8MJWSHobjuNhQrB0OxcDaU5ccMZZ6noWgDDOVJqKHcijaUpkRDKUg3lOg8Q/EoNRS7akPZ3GAoq1sNZVGXoUzvM5Thrw1lcNBQOn4wlIqfDCX5uaH4TxiKk0Yn24x1sm6mTkzn6GT2mzqZeksnD0110vuuTupW6yTLXCdhH+vEbZNOrL/QyYYdOlmxWyfzHXSic9bJUzed3D6lkxZ/nRSF6iQuWieeiTqxT9fJljydrCnViUm1TmY06GS0RSf3OnXS1auTyq91kjqok8AfdOL8k062P9eJTOhkqcZI5hgbiWqmkTx6zUj65xtJ/VtGkmNqJBHvGsnx1UZiY24kGz82kpWbjGTBF0ai32Ekz2yM5M4+I2k7ZCQlbkYSf8pIvP2NxCHUSLZGG8naRCNZnG4kM/OMZLzESO5XGUl3vZFUtxhJWqeRBPcaicvXRrJj0EjW/2Aky34ykrnPjUQzYSSP1XoZ0Oul8RW95L2ml8j5enF/Sy+2pnrZ9K5eVq3Wy0JzvUz7WC/PP9XL3a16af9SL2U2ekncpxffQ3pxdNOL5Sm9mPnrZUmoXmZF62UyQS8P0vTSk6uX2hK9ZFTpJaReL64terHq1ItFr16Wf62XeYN60f6glyeP9XLrF700jeulQG0s0Xpj8XjFWOxeM5bN841l9VvGssjUWKa/ayzD7xvLoJmxdKw3lopPjSV5q7H4f2ksTjbGsm2fsaw7ZCymbsYy+5Sx/H9VQ3De</binary>
+          </binaryDataArray>
+          <binaryDataArray encodedLength="2900">
+            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+            <binary>eJztWg+MFcUZ/5oAPQLIWY9wHqc+2mrxRERFpQnq3tt9u2jQvlOsp7XpO73Qo6I+DYnamDj88fq0J5wV4eSfz4TiVZE+BAOiJQtRS5XAxVBDI8Unag7/BC8Em4ux2O978627Ozv3bl9qqqE3yZdv5jffzszOzvfN980swFAaSt+VJAyAdCNAEclIAuSQ1iF1I3UhzUeagVSDBEhHUG4bkkCqpmeMb/kF/oeJ5onSrKTknzI/z5T8AubAvJPrLeZdzN9i3uDJa9LaMnW/KlPnpXxycJnTYrRzz+AyoiNGOySXjyn3ZDw5uC2m3MxvUO4AroHzY8i9nZQUR25EzH5bY87flphyf485L5Q+rkD25fiycddEKW2sQPZEBbIjrdiibn18WTE8viz8u4LxHqxA9pkKvkUF68FoqGDO5saXNX4bQ/aAtMNGNoYs66B7bQzZY1LWuCKGLNtXEUd2uJzXOGtH8PcSMXTI051YOuTtB2eUGUMibK/EdWVk+xTblioj216BrLpvlZNVxutOLyM7M2qLxUM4bxdWMBZKu010fco8c0zzTNYEY2aZZ3T7RMcgz/Q0RrFZFdgFSvfHkG8uI3NJmboqTd0YDTZOg9UPIFc0wljClL5oMF2HWHVgPnNYrvLLYjmWuwPPLA+3KxYofaeV8o+VsvpOnyrfcqNSJl9QXOmXF2O5EBhPHbY3NTBe8oUeCLSxT6l/yww9L8hvDLZ/hTK+E8p4xiv11yhldY20K+UlSvlBpXylUu4P9P9FID85IHe7nxcPB/K5QP73AfmnA/j+AD7M1x+3xs+LWn3e+FFA30w/nxF+vrgpIPNhWD+Nc1Jf57M9Mm9c62O178l8T7OPVR2Q+WrHxwp7ZD5zlo/ldst84nBgvPu4jyd8rP8dxiwfa+6VmDjuz03fEW57jo9lPmJsnv9d0h/4Y/BS1z+jmHEgitUeimLZ/ijWMdqOYBvqotgrE6PYl2dFsfpxUazme1GsXzNmY3MUO7JMIzcvihWnR7HM6CiW2B+165k/MBbQZWMKY0F9f4m/V3BP9b7hVA0WtC1zFF2kdJ4Ge0OzH7UOEMu0DYBnB8CXDYCrPoKXXh8khvJiJ7JLOl93BvtI5DPr4lR6ZnYSjGk4149r6v+MWE8S3DkWiHeUeto77sNn77DACNiakm1CHFoQGxH41hS3v5CUujkqgFPcWWOCOwH7+H4Ar5E4lPoN4NhGicg29gbG1NcoCfdP8aXmXRZi3zofCfdD4wHNmnw8ihUfjWLuPZo2L49iIfvqpbM17Wl8ap0v5E6JYqH589Lh6FwIHbZPgy3TzOMEDZbW+X0aH+1kSbp369Ng0zTzopM7mefqZEgF3TfTfFvdWdajGqwuqqeJjVGseoayf+LaaduqYEeT0H96eH8nvV3comBfmXB8aRhzL7Zg5R8V3wBtfe55RW6JBV0bwljmeQvuW688u8OCtXml360WjFgTxhIrLGhfFcaM2y3YpWCiyYLjTypj+bUFt6xQsAU4vk4Fm2vBjIcVbBKOeb7Sx7MmVDcp70F7iOpvoV+YP5aKYM0bFQxtYfdDCoa+SfYGBcM1lZ2iYBiLVY8MY8V3FT97b7icOBgui3+Fy4Ux4fYKE8Llvp+Ey/mzZbmT/e/CeMnTNeyr10uevYB9cvbde25k/CbJXfb9+wzJi9Mkz0/ici37+SO4HY4njB3M10pefETyzELG75Xc/SW/508lF6cx/4z17V32fT5nPtoK8a/rPb/IiwWfVe4tPN3PG/CdSAkej+fvFpgfUspefeJb2lu8ONw7X+jkcQxTxufxfq7PMP9/ulsbSpUlWlukj7RW6Dx8Mq6hDJ0tJWXskeY7W9LdxDdwT1t6HtvporXJd8Jt3Fcbl4dxfzmWo3HRWdwkJsr38N0xaMbk3UXTc9P4XdYiree7aPI36Mx32yDv5M0N9UNjwviudBe7AWkLt9fB80X91PJc0RjJ5tH5B8WjS/g+nN7xFpan8nbSV1OeBTaa8szMRpqCNBbpA6zfwTEayVIM+wZj67mNefw+FA/vSspzMYr1JiKdiXQq0jAmOg+9GmkB7skrzNJ5l1iDhPFqyXYvMeW5Jp39Eb4U+d1IhiljlVGmvOulWJ/OiOeijDDl2VoX8k3I/2GWYliDYtAGqxRbGegrCCzDGMxT/PmJlCudgW9F6kZaLcdBsbXAGFwsMkuxOI1BPIX5F5GTPJ3LvY18L9KrSLtMGW8dxbgX24dzsQ8b+2tFWmRBosuCYgHpTcz3Yv1XyNEvKI5NQXpcCjrrkCamoKcB+WVIuAf33Yx12RTkFqWgainKrkzBkWdS4KK/mN2Tgt29KWgbbsOWOhvExTbM+pkNk++04ec5G6avtmH+Zhu277Vh9lEbLhnpgHGGAwcvcuCRqxxwMw4cutcR9b9zYNtjjli1yhFPrXPE0g0OtG524JyXHNH7F0d073Tgtlcd6H3NEe8jnYL5611H/HW7I9agXN1zDjzxtCNaVjhif4cDFy10oOUuB16+GfuxHfgM+2tKODBqrAN7Ttiw8jD6YH+zwd5kQwP6hsfbbdj2GxuWXWND9aU2rP6hDelT8Z3Ahq5iCmp3pqCwDuejA/ndyJtSkL8U82ciVeGc4Fy6O3Fe0bcoCsyncW7PRz4e6Qf8vbFM91rCQUpa8hyqGqmI3+xP+M0WI7UgXY90A9IvTHkXT+dLtyI1IU1HqjXlfch21rc06xr9Q0J2gDjpcyvrt5uUukNn1LTugXXplaT/LwrpMv2nMpX1dTLrLNUtT8r/VrpZ32ezTSI74JKtYCLbQHtyotGnIuNU7+3bA9mRgfrIB57V2iWsN2gs/N7NbOPa2cbM5nei9nY3Sn8hzbZScNslYlucZlubZ8pp5IfSUPrv038AUfbRdQ==</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </chromatogram>
+      <chromatogram index="1" id="SRM SIC Q1=1059 Q3=244.15 Channel=1 Event=1 Segment=1 CE=50.647" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -66,7 +83,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="50.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="50.647" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -78,18 +95,18 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="64">
+          <binaryDataArray encodedLength="80">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYBgFo2CwggcODAwfHBkYCpwYGKY4QWgQf4MjhDaB8gscB9ql9AYAfGwKNw==</binary>
+            <binary>eJxjYBgFo2DQAQcgdmRgmAHELE4MDAZA7AHEDkCsAcQCQMwAxC+A8juAuAGIBYDYwWFgnU0/AADnyQfR</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="1" id="SRM SIC Q1=1059 Q3=359.2 Channel=2 Event=1 Segment=1 CE=38" defaultArrayLength="238">
+      <chromatogram index="2" id="SRM SIC Q1=1059 Q3=359.2 Channel=2 Event=1 Segment=1 CE=38" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -110,8 +127,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -121,7 +138,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="2" id="SRM SIC Q1=1059 Q3=529.3 Channel=3 Event=1 Segment=1 CE=48.6" defaultArrayLength="238">
+      <chromatogram index="3" id="SRM SIC Q1=1059 Q3=529.3 Channel=3 Event=1 Segment=1 CE=48.552" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -130,7 +147,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="48.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="48.552" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -142,8 +159,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -153,7 +170,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="3" id="SRM SIC Q1=1059 Q3=741.4 Channel=4 Event=1 Segment=1 CE=40.6" defaultArrayLength="238">
+      <chromatogram index="4" id="SRM SIC Q1=1059 Q3=741.4 Channel=4 Event=1 Segment=1 CE=40.647" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -162,7 +179,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.647" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -174,18 +191,18 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="44">
+          <binaryDataArray encodedLength="56">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYBgFo2CwgQJHBgYTJwaGKVAMYoPERgEMAABb2gP7</binary>
+            <binary>eJxjYBgFo2CwgAYHBoYARwaGC0Cs4MTA4ALFIDZIDCQHUjMKADN1BpU=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="4" id="SRM SIC Q1=1059 Q3=855.4 Channel=5 Event=1 Segment=1 CE=39" defaultArrayLength="238">
+      <chromatogram index="5" id="SRM SIC Q1=1059 Q3=855.4 Channel=5 Event=1 Segment=1 CE=39" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -206,8 +223,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -217,7 +234,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="5" id="SRM SIC Q1=1059 Q3=1041.5 Channel=6 Event=1 Segment=1 CE=38.6" defaultArrayLength="238">
+      <chromatogram index="6" id="SRM SIC Q1=1059 Q3=1041.5 Channel=6 Event=1 Segment=1 CE=38.558" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -226,7 +243,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.558" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -238,8 +255,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -249,7 +266,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="6" id="SRM SIC Q1=1059 Q3=1298.65 Channel=7 Event=1 Segment=1 CE=39" defaultArrayLength="238">
+      <chromatogram index="7" id="SRM SIC Q1=1059 Q3=1298.65 Channel=7 Event=1 Segment=1 CE=39" defaultArrayLength="238">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -270,8 +287,8 @@
           <binaryDataArray encodedLength="1084">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0Xkw1HEYx/GV0jWmpvucxpgloWSQ7O/7QZfuuzFdo9NIJZEioxLSpvtQqSkVoVnkirC5FdVWUipFZQq5hdzT56+d+e3+nmef11smk8kMw4cqDMOVCoW7hp9DpdlDTCSF+0pp4Sd3ic8lk9IwPlNJVpKazzWSXUQlv2uW5Dpagr8XM2xGCZPSSWKWm77gu8LivoWwkoSY+3Gh4BwhhjkKuwgnMQ8ugjOFg4ePkOv4C4N1QXxfKYwaznHGZWEcHMo5YcJU7y5nPRBmGVGcpxLmGx5zZrKwbErjXLWYo8zh7AJho1/M+RohqUu4o0zYOpZzT6Wwb6nirhqxIKSe+5rFInk7d3aJxVl93KuFSBNtGKwbhCifweD/R3ThcBg16CJm9EjwFjzaNgbGweOgip0A3oXY7ikw1ZuGOAc98EbEX5XDLMMQCT+MwHuROHMmzDeYIcnXHLwdyS+sYNlkjZSxCtABqTtsMUdpj7T4+aAJnvY6wEZ/KdKXLAd9kBm6GpJ6LdRV60ErPDPbCFvHzcjy2wq6Iad4O+xbdiJ3vDNoiLxdrlgQsg/5CW6gJwr6PbBI7oXny46AtnhxwxeLs/xQ9Os46IzdE0/y5gD8tg3k3UFwdj7F24NRffY071fCJekMDUJQ8/ksHc5hj+wCLS6i1uASPS7DdcUVmlxFnec1uoRib9h12txAffZN+oRhf/UtGt1Gg+4dOt2Fm0U4re6hcdN9ej3AAf8ImkWiOeoh3aLgrommXQxa2h7RT4WDk2NpGIdW+3g6PoanSwItE/H3fBI9k3EoJYWmT9BenkrXNHgNSKdtBjqmZ9JXjcOrntE4C/+8sumcA+/bubTOQ2duPr0L4FNbSPPn6BpRRPdiHLV6SftX6Nnymv4a+Aa8YYO36I15xw4l8Hv7ni1K0dfxgT3KcGzqJzb5jP75X9ilHMddv7LNN8guVbBPJU6kfmejH9Cq+MlOVfAf+IutfmOAcTV71SBgTS2b/YG2dx271SPwTgPbNWJQQRP7NSOoroUNW6Ezqo0d23HKuoMt/2GwUyd7duF0UDeb9mCIqpdd+6As6cd/GhCbtw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0XlQTWEcxvEbSUL2JUm2LNM0TdM0TdPkvE8hCVmTPSFZsoWsceXKleRKJRVumyKpJJWkG6FSWiUkV5JEqLEb4/njzJl5z5zfb97PVyaTycz0dKaY6cmn2Co1fOtIac5jJFslJE3paonnUtsEFc/Ukp9PBs810t+UKn7TSor2r/yuI4KG9hJtEwaIWbZGgv+K/h6ThZ+PlajbYyc4R5yPchF/U+aJlXlLBGeKcS82CEX7dtH6Z6/gfOFuqOAMpcgZFcI5KmFsGc5ZUeKgFMt5atHklsiZKcLR8xrnZoiEbTc5O1foye9wvkb4qIq5o0SUqcu5p0pYZNZxV4MILWrkPq3orG7hzjaxsPkT934V2V3fuPuXMNL9x/06cDDoDnfDHtg6sCd4F1wa0Rs5o/qiamw/8F7oZj4IxpZDYG09DLwj1tob46BkgggnU/C+eOg6Dk1uZvi5YCJ4d0xebg5HTwssXWsJOiB4szUSttkgf6ctaIKOA/bQkzvAVCGBPpgb4gQf1TTIw51BK2TGuqJMPRvNiW6gGwanLYBF5iJMz14MGsK/YBlCi1Yg+cEq0BMNFWvQWb0OBvXrQVvYN23CwmZf+LZuBZ1x4bMfsrt24ckPf9AcMtkBGOkG8DkM+sNK/wgNAjGzz1E6KODV/xgtgrB/8HF6KBE2/ARNgpE68iRdQlA8+hRtQtE4/jR9VPg+6QyNwmBocZZO4ZhoFUGrSEg25+gVBQ+78zSLxnaHGLrFQokLtLuIuGmX6KdGnkscDeNRMzuBjon4OC+Jlpeh655MzxSYLL1C06uwWZlK12uY45VG2+vw9k6nbwYObcyk8Q2c25JF55tI35FN61so2Z1D71xo9+XR/DZ+B+TT/Q4GBhbQ/i7Mgwrpr8HU4CI2uIfloffZoRi7wh6wxUOERD5ijxIkRZeySRkKLj5ml3LUx1ewzRN8uVzJPlXQT61moxqMSa9lpzrYZT1lq3rMz3nGXg3YmP+czV4gsPAluzUi5v4rtmtC1qPX7KdF+eM3bNiMlsq37NiCf7Xv2LIVwxres2cbLBs/sGk7Zmg/susneLZ04D+N3qBW</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="24">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -281,7 +298,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="7" id="SRM SIC Q1=582.3 Q3=595.3 Channel=1 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="8" id="SRM SIC Q1=582.3 Q3=595.3 Channel=1 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -302,8 +319,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="124">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -313,7 +330,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="8" id="SRM SIC Q1=582.3 Q3=708.4 Channel=2 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="9" id="SRM SIC Q1=582.3 Q3=708.4 Channel=2 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -334,18 +351,18 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="116">
+          <binaryDataArray encodedLength="136">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYIABVmcGhjgoBrENnBgoBjccGRiuAc1hc4bgG04QMXT5T0C8AIj3ALEuUJ0CCDuhqhEGilkjyYHEPwBpPaiYHhR7OCPUMjpDzIbZz+YMADTaGTI=</binary>
+            <binary>eJxjYAhwZGDwcWJgeAPE2s4MDPpAzADEbUD+DqBcgwMD2eAGUP81oDlszhB8wwkihi7/CYgXAPEeINYFqlMAYSdUNcJAMWskOZD4ByCtBxXTg2IPZ4RaRmeI2TD72ZwBX94c3w==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="9" id="SRM SIC Q1=582.3 Q3=837.45 Channel=3 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="10" id="SRM SIC Q1=582.3 Q3=837.45 Channel=3 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -366,8 +383,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="68">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -377,7 +394,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="10" id="SRM SIC Q1=582.3 Q3=951.5 Channel=4 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="11" id="SRM SIC Q1=582.3 Q3=951.5 Channel=4 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -398,18 +415,18 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="184">
+          <binaryDataArray encodedLength="196">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAEApwYGISdGRhCgXgeEMcDcRtQbAEQf4LKWQOxBxrWdYaoueHIwLAHSCc7MzTMB+I7QPHdQDwZiBWhatiA4suA+CAQTwKKXQOKBQD1hQDpHmeGAxwuDA3KEHxAyIWB4TtQ3UuIerD9IPMLgPQJIF4OFL8KxEB2wxmomjtQ9S+dAUrvMag=</binary>
+            <binary>eJxjYMAFFjgwMFxwZGCY4MTAcAmItZwZGOYBcTwQtwH5C4D4ExALA/nWQOyBhnWdIWpuAM3YA6STnRka5gPxHaD4biCeDMSKUDVsQPFlQHwQiCcBxa4BxQKA+kKAdI8zwwEOF4YGZQg+IOTCwPAdqO4lRD3YfpD5BUD6BBAvB4pfBWIgu+EMVM0dqPqXzgCN6TRs</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="11" id="SRM SIC Q1=582.3 Q3=1050.55 Channel=5 Event=2 Segment=2 CE=23" defaultArrayLength="60">
+      <chromatogram index="12" id="SRM SIC Q1=582.3 Q3=1050.55 Channel=5 Event=2 Segment=2 CE=23" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -430,8 +447,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/xkpbUBAWm1AZ4ttQI28bUC07W1A2x5uQAJQbkApgW5AULJuQHfjbkCeFG9AJN5vQKqncEAVsXFAgbpyQO3Dc0BZzXRALPl1QAAld0DUUHhAqHx5QHuoekBP1HtAIwB9QPcrfkDKV39Az0GAQLnXgEBifIFACyGCQLPFgkBcaoNABQ+EQK6zhEBWWIVA//yFQKihhkBRRodA+eqHQKKPiEBLNIlA9NiJQJx9ikBFIotA7saLQJdrjEA/EI1A6LSNQJFZjkA6/o5A4qKPQItHkEA07JBA3ZCRQIU1kkAu2pJAyp6TQGVjlEABKJVAneyVQHKfaj0=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/4dWXkOchF5DsLJeQ8XgXkPZDl9D7jxfQwJrX0MXmV9DK8dfQz/1X0NUI2BDQuBgQy+dYUMElmJD2Y5jQ66HZEODgGVDmplmQ7CyZ0PHy2hD3eRpQ/T9akMKF2xDITBtQzdJbkNOYm9DZHtwQ3uUcUM3yXJD9P1zQ7AydUNtZ3ZDKZx3Q+XQeEOiBXpDXjp7QxtvfEPXo31Dk9h+Q6gGgEMGoYBDZDuBQ8PVgUMhcIJDfwqDQ92kg0M7P4RDmtmEQ/hzhUNWDoZDtKiGQxJDh0Nx3YdDz3eIQy0SiUOLrIlD3WSKQy8di0OB1YtD042MQ/EOZuY=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -441,7 +458,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="12" id="SRM SIC Q1=540.3 Q3=460.3 Channel=1 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="13" id="SRM SIC Q1=540.3 Q3=460.3 Channel=1 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -462,8 +479,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -473,7 +490,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="13" id="SRM SIC Q1=540.3 Q3=574.3 Channel=2 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="14" id="SRM SIC Q1=540.3 Q3=574.3 Channel=2 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -494,8 +511,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -505,7 +522,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="14" id="SRM SIC Q1=540.3 Q3=673.4 Channel=3 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="15" id="SRM SIC Q1=540.3 Q3=673.4 Channel=3 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -526,8 +543,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -537,7 +554,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="15" id="SRM SIC Q1=540.3 Q3=836.45 Channel=4 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="16" id="SRM SIC Q1=540.3 Q3=836.45 Channel=4 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -558,8 +575,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -569,7 +586,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="16" id="SRM SIC Q1=540.3 Q3=907.5 Channel=5 Event=3 Segment=2 CE=22" defaultArrayLength="60">
+      <chromatogram index="17" id="SRM SIC Q1=540.3 Q3=907.5 Channel=5 Event=3 Segment=2 CE=22" defaultArrayLength="60">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -590,8 +607,8 @@
           <binaryDataArray encodedLength="336">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB8AAP/6xBbUDTcm1A+qNtQCHVbUBIBm5AbzduQJZobkC9mW5A48puQAr8bkAxLW9At/ZvQD3AcECpyXFAFdNyQIDcc0Ds5XRAwBF2QJQ9d0BnaXhAO5V5QA/BekDj7HtAthh9QIpEfkBecH9AGU6AQAPkgECriIFAVC2CQP3RgkCmdoNATxuEQPe/hECgZIVASQmGQPKthkCaUodAQ/eHQOybiECVQIlAPeWJQOaJikCPLotAONOLQOB3jECJHI1AMsGNQNtljkCDCo9ALK+PQNVTkEB++JBAJp2RQM9BkkB45pJAFKuTQK9vlEBLNJVA5viVQDZybCU=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB8AAP/5FtXkOmm15DusleQ8/3XkPjJV9D+FNfQwyCX0MhsF9DNd5fQ0oMYENeOmBDTPdgQzm0YUMOrWJD46VjQ7ieZEONl2VDpLBmQ7rJZ0PR4mhD5/tpQ/4Ua0MULmxDK0dtQ0JgbkNYeW9Db5JwQ4WrcUNC4HJD/hR0Q7pJdUN3fnZDM7N3Q/DneEOsHHpDaFF7QyWGfEPhun1Dnu9+Qy0SgEOLrIBD6UaBQ0jhgUOme4JDBBaDQ2Kwg0PBSoRDH+WEQ31/hUPbGYZDObSGQ5hOh0P26IdDVIOIQ7IdiUMQuIlDYnCKQ7Qoi0MG4YtDWJmMQ2NGaNQ=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -601,7 +618,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="17" id="SRM SIC Q1=653.35 Q3=712.45 Channel=1 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="18" id="SRM SIC Q1=653.35 Q3=712.45 Channel=1 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -622,8 +639,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -633,7 +650,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="18" id="SRM SIC Q1=653.35 Q3=841.5 Channel=2 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="19" id="SRM SIC Q1=653.35 Q3=841.5 Channel=2 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -654,8 +671,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -665,7 +682,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="19" id="SRM SIC Q1=653.35 Q3=956.5 Channel=3 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="20" id="SRM SIC Q1=653.35 Q3=956.5 Channel=3 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -686,8 +703,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -697,7 +714,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="20" id="SRM SIC Q1=653.35 Q3=1055.55 Channel=4 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="21" id="SRM SIC Q1=653.35 Q3=1055.55 Channel=4 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -718,8 +735,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -729,7 +746,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="21" id="SRM SIC Q1=653.35 Q3=1168.65 Channel=5 Event=4 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="22" id="SRM SIC Q1=653.35 Q3=1168.65 Channel=5 Event=4 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -750,8 +767,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/8VFb0BLD3BA0dhwQDzicUCo63JAFPVzQID+dEBTKnZAJ1Z3QPuBeEDPrXlAotl6QHYFfEBKMX1AHl1+QPGIf0BjWoBATPCAQPWUgUCeOYJAR96CQO+Cg0CYJ4RAQcyEQOpwhUCTFYZAO7qGQOReh0CNA4hANqiIQN5MiUCH8YlAMJaKQNk6i0CB34tAKoSMQNMojUB8zY1AJHKOQM0Wj0B2u49AH2CQQMcEkUBwqZFAGU6SQMLykkBdt5NA+XuUQJVAlUAwBZZA97+WQL56l0Dqjl1s</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/2hRYENWDmFDRMthQxnEYkPuvGNDw7VkQ5iuZUOux2ZDxeBnQ9v5aEPyEmpDCCxrQx9FbEM1Xm1DTHduQ2KQb0N5qXBDj8JxQ0z3ckMILHRDxWB1Q4GVdkM9yndD+v54Q7YzekNzaHtDL518Q+zRfUOoBn9Dsh2AQxC4gENvUoFDzeyBQyuHgkOJIYND57uDQ0ZWhEOk8IRDAouFQ2AlhkO+v4ZDHVqHQ3v0h0PZjohDNymJQ5bDiUPne4pDOTSLQ4vsi0PdpIxD+FONQxIDjkP5ZVuK</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -761,7 +778,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="22" id="SRM SIC Q1=740.4 Q3=274.2 Channel=1 Event=5 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="23" id="SRM SIC Q1=740.4 Q3=274.2 Channel=1 Event=5 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -782,8 +799,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -793,7 +810,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="23" id="SRM SIC Q1=740.4 Q3=387.25 Channel=2 Event=5 Segment=3 CE=26" defaultArrayLength="52">
+      <chromatogram index="24" id="SRM SIC Q1=740.4 Q3=387.25 Channel=2 Event=5 Segment=3 CE=26" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -814,8 +831,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -825,7 +842,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="24" id="SRM SIC Q1=740.4 Q3=685.45 Channel=3 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="25" id="SRM SIC Q1=740.4 Q3=685.45 Channel=3 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -846,8 +863,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -857,7 +874,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="25" id="SRM SIC Q1=740.4 Q3=813.5 Channel=4 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="26" id="SRM SIC Q1=740.4 Q3=813.5 Channel=4 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -878,8 +895,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -889,7 +906,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="26" id="SRM SIC Q1=740.4 Q3=960.55 Channel=5 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="27" id="SRM SIC Q1=740.4 Q3=960.55 Channel=5 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -910,8 +927,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -921,7 +938,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="27" id="SRM SIC Q1=740.4 Q3=1017.6 Channel=6 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="28" id="SRM SIC Q1=740.4 Q3=1017.6 Channel=6 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -942,8 +959,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -953,7 +970,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="28" id="SRM SIC Q1=740.4 Q3=1180.65 Channel=7 Event=5 Segment=3 CE=28" defaultArrayLength="52">
+      <chromatogram index="29" id="SRM SIC Q1=740.4 Q3=1180.65 Channel=7 Event=5 Segment=3 CE=28" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -974,8 +991,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/1heb0DeJ3BAZPFwQND6cUA8BHNApw10QBMXdUDnQnZAu253QI6aeEBixnlANvJ6QAoefEDdSX1AsXV+QIWhf0CsZoBAlvyAQD+hgUDoRYJAkOqCQDmPg0DiM4RAi9iEQDN9hUDcIYZAhcaGQC5rh0DWD4hAf7SIQChZiUDR/YlAeqKKQCJHi0DL64tAdJCMQB01jUDF2Y1Abn6OQBcjj0DAx49AaGyQQBERkUC6tZFAY1qSQAv/kkCnw5NAQ4iUQN5MlUB6EZZAQcyWQAiHl0AgjltJ</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/3NoYENgJWFDTuJhQyPbYkP402NDzcxkQ6LFZUO43mZDz/dnQ+UQaUP8KWpDEkNrQylcbEM/dW1DVo5uQ22nb0ODwHBDmtlxQ1YOc0MSQ3RDz3d1Q4usdkNI4XdDBBZ5Q8FKekN9f3tDObR8Q/bofUOyHX9DNymAQ5bDgEP0XYFDUviBQ7CSgkMOLYNDbceDQ8thhEMp/IRDh5aFQ+UwhkNEy4ZDomWHQwAAiENemohDvDSJQxvPiUNth4pDvj+LQxD4i0NisIxDfV+NQ5gOjkMbSlpT</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -985,7 +1002,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="29" id="SRM SIC Q1=858.9 Q3=628.3 Channel=1 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="30" id="SRM SIC Q1=858.9 Q3=628.3 Channel=1 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1006,8 +1023,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1017,7 +1034,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="30" id="SRM SIC Q1=858.9 Q3=687.3 Channel=2 Event=6 Segment=3 CE=31" defaultArrayLength="51">
+      <chromatogram index="31" id="SRM SIC Q1=858.9 Q3=687.3 Channel=2 Event=6 Segment=3 CE=31" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1038,8 +1055,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1049,7 +1066,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="31" id="SRM SIC Q1=858.9 Q3=816.3 Channel=3 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="32" id="SRM SIC Q1=858.9 Q3=816.3 Channel=3 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1070,8 +1087,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1081,7 +1098,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="32" id="SRM SIC Q1=858.9 Q3=929.4 Channel=4 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="33" id="SRM SIC Q1=858.9 Q3=929.4 Channel=4 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1102,8 +1119,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1113,7 +1130,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="33" id="SRM SIC Q1=858.9 Q3=1158.5 Channel=5 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="34" id="SRM SIC Q1=858.9 Q3=1158.5 Channel=5 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1134,8 +1151,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1145,7 +1162,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="34" id="SRM SIC Q1=858.9 Q3=1255.55 Channel=6 Event=6 Segment=3 CE=33" defaultArrayLength="51">
+      <chromatogram index="35" id="SRM SIC Q1=858.9 Q3=1255.55 Channel=6 Event=6 Segment=3 CE=33" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1166,8 +1183,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1177,7 +1194,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="35" id="SRM SIC Q1=858.9 Q3=1369.6 Channel=7 Event=6 Segment=3 CE=31" defaultArrayLength="51">
+      <chromatogram index="36" id="SRM SIC Q1=858.9 Q3=1369.6 Channel=7 Event=6 Segment=3 CE=31" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1198,8 +1215,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/8CAb0BGSnBAzBNxQDgdckCkJnNADzB0QHs5dUBPZXZAI5F3QPa8eEDK6HlAnhR7QHJAfEBFbH1AGZh+QO3Df0Dgd4BAyg2BQHOygUAcV4JAxPuCQG2gg0AWRYRAv+mEQGeOhUAQM4ZAudeGQGJ8h0ALIYhAs8WIQFxqiUAFD4pArrOKQFZYi0D//ItAqKGMQFFGjUD56o1Aoo+OQEs0j0D02I9AnH2QQEUikUDuxpFAl2uSQD8Qk0Db1JNAd5mUQBJelUCuIpZAdd2WQFVqWQY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/7SIYEOiRWFDjwJiQ2T7YkM59GNDDu1kQ+PlZUP6/mZDEBhoQycxaUM9SmpDVGNrQ2p8bEOBlW1DmK5uQ67Hb0PF4HBD2/lxQ5guc0NUY3RDEJh1Q83MdkOJAXhDRjZ5QwJrekO+n3tDe9R8QzcJfkP0PX9DWDmAQ7bTgEMUboFDcwiCQ9GigkMvPYNDjdeDQ+xxhENKDIVDqKaFQwZBhkNk24ZDw3WHQyEQiEN/qohD3USJQzvfiUONl4pD30+LQzEIjEODwIxDnm+NQ9eUVyc=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1209,7 +1226,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="36" id="SRM SIC Q1=533.3 Q3=310.2 Channel=1 Event=7 Segment=3 CE=19" defaultArrayLength="51">
+      <chromatogram index="37" id="SRM SIC Q1=533.3 Q3=310.2 Channel=1 Event=7 Segment=3 CE=19" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1230,8 +1247,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1241,7 +1258,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="37" id="SRM SIC Q1=533.3 Q3=425.2 Channel=2 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="38" id="SRM SIC Q1=533.3 Q3=425.2 Channel=2 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1262,8 +1279,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1273,7 +1290,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="38" id="SRM SIC Q1=533.3 Q3=526.25 Channel=3 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="39" id="SRM SIC Q1=533.3 Q3=526.25 Channel=3 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1294,8 +1311,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1305,7 +1322,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="39" id="SRM SIC Q1=533.3 Q3=641.3 Channel=4 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="40" id="SRM SIC Q1=533.3 Q3=641.3 Channel=4 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1326,8 +1343,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1337,7 +1354,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="40" id="SRM SIC Q1=533.3 Q3=754.35 Channel=5 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="41" id="SRM SIC Q1=533.3 Q3=754.35 Channel=5 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1358,8 +1375,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1369,7 +1386,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="41" id="SRM SIC Q1=533.3 Q3=853.45 Channel=6 Event=7 Segment=3 CE=21" defaultArrayLength="51">
+      <chromatogram index="42" id="SRM SIC Q1=533.3 Q3=853.45 Channel=6 Event=7 Segment=3 CE=21" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1390,8 +1407,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1401,7 +1418,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="42" id="SRM SIC Q1=533.3 Q3=966.5 Channel=7 Event=7 Segment=3 CE=19" defaultArrayLength="51">
+      <chromatogram index="43" id="SRM SIC Q1=533.3 Q3=966.5 Channel=7 Event=7 Segment=3 CE=19" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1422,8 +1439,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/yijb0CubHBANDZxQKA/ckAMSXNAd1J0QONbdUC3h3ZAi7N3QF7feEAyC3pABjd7QNpifECtjn1Agbp+QFXmf0AUiYBA/h6BQKfDgUBQaIJA+AyDQKGxg0BKVoRA8/qEQJyfhUBERIZA7eiGQJaNh0A/MohA59aIQJB7iUA5IIpA4sSKQIppi0AzDoxA3LKMQIVXjUAt/I1A1qCOQH9Fj0Ao6o9A0I6QQHkzkUAi2JFAy3ySQHMhk0AP5pNAq6qUQEZvlUDiM5ZAqe6WQEvrWyY=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz//aoYEPjZWFD0SJiQ6YbY0N7FGRDUA1lQyUGZkM7H2dDUjhoQ2hRaUN/ampDloNrQ6ycbEPDtW1D2c5uQ/Dnb0MGAXFDHRpyQ9lOc0OWg3RDUrh1Qw7tdkPLIXhDh1Z5Q0SLekMAwHtDvPR8Q3kpfkM1Xn9DeUmAQ9fjgEM1foFDkxiCQ/KygkNQTYNDrueDQwyChENqHIVDybaFQydRhkOF64ZD44WHQ0IgiEOguohD/lSJQ1zviUOup4pDAGCLQ1IYjEOk0IxDvn+NQ1x+Vng=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1433,7 +1450,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="43" id="SRM SIC Q1=621.3 Q3=676.35 Channel=1 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="44" id="SRM SIC Q1=621.3 Q3=676.35 Channel=1 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1454,8 +1471,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1465,7 +1482,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="44" id="SRM SIC Q1=621.3 Q3=775.4 Channel=2 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="45" id="SRM SIC Q1=621.3 Q3=775.4 Channel=2 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1486,8 +1503,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1497,7 +1514,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="45" id="SRM SIC Q1=621.3 Q3=890.45 Channel=3 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="46" id="SRM SIC Q1=621.3 Q3=890.45 Channel=3 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1518,8 +1535,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1529,7 +1546,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="46" id="SRM SIC Q1=621.3 Q3=991.5 Channel=4 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="47" id="SRM SIC Q1=621.3 Q3=991.5 Channel=4 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1550,8 +1567,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1561,7 +1578,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="47" id="SRM SIC Q1=621.3 Q3=1078.55 Channel=5 Event=8 Segment=4 CE=24" defaultArrayLength="51">
+      <chromatogram index="48" id="SRM SIC Q1=621.3 Q3=1078.55 Channel=5 Event=8 Segment=4 CE=24" defaultArrayLength="51">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1582,8 +1599,8 @@
           <binaryDataArray encodedLength="288">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwBzAAz/5DFb0AWj3BAnFhxQAhickB0a3NA33R0QEt+dUAfqnZA89V3QMYBeUCaLXpAbll7QEKFfEAVsX1A6dx+QF4EgEBImoBAMjCBQNvUgUCEeYJALR6DQNXCg0B+Z4RAJwyFQNCwhUB4VYZAIfqGQMqeh0BzQ4hAG+iIQMSMiUBtMYpAFtaKQL56i0BnH4xAEMSMQLlojUBhDY5ACrKOQLNWj0Bc+49ABKCQQK1EkUBW6ZFA/42SQKcyk0BD95NA37uUQHqAlUAWRZZA3f+WQIE5WOc=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwBzAAz/zfJYEMlhmFDEkNiQ+c7Y0O8NGRDkS1lQ2YmZkN9P2dDk1hoQ6pxaUPBimpD16NrQ+68bEME1m1DG+9uQzEIcENIIXFDXjpyQxtvc0PXo3RDk9h1Q1ANd0MMQnhDyXZ5Q4WrekNC4HtD/hR9Q7pJfkN3fn9DmlmAQ/jzgENWjoFDtCiCQxLDgkNxXYNDz/eDQy2ShEOLLIVD6caFQ0hhhkOm+4ZDBJaHQ2IwiEPByohDH2WJQ33/iUPPt4pDIXCLQ3MojEPF4IxD34+NQ3/dV8M=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1593,7 +1610,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="48" id="SRM SIC Q1=710.85 Q3=308.15 Channel=1 Event=9 Segment=5 CE=25" defaultArrayLength="52">
+      <chromatogram index="49" id="SRM SIC Q1=710.85 Q3=308.15 Channel=1 Event=9 Segment=5 CE=25" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1614,8 +1631,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1625,7 +1642,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="49" id="SRM SIC Q1=710.85 Q3=610.8 Channel=2 Event=9 Segment=5 CE=25" defaultArrayLength="52">
+      <chromatogram index="50" id="SRM SIC Q1=710.85 Q3=610.8 Channel=2 Event=9 Segment=5 CE=25" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1646,8 +1663,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="52">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1657,7 +1674,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="50" id="SRM SIC Q1=710.85 Q3=722.3 Channel=3 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="51" id="SRM SIC Q1=710.85 Q3=722.3 Channel=3 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1678,8 +1695,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1689,7 +1706,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="51" id="SRM SIC Q1=710.85 Q3=869.35 Channel=4 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="52" id="SRM SIC Q1=710.85 Q3=869.35 Channel=4 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1710,8 +1727,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1721,7 +1738,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="52" id="SRM SIC Q1=710.85 Q3=982.45 Channel=5 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="53" id="SRM SIC Q1=710.85 Q3=982.45 Channel=5 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1742,8 +1759,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1753,7 +1770,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="53" id="SRM SIC Q1=710.85 Q3=1083.5 Channel=6 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="54" id="SRM SIC Q1=710.85 Q3=1083.5 Channel=6 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1774,8 +1791,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1785,7 +1802,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="54" id="SRM SIC Q1=710.85 Q3=1220.55 Channel=7 Event=9 Segment=5 CE=27" defaultArrayLength="52">
+      <chromatogram index="55" id="SRM SIC Q1=710.85 Q3=1220.55 Channel=7 Event=9 Segment=5 CE=27" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1806,8 +1823,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/zBxcUCbenJAB4RzQHONdEDflnVAssJ2QIbud0BaGnlALkZ6QAFye0DVnXxAqcl9QH31fkCoEIBAkqaAQHw8gUAl4YFAzYWCQHYqg0Afz4NAyHOEQHEYhUAZvYVAwmGGQGsGh0AUq4dAvE+IQGX0iEAOmYlAtz2KQF/iikAIh4tAsSuMQFrQjEACdY1AqxmOQFS+jkD9Yo9ApQeQQE6skED3UJFAoPWRQEiakkDxPpNAjQOUQCjIlEDEjJVAYFGWQCcMl0A8mJdA1AaYQGt1mEB7Kll+</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/x1aYkPyUmNDx0tkQ5xEZUNxPWZDh1ZnQ55vaEO0iGlDy6FqQ+G6a0P402xDDu1tQyUGb0M7H3BDUjhxQ2hRckMlhnND4bp0Q57vdUNaJHdDF1l4Q9ONeUOPwnpDTPd7QwgsfUPFYH5DgZV/Qx9lgEN9/4BD25mBQzk0gkOYzoJD9miDQ1QDhEOynYRDEDiFQ2/ShUPNbIZDKweHQ4mhh0PnO4hDRtaIQ6RwiUMCC4pDVMOKQ6Z7i0P4M4xDSuyMQ2SbjUO4Ho5DZoaOQxTujkPUpVj/</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1817,7 +1834,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="55" id="SRM SIC Q1=875.35 Q3=751.3 Channel=1 Event=10 Segment=5 CE=33" defaultArrayLength="52">
+      <chromatogram index="56" id="SRM SIC Q1=875.35 Q3=751.3 Channel=1 Event=10 Segment=5 CE=33" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1838,8 +1855,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1849,7 +1866,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="56" id="SRM SIC Q1=875.35 Q3=912.3 Channel=2 Event=10 Segment=5 CE=37.7" defaultArrayLength="52">
+      <chromatogram index="57" id="SRM SIC Q1=875.35 Q3=912.3 Channel=2 Event=10 Segment=5 CE=37.678" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1858,7 +1875,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.7" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.678" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -1870,8 +1887,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1881,7 +1898,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="57" id="SRM SIC Q1=875.35 Q3=1041.35 Channel=3 Event=10 Segment=5 CE=33" defaultArrayLength="52">
+      <chromatogram index="58" id="SRM SIC Q1=875.35 Q3=1041.35 Channel=3 Event=10 Segment=5 CE=33" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1902,8 +1919,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1913,7 +1930,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="58" id="SRM SIC Q1=875.35 Q3=1169.4 Channel=4 Event=10 Segment=5 CE=33" defaultArrayLength="52">
+      <chromatogram index="59" id="SRM SIC Q1=875.35 Q3=1169.4 Channel=4 Event=10 Segment=5 CE=33" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1934,8 +1951,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1945,7 +1962,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="59" id="SRM SIC Q1=875.35 Q3=1316.5 Channel=5 Event=10 Segment=5 CE=33" defaultArrayLength="52">
+      <chromatogram index="60" id="SRM SIC Q1=875.35 Q3=1316.5 Channel=5 Event=10 Segment=5 CE=33" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1966,8 +1983,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -1977,7 +1994,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="60" id="SRM SIC Q1=875.35 Q3=1472.55 Channel=6 Event=10 Segment=5 CE=31" defaultArrayLength="52">
+      <chromatogram index="61" id="SRM SIC Q1=875.35 Q3=1472.55 Channel=6 Event=10 Segment=5 CE=31" defaultArrayLength="52">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -1998,8 +2015,8 @@
           <binaryDataArray encodedLength="292">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB0AAv/5iTcUADnXJAb6ZzQNuvdEBHuXVAGuV2QO4QeEDCPHlAlmh6QGmUe0A9wHxAEex9QOUXf0DcIYBAxreAQLBNgUBZ8oFAApeCQKo7g0BT4INA/ISEQKUphUBNzoVA9nKGQJ8Xh0BIvIdA8GCIQJkFiUBCqolA606KQJPzikA8mItA5TyMQI7hjEA2ho1A3yqOQIjPjkAxdI9A2RiQQIK9kEArYpFA1AaSQHyrkkAlUJNAwRSUQFzZlED4nZVAlGKWQFsdl0BwqZdACBiYQJ+GmEA0cV0S</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB0AAv/156YkMzc2NDCGxkQ91kZUOyXWZDyXZnQ9+PaEP2qGlDDMJqQyPba0M59GxDUA1uQ2Ymb0N9P3BDk1hxQ6pxckNmpnNDI9t0Q98PdkOcRHdDWHl4QxSueUPR4npDjRd8Q0pMfUMGgX5Dw7V/Qz91gEOeD4FD/KmBQ1pEgkO43oJDF3mDQ3UThEPTrYRDMUiFQ4/ihUPufIZDTBeHQ6qxh0MITIhDZuaIQ8WAiUMjG4pDddOKQ8eLi0MZRIxDavyMQ4WrjUPZLo5Dh5aOQzX+jkNxJlkY</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2009,7 +2026,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="61" id="SRM SIC Q1=471.25 Q3=175.1 Channel=1 Event=11 Segment=6 CE=16" defaultArrayLength="54">
+      <chromatogram index="62" id="SRM SIC Q1=471.25 Q3=175.1 Channel=1 Event=11 Segment=6 CE=16" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2030,8 +2047,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="32">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2041,7 +2058,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="62" id="SRM SIC Q1=471.25 Q3=274.2 Channel=2 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="63" id="SRM SIC Q1=471.25 Q3=274.2 Channel=2 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2062,8 +2079,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="32">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2073,7 +2090,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="63" id="SRM SIC Q1=471.25 Q3=387.25 Channel=3 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="64" id="SRM SIC Q1=471.25 Q3=387.25 Channel=3 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2094,8 +2111,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2105,7 +2122,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="64" id="SRM SIC Q1=471.25 Q3=484.3 Channel=4 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="65" id="SRM SIC Q1=471.25 Q3=484.3 Channel=4 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2126,8 +2143,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="56">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2137,7 +2154,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="65" id="SRM SIC Q1=471.25 Q3=599.35 Channel=5 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="66" id="SRM SIC Q1=471.25 Q3=599.35 Channel=5 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2158,8 +2175,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2169,7 +2186,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="66" id="SRM SIC Q1=471.25 Q3=712.45 Channel=6 Event=11 Segment=6 CE=16" defaultArrayLength="54">
+      <chromatogram index="67" id="SRM SIC Q1=471.25 Q3=712.45 Channel=6 Event=11 Segment=6 CE=16" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2190,8 +2207,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2201,7 +2218,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="67" id="SRM SIC Q1=471.25 Q3=769.45 Channel=7 Event=11 Segment=6 CE=19" defaultArrayLength="54">
+      <chromatogram index="68" id="SRM SIC Q1=471.25 Q3=769.45 Channel=7 Event=11 Segment=6 CE=19" defaultArrayLength="54">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2222,8 +2239,8 @@
           <binaryDataArray encodedLength="304">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwB2AAn/8TWdUCYAndAbC54QEBaeUAThnpA57F7QLvdfECPCX5AYjV/QJswgECFxoBAb1yBQBgBgkDApYJAaUqDQBLvg0C7k4RAYziFQAzdhUC1gYZAXiaHQAbLh0Cvb4hAWBSJQAG5iUCpXYpAUgKLQPumi0CkS4xATPCMQPWUjUCeOY5AR96OQO+Cj0CYJ5BAQcyQQOpwkUCTFZJAO7qSQORek0CAI5RAG+iUQLeslUBTcZZAGiyXQC+4l0DHJphAXpWYQAPkmECnMplATIGZQPHPmUCVHppAOm2aQPQUXWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwB2AAn/1h5ZkNvkmdDhatoQ5zEaUOy3WpDyfZrQ98PbUP2KG5DDEJvQyNbcEM5dHFDUI1yQwzCc0PJ9nRDhSt2Q0Jgd0P+lHhDusl5Q3f+ekMzM3xD8Gd9Q6ycfkNo0X9DEoOAQ3EdgUPPt4FDLVKCQ4vsgkPphoNDSCGEQ6a7hEMEVoVDYvCFQ8GKhkMfJYdDfb+HQ9tZiEM59IhDmI6JQ/YoikNI4YpDmpmLQ+xRjEM9Co1DWLmNQ6w8jkNapI5DCAyPQ8NVj0N9n49DN+mPQ/IykEOsfJBDZsaQQ5cyYGE=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="16">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2233,7 +2250,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="68" id="SRM SIC Q1=497.75 Q3=244.15 Channel=1 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="69" id="SRM SIC Q1=497.75 Q3=244.15 Channel=1 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2251,11 +2268,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2265,7 +2282,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="69" id="SRM SIC Q1=497.75 Q3=372.2 Channel=2 Event=12 Segment=7 CE=17" defaultArrayLength="69">
+      <chromatogram index="70" id="SRM SIC Q1=497.75 Q3=372.2 Channel=2 Event=12 Segment=7 CE=17" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2283,11 +2300,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2297,7 +2314,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="70" id="SRM SIC Q1=497.75 Q3=459.25 Channel=3 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="71" id="SRM SIC Q1=497.75 Q3=459.25 Channel=3 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2315,11 +2332,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2329,7 +2346,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="71" id="SRM SIC Q1=497.75 Q3=572.35 Channel=4 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="72" id="SRM SIC Q1=497.75 Q3=572.35 Channel=4 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2347,11 +2364,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2361,7 +2378,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="72" id="SRM SIC Q1=497.75 Q3=629.35 Channel=5 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="73" id="SRM SIC Q1=497.75 Q3=629.35 Channel=5 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2379,11 +2396,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2393,7 +2410,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="73" id="SRM SIC Q1=497.75 Q3=790.4 Channel=6 Event=12 Segment=7 CE=20" defaultArrayLength="69">
+      <chromatogram index="74" id="SRM SIC Q1=497.75 Q3=790.4 Channel=6 Event=12 Segment=7 CE=20" defaultArrayLength="69">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2411,11 +2428,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="376">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz78rRAEAwHGyWCxnuUEGuiulLoUTqW+J8iMmC8rAYnAMlFI67367H85zvHfvt+gMJqVLSZnojkEyCJfEIuUGDJLy/oBvn767s6sMOQS+8gL6eIC+iiDlvSBSfwg+QryJYURvhM7HCC/+KAlXjLZijJJvjXBtHM9xnLuJBP7KJE25JDcDKZbLKRoz61x1pFkspakXNrhwi8xdijjnNzlqzTDyk+H9dIuIsM1wt8RUQeLXKyPmZLzfMg89WfxiFtdzloJHwbei8HSi2J3CWbtKy4LKzqGKo6wSaNb4nNGY3te4fdXobdDJT+q4dR3pXqfaabA0atgvBmPXBsUak65Bk4OoSd25SbLK4g/LNizbsPgHUax/pA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNzr1LAmEAwOGgJmmIhoSQ4IaGhiCJgiBw+E1RSNAR0dAgFLpFoSX2oZ75qqn3fUGDS1NR1FAgR1uDSEhbU0s5tRy5BMEN+Rc8j363R/Rrn0AwSWs5hZI9IPJ0iP+dpjmRIbl2RLh0jPd8wk3vlFkziz6d46eVIxrLc+vnCVwoxMMFWq8FJnfOUAaKfF4WicwJGm8CP1Fic6hMs1EmuFAh3qvgXp8zHKuyNV4j3a7RWamTeawzFVLpbqs07lU2/lRG0ehUNcS7hjSi4y7pyIre/+iIXx1pxsBNGMhXBt6HgRgzkVZN3LKJ/GLi+SZi3kLatfqmhdy18EI2Yt1G0mzcto086OAtOoiUg/Tg8A8qYH0A</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2425,7 +2442,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="74" id="SRM SIC Q1=692.85 Q3=351.2 Channel=1 Event=13 Segment=8 CE=25" defaultArrayLength="104">
+      <chromatogram index="75" id="SRM SIC Q1=692.85 Q3=351.2 Channel=1 Event=13 Segment=8 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2443,11 +2460,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2457,7 +2474,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="75" id="SRM SIC Q1=692.85 Q3=460.75 Channel=2 Event=13 Segment=8 CE=25" defaultArrayLength="104">
+      <chromatogram index="76" id="SRM SIC Q1=692.85 Q3=460.75 Channel=2 Event=13 Segment=8 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2475,11 +2492,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2489,7 +2506,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="76" id="SRM SIC Q1=692.85 Q3=676.35 Channel=3 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="77" id="SRM SIC Q1=692.85 Q3=676.35 Channel=3 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2507,11 +2524,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2521,7 +2538,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="77" id="SRM SIC Q1=692.85 Q3=823.45 Channel=4 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="78" id="SRM SIC Q1=692.85 Q3=823.45 Channel=4 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2539,11 +2556,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2553,7 +2570,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="78" id="SRM SIC Q1=692.85 Q3=920.5 Channel=5 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="79" id="SRM SIC Q1=692.85 Q3=920.5 Channel=5 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2571,11 +2588,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2585,7 +2602,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="79" id="SRM SIC Q1=692.85 Q3=991.5 Channel=6 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="80" id="SRM SIC Q1=692.85 Q3=991.5 Channel=6 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2603,11 +2620,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2617,7 +2634,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="80" id="SRM SIC Q1=692.85 Q3=1090.6 Channel=7 Event=13 Segment=8 CE=27" defaultArrayLength="104">
+      <chromatogram index="81" id="SRM SIC Q1=692.85 Q3=1090.6 Channel=7 Event=13 Segment=8 CE=27" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2635,11 +2652,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="544">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx/GkCA+ZFBVJXVQIjTqEhAdBvxLuNBSFhuKlsAgqdhFJxCyUyCiJmrqX52XPy57t2fPs2eZqRdLB6lCJIoKgkCbEQuyQ0UBwFPj8AT8+v+/qSID+K5McLZ/CWpii7cU0Fd4gNWtB3nlCdOZD7B4ME+kK06KGKeyEGW+OcHEigjwfcXcCD9oEdkYFrs0JLP8XaG0SyQ2K1L4RCRRFDl2SGPBL/LQlfNsSn8/JNN6QMVWZ05syT85GKfVEuR2M8m0live4wvsOxTUU11Do2FMoq1N55VO5+Ujl1GuVLz9Uho5pXEBjw6/xXNJoXdAoljSMeh1ft075Y53ZvM7dgs56dYwj/hhNszHuHDbcHoN52WDvl0F9Y5zusTjjS3HenkmwdSvhGgk8B0wGvCZGyGSlYLodSRruJ+n7miRw0uLjdYu/jkV1yaLTY/PwpU32u83m+RSV91I0f0rhr3SQeh0WEw7/io77N03vszRP19L8vpyhK5Ah/ydDVXuWYTvLdu0MV8UZPpzIuf059gGjKMLk</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MFLFGEAQHEoIfBQbNRJhdBi2uziySIK9C1WS4iniqEipIOXCqkQBElFCdRxdmZnZ76ZnZ2d3Vkn8lB02aAymEiCwoOESIfwkB6sDi4OdFFq/oL34233zXDh3wzKm1k2Hs7RdVrh2rqCL8/T/3GevbRK/ZHK8JJK56EcWwM5fCeHvJkjbtNQbmhImkb0RUNu0okv6igjOtJrneiXjnwyT3w7j2LlkVbzRM0GcsYgHjOSpoHUMIjOFJDvFYhLBZT1AlLKJMqayFMm8ZLJ222TieMWV3osDt+3WBMW7ieLwR2LdKtg57JIjIKxsiDzVdD8V7DabiP6be6M2pwKbT5s2HRKDuKBQ1PdYXjf4UemSHauSP1bkY4WF3XQZe+Fy1DDZe1cid7xEi8/l2g54vHsupf4PO5ueaycLXP+cZnwXZmjB32eZn3+aD43v/ssn6jQNVTBe1VJHBVGLlX5OV1lYKXK+2MB6VsBZhBw4HeA2lujzamx2KjRfXWBZX+BxVSIOhnyZDdMnjznP1fkwqU=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2649,7 +2666,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="81" id="SRM SIC Q1=487.3 Q3=347.25 Channel=1 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="82" id="SRM SIC Q1=487.3 Q3=347.25 Channel=1 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2670,18 +2687,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="116">
+          <binaryDataArray encodedLength="128">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAELjgyMJg4MTC0AbEBEG9wJKiFJqAAaO8HIC5wQmAwH4d7QOIBQDU3gFjCmYHBFog9gNgIiFmdIf4ByecA8SYo/YHKfgOFlQHFYQcAGS8Wdg==</binary>
+            <binary>eJxjYCAELjgyMJg4MTC0AbEBEG9wJKiF6sDBgYGhAGQv0P4IIC6A0iA+WNwBXQMDwwygeAxQ/hIQ8zozMNgCsQcQGwExqzPEPwFAnAPEm6D0Byr7DRRWBhSHHQA1fBWL</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="82" id="SRM SIC Q1=487.3 Q3=462.25 Channel=2 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="83" id="SRM SIC Q1=487.3 Q3=462.25 Channel=2 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2702,18 +2719,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="88">
+          <binaryDataArray encodedLength="104">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYBhM4IMjA8MmJwYGEWcIXgdk33CEyBU4QuRNnCB0gSPx5oLMWALUpw40MwCILYH4HZAf4ESaOQMDACnCDwI=</binary>
+            <binary>eJxjYBg0wAGInRgYNgExvzMDAx8QrwOyLzgyMDwAyhUA6Q9ALOMEoUF8sB4CYAFQzQKg2iVAfepAMwOA2BKI3wH5AU5QcwY1AAAY9BAw</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="83" id="SRM SIC Q1=487.3 Q3=575.35 Channel=3 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="84" id="SRM SIC Q1=487.3 Q3=575.35 Channel=3 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2734,18 +2751,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="76">
+          <binaryDataArray encodedLength="84">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAHXHBkYJjhxMDwB4h5nRkY7gHpACAucCTLOKqBBw4MDBuAbhBxgmAQW2CA3UQ5AABXrwnc</binary>
+            <binary>eJxjYCAHXHBkYJjhxMDwD4g5nRkYbgDpECBuAIo32JNlJMUAbC/Q/g1AzOEEwSC2ABAzOAyMm6gDAGehCq8=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="84" id="SRM SIC Q1=487.3 Q3=646.4 Channel=4 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="85" id="SRM SIC Q1=487.3 Q3=646.4 Channel=4 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2766,18 +2783,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="104">
+          <binaryDataArray encodedLength="132">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYKA3KHBkYDBxYmCYAsUgNkgMWW4TEF8A4nVArALECY6kmfcBKJYDpN8BsY4zA4MDELsAsTIQiwLxH6j5bVC1Dxzo4nUyAQBCphcX</binary>
+            <binary>eJxjYKAnaLAHYkcGBgMnBoY+KAaxQWIMDhDaAshfA8SngHgFEMsAcQFUHgMAxTqg5nVAsQ0QSwBxExC/AmJVZwYGayB2AWJlIBYF4j9A8QtA3AbEH4D6H2Aze9AAAFxpF98=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="85" id="SRM SIC Q1=487.3 Q3=761.4 Channel=5 Event=14 Segment=9 CE=20" defaultArrayLength="105">
+      <chromatogram index="86" id="SRM SIC Q1=487.3 Q3=761.4 Channel=5 Event=14 Segment=9 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2798,18 +2815,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="236">
+          <binaryDataArray encodedLength="248">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjaGh1ZmA4AcQFQNwDxD5AXAnEEUBsCsR3nBgYDgDxEiB+AMT/gJjNGYL5gVgZiB2BOABKg/i8QPwOqG4TEJtAMYhtBFUHokF8ESgGsVmdIRgm/sCBgWGCI9A9QPYxJ4iZIH2WUNoDiDshbm/4AsSsLnB8gM+FwUERiN2A7HogvQWIP7kwMEi6MjQouTI4AOkF/10YHux1YVjQBNSjBZS7DjUzB2jX4AIA/l411w==</binary>
+            <binary>eJzNzS8PQVEYx/GfGQqbSDMkIyK6nGMzf4okioKgandGM1kUbJqJik0QvANF8AIE8wLwvbv3RTjbZ7/nec6zc+QujHTFBEt0McUAZdwb0hlbPPBB1PiSyKGGXpBen8CTvT2cwBEl5h3jp9fnAweEjM+rU8jUpTVG1FfEuSuigir6WOGCl5ETtnIjVk6MTFqd81ZqWw3nVo8d8zd9uik325RDbr7MT1abGfsF7m6808KYv/7r/ADanDSi</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="86" id="SRM SIC Q1=487.3 Q3=874.5 Channel=6 Event=14 Segment=9 CE=17" defaultArrayLength="105">
+      <chromatogram index="87" id="SRM SIC Q1=487.3 Q3=874.5 Channel=6 Event=14 Segment=9 CE=17" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2830,18 +2847,18 @@
           <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNz81LkwEAx3EGDUIDGxIpIcRGBpERiFTi4ZsdEjFCKHcaGR0kFARjB704CEUlKmhze7Y973t5nr08m7NLsLFD6A6CYHSxUjqIMqISZB5UoucP+PH5fZvffyD9JEh/e4jdnRAz2jL3fWFG6mF+eyPMrUe4cUlg84XAq5JAmyNK+XGU51KUL9+j9i7G6kgMTzBGcCuGsyWOfyjO/mIcby1O7ZzI3X4Rc1akvSKydCJyekdi3C/xoyQxdChR6ZK5NS4jGTIt+zIBj8LhqGIbim0ovG5S6bmncjCmIiyrDK6pnB2pWG6N0WENV0Djs6Xh39G4fkFnu1dn6aVOX0Tnz7qO0tC52J2A2QSTGwnky0m7J8m/QpKusyS+gRRvginKP1P8upnmynTaNtLMuAxMn8G2aXD+2LA7TMbemoS/mdQ6MxxPZeisZnjanGXOm+WjnmXvb5bWvhwPFnJMfc2hXc2zNZHH8SnPbadl/7V4J1pU6xbuhwXmEwXqjiKPnhUplot09KywmF+hca1k95cQnKv8B28RxJo=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0MtLFAEAgHEXI0GMggaEQETKk1FRQuGDDl/EICK0CNkSQREW0oOigzJohUGkuTszO899zM7Ouq54GBcEkYhkL3lYKohiIREZQqSLgpRQQTR/wffja7w6xfXD0/hr09Q9e030wgz3t2eojMR5+DlOS1eC2mQC5UOC/maZgzdlKgsy0k8Z4ZSCf0dBzCsE3xQkQUUYUPFfqogVleCPitSZRHiQxC8lEYMkwTENaVBDiGthU0OM6ARdOtITHcHX8bd1xDaDIGYgaQbCR4P13wZeu8ndKyanx032503efjGZrLPoO2lxZMgKjRbOosXtdYuOBpu9szYrN2yeTtlcXrbZ3LXpP59iZSJF+/sUyqE0/wbTjGTS1L6nudSRofw4Q8ubDK8iWfbFLLfkLJ9qWbpbHeaHndDn8PyXw05PjtiLHGvVHOeOurgxlybPZeyHy9aZPNHRPO9W86HDwxrwOGB4PNrw2DhRoO9egeWlAsf/FihHZ+ldmKUaKTJ0rchWuUi1bY6yOodRXwqflLj4tcR/38LAhg==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="108">
+          <binaryDataArray encodedLength="124">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYKAHKHBkYMhxYmBgc2Zg8ADiACCWAeIpQDERIDZxgrCnQNkg9dSydwLQPFmgXfVAvBCIlzszNEwA0uFA/A5q3wMH6thHGwAAAAgQwQ==</binary>
+            <binary>eJxjYKA1aLBnYOhwZGAocWJgYHVmYHAGYm8glgTiWUAxBSC2AOI+KDYA4gZHiD6KgAMDww5HiB2cQLvqgXghEC93ZmiYAKTDgfgdUM4EiB84UMGjNAMASIAS5Q==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="87" id="SRM SIC Q1=869.45 Q3=565.25 Channel=1 Event=15 Segment=10 CE=43.9" defaultArrayLength="109">
+      <chromatogram index="88" id="SRM SIC Q1=869.45 Q3=565.25 Channel=1 Event=15 Segment=10 CE=43.881" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2850,7 +2867,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="43.9" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="43.881" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2859,11 +2876,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2873,7 +2890,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="88" id="SRM SIC Q1=869.45 Q3=963.45 Channel=2 Event=15 Segment=10 CE=36.6" defaultArrayLength="109">
+      <chromatogram index="89" id="SRM SIC Q1=869.45 Q3=963.45 Channel=2 Event=15 Segment=10 CE=36.626" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2882,7 +2899,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="36.6" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="36.626" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2891,11 +2908,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2905,7 +2922,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="89" id="SRM SIC Q1=869.45 Q3=1062.5 Channel=3 Event=15 Segment=10 CE=29" defaultArrayLength="109">
+      <chromatogram index="90" id="SRM SIC Q1=869.45 Q3=1062.5 Channel=3 Event=15 Segment=10 CE=29.049" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2914,7 +2931,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="29.0" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="29.049" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2923,11 +2940,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2937,7 +2954,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="90" id="SRM SIC Q1=869.45 Q3=1175.6 Channel=4 Event=15 Segment=10 CE=38.1" defaultArrayLength="109">
+      <chromatogram index="91" id="SRM SIC Q1=869.45 Q3=1175.6 Channel=4 Event=15 Segment=10 CE=38.073" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2946,7 +2963,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.1" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.073" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2955,11 +2972,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -2969,7 +2986,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="91" id="SRM SIC Q1=869.45 Q3=1272.65 Channel=5 Event=15 Segment=10 CE=33.2" defaultArrayLength="109">
+      <chromatogram index="92" id="SRM SIC Q1=869.45 Q3=1272.65 Channel=5 Event=15 Segment=10 CE=33.247" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -2978,7 +2995,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="33.2" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="33.247" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -2987,21 +3004,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="60">
+          <binaryDataArray encodedLength="72">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAEHjgwMOxwZGAQcILgDY4QMXwApMYAqLbNCUKD+KOAWgAAGu4IXQ==</binary>
+            <binary>eJxjYCAEHjgwMOxwZGAQcGJg4ADiFY4QMVygwZ6BYQNQjQFQbY0ThAbxQeKjgBoAAPM3CcE=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="92" id="SRM SIC Q1=869.45 Q3=1385.75 Channel=6 Event=15 Segment=10 CE=40" defaultArrayLength="109">
+      <chromatogram index="93" id="SRM SIC Q1=869.45 Q3=1385.75 Channel=6 Event=15 Segment=10 CE=40.009" defaultArrayLength="109">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3010,7 +3027,7 @@
           </isolationWindow>
           <activation>
             <cvParam cvRef="MS" accession="MS:1000133" name="collision-induced dissociation" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.0" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+            <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.009" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
           </activation>
         </precursor>
         <product>
@@ -3019,11 +3036,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="568">
+          <binaryDataArray encodedLength="564">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0MtLFAEAx3ESL1agoAVKkiRYdEiUFYyMvmavNYggKiFa6tAqZAkrSLFiFD1Oiif3MTuzOzM7szu7M/teK2olofAg2YMUsYs9CAzDi5AQtM5f8Pl9f53ZKcq3fezZ8mG6/Zxa9LPWHGDcE6B9NsBSdRCvK0iTFWTyd5AdhwQ8twS+KwKXVgXeNoZwXAuh+UPsXQrxtFbk70WR/gmR5XkRZ5XEyzMShx9LCLMSu8oSo11h/twPc/15mIXNMCfaI6SHIrYRsY0IJ+tlNs/K6CMyfZpM1ReZVxUKd9oU9t9Q+Dih8Kik4FhX+NWg4nOqOO+p/NNVrEUVV2WUD91RyuNRjqxEcbVodo9GaUZjfafOvqs651Ud74ZO4liMlWcx24hxtCnOwGAc/4s4c5WG3WHQIhpcWTN40pGg+DDBz/cJ6hqS9LiTDOeSKP+TfO41qfCZtP0wudlqMem1eDNnsVGbsvemuGCmGNtK8e1ymtP5NPGaDLvvZhiaz/C1J8u511kKjpzdn6OvLs+nwTy97/L2twWOjxSYXijQerCI8aDIgeUi221tzT4=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGwKJ9cRRBxiBSMgjAhySjpB377RcQ9RPiSUIjSkAikhNCXrkEUS7e72+3udtvtdtvcdg8accbACoQkJCKiIoYPRRJX9JA9qL0U3X/w4RM9O8nJtUnUO1P0fZli9VwST04ytJykI5qieTOF2kghtsgEvTLSmIwwK+N/lxH3KgRXFCRNQXir4LeqiH0qwYSKNKci/FLx96cRB9MEVhrpYxohouGf1xDvaQTzGtKahtCVwY9lEN0MwXKGma06Y906vVd1WhI6S091kl91+tsM2o8ZrAwbodFg9LnBkR8G/3aaLJ4ySdwwuWSY7H5p8uSvSceZLIlHWf68zzIkWLwbtDjuWXi/LXYdzRG/m2P1VY6BSJ6l/jyH7TzutzxtnTYTt+3QZ3N5U4GFCwU6lQLZZoEtexxuxRw+zzpc3HBonCgSvV9EflMMHS4jAy6fSi6nf7o8PlSifbzEw4US661l4tfKbGuUsSMVDlyv0HhRwe6aJu5ME9teDU+q7FipsrmnxvqDWnhRo3mwzmupzrMPdWb2eTjjHv8BM43K7A==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3033,7 +3050,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="93" id="SRM SIC Q1=634.35 Q3=288.2 Channel=1 Event=16 Segment=11 CE=22" defaultArrayLength="104">
+      <chromatogram index="94" id="SRM SIC Q1=634.35 Q3=288.2 Channel=1 Event=16 Segment=11 CE=22" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3051,11 +3068,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3065,7 +3082,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="94" id="SRM SIC Q1=634.35 Q3=658.4 Channel=2 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="95" id="SRM SIC Q1=634.35 Q3=658.4 Channel=2 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3083,11 +3100,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3097,7 +3114,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="95" id="SRM SIC Q1=634.35 Q3=771.45 Channel=3 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="96" id="SRM SIC Q1=634.35 Q3=771.45 Channel=3 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3115,11 +3132,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3129,7 +3146,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="96" id="SRM SIC Q1=634.35 Q3=934.55 Channel=4 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="97" id="SRM SIC Q1=634.35 Q3=934.55 Channel=4 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3147,11 +3164,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3161,7 +3178,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="97" id="SRM SIC Q1=634.35 Q3=991.55 Channel=5 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="98" id="SRM SIC Q1=634.35 Q3=991.55 Channel=5 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3179,11 +3196,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3193,7 +3210,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="98" id="SRM SIC Q1=634.35 Q3=1104.65 Channel=6 Event=16 Segment=11 CE=25" defaultArrayLength="104">
+      <chromatogram index="99" id="SRM SIC Q1=634.35 Q3=1104.65 Channel=6 Event=16 Segment=11 CE=25" defaultArrayLength="104">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3211,11 +3228,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="552">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0dtLUwEAgHGQUAoGpqkomGBQEqUSCiJSX6gPSmAEYTcUURkSiHh5UREqM1IY6oOQFibtbDs7u9+3s9vZBCU1BCXEC5JhadCNHjKsdH/C9/ty07VobmoJv9TydU9LbqnAjUcC/UsCUraOjVYdpxw6yv/raKvV82JCz/yOnoNCAxf6DNTPGRhKF/E0iuxKIhkHIlVVRrpHjbzZNLJSIJHUI3FFkWhSmRi7ayIqmPjx00TeVTN1w2YG3pux5FvYaregki1UpFh53WLlRMyKOs/GQr+NwnUbk7fsJC/Y6ap0sC07yDrnZLTPyclVJ08uufg76KJny8W3UjdqjZsPn9xMFXu43eshddbDW5WXp/Vers14+fPFi6vER/uAj4J5Hx9P+3l1388dwU/adz+LZQGePQ5wfTHAYYac6JPpEGUu/pLZrQgyPRTk3nKQMzkh3jWHeG4OUfk7xD/C+IbDdK6GuXw2wmd1hBl7hAeHETKroyxrooysRanOVzh6qBBwK3QfKRTVxNgfjyXMYjScjycexCnfjHMM0abMMA==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0M9LUwEAwHFRBEEP2sGdZCwEEaMOIUIqCl+QFImIWh3EkweLioY/wsNAC1kgpiIFvb29bW+/t7e39962ZwzyIjsMi6EQMj2IiogQQxJiIlT7C758vr92vrDYKPD7kcC4ILB9JNDT6Sb4xk3zVzfOf27Oh0TsH0W2forcafMgTnhoUDzMXHo4uifx4J1EriDR0eJl/ZmXGp+XV2deSrd9DM36ML75sNb7WRr1U1n3M3HgZ+emTP8LmbguY7mSeT8Y4MIVYKwYoNAaxP46yEk+iKMtxN/pEEvfQzj6w9jVML3WCLbVCKcXEfaIUvgcJXceRemLIa3EWDmOsdAdZ+pDnLUfcbQbCYpPE5TFBE3HCbo6FEZeKkzqCq4/CuHeJPn5ZLWXpLZRxfZQZeCTyvi+itOaqnpT5GIpSuUUlbsaljmN7k2Nx3U6U/d11pZ1tF2dosWgPGbQJBt0nRmM3Eoz6UjjMtOEr9PkBzOcLGao3c5ga84y8CRbfZ7FeZhFbDfJPTcpqSaVS5Oe4Q3eShv8B43nyjw=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3225,7 +3242,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="99" id="SRM SIC Q1=610.8 Q3=332.2 Channel=1 Event=17 Segment=12 CE=22" defaultArrayLength="103">
+      <chromatogram index="100" id="SRM SIC Q1=610.8 Q3=332.2 Channel=1 Event=17 Segment=12 CE=22" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3243,11 +3260,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="200">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3257,7 +3274,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="100" id="SRM SIC Q1=610.8 Q3=576.3 Channel=2 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="101" id="SRM SIC Q1=610.8 Q3=576.3 Channel=2 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3275,11 +3292,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="220">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3289,7 +3306,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="101" id="SRM SIC Q1=610.8 Q3=675.4 Channel=3 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="102" id="SRM SIC Q1=610.8 Q3=675.4 Channel=3 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3307,11 +3324,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="128">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3321,7 +3338,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="102" id="SRM SIC Q1=610.8 Q3=790.4 Channel=4 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="103" id="SRM SIC Q1=610.8 Q3=790.4 Channel=4 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3339,11 +3356,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="144">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3353,7 +3370,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="103" id="SRM SIC Q1=610.8 Q3=889.5 Channel=5 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="104" id="SRM SIC Q1=610.8 Q3=889.5 Channel=5 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3371,11 +3388,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="180">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3385,7 +3402,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="104" id="SRM SIC Q1=610.8 Q3=988.55 Channel=6 Event=17 Segment=12 CE=24" defaultArrayLength="103">
+      <chromatogram index="105" id="SRM SIC Q1=610.8 Q3=988.55 Channel=6 Event=17 Segment=12 CE=24" defaultArrayLength="103">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3403,11 +3420,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="536">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0ctLFAEAgHGz8GDhqSTCQCJkDz0YLIRE+mKTIg0jD2VEVocIwQ4+SQoPHWITKQsPC1kps++dndWd3ZmdnZ2dnTXIELS0hTAUCtMyDx6iJJT2T/h+38VWkQchkfAfkQWnh93PPJz64qHN4cXd5WXK8vJ3jw9Hi4+rHh+PN3yodX6+u/yU5/3UHwrQfS+AqAeYLwmyszlI9esgt9eCPK8JkX0UYmMmRGVFmEt3w/QrYeQiicVGiTK3RN2yRLsQ4eXDCNNTEf7tk2ntlLFnZaqORXENRFlfjdJya5y3n8cRLk/w6v0EeSFG05MY777GOFOrkHqhcOKXgnQ2TtVInDe/41w7nWCvK8HMxwSuChXnHZVtWUXbVOl0ahwd1FjJa4xVJrnelqRcSfJhK8nAOZ36IZ2iBR39cKrQl+K4luLHDgOxweDGsMH+JYM5R5rBjjTnjTTFJSZGk0mv20T4ZrJ2JIO3J8NNK8OBUotPzRZPRywurFjsErKYfVnuT2apLrNZv2LjH7ULZjYHT+YKD3Js/szxHx0oyNw=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHGUiBKK2lM+LBKUGCJpBEIGEl8ZS0EWiMYgETMfehF9MSMVsnxbBJLIdnfb/Zjbbne7/bjdFAYi5dN6CZEiCQNf3EMoMglChvsLvny+z5pD7IyF6EqEkI5DNHWHmV0Ic7gTxn9NoDQk4BEEVg8FGttFpmZE9jdFfA0Stk+i5ZNE8IfE/9sRJicj7JoRes8iGI+iNL+P8qEc5dQlMxqQKcsy3RUZrVPhxmuF+S2FymWV4UGVL59V7v1WEVo1PG81nF2NvvYY39/FGP0Vo29gHU9pnesdcapinI1aHP1pAkFLEPyXYLE/ybSYZPwkyRA63lWdiX2dpTsplJcptvUUB8cpag8M3G8MerYMApdM5p6YrH006z2TvVtpqs/TuNQ0XUdp/B1W3WsRLFoY5xblxxkqyxmufMtw92YW73CWiXCWpT9ZlLYc269yHFg5atUc7od5ehbzBL7mmbtqszZo46zY7P20qboLuF4U6s8L+P8WmLrvEJx1MEoO5YYiTSNF+o0iF9s4xR0=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="100">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3417,7 +3434,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="105" id="SRM SIC Q1=860.45 Q3=645.35 Channel=1 Event=18 Segment=13 CE=31" defaultArrayLength="102">
+      <chromatogram index="106" id="SRM SIC Q1=860.45 Q3=645.35 Channel=1 Event=18 Segment=13 CE=31" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3438,8 +3455,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="40">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3449,7 +3466,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="106" id="SRM SIC Q1=860.45 Q3=801.4 Channel=2 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="107" id="SRM SIC Q1=860.45 Q3=801.4 Channel=2 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3470,8 +3487,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3481,7 +3498,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="107" id="SRM SIC Q1=860.45 Q3=930.45 Channel=3 Event=18 Segment=13 CE=31" defaultArrayLength="102">
+      <chromatogram index="108" id="SRM SIC Q1=860.45 Q3=930.45 Channel=3 Event=18 Segment=13 CE=31" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3502,8 +3519,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3513,7 +3530,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="108" id="SRM SIC Q1=860.45 Q3=1059.5 Channel=4 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="109" id="SRM SIC Q1=860.45 Q3=1059.5 Channel=4 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3534,8 +3551,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3545,7 +3562,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="109" id="SRM SIC Q1=860.45 Q3=1174.55 Channel=5 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="110" id="SRM SIC Q1=860.45 Q3=1174.55 Channel=5 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3566,8 +3583,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3577,7 +3594,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="110" id="SRM SIC Q1=860.45 Q3=1287.6 Channel=6 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="111" id="SRM SIC Q1=860.45 Q3=1287.6 Channel=6 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3598,8 +3615,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3609,7 +3626,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="111" id="SRM SIC Q1=860.45 Q3=1507.7 Channel=7 Event=18 Segment=13 CE=33" defaultArrayLength="102">
+      <chromatogram index="112" id="SRM SIC Q1=860.45 Q3=1507.7 Channel=7 Event=18 Segment=13 CE=33" defaultArrayLength="102">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3630,8 +3647,8 @@
           <binaryDataArray encodedLength="540">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzttLUwEAwGHRERIiPVQYlSUECj6EGnZR8AdRDCsfFAQlpxXpQyn6IKIh4lSil4h0jAoiIrzkYNPN7eycnbPt7L6zTUJCJEIKBwrelqDlU/v+gk+8YqXYaGV03Uq61ob+vQ3LkY2i3gXGNxfY71jk4doiJuwUvrPzMmMnp97B0GcHB8cOnjctkZ5fwqBzcq7ByYrZyetfTvTlLnL7XciKi4F8gYpGge0PAtNpgUdX3ZwfdPNddfOmQKS+WUT3ScS7JTJYJVE1LLEblpg95eFJq4eLXzys7nh4e13m/qjMCU3Gf1rhhUGhelZhP6PwtcbL0wkvl5a9rBX5mHrso8HiI//QR6DOz/ArPzdW/Py5oGLpVOmyqZQcq/y4HSD+MYDwL0CbPkiuOZg9Brl3LcSeMcTUtxA3L4f52RPGKIcpLYigtUbonYtw5m8E990oBlOUvI0oM5Wx7C9GZjmGqTjOre4461KcsZMaZS0ayRmNvkONs3cSSJMJ2n8n0FUkmRtJ8iCVzN5SmJ+lqBFT/AdUr8uY</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwN0N9LEwEAwHFQMxFRkWD4YBFCQaGgIsN8kX2DXmZloCUY7WFE6INBCYGKPiQxIiiMFAwjurm73Xa73X7dbrfbpugoKLCXEPFhDxN7KJaED6XR/QUfvt/JboFjn4CvJODo8yO89NN14McxusbxxzVKVwIU5QDPG0Rm74lMaiKeUxK37khclSV6/0lcHArSKgRxfg8y0ikz9UhmUZfRTmS2XSEqz0I0fg7R0RLGfTvM+Nuw7YURLygUJxTKqkLNkUJ7fwTXfATPZoS5epXVGyrma5XdHZU/Z6O0eqM4pSgjP6NM9WgsPtHQshrbVTEq12I0vojR8TWG2xFnfCyO730ccT9O8XKC8sMENckE7X8TuAaSeBaSzH1KstqUYs+bos1I8a1a59WgjntJp7akU7iUZvpxml4rTeW0QXDIwLticK5ssNOZsf0M19cz1DWYbAybzL4z7Qcmh91ZQjNZ7m9lOd9ssTtq8eaDxc0fFvXOHJvzOdvO0Xcmz++7eZRAnge/8nZ/gb2nBZa/FPgPLrbFyA==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="20">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3641,7 +3658,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="112" id="SRM SIC Q1=482.25 Q3=400.75 Channel=1 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="113" id="SRM SIC Q1=482.25 Q3=400.75 Channel=1 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3659,11 +3676,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3673,7 +3690,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="113" id="SRM SIC Q1=482.25 Q3=516.3 Channel=2 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="114" id="SRM SIC Q1=482.25 Q3=516.3 Channel=2 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3691,11 +3708,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="48">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3705,7 +3722,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="114" id="SRM SIC Q1=482.25 Q3=573.35 Channel=3 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="115" id="SRM SIC Q1=482.25 Q3=573.35 Channel=3 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3723,11 +3740,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="64">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3737,7 +3754,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="115" id="SRM SIC Q1=482.25 Q3=686.4 Channel=4 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="116" id="SRM SIC Q1=482.25 Q3=686.4 Channel=4 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3755,11 +3772,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="68">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3769,7 +3786,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="116" id="SRM SIC Q1=482.25 Q3=800.45 Channel=5 Event=19 Segment=14 CE=20" defaultArrayLength="105">
+      <chromatogram index="117" id="SRM SIC Q1=482.25 Q3=800.45 Channel=5 Event=19 Segment=14 CE=20" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3787,11 +3804,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="556">
+          <binaryDataArray encodedLength="544">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzs9LUwEAwHHUwzSLCOkgIlj5AzwURZjEDl8so8SoISZh0MFC0EqogwRiWtGhg5g/qS4hFlaYPLe9vfe2t+1tb9t7e9veDh5CLZd0iiTKTOqg7fMXfHLFAq3DAtJfgeq7i4x+W8R0uWl658Zf6OFkp4cPbg91e728uuGlXPUyflDk4nURx1uRyC+RAaePhic+fto+3pdL3OySqJqXWP4jMYnMpacyJUsyeqXCYLdCo6Cw+U9h/qyf7hE/hz/6WT0UYLo3gMsboHQ3QPy8ytCYyulVla2aIAt9QXrkINVFIT63hng+FaItF2JffRjjXpiHahinQ2P7sobwQuPWV43aoxFy/RFeahHaS6Psb4+ysxDl+x6dZ1d1Gub0/FHnQXOMIxMxjPUYt4/HOTAUR8zE6axMsNubYFZJcKHEYKPDYOyNwaktg5UzZv5nUvPFxDyW5M5gkrJ0El+FxbUeiwLZ4rUjRcuVFD9mU4xvpmhsSvNpNM3wWjp/y2ANZOizMuSKbVznbLRHNic0m5kdmzJnlsf3s/wWs/wHJjXSEg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN9LEwEAgNGHvUgxrEDKMEKR6GFvlUkGfkKCILYHGYGEUpTQElHwoaeRkjEhH1J6SPFB3Xa77Xa72+222267G0UWKij6IChUxBB8UVAsbHh/wffDe7rE3cFlru8sU90VomyEEOvDzA+F+WCHCVyJMPIywjMjQu9Fgc5+gRZVwPdXYKwtyuzbKOq3KJsXRI68Iu5PIp5dke6bMfwvYgTFGMJhjJU7ccpv4risOE0uiY4uiYFpicCWxMLVBObTBLuLCc72E1zzyLSMyvgyMmMVmVmSqJNJNleTHNUquH0KnjmF7l8K/maV4CsVQVZZOVEpt6ZwBVI0fU3RUaMx0KMRmNFY2NEwG9JURtM8+J7m9JJOsk/HH9JpPtT5eT/D5/EMvWsZ3HVZfvRnmYhmeXic5V+b4fANhjYMbtXn+P08x7yUcx7kqCXP6lSed9t52m+YnA2aaIrJ8H+T248K/JkuOOwCTxqLXH5dZD1d5H2V5fRbVD5a6HsW3jqbg8c2E0Gbhi82esXGe6/EwXDJcShxDpmc0Eo=</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="40">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3801,7 +3818,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="117" id="SRM SIC Q1=713.3 Q3=395.2 Channel=1 Event=20 Segment=15 CE=25" defaultArrayLength="105">
+      <chromatogram index="118" id="SRM SIC Q1=713.3 Q3=395.2 Channel=1 Event=20 Segment=15 CE=25" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3819,11 +3836,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="104">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3833,7 +3850,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="118" id="SRM SIC Q1=713.3 Q3=524.25 Channel=2 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="119" id="SRM SIC Q1=713.3 Q3=524.25 Channel=2 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3851,11 +3868,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="92">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3865,7 +3882,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="119" id="SRM SIC Q1=713.3 Q3=637.35 Channel=3 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="120" id="SRM SIC Q1=713.3 Q3=637.35 Channel=3 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3883,11 +3900,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="116">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3897,7 +3914,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="120" id="SRM SIC Q1=713.3 Q3=736.4 Channel=4 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="121" id="SRM SIC Q1=713.3 Q3=736.4 Channel=4 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3915,11 +3932,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="104">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3929,7 +3946,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="121" id="SRM SIC Q1=713.3 Q3=865.45 Channel=5 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="122" id="SRM SIC Q1=713.3 Q3=865.45 Channel=5 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3947,11 +3964,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="100">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3961,7 +3978,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="122" id="SRM SIC Q1=713.3 Q3=1051.5 Channel=6 Event=20 Segment=15 CE=28" defaultArrayLength="105">
+      <chromatogram index="123" id="SRM SIC Q1=713.3 Q3=1051.5 Channel=6 Event=20 Segment=15 CE=28" defaultArrayLength="105">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -3979,11 +3996,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="548">
+          <binaryDataArray encodedLength="552">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwNzt9LEwEAwPEsKmjEyDX0VWhie+ihBwtR+/o2I0ILESmDfhGULiVIodAhGhQGUmFkWBLka+zH3XbbbrfbdrfddrftTWorRHyIsuwlRXzQff6Cj9vpZ/6ln4NHAngnAnzbClB/I8isGOSwPcTEvRDbSojRRoFfIwK3DYFqk8jbByK9gohtT0T3hPG9CtNWDfPfFeHLwwj3pQinDkn8uCTxbl7i6qrEcXeU3KMoU3KU9qMxtnti+BdiDK3HaD4TZ3Uszns1Tp9Nxt4nk/8gM/1T5sLZBDtPEgS1BF67QsuAwtonhcUNhf7WJCd8SUwjyTOHStegyu6yivBPZaQthXs6xbqV4mNDmoGbaTzxNK0NGSp3M0yGMrWjhtGrMbykUb+pEe7QuTarc6Ci8/l0lu7xLH/1LK+dOc7dyVEN5PDVGbh6jNrPwPvHwNGeJ/Iiz/WveepaCiw/LnBRK7DpMHlzy+S83+T7nsnUZYvmRYvCb6t2K3LyeRFppYjbWWLhSgnbXImnVomNY2UGPWWsmTKd6TL7tWLOZg==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkN1LEwEAwCVj1KgwCEEGhgwrEBn1Eia++BOjHlZIiBD1UBB+tIdlYSGi4oMPBvYQS6oH+2But9t2u9222253t+0qESoKiyEyQsGPgl5GSQ8Tur/g91GuD5K/H+T1VpDZ/iV8y0ucPRPCPR7ixOcQjpYw/0bD/PwQZr1J4NNdAcMUqByMULsUwTUfoeNbhIEmkbGbIoE3IsquyGp7lOq9KA1qFM9+FG93DN9sjLmPMYTjcVb64+y8iOPYiNN6SqJnROKWJDH9V2LxQgJjMkHlXYLaYRnXFZmOpzIDazJjzUkCt5MooSSrv5NUzyk0PFTw6AreAyl8F1PMPU4hfE2x0phm53oax6s0rdtpetoyzExlsL5nmDipcn5IpSqriDWVO71ZWp5kWV/LEnDnuOrL4czkeF+nMXlZs/kafyoasdN5Bv153FrefqCz4NXpW9A5sqmz3GYw/cCg0zTYO2Qi9ZkMvzRttskPT4HnjwpcswocO1q0+4vMLBbp+lWk7C7hv1HC+azE2y8lupwWZSz8E5btYPEfRLXMpQ==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="72">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -3993,7 +4010,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="123" id="SRM SIC Q1=734.4 Q3=530.3 Channel=1 Event=21 Segment=16 CE=26" defaultArrayLength="183">
+      <chromatogram index="124" id="SRM SIC Q1=734.4 Q3=530.3 Channel=1 Event=21 Segment=16 CE=26" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4011,11 +4028,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4025,7 +4042,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="124" id="SRM SIC Q1=734.4 Q3=643.4 Channel=2 Event=21 Segment=16 CE=26" defaultArrayLength="183">
+      <chromatogram index="125" id="SRM SIC Q1=734.4 Q3=643.4 Channel=2 Event=21 Segment=16 CE=26" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4043,11 +4060,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="44">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4057,7 +4074,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="125" id="SRM SIC Q1=734.4 Q3=714.45 Channel=3 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="126" id="SRM SIC Q1=734.4 Q3=714.45 Channel=3 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4075,11 +4092,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="88">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4089,7 +4106,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="126" id="SRM SIC Q1=734.4 Q3=785.45 Channel=4 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="127" id="SRM SIC Q1=734.4 Q3=785.45 Channel=4 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4107,11 +4124,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="92">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4121,7 +4138,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="127" id="SRM SIC Q1=734.4 Q3=898.55 Channel=5 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="128" id="SRM SIC Q1=734.4 Q3=898.55 Channel=5 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4139,11 +4156,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="84">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4153,7 +4170,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="128" id="SRM SIC Q1=734.4 Q3=1013.55 Channel=6 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="129" id="SRM SIC Q1=734.4 Q3=1013.55 Channel=6 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4171,11 +4188,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="64">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4185,7 +4202,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="129" id="SRM SIC Q1=734.4 Q3=1217.65 Channel=7 Event=21 Segment=16 CE=28" defaultArrayLength="183">
+      <chromatogram index="130" id="SRM SIC Q1=734.4 Q3=1217.65 Channel=7 Event=21 Segment=16 CE=28" defaultArrayLength="183">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4203,11 +4220,11 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="884">
+          <binaryDataArray encodedLength="876">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0odvDQEAx3HEqK0RtIi9YjWIooJvJUXFjL1XShBSQhBihlqxQqVWEGLWjhGhaPva1/b1vdvv7t69u3e1KjFjlFj3H/x+33wSMvOpXZrPt84F5KwpYGh+ARXxhWTNL6TnzUKEP4WsHeOj5UkfeZU+Fg0sIi6riFyliImdivm+upiTz4sZ1sTPy7l+9uT66fXbjzi6hHU5JbR6W8Kz5FIydpZSVy7lRocyJq0q40deGacaBUidE+DVtQB7fwVISi9HOl7O+tflVHYMMmNBkJIzQVIiQa4lhmg9LcT+oyH+CCEyvoYINBfoP0jg9CyBWpsFVpwVUF4IDHklcLGOSMPuorddxFopknZY5MZdkeaqyOYqkdctJcYNkbg/T6LNdoldFyQ++CSmVko8rS/TpbfMgQmy909m7jEZ3wOZ3oZM9m+Zv20UFqcqlC9SSN6lcOay4jVUWPleQW2sMqyvyqXJKo3XqV4DFfuxysioys1qGi06amxJ03izRGP8Xo0H1zXaBjWyPmt8bBpmWnKYvOlhum4Mc/B02OsUZp4bpqimTlJXnePpOv+W6yw5oBO6pTNQ0jn7TScuwSAzxSA824AtBpfPGTQpMLyWBk6cyageJrfGmiRkmmw9YvL2nskEzeThT5N2rSPsHhrh0/wI03dEeHYxQrfiCIfeRahqYLEgycI/0aLPGoucbIvqjyyWmpZnw2JQuyjnhkepmxFlVVYU/UqU1LIoVz5EiY+32dDPJjbFJn29ze0TNolPbLbZNpXVHc+Pw6MRDu2XOuzZ5/Al12FmyOHFF4fuzWIcGRDj14wYCzfFPAcx+j6PcaIiRo3aLsu6uZ4xl5QVLucPutS747JadjG+uwxPrODq4Ar+A8J1fWk=</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLVAEAgNvDlk0riaZJiIREw8qKPptEmIhERIiESGW7bFvZHjYJkYqyMjlCRCQ9z/M878179+7du3cSESYiItLOhu3eP/g+vi8muYbMohrutNeQllhLVH4tYmMtBVFOkjOcfLnnpKLTSW5SHdOP1tEi1FE83EX6RhdDS13Ib1ycmlvPooJ6vin1VI5ys22zm7gyN60f3JQkN5BR2MBwvQF1nIfCLA8pDg893R6qUhrJO99IvNlI20Qvd7d6yazwEt3jxZHUROr2JloeN5H/uono8T4cG3ykXvbZDD4md/jI6i9QGifQvkIgLkcg55xAeZlAlySQ0CmQN1CkIl7k4yqRpFyRfRdEqstFm1NkfpfI4cESdbMkfq+RSNkmUXBJwuuQ6KNJpL6RODtERk6QGbROZu0OmctXZPRnsu0ik/ZO5sYwBStRYcx6hcydCsVFCi8rFGINhc0fFO6PUGmdrTI1TSV7t8rj6yodlartq5L7ScUx0s/bJD+J6X527fVTedPP5yo/cyw/B7r9PB+t0TNHsztoHN2vUX9b42+1xtJmjVNfNXxjA/SbF2BlZoDzBwOodwJE1QRY9yLA1e8BjBid6AW63Urn1iGd5mKdGKfOxpc6JT90Xk0IMmlhkC2bgjw4EqStJMh0V5Ctr4KU/QrSGWswa7Fh9zR4dszg/V2D2W6DPS0GVX8MvkwKMXdJiPwtIWpPhPh5P8QiT4jjrSEa/oXoNcVk+TLTbm4injQZ8NBktdfkYpuJ1jvM0Glh1i8Pcy07jHk6zKhHYTJ8YfvFMC/6WkyYYbEp1bK/sGg5YzH5iUWWaFHaYdHeP0LczAg5KyOU50ToOhch4WmEPDli/xrh48Bm/gNin3TO</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="116">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
@@ -4217,7 +4234,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="130" id="SRM SIC Q1=489.95 Q3=416.25 Channel=1 Event=22 Segment=17 CE=16" defaultArrayLength="188">
+      <chromatogram index="131" id="SRM SIC Q1=489.95 Q3=416.25 Channel=1 Event=22 Segment=17 CE=16" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4235,21 +4252,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="232">
+          <binaryDataArray encodedLength="240">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAEDJwYGEScGRj2OjMcMHRheNDtwqCwy4WB4SoQP3JhaHjhwuDww4VBgNmVoQGIHb67MCTcBao5DpTbClGbcASo5hIQA+kHG4B4ugvDgQYg3w1I8wHN+ePM4MAGVP/PmaHhMNCucCC+B7R3ExAfAuIlQKwDxAGOCHcVANkfgLgAKD4FiC8A8QMoBqkPAOINQPkHDph+guk1cYKa4YipZhQMRwAATXk3MA==</binary>
+            <binary>eJztzzEKwjAYhuEPFEdx6AE8gIOewNhGJ68g5CjZPYDg5OABXHRQlA4FHUVwUyhOxQvoIOJbiji6iz99+JvkS9JK36oZSkEkrSPFLat0aFVfWumIi5XPrMzdqlbqysPcrNyZzJa1eZF1CZkD6OkMI6vYM+7Rq5zziGQq5J+R/Iq7Brhy7wIbTNCA6fBBhgeO9zJzDmMkOGGPKfrY5Xn49ud/3nszBGHR83E+/69frxecVjdl</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="131" id="SRM SIC Q1=489.95 Q3=530.3 Channel=2 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="132" id="SRM SIC Q1=489.95 Q3=530.3 Channel=2 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4267,21 +4284,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="220">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYEAHDxwYGD44MjC0OTEwvANiK2eGhi/ODAxdLgwMXK4MBpGuDCumuzJo7HJl6LjiyqDwACj2CCh2x5XhxHVXhglA/OMekP3KleHDRyB+58oQcdeVoeKoK8ON5a4ML7pcGQRCXBkcJIF6LwPNXOzC4NAGxLFAtqwLQ8M7oF17gXYuA+JWIDsOiB2BWAaIDwHd4wHEBY4Yzh4Fo4AIAAAlDDJS</binary>
+            <binary>eJztzqEKAlEQheE/m6wKgtFoNl3dnWY0aBBfw2i6yCabdhHNRotJsCtoUFlMsmFZwWD0ZA2+wB74uMPA3Bn4Tuwga4JvQSqNgNErgCiEglHvGaupUdsY46NRjdW7q3cx9idjIu+b6sTInpIa3asx3BnnpfGIjGLHcCXNHvTnPMR56auuSKJdW+1c6PUyECdlWeuetsx0n3M/p+fJ8ycfG1Ux6g==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="132" id="SRM SIC Q1=489.95 Q3=643.4 Channel=3 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="133" id="SRM SIC Q1=489.95 Q3=643.4 Channel=3 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4299,21 +4316,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="176">
+          <binaryDataArray encodedLength="196">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYEAHBY4MDB+A2MQJQoP4BkB2uDPDAR4XBoUOF4YDp4H4LxCzuTJMYHJlOPDHhWHBfwgfhBNYXRk2MLgyFLBA2BeAeAFQXcNXFwaHe0AzdrkwPJgOVJ8K5Iu4MDTMdmZgOAW044EjhnNGARnggQMk3kScIPEYgBSXIxsAAPwBKII=</binary>
+            <binary>eJxjYEAHBY4MDB+A2MQJQoP4BkB2uDPDAR4XBoUOF4YDp4H4LxCzuTJMYHJlOPDHhWHBfwgfhBNYXRk2MLgyFLBA2BeAeAFQXcNXFwaHe0AzdrkwPJgOVJ8K5Iu4MDTMdmZgOAW044EjhnNGAYmgwR4Yjg4MDBOAYcniBIk7EP4B5CcAsYPDQLtwIAEANDoppQ==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="133" id="SRM SIC Q1=489.95 Q3=683.35 Channel=4 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="134" id="SRM SIC Q1=489.95 Q3=683.35 Channel=4 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4331,21 +4348,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="280">
+          <binaryDataArray encodedLength="296">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYCAWBDgxMOQ6MzQIuDAcaHBhWLDFhSHhDpD+7MLw4DeQ/gQUv+7CoHDMhcHhIlDsjwuDAL8rwwcBV4YANleGhG9AsUdAOaD8gxkuDA2+QPwfaN55IH7qzMDA6MLA8AdIPwPyXwJpTqB5akAxayBtB6EdNIBscSDmA+qVBYp5AHE+xD0N9VDcDDS/CyjWA1TfDuSXAOkEiFoHHSBmBbIvA81fDrSnE0h7AjEvEB8C+q8NiAuA+AIQywDFHIGYzRki/sCB6KAaBYMWAAA3oEdA</binary>
+            <binary>eJxjYCAWBDgxMOQ6MzQIuDAcaHBhWLDFhSHhDpD+7MLw4DeQ/gQUv+7CoHDMhcHhIlDsjwuDAL8rwwcBV4YANleGhG9AsUdAOaD8gxkuDA2+QPwfaN55IH7qzMDA6MLA8AdIPwPy3zgzHOAEmqcKVGMJFLcDsoF0A5B/QAJIiwDNUQGKuwP5mUB2DZCuB7oB6K6EFqB8J9COLiC7FSheCpSPh6h10ATSHED5q0A7VgFxO9A+HyAWAOITQP9NgOJLQCwBFNMEYhYg7gDyFzgyMDTYEx1co2BQAgBxsEo5</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="134" id="SRM SIC Q1=489.95 Q3=714.45 Channel=5 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="135" id="SRM SIC Q1=489.95 Q3=714.45 Channel=5 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4363,21 +4380,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
           <binaryDataArray encodedLength="168">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYMAHNjgyMCxxYmAwcmZg2OTM0CDkwuBQ5sKgsMuF4QOzK4OCoitDgLYrQ4OSK0OCoCvDAxag2A8XBoa3QPzQheHAdReGhAtA9kmIngeLXRgWNALFHVwYGn4AzVwMxFZAfA9ohw8QrwDa98ABr5NGwSigAAAAZxEf5Q==</binary>
+            <binary>eJxjYMAHNjgyMCxxYmAwcmZg2OTM0CDkwuBQ5sKgsMuF4QOzK4OCoitDgLYrQ4OSK0OCoCvDAxag2A8XBoa3QPzQheHAdReGhAtA9kmIngeLXRgWNALFHVwYGn4AzVwMxFZAfA9ohw8QrwDad8ABr5NGwSigAAAAG1EfxQ==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="135" id="SRM SIC Q1=489.95 Q3=754.4 Channel=6 Event=22 Segment=17 CE=20" defaultArrayLength="188">
+      <chromatogram index="136" id="SRM SIC Q1=489.95 Q3=754.4 Channel=6 Event=22 Segment=17 CE=20" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4395,21 +4412,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="280">
+          <binaryDataArray encodedLength="284">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJxjYMAHNjgyMGxyYmAIdwbSzgwNP5wZHBRdGBpKXBgO7HdhuMDjytCg6cpQoOXK8EDQleHAR6D4DQh2uOfCwPDQhUHhAZB/yoXhwQYXhgWNQL1RLmAzHOSBmB2CG24BzV4CtMMFiLmB+B3EzoZVID5QjR5QTRAQRwLNDAXSDkAz1YC0FhD7A+XbgfZMBbInQN0WBhRzgaozhNrHCtT7CGjmVqCZU4A4DYgtgVgGiHmBmA2I/wHtfeAE8XMbEJs4QcLggQPeYBoFQwYAAE2rREo=</binary>
+            <binary>eJzt0DFLw0AYxvFnMgRE8AuYOuog2llJmrxH1y4S0q/QxaGD4ymODg5+gA6dJThlM7OTo5RS0o/QrXTqX7NnF3zhx10e7t7LndRV5UB6T6U8Y8zkt5mSU5OfmuoP09ehkz9zujt3ao6d6g35dytZmbQ29Rq+P01NaZo9sHdsvz2SCEHLL+g95wxDCKHAG+eFrLmg14h1ORgVg6zu4xaP5C9kz7hnXpANccPeK5yQBz//Q88Kr5jgGhGOcIAdd12m7Z2fcImKNxB83PlU//Unag/8N0Fr</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="136" id="SRM SIC Q1=489.95 Q3=825.45 Channel=7 Event=22 Segment=17 CE=16" defaultArrayLength="188">
+      <chromatogram index="137" id="SRM SIC Q1=489.95 Q3=825.45 Channel=7 Event=22 Segment=17 CE=16" defaultArrayLength="188">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4427,21 +4444,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="924">
+          <binaryDataArray encodedLength="900">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwN0glPFAcAhuHUetaiwaPeNp5RLKZqaati+zbeeMYzoZR4xHpUqaKYiNqolXi3Kt63eMU7IpooQgkuCyzsMbMzuzO7M7M7M1KNRzRCbMRonX/wfW+egd+58Oa5yJZcdOpTQfGqCuaVVdCsrZvLv7iZes1NfaObwxMrST1SiflvJXkpVSRtrcIvVrG6VzWdV1ZTUlrN/AQPzTM8XL3iYdpbDw3jazh6qIZRdTVYw2rZtqWWQUItgS+95GR56VLipbS1j4XpPlpc9nHtPx89Uvzsyfbz4aafrBd+YkkBpi8JUHYhwBA7wNFmAp8MEFiaJiAsFxj+t8DZWwKtJIFVbwTUziI/jRSd7SKJm0RyC0Qsl0jaY5HCVkG6fhVky9QgT1cGmZEf5P6dIL2VIDsbg7zuLpH+o0T5fMn5J7H/okRjlcSCZxKeBJmhX8scmyHTJEdm2WEZ8Z7MCE2m4INM614hVo8OEV0UYvT2kNMgRHtviPUvQ9iJYSZ9E+b2nDDd1oX583iYZyVhZsbDFDdR6NNPYdd4hfqlCj/vVnh4Q3E6KeTXK7zrqLLwe5WadJVhG1VOnFZpWq6y/JGK1DxC6sAI5ydF+Dwrwpq9EbTCCGPkiNMyQoeuUTakRnmUGWXy5ihF56J0d0fZ+iTK8880ZiVrPJim0TdbY/cBjYa7GhmqhuudRnJPnYPovF+gsyhPx3tJJ8Wjc/K57tgwWDHEQJ5pMGqtwYUjBgnFBjm6gf6/wdjeMa6PidFxcYyNO2LUXY0xxRfjzqsYPdrHHT9xXsyNMzs3TumJOP3/ifOXGefNpyaZ/U3cE0wG/2ZyaI/pODD5VTTxNZh828ni1HDLMWaR9YdF6IzFDw8tLtZZtGlpszbJxphs0y7TZtzvNrmbbG7ss7EKbL4oskmrsPkIc5+Guw==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwNkgdLFQEAgK1s2d5ZWFS0sGXLIqTsM7GwCAmREKmQEGnvvcuWLSOlIkQioj3Mns/n0zfu3bt3797dvbtDJCJCRKS9h2XdP/g+vq/qy3M2pzhILHLQrDkoH1bNyvxqBj6oRv1RzalUJ2lnnLSbThwjathaUMPkJzW0tNVQschF7nkXQxpd6KNrObOulvSqWmJi3DgXu9le4mbqSzet4+q4uamOPGcd8bH1GEvrKS6tJ+N1PR0TPbi2edjp9pDUzYuc6iV/r5f2Si9l770kTfAhr/aRf81nM/iY/83H4UF+fLP8xGb7Sd/hp+iKH6nKT1yDn8wffoqHCKjJAn1zBLJ2CZSUCVgOweYUyPklcDU+wIu5ARJWBsjbE6D8aoDXzgBjXgTIbwtwa7hIyzyRibkihftE7l0Xee8SbReRzX9FniQE+ZoSZFZekJ0HgjhuBPntDjLvVZD9/4K4R0rELJBYuEri6CEJoVyii0eyfSVOdQghjwrRc2GIZWtCnD8SQq8I0d8XYkVTiCudZBrGyMSnyXYHmevHZF7elBkpyKxqlqnoHKZpbJix6WHWrg1z+0SY1lthEsUw61vCPOiq8HG8QlKGYrdSqDyp8P22QrKksLtVwdk9wp+JEVKWRDhYGMFzOkLHuxHS5AjH30QQe6h0m6SyJFO1e6ooZ1V631dZrqhcfKdi9NIYOEUje5lG2QaNxnMawx9q5KoaNz5ovOqjM2qazprlut1cp/mCzvjHOgW6zp1POm/7RZk8PcrGrCiPtkT5fCnKjKdRthtRqr5E+TnAYO5Mg70rDPsLg/bLBvOfGRy2DHzfDGIHm6TPNinKNpF2mMSVmmQ+NyluMO1fTfoOtexnLLLmWGzNsCjJsagssLB2WXw/afEf7nF/Ww==</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="300">
+          <binaryDataArray encodedLength="328">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztkD8LQWEUxh+DQVksNuVPme9qUNz7vrIxKiUSJYPJprySxXQHKYPYbNIdlTIafQL5EGwGD0eZbGxO/XrOOZ2eczrAp9hkAc8G8g7MwgECCtURuSpkUhrHusa5o+E2NVAWTE3DamtsKtScRjSmUQ1xjpi41MUgZw8K57Git8I+SXzMt9wz454V9ST7ECYJkuZMQ8H05QYzZK9HbQnLAesp8zlxpd7XSelxK3sRcqHnTvzhvXbcCNQzN2syYt2lTqhrmTcutUBOtvzDsuU33wrr5et33v7/+FXcAU+MTRc=</binary>
+            <binary>eJztkLFLQlEUxj+nCFxaWlxUwtnVBjHfvRG0CI5CKIYIQe5Nt8RFHCwaatKpxchHo9NbBMfmBvGfMBz7PW6r4OLWgR/fdw7nnnM50rYIz6TPsnQRyI0C6dCo3oO1Ualg9dW0WnWshi0r1TyuYZW/sQqv0HOrdMaqfkQfuKzPK0l6F0arvmG2UZSDBH7Gnlf2vMMyUHRA7RhOoGjkrlFnNO7iH/B3cMvbDn+iFj2hL9SG6D15m74q+SmaQjfMncM08Lu+YQ0/3itEB9DFP8MEPuARLiEBb9zDlP1txqWtp9s50szJx/Ng+adxHtf/Yx/xC7QVTeA=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="137" id="SRM SIC Q1=585.35 Q3=232.15 Channel=1 Event=23 Segment=18 CE=21" defaultArrayLength="555">
+      <chromatogram index="138" id="SRM SIC Q1=585.35 Q3=232.15 Channel=1 Event=23 Segment=18 CE=21" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4459,21 +4476,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="532">
+          <binaryDataArray encodedLength="620">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztkz1IQlEUx/99KBYpDQYuUdQSRSAhTQ1+vPMIanjQ4hS1FzgUSEO45GZERGMYNEQEiQWNhQRJDblEERKOuYRDLQ3R//auFIFFSw164Mc597x77j0f9wEN+RuphIBsGPBGbJStfPUoqu451v+ocbIfBW0rrXoTIDHdH6VVTED37LNf+XZITscpe4MkVa/DH3HZGmdXJROyY+41SR1b0X4V+0rczHWIWGSeTJMQ6YrY+as8SmSE61QEiTNSJi0GTj0GEt3UAwa/U08YCC4ZmNmiP0ddNmB1CDr7BBgVBEWQiQpKi4KHlKB3W+A6oD4WxE8EhQt+vxb4bgSxK0EiL4iec8+lwLoT+J95TruJosfEZJsJX6uJI4eJoMuEv4kUBbuHgvw69y4zfpaM86wxrod5Rg/vcPC+FwNrzbzLzZycgvQt895nDZsG0qvMe4X5L9AXt3m3p6gHyRNr39O96tc9qs7iu3n8RkpBe35ePXNlK58ipv3qDuvL+/npjdbj/1qrlw1pyP/KG+eel10=</binary>
+            <binary>eJzt0z9oFEEUx/Ef5BRBEMEUKYKepBOEKyyCBG6i+w6DFikUUlhcIRi0CWJxnUsKOYzKgSIHNmeqi9UVgsFCrwoSNQZECKS5SqKNAVMp/vk+80ALC5sgagY+zO6+t7PzZmal7bY1LS9LrUQ/KhWOSafRQDs04pnHPOd7bvlPz3prmteVJ2mcOpdR8ppxHwtYCc/RibWZwCDWyH+K+Z90Rzef9xNPuIybaOI2rqGGyeDX08HvR2Ldfaw2VlCMb+bxfh1XY9zZmOcG9h2XDuEoEkZQwkEMYD+GcR638BCr+Iw9GfFM3VKmfAwXM1WvZ+q16Re5f59parepe8C0fsTUOmmaOmdKV0ztG6bOXdOuOdPaA3Iem4YXTMVnpvyFqbpkWn5J7JWpuYo3vPfBNP7VNFio6NTOijZ2VKS+iqofTQNvTXvJnXxkmr9nqs2Qf8nUOMM3y4x1eHMeeb+px5w6BeKfMhXfMdfX1PGEec9x38QMc5/OlGq4QGyCGsv0Q/R9xBap/Q7OYghfWMel2H9f4xOxH032QUjp98+U5/u5qsdedqJvxbWflR7Wg58l/07JY/5++jHe//q//motW6EezzzmOf9Kzdvtb2vfAIQUswo=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="138" id="SRM SIC Q1=585.35 Q3=619.3 Channel=2 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="139" id="SRM SIC Q1=585.35 Q3=619.3 Channel=2 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4491,21 +4508,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="584">
+          <binaryDataArray encodedLength="672">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztk00ohFEUht8UjcxI+UlRlKIUSUrT+Jvx3dMki0kpsjALpPxnM6TMhmyssEJZKKVM09iwUEPIRimRhcXsxEKzluS9uVMfZUdR89bTOfeee797zvnuBdL6X0q0AVEvMOoDtkmMBHwfc9+tTzK2aNbqPQ1k0vsR01bvTY1/W/ocff6qIZWLXVGTb2Y7UE3qSSlxkSzybKu7wEbU1JDqUcDUmyBvvs979blJk8uJiRWauN6jz4/r73KugriJvx3hBdplskP/mrbIAjzEbyHeQltLW0lK6OcQ0M+10OamP2GhfM3C1j7HZ/TPLYRPOH9L36GwVaMQDCjEBxQCkwqORYW6Tc4f0d4r5L0onDoFr6WC8lpBolkQ7BAcdAmcPYLhPoE/KNgeIlOCZEiwNMfYjCA8LbgfFwyMCApGBXODguJewV0r11bR5guaXILObMFVhuDiSSF0o9BzTCLMZUUhPKuQ7GYeHuZYxhydCnhhDQ+s6ZI17bHWeY4bSR7remWPHskhibBXGyRGf5es0+83PY/Z7oGmztZ79hxjZMjcg5j5b2n9DaXe2tc3mFZaP6t3qvianw==</binary>
+            <binary>eJzt1D9oFEEUx/EfVkdM5ESLFMEswUDIaThEwULMnjczVQIB/6AQ4YwpgoVKSJHCYokgp9WBh6QQOYjIYUCDhYiFrBDiCUFCUEiTECGNYBHFIqCF382Otc0VKe7Bh515M3v7ZmZvpVbs/YgGEUr5grSAzDnpJIa8YxBqjAWoMTfGCO0YWcbOYMTPz6MdDcYqhXRect9mmN6rMH1msyJMfpPfj7Di6+nzkvYaubonX+cTfE7WVZQO4CDasOPzL/AAFxBgp5CuJ7GNo+QmMIu3WMYnxHju81X/nFdYwmpSi7eBn9jPM3swiGtFRfe4zuED7e2iwg4jdRtF/RgwinP0e43CI+ii38P1FLnzjE/TrpCbMyq9Ntr8iK/0ZVU5bLWSs1qwVhqzakRW2YdWtbpV/b3V7Dpjv63GO5waXU7jOaf6aadO41QddoouOo2OOsVjmHAKbjr1TTpdnnIq4xft5VtOWze4Xndau8Ic7hs6S27AKR84lQ7RzzD2x6r0zar8xepNbBXN45FV5i41UlveWAX9VjE1395HvVtGtUXW9swouM96rrLeE6w3ix/s1SresV8vwd5FVfozuIRefGefn+IOpvHYn3Gb3/vjfl57MT2j5Nw7UfbvejPf1Vb8P/59j+S/Hbvn4JV9bvf/HrbOphXNir8iga5A</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="139" id="SRM SIC Q1=585.35 Q3=690.35 Channel=3 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="140" id="SRM SIC Q1=585.35 Q3=690.35 Channel=3 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4523,21 +4540,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="808">
+          <binaryDataArray encodedLength="968">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztlE1oE0EUx/8HrQpVIwQVqRJtDoVeiuRgxUja3XnrsQhiT7Uo0h4Ug+QgpcIWaQSpYktugkYoVItITQ/WgxBERIuH+lFEqiEXUQ+W4KF4EPE/7FsIOSyIih468OPNvnnzvmZmgT85sl1AqhsoKHZudf9y/E5OM7TL0/472egAFcqev1RTNRP4rSmnNN9ydzCvRcQMayyRBZX22+Yf+oxr7j0Na9m6eMtkL+s8RFqdwFeH1mvzs3ubqD9GTjuBbUl95nV/C3XtTmA3qbnbGuJOQEl1pQZdKsjdH+X3Gwf+Z8qHlCOUXRrLyqOkj3Q6QbyC+mrSuEknOKuq6gt1TGqeeY2X0lzs+dKvXyB3SZl8IDEXmU4X/oCL8mXOi+SGi+olFzhD3QlylpwPdHbNf0T5gnKJ8qWL/vfBHF9cJDYZ9KcN/JxBbMyg95pB4p7BuUWD7DeDwQ2CwS2CRKug96Bg7qTg9QXBlXHB8aLAnRWszAuGlgTvPnF9RTC/1sPbzR5ubvWQ2+HhwE4PzQkPmT0eJpIebpNFzj9Sf3Gbh1naptd5ePxD0Fyjn6pgzSvBnSeCW3OC4pRgO+PlhgRtRwSxtGBfuyC5S9hX2nxlrs8MqtMGbeOcj7CWAYOOw6xlP9lN1htkKqz9PrlOJtijMcpR9mGYfemjTFPGbV/Y5wc8L/YewwH+VTJNnvL7OZnSsw/v9rK+xxa9p3F9m3a9ondhQc95Ru9u1Nux9z+r9qU6svru6vdH/U+sbeO9jnq34ZsP32JUnuH41RhRI/y/VZSwX6tjdfx/4ydbPfif</binary>
+            <binary>eJzt1E9IFFEcB/CvZX/8U1ppSUu2GxISHhI8bBG4u8686R+ykIiHgiU0IjKkOnRQGE0oRWj7g0ilbWrhQUJEw0PFQNIhKhY0WaLDEiEGEkvdQqjvc37SHuq00cmBz77fzLx5897b+f2ATI9AgD9BwKY4FYaAcqHjuNzTfZb7/ocjkznZPA/zeoKq2NemAXpMfdRCXprifW+Ga7Kr3ecdCnCsGKWojOMfppPUQH7Kp7Gg9Au489Tz79Pr4L1DdJZa6TLVhdz5l8iaCyUukrH0M9myJ+dlfQlaorU1wDe2rylGPdRLLyhFm3i/mApoDS3yWpI+h9w4Ja0+/0CzYk7Mpvko7yzlOMeoje7QA+qvgR0lm3Ej1VI1VZKPtlA2gbIk1vR48/SGJmhQ5q/X0UkdEo/SAu3mM/V8TzfbJ2zn9DgGbB+F6LSBQJsB7zUDyS4DuM6404DTTlepm3rpEftO8v5L9n9HCfabZ7tkIFpgorDchGOZiDWbKOkxERky4X9mIj5nIvzdxP0chQWPQkOlQtFRBf8Zhd4OhfzbCtuHFS5MKqReKdQmFC5+UdjzQyF3nYXj+Rb6tlqI77Cw6LEwX2rhudfCOZ+FcbZNPL+008K2Ygs3N1s4tYF9fyosphT2feL7ZhT2TiuUTSjUD7G9pWC3K1Q1KpQcURjlfCK72D9XIcZ5js2YSD2lfhP7u6iFazlhInqAa/OZaMkzkfzKfXhrIDLO9Q/QDe5PBzXzeh33yc/YwziL3nO/J+gh3eP+83/HoLhLXdREB8lDebSeNlKOxPobSMn3NE3DkgsVku9hyRsIR/J8SuqDzrcr1C3fhs77sOSMrgUjQTf/kmn1pCKtNSTv9Hc2IqKShzrPdL1x0t6v55IMuDVkRTLwe466NqzUiOV8D7rj1Mm4f3tHLO3ZP9YcqTVO0K1jDbJPrRLra47UGTuD2rZ6rB7/9vgFu9oQXg==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="140" id="SRM SIC Q1=585.35 Q3=803.45 Channel=4 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="141" id="SRM SIC Q1=585.35 Q3=803.45 Channel=4 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4555,21 +4572,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="708">
+          <binaryDataArray encodedLength="820">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztlE9IVFEUxr9FlosJCmZnwkARSlEiQyoRzMx791Di4i2C3OVKEpQkXLQoeBgqMxA0NLQYsgYaTERksKSEoMGFtHwqLUKZhllEYEhEhAsXftd3H81KRnB2c+DHuefdd8+fe857wHHKaBz4TaIJX2u7XjJq4iwSz2ht1zPmcUst93XYO9rWdXdagGP5WtvhxP9zAdoux2rPS8fLGKJV/rT/S4xz08Qr0R4medJD+yV5Q+6aXI5Sk857LwF3woK7QOboY5Ccs/weeybWsOl32PJZNH50fYFv7cvR8U1uJXNP9Kf9Y4TEyUmyw73TpqakX4O7TJa4/mL0BvVfC8UWG7HLNtwuG+jg+grXfOa2+hrXbRQf2CjnbUQ2aO/YGPjHvZ9cf+XeZ55Zow4peL0KzmOSVOieUiikFCKvFJpXFDr+KOydFdjtglCCDAii44LmtMCZFiy85d47wcwnQduqIO8J7m0JPlYEWdL3XdBP+/2mIEJC3wQX13mO785/EJTmBFuvBetZQea5YDYlCI8Jum8Lfl0T5C4IzoQFJ5oE2FbIeQrFJYXdF8x7SKF8Q8G9qvAsqhDrZL4R5n+KzzZZ3zLJse40637C9UPWfp819/t3hwrv8ym5Re6QcYO+f/b/oB+OP0duifoHNfuAR6ZfwdxUz6hjCObiPGkik7QLNf4TgvkpHPF7aUhDGlJv2QfPTdJx</binary>
+            <binary>eJzt009IVEEcB/Bv/yMMLAtEOiy00mIFYkKHjN7uvvm1BIGQhz1IbUkZedkuoSD1MpMIpCgi2w5ttIl0kC0WklhisYjAEJE0+kd7KywWD10qiL7j+wUW0UWIDjvw4Tdv3ryZ+c3MAxZcHCBNgTDgUZqyGu2zbS84fr8FT2XH4HgDhAjQREepU6N9tu1z78Pa/38rzt/3q17XDq3P7zOksWjfMc8+ytMH+kolemrzpxaqpAn9Pqnj2bOw++Lt+m1Zjj+nnc9+Y7/dQo6O1U1pHd/OszgKrKBVVEUbaTsZClOIvrNfJuKvNa13YX5OI5pLUHOZphp+F6PD1EFxHXctzej8D6mgcppvkho15woKUYJSdg8i/lprqUnHF9pJ26iBHGql01F4lxlvU471R/ScPvJ5iQtnjYvCBgrSJhdeyAXqGBv4TtjWzvp51jOMeRfpcReBl+zzzkXiPdu+MK42qK81KIQNkgcMLnYbeP0GQzcMqu+zbcrA+WawdJ1g5VbBm92CfJvg0ylBql9wMiXoGxRM3xW05gWVTwSD4zQl6HklqHsrKFGIKl4Lzr0QHJoUtIwJBkYFwyOCI8OCmoxg9prgxAXBsV72Py74HBe4YYG3WYBqwePljCWuacIgnjPoTBnMnuHa2yhmkG3k2oMGzeuZxzKDxAzzHWP+WcbrzJ974XXxeT/3xqEA64u4H8+4pze5p2epnfbRHtpLB6mH76/QLT2Lq9RFO6L+3bvHM+3Vc7d38xLdoVGa1DN/oO2xiH/Pmu3dc36993P/gf6TRf0vfypqO/7wv5RLuZTLvyw/AN7v4p8=</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="141" id="SRM SIC Q1=585.35 Q3=916.55 Channel=5 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="142" id="SRM SIC Q1=585.35 Q3=916.55 Channel=5 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4587,21 +4604,21 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="408">
+          <binaryDataArray encodedLength="472">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztkqFLA2EYxh+QJctAwQXDZMW4YBFk7LbvjcpMqyuC0WBUPBSHTcGJUR3KVETGlmZSLEabYBhXBC1ywT/A37FLSwORlXvgx/Ps/d5v3/vdnZQo0aja8KSFktSIiXJU+28FxcE50/GZFQi90c6OesJ47lH3DO+P9nbgO6YzdPc2Xud3qix5Zfn7+D28kb/gndyBXajCFrVbvI//xEw4Ke/k7+Btp2LfqZYyFadMrxlTmIMlU37NVNk2peumA6gcsn5CPjPVLkzzl6aXa9Nn15R5Mq0/s/5gat/Rc0U/nLfITZOOTf4m/7VCLpmyy/Su0lMwBTP0fTBHj5lunLJNp+CUvMd8VciR06zPOT0W8EVqk9R63KXB3VqDZ+Af4bPlwTsbl/76DSRKlGjc+gVC0GnP</binary>
+            <binary>eJztkrEvQ1EUxj+JUWiCxNZO0piwiMmj7wiTDoYmBpUYJAb/gbxBREjoIpGQppWGJiIpikEknTAYukgspKNJjEa/yxsMWBgM70t+7zv33XvOPfe+J0WK9JM8j8ewFEAdYiNSMsTF9XDOrXlf+0cKhj7qNSBN7QLcw0vIDWxBL9Tcvp/3Ji5AIuzN5VZCd+PEVzlfnNnVb+GMk7AKOyEungUPfFiCK+hISROwDEWophRcwDnxIb4LeeISfoLf4s8peW2+gj5fmvFVW/flHflK3PlqvOKtpkbcVOmHUVMwZUovmGqBqbBiym2YtjZNc9smr2jK7Jt6D03JY+JTU9cZXmV9xfRyYNKeqZwnl5zEGmPqxObZI0P+OD4ISeY7qd1kyj7Q2yV9lOgvB4v0mIUx4gHoYT4O7bxrxp840zWUYY0zTkM3PHI/wcjHt3P3/93d/5l++Q9EihTpP+kN9LF+MQ==</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>
-      <chromatogram index="142" id="SRM SIC Q1=585.35 Q3=1070.6 Channel=6 Event=23 Segment=18 CE=23" defaultArrayLength="555">
+      <chromatogram index="143" id="SRM SIC Q1=585.35 Q3=1070.6 Channel=6 Event=23 Segment=18 CE=23" defaultArrayLength="555">
         <cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" value=""/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
         <precursor>
@@ -4619,17 +4636,17 @@
           </isolationWindow>
         </product>
         <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="2420">
+          <binaryDataArray encodedLength="2492">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary>eJwFwQNglgkAgOH6Pxt5cS3b7urN1m655Za9bNu1bC3bXLbdLtxadq0u7Z4n5a4A/Q4GuBUToOj5AHOuBfhyN0Do4wA7ngfw3wfolRDg2u8ABSSBGabA+2QCddMKbMksYOUS6FZQ4GIJgTzlBSZXFXhdR6BGQ4HoFgJae4GOXQXO9hHIPlhg/CiB+IkClWcKrJkvIC4XaLdO4MQWgZA9AqMOCzw9KcBFgeU3BJI8EGj5VODoS4EMHwWGfReITRQoo4gstkV+phBpll7kQBaRoDwiAwuL3CslUqKCSFR1kW/1RBo2FtnTUiRFhEhkd5GbkSKFh4rMHiPyabJIg9ki2xeKeCtFekaLXN0mkn+fyLSjIu9Oi9S+LLL5logZK9I1TuTCa5Fcn0Um/RB5mVSiuiax3pVQU0tEZJQ4k00iWz6JsUUlnpWRqFRJYnVNCSFUom1TiZjWEsGdJEb2lHjcX6L8cIll4yQSp0qEz5U4slgi/WqJIRslHu6QKH1AYtFxiR9nJZpeldh/RyL1I4kB8RJ33koU/yox75dEgiATZsjs8mWSB8n0CZa5kUOmUAGZWcVlPv4lU7+KzLbaMk6YTI/mMpfbyuTrIjO1t8zbgTK1RspsnCBjzJDpHCVzfqlMzrUyEzfLvNglU+2QzLoTMvIFmQ7XZU7dk8n6RGbMC5m49zIVv8ms/CMTkBVaWwrHkytkSqcwIkThUS6FcoUUlpZU+F1eoUU1hUN1FdI1UhgcrvCgvUKpbgoL+ir8N1ih8WiFfZMUUs1S6L9A4fZyhWLrFeZuVfiyR+HvIwo7Tykku6TQ+6bC9QcKBf9VmPFK4cNHhbr/KWxNomKrKt0dlUspVfJmUJmSVeV1HpWaRVQ2lFbRK6p0qqFyrr5KjiYq41upPI9QqdJDZW0/FWmYSvuxKienqITMURm9SOXpSpUKG1RWbFdJul+l1TGVY2dUMl5RGXZb5Z9YlbLPVJa8Ufn1WaX5T5WDAY0gXWOQp3EvtUbJTBrzs2t8z6fRqJjG3rIaKStrRNbSuBWqUaSZxpw2Gp87aYT20tgxQMMbodFrvMbVaRoF5mlMX6LxfrVGnU0aW3ZqWAc1usZoXDynkfuaxuS7Gq8eadR4rhH9TkNN0Oj4W+OMqJPd1BmXTCc+SKdyZp01OXXEgjptS+icKKeTuarOqDo6T8J0aKGzvJ1OYhedln10jgzSyTBKZ+hEndgZOmXm6yxepvNzrU7TLToHduukOawz8KTO3Qs6JW7oRN3XSXii0/Clzu4POim+6/RN1LkpGxS2DWanMPiUzqB+FoPtuQ3cwgY9SxlcwSB/dYNp9QzeNjKo3dJgUwcDs7tBl0iDC0MMco0xmDjZ4OUsg2oLDdavMFCiDSK2GZzea5DtqMHY0wZxlwwq3TJY9dBAiDNo89og5pNB8A+DEUlNHqsm5VyTZalM/mQwCc9mcjivSfqiJkPKmDyoaFK6psnCBiY/mpg0aW2yv6NJ6p4m/fub3BlmUmycybypJl/nmIQtNtm1yiT5RpM+O0yu7zcpdNxk5lmTj1dM6t0x2faPiRNv0v2tyeUvJnl/mUwVLN7oFrV8i41pLIxgi845LM7lt8hZ3GLCXxYvKltUrW2x7m8LublF+7YWpzpbZOltMWagxb8jLCpOsFg53SIQZdF6qcWxNRaZNlsM32Xx6KDFXycslp63+H3Novk9i0OPLdK+sBj83uJ+gkWpPxYLJJvvpk3j5DZ709qkCrHpl8vmdkGboiVt5pa3+VLVJrSuzc6GNn64Te/2Nte62hTsazNjsM37UTZ1J9lsmWljL7Dpttzm0jqbPFttpuyxeX3YpsYpmw0XbbSbNp0e2Jx9apPjlc34jzbx322qJHFYozhIjkO7lA4n0zuEZHUYncfhaWEHSjusqOCQpIZDq/oORxs7ZGzlMCzCIba7Q9l+DouHOvwa49BsisPB2Q5BixwGrXS4F+1QYrvD/H0O3446NDrjsOeyQ8rbDpGxDjfjHIq8cZj92eHzD4cGAZcdmovnufRK7XI1o0v+7C7T87m8K+pSp6zL5kouVi2XrqEuF5q65G7jMqmTy6ueLtUHuEQPd1HHu0RMczkz1yXbEpdxq12ebXSpvNNl9QEXMcal7TmXmKsume+6jHzk8iTepfw7l+VfXRJ/uYSLHkcMj/TJPIYGeTwM9iiT02NRAY+fxT2alvPYX8UjTR2PAWEed5t7FG/nEdXFI6G3R9ggj90jPZJP9Og7w+NGlEfhZR6z1np82uxRf7fHtkMe7kmPHhc8rlz3yHffY9oTj7cvPGp98Nj0zcNI9Ogi+5y3fHKl8JmYzudliE+13D7rCvkopXw64HO6mk/Wej5jG/nEhftU7OCzqptPINKnzRCf46N9gif7jJjl83iBT7kVPkvX+/wPQkvL+g==</binary>
+            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+            <binary>eJwFwQtIVQkCBuDzfkiURmTRqkRaNCqRTjQm4eP/UTdKJVSiLEIlygizCJVQi1Yl0olWN0olVKI0wiTKIlRoVcIsWpVINxqVSDdQifK+zjn33v2+R2EuVEe5kBvvwrZkF9xZLowVuNBe4kLZBRfSr7iw4U8XFttceNXjQtMLF06OupA45YI278LMiguPHRdqQ9w4vMmNmO1ueBPdGE9z416OG+XH3eBZN8Kr3Phe78ZAixs3u9wo6nNjz5Abxjs3Ps+40bvoxlWXG3myBzvCPLAiPXgf50HHPg8uZnmQUeDB5hIPlso9GKr14FaTByVtHuzt8SDkhQdfRjzom/Tg2pwHBSse7HQ8cEwvPoR70RXjxaVEL7LSvNiS48VKoRevS71orvTiVL0XSS1erOnyYvaJF08Hvagb9+LIjBexi14EVr2YkHy4H+pDRaQPB+J8iNjnw49MH4bzfbhd7MPpch+Sa31Y2+TDfKsPz7p9aOj34eiID/GTPghzPkwt+/DA9qHKtHAw3EJUjIWfCRZGUy3cybZQWmhhf6mF0EoLX+ss9DdbuN5pofCJhV2DFqRxCx+nLXQvWLi8aiFbsrE11MZqhI03sTZak2ycy7SRkm9jfbGNb+dtvKyxcaPRxolWG7u7bSj9Nj4N23g0YaN61kbuso1ttg234WBso4P2aAdlCQ7SUx1syHaweMzBqzMOmiocnKxzkNjsQOt0MNPr4PGAg9q3Dg5PO4hZcOD95WBc9OPeOj/KI/xgrB/hSX58z/BjIM+Pm0V+FJ33Y0+NH0ajH5/v+tH70I+rz/3IG/Zjx4Qf1l9+vF/yo8Py46IRQMbGADZHB7C0O4ChlABuHQqg5FgAe88EEFIRwJd/BND3zwCudQRQ0BvAzoEAnLEAPnwKoOtbAJd+BZAlBrFlXRArfwvi9W9BNP8RxKmMIJLyglhTFMRsWRBPq4OouxHEkbtBxD4MIvAsiIl/B3H/P0FU/BXEgaUgIqwgvLLA+RCB42ECn20SeC9KYMN2geXxAo/+LpDJAuPTBYb/XaCQK/B7gcCp4wIHSgQ+OCvw5gWBVVUCi64IPNggcM+fAqP+JdBoF/izS+DnHoGjfQJ7Xwi8MyTw6qjA0ncC86YE7v+vwB3zAkP/J9BaEfjVJfC9I7BfFtkRIvJ6mMiLm0QWRonM2C5yV7zIzb+LlJJFLqWJ/JglcihHZHeByFvHRV4uEVlyVmT2BZF7q0RuvSIypEHkapPILy0i37SJ7OsS2doj8lqfyHMvRBYMiUwZFbnzncj1UyKdGZHf5kR+WBT5ckVkl0vkDUfkJVniiRCJWWESd2+SuCVKorJd4kqcxE+JEl/vk/goTWJzlsTqHImnCiTmHpeYVCJx21mJay5IdFdKnK2VOFYv8WmTxPYWiXVtEsu6JB7pkZjeJzH2hcQNQxIDIxIXxyVOTEp8NSPx/pzEpkWJFSsST7okHnAkJsoyI0JkamEyf4TLnImUORwj83GczNuJMmv3yTydJvNwlszkHJkxBTLXHpfpLZY5XypzvFzms0qZ92plNtTLLG+SebRFJttkxnfJDO+RKfTJ/N4vc2pQ5sCIzAfjMm9OyqyakVk0J/Pgosw9KzKjXDINR+ZPSeFnU+FoqMLecIV3IhVejVFYGqcwL1Hh/n0Kd6QpDM1SaGUr/Jqv8H2hwv5ihR2lCq+XK7xYqbCwVmFGvcJdTQo3tyiU2hQudSr82K1w6InC7n6FtwYVXh5RWDKuMHtS4d4ZhVvnFIYsKlxdVvhlVeEbW2GfpLLVVHktVOW5cJUFkSpTYlTujFO5PlGlk6TyW6rKD5kqX2ar7MpXeaNQ5aVilSdKVWaVq9xdqXJLrUqlXuVKo8pPzSpft6p81KmyuVtl9ROVp/pV5g6qTBpRuW1c5ZpJle5plbOzKscWVD5dVtm+qrLOVlkmaTxiakwP1RgbrnFDpMZAtMbFWI0TCRpfJWm8n6qxKVNjRbbGk/kaDxRqTCzWGFGqUSvX+KNC40yNxuE6jY8bNd5u1ljbqvF0p8bD3RqTn2iM6de4dlCjd1jj/FuN4xMan01rvDersWFBY/myxqOrGmlrjJd0hps6hVCd3zfqnIrQORCt80GszpsJOquSdBal6jyYqXNPts6ofJ1Goc6fRTo/n9E5el5nb4XOOzU6r9bpLG3Umdesc3+rzh2dOkO7dVq9Or8+1/l+QGf/sM6OtzqvT+i8OK2zcFZnxoLOXcs6N6/qlGydS6LBj4bBoXUGuzcavBVh8HK0wZJYg9kJBvcmGdyaajAk0+DqIYNf8gy+OWawr8hg6xmD184bPFdhsKDGYEqdwZ2NBtc3G3TuGvzWYfDDQ4Mvew12PTd4Y8DgpWGDJ94azJowuHva4JZZg8qCwZUlg59+GXxtGXwkmmw2TFavM3lqo8ncCJNJ0Sa3xZpck2DS/YfJ2RSTYxkmnx4y2Z5nsu6YybIik0fOmEw/bzK2wuSGGpP/ByRngSk=</binary>
           </binaryDataArray>
-          <binaryDataArray encodedLength="328">
+          <binaryDataArray encodedLength="368">
             <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary>eJztkDFKQ0EURY+WFpJC0lhEBMVGiFnBz595INgIYmeRDQhmB7/RRhAFsU6nWEj4KxhttLS1kb8AkSxA0DvMR+vUzoXDffO485h5kJX1X9UUMB3CSpmIdezNcyeyL2rRiFdxJmbDv+x1zDkYuOR1m3kqU+9WfDnCqqfoesKyvOfh0DO58Kw9iGfVb/IP+bfnZMmga1TrRmfLmG6mutgwJttGGBj96D1j1lFW+ctFo/lMs6o7zb/xjK48zbn8VOex+kfyXb1hL1EcJK9K+Y5cbwwLyrw4qvsEj+73zLF4b/cSd1C3f4+Edlfz7DsrKysLfgBwy1TG</binary>
+            <binary>eJzt0DFLA0EQhuEPsTGt0UJSHCga0NrWizcLIgqCjVhICgXLgK3FJdWJEiwES69RRBvLYGFSC0JMkTqIhYj4C0R8D64R8g+yAw87Ozu3e7uSDx+jFPEKQpKKtIUEaS7Ja9la1pP1Dvsm6/1AsCpt4BhNXOAsn+/jEAlu8Yw3fOMXUxHboYH7SHE/UihTp2gKl7BuUs1UbZrSG1PQNnrIv0xdOZ0XnMJJxhmnIMCcU3feqVZ2SqEFzLJeok5fPEHPD3u8s9cLWqbBNeMlZ51ybp3xiPEAu5y9Te8m1qhXqC1TKzOfJh8n/+SfX9HGA664xwn2sIgx9LhnB094xF3+TjsoosUbVoe8tw8fPnz8jz8Dz1w6</binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>

--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/Jamfile.jam
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/Jamfile.jam
@@ -126,6 +126,7 @@ rule install-requirements ( properties * )
     local dll_location = [ shimadzu-dll-location $(API_PATH) : $(properties) ] ;
     if $(dll_location)
     {
+        result += <source>$(dll_location)/DataReader.dll ; # not used by pwiz, but used by Shimadzu's method exporter from Skyline
         result += <source>$(dll_location)/CLFIO32.dll ;
         result += <source>$(dll_location)/CRHAKEI2.dll ;
         result += <source>$(dll_location)/IOModuleQTFL.dll ;

--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/Jamfile.jam
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/Jamfile.jam
@@ -61,7 +61,6 @@ rule vendor-api-usage-requirements ( properties * )
             result += <library>$(PWIZ_ROOT_PATH)/pwiz/utility/misc//pwiz_utility_misc ;
         }
 
-        result += <assembly>$(dll_location)/DataReader.dll ;
         result += <assembly-dependency>$(dll_location)/CLFIO32.dll ;
         result += <assembly-dependency>$(dll_location)/CRHAKEI2.dll ;
         result += <assembly-dependency>$(dll_location)/IOModuleQTFL.dll ;
@@ -127,7 +126,6 @@ rule install-requirements ( properties * )
     local dll_location = [ shimadzu-dll-location $(API_PATH) : $(properties) ] ;
     if $(dll_location)
     {
-        result += <source>$(dll_location)/DataReader.dll ;
         result += <source>$(dll_location)/CLFIO32.dll ;
         result += <source>$(dll_location)/CRHAKEI2.dll ;
         result += <source>$(dll_location)/IOModuleQTFL.dll ;

--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
@@ -34,20 +34,17 @@ using namespace pwiz::util;
 
 #ifdef __INTELLISENSE__
 #using <Shimadzu.LabSolutions.IO.IoModule.dll>
-#using <DataReader.dll>
 #endif
 
 using System::String;
 using System::Math;
 using System::Collections::Generic::IList;
 using System::Collections::Generic::Dictionary;
-namespace ShimadzuAPI = Shimadzu::LabSolutions::DataReader;
 namespace ShimadzuIO = Shimadzu::LabSolutions::IO;
 namespace ShimadzuGeneric = ShimadzuIO::Generic;
 using ShimadzuIO::Data::DataObject;
 using ShimadzuIO::Method::MethodObject;
 typedef ShimadzuGeneric::Tool ShimadzuUtil;
-using ShimadzuAPI::ReaderResult;
 
 namespace pwiz {
 namespace vendor_api {

--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
@@ -40,6 +40,7 @@ using namespace pwiz::util;
 using System::String;
 using System::Math;
 using System::Collections::Generic::IList;
+using System::Collections::Generic::Dictionary;
 namespace ShimadzuAPI = Shimadzu::LabSolutions::DataReader;
 namespace ShimadzuIO = Shimadzu::LabSolutions::IO;
 namespace ShimadzuGeneric = ShimadzuIO::Generic;
@@ -54,65 +55,34 @@ namespace Shimadzu {
 
 
 // constants for converting integer representations of mass and time to double
-static const double MASS_MULTIPLIER = 0.000000001;
+static const double MASS_MULTIPLIER = 1.0 / ShimadzuUtil::MASSNUMBER_UNIT;
 static const double TIME_MULTIPLIER = 0.001;
 
 
 class ShimadzuReaderImpl;
-   
-class MRMChromatogramImpl : public SRMChromatogram
-{
-    public:
-        MRMChromatogramImpl(ShimadzuAPI::MRMChromatogram^ chromatogram, const SRMTransition& transition)
-        : transition_(transition),
-          chromatogram_(chromatogram)
-    {}
-
-    virtual const SRMTransition& getTransition() const { return transition_; }
-    virtual int getTotalDataPoints() const { try { return chromatogram_->NumDataPoints; } CATCH_AND_FORWARD }
-    virtual void getXArray(pwiz::util::BinaryData<double>& x) const { try { ToBinaryData<double>(chromatogram_->Times, x); } CATCH_AND_FORWARD }
-    virtual void getYArray(pwiz::util::BinaryData<double>& y) const { try { ToBinaryData<double>(chromatogram_->Intensities, y); } CATCH_AND_FORWARD }
-
-    private:
-    SRMTransition transition_;
-    gcroot<ShimadzuAPI::MRMChromatogram^> chromatogram_;
-};
 
 class TOFChromatogramImpl : public SRMChromatogram
 {
     public:
-    TOFChromatogramImpl(ShimadzuIO::Generic::MassChromatogramObject^ chromatogram, const SRMTransition& transition)
-        : transition_(transition),
-          chromatogram_(chromatogram)
-    {}
+    TOFChromatogramImpl(const ShimadzuReaderImpl& reader, DataObject^ dataObject, const SRMTransition& transition);
 
     virtual const SRMTransition& getTransition() const { return transition_; }
-    virtual int getTotalDataPoints() const { try { return (int) chromatogram_->TotalPoints; } CATCH_AND_FORWARD }
+
+    virtual int getTotalDataPoints() const { try { return (int)x_.size(); } CATCH_AND_FORWARD }
     virtual void getXArray(pwiz::util::BinaryData<double>& x) const
     {
-        try
-        {
-            auto timeArray = chromatogram_->RetTimeList;
-            x.resize(timeArray->Length);
-            for (size_t i = 0; i < x.size(); ++i)
-                x[i] = timeArray[i] * TIME_MULTIPLIER;
-        } CATCH_AND_FORWARD
+        x = x_;
     }
 
     virtual void getYArray(pwiz::util::BinaryData<double>& y) const
     {
-        try
-        {
-            auto intensityArray = chromatogram_->ChromIntList;
-            y.resize(intensityArray->Length);
-            for (size_t i = 0; i < y.size(); ++i)
-                y[i] = intensityArray[i];
-        } CATCH_AND_FORWARD
+        y = y_;
     }
 
     private:
+    pwiz::util::BinaryData<double> x_;
+    pwiz::util::BinaryData<double> y_;
     SRMTransition transition_;
-    gcroot<ShimadzuIO::Generic::MassChromatogramObject^> chromatogram_;
 };
 
 
@@ -151,7 +121,7 @@ public:
             precursorCharge_ = precursorInfo->second;
         }
         else
-            precursorMz_ = (double) spectrum_->AcqModeMz / ShimadzuUtil::MASSNUMBER_UNIT;
+            precursorMz_ = (double) spectrum_->AcqModeMz * MASS_MULTIPLIER;
     }
 
     virtual double getScanTime() const { return spectrum_->RetentionTime; }
@@ -159,10 +129,10 @@ public:
     virtual Polarity getPolarity() const { return (Polarity) (int) spectrum_->Polarity; }
 
     virtual double getSumY() const { return spectrum_->TotalInt; }
-    virtual double getBasePeakX() const { return (double) spectrum_->BPMass / ShimadzuUtil::MASSNUMBER_UNIT; }
+    virtual double getBasePeakX() const { return (double) spectrum_->BPMass * MASS_MULTIPLIER; }
     virtual double getBasePeakY() const { return spectrum_->BPInt; }
-    virtual double getMinX() const { return ((ShimadzuGeneric::Param::MS::MassEventInfo^) eventInfo_) == nullptr ? 0 : (double) eventInfo_->StartMz / ShimadzuUtil::MASSNUMBER_UNIT; }
-    virtual double getMaxX() const { return ((ShimadzuGeneric::Param::MS::MassEventInfo^) eventInfo_) == nullptr ? 0 : (double) eventInfo_->EndMz / ShimadzuUtil::MASSNUMBER_UNIT; }
+    virtual double getMinX() const { return ((ShimadzuGeneric::Param::MS::MassEventInfo^) eventInfo_) == nullptr ? 0 : (double) eventInfo_->StartMz * MASS_MULTIPLIER; }
+    virtual double getMaxX() const { return ((ShimadzuGeneric::Param::MS::MassEventInfo^) eventInfo_) == nullptr ? 0 : (double) eventInfo_->EndMz * MASS_MULTIPLIER; }
 
     virtual bool getHasIsolationInfo() const { return false; }
     virtual void getIsolationInfo(double& centerMz, double& lowerLimit, double& upperLimit) const { }
@@ -189,7 +159,7 @@ public:
             for (size_t i = 0; i < x.size(); ++i)
             {
                 auto point = profileArray[i];
-                x[i] = (double) point->Mass / ShimadzuUtil::MASSNUMBER_UNIT;
+                x[i] = (double) point->Mass * MASS_MULTIPLIER;
                 y[i] = point->Intensity;
             }
         } CATCH_AND_FORWARD
@@ -205,7 +175,7 @@ public:
             for (size_t i = 0; i < x.size(); ++i)
             {
                 auto point = centroidArray[i];
-                x[i] = (double) point->Mass / ShimadzuUtil::MASSNUMBER_UNIT;
+                x[i] = (double) point->Mass * MASS_MULTIPLIER;
                 y[i] = point->Intensity;
             }
         } CATCH_AND_FORWARD
@@ -228,118 +198,106 @@ class ShimadzuReaderImpl : public ShimadzuReader
         {
             scanCount_ = 0;
 
-            reader_ = gcnew ShimadzuAPI::MassDataReader();
             String^ systemFilepath = ToSystemString(filepath);
 
-            // first try to open with MRM reader
-            ReaderResult result = reader_->OpenDataFile(systemFilepath);
+            dataObject_ = gcnew DataObject();
+            auto result2 = dataObject_->IO->LoadData(systemFilepath);
+            if (ShimadzuUtil::Failed(result2))
+                throw runtime_error("[ShimadzuReader::ctor] LoadData error: " + ToStdString(System::Enum::GetName(result2.GetType(), (System::Object^) result2)));
 
-            // if that fails or if the file has no transitions, try to load data with QTOF reader
-            if (result != ReaderResult::OK || getTransitions().empty())
+            /*methodObject_ = gcnew MethodObject();
+            result = methodObject_->IO->LoadMethod(systemFilepath);
+            if (ShimadzuUtil::Failed(result))
+            throw runtime_error("[ShimadzuReader::ctor] LoadMethod error: " + ToStdString(System::Enum::GetName(result.GetType(), (System::Object^) result)));*/
+
+            try
             {
-                if (result == ReaderResult::OK)
-                    reader_->CloseDataFile();
-
-                dataObject_ = gcnew DataObject();
-                auto result2 = dataObject_->IO->LoadData(systemFilepath);
-                if (ShimadzuUtil::Failed(result2))
-                    throw runtime_error("[ShimadzuReader::ctor] LoadData error: " + ToStdString(System::Enum::GetName(result2.GetType(), (System::Object^) result2)));
-
-                /*methodObject_ = gcnew MethodObject();
-                result = methodObject_->IO->LoadMethod(systemFilepath);
-                if (ShimadzuUtil::Failed(result))
-                throw runtime_error("[ShimadzuReader::ctor] LoadMethod error: " + ToStdString(System::Enum::GetName(result.GetType(), (System::Object^) result)));*/
-
-                try
-                {
-                    auto eventInfo = gcnew System::Collections::Generic::Dictionary<short, ShimadzuGeneric::Param::MS::MassEventInfo^>();
-                    auto eventInfoList = gcnew System::Collections::Generic::List<ShimadzuGeneric::Param::MS::MassEventInfo^>();
-                    dataObject_->MS->Parameters->GetEventInfo(eventInfoList);
-                    for each (auto evt in eventInfoList)
-                        eventInfo[evt->Event] = evt;
-                    eventInfo_ = eventInfo;
-                }
-                catch (System::Exception^)
-                {
-                    // TODO: log warning
-                }
-
-                auto chromatogramMng = dataObject_->MS->Chromatogram;
-
-                auto dummySpectrum = gcnew ShimadzuGeneric::MassSpectrumObject();
-                try { dataObject_->MS->Spectrum->GetMSSpectrumByScan(dummySpectrum, 1, true); }
-                catch (...) {}
-
-                //int lastScanTime = 0;
-                unsigned int lastScanNumber = 0;
-
-                int startTime, endTime;
-                dataObject_->MS->Parameters->GetAnalysisTime(startTime, endTime, 0);
-
-                segmentCount_ = chromatogramMng->SegmentCount;
-                eventNumbersBySegment_.resize(segmentCount_);
-                for (int i = 1; i <= segmentCount_; ++i)
-                {
-                    auto& eventNumbers = eventNumbersBySegment_[i - 1];
-                    int eventCount = chromatogramMng->EventCount(i);
-                    eventNumbers.resize(eventCount);
-                    for (int j = 1; j <= eventNumbers.size(); ++j)
-                    {
-                        eventNumbers[j - 1] = chromatogramMng->GetEventNo(i, j);
-
-                        unsigned int eventLastScanNumber;
-                        result2 = dataObject_->MS->Spectrum->RetTimeToScan(eventLastScanNumber, endTime, eventNumbers[j - 1]);
-                        if (ShimadzuUtil::Failed(result2))
-                        {
-                            cerr << ("[ShimadzuReader::ctor] RetTimeToScan error for time " + lexical_cast<string>(endTime) + " and event " + lexical_cast<string>(eventNumbers[j - 1]) + ": " +
-                                                ToStdString(System::Enum::GetName(result2.GetType(), (System::Object^) result2))) << endl;
-                            continue;
-                        }
-
-                        if (msLevels_.size() < 2)
-                        {
-                            auto spectrumPtr = getSpectrum(eventLastScanNumber, false);
-                            msLevels_.insert(spectrumPtr->getMSLevel());
-                        }
-
-                        if (eventLastScanNumber > lastScanNumber)
-                            lastScanNumber = eventLastScanNumber;
-                    }
-                }
-
-                scanCount_ = lastScanNumber;
-
-                ShimadzuGeneric::PrecursorResultData^ precursorResultData;
-                dataObject_->MS->Spectrum->GetPrecursorList(gcnew ShimadzuGeneric::DdaPrecursorFilter(), precursorResultData);
-                if (precursorResultData->SurveyList->Count > 0)
-                    for each(auto dependent in precursorResultData->SurveyList[0]->DependentList)
-                        for each(int scan in dependent->ScanNoList)
-                        {
-                            int charge = 0;
-                            switch (dependent->Charge)
-                            {
-                                default: break;
-                                case ShimadzuGeneric::Charges::Charge1: charge = 1; break;
-                                case ShimadzuGeneric::Charges::Charge2: charge = 2; break;
-                                case ShimadzuGeneric::Charges::Charge3: charge = 3; break;
-                                case ShimadzuGeneric::Charges::Charge4: charge = 4; break;
-                                case ShimadzuGeneric::Charges::Charge5: charge = 5; break;
-                                case ShimadzuGeneric::Charges::Charge6: charge = 6; break;
-                                case ShimadzuGeneric::Charges::Charge7: charge = 7; break;
-                            }
-                            precursorInfoByScan_[scan] = make_pair(dependent->PrecursorMass * MASS_MULTIPLIER, charge);
-                        }
+                auto eventInfo = gcnew EventInfoMap();
+                auto eventInfoList = gcnew System::Collections::Generic::List<ShimadzuGeneric::Param::MS::MassEventInfo^>();
+                dataObject_->MS->Parameters->GetEventInfo(eventInfoList);
+                for each (auto evt in eventInfoList)
+                    eventInfo[EventChannelPair(evt->Event, max(short(1), evt->Channel))] = evt;
+                eventInfo_ = eventInfo;
             }
+            catch (System::Exception^)
+            {
+                // TODO: log warning
+            }
+
+            auto chromatogramMng = dataObject_->MS->Chromatogram;
+
+            auto dummySpectrum = gcnew ShimadzuGeneric::MassSpectrumObject();
+            try { dataObject_->MS->Spectrum->GetMSSpectrumByScan(dummySpectrum, 1, true); }
+            catch (...) {}
+
+            //int lastScanTime = 0;
+            unsigned int lastScanNumber = 0;
+
+            int startTime, endTime;
+            dataObject_->MS->Parameters->GetAnalysisTime(startTime, endTime, 0);
+
+            segmentCount_ = chromatogramMng->SegmentCount;
+            eventNumbersBySegment_.resize(segmentCount_);
+            for (int i = 1; i <= segmentCount_; ++i)
+            {
+                auto& eventNumbers = eventNumbersBySegment_[i - 1];
+                int eventCount = chromatogramMng->EventCount(i);
+                eventNumbers.resize(eventCount);
+                for (int j = 1; j <= eventNumbers.size(); ++j)
+                {
+                    short eventNo = eventNumbers[j - 1] = chromatogramMng->GetEventNo(i, j);
+                    if (getEventInfo(eventNo)->AnalysisMode == ShimadzuGeneric::AcqModes::MRM)
+                        continue;
+
+                    unsigned int eventLastScanNumber;
+                    result2 = dataObject_->MS->Spectrum->RetTimeToScan(eventLastScanNumber, endTime, eventNo);
+                    if (ShimadzuUtil::Failed(result2))
+                    {
+                        cerr << ("[ShimadzuReader::ctor] RetTimeToScan error for time " + lexical_cast<string>(endTime) + " and event " + lexical_cast<string>(eventNo) + ": " +
+                                            ToStdString(System::Enum::GetName(result2.GetType(), (System::Object^) result2))) << endl;
+                        continue;
+                    }
+
+                    if (msLevels_.size() < 2)
+                    {
+                        auto spectrumPtr = getSpectrum(eventLastScanNumber, false);
+                        msLevels_.insert(spectrumPtr->getMSLevel());
+                    }
+
+                    if (eventLastScanNumber > lastScanNumber)
+                        lastScanNumber = eventLastScanNumber;
+                }
+            }
+
+            scanCount_ = lastScanNumber;
+
+            ShimadzuGeneric::PrecursorResultData^ precursorResultData;
+            dataObject_->MS->Spectrum->GetPrecursorList(gcnew ShimadzuGeneric::DdaPrecursorFilter(), precursorResultData);
+            if (precursorResultData->SurveyList->Count > 0)
+                for each(auto dependent in precursorResultData->SurveyList[0]->DependentList)
+                    for each(int scan in dependent->ScanNoList)
+                    {
+                        int charge = 0;
+                        switch (dependent->Charge)
+                        {
+                            default: break;
+                            case ShimadzuGeneric::Charges::Charge1: charge = 1; break;
+                            case ShimadzuGeneric::Charges::Charge2: charge = 2; break;
+                            case ShimadzuGeneric::Charges::Charge3: charge = 3; break;
+                            case ShimadzuGeneric::Charges::Charge4: charge = 4; break;
+                            case ShimadzuGeneric::Charges::Charge5: charge = 5; break;
+                            case ShimadzuGeneric::Charges::Charge6: charge = 6; break;
+                            case ShimadzuGeneric::Charges::Charge7: charge = 7; break;
+                        }
+                        precursorInfoByScan_[scan] = make_pair(dependent->PrecursorMass * MASS_MULTIPLIER, charge);
+                    }
         }
         CATCH_AND_FORWARD
     }
 
     virtual ~ShimadzuReaderImpl()
     {
-        if ((System::Object^)dataObject_ == nullptr)
-            reader_->CloseDataFile();
-        else
-            dataObject_->IO->Close();
+        dataObject_->IO->Close();
     }
 
     virtual int getScanCount() const { return scanCount_; }
@@ -355,19 +313,24 @@ class ShimadzuReaderImpl : public ShimadzuReader
 
         try
         {
-            for each (ShimadzuAPI::MrmTransition^ transition in reader_->GetMrmTransition())
+            for each (auto kvp in (EventInfoMap^) eventInfo_)
             {
+                auto transition = kvp.Value;
+                if (transition->AnalysisMode != ShimadzuGeneric::AcqModes::MRM)
+                    continue;
+
                 SRMTransition t;
-                t.id = transition->Number;
+                t.id = transitionSet_.size(); // transition->Number;
                 t.channel = transition->Channel;
                 t.event = transition->Event;
                 t.segment = transition->Segment;
-                t.collisionEnergy = transition->CE; // always non-negative, even if scan polarity is negative
-                t.polarity = transition->Polarity;
-                t.Q1 = (transition->ParentMz[0] + transition->ParentMz[1]) / 2;
-                t.Q3 = (transition->ChildMz[0] + transition->ChildMz[1]) / 2;
+                t.collisionEnergy = abs(transition->CE); // always non-negative, even if scan polarity is negative
+                t.polarity = (Polarity) transition->Polarity;
+                t.startMz = transition->StartMz;
+                t.endMz = transition->EndMz;
+                t.Q1 = t.startMz * MASS_MULTIPLIER;
+                t.Q3 = t.endMz * MASS_MULTIPLIER;
                 transitionSet_.insert(transitionSet_.end(), t);
-                transitions_[t.id] = transition;
             }
             return transitionSet_;
         }
@@ -401,7 +364,7 @@ class ShimadzuReaderImpl : public ShimadzuReader
 
     virtual SRMChromatogramPtr getSRM(const SRMTransition& transition) const
     {
-        try { return SRMChromatogramPtr(new MRMChromatogramImpl(reader_->GetChromatogram(transitions_[transition.id]), transition)); } CATCH_AND_FORWARD
+        try { return SRMChromatogramPtr(new TOFChromatogramImpl(*this, dataObject_, transition)); } CATCH_AND_FORWARD
     }
 
     virtual ChromatogramPtr getTIC(bool ms1Only) const
@@ -451,21 +414,21 @@ class ShimadzuReaderImpl : public ShimadzuReader
 
     private:
     friend class TICChromatogramImpl;
-    gcroot<ShimadzuAPI::MassDataReader^> reader_;
     gcroot<DataObject^> dataObject_;
-    gcroot<System::Collections::Generic::Dictionary<short, ShimadzuGeneric::Param::MS::MassEventInfo^>^> eventInfo_;
+    typedef System::ValueTuple<short, short> EventChannelPair;
+    typedef Dictionary<EventChannelPair, ShimadzuGeneric::Param::MS::MassEventInfo^> EventInfoMap;
+    gcroot<EventInfoMap^> eventInfo_;
     //gcroot<MethodObject^> methodObject_;
     int segmentCount_;
     int scanCount_;
     set<int> msLevels_;
     vector<vector<int>> eventNumbersBySegment_;
     map<int, pair<double, int>> precursorInfoByScan_;
-    mutable map<short, gcroot<ShimadzuAPI::MrmTransition^> > transitions_;
     mutable set<SRMTransition> transitionSet_;
 
-    ShimadzuGeneric::Param::MS::MassEventInfo^ getEventInfo(short eventNo) const
+    ShimadzuGeneric::Param::MS::MassEventInfo^ getEventInfo(short eventNo, short channel = 1) const
     {
-        return ((System::Collections::Generic::Dictionary<short, ShimadzuGeneric::Param::MS::MassEventInfo^>^) eventInfo_) == nullptr ? nullptr : ((System::Collections::Generic::Dictionary<short, ShimadzuGeneric::Param::MS::MassEventInfo^>^) eventInfo_)[eventNo];
+        return ((EventInfoMap^) eventInfo_) == nullptr ? nullptr : ((EventInfoMap^) eventInfo_)[EventChannelPair(eventNo, channel)];
     }
 };
 
@@ -476,6 +439,34 @@ ShimadzuReaderPtr ShimadzuReader::create(const string& filepath)
     try { return ShimadzuReaderPtr(new ShimadzuReaderImpl(filepath)); } CATCH_AND_FORWARD
 }
 
+
+TOFChromatogramImpl::TOFChromatogramImpl(const ShimadzuReaderImpl& reader, DataObject^ dataObject, const SRMTransition& transition)
+{
+    auto chromatogramMng = dataObject->MS->Chromatogram;
+    auto tofChromatogram = gcnew ShimadzuGeneric::MassChromatogramObject();
+    map<int, int> fullFileTIC;
+
+    ShimadzuGeneric::MzTransition mzTransition;
+    mzTransition.Segment = transition.segment;
+    mzTransition.Event = transition.event;
+    mzTransition.Channel = transition.channel;
+    mzTransition.StartMass = transition.startMz;
+    mzTransition.EndMass = transition.endMz;
+    mzTransition.StartMassRaw = transition.startMz;
+    mzTransition.EndMassRaw = transition.endMz;
+
+    auto result = chromatogramMng->GetChromatogrambyEvent(tofChromatogram, %mzTransition, true, true);
+    if (ShimadzuUtil::Failed(result))
+        throw runtime_error("failed to get TOF chromatogram for segment " + lexical_cast<string>(transition.segment) + ", event " + lexical_cast<string>(transition.event));
+
+    x_.reserve(tofChromatogram->ChromIntList->Length);
+    y_.reserve(tofChromatogram->ChromIntList->Length);
+    for (int j = 0, end = tofChromatogram->ChromIntList->Length; j < end; ++j)
+    {
+        x_.push_back(tofChromatogram->RetTimeList[j] * TIME_MULTIPLIER);
+        y_.push_back((double) tofChromatogram->ChromIntList[j]);
+    }
+}
 
 TICChromatogramImpl::TICChromatogramImpl(const ShimadzuReaderImpl& reader, DataObject^ dataObject, bool ms1Only)
 {
@@ -507,7 +498,7 @@ TICChromatogramImpl::TICChromatogramImpl(const ShimadzuReaderImpl& reader, DataO
     y_.reserve(fullFileTIC.size());
     for (const auto& kvp : fullFileTIC)
     {
-        x_.push_back((double) kvp.first / 1e3);
+        x_.push_back((double) kvp.first * TIME_MULTIPLIER);
         y_.push_back((double) kvp.second);
     }
 }

--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.hpp
@@ -44,7 +44,7 @@ PWIZ_API_DECL enum Polarity
 {
     Positive = 0,
     Negative = 1,
-    Undefined = 2
+    Undefined = -1
 };
 
 struct PWIZ_API_DECL SRMTransition
@@ -54,7 +54,10 @@ struct PWIZ_API_DECL SRMTransition
     short event;
     short segment;
     double collisionEnergy;
-    short polarity;
+    Polarity polarity;
+    int startMz;
+    int endMz;
+
     double Q1;
     double Q3;
     //TimeRange acquiredTimeRange;

--- a/scripts/wix/vendor-dlls.wxs-fragment
+++ b/scripts/wix/vendor-dlls.wxs-fragment
@@ -233,7 +233,6 @@
 
 <!-- Shimadzu DLLs -->
 <Component Feature="MainFeature"><File Source="msvc-release\EULA.SFCS" KeyPath="yes"/></Component>
-<Component Feature="MainFeature"><File Source="msvc-release\DataReader.dll" KeyPath="yes"/></Component>
 <Component Feature="MainFeature"><File Source="msvc-release\CABINET.dll" KeyPath="yes"/></Component>
 <Component Feature="MainFeature"><File Source="msvc-release\DualProbeInterfaceParametersCS.dll" KeyPath="yes"/></Component>
 <Component Feature="MainFeature"><File Source="msvc-release\Google.Protobuf.dll" KeyPath="yes"/></Component>


### PR DESCRIPTION
- replaced Shimadzu DataReader with IoModule for MRM files as the for…mer was causing debug assertions on some new QTOF files (MRM files will also get TIC chromatograms now)

@brendanx67 We should get this in 20.2.