### PR TITLE
Fix ImportPeptideSearchDlg height

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -300,14 +300,19 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             : this(skylineWindow, libraryManager)
         {
             BuildPepSearchLibControl.ForceWorkflow(workflowType);
-            var ionMobilityControlHeight = FullScanSettingsControl.IonMobilityFiltering.Height + 2*label1.Height; // Might need real estate to ask about using ion mobility data found in imported spectral libraries
-            var adjustedHeight = MinimumSize.Height + ionMobilityControlHeight;
             if (workflowType == Workflow.dda)
             {
-                adjustedHeight -= FullScanSettingsControl.GroupBoxMS2Height; // No MS2 control
+                AdjustHeight(-FullScanSettingsControl.GroupBoxMS2Height); // No MS2 control
             }
-            MinimumSize = new Size(MinimumSize.Width, adjustedHeight);
-            Height = adjustedHeight;
+        }
+
+        public void AdjustHeight(int change)
+        {
+            MinimumSize = new Size(MinimumSize.Width, MinimumSize.Height + change);
+            if (change < 0)
+            {
+                Height += change;
+            }
         }
 
         private SkylineWindow SkylineWindow { get; set; }
@@ -483,7 +488,13 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                         }
 
                         // Set up full scan settings page
-                        FullScanSettingsControl.ModifyOptionsForImportPeptideSearchWizard(WorkflowType, BuildPepSearchLibControl.ImportPeptideSearch.DocLib);
+                        var lib = BuildPepSearchLibControl.ImportPeptideSearch.DocLib;
+                        var libIonMobilities = lib != null && PeptideLibraries.HasIonMobilities(lib, null);
+                        FullScanSettingsControl.ModifyOptionsForImportPeptideSearchWizard(WorkflowType, libIonMobilities);
+                        if (libIonMobilities)
+                        {
+                            AdjustHeight(FullScanSettingsControl.IonMobilityFiltering.Height + 2 * label1.Height); // Need real estate to ask about using ion mobility data found in imported spectral libraries
+                        }
 
                         bool hasMatchedMods = MatchModificationsControl.Initialize(Document);
                         if (!hasMatchedMods && !BuildPepSearchLibControl.PerformDDASearch)

--- a/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
@@ -893,7 +893,7 @@ namespace pwiz.Skyline.SettingsUI
             usercontrolIonMobilityFiltering.InitializeSettings(_documentContainer);
         }
 
-        public void ModifyOptionsForImportPeptideSearchWizard(ImportPeptideSearchDlg.Workflow workflow, Library lib)
+        public void ModifyOptionsForImportPeptideSearchWizard(ImportPeptideSearchDlg.Workflow workflow, bool libIonMobilities)
         {
             var settings = _documentContainer.Document.Settings;
 
@@ -970,7 +970,7 @@ namespace pwiz.Skyline.SettingsUI
             }
 
             // Ask about ion mobility filtering if any IM values in library
-            if (lib != null && PeptideLibraries.HasIonMobilities(lib, null))
+            if (libIonMobilities)
             {
                 usercontrolIonMobilityFiltering.Top = groupBoxRetentionTimeToKeep.Bottom + sepMS1FromMS2;
                 usercontrolIonMobilityFiltering.InitializeSettings(_documentContainer, true);

--- a/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
@@ -29,7 +29,6 @@ using pwiz.Skyline.Controls;
 using pwiz.Skyline.FileUI.PeptideSearch;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Irt;
-using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
 


### PR DESCRIPTION
Here we only increase the height of the ImportPeptideSearchDlg if the built library contains ion mobilities.
(Side note: we can't decrease the height when selected from the start page even though the workflow group box is hidden, because it cuts off stuff on the Full Scan settings page.)