### PR TITLE
* added support for BiblioSpec to read .mzid.gz files

### DIFF
--- a/pwiz_tools/BiblioSpec/src/BlibBuild.cpp
+++ b/pwiz_tools/BiblioSpec/src/BlibBuild.cpp
@@ -158,7 +158,8 @@ int main(int argc, char* argv[])
                     MSFReader msfReader(builder, result_file, progress_cptr);
 
                     success = msfReader.parseFile();
-                } else if (has_extension(result_file, ".mzid")) {
+                } else if (has_extension(result_file, ".mzid") ||
+                           has_extension(result_file, ".mzid.gz")) {
                     MzIdentMLReader mzidReader(builder, result_file, progress_cptr);
                     success = mzidReader.parseFile();
 

--- a/pwiz_tools/BiblioSpec/src/BlibBuilder.cpp
+++ b/pwiz_tools/BiblioSpec/src/BlibBuilder.cpp
@@ -96,6 +96,7 @@ static vector<string> supportedTypes = {
     ".msf",
     ".pdResult",
     ".mzid",
+    ".mzid.gz",
     "msms.txt",
     "final_fragment.csv",
     ".proxl.xml",

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/DDASearchControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/DDASearchControl.cs
@@ -132,7 +132,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         public void Cancel()
         {
-            cancelToken.Cancel();
+            cancelToken?.Cancel();
             btnCancel.Enabled = false;
         }
 

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -621,8 +621,6 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                     if (!ImportFastaControl.ImportFasta(ImportPeptideSearch.IrtStandard))
                         return;
 
-                    ImportPeptideSearch.SearchEngine.Dispose();
-
                     WizardFinish();
                     return;
 
@@ -1039,6 +1037,10 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             // Close file handles to the peptide search library
             ImportPeptideSearch.ClosePeptideSearchLibraryStreams(Document);
+
+            // Dispose DDA SearchEngine if it is initialized
+            ImportPeptideSearch.SearchEngine?.Dispose();
+
             DialogResult = result;
         }
 

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -613,19 +613,15 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                         ImportPeptideSearch.SearchFilenames[i] = outFilePath;
                     }
                     BuildPepSearchLibControl.AddSearchFiles(ImportPeptideSearch.SearchFilenames);
-                    ImportPeptideSearch.SearchEngine.Dispose();
 
                     if (!BuildPeptideSearchLibrary(eCancel2))
-                    {
-                        // Page shows error
-                        if (eCancel2.Cancel)
-                            return;
-                        CloseWizard(DialogResult.Cancel);
-                    }
+                        return;
 
                     //load proteins after search
                     if (!ImportFastaControl.ImportFasta(ImportPeptideSearch.IrtStandard))
                         return;
+
+                    ImportPeptideSearch.SearchEngine.Dispose();
 
                     WizardFinish();
                     return;

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -598,6 +598,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                     btnNext.Enabled = false;
                     btnCancel.Enabled = false;
                     btnBack.Enabled = false;
+                    ControlBox = false;
                     SearchControl.RunSearch();
                     break;
 
@@ -676,6 +677,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             btnCancel.Enabled = true;
             btnBack.Enabled = true;
+            ControlBox = true;
             if (success)
                 btnNext.Enabled = true;
         }
@@ -1035,13 +1037,19 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         public void CloseWizard(DialogResult result)
         {
+            DialogResult = result;
+        }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
             // Close file handles to the peptide search library
             ImportPeptideSearch.ClosePeptideSearchLibraryStreams(Document);
 
-            // Dispose DDA SearchEngine if it is initialized
+            // Cancel and dispose DDA SearchEngine
+            SearchControl?.Cancel();
             ImportPeptideSearch.SearchEngine?.Dispose();
 
-            DialogResult = result;
+            base.OnFormClosing(e);
         }
 
         private void BuildPepSearchLibForm_OnInputFilesChanged(object sender,

--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -33,6 +33,7 @@ using MSAmandaSettings = MSAmanda.InOutput.Settings;
 using pwiz.Common.Chemistry;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Model.Results;
 using MSAmandaEnzyme = MSAmanda.Utils.Enzyme;
 using OperationCanceledException = System.OperationCanceledException;
 using pwiz.Skyline.Properties;
@@ -312,6 +313,12 @@ namespace pwiz.Skyline.Model.DdaSearch
                     Settings.SelectedModifications.AddRange(GenerateNewModificationsForEveryAA(item));
                 }
             }
+
+        }
+
+        public override string GetSearchResultFilepath(MsDataFileUri searchFilepath)
+        {
+            return Path.ChangeExtension(searchFilepath.GetFilePath(), @".mzid.gz");
         }
 
         private List<Modification> GenerateNewModificationsForEveryAA(StaticMod mod)

--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLiteBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLiteBuilder.cs
@@ -46,6 +46,7 @@ namespace pwiz.Skyline.Model.Lib
         public const string EXT_PEP_XML = ".pep.xml";
         public const string EXT_PEP_XML_ONE_DOT = ".pepXML";
         public const string EXT_MZID = ".mzid";
+        public const string EXT_MZID_GZ = ".mzid.gz";
         public const string EXT_IDP_XML = ".idpXML";
         public const string EXT_SQT = ".sqt";
         public const string EXT_DAT = ".dat";

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.cs
@@ -46,6 +46,7 @@ namespace pwiz.Skyline.SettingsUI
             BiblioSpecLiteBuilder.EXT_PEP_XML,
             BiblioSpecLiteBuilder.EXT_PEP_XML_ONE_DOT,
             BiblioSpecLiteBuilder.EXT_MZID,
+            BiblioSpecLiteBuilder.EXT_MZID_GZ,
             BiblioSpecLiteBuilder.EXT_XTAN_XML,
             BiblioSpecLiteBuilder.EXT_PROTEOME_DISC,
             BiblioSpecLiteBuilder.EXT_PROTEOME_DISC_FILTERED,

--- a/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDdaTutorial.log
+++ b/pwiz_tools/Skyline/TestTutorial/TutorialAuditLogs/en/TestDdaTutorial.log
@@ -9,7 +9,7 @@ Summary   : Added spectral library "TestDdaTutorial"
 All Info  :
 Added spectral library "TestDdaTutorial"
 Build Spectral Library > Cut-off score is "0.95"
-Build Spectral Library > Search files : contains "QE_140221_01_UPS1_100fmolspiked.mzid"
+Build Spectral Library > Search files : contains "QE_140221_01_UPS1_100fmolspiked.mzid.gz"
 Build Spectral Library > iRT standard peptides is None
 Build Spectral Library > Include ambiguous matches is False
 Build Spectral Library > Filter for document peptides is False
@@ -17,7 +17,7 @@ Build Spectral Library > Workflow is "DDA with MS1 filtering"
 Extra Info: Cut-off score = "0.95",
 Search files = 
 [
-    "QE_140221_01_UPS1_100fmolspiked.mzid"
+    "QE_140221_01_UPS1_100fmolspiked.mzid.gz"
 ],
 iRT standard peptides = None,
 Include ambiguous matches = False,


### PR DESCRIPTION
* added support for BiblioSpec to read .mzid.gz files (pwiz can read them just like uncompressed files)
* changed MSAmandaWrapper's expected output filepath to the .mzid.gz file
* fixed ImportPeptideSearchDlg continuing to import library even when DDA search fails

@nickshulman Does the ImportPeptideSearchDlg change make sense to you? It didn't make sense to me to run CloseWizard() if the build library step failed (without cancellation). It makes more sense to me to let the user go back and try again, or let the user cancel explicitly from the wizard.