### PR TITLE
DefineAnnotationDlg and MeasuredResults changes

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
+++ b/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
@@ -80,7 +80,17 @@ namespace pwiz.Skyline.Model.Results
                 for (int i = 0; i < count; i++)
                 {
                     var set = _chromatograms[i];
-                    dictNameToIndex.Add(set.Name, i);
+                    try
+                    {
+                        dictNameToIndex.Add(set.Name, i);
+                    }
+                    catch (ArgumentException argumentException)
+                    {
+                        throw new ArgumentException(
+                            set.Name + @" appears multiple times in the list ('" +
+                            string.Join(@"','", value.Select(c => c.Name)) + @"')", argumentException);
+                    }
+
                     dictIdToIndex.Add(set.Id.GlobalIndex, i);
                     foreach (var path in set.MSDataFilePaths)
                         _setFiles.Add(path.GetLocation());

--- a/pwiz_tools/Skyline/SettingsUI/DefineAnnotationDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/DefineAnnotationDlg.Designer.cs
@@ -30,23 +30,23 @@ namespace pwiz.Skyline.SettingsUI
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DefineAnnotationDlg));
-            this.label1 = new System.Windows.Forms.Label();
+            this.lblName = new System.Windows.Forms.Label();
             this.tbxName = new System.Windows.Forms.TextBox();
             this.comboType = new System.Windows.Forms.ComboBox();
-            this.label2 = new System.Windows.Forms.Label();
+            this.lblType = new System.Windows.Forms.Label();
             this.tbxValues = new System.Windows.Forms.TextBox();
-            this.label3 = new System.Windows.Forms.Label();
+            this.lblValues = new System.Windows.Forms.Label();
             this.checkedListBoxAppliesTo = new System.Windows.Forms.CheckedListBox();
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
-            this.label4 = new System.Windows.Forms.Label();
+            this.lblAppliesTo = new System.Windows.Forms.Label();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPageEditable = new System.Windows.Forms.TabPage();
             this.tabPageCalculated = new System.Windows.Forms.TabPage();
-            this.comboAggregateOperation = new System.Windows.Forms.ComboBox();
             this.lblAggregateOperation = new System.Windows.Forms.Label();
+            this.comboAggregateOperation = new System.Windows.Forms.ComboBox();
             this.availableFieldsTree1 = new pwiz.Common.DataBinding.Controls.Editor.AvailableFieldsTree();
-            this.label5 = new System.Windows.Forms.Label();
+            this.lblCalculatedAppliesTo = new System.Windows.Forms.Label();
             this.comboAppliesTo = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.tabControl1.SuspendLayout();
@@ -54,10 +54,10 @@ namespace pwiz.Skyline.SettingsUI
             this.tabPageCalculated.SuspendLayout();
             this.SuspendLayout();
             // 
-            // label1
+            // lblName
             // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
+            resources.ApplyResources(this.lblName, "lblName");
+            this.lblName.Name = "lblName";
             // 
             // tbxName
             // 
@@ -72,10 +72,10 @@ namespace pwiz.Skyline.SettingsUI
             this.comboType.Name = "comboType";
             this.comboType.SelectedIndexChanged += new System.EventHandler(this.comboType_SelectedIndexChanged);
             // 
-            // label2
+            // lblType
             // 
-            resources.ApplyResources(this.label2, "label2");
-            this.label2.Name = "label2";
+            resources.ApplyResources(this.lblType, "lblType");
+            this.lblType.Name = "lblType";
             // 
             // tbxValues
             // 
@@ -83,10 +83,10 @@ namespace pwiz.Skyline.SettingsUI
             resources.ApplyResources(this.tbxValues, "tbxValues");
             this.tbxValues.Name = "tbxValues";
             // 
-            // label3
+            // lblValues
             // 
-            resources.ApplyResources(this.label3, "label3");
-            this.label3.Name = "label3";
+            resources.ApplyResources(this.lblValues, "lblValues");
+            this.lblValues.Name = "lblValues";
             // 
             // checkedListBoxAppliesTo
             // 
