### PR TITLE
Fix bug where custom formats on columns in the Document Grid would be…

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/ItemProperties.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/ItemProperties.cs
@@ -46,5 +46,23 @@ namespace pwiz.Common.DataBinding
         {
             return _properties;
         }
+
+        protected bool Equals(ItemProperties other)
+        {
+            return _properties.Equals(other._properties);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((ItemProperties) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return _properties.GetHashCode();
+        }
     }
 }

--- a/pwiz_tools/Shared/Common/DataBinding/ViewSpecList.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/ViewSpecList.cs
@@ -56,6 +56,7 @@ namespace pwiz.Common.DataBinding
             get { return Views.Select(vsl => vsl.ViewSpec); }
         }
 
+        [TrackChildren]
         public IEnumerable<ViewLayoutList> ViewLayouts
         {
             get { return Views.Select(vsl => vsl.ViewLayoutList).Where(vll => !vll.IsEmpty); }

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.Designer.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.Designer.cs
@@ -4507,6 +4507,15 @@ namespace pwiz.Skyline.Model.AuditLog {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Layouts.
+        /// </summary>
+        public static string ViewSpecList_ViewLayouts {
+            get {
+                return ResourceManager.GetString("ViewSpecList_ViewLayouts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Reports.
         /// </summary>
         public static string ViewSpecList_Views {

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.resx
@@ -423,6 +423,9 @@
   <data name="ViewSpecList_Views" xml:space="preserve">
     <value>Reports</value>
   </data>
+  <data name="ViewSpecList_ViewLayouts" xml:space="preserve">
+    <value>Layouts</value>
+  </data>
   <data name="PivotSpec_ColumnHeaders" xml:space="preserve">
     <value>Column headers</value>
   </data>


### PR DESCRIPTION
… forgotten as soon as the data was refreshed.

Reported by jrenders.