### PR TITLE
- enabled reference and exception peaks in Thermo vendor centroids

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -955,7 +955,7 @@ MassListPtr RawFileImpl::getMassList(long scanNumber,
 #else
         if (centroidResult && raw_->GetFilterForScanNumber(scanNumber)->MassAnalyzer == ThermoEnum::MassAnalyzerType::MassAnalyzerFTMS)
         {
-            auto centroidStream = raw_->GetCentroidStream(scanNumber, false);
+            auto centroidStream = raw_->GetCentroidStream(scanNumber, true);
             if (centroidStream != nullptr && centroidStream->Length > 0)
             {
                 ToBinaryData(centroidStream->Masses, result->mzArray);


### PR DESCRIPTION
- enabled reference and exception peaks in Thermo vendor centroids (one user reported their m/z of interest being mislabeled as an exception peak due to being too close to the lockmass m/z)