### PR TITLE
Make it so that "ModeUIExtender" does not implement ISupportInitialize

### DIFF
--- a/pwiz_tools/Skyline/Alerts/NoModeUIDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Alerts/NoModeUIDlg.Designer.cs
@@ -64,7 +64,6 @@ namespace pwiz.Skyline.Alerts
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.buttonOK = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // imageListModeUI
@@ -131,7 +130,6 @@ namespace pwiz.Skyline.Alerts
             this.MinimizeBox = false;
             this.Name = "NoModeUIDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/Controls/AuditLog/AuditLogForm.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/AuditLog/AuditLogForm.Designer.cs
@@ -29,7 +29,6 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AuditLogForm));
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).BeginInit();
             this.SuspendLayout();
             // 
             // AuditLogForm
@@ -38,7 +37,6 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Name = "AuditLogForm";
             this.ShowViewsMenu = true;
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).EndInit();
             this.ResumeLayout(false);
 
         }

--- a/pwiz_tools/Skyline/Controls/Clustering/HierarchicalClusterGraph.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/Clustering/HierarchicalClusterGraph.Designer.cs
@@ -31,7 +31,6 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(HierarchicalClusterGraph));
             this.zedGraphControl1 = new ZedGraph.ZedGraphControl();
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).BeginInit();
             this.SuspendLayout();
             // 
             // zedGraphControl1
@@ -55,7 +54,6 @@
             this.BackColor = System.Drawing.SystemColors.ButtonHighlight;
             this.Controls.Add(this.zedGraphControl1);
             this.Name = "HierarchicalClusterGraph";
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).EndInit();
             this.ResumeLayout(false);
 
         }

--- a/pwiz_tools/Skyline/Controls/Databinding/ChooseFormatDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/ChooseFormatDlg.Designer.cs
@@ -35,7 +35,6 @@
             this.tbxCustomFormat = new System.Windows.Forms.TextBox();
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // label1
@@ -96,7 +95,6 @@
             this.Name = "ChooseFormatDlg";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/Controls/Graphs/DetectionToolbarProperties.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/DetectionToolbarProperties.Designer.cs
@@ -48,7 +48,6 @@
             this.cbShowAtLeastN = new System.Windows.Forms.CheckBox();
             this.tbAtLeastN = new System.Windows.Forms.TrackBar();
             this.gbAtLeastN = new System.Windows.Forms.GroupBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.tbAtLeastN)).BeginInit();
@@ -223,7 +222,6 @@
             this.Name = "DetectionToolbarProperties";
             this.ShowInTaskbar = false;
             this.Load += new System.EventHandler(this.DetectionToolbarProperties_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.groupBox2.ResumeLayout(false);

--- a/pwiz_tools/Skyline/Controls/Graphs/ExportMethodScheduleGraph.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ExportMethodScheduleGraph.Designer.cs
@@ -34,7 +34,6 @@
             this.btnOk = new System.Windows.Forms.Button();
             this.cbGraphType = new System.Windows.Forms.ComboBox();
             this.dataGridView = new System.Windows.Forms.DataGridView();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).BeginInit();
             this.SuspendLayout();
             // 
@@ -93,7 +92,6 @@
             this.Name = "ExportMethodScheduleGraph";
             this.ShowInTaskbar = false;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ExportMethodScheduleGraph_FormClosing);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).EndInit();
             this.ResumeLayout(false);
 

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.Designer.cs
@@ -39,7 +39,6 @@
             this.comboCE = new System.Windows.Forms.ToolStripComboBox();
             this.GraphPanel = new System.Windows.Forms.Panel();
             this.graphControl = new pwiz.MSGraph.MSGraphControl();
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).BeginInit();
             this.toolBar.SuspendLayout();
             this.GraphPanel.SuspendLayout();
             this.SuspendLayout();
