### PR TITLE
Move "fragmentIons not in combo box" message out of resx

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
@@ -171,7 +171,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         public void SetFragmentIons(string fragmentIons)
         {
             int i = cbFragmentIons.Items.IndexOf(fragmentIons);
-            Assume.IsTrue(i >= 0, Resources.DdaSearch_SearchSettingsControl_Fragmentions_not_found_in_combobox); 
+            Assume.IsTrue(i >= 0, $@"fragmentIons value ""{fragmentIons}"" not found in ComboBox items");
             cbFragmentIons.SelectedIndex = i;
             ImportPeptideSearch.SearchEngine.SetFragmentIons(fragmentIons);
         }

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -8102,15 +8102,6 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to fragmentIons value not found in ComboBox items.
-        /// </summary>
-        public static string DdaSearch_SearchSettingsControl_Fragmentions_not_found_in_combobox {
-            get {
-                return ResourceManager.GetString("DdaSearch_SearchSettingsControl_Fragmentions_not_found_in_combobox", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to MS1 Tolerance incorrect.
         /// </summary>
         public static string DdaSearch_SearchSettingsControl_MS1_Tolerance_incorrect {

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -10975,9 +10975,6 @@ Invalid peptide sequence at position 18
   <data name="DdaSearch_MSAmandaSearchWrapper_unimod_file__0__not_found" xml:space="preserve">
     <value>Unimodファイル{0}が見つかりません</value>
   </data>
-  <data name="DdaSearch_SearchSettingsControl_Fragmentions_not_found_in_combobox" xml:space="preserve">
-    <value>ComboBox項目に断片化値が見つかりません</value>
-  </data>
   <data name="DdaSearch_SearchSettingsControl_Fragment_ions_must_be_selected" xml:space="preserve">
     <value>断片イオンを選択する必要があります</value>
   </data>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -10988,9 +10988,6 @@ Invalid peptide sequence at position 18
   <data name="DdaSearch_MSAmandaSearchWrapper_unimod_file__0__not_found" xml:space="preserve">
     <value>Unimod file {0} not found</value>
   </data>
-  <data name="DdaSearch_SearchSettingsControl_Fragmentions_not_found_in_combobox" xml:space="preserve">
-    <value>fragmentIons value not found in ComboBox items</value>
-  </data>
   <data name="DdaSearch_SearchSettingsControl_Fragment_ions_must_be_selected" xml:space="preserve">
     <value>Fragment ions must be selected</value>
   </data>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -10985,9 +10985,6 @@ Invalid peptide sequence at position 18
   <data name="DdaSearch_MSAmandaSearchWrapper_unimod_file__0__not_found" xml:space="preserve">
     <value>找不到 Unimod 文件 {0}</value>
   </data>
-  <data name="DdaSearch_SearchSettingsControl_Fragmentions_not_found_in_combobox" xml:space="preserve">
-    <value>在组合框项目中找不到碎片离子值</value>
-  </data>
   <data name="DdaSearch_SearchSettingsControl_Fragment_ions_must_be_selected" xml:space="preserve">
     <value>必须选择碎片离子</value>
   </data>


### PR DESCRIPTION
* moved "fragmentIons not in combo box" message out of resx to an inline verbatim string; it is intended to catch programming errors