### PR TITLE
Skyline: refactor our ParseEnum method to use Enum.TryParse() instead of Enum.Parse() in a try/catch block.

### DIFF
--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -922,7 +922,7 @@ namespace pwiz.Skyline.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("detection")]
+        [global::System.Configuration.DefaultSettingValueAttribute("detections")]
         public string DetectionGraphType
         {
             get

--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -922,7 +922,7 @@ namespace pwiz.Skyline.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("detections")]
+        [global::System.Configuration.DefaultSettingValueAttribute("detection")]
         public string DetectionGraphType
         {
             get

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -1478,16 +1478,13 @@ namespace pwiz.Skyline.Util
         /// <param name="value">The string to parse</param>
         /// <param name="defaultValue">The value to return, if parsing fails</param>
         /// <returns>An enum value of type <see cref="TEnum"/></returns>
-        public static TEnum ParseEnum<TEnum>(string value, TEnum defaultValue)
+        public static TEnum ParseEnum<TEnum>(string value, TEnum defaultValue) where TEnum : struct
         {
-            try
+            if (Enum.TryParse(value, true, out TEnum result))
             {
-                return (TEnum)Enum.Parse(typeof(TEnum), value, true);
+                return result;
             }
-            catch (Exception)
-            {
-                return defaultValue;
-            }                            
+            return defaultValue;
         }
 
         /// <summary>


### PR DESCRIPTION
When debugging, "Exceptions Settings">"Break When Thrown">(all possible exceptions) is a great way to quickly locate a test exception. Employing exceptions as normal flow of control severely limits that feature's usefulness.

We should always use things like TryParse in favor of Parse when the language provides them. Exceptions should be exceptional.

Also, fix the typo in DetectionGraphType default value that was causing this to trip in the first place.