### PR TITLE
Make it so that the "Refine > Permute Isotope Modification" dialog ad…

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/RowSources/PropertyChangeSupport.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/RowSources/PropertyChangeSupport.cs
@@ -21,11 +21,13 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using pwiz.Common.Collections;
 
 namespace pwiz.Common.DataBinding.RowSources
 {
+    [SuppressMessage("ReSharper", "UnusedType.Global")]
     public class PropertyChangedSupport : INotifyPropertyChanged
     {
         private readonly object _sender;

--- a/pwiz_tools/Skyline/TestFunctional/ModificationPermuterTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ModificationPermuterTest.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Collections;
+using pwiz.Skyline.Controls;
 using pwiz.Skyline.EditUI;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Properties;
@@ -49,6 +50,20 @@ namespace pwiz.SkylineTestFunctional
                 pasteDlg.OkDialog();
             });
             Assert.AreEqual(4, SkylineWindow.Document.PeptideCount);
+
+            // Turn off "Auto manage children" on the second peptide and make sure the appropriate precursors still get added.
+            RunUI(()=>
+            {
+                SkylineWindow.SelectedPath = SkylineWindow.Document.GetPathTo((int) SrmDocument.Level.Molecules, 1);
+            });
+            RunDlg<PopupPickList>(SkylineWindow.ShowPickChildrenInTest, dlg =>
+            {
+                dlg.AutoManageChildren = false;
+                dlg.OnOk();
+            });
+            CollectionAssert.AreEqual(new[] {true, false, true, true},
+                SkylineWindow.Document.Peptides.Select(p => p.AutoManageChildren).ToList());
+
             var permuteIsotopeModificationsDlg =
                 ShowDialog<PermuteIsotopeModificationsDlg>(SkylineWindow.ShowPermuteIsotopeModificationsDlg);
             RunDlg<EditStaticModDlg>(permuteIsotopeModificationsDlg.AddIsotopeModification, editStaticModDlg =>
@@ -141,6 +156,9 @@ namespace pwiz.SkylineTestFunctional
                 }
                 Assert.AreEqual(Math.Pow(2, leucineCount) - 1, modificationIndexSets.Count);
             }
+
+            CollectionAssert.AreEqual(new[] {true, false, true, true},
+                SkylineWindow.Document.Peptides.Select(p => p.AutoManageChildren).ToList());
         }
     }
 }


### PR DESCRIPTION
…ds the correct precursors, even if "Peptide.Auto Manage Precursors" is false.

This prevents the user from having to go to Refine > Advanced > Auto Select All Precursors in order to get the desired results.
(Reported by Natan).