### PR TITLE
Add some things to Settings.settings that had been manually added to Settings.Designer.cs

### DIFF
--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -2953,9 +2953,9 @@ namespace pwiz.Skyline.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0.01")]
-        public global::System.Float DetectionsQValueCutoff {
+        public float DetectionsQValueCutoff {
             get {
-                return ((global::System.Float)(this["DetectionsQValueCutoff"]));
+                return ((float)(this["DetectionsQValueCutoff"]));
             }
             set {
                 this["DetectionsQValueCutoff"] = value;
@@ -3001,23 +3001,12 @@ namespace pwiz.Skyline.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("10")]
-        public global::System.Integer DetectionsRepCount {
+        public int DetectionsRepCount {
             get {
-                return ((global::System.Integer)(this["DetectionsRepCount"]));
+                return ((int)(this["DetectionsRepCount"]));
             }
             set {
                 this["DetectionsRepCount"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        public global::System.Float DetectionsFontSize {
-            get {
-                return ((global::System.Float)(this["DetectionsFontSize"]));
-            }
-            set {
-                this["DetectionsFontSize"] = value;
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -919,22 +919,19 @@ namespace pwiz.Skyline.Properties {
                 this["AreaGraphType"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("detection")]
-        public string DetectionGraphType
-        {
-            get
-            {
+        [global::System.Configuration.DefaultSettingValueAttribute("detections")]
+        public string DetectionGraphType {
+            get {
                 return ((string)(this["DetectionGraphType"]));
             }
-            set
-            {
+            set {
                 this["DetectionGraphType"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -946,22 +943,19 @@ namespace pwiz.Skyline.Properties {
                 this["ShowPeakAreaGraph"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool ShowDetectionGraph
-        {
-            get
-            {
+        public bool ShowDetectionGraph {
+            get {
                 return ((bool)(this["ShowDetectionGraph"]));
             }
-            set
-            {
+            set {
                 this["ShowDetectionGraph"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -2943,6 +2937,7 @@ namespace pwiz.Skyline.Properties {
                 this["GroupApplyToBy"] = value;
             }
         }
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -2954,138 +2949,122 @@ namespace pwiz.Skyline.Properties {
                 this["BrukerPrmSqliteFile"] = value;
             }
         }
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0.01")]
-        public float DetectionsQValueCutoff
-        {
-            get
-            {
-                return ((float)(this["DetectionsQValueCutoff"]));
+        public global::System.Float DetectionsQValueCutoff {
+            get {
+                return ((global::System.Float)(this["DetectionsQValueCutoff"]));
             }
-            set
-            {
+            set {
                 this["DetectionsQValueCutoff"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Precursor")]
-        public string DetectionsTargetType
-        {
-            get { return ((string) (this["DetectionsTargetType"])); }
-            set { this["DetectionsTargetType"] = value; }
+        public string DetectionsTargetType {
+            get {
+                return ((string)(this["DetectionsTargetType"]));
+            }
+            set {
+                this["DetectionsTargetType"] = value;
+            }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("10")]
-        public double ExportMs1RepetitionTime
-        {
-            get { return ((double) (this["ExportMs1RepetitionTime"])); }
-            set { this["ExportMs1RepetitionTime"] = value; }
+        public double ExportMs1RepetitionTime {
+            get {
+                return ((double)(this["ExportMs1RepetitionTime"]));
+            }
+            set {
+                this["ExportMs1RepetitionTime"] = value;
+            }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Thousands")]
-        public string DetectionsYScaleFactor
-        {
-            get
-            {
+        public string DetectionsYScaleFactor {
+            get {
                 return ((string)(this["DetectionsYScaleFactor"]));
             }
-            set
-            {
+            set {
                 this["DetectionsYScaleFactor"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("10")]
-        public int DetectionsRepCount
-        {
-            get
-            {
-                return ((int)(this["DetectionsRepCount"]));
+        public global::System.Integer DetectionsRepCount {
+            get {
+                return ((global::System.Integer)(this["DetectionsRepCount"]));
             }
-            set
-            {
+            set {
                 this["DetectionsRepCount"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public float DetectionsFontSize
-        {
-            get
-            {
-                return ((float)(this["DetectionsFontSize"]));
+        public global::System.Float DetectionsFontSize {
+            get {
+                return ((global::System.Float)(this["DetectionsFontSize"]));
             }
-            set
-            {
+            set {
                 this["DetectionsFontSize"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("true")]
-        public bool DetectionsShowAtLeastN
-        {
-            get
-            {
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool DetectionsShowAtLeastN {
+            get {
                 return ((bool)(this["DetectionsShowAtLeastN"]));
             }
-            set
-            {
+            set {
                 this["DetectionsShowAtLeastN"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("true")]
-        public bool DetectionsShowSelection
-        {
-            get
-            {
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool DetectionsShowSelection {
+            get {
                 return ((bool)(this["DetectionsShowSelection"]));
             }
-            set
-            {
+            set {
                 this["DetectionsShowSelection"] = value;
             }
         }
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("true")]
-        public bool DetectionsShowMean
-        {
-            get
-            {
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool DetectionsShowMean {
+            get {
                 return ((bool)(this["DetectionsShowMean"]));
             }
-            set
-            {
+            set {
                 this["DetectionsShowMean"] = value;
             }
         }
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("true")]
-        public bool DetectionsShowLegend
-        {
-            get
-            {
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool DetectionsShowLegend {
+            get {
                 return ((bool)(this["DetectionsShowLegend"]));
             }
-            set
-            {
+            set {
                 this["DetectionsShowLegend"] = value;
             }
         }

--- a/pwiz_tools/Skyline/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Properties/Settings.settings
@@ -737,7 +737,7 @@
     <Setting Name="BrukerPrmSqliteFile" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="DetectionsQValueCutoff" Type="System.Float" Scope="User">
+    <Setting Name="DetectionsQValueCutoff" Type="System.Single" Scope="User">
       <Value Profile="(Default)">0.01</Value>
     </Setting>
     <Setting Name="DetectionsTargetType" Type="System.String" Scope="User">
@@ -749,11 +749,8 @@
     <Setting Name="DetectionsYScaleFactor" Type="System.String" Scope="User">
       <Value Profile="(Default)">Thousands</Value>
     </Setting>
-    <Setting Name="DetectionsRepCount" Type="System.Integer" Scope="User">
+    <Setting Name="DetectionsRepCount" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">10</Value>
-    </Setting>
-    <Setting Name="DetectionsFontSize" Type="System.Float" Scope="User">
-      <Value Profile="(Default)"></Value>
     </Setting>
     <Setting Name="DetectionsShowAtLeastN" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>

--- a/pwiz_tools/Skyline/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Properties/Settings.settings
@@ -227,7 +227,13 @@
     <Setting Name="AreaGraphType" Type="System.String" Scope="User">
       <Value Profile="(Default)">replicate</Value>
     </Setting>
+    <Setting Name="DetectionGraphType" Type="System.String" Scope="User">
+      <Value Profile="(Default)">detections</Value>
+    </Setting>
     <Setting Name="ShowPeakAreaGraph" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ShowDetectionGraph" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="ShowResultsGrid" Type="System.Boolean" Scope="User">
@@ -731,8 +737,35 @@
     <Setting Name="BrukerPrmSqliteFile" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="DetectionsQValueCutoff" Type="System.Float" Scope="User">
+      <Value Profile="(Default)">0.01</Value>
+    </Setting>
+    <Setting Name="DetectionsTargetType" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Precursor</Value>
+    </Setting>
     <Setting Name="ExportMs1RepetitionTime" Type="System.Double" Scope="User">
       <Value Profile="(Default)">10</Value>
+    </Setting>
+    <Setting Name="DetectionsYScaleFactor" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Thousands</Value>
+    </Setting>
+    <Setting Name="DetectionsRepCount" Type="System.Integer" Scope="User">
+      <Value Profile="(Default)">10</Value>
+    </Setting>
+    <Setting Name="DetectionsFontSize" Type="System.Float" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
+    <Setting Name="DetectionsShowAtLeastN" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="DetectionsShowSelection" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="DetectionsShowMean" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="DetectionsShowLegend" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Settings.Designer.cs should never be edited by hand.
Visual Studio generates it from the file Settings.settings whenever Settings.settings is modified.

Visual Studio provides an editor for Settings.settings, but it's sometimes easier to edit the XML in Settings.settings directly.
If you have a complicated setting value type that cannot be represented by the XML in Settings.settings, then you can add the setting to Settings.cs, but never Settings.Designer.cs.

(Also, removed setting "DetectionsFontSize" since it was not being used, and I could not figure out what default value it should have).