### PR TITLE
Skyline: fix for exception report https://skyline.ms/announcements/ho…

### DIFF
--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
@@ -216,7 +216,7 @@ namespace pwiz.Skyline.EditUI
             var i = 0;
             foreach (var entry in proteinAssociations)
             {
-                checkBoxListMatches.Items.Add(entry.Key.Name);
+                checkBoxListMatches.Items.Add(entry.Key.DisplayName);
                 checkBoxListMatches.SetItemCheckState(i, CheckState.Checked);
                 i++;
             }
@@ -306,7 +306,7 @@ namespace pwiz.Skyline.EditUI
             get
             {
                 var proteins = checkBoxListMatches.CheckedIndices.OfType<int>()
-                    .Select(i => _associatedProteins[i].Key.Name)
+                    .Select(i => _associatedProteins[i].Key.DisplayName)
                     .ToList();
 
                 var fileName = Path.GetFileName(_fileName);

--- a/pwiz_tools/Skyline/Model/PeptideGroup.cs
+++ b/pwiz_tools/Skyline/Model/PeptideGroup.cs
@@ -186,6 +186,7 @@ namespace pwiz.Skyline.Model
         }
 
         public override string Name { get { return _name; } }
+        public string DisplayName => string.IsNullOrEmpty(_name) ? _sequence : _name;
         public override string Description { get { return _description; } }
         public override string Sequence { get { return _sequence; } }
         public new bool IsDecoy { get { return _isDecoy; } }

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -3126,7 +3126,7 @@ namespace pwiz.Skyline
                     if (fastaSequence != null)
                     {
                         if (peptideSequence == null)
-                            modifyMessage = string.Format(Resources.SkylineWindow_sequenceTree_AfterNodeEdit_Add__0__, fastaSequence.Name);
+                            modifyMessage = string.Format(Resources.SkylineWindow_sequenceTree_AfterNodeEdit_Add__0__, fastaSequence.DisplayName);
                         else
                         {
                             modifyMessage = string.Format(Resources.SkylineWindow_sequenceTree_AfterNodeEdit_Add__0__, peptideSequence);


### PR DESCRIPTION
…me/issues/exceptions/thread.view?rowId=49522 wherein Associate Proteins is used with a nameless FastaSequence. We'll show the sequence in the checkboxlist if there is no name for the protein.

Reported anonymously.