### PR TITLE
Fix exception typing ")" into blank node at bottom of Sequence Tree.

### DIFF
--- a/pwiz_tools/Skyline/Controls/SequenceTree.cs
+++ b/pwiz_tools/Skyline/Controls/SequenceTree.cs
@@ -1069,6 +1069,10 @@ namespace pwiz.Skyline.Controls
                 string keyChar = e.KeyChar.ToString(LocalizationHelper.CurrentCulture);
                 if (IsKeyLocked(Keys.CapsLock))
                     keyChar = keyChar.ToLower();
+                if (@"+^%~(){}[]".IndexOf(keyChar, StringComparison.Ordinal) >= 0)
+                {
+                    keyChar = @"{" + keyChar + @"}";
+                }
                 SendKeys.Send(keyChar);
                 e.Handled = true;
             }

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonDef.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonDef.cs
@@ -32,7 +32,13 @@ namespace pwiz.Skyline.Model.GroupComparison
     [XmlRoot("group_comparison")]
     public sealed class GroupComparisonDef : XmlNamedElement
     {
-        public static readonly GroupComparisonDef EMPTY = new GroupComparisonDef(NAME_INTERNAL);
+        public static readonly GroupComparisonDef EMPTY = new GroupComparisonDef
+        {
+            NormalizationMethod = NormalizationMethod.NONE,
+            SummarizationMethod = SummarizationMethod.AVERAGING,
+            ConfidenceLevelTimes100 = 95,
+            ColorRows = ImmutableList<MatchRgbHexColor>.EMPTY
+        };
 
         public GroupComparisonDef(string name) : base(name)
         {

--- a/pwiz_tools/Skyline/TestFunctional/GroupComparisonTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/GroupComparisonTest.cs
@@ -45,7 +45,7 @@ namespace pwiz.SkylineTestFunctional
             RunFunctionalTest();
         }
 
-      [TestMethod]
+        [TestMethod]
         public void TestGroupComparisonAsSmallMolecules()
         {
             if (!RunSmallMoleculeTestVersions)
@@ -78,6 +78,7 @@ namespace pwiz.SkylineTestFunctional
             var editGroupComparisonDlg = ShowDialog<EditGroupComparisonDlg>(SkylineWindow.AddGroupComparison);
             RunUI(() =>
             {
+                Assert.IsTrue(string.IsNullOrEmpty(editGroupComparisonDlg.TextBoxName.Text));
                 editGroupComparisonDlg.TextBoxName.Text = "One-Two";
                 editGroupComparisonDlg.ComboControlAnnotation.SelectedItem = "DilutionNumber";
             });


### PR DESCRIPTION
Certain characters need to be escaped before being passed to SendKeys.Send method.

(Reported on exception web)

Also, fix problem where bringing up Group Comparison dialog would have the "Name" filled in as "__internal__".
(This bug was introduced a few weeks ago and has not made it into a Skyline-Daily)