@@ -109,10 +109,10 @@ namespace pwiz.Skyline.SettingsUI
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             // 
-            // label4
+            // lblAppliesTo
             // 
-            resources.ApplyResources(this.label4, "label4");
-            this.label4.Name = "label4";
+            resources.ApplyResources(this.lblAppliesTo, "lblAppliesTo");
+            this.lblAppliesTo.Name = "lblAppliesTo";
             // 
             // tabControl1
             // 
@@ -124,11 +124,11 @@ namespace pwiz.Skyline.SettingsUI
             // 
             // tabPageEditable
             // 
-            this.tabPageEditable.Controls.Add(this.label2);
+            this.tabPageEditable.Controls.Add(this.lblType);
             this.tabPageEditable.Controls.Add(this.comboType);
-            this.tabPageEditable.Controls.Add(this.label4);
+            this.tabPageEditable.Controls.Add(this.lblValues);
             this.tabPageEditable.Controls.Add(this.tbxValues);
-            this.tabPageEditable.Controls.Add(this.label3);
+            this.tabPageEditable.Controls.Add(this.lblAppliesTo);
             this.tabPageEditable.Controls.Add(this.checkedListBoxAppliesTo);
             resources.ApplyResources(this.tabPageEditable, "tabPageEditable");
             this.tabPageEditable.Name = "tabPageEditable";
@@ -136,14 +136,19 @@ namespace pwiz.Skyline.SettingsUI
             // 
             // tabPageCalculated
             // 
-            this.tabPageCalculated.Controls.Add(this.comboAggregateOperation);
             this.tabPageCalculated.Controls.Add(this.lblAggregateOperation);
+            this.tabPageCalculated.Controls.Add(this.comboAggregateOperation);
             this.tabPageCalculated.Controls.Add(this.availableFieldsTree1);
-            this.tabPageCalculated.Controls.Add(this.label5);
+            this.tabPageCalculated.Controls.Add(this.lblCalculatedAppliesTo);
             this.tabPageCalculated.Controls.Add(this.comboAppliesTo);
             resources.ApplyResources(this.tabPageCalculated, "tabPageCalculated");
             this.tabPageCalculated.Name = "tabPageCalculated";
             this.tabPageCalculated.UseVisualStyleBackColor = true;
+            // 
+            // lblAggregateOperation
+            // 
+            resources.ApplyResources(this.lblAggregateOperation, "lblAggregateOperation");
+            this.lblAggregateOperation.Name = "lblAggregateOperation";
             // 
             // comboAggregateOperation
             // 
@@ -151,11 +156,6 @@ namespace pwiz.Skyline.SettingsUI
             this.comboAggregateOperation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboAggregateOperation.FormattingEnabled = true;
             this.comboAggregateOperation.Name = "comboAggregateOperation";
-            // 
-            // lblAggregateOperation
-            // 
-            resources.ApplyResources(this.lblAggregateOperation, "lblAggregateOperation");
-            this.lblAggregateOperation.Name = "lblAggregateOperation";
             // 
             // availableFieldsTree1
             // 
@@ -166,10 +166,10 @@ namespace pwiz.Skyline.SettingsUI
             this.availableFieldsTree1.ShowNodeToolTips = true;
             this.availableFieldsTree1.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.availableFieldsTree1_AfterSelect);
             // 
-            // label5
+            // lblCalculatedAppliesTo
             // 
-            resources.ApplyResources(this.label5, "label5");
-            this.label5.Name = "label5";
+            resources.ApplyResources(this.lblCalculatedAppliesTo, "lblCalculatedAppliesTo");
+            this.lblCalculatedAppliesTo.Name = "lblCalculatedAppliesTo";
             // 
             // comboAppliesTo
             // 
@@ -185,11 +185,11 @@ namespace pwiz.Skyline.SettingsUI
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.Controls.Add(this.tabControl1);
-            this.Controls.Add(this.btnCancel);
-            this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.lblName);
             this.Controls.Add(this.tbxName);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.tabControl1);
