### PR TITLE
- fixed precursor ion spectrum support for WIFF files

### DIFF
--- a/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
@@ -95,7 +95,7 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_ABI::spectrum(size_t index, DetailLevel d
 
 PWIZ_API_DECL SpectrumPtr SpectrumList_ABI::spectrum(size_t index, bool getBinaryData, const pwiz::util::IntegerSet& msLevelsToCentroid) const
 {
-	return spectrum(index, getBinaryData ? DetailLevel_FullData : DetailLevel_FullMetadata, msLevelsToCentroid);
+    return spectrum(index, getBinaryData ? DetailLevel_FullData : DetailLevel_FullMetadata, msLevelsToCentroid);
 }
 
 PWIZ_API_DECL SpectrumPtr SpectrumList_ABI::spectrum(size_t index, DetailLevel detailLevel, const pwiz::util::IntegerSet& msLevelsToCentroid) const
@@ -145,7 +145,8 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_ABI::spectrum(size_t index, DetailLevel d
     ExperimentType experimentType = msExperiment->getExperimentType();
     int msLevel = spectrum->getMSLevel();
     result->set(MS_ms_level, msLevel);
-    result->set(translateAsSpectrumType(experimentType));
+    CVID spectrumType = translateAsSpectrumType(experimentType);
+    result->set(spectrumType);
     result->set(translate(msExperiment->getPolarity()));
 
     double startMz, stopMz;
@@ -162,33 +163,54 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_ABI::spectrum(size_t index, DetailLevel d
 
     if (spectrum->getHasPrecursorInfo())
     {
-        double selectedMz, intensity, collisionEnergy = 0;
+        double selectedMz = 0, intensity, collisionEnergy = 0;
+        double centerMz = 0, lowerLimit, upperLimit;
         int charge;
         spectrum->getPrecursorInfo(selectedMz, intensity, charge);
 
-        Precursor precursor;
         if (spectrum->getHasIsolationInfo())
         {
-            double centerMz, lowerLimit, upperLimit;
             spectrum->getIsolationInfo(centerMz, lowerLimit, upperLimit, collisionEnergy);
-            precursor.isolationWindow.set(MS_isolation_window_target_m_z, centerMz, MS_m_z);
-            precursor.isolationWindow.set(MS_isolation_window_lower_offset, centerMz - lowerLimit, MS_m_z);
-            precursor.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit - centerMz, MS_m_z);
-			selectedMz = centerMz;
+            selectedMz = centerMz;
         }
 
-        SelectedIon selectedIon;
+        if (spectrumType == MS_precursor_ion_spectrum)
+        {
+            Product product;
 
-        selectedIon.set(MS_selected_ion_m_z, selectedMz, MS_m_z);
-        if (charge > 0)
-            selectedIon.set(MS_charge_state, charge);
+            // CONSIDER: error/warn if no isolation info?
+            if (centerMz > 0)
+            {
+                product.isolationWindow.set(MS_isolation_window_target_m_z, centerMz, MS_m_z);
+                product.isolationWindow.set(MS_isolation_window_lower_offset, centerMz - lowerLimit, MS_m_z);
+                product.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit - centerMz, MS_m_z);
+            }
 
-        precursor.activation.set(MS_beam_type_collision_induced_dissociation); // assume beam-type CID since all ABI instruments that write WIFFs are either QqTOF or QqLIT
-        if (collisionEnergy > 0)
-            precursor.activation.set(MS_collision_energy, collisionEnergy, UO_electronvolt);
+            result->products.push_back(product);
+        }
+        else
+        {
+            Precursor precursor;
+            SelectedIon selectedIon;
 
-        precursor.selectedIons.push_back(selectedIon);
-        result->precursors.push_back(precursor);
+            if (centerMz > 0)
+            {
+                precursor.isolationWindow.set(MS_isolation_window_target_m_z, centerMz, MS_m_z);
+                precursor.isolationWindow.set(MS_isolation_window_lower_offset, centerMz - lowerLimit, MS_m_z);
+                precursor.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit - centerMz, MS_m_z);
+            }
+
+            selectedIon.set(MS_selected_ion_m_z, selectedMz, MS_m_z);
+            if (charge > 0)
+                selectedIon.set(MS_charge_state, charge);
+
+            precursor.activation.set(MS_beam_type_collision_induced_dissociation); // assume beam-type CID since all ABI instruments that write WIFFs are either QqTOF or QqLIT
+            if (collisionEnergy > 0)
+                precursor.activation.set(MS_collision_energy, collisionEnergy, UO_electronvolt);
+
+            precursor.selectedIons.push_back(selectedIon);
+            result->precursors.push_back(precursor);
+        }
     }
 
     if (detailLevel == DetailLevel_InstantMetadata)

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile.cpp
@@ -729,7 +729,12 @@ int SpectrumImpl::getMSLevel() const
     try {return spectrumInfo->MSLevel == 0 ? 1 : spectrumInfo->MSLevel;} CATCH_AND_FORWARD
 }
 
-bool SpectrumImpl::getHasIsolationInfo() const { return selectedMz != 0; }
+bool SpectrumImpl::getHasIsolationInfo() const
+{
+    return ((ExperimentType)experiment->msExperiment->Details->ExperimentType == Product ||
+            (ExperimentType)experiment->msExperiment->Details->ExperimentType == Precursor) &&
+           experiment->msExperiment->Details->MassRangeInfo->Length > 0;
+}
 
 void SpectrumImpl::getIsolationInfo(double& centerMz, double& lowerLimit, double& upperLimit, double& collisionEnergy) const
 {

--- a/scripts/misc/clean_vendor_targets.bat
+++ b/scripts/misc/clean_vendor_targets.bat
@@ -8,9 +8,9 @@ pushd %PWIZ_ROOT%
 
 echo Cleaning project of vendor-related files...
 IF EXIST build-nt-x86\msvc-release rmdir /s /q build-nt-x86\msvc-release
-IF EXIST build-nt-x86\msvc-release-x64 rmdir /s /q build-nt-x86\msvc-release-x64
+IF EXIST build-nt-x86\msvc-release-x86_64 rmdir /s /q build-nt-x86\msvc-release-x86_64
 IF EXIST build-nt-x86\msvc-debug rmdir /s /q build-nt-x86\msvc-debug
-IF EXIST build-nt-x86\msvc-debug-x64 rmdir /s /q build-nt-x86\msvc-debug-x64
+IF EXIST build-nt-x86\msvc-debug-x86_64 rmdir /s /q build-nt-x86\msvc-debug-x86_64
 IF EXIST build-nt-x86\gcc-release rmdir /s /q build-nt-x86\gcc-release
 IF EXIST build-nt-x86\gcc-debug rmdir /s /q build-nt-x86\gcc-debug
 IF EXIST build-nt-x86\pwiz\data\vendor_readers rmdir /s /q build-nt-x86\pwiz\data\vendor_readers


### PR DESCRIPTION
- fixed precursor ion spectrum support for WIFF files (use `<product>` element instead of `<precursor>`)