### PR TITLE
Skyline/work/20201103 covershots

### DIFF
--- a/pwiz_tools/Skyline/Controls/Startup/ActionTutorial.cs
+++ b/pwiz_tools/Skyline/Controls/Startup/ActionTutorial.cs
@@ -33,31 +33,6 @@ namespace pwiz.Skyline.Controls.Startup
 {
     public class ActionTutorial
     {
-        public enum TutorialType
-        {
-            targeted_method_editing,
-            targeted_method_refinement,
-            existing_and_quantitative_experiments,
-            absolute_quantifiaction,
-            ms1_fullscan_filtering,
-            targeted_ms_ms,
-            custom_reports_results_grid,
-            advanced_peak_picking_models,
-            irt_retention_time_prediction,
-            collision_energy_optimization,
-            spectral_library_explorer,
-            grouped_study_data_processing,
-            data_independent_acquisition,
-            small_molecule_targets,
-            small_molecule_method_dev_and_ce_opt,
-            small_molecule_quant,
-            hi_res_metabolomics,
-            ion_mobility,
-            audit_logging,
-            dia_swath,
-        }
-
-        public TutorialType ImportType { get; set; }
         public string TutorialZipFileLocation { get; set; }
         public string PdfFileLocation { get; set; }
         public string SkyFileLocationInZip { get; set; }
@@ -66,10 +41,9 @@ namespace pwiz.Skyline.Controls.Startup
         private long ExtractedSize { get; set; }
         private readonly string TempPath = Path.GetTempPath();
 
-        public ActionTutorial(TutorialType action, string extractPath, string skyFileLocation, string pdfFileLocation, string skyFileLocationInZip)
+        public ActionTutorial(string extractPath, string skyFileLocation, string pdfFileLocation, string skyFileLocationInZip)
         {
             ExtractPath = extractPath;
-            ImportType = action;
             TutorialZipFileLocation = skyFileLocation;
             PdfFileLocation = pdfFileLocation;
             SkyFileLocationInZip = skyFileLocationInZip;
@@ -206,9 +180,10 @@ namespace pwiz.Skyline.Controls.Startup
                             throw;
                     }
                 }
+                var hasSkylineFile = !string.IsNullOrEmpty(SkyFileLocationInZip) && !string.IsNullOrEmpty(ExtractPath);
                 Program.MainWindow.BeginInvoke(new Action(() =>
                 {
-                    if (!string.IsNullOrEmpty(SkyFileLocationInZip) && !string.IsNullOrEmpty(ExtractPath))
+                    if (hasSkylineFile)
                     {
                         Program.MainWindow.OpenFile(skyFileToOpen);
                     }
@@ -234,7 +209,20 @@ namespace pwiz.Skyline.Controls.Startup
                         MessageDlg.ShowWithException(Program.MainWindow, message, e);
                     }
                 }));
-               
+
+                // Make it convenient for user to locate tutorial files if we haven't already opened anything
+                if (!hasSkylineFile && !string.IsNullOrEmpty(ExtractPath))
+                {
+                    Directory.SetCurrentDirectory(ExtractPath);
+                    Settings.Default.LibraryDirectory =
+                        Settings.Default.ActiveDirectory =
+                            Settings.Default.ExportDirectory =
+                                Settings.Default.FastaDirectory =
+                                    Settings.Default.LibraryResultsDirectory =
+                                        Settings.Default.SrmResultsDirectory =
+                                            Settings.Default.ProteomeDbDirectory =
+                                                ExtractPath;
+                }
             }
         }
 

--- a/pwiz_tools/Skyline/Controls/Startup/StartPage.cs
+++ b/pwiz_tools/Skyline/Controls/Startup/StartPage.cs
@@ -279,7 +279,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.MethodEdit_Caption,
                     Icon = TutorialImageResources.MethodEdit_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.targeted_method_editing,
                         TutorialLinkResources.MethodEdit_zip,
                         TutorialLinkResources.MethodEdit_pdf,
                         string.Empty
@@ -291,7 +290,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.MethodRefine_Caption,
                     Icon = TutorialImageResources.MethodRefine_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.targeted_method_refinement,
                         TutorialLinkResources.MethodRefine_zip,
                         TutorialLinkResources.MethodRefine_pdf,
                         TutorialLinkResources.MethodRefine_sky
@@ -303,7 +301,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.GroupedStudy_Caption,
                     Icon = TutorialImageResources.GroupedStudies_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.grouped_study_data_processing,
                         TutorialLinkResources.GroupedStudy_zip,
                         TutorialLinkResources.GroupedStudy_pdf,
                         TutorialLinkResources.GroupedStudy_sky
@@ -315,7 +312,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.ExistingQuant_Caption,
                     Icon = TutorialImageResources.ExistingQuant_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.existing_and_quantitative_experiments,
                         TutorialLinkResources.ExistingQuant_zip,
                         TutorialLinkResources.ExistingQuant_pdf,
                         string.Empty
@@ -334,7 +330,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.MS1Filtering_Caption,
                     Icon = TutorialImageResources.MS1Filtering_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.ms1_fullscan_filtering,
                         TutorialLinkResources.MS1Filtering_zip,
                         TutorialLinkResources.MS1Filtering_pdf,
                         string.Empty
@@ -346,7 +341,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.TargetedMSMS_Caption,
                     Icon = TutorialImageResources.TargetedMSMS_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.targeted_ms_ms,
                         TutorialLinkResources.TargetedMSMS_zip,
                         TutorialLinkResources.TargetedMSMS_pdf,
                         TutorialLinkResources.TargetedMSMS_sky
@@ -358,7 +352,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.DIA_Caption,
                     Icon = TutorialImageResources.DIA_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.data_independent_acquisition,
                         TutorialLinkResources.DIA_zip,
                         TutorialLinkResources.DIA_pdf,
                         TutorialLinkResources.DIA_sky
@@ -370,7 +363,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.DIA_SWATH_Caption,
                     Icon = TutorialImageResources.DIA_SWATH_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.dia_swath,
                         TutorialLinkResources.DIA_TTOF_zip,
                         TutorialLinkResources.DIA_TTOF_pdf,
                         string.Empty
@@ -392,7 +384,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.SmallMolecule_Caption,
                     Icon = TutorialImageResources.SmallMolecule_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.small_molecule_targets,
                         TutorialLinkResources.SmallMolecule_zip,
                         TutorialLinkResources.SmallMolecule_pdf,
                         string.Empty
@@ -404,7 +395,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.SmallMoleculeMethodDevCEOpt_Caption,
                     Icon = TutorialImageResources.SmallMoleculeMethodDevCEOpt_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.small_molecule_method_dev_and_ce_opt,
                         TutorialLinkResources.SmallMoleculeMethodDevCEOpt_zip,
                         TutorialLinkResources.SmallMoleculeMethodDevCEOpt_pdf,
                         string.Empty