@@ -132,7 +131,6 @@
             this.Name = "GraphSpectrum";
             this.VisibleChanged += new System.EventHandler(this.GraphSpectrum_VisibleChanged);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.GraphSpectrum_KeyDown);
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).EndInit();
             this.toolBar.ResumeLayout(false);
             this.toolBar.PerformLayout();
             this.GraphPanel.ResumeLayout(false);

--- a/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.Designer.cs
@@ -62,7 +62,6 @@
             this.panelName = new System.Windows.Forms.Panel();
             this.panelButtons = new System.Windows.Forms.Panel();
             this.panelAdvanced = new System.Windows.Forms.Panel();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.panelMain.SuspendLayout();
             this.groupBoxScope.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
@@ -327,7 +326,6 @@
             this.Name = "EditGroupComparisonDlg";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.panelMain.ResumeLayout(false);
             this.panelMain.PerformLayout();
             this.groupBoxScope.ResumeLayout(false);

--- a/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.Designer.cs
@@ -31,7 +31,6 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FoldChangeVolcanoPlot));
             this.zedGraphControl = new ZedGraph.ZedGraphControl();
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).BeginInit();
             this.SuspendLayout();
             // 
             // zedGraphControl
@@ -57,7 +56,6 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.zedGraphControl);
             this.Name = "FoldChangeVolcanoPlot";
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).EndInit();
             this.ResumeLayout(false);
 
         }

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotPropertiesDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotPropertiesDlg.Designer.cs
@@ -39,7 +39,6 @@
             this.foldChangeUnitLabel = new System.Windows.Forms.Label();
             this.pValueLowerBoundLabel = new System.Windows.Forms.Label();
             this.checkBoxFilter = new System.Windows.Forms.CheckBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // btnCancel
@@ -127,7 +126,6 @@
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.VolcanoPlotProperties_FormClosing);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/Controls/LongWaitDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/LongWaitDlg.Designer.cs
@@ -36,7 +36,6 @@
             this.timerUpdate = new System.Windows.Forms.Timer(this.components);
             this.timerClose = new System.Windows.Forms.Timer(this.components);
             this.panel1 = new System.Windows.Forms.Panel();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -87,7 +86,6 @@
             this.MinimizeBox = false;
             this.Name = "LongWaitDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.ResumeLayout(false);

--- a/pwiz_tools/Skyline/EditUI/EditPepModsDlg.Designer.cs
+++ b/pwiz_tools/Skyline/EditUI/EditPepModsDlg.Designer.cs
@@ -43,7 +43,6 @@
             this.btnReset = new System.Windows.Forms.Button();
             this.cbCreateCopy = new System.Windows.Forms.CheckBox();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.panelMain.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -142,7 +141,6 @@
             this.MinimizeBox = false;
             this.Name = "EditPepModsDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.panelMain.ResumeLayout(false);
             this.panelMain.PerformLayout();
             this.ResumeLayout(false);

--- a/pwiz_tools/Skyline/EditUI/PasteDlg.Designer.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.Designer.cs
@@ -72,7 +72,6 @@ namespace pwiz.Skyline.EditUI
             this.btnCustomMoleculeColumns = new System.Windows.Forms.Button();
             this.radioMolecule = new System.Windows.Forms.RadioButton();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.tabControl1.SuspendLayout();
             this.tabPageFasta.SuspendLayout();
             this.tabPageProteinList.SuspendLayout();
@@ -396,7 +395,6 @@ namespace pwiz.Skyline.EditUI
             this.ShowInTaskbar = false;
             this.Load += new System.EventHandler(this.OnLoad);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.PasteDlg_KeyDown);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.tabControl1.ResumeLayout(false);
             this.tabPageFasta.ResumeLayout(false);
             this.tabPageFasta.PerformLayout();