+            this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.btnCancel);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "DefineAnnotationDlg";
@@ -207,20 +207,20 @@ namespace pwiz.Skyline.SettingsUI
 
         #endregion
 
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label lblName;
         private System.Windows.Forms.TextBox tbxName;
         private System.Windows.Forms.ComboBox comboType;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label lblType;
         private System.Windows.Forms.TextBox tbxValues;
-        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label lblValues;
         private System.Windows.Forms.CheckedListBox checkedListBoxAppliesTo;
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.Button btnCancel;
-        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label lblAppliesTo;
         private System.Windows.Forms.TabControl tabControl1;
         private System.Windows.Forms.TabPage tabPageEditable;
         private System.Windows.Forms.TabPage tabPageCalculated;
-        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label lblCalculatedAppliesTo;
         private System.Windows.Forms.ComboBox comboAppliesTo;
         private Common.DataBinding.Controls.Editor.AvailableFieldsTree availableFieldsTree1;
         private System.Windows.Forms.ComboBox comboAggregateOperation;

--- a/pwiz_tools/Skyline/SettingsUI/DefineAnnotationDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/DefineAnnotationDlg.cs
@@ -286,6 +286,14 @@ namespace pwiz.Skyline.SettingsUI
                     messageBoxHelper.ShowTextBoxError(checkedListBoxAppliesTo, Resources.DefineAnnotationDlg_OkDialog_Choose_at_least_one_type_for_this_annotation_to_apply_to);
                     return;
                 }