@@ -416,7 +406,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.SmallMoleculeQuantification_Caption,
                     Icon = TutorialImageResources.SmallMoleculeQuantification_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.small_molecule_quant,
                         TutorialLinkResources.SmallMoleculeQuantification_zip,
                         TutorialLinkResources.SmallMoleculeQuantification_pdf,
                         string.Empty
@@ -428,7 +417,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.HiResMetabolomics_Caption,
                     Icon = TutorialImageResources.HiResMetabolomics_start,
                     EventAction = () => Tutorial(
-                        ActionTutorial.TutorialType.hi_res_metabolomics,
                         TutorialLinkResources.HiResMetabolomics_zip,
                         TutorialLinkResources.HiResMetabolomics_pdf,
                         string.Empty
@@ -450,7 +438,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.AbsoluteQuant_Caption, 
                     Icon = TutorialImageResources.AbsoluteQuant_start, 
                     EventAction = ()=>Tutorial(
-                        ActionTutorial.TutorialType.absolute_quantifiaction, 
                         TutorialLinkResources.AbsoluteQuant_zip,
                         TutorialLinkResources.AbsoluteQuant_pdf,
                         string.Empty
@@ -462,7 +449,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.CustomReports_Caption, 
                     Icon = TutorialImageResources.CustomReports_start, 
                     EventAction = ()=>Tutorial(
-                        ActionTutorial.TutorialType.custom_reports_results_grid, 
                         TutorialLinkResources.CustomReports_zip,
                         TutorialLinkResources.CustomReports_pdf,
                         TutorialLinkResources.CustomReports_sky
@@ -474,7 +460,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.PeakPicking_Caption, 
                     Icon = TutorialImageResources.PeakPicking_start, 
                     EventAction = ()=>Tutorial(
-                        ActionTutorial.TutorialType.advanced_peak_picking_models, 
                         TutorialLinkResources.PeakPicking_zip,
                         TutorialLinkResources.PeakPicking_pdf,
                         TutorialLinkResources.PeakPicking_sky
@@ -486,7 +471,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.iRT_Caption, 
                     Icon = TutorialImageResources.iRT_start, 
                     EventAction = ()=>Tutorial(
-                        ActionTutorial.TutorialType.irt_retention_time_prediction, 
                         TutorialLinkResources.iRT_zip,
                         TutorialLinkResources.iRT_pdf,
                         TutorialLinkResources.iRT_sky
@@ -497,7 +481,7 @@ namespace pwiz.Skyline.Controls.Startup
                 {
                     Caption = TutorialTextResources.OptimizeCE_Caption, 
                     Icon = TutorialImageResources.OptimizeCE_start, 
-                    EventAction = ()=>Tutorial(ActionTutorial.TutorialType.collision_energy_optimization, 
+                    EventAction = ()=>Tutorial(
                         TutorialLinkResources.OptimizeCE_zip,
                         TutorialLinkResources.OptimizeCE_pdf,
                         TutorialLinkResources.OptimizeCE_sky
@@ -508,7 +492,7 @@ namespace pwiz.Skyline.Controls.Startup
                 {
                     Caption = TutorialTextResources.IMSFiltering_Caption,
                     Icon = TutorialImageResources.IMSFiltering_start,
-                    EventAction = ()=>Tutorial(ActionTutorial.TutorialType.ion_mobility,
+                    EventAction = ()=>Tutorial(
                         TutorialLinkResources.IMSFiltering_zip,
                         TutorialLinkResources.IMSFiltering_pdf,
                         TutorialLinkResources.IMSFiltering_sky
@@ -520,7 +504,6 @@ namespace pwiz.Skyline.Controls.Startup
                     Caption = TutorialTextResources.LibraryExplorer_Caption, 
                     Icon = TutorialImageResources.LibraryExplorer_start, 
                     EventAction = ()=>Tutorial(
-                        ActionTutorial.TutorialType.spectral_library_explorer, 
                         TutorialLinkResources.LibraryExplorer_zip,
                         TutorialLinkResources.LibraryExplorer_pdf,
                         string.Empty
@@ -531,7 +514,7 @@ namespace pwiz.Skyline.Controls.Startup
                 {
                     Caption = TutorialTextResources.AuditLog_Caption,
                     Icon = TutorialImageResources.AuditLog_start,
-                    EventAction = ()=>Tutorial(ActionTutorial.TutorialType.audit_logging,
+                    EventAction = ()=>Tutorial(
                         TutorialLinkResources.AuditLog_zip,
                         TutorialLinkResources.AuditLog_pdf,
                         string.Empty
@@ -616,7 +599,7 @@ namespace pwiz.Skyline.Controls.Startup
             DoAction(new ActionImport(type).DoStartupAction);
         }
         
-        private void Tutorial(ActionTutorial.TutorialType type, string skyFileLocation, string pdfFileLocation, string zipSkyFileLocation)
+        private void Tutorial(string skyFileLocation, string pdfFileLocation, string zipSkyFileLocation)
         {
             Assume.IsNotNull(skyFileLocation);
 
@@ -627,7 +610,7 @@ namespace pwiz.Skyline.Controls.Startup
             DialogResult = DialogResult.OK;
 
             string paths = pathChooserDlg.ExtractionPath;
-            DoAction(new ActionTutorial(type, paths, skyFileLocation, pdfFileLocation, zipSkyFileLocation)
+            DoAction(new ActionTutorial( paths, skyFileLocation, pdfFileLocation, zipSkyFileLocation)
                 .DoStartupAction);
         }
 
@@ -780,10 +763,9 @@ namespace pwiz.Skyline.Controls.Startup
             DoAction(action.DoStartupAction);
         }
 
-        public void TestTutorialAction(ActionTutorial.TutorialType type)
+        public void TestTutorialAction()
         {
             Tutorial(
-                ActionTutorial.TutorialType.spectral_library_explorer,
                 TutorialLinkResources.LibraryExplorer_zip,
                 TutorialLinkResources.LibraryExplorer_pdf,
                 string.Empty

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
@@ -102,6 +102,7 @@ namespace SkylineTester
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.tutorialsTree = new SkylineTester.MyTreeView();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.modeTutorialsCoverShots = new System.Windows.Forms.RadioButton();
             this.pauseTutorialsSeconds = new System.Windows.Forms.NumericUpDown();
             this.tutorialsDemoMode = new System.Windows.Forms.RadioButton();
             this.label5 = new System.Windows.Forms.Label();
@@ -297,7 +298,6 @@ namespace SkylineTester
             this.radioButton5 = new System.Windows.Forms.RadioButton();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.myTreeView1 = new SkylineTester.MyTreeView();
-            this.pauseTutorialsCoverShots = new System.Windows.Forms.RadioButton();
             this.mainPanel.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.tabs.SuspendLayout();
@@ -426,7 +426,7 @@ namespace SkylineTester
             this.tabs.Padding = new System.Drawing.Point(20, 6);
             this.tabs.SelectedIndex = 0;
             this.tabs.Size = new System.Drawing.Size(717, 721);
-            this.tabs.TabIndex = 4;
+            this.tabs.TabIndex = 0;
             this.tabs.SelectedIndexChanged += new System.EventHandler(this.TabChanged);
             // 
             // tabForms
@@ -753,7 +753,7 @@ namespace SkylineTester
             // 
             // groupBox4
             // 
-            this.groupBox4.Controls.Add(this.pauseTutorialsCoverShots);
+            this.groupBox4.Controls.Add(this.modeTutorialsCoverShots);
             this.groupBox4.Controls.Add(this.pauseTutorialsSeconds);
             this.groupBox4.Controls.Add(this.tutorialsDemoMode);
             this.groupBox4.Controls.Add(this.label5);
@@ -764,21 +764,33 @@ namespace SkylineTester
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Padding = new System.Windows.Forms.Padding(4);
             this.groupBox4.Size = new System.Drawing.Size(280, 132);
-            this.groupBox4.TabIndex = 2;
+            this.groupBox4.TabIndex = 1;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Pause";
             // 
+            // modeTutorialsCoverShots
+            // 
+            this.modeTutorialsCoverShots.AutoSize = true;
+            this.modeTutorialsCoverShots.Location = new System.Drawing.Point(7, 97);
+            this.modeTutorialsCoverShots.Margin = new System.Windows.Forms.Padding(4);
+            this.modeTutorialsCoverShots.Name = "modeTutorialsCoverShots";
+            this.modeTutorialsCoverShots.Size = new System.Drawing.Size(110, 17);
+            this.modeTutorialsCoverShots.TabIndex = 5;
+            this.modeTutorialsCoverShots.Text = "Cover shots mode";
+            this.toolTip1.SetToolTip(this.modeTutorialsCoverShots, "Runs the tutorial until cover shot is reached, saves the image, then exits");
+            this.modeTutorialsCoverShots.UseVisualStyleBackColor = true;
+            // 
             // pauseTutorialsSeconds
             // 
-            this.pauseTutorialsSeconds.Location = new System.Drawing.Point(99, 71);
+            this.pauseTutorialsSeconds.Location = new System.Drawing.Point(99, 48);
             this.pauseTutorialsSeconds.Name = "pauseTutorialsSeconds";
             this.pauseTutorialsSeconds.Size = new System.Drawing.Size(41, 20);
-            this.pauseTutorialsSeconds.TabIndex = 1;
+            this.pauseTutorialsSeconds.TabIndex = 2;
             // 
             // tutorialsDemoMode
             // 
             this.tutorialsDemoMode.AutoSize = true;
-            this.tutorialsDemoMode.Location = new System.Drawing.Point(7, 95);
+            this.tutorialsDemoMode.Location = new System.Drawing.Point(7, 72);
             this.tutorialsDemoMode.Margin = new System.Windows.Forms.Padding(4);
             this.tutorialsDemoMode.Name = "tutorialsDemoMode";
             this.tutorialsDemoMode.Size = new System.Drawing.Size(82, 17);
@@ -789,21 +801,21 @@ namespace SkylineTester
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(147, 73);
+            this.label5.Location = new System.Drawing.Point(147, 50);
             this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(47, 13);
-            this.label5.TabIndex = 2;
+            this.label5.TabIndex = 3;
             this.label5.Text = "seconds";
             // 
             // pauseTutorialsDelay
             // 
             this.pauseTutorialsDelay.AutoSize = true;
-            this.pauseTutorialsDelay.Location = new System.Drawing.Point(7, 71);
+            this.pauseTutorialsDelay.Location = new System.Drawing.Point(7, 48);
             this.pauseTutorialsDelay.Margin = new System.Windows.Forms.Padding(4);
             this.pauseTutorialsDelay.Name = "pauseTutorialsDelay";
             this.pauseTutorialsDelay.Size = new System.Drawing.Size(70, 17);
-            this.pauseTutorialsDelay.TabIndex = 0;
+            this.pauseTutorialsDelay.TabIndex = 1;
             this.pauseTutorialsDelay.Text = "Pause for";
             this.pauseTutorialsDelay.UseVisualStyleBackColor = true;
             // 
@@ -815,8 +827,10 @@ namespace SkylineTester
             this.pauseTutorialsScreenShots.Margin = new System.Windows.Forms.Padding(4);
             this.pauseTutorialsScreenShots.Name = "pauseTutorialsScreenShots";
             this.pauseTutorialsScreenShots.Size = new System.Drawing.Size(133, 17);
-            this.pauseTutorialsScreenShots.TabIndex = 3;
+            this.pauseTutorialsScreenShots.TabIndex = 0;
+            this.pauseTutorialsScreenShots.TabStop = true;
             this.pauseTutorialsScreenShots.Text = "Pause for screen shots";
+            this.toolTip1.SetToolTip(this.pauseTutorialsScreenShots, "Interactively pauses the tutorial test at calls to PauseForScreenShot()");
             this.pauseTutorialsScreenShots.UseVisualStyleBackColor = true;
             this.pauseTutorialsScreenShots.CheckedChanged += new System.EventHandler(this.pauseTutorialsScreenShots_CheckedChanged);
             // 
@@ -3079,17 +3093,6 @@ namespace SkylineTester
             this.myTreeView1.Size = new System.Drawing.Size(309, 350);
             this.myTreeView1.TabIndex = 15;
             // 
-            // pauseTutorialsCoverShots
-            // 
-            this.pauseTutorialsCoverShots.AutoSize = true;
-            this.pauseTutorialsCoverShots.Location = new System.Drawing.Point(7, 47);
-            this.pauseTutorialsCoverShots.Margin = new System.Windows.Forms.Padding(4);
-            this.pauseTutorialsCoverShots.Name = "pauseTutorialsCoverShots";
-            this.pauseTutorialsCoverShots.Size = new System.Drawing.Size(128, 17);
-            this.pauseTutorialsCoverShots.TabIndex = 5;
-            this.pauseTutorialsCoverShots.Text = "Pause for cover shots";
-            this.pauseTutorialsCoverShots.UseVisualStyleBackColor = true;
-            // 
             // SkylineTesterWindow
             // 
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
@@ -3418,6 +3421,6 @@ namespace SkylineTester
         private Panel panel4;
         private CheckBox nightlyRunIndefinitely;
         private CheckBox recordAuditLogs;
-        private RadioButton pauseTutorialsCoverShots;
+        private RadioButton modeTutorialsCoverShots;
     }
 }

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -1002,7 +1002,7 @@ namespace SkylineTester
 
                 // Tutorials
                 pauseTutorialsScreenShots,
-                pauseTutorialsCoverShots,
+                modeTutorialsCoverShots,
                 pauseTutorialsDelay,
                 pauseTutorialsSeconds,
                 tutorialsDemoMode,
@@ -1437,7 +1437,7 @@ namespace SkylineTester
         public SplitContainer   OutputSplitContainer        { get { return outputSplitContainer; } }
         public CheckBox         Pass0                       { get { return pass0; } }
         public CheckBox         Pass1                       { get { return pass1; } }
-        public RadioButton      PauseTutorialsCoverShots   { get { return pauseTutorialsCoverShots; } }
+        public RadioButton      ModeTutorialsCoverShots   { get { return modeTutorialsCoverShots; } }
         public RadioButton      PauseTutorialsScreenShots   { get { return pauseTutorialsScreenShots; } }
         public NumericUpDown    PauseTutorialsSeconds       { get { return pauseTutorialsSeconds; } }
         public RadioButton      QualityChooseTests          { get { return qualityChooseTests; } }

--- a/pwiz_tools/Skyline/SkylineTester/TabTutorials.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabTutorials.cs
@@ -48,8 +48,8 @@ namespace SkylineTester
             else
             {
                 int pauseSeconds = -1;
-                if (MainWindow.PauseTutorialsCoverShots.Checked)
-                    pauseSeconds = -2;
+                if (MainWindow.ModeTutorialsCoverShots.Checked)
+                    pauseSeconds = -2; // Magic number that tells TestRunner to grab tutorial cover shot then move on to next test
                 else if (!MainWindow.PauseTutorialsScreenShots.Checked &&
                          !Int32.TryParse(MainWindow.PauseTutorialsSeconds.Text, out pauseSeconds))
                     pauseSeconds = 0;

--- a/pwiz_tools/Skyline/TestFunctional/StartPageTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/StartPageTest.cs
@@ -288,7 +288,7 @@ namespace pwiz.SkylineTestFunctional
         {
             var startPage = WaitForOpenForm<StartPage>();
             var pathChooser = ShowDialog<PathChooserDlg>(()=>startPage
-                .TestTutorialAction(ActionTutorial.TutorialType.absolute_quantifiaction));
+                .TestTutorialAction());
             OkDialog(pathChooser, pathChooser.Dispose);
             RunUI(() => startPage.DoAction(skylineWindow => true));
             WaitForOpenForm<SkylineWindow>();

--- a/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
@@ -41,7 +41,7 @@ namespace TestPerf
         {
             // Set true to look at tutorial screenshots.
             //IsPauseForScreenShots = true;
-            //IsPauseForCoverShot = true;
+            //IsCoverShotMode = true;
             //RunPerfTests = true;
 
             TestFilesZipPaths = new[]
@@ -258,7 +258,7 @@ namespace TestPerf
 
             PauseForScreenShot("Main window with peptide search results", tutorialPage++);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -274,7 +274,7 @@ namespace TestPerf
                 WaitForGraphs();
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SelectedNode.Nodes[0]);
                 RunUI(SkylineWindow.FocusDocument);
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.cs
@@ -165,7 +165,7 @@ namespace TestPerf
                 PolishedProteins = 2465,
             };
 
-            if (!IsPauseForCoverShot)
+            if (!IsCoverShotMode)
                 TestTtofData();
         }
 
@@ -221,7 +221,7 @@ namespace TestPerf
                 UnpolishedProteins = 7,
             };
 
-            if (!IsPauseForCoverShot)
+            if (!IsCoverShotMode)
                 TestQeData();
         }
 
@@ -255,7 +255,7 @@ namespace TestPerf
                 PolishedProteins = 2034,
             };
 
-            if (!IsPauseForCoverShot)
+            if (!IsCoverShotMode)
                 TestQeData();
         }
        
@@ -306,7 +306,7 @@ namespace TestPerf
         {
 //            IsPauseForScreenShots = true;
 //            RunPerfTests = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "DIA-SWATH";
 
             RunFunctionalTest();
@@ -918,7 +918,7 @@ namespace TestPerf
                         }
                     }
                 }
-                if (IsPauseForCoverShot)
+                if (IsCoverShotMode)
                 {
                     RunUI(() =>
                     {
@@ -941,7 +941,7 @@ namespace TestPerf
                         fcFloatingWindow.Left = SkylineWindow.Left + 8;
                         fcFloatingWindow.Top = SkylineWindow.Bottom - fcFloatingWindow.Height - 8;
                     });
-                    PauseForCoverShot();
+                    TakeCoverShot();
                 }
             }
         }

--- a/pwiz_tools/Skyline/TestPerf/DriftTimePredictorTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DriftTimePredictorTutorialTest.cs
@@ -57,7 +57,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't take about 10
         {
 //            IsPauseForScreenShots = true;
 //            RunPerfTests = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "IMSFiltering";
 
             LinkPdf = "https://skyline.ms/_webdav/home/software/Skyline/%40files/tutorials/DriftTraining-3_1_1.pdf";
@@ -214,7 +214,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't take about 10
                 RunUI(() => fullScanGraph.SetZoom(false));
                 PauseForScreenShot("Full scan unzoomed 3D MS/MS graph", 14);
 
-                if (IsPauseForCoverShot)
+                if (IsCoverShotMode)
                 {
                     RunUI(() =>
                     {
@@ -234,7 +234,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't take about 10
 
                     RunUI(SkylineWindow.FocusDocument);
 
-                    PauseForCoverShot();
+                    TakeCoverShot();
                     return;
                 }
 

--- a/pwiz_tools/Skyline/TestPerf/HiResMetabolomicsTutorial.cs
+++ b/pwiz_tools/Skyline/TestPerf/HiResMetabolomicsTutorial.cs
@@ -52,7 +52,7 @@ namespace TestPerf // This would be in TestTutorials if it didn't involve a 2GB 
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "HiResMetabolomics";
 
             LinkPdf = "https://skyline.gs.washington.edu/labkey/_webdav/home/software/Skyline/%40files/tutorials/HiResMetabolomics-20_1.pdf";
@@ -262,7 +262,7 @@ namespace TestPerf // This would be in TestTutorials if it didn't involve a 2GB 
                     RunUI(() => SkylineWindow.ShowDocumentGrid(true));
                     documentGrid = FindOpenForm<DocumentGridForm>();
                 }
-                if (!IsPauseForCoverShot)
+                if (!IsCoverShotMode)
                     RunUI(() => documentGrid.ChooseView(Resources.Resources_ReportSpecList_GetDefaults_Peptide_Quantification));
                 else
                 {
@@ -271,7 +271,7 @@ namespace TestPerf // This would be in TestTutorials if it didn't involve a 2GB 
                 }
                 PauseForScreenShot<SkylineWindow>("Skyline window multi-replicate layout", 13);
 
-                if (IsPauseForCoverShot)
+                if (IsCoverShotMode)
                 {
                     RunUI(() =>
                     {
@@ -296,7 +296,7 @@ namespace TestPerf // This would be in TestTutorials if it didn't involve a 2GB 
                     RunUI(() => SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SelectedNode.NextNode);
                     WaitForGraphs();
 
-                    PauseForCoverShot();
+                    TakeCoverShot();
                     return;
                 }
 

--- a/pwiz_tools/Skyline/TestTutorial/AbsoluteQuantTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AbsoluteQuantTutorialTest.cs
@@ -50,7 +50,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "AbsoluteQuant";
 
             ForceMzml = true;   // Mzml is ~8x faster for this test.
@@ -321,7 +321,7 @@ namespace pwiz.SkylineTestTutorial
             // View the calibration curve p. 18
             RunUI(() => SkylineWindow.ShowDocumentGrid(false));
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -340,7 +340,7 @@ namespace pwiz.SkylineTestTutorial
                     calibrationFloatingWindow.Left = SkylineWindow.Left + 15;
 
                 });
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
@@ -74,7 +74,7 @@ namespace pwiz.SkylineTestTutorial
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
 //            PauseStartPage = 16;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "AuditLog";
 
             ForceMzml = true;   // Mzml is ~8x faster for this test.
@@ -404,7 +404,7 @@ namespace pwiz.SkylineTestTutorial
                 floatingWindow.Width -= 15;
             });
             PauseForScreenShot<AuditLogForm>("Audit Log with UndoRedo view.", 17);
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -427,7 +427,7 @@ namespace pwiz.SkylineTestTutorial
                     SkylineWindow.AuditLogForm.DataGridView.AutoResizeColumn(reasonIndex);
                     SkylineWindow.AuditLogForm.DataGridView.AutoResizeColumn(reasonIndex - 1);
                 });
-                PauseForCoverShot();
+                TakeCoverShot();
             }
 
             var customizeDialog = ShowDialog<ViewEditor>(SkylineWindow.AuditLogForm.NavBar.CustomizeView);

--- a/pwiz_tools/Skyline/TestTutorial/CEOptimizationTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/CEOptimizationTutorialTest.cs
@@ -68,7 +68,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "OptimizeCE";
 
             ForceMzml = true;   // Mzml is ~2x faster for this test.
@@ -227,7 +227,7 @@ namespace pwiz.SkylineTestTutorial
 
             PauseForScreenShot("Main Skyline window", 8);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -241,7 +241,7 @@ namespace pwiz.SkylineTestTutorial
 
                 RunUI(SkylineWindow.FocusDocument);
 
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
@@ -56,7 +56,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "CustomReports";
 
             LinkPdf = "https://skyline.gs.washington.edu/labkey/_webdav/home/software/Skyline/%40files/tutorials/CustomReports-2_5.pdf";
@@ -396,7 +396,7 @@ namespace pwiz.SkylineTestTutorial
 
             PauseForScreenShot<DocumentGridForm>("Document Grid with summary statistics", 20);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RestoreCoverViewOnScreen();
                 var documentGridFormCover = WaitForOpenForm<DocumentGridForm>();
@@ -419,7 +419,7 @@ namespace pwiz.SkylineTestTutorial
                         Assert.IsTrue(viewEditorCover.ChooseColumnsTab.TrySelect(id), "Unable to select {0}", id);
                     }
                 });
