### PR TITLE
Fix NullReferenceException in FastaSequence.StripModifications (comin…

### DIFF
--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkSequenceParser.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkSequenceParser.cs
@@ -45,6 +45,10 @@ namespace pwiz.Skyline.Model.Crosslinking
         }
         private static bool LooksLikeCrosslinkSequence(string str)
         {
+            if (string.IsNullOrEmpty(str))
+            {
+                return false;
+            }
             return FastaSequence.StripModifications(str).IndexOf('-') >= 0;
         }
 


### PR DESCRIPTION
…g from "CrosslinkSequenceParser.LooksLikeCrosslinkSequence).

(Reported on exception web)