### PR TITLE
Add some more asserts to TestRetentionTimeFilter in order to figure o…

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/RetentionTimeFilterTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/RetentionTimeFilterTest.cs
@@ -188,13 +188,16 @@ namespace pwiz.SkylineTestFunctional
                     peptideSettingsDlg.UseMeasuredRT(false);
                 });
                 OkDialog(peptideSettingsDlg, peptideSettingsDlg.OkDialog);
+                AssertEx.AreEqual(calcName, SkylineWindow.Document.Settings.PeptideSettings.Prediction.RetentionTime?.Calculator.Name);
                 docBeforeImport = WaitForDocumentChange(docBeforeSettingsChange);
                 Assert.IsFalse(SkylineWindow.Document.Settings.PeptideSettings.Prediction.UseMeasuredRTs);
                 var importResultsDlg = ShowDialog<ImportResultsDlg>(SkylineWindow.ImportResults);
                 var openDataSourceDialog = ShowDialog<OpenDataSourceDialog>(importResultsDlg.OkDialog);
                 RunUI(() => openDataSourceDialog.SelectFile("8fmol" + extension));
                 OkDialog(openDataSourceDialog, openDataSourceDialog.Open);
+                AssertEx.AreEqual(calcName, SkylineWindow.Document.Settings.PeptideSettings.Prediction.RetentionTime?.Calculator.Name);
                 var document = WaitForDocumentChangeLoaded(docBeforeImport);
+                AssertEx.AreEqual(calcName, SkylineWindow.Document.Settings.PeptideSettings.Prediction.RetentionTime?.Calculator.Name);
                 var chromatogramSet = document.Settings.MeasuredResults.Chromatograms.First(cs => cs.Name == "8fmol");
                 
                 var regressionLine =


### PR DESCRIPTION
…ut why it fails intermittently on Nat's machine.

When it fails, the retention time calculator seems to be set to "SSRCalc 3.0 (100A)" instead of "TestCalculator", so it would be interesting to see when that occurs.