--- a/pwiz_tools/Skyline/EditUI/PermuteIsotopeModificationsDlg.designer.cs
+++ b/pwiz_tools/Skyline/EditUI/PermuteIsotopeModificationsDlg.designer.cs
@@ -20,7 +20,6 @@ namespace pwiz.Skyline.EditUI
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOK = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.groupBoxPermutationStyle.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -88,7 +87,6 @@ namespace pwiz.Skyline.EditUI
             this.MinimizeBox = false;
             this.Name = "PermuteIsotopeModificationsDlg";
             this.ShowIcon = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.groupBoxPermutationStyle.ResumeLayout(false);
             this.groupBoxPermutationStyle.PerformLayout();
             this.ResumeLayout(false);

--- a/pwiz_tools/Skyline/EditUI/RefineDlg.Designer.cs
+++ b/pwiz_tools/Skyline/EditUI/RefineDlg.Designer.cs
@@ -102,7 +102,6 @@
             this.labelGroupComparison = new System.Windows.Forms.Label();
             this.btnEditGroupComparisons = new System.Windows.Forms.Button();
             this.checkedListBoxGroupComparisons = new System.Windows.Forms.CheckedListBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.tabControl1.SuspendLayout();
             this.tabDocument.SuspendLayout();
             this.tabResults.SuspendLayout();
@@ -630,7 +629,6 @@
             this.MinimizeBox = false;
             this.Name = "RefineDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.tabControl1.ResumeLayout(false);
             this.tabDocument.ResumeLayout(false);
             this.tabDocument.PerformLayout();

--- a/pwiz_tools/Skyline/EditUI/SchedulingGraphPropertyDlg.Designer.cs
+++ b/pwiz_tools/Skyline/EditUI/SchedulingGraphPropertyDlg.Designer.cs
@@ -39,7 +39,6 @@
             this.textBrukerTemplate = new System.Windows.Forms.TextBox();
             this.label4 = new System.Windows.Forms.Label();
             this.btnBrukerTemplateBrowse = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // btnCancel
@@ -119,7 +118,6 @@
             this.MinimizeBox = false;
             this.Name = "SchedulingGraphPropertyDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/FileUI/ChooseIrtStandardPeptidesDlg.Designer.cs
+++ b/pwiz_tools/Skyline/FileUI/ChooseIrtStandardPeptidesDlg.Designer.cs
@@ -38,7 +38,6 @@
             this.btnBrowseTransitionList = new System.Windows.Forms.Button();
             this.radioExisting = new System.Windows.Forms.RadioButton();
             this.comboExisting = new System.Windows.Forms.ComboBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // btnOk
@@ -124,7 +123,6 @@
             this.MinimizeBox = false;
             this.Name = "ChooseIrtStandardPeptidesDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/FileUI/ExportAnnotationsDlg.Designer.cs
+++ b/pwiz_tools/Skyline/FileUI/ExportAnnotationsDlg.Designer.cs
@@ -40,7 +40,6 @@
             this.lblElementTypes = new System.Windows.Forms.Label();
             this.cbxRemoveBlankRows = new System.Windows.Forms.CheckBox();
             this.lblInstructions = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -142,7 +141,6 @@
             this.Name = "ExportAnnotationsDlg";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.Designer.cs
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.Designer.cs
@@ -80,7 +80,6 @@
             this.panelBrukerTimsTof = new System.Windows.Forms.Panel();
             this.textMs1RepetitionTime = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.panelThermoColumns.SuspendLayout();
             this.panelAbSciexTOF.SuspendLayout();
             this.panelTriggered.SuspendLayout();
@@ -479,7 +478,6 @@
             this.Name = "ExportMethodDlg";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.panelThermoColumns.ResumeLayout(false);
             this.panelThermoColumns.PerformLayout();
             this.panelAbSciexTOF.ResumeLayout(false);

