### PR TITLE
Enable running tests from the IDE.

### DIFF
--- a/pwiz_tools/Skyline/TestSettings_x64-template.testsettings
+++ b/pwiz_tools/Skyline/TestSettings_x64-template.testsettings
@@ -20,7 +20,7 @@
     <DeploymentItem filename="bin\x64\Release\zh-CHS\ZedGraph.resources.dll" outputDirectory="zh-CHS" />
     <DeploymentItem filename="bin\x64\Debug\zh-CHS\ZedGraph.resources.dll" outputDirectory="zh-CHS" />
     <!-- Vendor readers -->
-    <DeploymentItem filename="..\..\pwiz_aux\msrc\utility\vendor_api\Shimadzu\DataReader.dll" />
+    <DeploymentItem filename="..\..\pwiz_aux\msrc\utility\vendor_api\Shimadzu\x64\DataReader.dll" />
     <!-- Vendor method building -->
     <DeploymentItem filename="Method\Agilent\BuildAgilentMethod.exe" outputDirectory="Method\Agilent" />
     <DeploymentItem filename="Method\Agilent\MethodCreator.dll" outputDirectory="Method\Agilent" />
@@ -47,6 +47,7 @@
     <DeploymentItem filename="SkylineCmd.exe" />
     <!-- Prosit gRPC -->
     <DeploymentItem filename="..\Shared\Lib\grpc_csharp_ext.x64.dll" />
+    <DeploymentItem filename="prmscheduler.dll" />
 
     __VENDOR_DLLS__
 

--- a/pwiz_tools/Skyline/TestSettings_x86-template.testsettings
+++ b/pwiz_tools/Skyline/TestSettings_x86-template.testsettings
@@ -71,6 +71,7 @@
     <DeploymentItem filename="SkylineCmd.exe" />
     <!-- Prosit gRPC -->
     <DeploymentItem filename="..\Shared\Lib\grpc_csharp_ext.x86.dll" />
+    <DeploymentItem filename="prmscheduler.dll" />
 
     __VENDOR_DLLS_
 


### PR DESCRIPTION
I do not know why this has suddenly stopped working for me, but I can't run tests in the IDE anymore.

I always build Skyline from the commandline with:
quickbuild ..... pwiz_tools/Skyline//Skyline.exe

For some reason, when I do this now, I always fail tests because "prmschduler.dll" and Shimadzu's DataReader.dll have not been copied into the TestResults/.../Out directory

These changes to the testsettings file fix this for me.
(I don't think this has anything to do with recent pull request #1349)