### PR TITLE
Remove "Helpers.TryTwice" around code that shares a Skyline document.

### DIFF
--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -1241,16 +1241,13 @@ namespace pwiz.Skyline
         {
             try
             {
-                bool success = false;
-                Helpers.TryTwice(() =>
+                bool success;
+                using (var longWaitDlg = new LongWaitDlg { Text = Resources.SkylineWindow_ShareDocument_Compressing_Files, })
                 {
-                    using (var longWaitDlg = new LongWaitDlg { Text = Resources.SkylineWindow_ShareDocument_Compressing_Files, })
-                    {
-                        var sharing = new SrmDocumentSharing(DocumentUI, DocumentFilePath, fileDest, shareType);
-                        longWaitDlg.PerformWork(this, 1000, sharing.Share);
-                        success = !longWaitDlg.IsCanceled;
-                    }
-                });
+                    var sharing = new SrmDocumentSharing(DocumentUI, DocumentFilePath, fileDest, shareType);
+                    longWaitDlg.PerformWork(this, 1000, sharing.Share);
+                    success = !longWaitDlg.IsCanceled;
+                }
                 return success;
             }
             catch (Exception x)


### PR DESCRIPTION
This code was originally added in 2012 with a comment relating to stress testing and anti virus.
I could not get any document sharing test to fail even with antivirus enabled and running tests in a loop.

If we do see that some part of the sharing a document might fail, then we could put a TryTwice around a particular step, but it is a not good to put it around the whole process.