--- a/pwiz_tools/Skyline/FileUI/OpenDataSourceDialog.Designer.cs
+++ b/pwiz_tools/Skyline/FileUI/OpenDataSourceDialog.Designer.cs
@@ -57,7 +57,6 @@ namespace pwiz.Skyline.FileUI
             this.desktopButton = new System.Windows.Forms.Button();
             this.myDocumentsButton = new System.Windows.Forms.Button();
             this.myComputerButton = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.navToolStrip.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
@@ -308,7 +307,6 @@ namespace pwiz.Skyline.FileUI
             this.Name = "OpenDataSourceDialog";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.navToolStrip.ResumeLayout(false);
             this.navToolStrip.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.designer.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.designer.cs
@@ -73,7 +73,6 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             this.lblSearchSettings = new System.Windows.Forms.Label();
             this.ddaSearchTitlePanel = new System.Windows.Forms.Panel();
             this.lblDDASearch = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.wizardPagesImportPeptideSearch.SuspendLayout();
             this.buildSearchSpecLibPage.SuspendLayout();
             this.buildSpectralLibraryTitlePanel.SuspendLayout();
@@ -435,7 +434,6 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             this.MinimizeBox = false;
             this.Name = "ImportPeptideSearchDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.wizardPagesImportPeptideSearch.ResumeLayout(false);
             this.buildSearchSpecLibPage.ResumeLayout(false);
             this.buildSpectralLibraryTitlePanel.ResumeLayout(false);

--- a/pwiz_tools/Skyline/Menus/EditMenu.Designer.cs
+++ b/pwiz_tools/Skyline/Menus/EditMenu.Designer.cs
@@ -76,7 +76,6 @@
             this.manageUniquePeptidesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator30 = new System.Windows.Forms.ToolStripSeparator();
             this.manageResultsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -418,7 +417,6 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.menuStrip1);
             this.Name = "EditMenu";
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.ResumeLayout(false);

--- a/pwiz_tools/Skyline/Menus/RefineMenu.Designer.cs
+++ b/pwiz_tools/Skyline/Menus/RefineMenu.Designer.cs
@@ -54,7 +54,6 @@
             this.toolStripSeparator35 = new System.Windows.Forms.ToolStripSeparator();
             this.permuteIsotopeModificationsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.refineAdvancedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -243,7 +242,6 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.menuStrip1);
             this.Name = "RefineMenu";
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.ResumeLayout(false);

--- a/pwiz_tools/Skyline/Menus/ViewMenu.Designer.cs
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.Designer.cs
@@ -140,7 +140,6 @@
             this.toolStripSeparator36 = new System.Windows.Forms.ToolStripSeparator();
             this.toolBarToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -960,7 +959,6 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.menuStrip1);
             this.Name = "ViewMenu";
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.Designer.cs
@@ -64,7 +64,6 @@
             this.helpTip = new System.Windows.Forms.ToolTip(this.components);
             this.ceLabel = new System.Windows.Forms.Label();
             this.ceCombo = new System.Windows.Forms.ComboBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.panelProperties.SuspendLayout();
             this.panelFilesPrositProperties.SuspendLayout();
             this.panelFilesProps.SuspendLayout();
@@ -337,7 +336,6 @@
             this.Name = "BuildLibraryDlg";
             this.ShowInTaskbar = false;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.BuildLibraryDlg_FormClosing);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.panelProperties.ResumeLayout(false);
             this.panelProperties.PerformLayout();
             this.panelFilesPrositProperties.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/DefineAnnotationDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/DefineAnnotationDlg.Designer.cs
@@ -48,7 +48,6 @@ namespace pwiz.Skyline.SettingsUI
             this.availableFieldsTree1 = new pwiz.Common.DataBinding.Controls.Editor.AvailableFieldsTree();
             this.lblCalculatedAppliesTo = new System.Windows.Forms.Label();
             this.comboAppliesTo = new System.Windows.Forms.ComboBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.tabControl1.SuspendLayout();
             this.tabPageEditable.SuspendLayout();
             this.tabPageCalculated.SuspendLayout();