-                PauseForCoverShot();
+                TakeCoverShot();
 
                 OkDialog(viewEditorCover, viewEditorCover.CancelButton.PerformClick);
                 return false;

--- a/pwiz_tools/Skyline/TestTutorial/DiaTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/DiaTutorialTest.cs
@@ -57,14 +57,14 @@ namespace pwiz.SkylineTestTutorial
         /// to regenerate checkpoint files for non-full-import mode,
         /// when something changes in the test.
         /// </summary>
-        private bool IsFullImportMode { get { return IsPauseForCoverShot || IsPauseForScreenShots; } }
+        private bool IsFullImportMode { get { return IsCoverShotMode || IsPauseForScreenShots; } }
 
         [TestMethod]
         public void TestDiaTutorial()
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "DIA";
 
             LinkPdf = "https://skyline.gs.washington.edu/tutorials/DIA-2_6.pdf";
@@ -389,7 +389,7 @@ namespace pwiz.SkylineTestTutorial
 
             PauseForScreenShot<GraphChromatogram>("Chromatogram graph metafile - split between two precursors", 35);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -428,7 +428,7 @@ namespace pwiz.SkylineTestTutorial
                     isolationSchemeGraph.Left = SkylineWindow.Left;
                     isolationSchemeGraph.Width = 480;
                 });
