### PR TITLE
Fixes from the exception web:

### DIFF
--- a/pwiz_tools/Shared/Common/Controls/Clustering/DendrogramScale.cs
+++ b/pwiz_tools/Shared/Common/Controls/Clustering/DendrogramScale.cs
@@ -90,6 +90,10 @@ namespace pwiz.Common.Controls.Clustering
         public override SizeF GetScaleMaxSpace(Graphics g, GraphPane pane, float scaleFactor,
             bool applyAngle)
         {
+            if (_formats == null)
+            {
+                return new SizeF(0, 0);
+            }
             return new SizeF(Width, 100);
         }
 
@@ -102,7 +106,7 @@ namespace pwiz.Common.Controls.Clustering
         /// <param name="formats"></param>
         public void Update(List<DendrogramFormat> formats)
         {
-            this._formats = formats;
+            _formats = formats;
         }
 
         private PointF CoordinatesToPoint(double location, double yFraction, GraphPane pane, float xAxisHeight, float yAxisWidth)

--- a/pwiz_tools/Skyline/Controls/Clustering/HierarchicalClusterGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Clustering/HierarchicalClusterGraph.cs
@@ -221,6 +221,10 @@ namespace pwiz.Skyline.Controls.Clustering
 
         public List<DendrogramFormat> GetUpdatedColumnDendrograms()
         {
+            if (!GraphResults.ColumnGroups.Any())
+            {
+                return null;
+            }
             var columnDendrograms = new List<DendrogramFormat>();
             double xStart = .5;
             foreach (var group in GraphResults.ColumnGroups)
@@ -243,9 +247,13 @@ namespace pwiz.Skyline.Controls.Clustering
 
         public List<DendrogramFormat> GetUpdatedRowDendrograms()
         {
-            int rowCount = GraphResults.RowCount;
+            if (GraphResults.RowDendrogramData == null)
+            {
+                return null;
+            }
             var rowLocations = new List<KeyValuePair<double, double>>();
             var colors = new List<ImmutableList<Color>>();
+            int rowCount = GraphResults.RowCount;
             for (int rowIndex = 0; rowIndex < rowCount; rowIndex++)
             {
                 var y1 = rowCount + .5 - rowIndex;
@@ -253,7 +261,6 @@ namespace pwiz.Skyline.Controls.Clustering
                 rowLocations.Add(new KeyValuePair<double, double>(y1, y2));
                 colors.Add(GraphResults.RowHeaders[rowIndex].Colors);
             }
-
             return new List<DendrogramFormat>
                 {new DendrogramFormat(GraphResults.RowDendrogramData, rowLocations, colors)};
         }

--- a/pwiz_tools/Skyline/Controls/Databinding/DataboundGridControl.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/DataboundGridControl.cs
@@ -750,7 +750,7 @@ namespace pwiz.Skyline.Controls.Databinding
                     }
                 }
             }
-            var graphResults = new ClusterGraphResults(clusteredResults.RowDendrogramData.DendrogramData, rowHeaders, columnGroups, points);
+            var graphResults = new ClusterGraphResults(clusteredResults.RowDendrogramData?.DendrogramData, rowHeaders, columnGroups, points);
             var heatMapGraph = new HierarchicalClusterGraph()
             {
                 SkylineWindow = DataSchemaSkylineWindow,
@@ -836,10 +836,11 @@ namespace pwiz.Skyline.Controls.Databinding
                 rowDendrogram.Bounds = new Rectangle(0, dendrogramTop, splitContainerVertical.Panel1.Width,
                     splitContainerVertical.Panel1.Height - dendrogramTop);
                 var firstDisplayedCell = DataGridView.FirstDisplayedCell;
-                var rowHeight = firstDisplayedCell.Size.Height;
+                var rowHeight = firstDisplayedCell?.Size.Height ?? DataGridView.Rows[0].Height;
+                int firstDisplayedRowIndex = firstDisplayedCell?.RowIndex ?? 0;
                 var firstLocation = 3.5;
                 var rowLocations = ImmutableList.ValueOf(Enumerable.Range(0, reportResults.RowCount).Select(rowIndex =>
-                        (rowIndex - firstDisplayedCell.RowIndex) * rowHeight + firstLocation))
+                        (rowIndex - firstDisplayedRowIndex) * rowHeight + firstLocation))
                     .Select(d => new KeyValuePair<double, double>(d, d + rowHeight));
                 IEnumerable<IEnumerable<Color>> rowColors = null;
                 if (colorScheme != null)

--- a/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
@@ -731,7 +731,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 foreach (var nodePeptide in document.Molecules)
                 {
                     ProgressMonitor.CheckCanceled(token.Token);
-
+                    index++;
                     switch (RTGraphController.PointsType)
                     {
                         case PointsTypeRT.targets:


### PR DESCRIPTION
1. NullReferenceException bringing up a Heat Map which had either no rows or no columns
2. IndexOutOfRangeException clicking on any point in LinearRegressionGraphPane.