@@ -194,7 +193,6 @@ namespace pwiz.Skyline.SettingsUI
             this.MinimizeBox = false;
             this.Name = "DefineAnnotationDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.tabControl1.ResumeLayout(false);
             this.tabPageEditable.ResumeLayout(false);
             this.tabPageEditable.PerformLayout();

--- a/pwiz_tools/Skyline/SettingsUI/DocumentSettingsDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/DocumentSettingsDlg.Designer.cs
@@ -57,7 +57,6 @@ namespace pwiz.Skyline.SettingsUI
             this.chooseViewsControl = new pwiz.Common.DataBinding.Controls.Editor.ChooseViewsControl();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOK = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.tabControl.SuspendLayout();
             this.tabPageAnnotations.SuspendLayout();
             this.tabPageResultFileRules.SuspendLayout();
@@ -289,7 +288,6 @@ namespace pwiz.Skyline.SettingsUI
             this.Name = "DocumentSettingsDlg";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.tabControl.ResumeLayout(false);
             this.tabPageAnnotations.ResumeLayout(false);
             this.tabPageResultFileRules.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/EditCustomMoleculeDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditCustomMoleculeDlg.Designer.cs
@@ -62,7 +62,6 @@
             this.comboIsotopeLabelType = new System.Windows.Forms.ComboBox();
             this.labelPrecursorCollisionEnergy = new System.Windows.Forms.Label();
             this.textBoxPrecursorCollisionEnergy = new System.Windows.Forms.TextBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.groupBoxOptionalValues.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -293,7 +292,6 @@
             this.MinimizeBox = false;
             this.Name = "EditCustomMoleculeDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.groupBoxOptionalValues.ResumeLayout(false);
             this.groupBoxOptionalValues.PerformLayout();
             this.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/EditFragmentLossDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditFragmentLossDlg.Designer.cs
@@ -35,7 +35,6 @@
             this.lblCharge = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.comboIncludeLoss = new System.Windows.Forms.ComboBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // btnOk
@@ -91,7 +90,6 @@
             this.MinimizeBox = false;
             this.Name = "EditFragmentLossDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/SettingsUI/EditStaticModDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditStaticModDlg.Designer.cs
@@ -58,7 +58,6 @@
             this.tbbDeleteLoss = new System.Windows.Forms.ToolStripButton();
             this.comboMod = new System.Windows.Forms.ComboBox();
             this.cbCrosslinker = new System.Windows.Forms.CheckBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.panelAtoms.SuspendLayout();
             this.panelLoss.SuspendLayout();
             this.toolBarLosses.SuspendLayout();
@@ -296,7 +295,6 @@
             this.MinimizeBox = false;
             this.Name = "EditStaticModDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.panelAtoms.ResumeLayout(false);
             this.panelAtoms.PerformLayout();
             this.panelLoss.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/FilterMidasLibraryDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FilterMidasLibraryDlg.Designer.cs
@@ -36,7 +36,6 @@
             this.txtPath = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.btnBrowse = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // label2
@@ -98,7 +97,6 @@
             this.Name = "FilterMidasLibraryDlg";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.designer.cs
@@ -64,7 +64,6 @@
             this.toolTipMeasuredPeptidesGrid = new System.Windows.Forms.ToolTip(this.components);
             this.btnUseResults = new System.Windows.Forms.Button();
             this.cbOffsetHighEnergySpectra = new System.Windows.Forms.CheckBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceLibrary)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).BeginInit();
             this.contextMenuAdd.SuspendLayout();
@@ -287,7 +286,6 @@
             this.Name = "EditIonMobilityLibraryDlg";
             this.ShowInTaskbar = false;
             this.Load += new System.EventHandler(this.OnLoad);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceLibrary)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).EndInit();
             this.contextMenuAdd.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/ImportIonMobilityFromSpectralLibraryDlg.designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/ImportIonMobilityFromSpectralLibraryDlg.designer.cs