-                PauseForCoverShot();
+                TakeCoverShot();
                 OkDialog(isolationSchemeGraph, isolationSchemeGraph.CloseButton);
                 OkDialog(isolationSchemeForm, isolationSchemeForm.OkDialog);
                 OkDialog(transitionSettingsUI, transitionSettingsUI.OkDialog);

--- a/pwiz_tools/Skyline/TestTutorial/ExistingExperimentsTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/ExistingExperimentsTutorialTest.cs
@@ -54,7 +54,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
 //            IsPauseForAuditLog = true;
             CoverShotName = "ExistingQuant";
 
@@ -101,7 +101,7 @@ namespace pwiz.SkylineTestTutorial
 
         protected override void DoTest()
         {
-            if (!IsPauseForCoverShot)
+            if (!IsCoverShotMode)
                 DoMrmerTest();
             DoStudy7Test();
         }
@@ -299,7 +299,7 @@ namespace pwiz.SkylineTestTutorial
             // Preparing a Document to Accept the Study 7 Transition List, p. 18
             RunUI(() => SkylineWindow.NewDocument());
             var peptideSettingsUI1 = ShowDialog<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI);
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 var modHeavyK = new StaticMod(HEAVY_K, "K", ModTerminus.C, false, null, LabelAtoms.C13 | LabelAtoms.N15, // Not L10N
                     RelativeRT.Matching, null, null, null);
