### PR TITLE
Fix parenting of the window that warns you that the audit log is out …

### DIFF
--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -254,7 +254,7 @@ namespace pwiz.Skyline
             return skypSupport.Open(skypPath, Settings.Default.ServerList, parentWindow);
         }
 
-        private AuditLogEntry AskForLogEntry()
+        private AuditLogEntry AskForLogEntry(FormEx parentWindow)
         {
             AuditLogEntry result = null;
             Invoke((Action)(() =>
@@ -264,11 +264,11 @@ namespace pwiz.Skyline
                         .SkylineWindow_AskForLogEntry_The_audit_log_does_not_match_the_current_document__Would_you_like_to_add_a_log_entry_describing_the_changes_made_to_the_document_,
                     MessageBoxButtons.YesNo))
                 {
-                    if (alert.ShowDialog(this) == DialogResult.Yes)
+                    if (alert.ShowDialog(parentWindow ?? this) == DialogResult.Yes)
                     {
                         using (var docChangeEntryDlg = new DocumentChangeLogEntryDlg())
                         {
-                            docChangeEntryDlg.ShowDialog(this);
+                            docChangeEntryDlg.ShowDialog(parentWindow ?? this);
                             result = docChangeEntryDlg.Entry;
                             return;
                         }
@@ -331,7 +331,7 @@ namespace pwiz.Skyline
 
                         try
                         {
-                            document = document.ReadAuditLog(path, skylineDocumentHash, AskForLogEntry);
+                            document = document.ReadAuditLog(path, skylineDocumentHash, ()=>AskForLogEntry(parentWindow));
                         }
                         catch (Exception e)
                         {


### PR DESCRIPTION
…of sync.

It was not getting the correct parent if the document was opened from the Start Page.