@@ -41,7 +41,6 @@
             this.label3 = new System.Windows.Forms.Label();
             this.btnBrowseFile = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // btnCancel
@@ -131,7 +130,6 @@
             this.MinimizeBox = false;
             this.Name = "ImportIonMobilityFromSpectralLibraryDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.Designer.cs
@@ -53,7 +53,6 @@
             this.Equation = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.R = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Result = new System.Windows.Forms.DataGridViewLinkColumn();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).BeginInit();
             this.panelKeep.SuspendLayout();
             this.panelOverwrite.SuspendLayout();
@@ -245,7 +244,6 @@
             this.MinimizeBox = false;
             this.Name = "AddIrtPeptidesDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).EndInit();
             this.panelKeep.ResumeLayout(false);
             this.panelKeep.PerformLayout();

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtStandardsDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtStandardsDlg.Designer.cs
@@ -35,7 +35,6 @@
             this.btnOk = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnGraph = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // labelMessage
@@ -92,7 +91,6 @@
             this.MinimizeBox = false;
             this.Name = "AddIrtStandardsDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.Designer.cs
@@ -62,7 +62,6 @@
             this.calibratePeptides = new pwiz.Skyline.Controls.TargetColumn();
             this.calibrateMeasuredRt = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.colIrt = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.gridViewCalibrate)).BeginInit();
             this.grpRegressionEquation.SuspendLayout();
@@ -300,7 +299,6 @@
             this.ShowInTaskbar = false;
             this.Load += new System.EventHandler(this.OnLoad);
             this.Shown += new System.EventHandler(this.CalibrateIrtDlg_Shown);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.gridViewCalibrate)).EndInit();
             this.grpRegressionEquation.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/Irt/ChangeIrtPeptidesDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/ChangeIrtPeptidesDlg.Designer.cs
@@ -38,7 +38,6 @@
             this.label1 = new System.Windows.Forms.Label();
             this.textPeptides = new System.Windows.Forms.TextBox();
             this.btnOk = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).BeginInit();
             this.SuspendLayout();
             // 
@@ -103,7 +102,6 @@
             this.Name = "ChangeIrtPeptidesDlg";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.Designer.cs
@@ -70,7 +70,6 @@
             this.comboStandards = new System.Windows.Forms.ComboBox();
             this.comboRegressionType = new System.Windows.Forms.ComboBox();
             this.label5 = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceLibrary)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).BeginInit();
             this.contextMenuAdd.SuspendLayout();
@@ -366,7 +365,6 @@
             this.ShowInTaskbar = false;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.EditIrtCalcDlg_FormClosing);
             this.Load += new System.EventHandler(this.OnLoad);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceLibrary)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).EndInit();
             this.contextMenuAdd.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/Irt/SelectIrtStandardDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/SelectIrtStandardDlg.Designer.cs
@@ -33,7 +33,6 @@
             this.comboStandards = new System.Windows.Forms.ComboBox();
             this.btnOk = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // label1
@@ -76,7 +75,6 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "SelectIrtStandardDlg";
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/SettingsUI/Irt/UseCurrentCalculatorDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/UseCurrentCalculatorDlg.Designer.cs
@@ -35,7 +35,6 @@
             this.radioCalibrate = new System.Windows.Forms.RadioButton();
             this.btnOk = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.SuspendLayout();
             // 
             // radioUseCurrent
@@ -96,7 +95,6 @@
             this.MinimizeBox = false;
             this.Name = "UseCurrentCalculatorDlg";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/pwiz_tools/Skyline/SettingsUI/MetadataRuleEditor.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/MetadataRuleEditor.Designer.cs
@@ -45,7 +45,6 @@
             this.lblReplacement = new System.Windows.Forms.Label();
             this.tbxReplacement = new System.Windows.Forms.TextBox();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.panelButtons.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.bindingListSource1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.boundDataGridView1)).BeginInit();