@@ -593,7 +593,7 @@ namespace pwiz.SkylineTestTutorial
             RunUI(SkylineWindow.ShowPeakAreaReplicateComparison);
             PauseForScreenShot<GraphSummary.AreaGraphView>("Peak Areas normalized to heave graph metafile", 39);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -607,7 +607,7 @@ namespace pwiz.SkylineTestTutorial
                 WaitForGraphs();
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SelectedNode.Nodes[0]);
                 RunUI(SkylineWindow.FocusDocument);
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
@@ -61,7 +61,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "GroupedStudies";
 
             ForceMzml = true;   // Mzml is faster for this test.
@@ -1374,13 +1374,13 @@ namespace pwiz.SkylineTestTutorial
                 foldChangeGrid.ShowGraph();
             });
             PauseForScreenShot<FoldChangeBarGraph>("Healthy v Diseased:Graph", 66);
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RestoreCoverViewOnScreen();
                 foldChangeGrid = WaitForOpenForm<FoldChangeGrid>();
             }
             var foldChangeGraph = WaitForOpenForm<FoldChangeBarGraph>();
-            if (!IsPauseForCoverShot)
+            if (!IsCoverShotMode)
                 RunUI(() => foldChangeGraph.Show(foldChangeGraph.DockPanel, DockState.Floating));
             RunUI(() =>
             {
@@ -1411,7 +1411,7 @@ namespace pwiz.SkylineTestTutorial
             RunUI(() => Assert.AreEqual(11, foldChangeGrid.DataboundGridControl.RowCount));
             PauseForScreenShot<FoldChangeBarGraph>("Right click on the graph and choose Copy", 67);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -1437,7 +1437,7 @@ namespace pwiz.SkylineTestTutorial
                     gcFloatingWindow.Height = SkylineWindow.Height - 10;
                     gcFloatingWindow.Left = SkylineWindow.Right - gcFloatingWindow.Width - 5;
                 });
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
@@ -51,7 +51,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "iRT";
 
             ForceMzml = true;   // 2-3x faster than raw files for this test.
