### PR TITLE
* fixed ImportFastaControl not checking for existence of filepath

### DIFF
--- a/pwiz_tools/Skyline/EditUI/PasteDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.cs
@@ -2076,19 +2076,32 @@ namespace pwiz.Skyline.EditUI
                 TbxError.Visible = false;
                 return;
             }
-            TbxError.BackColor = Color.Red;
-            TbxError.ForeColor = Color.White;
-            TbxError.Text = pasteError.Message;
-            TbxError.Visible = true;
-            if (HelpTip != null)
-            {
-                // In case message is long, make it possible to see in a tip
-                HelpTip.SetToolTip(TbxError, pasteError.Message);
-            }
+
+            ShowFastaError(pasteError.Message);
 
             TbxFasta.SelectionStart = Math.Max(0, TbxFasta.GetFirstCharIndexFromLine(pasteError.Line) + pasteError.Column);
             TbxFasta.SelectionLength = Math.Min(pasteError.Length, TbxFasta.Text.Length - TbxFasta.SelectionStart);
             TbxFasta.Focus();
+        }
+
+        public void ShowFastaError(string errorMsg)
+        {
+            PanelError.Visible = true;
+            if (string.IsNullOrEmpty(errorMsg))
+            {
+                TbxError.Text = string.Empty;
+                TbxError.Visible = false;
+                return;
+            }
+            TbxError.BackColor = Color.Red;
+            TbxError.ForeColor = Color.White;
+            TbxError.Text = errorMsg;
+            TbxError.Visible = true;
+            if (HelpTip != null)
+            {
+                // In case message is long, make it possible to see in a tip
+                HelpTip.SetToolTip(TbxError, errorMsg);
+            }
         }
 
         public void ClearFastaError()

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.cs
@@ -83,9 +83,19 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             }
         }
         private readonly int tbxFastaHeightDifference;
+        private bool _isDdaSearch;
 
         public bool ContainsFastaContent { get { return !string.IsNullOrWhiteSpace(tbxFasta.Text); } }
-        public bool IsDDASearch { get; set; }
+
+        public bool IsDDASearch
+        {
+            get => _isDdaSearch;
+            set
+            {
+                _isDdaSearch = value;
+                _fastaFile = true;
+            }
+        }
 
         public ImportFastaSettings ImportSettings
         {
@@ -222,12 +232,20 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         private void tbxFasta_TextChanged(object sender, EventArgs e)
         {
             ImportFastaHelper.ClearFastaError();
+            if (_fastaFile)
+            {
+                FastaFile = tbxFasta.Text;
+                if (!File.Exists(FastaFile))
+                    ImportFastaHelper.ShowFastaError(Resources.ToolDescription_RunTool_File_not_found_);
+            }
         }
 
         public void SetFastaContent(string fastaFilePath)
         {
             try
             {
+                FastaFile = fastaFilePath;
+
                 var fileInfo = new FileInfo(fastaFilePath);
                 if (IsDDASearch || fileInfo.Length > MAX_FASTA_TEXTBOX_LENGTH)
                 {
@@ -239,8 +257,6 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                     _fastaFile = false;
                     tbxFasta.Text = GetFastaFileContent(fastaFilePath);
                 }
-
-                FastaFile = fastaFilePath;
             }
             catch (Exception x)
             {
@@ -451,8 +467,8 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         private void clearBtn_Click(object sender, EventArgs e)
         {
+            _fastaFile = IsDDASearch;
             tbxFasta.Clear();
-            _fastaFile = false;
         }
 
         private void enzyme_SelectedIndexChanged(object sender, EventArgs e)

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -556,7 +556,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                 case Pages.import_fasta_page: // This is the last page (if there is no dda search)
                     if (ImportPeptideSearch.IsDDASearch)
                     {
-                        if (!ImportFastaControl.ContainsFastaContent) 
+                        if (!File.Exists(ImportFastaControl.FastaFile)) 
                         {
                             MessageBox.Show(this, Resources.ImportPeptideSearchDlg_NextPage_FastFileMissing_DDASearch,
                                 Program.Name, MessageBoxButtons.OK);


### PR DESCRIPTION
* fixed ImportFastaControl not checking for existence of filepath before letting user continue, and in DDA search mode, disabled multiline FASTA control even before Browse button is clicked, and made Clear button not restore to multiline mode
* added a generic string-only override for ImportFastaHelper.ShowFastaError