@@ -165,7 +164,6 @@
             this.Name = "MetadataRuleEditor";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.panelButtons.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.bindingListSource1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.boundDataGridView1)).EndInit();

--- a/pwiz_tools/Skyline/SettingsUI/MetadataRuleSetEditor.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/MetadataRuleSetEditor.Designer.cs
@@ -52,7 +52,6 @@
             this.panelButtons = new System.Windows.Forms.FlowLayoutPanel();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOK = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -247,7 +246,6 @@
             this.Name = "MetadataRuleSetEditor";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.Designer.cs
@@ -131,7 +131,6 @@ namespace pwiz.Skyline.SettingsUI
             this.editCalculatorCurrentContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editCalculatorListContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cbxSimpleRatios = new System.Windows.Forms.CheckBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.tabControl1.SuspendLayout();
             this.tabDigestion.SuspendLayout();
             this.tabPrediction.SuspendLayout();
@@ -911,7 +910,6 @@ namespace pwiz.Skyline.SettingsUI
             this.MinimizeBox = false;
             this.Name = "PeptideSettingsUI";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.tabControl1.ResumeLayout(false);
             this.tabDigestion.ResumeLayout(false);
             this.tabDigestion.PerformLayout();

--- a/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.Designer.cs
@@ -122,7 +122,6 @@
             this.helpTip = new System.Windows.Forms.ToolTip(this.components);
             this.contextMenuStripPrecursorAdduct = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.contextMenuStripFragmentAdduct = new System.Windows.Forms.ContextMenuStrip(this.components);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.tabControl1.SuspendLayout();
             this.tabGeneral.SuspendLayout();
             this.tabFilter.SuspendLayout();
@@ -806,7 +805,6 @@
             this.MinimizeBox = false;
             this.Name = "TransitionSettingsUI";
             this.ShowInTaskbar = false;
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.tabControl1.ResumeLayout(false);
             this.tabGeneral.ResumeLayout(false);
             this.tabGeneral.PerformLayout();

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.Designer.cs
@@ -102,7 +102,6 @@ namespace pwiz.Skyline.SettingsUI
             this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
             this.zoomSpectrumContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator27 = new System.Windows.Forms.ToolStripSeparator();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitPeptideList)).BeginInit();
             this.splitPeptideList.Panel1.SuspendLayout();
             this.splitPeptideList.Panel2.SuspendLayout();
@@ -709,7 +708,6 @@ namespace pwiz.Skyline.SettingsUI
             this.Load += new System.EventHandler(this.ViewLibraryDlg_Load);
             this.Shown += new System.EventHandler(this.ViewLibraryDlg_Shown);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ViewLibraryDlg_KeyDown);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.splitPeptideList.Panel1.ResumeLayout(false);
             this.splitPeptideList.Panel2.ResumeLayout(false);
             this.splitPeptideList.Panel2.PerformLayout();

--- a/pwiz_tools/Skyline/Skyline.Designer.cs
+++ b/pwiz_tools/Skyline/Skyline.Designer.cs
@@ -344,7 +344,6 @@ namespace pwiz.Skyline
             this.detectionsToolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.detectionsPropertiesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.detectionsToolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.contextMenuTreeNode.SuspendLayout();
             this.contextMenuSpectrum.SuspendLayout();
             this.contextMenuRetentionTimes.SuspendLayout();
@@ -2556,7 +2555,6 @@ namespace pwiz.Skyline
             this.Activated += new System.EventHandler(this.SkylineWindow_Activated);
             this.Move += new System.EventHandler(this.SkylineWindow_Move);
             this.Resize += new System.EventHandler(this.SkylineWindow_Resize);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.contextMenuTreeNode.ResumeLayout(false);
             this.contextMenuSpectrum.ResumeLayout(false);
             this.contextMenuRetentionTimes.ResumeLayout(false);

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.Designer.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.Designer.cs
@@ -64,7 +64,6 @@ namespace pwiz.Skyline.ToolsUI
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOK = new System.Windows.Forms.Button();
             this.tbxPrositServer = new System.Windows.Forms.TextBox();
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
             this.tabControl.SuspendLayout();
             this.tabPanorama.SuspendLayout();
             this.tabRemote.SuspendLayout();
