### PR TITLE
Enable /PDBCOMPRESS via <debug-store-compress>

### DIFF
--- a/libraries/boost-build/src/tools/msvc.jam
+++ b/libraries/boost-build/src/tools/msvc.jam
@@ -2090,7 +2090,7 @@ local rule register-toolset-really ( )
     toolset.flags msvc.compile CFLAGS $(.cpu-arch-ia64)/<instruction-set>$(.cpu-type-itanium2) : /G2 ;
 
     toolset.flags msvc.compile CFLAGS <debug-symbols>on/<debug-store>object : /Z7 ;
-    toolset.flags msvc.compile CFLAGS <debug-symbols>on/<debug-store>database : /Zi ;
+    toolset.flags msvc.compile CFLAGS <debug-symbols>on/<debug-store>database : "/Zi /PDBCOMPRESS" ;
     toolset.flags msvc.compile CFLAGS <optimization>off : /Od ;
     toolset.flags msvc.compile CFLAGS <inlining>off : /Ob0 ;
     toolset.flags msvc.compile CFLAGS <inlining>on : /Ob1 ;

--- a/libraries/boost-build/src/tools/msvc.jam
+++ b/libraries/boost-build/src/tools/msvc.jam
@@ -2150,6 +2150,7 @@ local rule register-toolset-really ( )
     {
         toolset.flags msvc.link PDB_LINKFLAG <debug-symbols>on/<debug-store>database : "/PDB:" ;  # not used yet
         toolset.flags msvc.link LINKFLAGS <debug-symbols>on : /DEBUG ;
+        toolset.flags msvc.link LINKFLAGS <debug-symbols>on/<debug-store>database : /PDBCOMPRESS ;
         toolset.flags msvc.link DEF_FILE <def-file> ;
         toolset.flags msvc.link ASSEMBLIES <assembly> ;
 

--- a/libraries/boost-build/src/tools/msvc.jam
+++ b/libraries/boost-build/src/tools/msvc.jam
@@ -1997,6 +1997,7 @@ local rule register-toolset-really ( )
     # Declare msvc toolset specific features.
     {
         feature.feature debug-store : object database : propagated ;
+        feature.feature debug-store-compress : on off : propagated ;
         feature.feature pch-source  :                 : dependency free ;
         feature.feature secure-scl          : default on off        : propagated ;
         feature.feature iterator-debugging  : default on off        : propagated ;
@@ -2090,7 +2091,7 @@ local rule register-toolset-really ( )
     toolset.flags msvc.compile CFLAGS $(.cpu-arch-ia64)/<instruction-set>$(.cpu-type-itanium2) : /G2 ;
 
     toolset.flags msvc.compile CFLAGS <debug-symbols>on/<debug-store>object : /Z7 ;
-    toolset.flags msvc.compile CFLAGS <debug-symbols>on/<debug-store>database : "/Zi /PDBCOMPRESS" ;
+    toolset.flags msvc.compile CFLAGS <debug-symbols>on/<debug-store>database : /Zi ;
     toolset.flags msvc.compile CFLAGS <optimization>off : /Od ;
     toolset.flags msvc.compile CFLAGS <inlining>off : /Ob0 ;
     toolset.flags msvc.compile CFLAGS <inlining>on : /Ob1 ;
@@ -2150,7 +2151,7 @@ local rule register-toolset-really ( )
     {
         toolset.flags msvc.link PDB_LINKFLAG <debug-symbols>on/<debug-store>database : "/PDB:" ;  # not used yet
         toolset.flags msvc.link LINKFLAGS <debug-symbols>on : /DEBUG ;
-        toolset.flags msvc.link LINKFLAGS <debug-symbols>on/<debug-store>database : /PDBCOMPRESS ;
+        toolset.flags msvc.link LINKFLAGS <debug-store-compress>on : /PDBCOMPRESS ;
         toolset.flags msvc.link DEF_FILE <def-file> ;
         toolset.flags msvc.link ASSEMBLIES <assembly> ;
 


### PR DESCRIPTION
Should greatly reduce PDB size-on-disk when building debug build (without optimization). Defaults to on but can be turned off with debug-store-compress=off.