@@ -570,7 +570,7 @@ namespace pwiz.SkylineTestTutorial
 
             PauseForScreenShot<GraphSummary.RTGraphView>("RT Regression graph metafile", 25);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -599,7 +599,7 @@ namespace pwiz.SkylineTestTutorial
                     irtEditor.Top = SkylineWindow.Bottom - irtEditor.Height - SkylineWindow.StatusBarHeight - 5;
                     irtEditor.Left = SkylineWindow.Right - irtEditor.Width - 5;
                 });
-                PauseForCoverShot();
+                TakeCoverShot();
                 OkDialog(irtEditor, irtEditor.CancelDialog);
                 OkDialog(peptideSettingsUI, peptideSettingsUI.CancelDialog);
                 return;

--- a/pwiz_tools/Skyline/TestTutorial/LibraryExplorerTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/LibraryExplorerTutorialTest.cs
@@ -44,7 +44,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "LibraryExplorer";
 
             LinkPdf = "https://skyline.gs.washington.edu/labkey/_webdav/home/software/Skyline/%40files/tutorials/LibraryExplorer-1_4.pdf";
@@ -167,14 +167,14 @@ namespace pwiz.SkylineTestTutorial
                 SkylineWindow.Document.Settings.PeptideSettings.Modifications.AllHeavyModifications.Any()));
             PauseForScreenShot("Peptide list clipped from Library Explorer", 11);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RestoreCoverViewOnScreen(false);
                 RunUI(() =>
                 {
                     viewLibraryDlg.SetBounds(SkylineWindow.Left, SkylineWindow.Top, SkylineWindow.Width, SkylineWindow.Height);
                 });
-                PauseForCoverShot();
+                TakeCoverShot();
 
                 OkDialog(viewLibraryDlg, viewLibraryDlg.CancelDialog);
                 return;

--- a/pwiz_tools/Skyline/TestTutorial/MethodEditTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/MethodEditTutorialTest.cs
@@ -58,7 +58,7 @@ namespace pwiz.SkylineTestTutorial
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
 //            IsPauseForAuditLog = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "MethodEdit";
 
             LinkPdf = "https://skyline.gs.washington.edu/labkey/_webdav/home/software/Skyline/%40files/tutorials/MethodEdit-3_7.pdf";
@@ -207,7 +207,7 @@ namespace pwiz.SkylineTestTutorial
             }
             PauseForScreenShot("Targets tree clipped from main window", 11); // Not L10N
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -219,7 +219,7 @@ namespace pwiz.SkylineTestTutorial
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SelectedNode.PrevNode);
                 WaitForGraphs();
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SelectedNode.NextNode);
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestTutorial/MethodRefinementTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/MethodRefinementTutorialTest.cs
@@ -52,7 +52,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "MethodRefine";
 
             // Multi-file import has problems with mzML on this test
@@ -171,7 +171,7 @@ namespace pwiz.SkylineTestTutorial
             RestoreViewOnScreen(8);
             PauseForScreenShot("Chromatogram graph metafile", 8);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RestoreCoverViewOnScreen();
                 RunUI(SkylineWindow.AutoZoomBestPeak);
@@ -179,7 +179,7 @@ namespace pwiz.SkylineTestTutorial
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SelectedNode.PrevNode);
                 WaitForGraphs();
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SelectedNode.NextNode);
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
@@ -59,7 +59,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
 //            PauseStartPage = 30;
             CoverShotName = "MS1Filtering";
 
@@ -456,7 +456,7 @@ namespace pwiz.SkylineTestTutorial
             PauseForScreenShot("Status bar clipped from main window - 4/51 pep 4/52 prec 10/156 tran", 23);
 
             const string TIP_NAME = "5b_MCF7_TiTip3";
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RestoreCoverViewOnScreen();
                 ClickChromatogram(TIP_NAME, 34.5, 366);
@@ -465,7 +465,7 @@ namespace pwiz.SkylineTestTutorial
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SequenceTree.Nodes[0]);
                 WaitForGraphs();
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = selectedNode);
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
@@ -64,7 +64,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "PeakPicking";
 
             ForceMzml = false;  // Mzml isn't faster for this test.
@@ -253,7 +253,7 @@ namespace pwiz.SkylineTestTutorial
                     RemovePeptide(missingPeptides[i], isDecoys[i]);
             }
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RestoreCoverViewOnScreen();
                 var reintegrateDlgCover = ShowDialog<ReintegrateDlg>(SkylineWindow.ShowReintegrateDialog);
@@ -265,7 +265,7 @@ namespace pwiz.SkylineTestTutorial
                     editModelCover.PeakScoringModelName = "SRMCourse";
                     editModelCover.TrainModelClick();
                 });
-                PauseForCoverShot();
+                TakeCoverShot();
 
                 OkDialog(editModelCover, editModelCover.CancelDialog);
                 OkDialog(reintegrateDlgCover, reintegrateDlgCover.CancelDialog);

