### PR TITLE
Fix a couple of exceptions from Exception Web:

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/Calibration/CalibrationForm.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/Calibration/CalibrationForm.cs
@@ -478,8 +478,8 @@ namespace pwiz.Skyline.Controls.Graphs.Calibration
             }
             else
             {
-                if (_skylineWindow.Document.Settings.MeasuredResults.Chromatograms.Select(c => c.BatchName).Distinct()
-                        .Count() > 1)
+                if (_skylineWindow.Document.Settings.HasResults && _skylineWindow.Document.Settings.MeasuredResults
+                    .Chromatograms.Select(c => c.BatchName).Distinct().Count() > 1)
                 {
                     title = TextUtil.SpaceSeparate(title, QuantificationStrings.CalibrationForm_GetFormTitle__All_Replicates_);
                 }

--- a/pwiz_tools/Skyline/Controls/Graphs/SummaryReplicateGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SummaryReplicateGraphPane.cs
@@ -117,7 +117,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
         public void SetSelectedFile(string file)
         {
-            var group = _replicateGroups.FirstOrDefault(g => (g.FileInfo != null && g.FileInfo.FilePath.GetFileName() == file) || (g.FileInfo == null && file == null));
+            var group = _replicateGroups?.FirstOrDefault(g => (g.FileInfo != null && g.FileInfo.FilePath.GetFileName() == file) || (g.FileInfo == null && file == null));
             if (group != null)
             {
                 SelectedGroup = group;


### PR DESCRIPTION
NullReferenceException in CalibrationForm.GetFormTitle (reported on 8/31/2020)
ArgumentNullException in SummaryReplicateGraphPane.SetSelectedFile (reported on 9/17/2020)
(reported anonymously on Exception Web).