### PR TITLE
Fix UI Modes on Refine menu items

### DIFF
--- a/pwiz_tools/Skyline/Menus/RefineMenu.Designer.cs
+++ b/pwiz_tools/Skyline/Menus/RefineMenu.Designer.cs
@@ -54,6 +54,7 @@
             this.toolStripSeparator35 = new System.Windows.Forms.ToolStripSeparator();
             this.permuteIsotopeModificationsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.refineAdvancedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -99,7 +100,7 @@
             // 
             this.generateDecoysMenuItem.Name = "generateDecoysMenuItem";
             resources.ApplyResources(this.generateDecoysMenuItem, "generateDecoysMenuItem");
-            generateDecoysMenuItem.Click += generateDecoysMenuItem_Click;
+            this.modeUIHandler.SetUIMode(this.generateDecoysMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             // 
             // compareModelsToolStripMenuItem
             // 
@@ -127,7 +128,7 @@
             // 
             this.acceptProteinsMenuItem.Name = "acceptProteinsMenuItem";
             resources.ApplyResources(this.acceptProteinsMenuItem, "acceptProteinsMenuItem");
-            this.acceptPeptidesMenuItem.Click += acceptProteinsMenuItem_Click;
+            this.modeUIHandler.SetUIMode(this.acceptProteinsMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             // 
             // removeEmptyProteinsMenuItem
             // 
@@ -139,13 +140,13 @@
             // 
             this.associateFASTAMenuItem.Name = "associateFASTAMenuItem";
             resources.ApplyResources(this.associateFASTAMenuItem, "associateFASTAMenuItem");
-            this.associateFASTAMenuItem.Click += associateFASTAMenuItem_Click;
+            this.modeUIHandler.SetUIMode(this.associateFASTAMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             // 
             // renameProteinsMenuItem
             // 
             this.renameProteinsMenuItem.Name = "renameProteinsMenuItem";
             resources.ApplyResources(this.renameProteinsMenuItem, "renameProteinsMenuItem");
-            this.renameProteinsMenuItem.Click += renameProteinsToolStripMenuItem_Click;
+            this.modeUIHandler.SetUIMode(this.renameProteinsMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             // 
             // sortProteinsMenuItem
             // 
@@ -167,18 +168,21 @@
             // 
             this.sortProteinsByAccessionToolStripMenuItem.Name = "sortProteinsByAccessionToolStripMenuItem";
             resources.ApplyResources(this.sortProteinsByAccessionToolStripMenuItem, "sortProteinsByAccessionToolStripMenuItem");
+            this.modeUIHandler.SetUIMode(this.sortProteinsByAccessionToolStripMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             this.sortProteinsByAccessionToolStripMenuItem.Click += new System.EventHandler(this.sortProteinsByAccessionToolStripMenuItem_Click);
             // 
             // sortProteinsByPreferredNameToolStripMenuItem
             // 
             this.sortProteinsByPreferredNameToolStripMenuItem.Name = "sortProteinsByPreferredNameToolStripMenuItem";
             resources.ApplyResources(this.sortProteinsByPreferredNameToolStripMenuItem, "sortProteinsByPreferredNameToolStripMenuItem");
+            this.modeUIHandler.SetUIMode(this.sortProteinsByPreferredNameToolStripMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             this.sortProteinsByPreferredNameToolStripMenuItem.Click += new System.EventHandler(this.sortProteinsByPreferredNameToolStripMenuItem_Click);
             // 
             // sortProteinsByGeneToolStripMenuItem
             // 
             this.sortProteinsByGeneToolStripMenuItem.Name = "sortProteinsByGeneToolStripMenuItem";
             resources.ApplyResources(this.sortProteinsByGeneToolStripMenuItem, "sortProteinsByGeneToolStripMenuItem");
+            this.modeUIHandler.SetUIMode(this.sortProteinsByGeneToolStripMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             this.sortProteinsByGeneToolStripMenuItem.Click += new System.EventHandler(this.sortProteinsByGeneToolStripMenuItem_Click);
             // 
             // toolStripSeparator43
@@ -190,6 +194,7 @@
             // 
             this.acceptPeptidesMenuItem.Name = "acceptPeptidesMenuItem";
             resources.ApplyResources(this.acceptPeptidesMenuItem, "acceptPeptidesMenuItem");
+            this.modeUIHandler.SetUIMode(this.acceptPeptidesMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             this.acceptPeptidesMenuItem.Click += new System.EventHandler(this.acceptPeptidesMenuItem_Click);
             // 
             // removeEmptyPeptidesMenuItem
@@ -219,6 +224,7 @@
             // 
             this.permuteIsotopeModificationsMenuItem.Name = "permuteIsotopeModificationsMenuItem";
             resources.ApplyResources(this.permuteIsotopeModificationsMenuItem, "permuteIsotopeModificationsMenuItem");
+            this.modeUIHandler.SetUIMode(this.permuteIsotopeModificationsMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
             this.permuteIsotopeModificationsMenuItem.Click += new System.EventHandler(this.permuteIsotopeModificationsMenuItem_Click);
             // 
             // refineAdvancedMenuItem
@@ -233,6 +239,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.menuStrip1);
             this.Name = "RefineMenu";
+            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.ResumeLayout(false);

--- a/pwiz_tools/Skyline/Menus/RefineMenu.Designer.cs
+++ b/pwiz_tools/Skyline/Menus/RefineMenu.Designer.cs
@@ -101,6 +101,7 @@
             this.generateDecoysMenuItem.Name = "generateDecoysMenuItem";
             resources.ApplyResources(this.generateDecoysMenuItem, "generateDecoysMenuItem");
             this.modeUIHandler.SetUIMode(this.generateDecoysMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
+            this.generateDecoysMenuItem.Click += new System.EventHandler(this.generateDecoysMenuItem_Click);
             // 
             // compareModelsToolStripMenuItem
             // 
@@ -129,6 +130,7 @@
             this.acceptProteinsMenuItem.Name = "acceptProteinsMenuItem";
             resources.ApplyResources(this.acceptProteinsMenuItem, "acceptProteinsMenuItem");
             this.modeUIHandler.SetUIMode(this.acceptProteinsMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
+            this.acceptProteinsMenuItem.Click += new System.EventHandler(this.acceptProteinsMenuItem_Click);
             // 
             // removeEmptyProteinsMenuItem
             // 
@@ -141,12 +143,14 @@
             this.associateFASTAMenuItem.Name = "associateFASTAMenuItem";
             resources.ApplyResources(this.associateFASTAMenuItem, "associateFASTAMenuItem");
             this.modeUIHandler.SetUIMode(this.associateFASTAMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
+            this.associateFASTAMenuItem.Click += new System.EventHandler(this.associateFASTAMenuItem_Click);
             // 
             // renameProteinsMenuItem
             // 
             this.renameProteinsMenuItem.Name = "renameProteinsMenuItem";
             resources.ApplyResources(this.renameProteinsMenuItem, "renameProteinsMenuItem");
             this.modeUIHandler.SetUIMode(this.renameProteinsMenuItem, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.proteomic);
+            this.renameProteinsMenuItem.Click += new System.EventHandler(this.renameProteinsToolStripMenuItem_Click);
             // 
             // sortProteinsMenuItem
             // 

--- a/pwiz_tools/Skyline/Menus/RefineMenu.resx
+++ b/pwiz_tools/Skyline/Menus/RefineMenu.resx
@@ -117,8 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="reintegrateToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -186,19 +189,19 @@
     <value>By &amp;Name</value>
   </data>
   <data name="sortProteinsByAccessionToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="sortProteinsByAccessionToolStripMenuItem.Text" xml:space="preserve">
     <value>By &amp;Accession</value>
   </data>
   <data name="sortProteinsByPreferredNameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="sortProteinsByPreferredNameToolStripMenuItem.Text" xml:space="preserve">
     <value>By &amp;Preferred Name</value>
   </data>
   <data name="sortProteinsByGeneToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="sortProteinsByGeneToolStripMenuItem.Text" xml:space="preserve">
     <value>By &amp;Gene</value>
@@ -294,6 +297,12 @@ first occurrence of any peptide.</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline-daily, Version=20.2.1.350, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;refineToolStripMenuItem.Name" xml:space="preserve">
     <value>refineToolStripMenuItem</value>
@@ -443,6 +452,6 @@ first occurrence of any peptide.</value>
     <value>RefineMenu</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Menus.SkylineControl, Skyline-daily, Version=20.2.1.346, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Menus.SkylineControl, Skyline-daily, Version=20.2.1.350, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Menus/RefineMenu.resx
+++ b/pwiz_tools/Skyline/Menus/RefineMenu.resx
@@ -183,7 +183,7 @@
     <value>Re&amp;name Proteins...</value>
   </data>
   <data name="sortProteinsByNameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="sortProteinsByNameToolStripMenuItem.Text" xml:space="preserve">
     <value>By &amp;Name</value>

--- a/pwiz_tools/Skyline/Menus/SkylineControl.cs
+++ b/pwiz_tools/Skyline/Menus/SkylineControl.cs
@@ -42,6 +42,11 @@ namespace pwiz.Skyline.Menus
             SkylineWindow = skylineWindow;
         }
 
+        public Helpers.ModeUIExtender ModeUiHandler
+        {
+            get { return modeUIHandler; }
+        }
+
         private void InitializeComponent()
         {
             _components = new Container();

--- a/pwiz_tools/Skyline/Menus/SkylineControl.cs
+++ b/pwiz_tools/Skyline/Menus/SkylineControl.cs
@@ -17,9 +17,11 @@
  * limitations under the License.
  */
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.AuditLog;
+using pwiz.Skyline.Util;
 
 namespace pwiz.Skyline.Menus
 {
@@ -28,13 +30,22 @@ namespace pwiz.Skyline.Menus
     /// </summary>
     public class SkylineControl : UserControl
     {
+        private Container _components; // For IExtender use
+        protected Helpers.ModeUIExtender modeUIHandler; // Allows UI mode management in Designer
         public SkylineControl()
         {
+            InitializeComponent();
         }
 
-        public SkylineControl(SkylineWindow skylineWindow)
+        public SkylineControl(SkylineWindow skylineWindow) : this()
         {
             SkylineWindow = skylineWindow;
+        }
+
+        private void InitializeComponent()
+        {
+            _components = new Container();
+            modeUIHandler = new Helpers.ModeUIExtender(_components);
         }
 
         public SkylineWindow SkylineWindow { get; private set; }

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -5654,11 +5654,6 @@ namespace pwiz.Skyline
             UpdateGraphPanes();
         }
 
-        private void permuteIsotopeModificationsMenuItem_Click(object sender, EventArgs e)
-        {
-            ShowPermuteIsotopeModificationsDlg();
-        }
-
         public void ShowPermuteIsotopeModificationsDlg()
         {
             RefineMenu.ShowPermuteIsotopeModificationsDlg();
@@ -5671,6 +5666,10 @@ namespace pwiz.Skyline
             RefineMenu = new RefineMenu(this);
             refineToolStripMenuItem.DropDownItems.Clear();
             refineToolStripMenuItem.DropDownItems.AddRange(RefineMenu.DropDownItems.ToArray());
+            foreach (var entry in RefineMenu.ModeUiHandler.GetHandledComponents())
+            {
+                modeUIHandler.AddHandledComponent(entry.Key, entry.Value);
+            }
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/SkylineMenuTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SkylineMenuTest.cs
@@ -1,0 +1,93 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2020 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Linq;
+using System.Windows.Forms;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline.Model;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTestFunctional
+{
+    [TestClass]
+    public class SkylineMenuTest : AbstractFunctionalTest
+    {
+        [TestMethod]
+        public void TestSkylineMenu()
+        {
+            RunFunctionalTest();
+        }
+
+        protected override void DoTest()
+        {
+            RunUI(()=>SkylineWindow.SetUIMode(SrmDocument.DOCUMENT_TYPE.small_molecules));
+            AssertMenuItemAvailableIs("reintegrateToolStripMenuItem", true);
+            AssertMenuItemAvailableIs("generateDecoysMenuItem", false);
+            AssertMenuItemAvailableIs("acceptProteinsMenuItem", false);
+            AssertMenuItemAvailableIs("associateFASTAMenuItem", false);
+            AssertMenuItemAvailableIs("renameProteinsMenuItem", false);
+            AssertMenuItemAvailableIs("sortProteinsByAccessionToolStripMenuItem", false);
+            AssertMenuItemAvailableIs("sortProteinsByPreferredNameToolStripMenuItem", false);
+            AssertMenuItemAvailableIs("sortProteinsByGeneToolStripMenuItem", false);
+            AssertMenuItemAvailableIs("acceptPeptidesMenuItem", false);
+            AssertMenuItemAvailableIs("removeEmptyPeptidesMenuItem", true);
+            AssertMenuItemAvailableIs("viewProteinsMenuItem", false);
+            RunUI(() => SkylineWindow.SetUIMode(SrmDocument.DOCUMENT_TYPE.proteomic));
+            AssertMenuItemAvailableIs("reintegrateToolStripMenuItem", true);
+            AssertMenuItemAvailableIs("generateDecoysMenuItem", true);
+            AssertMenuItemAvailableIs("acceptProteinsMenuItem", true);
+            AssertMenuItemAvailableIs("associateFASTAMenuItem", true);
+            AssertMenuItemAvailableIs("renameProteinsMenuItem", true);
+            AssertMenuItemAvailableIs("sortProteinsByAccessionToolStripMenuItem", true);
+            AssertMenuItemAvailableIs("sortProteinsByPreferredNameToolStripMenuItem", true);
+            AssertMenuItemAvailableIs("sortProteinsByGeneToolStripMenuItem", true);
+            AssertMenuItemAvailableIs("acceptPeptidesMenuItem", true);
+            AssertMenuItemAvailableIs("removeEmptyPeptidesMenuItem", true);
+            AssertMenuItemAvailableIs("viewProteinsMenuItem", true);
+        }
+
+        protected void AssertMenuItemAvailableIs(string menuItemName, bool expectedAvailable)
+        {
+            var menuItem = FindItemByName(SkylineWindow.MainMenuStrip.Items, menuItemName);
+            Assert.IsNotNull(menuItem);
+            Assert.AreEqual(expectedAvailable, menuItem.Available);
+        }
+
+        private ToolStripItem FindItemByName(ToolStripItemCollection items, string name)
+        {
+            foreach (var item in items.Cast<ToolStripItem>())
+            {
+                if (item.Name == name)
+                {
+                    return item;
+                }
+
+                if (item is ToolStripDropDownItem toolStripDropDownItem)
+                {
+                    var childResult = FindItemByName(toolStripDropDownItem.DropDownItems, name);
+                    if (childResult != null)
+                    {
+                        return childResult;
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -184,6 +184,7 @@
     <Compile Include="RescoreRawChromatogramsTest.cs" />
     <Compile Include="SettingsChangeReimportTest.cs" />
     <Compile Include="SimpleRatiosTest.cs" />
+    <Compile Include="SkylineMenuTest.cs" />
     <Compile Include="SkypTest.cs" />
     <Compile Include="AddLibraryTest.cs" />
     <Compile Include="AreaCVHistogramTest.cs" />


### PR DESCRIPTION
Fix the UI mode hiding/showing of Refine menu items.
This was broken by previous pull request #1354 
(also, a couple of menu items did not have their event handlers hooked up right).