### PR TITLE
Fix bug where Protein Abundance was always #N/A if normalization meth…

### DIFF
--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Protein.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Protein.cs
@@ -254,7 +254,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
                 bool incomplete;
                 if (allowMissingTransitions)
                 {
-                    incomplete = true;
+                    incomplete = false;
                 }
                 else
                 {


### PR DESCRIPTION
…od is Ratio to Heavy

(reported by Roman in October, and by Barbara in February)