+                if (new ListPropertyType(AnnotationDef.AnnotationType.value_list, null).Equals(ListPropertyType))
+                {
+                    if (Items.Count == 0)
+                    {
+                        messageBoxHelper.ShowTextBoxError(tbxValues, Resources.MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty);
+                        return;
+                    }
+                }
             }
             else
             {

--- a/pwiz_tools/Skyline/SettingsUI/DefineAnnotationDlg.resx
+++ b/pwiz_tools/Skyline/SettingsUI/DefineAnnotationDlg.resx
@@ -121,33 +121,33 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="lblName.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="lblName.Size" type="System.Drawing.Size, System.Drawing">
     <value>38, 13</value>
   </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+  <data name="lblName.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="label1.Text" xml:space="preserve">
+  <data name="lblName.Text" xml:space="preserve">
     <value>&amp;Name:</value>
   </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
+  <data name="&gt;&gt;lblName.Name" xml:space="preserve">
+    <value>lblName</value>
   </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblName.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblName.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;lblName.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tbxName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -172,7 +172,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;tbxName.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>1</value>
   </data>
   <data name="comboType.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 23</value>
@@ -195,31 +195,31 @@
   <data name="&gt;&gt;comboType.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblType.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="lblType.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 7</value>
   </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="lblType.Size" type="System.Drawing.Size, System.Drawing">
     <value>34, 13</value>
   </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+  <data name="lblType.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="label2.Text" xml:space="preserve">
+  <data name="lblType.Text" xml:space="preserve">
     <value>&amp;Type:</value>
   </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
+  <data name="&gt;&gt;lblType.Name" xml:space="preserve">
+    <value>lblType</value>
   </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblType.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblType.Parent" xml:space="preserve">
     <value>tabPageEditable</value>
   </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;lblType.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="tbxValues.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -252,32 +252,32 @@
   <data name="&gt;&gt;tbxValues.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblValues.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="lblValues.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 47</value>
   </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="lblValues.Size" type="System.Drawing.Size, System.Drawing">
     <value>42, 13</value>
   </data>
-  <data name="label3.TabIndex" type="System.Int32, mscorlib">
+  <data name="lblValues.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="label3.Text" xml:space="preserve">
+  <data name="lblValues.Text" xml:space="preserve">
     <value>&amp;Values:</value>
   </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
+  <data name="&gt;&gt;lblValues.Name" xml:space="preserve">
+    <value>lblValues</value>
   </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblValues.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblValues.Parent" xml:space="preserve">
     <value>tabPageEditable</value>
   </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="&gt;&gt;lblValues.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="checkedListBoxAppliesTo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
@@ -328,7 +328,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -355,37 +355,37 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label4.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
-  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 174</value>
-  </data>
-  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
-  </data>
-  <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="label4.Text" xml:space="preserve">
+  <data name="lblAppliesTo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="lblAppliesTo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAppliesTo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 174</value>
+  </data>
+  <data name="lblAppliesTo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 13</value>
+  </data>
+  <data name="lblAppliesTo.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="lblAppliesTo.Text" xml:space="preserve">
     <value>&amp;Applies to:</value>
   </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
+  <data name="&gt;&gt;lblAppliesTo.Name" xml:space="preserve">
+    <value>lblAppliesTo</value>
   </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblAppliesTo.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblAppliesTo.Parent" xml:space="preserve">
     <value>tabPageEditable</value>
   </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;lblAppliesTo.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="tabControl1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
@@ -420,30 +420,6 @@
   <data name="&gt;&gt;tabPageEditable.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="comboAggregateOperation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left, Right</value>
-  </data>
-  <data name="comboAggregateOperation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 309</value>
-  </data>
-  <data name="comboAggregateOperation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>319, 21</value>
-  </data>
-  <data name="comboAggregateOperation.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;comboAggregateOperation.Name" xml:space="preserve">
-    <value>comboAggregateOperation</value>
-  </data>
-  <data name="&gt;&gt;comboAggregateOperation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboAggregateOperation.Parent" xml:space="preserve">
-    <value>tabPageCalculated</value>
-  </data>
-  <data name="&gt;&gt;comboAggregateOperation.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lblAggregateOperation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -472,6 +448,30 @@
     <value>tabPageCalculated</value>
   </data>
   <data name="&gt;&gt;lblAggregateOperation.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="comboAggregateOperation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="comboAggregateOperation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 309</value>
+  </data>
+  <data name="comboAggregateOperation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>319, 21</value>
+  </data>
+  <data name="comboAggregateOperation.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;comboAggregateOperation.Name" xml:space="preserve">
+    <value>comboAggregateOperation</value>
+  </data>
+  <data name="&gt;&gt;comboAggregateOperation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboAggregateOperation.Parent" xml:space="preserve">
+    <value>tabPageCalculated</value>
+  </data>
+  <data name="&gt;&gt;comboAggregateOperation.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="availableFieldsTree1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -504,34 +504,34 @@
   <data name="&gt;&gt;availableFieldsTree1.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblCalculatedAppliesTo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="lblCalculatedAppliesTo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="lblCalculatedAppliesTo.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 10</value>
   </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="lblCalculatedAppliesTo.Size" type="System.Drawing.Size, System.Drawing">
     <value>56, 13</value>
   </data>
-  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+  <data name="lblCalculatedAppliesTo.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="label5.Text" xml:space="preserve">
+  <data name="lblCalculatedAppliesTo.Text" xml:space="preserve">
     <value>&amp;Applies to:</value>
   </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
+  <data name="&gt;&gt;lblCalculatedAppliesTo.Name" xml:space="preserve">
+    <value>lblCalculatedAppliesTo</value>
   </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblCalculatedAppliesTo.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblCalculatedAppliesTo.Parent" xml:space="preserve">
     <value>tabPageCalculated</value>
   </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;lblCalculatedAppliesTo.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="comboAppliesTo.Location" type="System.Drawing.Point, System.Drawing">
@@ -601,7 +601,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;tabControl1.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -622,12 +622,12 @@
     <value>modeUIHandler</value>
   </data>
   <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline-daily, Version=20.1.1.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline-daily, Version=20.1.1.281, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>DefineAnnotationDlg</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=20.1.1.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=20.1.1.281, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>


### PR DESCRIPTION
1. Fix Issue 753: Value list annotations should not allow empty lists
Also fix order of controls on DefineAnnotationDlg so labels come before their textboxes so that MessageBoxHelper displays the correct name when showing error messages

Add extra information to Duplicate Key exception thrown by MeasuredResults.set_Chromatograms to try to track down exception that keeps getting reported on Exception Web.