--- a/pwiz_tools/Skyline/TestTutorial/SmallMolMethodDevCEOptTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/SmallMolMethodDevCEOptTutorial.cs
@@ -54,8 +54,8 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
+//            IsCoverShotMode = true;
             CoverShotName = "SmallMoleculeMethodDevCEOpt";
 
             ForceMzml = true; // Prefer mzML as being the more efficient download
@@ -468,7 +468,7 @@ namespace pwiz.SkylineTestTutorial
                 SelectNode(SrmDocument.Level.Molecules, 6);
                 PauseForScreenShot<SkylineWindow>("Pentose-P", 35);
 
-                if (IsPauseForCoverShot)
+                if (IsCoverShotMode)
                 {
                     RunUI(() =>
                     {
@@ -479,7 +479,7 @@ namespace pwiz.SkylineTestTutorial
                     });
 
                     RestoreCoverViewOnScreen();
-                    PauseForCoverShot();
+                    TakeCoverShot();
                     return;
                 }
 

--- a/pwiz_tools/Skyline/TestTutorial/SmallMoleculesQuantificationTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/SmallMoleculesQuantificationTutorial.cs
@@ -61,7 +61,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "SmallMoleculeQuantification";
 
             LinkPdf = "https://skyline.gs.washington.edu/labkey/_webdav/home/software/Skyline/%40files/tutorials/SmallMoleculeQuantification.pdf";
@@ -367,7 +367,7 @@ namespace pwiz.SkylineTestTutorial
                 SetDocumentGridExcludeFromCalibration();
                 PauseForScreenShot<CalibrationForm>("Calibration Curve - outliers disabled", 20);
 
-                if (IsPauseForCoverShot)
+                if (IsCoverShotMode)
                 {
                     RunUI(() =>
                     {
@@ -388,7 +388,7 @@ namespace pwiz.SkylineTestTutorial
                     });
 
                     RunUI(SkylineWindow.FocusDocument);
-                    PauseForCoverShot();
+                    TakeCoverShot();
                     return;
                 }
 

--- a/pwiz_tools/Skyline/TestTutorial/SmallMoleculesTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/SmallMoleculesTutorial.cs
@@ -56,7 +56,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "SmallMolecule";
 
             LinkPdf = "https://skyline.gs.washington.edu/labkey/_webdav/home/software/Skyline/%40files/tutorials/SmallMolecule-3_6.pdf";
@@ -218,7 +218,7 @@ namespace pwiz.SkylineTestTutorial
                 RestoreViewOnScreen(9);
                 PauseForScreenShot<SkylineWindow>("Skyline window multi-replicate layout", 9);
 
-                if (IsPauseForCoverShot)
+                if (IsCoverShotMode)
                 {
                     RunUI(() =>
                     {
@@ -242,7 +242,7 @@ namespace pwiz.SkylineTestTutorial
                         columnsOrdered.Remove(SmallMoleculeTransitionListColumnHeaders.labelType);
                         pasteCoverDlg.SetSmallMoleculeColumns(columnsOrdered);
                     });
-                    PauseForCoverShot();
+                    TakeCoverShot();
 
                     OkDialog(pasteCoverDlg, pasteCoverDlg.CancelDialog);
                 }

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -81,7 +81,7 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
-//            IsPauseForCoverShot = true;
+//            IsCoverShotMode = true;
             CoverShotName = "TargetedMSMS";
 
             if (smallMoleculesTestMode != RefinementSettings.ConvertToSmallMoleculesMode.none && !RunSmallMoleculeTestVersions)
@@ -118,7 +118,7 @@ namespace pwiz.SkylineTestTutorial
         protected override void DoTest()
         {
             LowResTest();
-            if (!IsPauseForCoverShot)
+            if (!IsCoverShotMode)
                 TofTest();
         }
 
@@ -524,7 +524,7 @@ namespace pwiz.SkylineTestTutorial
             RunUI(() =>
                 {
                     SkylineWindow.ShowAllTransitions();
-                    if (!IsPauseForCoverShot)
+                    if (!IsCoverShotMode)
                         SkylineWindow.ShowSplitChromatogramGraph(true);                    
                 });
 
@@ -538,7 +538,7 @@ namespace pwiz.SkylineTestTutorial
             WaitForGraphs();
             PauseForScreenShot<GraphSummary.AreaGraphView>("Peak Areas Replicate Comparison graph metafile with split graphs", 24);
 
