### PR TITLE
Skyline: when creating an ion mobility library, use the filename as basis for the library name

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
@@ -183,7 +183,11 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
         public void CreateDatabaseFile(string fileName)
         {
             Settings.Default.ActiveDirectory = Path.GetDirectoryName(fileName);
-
+            if (string.IsNullOrEmpty(LibraryName))
+            {
+                // User has not provided a library name - use file name as a reasonable guess
+                LibraryName = Path.GetFileNameWithoutExtension(fileName);
+            }
             CreateDatabase(fileName, LibraryName);
             textDatabase.Focus();
         }

--- a/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
@@ -139,14 +139,15 @@ namespace pwiz.SkylineTestFunctional
                 string databasePath = testFilesDir.GetTestPath(testlibName + IonMobilityDb.EXT);
                 RunUI(() =>
                 {
-                    ionMobilityLibDlg1.LibraryName = testlibName;
-                    ionMobilityLibDlg1.CreateDatabaseFile(databasePath); // Simulare user click on Create button
+                    // N.B no library name provided, so we'll automatically use filename as basis
+                    ionMobilityLibDlg1.CreateDatabaseFile(databasePath); // Simulate user click on Create button
                     ionMobilityLibDlg1.SetOffsetHighEnergySpectraCheckbox(true);
                     string libraryText = BuildPasteLibraryText(ionMobilityPeptides,
                         seq => seq.Substring(0, seq.Length - 1),
                         ionMobilityLibDlg1.GetOffsetHighEnergySpectraCheckbox());
                     SetClipboardText(libraryText);
                 });
+                AssertEx.AreEqual(testlibName, ionMobilityLibDlg1.LibraryName);
                 // Expect to be warned about multiple conformer
                 var warnDlg = ShowDialog<MessageDlg>(() => ionMobilityLibDlg1.DoPasteLibrary());
                 RunUI(() =>


### PR DESCRIPTION
…  if the user does not specify otherwise.

Issue was rasied in https://skyline.ms/announcements/home/issues/exceptions/thread.view?rowId=48729

> User comments:
> Came across this error the other week and didn't report it because it didn't seem significant enough but I figure this could be useful for the stable non-daily release.
> 
> If you open or create an ion mobility library file before the "Name" field is completed, this error pops up. I clicked open, thinking the name would be auto-completed and got this error, so others users may encounter this issue too.
>
>Cheers,
>Chris

reported by Chris Ashwood