### PR TITLE
Fix fragment tolerance always using precursor tolerance units

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
@@ -141,7 +141,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                     Resources.DdaSearch_SearchSettingsControl_MS2_Tolerance_incorrect);
                 return false;
             }
-            ImportPeptideSearch.SearchEngine.SetFragmentIonMassTolerance(new MzTolerance(ms2Tol, (MzTolerance.Units) cbMS1TolUnit.SelectedIndex));
+            ImportPeptideSearch.SearchEngine.SetFragmentIonMassTolerance(new MzTolerance(ms2Tol, (MzTolerance.Units) cbMS2TolUnit.SelectedIndex));
 
             string fragmentIons;
             if (!ValidateCombobox(cbFragmentIons, out fragmentIons))


### PR DESCRIPTION
:facepalm:

This is causing users to think they are using a wide tolerance for fragment ions (like 1 Da) but it's being treated as 1 ppm if they're using ppm for parent tolerance.