-            if (IsPauseForCoverShot)
+            if (IsCoverShotMode)
             {
                 RunUI(() =>
                 {
@@ -555,7 +555,7 @@ namespace pwiz.SkylineTestTutorial
                 WaitForGraphs();
                 RunUI(() => SkylineWindow.SequenceTree.SelectedNode = selectedNode);
                 RunUI(() => selectedNode.Nodes[0].Expand());
-                PauseForCoverShot();
+                TakeCoverShot();
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1169,7 +1169,7 @@ namespace pwiz.SkylineTestUtil
             }
             else if (coverSavePath2 != null)
             {
-                Console.WriteLine(@"Cover shot at 1200 x 800 has been saved as " + coverSavePath + @" and as " + coverSavePath2);
+                Console.WriteLine(@"Cover shot at 1200 x 800 has been saved as " + coverSavePath + @" and as Start Page thumbnail " + coverSavePath2);
             }
             else
             {
@@ -1818,7 +1818,7 @@ namespace pwiz.SkylineTestUtil
                 var screenRect = Screen.FromControl(SkylineWindow).Bounds;
                 AssertEx.IsTrue(screenRect.Width >=  width + marginW && screenRect.Height >= height + marginH,  // SetSkylineWindowSize adds margins, make sure that's going to fit
                     @"Screen is too small for requested Skyline window size");
-                var skylineSize = new Size(width,  height);
+                var skylineSize = new Size(width + marginW,  height + marginH);
                 var skylineLocation = new Point(screenRect.Left + screenRect.Width / 2 - skylineSize.Width / 2,
                     screenRect.Top + screenRect.Height / 2 - skylineSize.Height / 2);
                 SkylineWindow.Bounds = new Rectangle(skylineLocation, skylineSize);

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1154,6 +1154,12 @@ namespace pwiz.SkylineTestUtil
         public void TakeCoverShot()
         {
             Thread.Sleep(1000); // Give windows time to repaint
+            RunUI(() =>
+            {
+                var screenRect = Screen.FromControl(SkylineWindow).Bounds;
+                AssertEx.IsTrue(screenRect.Width == 1920 && screenRect.Height == 1080,
+                    "Cover shots must be taken at screen resolution 1920x1080 at scale factor 100% (96DPI)");
+            });
             var coverSavePath = GetCoverShotPath();
             ScreenshotManager.TakeNextShot(SkylineWindow, coverSavePath, ProcessCoverShot);
             string coverSavePath2 = null;

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -115,7 +115,7 @@ namespace pwiz.SkylineTestUtil
         protected bool ForceMzml
         {
             get { return _forceMzml; }
-            set { _forceMzml = value && !IsPauseForScreenShots && !IsPauseForCoverShot;  }    // Don't force mzML during screenshots
+            set { _forceMzml = value && !IsPauseForScreenShots && !IsCoverShotMode;  }    // Don't force mzML during screenshots
         }
 
         protected static bool LaunchDebuggerOnWaitForConditionTimeout { get; set; } // Use with caution - this will prevent scheduled tests from completing, so we can investigate a problem
@@ -1008,31 +1008,29 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
-        private static bool _isPauseForCoverShot;
+        private static bool _isCoverShotMode;
 
-        public bool IsPauseForCoverShot
+        public bool IsCoverShotMode
         {
-            get { return _isPauseForCoverShot || Program.PauseSeconds == -2; }
+            get { return _isCoverShotMode || Program.PauseSeconds == -2; } // -2 is the magic number SkylineTester uses to indicate cover shot mode
             set
             {
-                _isPauseForCoverShot = value;
-                if (_isPauseForCoverShot)
+                _isCoverShotMode = value;
+                if (_isCoverShotMode)
                 {
-                    Program.PauseSeconds = -2;
+                    Program.PauseSeconds = -2; // -2 is the magic number SkylineTester uses to indicate cover shot mode
                 }
             }
         }
 
-        public bool IsSavingCoverShots
-        {
-            get { return /* CoverShotName != null*/ false; }
-        }
         public string CoverShotName { get; set; }
 
         private string GetCoverShotPath(string folderPath = null, string suffix = null)
         {
-            if (!IsSavingCoverShots)
+            if (CoverShotName == null)
+            {
                 return null;
+            }
 
             if (folderPath == null)
                 folderPath = Path.Combine(PathEx.GetDownloadsPath(), "covershots");
@@ -1076,7 +1074,7 @@ namespace pwiz.SkylineTestUtil
 
         public static bool IsPass0 { get { return Program.IsPassZero; } }
 
-        public bool IsFullData { get { return IsPauseForScreenShots || IsPauseForCoverShot || IsDemoMode || IsPass0; } }
+        public bool IsFullData { get { return IsPauseForScreenShots || IsCoverShotMode || IsDemoMode || IsPass0; } }
 
         public static bool IsCheckLiveReportsCompatibility { get; set; }
 
@@ -1153,19 +1151,30 @@ namespace pwiz.SkylineTestUtil
             // Override to modify the cover shot before it is saved or put on the clipboard
         }
 
-        public void PauseForCoverShot()
+        public void TakeCoverShot()
         {
             Thread.Sleep(1000); // Give windows time to repaint
             var coverSavePath = GetCoverShotPath();
             ScreenshotManager.TakeNextShot(SkylineWindow, coverSavePath, ProcessCoverShot);
+            string coverSavePath2 = null;
             if (coverSavePath != null)
             {
                 // Screenshot for the StartPage
-                coverSavePath = GetCoverShotPath(TestContext.GetProjectDirectory(@"Resources\StartPage"), "_start");
-                ScreenshotManager.TakeNextShot(SkylineWindow, coverSavePath, ProcessCoverShot, 0.20);
+                coverSavePath2 = GetCoverShotPath(TestContext.GetProjectDirectory(@"Resources\StartPage"), "_start");
+                ScreenshotManager.TakeNextShot(SkylineWindow, coverSavePath2, ProcessCoverShot, 0.20);
             }
             if (coverSavePath == null)
+            {
                 PauseTest("Cover shot at 1200 x 800");
+            }
+            else if (coverSavePath2 != null)
+            {
+                Console.WriteLine(@"Cover shot at 1200 x 800 has been saved as " + coverSavePath + @" and as " + coverSavePath2);
+            }
+            else
+            {
+                Console.WriteLine(@"Cover shot at 1200 x 800 has been saved as " + coverSavePath);
+            }
         }
 
         public void PauseForAuditLog()
@@ -1603,7 +1612,7 @@ namespace pwiz.SkylineTestUtil
                 {
                     SkylineWindow.UseKeysOverride = true;
                     SkylineWindow.AssumeNonNullModificationAuditLogging = true;
-                    if (IsPauseForScreenShots || IsPauseForCoverShot)
+                    if (IsPauseForScreenShots || IsCoverShotMode)
                     {
                         // Screenshots should be taken with release icon and "Skyline" in the window title
                         SkylineWindow.Icon = Resources.Skyline_Release1;
@@ -1789,11 +1798,27 @@ namespace pwiz.SkylineTestUtil
             if (hasSavedView)
                 RestoreViewNameOnScreen("cover");
             // Make sure Skyline is the standard size for a cover shot - Window size and screen shot size differ
-            // And center it in the screen to have the best chance of not needing to move it before Alt-PtrSc
+            SetSkylineWindowSize(1200, 800);
+        }
+
+        // Make the Skyline window as large as possible, without actually putting it into
+        // Maximized state which prevents further resizing
+        const int marginW = 14;
+        const int marginH = 7;
+        public void MaximizeSkylineWindow()
+        {
+            SetSkylineWindowSize(int.MaxValue - marginW, int.MaxValue - marginH);
+        }
+
+        // Set the Skyline window size, and center it in the screen to have the best chance of not needing to move it before Alt-PtrSc
+        public void SetSkylineWindowSize(int width, int height)
+        {
             RunUI(() =>
             {
-                var skylineSize = new Size(1200 + 14, 800 + 7);
                 var screenRect = Screen.FromControl(SkylineWindow).Bounds;
+                AssertEx.IsTrue(screenRect.Width >=  width + marginW && screenRect.Height >= height + marginH,  // SetSkylineWindowSize adds margins, make sure that's going to fit
+                    @"Screen is too small for requested Skyline window size");
+                var skylineSize = new Size(width,  height);
                 var skylineLocation = new Point(screenRect.Left + screenRect.Width / 2 - skylineSize.Width / 2,
                     screenRect.Top + screenRect.Height / 2 - skylineSize.Height / 2);
                 SkylineWindow.Bounds = new Rectangle(skylineLocation, skylineSize);


### PR DESCRIPTION
Skyline: some improvements around tutorials:

- Start Page tutorials: if the tutorial doesn't begin by opening a Skyline document, set the various Skyline directory search defaults to the the tutorial download directory.
- SkylineTester UI more accurately reflects how we gather tutorial covershots (there is no pause, just grab and move on). Not anything users ever see, but less confusing for developers.
- Removed some dead code from start page tutorial handling