### PR TITLE
Skyline: fix some issues with background loading of ion mobility libraries (.imsdb files)...

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
@@ -1745,7 +1745,7 @@ namespace pwiz.Skyline.Model.DocSettings
                 // cancel
                 return null;
             }
-            if (ionMobilityLibSpec.FilePath == ionMobilityLibrary.FilePath && ionMobilityLibSpec.IsUsable)
+            if (ionMobilityLibSpec.FilePath == ionMobilityLibrary.FilePath && ionMobilityLibrary.IsUsable)
             {
                 return this;
             }

--- a/pwiz_tools/Skyline/Model/IonMobility/IonMobilityDb.cs
+++ b/pwiz_tools/Skyline/Model/IonMobility/IonMobilityDb.cs
@@ -29,7 +29,6 @@ using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
-using pwiz.Skyline.Util.Extensions;
 
 namespace pwiz.Skyline.Model.IonMobility
 {
@@ -65,12 +64,6 @@ namespace pwiz.Skyline.Model.IonMobility
     public class IonMobilityDb : Immutable, IValidating, IDisposable
     {
         public const string EXT = ".imsdb";
-
-        public static string FILTER_IONMOBILITYLIBRARY
-        {
-            get { return TextUtil.FileDialogFilter(Resources.IonMobilityDb_FILTER_IONMOBILITYLIBRARY_Ion_Mobility_Library_Files, EXT); }
-        }
-
 
         private readonly string _path;
         private readonly ISessionFactory _sessionFactory;

--- a/pwiz_tools/Skyline/Model/IonMobility/IonMobilityLibraryManager.cs
+++ b/pwiz_tools/Skyline/Model/IonMobility/IonMobilityLibraryManager.cs
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 using System.Collections.Generic;
+using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.Extensions;
 using pwiz.Skyline.Util;
 
@@ -124,9 +125,11 @@ namespace pwiz.Skyline.Model.IonMobility
         private static IonMobilityLibrary GetIonMobilityLibrary(SrmDocument document)
         {
             if (document == null)
-                return null;
-            var ionMobilityFiltering = document.Settings.TransitionSettings.IonMobilityFiltering;
-            return ionMobilityFiltering?.IonMobilityLibrary;
+            {
+                return IonMobilityLibrary.NONE;
+            }
+            var ionMobilityFiltering = document.Settings.TransitionSettings.IonMobilityFiltering ?? TransitionIonMobilityFiltering.EMPTY;
+            return ionMobilityFiltering.IonMobilityLibrary;
         }
 
     }

--- a/pwiz_tools/Skyline/Model/IonMobility/IonMobilityLibraryManager.cs
+++ b/pwiz_tools/Skyline/Model/IonMobility/IonMobilityLibraryManager.cs
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 using System.Collections.Generic;
-using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.Extensions;
 using pwiz.Skyline.Util;
 
@@ -124,12 +123,8 @@ namespace pwiz.Skyline.Model.IonMobility
 
         private static IonMobilityLibrary GetIonMobilityLibrary(SrmDocument document)
         {
-            if (document == null)
-            {
-                return IonMobilityLibrary.NONE;
-            }
-            var ionMobilityFiltering = document.Settings.TransitionSettings.IonMobilityFiltering ?? TransitionIonMobilityFiltering.EMPTY;
-            return ionMobilityFiltering.IonMobilityLibrary;
+            return document?.Settings?.TransitionSettings?.IonMobilityFiltering?.IonMobilityLibrary
+                   ?? IonMobilityLibrary.NONE;
         }
 
     }

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
@@ -42,7 +42,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
 {
     public partial class EditIonMobilityLibraryDlg : FormEx
     {
-        private readonly IEnumerable<IonMobilityLibrary> _existingLibs;
+        private readonly IEnumerable<IonMobilityLibrarySpec> _existingLibs;
 
         public IonMobilityLibrary IonMobilityLibrary { get; private set; }
 
@@ -61,7 +61,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
         public const int COLUMN_HIGH_ENERGY_OFFSET = 5;
 
 
-        public EditIonMobilityLibraryDlg(IonMobilityLibrary library, IEnumerable<IonMobilityLibrary> existingLibs)
+        public EditIonMobilityLibraryDlg(IonMobilityLibrarySpec library, IEnumerable<IonMobilityLibrarySpec> existingLibs)
         {
             _existingLibs = existingLibs;
 
@@ -169,7 +169,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
                 InitialDirectory = Settings.Default.ActiveDirectory,
                 OverwritePrompt = true,
                 DefaultExt = IonMobilityDb.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(IonMobilityDb.FILTER_IONMOBILITYLIBRARY) 
+                Filter = TextUtil.FileDialogFiltersAll(IonMobilityLibrarySpec.FILTER_IONMOBILITYLIBRARY) 
             })
             {
                 if (dlg.ShowDialog(this) == DialogResult.OK)
@@ -246,7 +246,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
                 Title = Resources.EditIonMobilityLibraryDlg_btnBrowseDb_Click_Open_Ion_Mobility_Library,
                 InitialDirectory = Settings.Default.ActiveDirectory,
                 DefaultExt = IonMobilityDb.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(IonMobilityDb.FILTER_IONMOBILITYLIBRARY)
+                Filter = TextUtil.FileDialogFiltersAll(IonMobilityLibrarySpec.FILTER_IONMOBILITYLIBRARY)
             })
             {
                 if (dlg.ShowDialog(this) == DialogResult.OK)

--- a/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
@@ -771,8 +771,18 @@ namespace pwiz.SkylineTestFunctional
                 transitionSettingsDlg.OkDialog();
             });
             WaitForClosedForm(transitionSettingsDlg);
-            doc = WaitForDocumentChange(doc);
-            
+            WaitForDocumentChange(doc);
+
+            // Now close the document, then reopen to verify imsdb background loader operation
+            var docName = TestContext.GetTestPath("reloaded.sky");
+            RunUI(() =>
+            {
+                SkylineWindow.SaveDocument(docName);
+                SkylineWindow.NewDocument();
+                SkylineWindow.OpenFile(docName);
+            });
+            doc = WaitForDocumentLoaded();
+
             var result = doc.Settings.TransitionSettings.IonMobilityFiltering.IonMobilityLibrary;
             AssertEx.AreEqual(2, result.Count);
             var key3 = new LibKey("GLAGVENVTELKK", Adduct.TRIPLY_PROTONATED);


### PR DESCRIPTION
…, including potential timing issues that could prevent a full loading of the dB or spurious complaints from audit logger about unlogged document changes. The root problem was the original implementation not following the library/librarySpec pattern.  TestIonMobility() was modified to demonstrate the issue and verify the fix.

Not reported by any user: problem discovered while working on FAIMS improvements.