### PR TITLE
Nightly test fixes:

### DIFF
--- a/pwiz_tools/Skyline/TestData/Results/ThermoQuantTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/ThermoQuantTest.cs
@@ -20,6 +20,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.SystemUtil;
@@ -217,6 +218,7 @@ namespace pwiz.SkylineTestData.Results
             DoThermoRatioTest(RefinementSettings.ConvertToSmallMoleculesMode.masses_and_names);
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization)]
         public void DoThermoRatioTest(RefinementSettings.ConvertToSmallMoleculesMode smallMoleculesTestMode)
         {
             var testFilesDir = new TestFilesDir(TestContext, ZIP_FILE);

--- a/pwiz_tools/Skyline/TestPerf/PerfTicAreaTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfTicAreaTest.cs
@@ -50,7 +50,7 @@ namespace TestPerf
             // TIC chromatogram includes MS2 scans
             ticAreas.Add("DemuxedMzML.mzML", 231215169536);
             // TIC chromatogram has zero points because MS1 scans were marked as SIM
-            ticAreas.Add("SIMRawFile.raw", 231215169536);
+            ticAreas.Add("SIMRawFile.raw", 233751478272);
             // TIC chromatogram is usable
             ticAreas.Add("XlinkRawFile.raw", 1021147086848);
             // TIC chromatogram includes MS2 scans, but is otherwise the same as XlinkRawFile.raw


### PR DESCRIPTION
1. Change expected values in PerfTicAreaTest. The expected numbers are slightly different because lockmass peaks are now being included in the spectra.
2. Turn off optimization in ThermoQuantTest to get better information about line number of test failure.