### PR TITLE
* fixed MsDataFileImpl.GetChromatogram() to convert time arrays to minutes

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
@@ -255,6 +255,10 @@ class ShimadzuReaderImpl : public ShimadzuReader
                         continue;
                     }
 
+                    // if eventLastScanNumber is 0 then there is no scan near endTime for this event
+                    if (eventLastScanNumber == 0)
+                        continue;
+
                     if (msLevels_.size() < 2)
                     {
                         auto spectrumPtr = getSpectrum(eventLastScanNumber, false);
@@ -376,7 +380,7 @@ class ShimadzuReaderImpl : public ShimadzuReader
             ShimadzuGeneric::MassSpectrumObject^ spectrum;
             auto result = dataObject_->MS->Spectrum->GetMSSpectrumByScan(spectrum, scanNumber, profileDesired);
             if (ShimadzuUtil::Failed(result))
-                throw runtime_error("[ShimadzuReader::getSpectrum] GetMSSpectrumByScan: " + ToStdString(System::Enum::GetName(result.GetType(), (System::Object^) result)));
+                throw runtime_error("[ShimadzuReader::getSpectrum] GetMSSpectrumByScan for scan " + lexical_cast<string>(scanNumber) + ": " + ToStdString(System::Enum::GetName(result.GetType(), (System::Object^) result)));
 
             const pair<double, int>* precursorInfo = nullptr;
             auto findItr = precursorInfoByScan_.find(scanNumber);

--- a/pwiz_tools/Skyline/TestData/Results/ShimadzuSrmTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/ShimadzuSrmTest.cs
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.ProteowizardWrapper;
 using pwiz.Skyline.Model;
@@ -44,6 +46,10 @@ namespace pwiz.SkylineTestData.Results
             using (var msData = new MsDataFileImpl(testFilesDir.GetTestPath("BSA-digest__MRM_optimisation_SL_scheduled_001" + extRaw)))
             {
                 Assert.IsTrue(msData.IsShimadzuFile);
+
+                // check time is minutes
+                msData.GetChromatogram(0, out _, out float[] times, out _);
+                Assert.AreEqual(new KeyValuePair<float, float>(1.335f, 8.905833f), new KeyValuePair<float, float>(times.First(), times.Last()));
             }
         }
 

--- a/pwiz_tools/Skyline/TestData/Results/ShimadzuSrmTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/ShimadzuSrmTest.cs
@@ -46,10 +46,10 @@ namespace pwiz.SkylineTestData.Results
             using (var msData = new MsDataFileImpl(testFilesDir.GetTestPath("BSA-digest__MRM_optimisation_SL_scheduled_001" + extRaw)))
             {
                 Assert.IsTrue(msData.IsShimadzuFile);
-
+                
                 // check time is minutes
-                msData.GetChromatogram(0, out _, out float[] times, out _);
-                Assert.AreEqual(new KeyValuePair<float, float>(1.335f, 8.905833f), new KeyValuePair<float, float>(times.First(), times.Last()));
+                msData.GetChromatogram(msData.ChromatogramCount - 1, out _, out float[] times, out _);
+                Assert.AreEqual(new KeyValuePair<float, float>(5.908167f, 8.905833f), new KeyValuePair<float, float>(times.First(), times.Last()));
             }
         }
 


### PR DESCRIPTION
* fixed MsDataFileImpl.GetChromatogram() to convert time arrays to minutes rather than assuming they're always in minutes

@brendanx67  @nickshulman My first attempt at this got the math wrong, but no tests failed (at least in TestData and TestFunctional, haven't tried TestPerf). Any ideas which test I should augment to check that the time units are correct?