@@ -339,7 +338,6 @@ namespace pwiz.Skyline.ToolsUI
             this.Name = "ToolOptionsUI";
             this.ShowInTaskbar = false;
             this.Shown += new System.EventHandler(this.ToolOptionsUI_Shown);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).EndInit();
             this.tabControl.ResumeLayout(false);
             this.tabPanorama.ResumeLayout(false);
             this.tabPanorama.PerformLayout();

--- a/pwiz_tools/Skyline/Util/DockableFormEx.cs
+++ b/pwiz_tools/Skyline/Util/DockableFormEx.cs
@@ -56,7 +56,6 @@ namespace pwiz.Skyline.Util
             this._components = new System.ComponentModel.Container();
             this.ModeUIExtender = new Helpers.ModeUIExtender(_components);
             this._modeUIHelper = new Helpers.ModeUIAwareFormHelper(ModeUIExtender);
-            ((System.ComponentModel.ISupportInitialize)(this.ModeUIExtender)).BeginInit();
         }
         #endregion
 

--- a/pwiz_tools/Skyline/Util/FormEx.cs
+++ b/pwiz_tools/Skyline/Util/FormEx.cs
@@ -63,7 +63,6 @@ namespace pwiz.Skyline.Util
             this._components = new System.ComponentModel.Container();
             this.modeUIHandler = new Helpers.ModeUIExtender(_components);
             this._modeUIHelper = new Helpers.ModeUIAwareFormHelper(modeUIHandler);
-            ((System.ComponentModel.ISupportInitialize)(this.modeUIHandler)).BeginInit();
         }
         #endregion
 

--- a/pwiz_tools/Skyline/Util/ModeUIAwareForm.cs
+++ b/pwiz_tools/Skyline/Util/ModeUIAwareForm.cs
@@ -38,7 +38,7 @@ namespace pwiz.Skyline.Util
         /// </summary>
 
         [ProvideProperty("UIMode", typeof(Component))]   // Custom component property that appears in Designer (via IExtenderProvider)
-        public class ModeUIExtender : Component, ISupportInitialize, IExtenderProvider // Behaves like a ToolTip, in that its presence in a form allows us to tag components with ModeUI info in the designer
+        public class ModeUIExtender : Component, IExtenderProvider // Behaves like a ToolTip, in that its presence in a form allows us to tag components with ModeUI info in the designer
         {
             private Dictionary<IComponent, MODE_UI_HANDLING_TYPE> _handledComponents = new Dictionary<IComponent, MODE_UI_HANDLING_TYPE>();
             private Dictionary<IComponent, string> _originalToolStripText = new Dictionary<IComponent, string>();
@@ -103,14 +103,6 @@ namespace pwiz.Skyline.Util
             public void AddHandledComponent(IComponent component, MODE_UI_HANDLING_TYPE type)
             {
                 _handledComponents[component] = type;
-            }
-
-            public void BeginInit() // Required by ISupportInitialize
-            {
-            }
-
-            public void EndInit() // Required by ISupportInitialize
-            {
             }
         }
 


### PR DESCRIPTION
Remove modeUIHandler ISupportInitialize calls from .designer.cs files.

ModeUIExtender does not make use of any of the ISupportInitialize functionality.
I think we should remove it since it adds unnecessary complexity to our .designer.cs files.

Visual Studio Designer adds the BeginInit and EndInit calls whenever it notices that the thing supports ISupportInitialize. Eventually, those calls will get added to all of our .designer.cs files. But, if we remove that interface from this class now, we can prevent all those calls from making it into the code base.