### PR TITLE
override IonMobilityLibraryList.GetDisplayName so that "None" gets localized properly

### DIFF
--- a/pwiz_tools/Skyline/Properties/Settings.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.cs
@@ -2210,6 +2210,12 @@ namespace pwiz.Skyline.Properties
             return true;
         }
 
+        public override string GetDisplayName(IonMobilityLibrary item)
+        {
+            // Use the localized text in the UI
+            return Equals(item, IonMobilityLibrary.NONE) ? Resources.SettingsList_ELEMENT_NONE_None : base.GetDisplayName(item);
+        }
+
         public override IonMobilityLibrary EditItem(Control owner, IonMobilityLibrary item,
             IEnumerable<IonMobilityLibrary> existing, object tag)
         {


### PR DESCRIPTION
 (thanks to Brendan for noticing this)