### PR TITLE
Fix problem where "Refine > Permute Isotope Modifications" would prod…

### DIFF
--- a/pwiz_tools/Skyline/Model/IsotopeModificationPermuter.cs
+++ b/pwiz_tools/Skyline/Model/IsotopeModificationPermuter.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Model.DocSettings.Extensions;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
 
@@ -120,7 +121,13 @@ namespace pwiz.Skyline.Model
             }
 
             document = (SrmDocument) document.ChangeChildren(ImmutableList.ValueOf(newMoleculeGroups.Cast<DocNode>()));
-
+            var pepModsNew = document.Settings.PeptideSettings.Modifications;
+            pepModsNew = pepModsNew.DeclareExplicitMods(document, GlobalStaticMods, GlobalIsotopeMods);
+            if (!Equals(pepModsNew, document.Settings.PeptideSettings.Modifications))
+            {
+                var newSettings = document.Settings.ChangePeptideModifications(m => pepModsNew);
+                document = document.ChangeSettings(newSettings);
+            }
             return document;
         }
 

--- a/pwiz_tools/Skyline/TestFunctional/ModificationPermuterTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ModificationPermuterTest.cs
@@ -18,6 +18,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Collections;
@@ -159,6 +160,12 @@ namespace pwiz.SkylineTestFunctional
 
             CollectionAssert.AreEqual(new[] {true, false, true, true},
                 SkylineWindow.Document.Peptides.Select(p => p.AutoManageChildren).ToList());
+            var filePath = Path.Combine(TestContext.TestDir, "ModificationPermuterTest.sky");
+            RunUI(()=>
+            {
+                SkylineWindow.SaveDocument(filePath);
+                SkylineWindow.OpenFile(filePath);
+            });
         }
     }
 }


### PR DESCRIPTION
…uce a document which could not be opened after it was saved.

The label types would not have the necessary explicit modifications.

(This bug was introduced on 12/24/2020, and does not occur in any released version of Skyline-Daily)