### PR TITLE
- fixed BiblioSpec's MaxQuant reader not applying terminal label-type mods

### DIFF
--- a/pwiz_tools/BiblioSpec/src/MaxQuantModReader.h
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantModReader.h
@@ -84,6 +84,7 @@ struct MaxQuantLabelingState
 public:
     vector<string> modsStrings;
     vector<const MaxQuantModification*> mods;
+    map< MaxQuantModification::MAXQUANT_MOD_POSITION, vector<const MaxQuantModification*> > modsByPosition;
 };
 
 /**
@@ -116,6 +117,16 @@ public:
     void addMods(vector<MaxQuantLabelingState>::iterator iter, vector<const MaxQuantModification*> modsToAdd)
     {
         iter->mods = modsToAdd;
+
+        // initialize fixed mod vectors for supported positions
+        iter->modsByPosition[MaxQuantModification::ANYWHERE].clear();
+        iter->modsByPosition[MaxQuantModification::ANY_N_TERM].clear();
+        iter->modsByPosition[MaxQuantModification::ANY_C_TERM].clear();
+        iter->modsByPosition[MaxQuantModification::NOT_N_TERM].clear();
+        iter->modsByPosition[MaxQuantModification::NOT_C_TERM].clear();
+
+        for (const auto& mod : modsToAdd)
+            iter->modsByPosition[mod->position].push_back(mod);
     }
 
     /**

--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
@@ -751,7 +751,6 @@ void MaxQuantReader::addFixedMods(vector<SeqMod>& v, const string& sequence, con
     // iterate over sequence
     for (int i = 0; i < (int)sequence.length(); i++)
     {
-        // check for label mods
         boost::range::insert(v, v.end(), getFixedMods(sequence[i], i + 1, modsAnywhere));
         if (i == 0)
             boost::range::insert(v, v.end(), getFixedMods(sequence[i], i + 1, modsAnyNTerm));

--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
@@ -682,7 +682,7 @@ void MaxQuantReader::storeLine(MaxQuantLine& entry)
 
     try
     {
-        addModsToVector(curMaxQuantPSM_->mods, entry.modifications, entry.modifiedSequence);
+        addModsToVector(curMaxQuantPSM_->mods, entry.modifications, entry.modifiedSequence, entry.sequence);
     }
     catch (const MaxQuantWrongSequenceException& e)
     {
@@ -731,12 +731,48 @@ void MaxQuantReader::addDoublesToVector(vector<double>& v, const string& valueLi
     }
 }
 
+void MaxQuantReader::addFixedMods(vector<SeqMod>& v, const string& sequence, const map< MaxQuantModification::MAXQUANT_MOD_POSITION, vector<const MaxQuantModification*> >& modsByPosition)
+{
+
+    // get fixed modifications by position
+    const vector<const MaxQuantModification*>& modsAnywhere = modsByPosition.find(MaxQuantModification::ANYWHERE)->second;
+    const vector<const MaxQuantModification*>& modsAnyNTerm = modsByPosition.find(MaxQuantModification::ANY_N_TERM)->second;
+    const vector<const MaxQuantModification*>& modsAnyCTerm = modsByPosition.find(MaxQuantModification::ANY_C_TERM)->second;
+    const vector<const MaxQuantModification*>& modsNotNTerm = modsByPosition.find(MaxQuantModification::NOT_N_TERM)->second;
+    const vector<const MaxQuantModification*>& modsNotCTerm = modsByPosition.find(MaxQuantModification::NOT_C_TERM)->second;
+
+    /* Do not use since we don't know where the peptide is in relation to the Protein N-term/C-term
+    vector<const MaxQuantModification*> modsProteinNTerm;
+    vector<const MaxQuantModification*> modsProteinCTerm;
+    */
+
+    for (const auto& mod : modsAnyNTerm) { if (mod->sites.empty()) v.insert(v.begin(), SeqMod(1, mod->massDelta)); }
+
+    // iterate over sequence
+    for (int i = 0; i < (int)sequence.length(); i++)
+    {
+        // check for label mods
+        boost::range::insert(v, v.end(), getFixedMods(sequence[i], i + 1, modsAnywhere));
+        if (i == 0)
+            boost::range::insert(v, v.end(), getFixedMods(sequence[i], i + 1, modsAnyNTerm));
+        else if (i + 1 == sequence.length())
+            boost::range::insert(v, v.end(), getFixedMods(sequence[i], i + 1, modsAnyCTerm));
+
+        if (i > 0)
+            boost::range::insert(v, v.end(), getFixedMods(sequence[i], i + 1, modsNotNTerm));
+        if (i + 1 < sequence.length())
+            boost::range::insert(v, v.end(), getFixedMods(sequence[i], i + 1, modsNotCTerm));
+    }
+
+    for (const auto& mod : modsAnyCTerm) { if (mod->sites.empty()) v.emplace_back(sequence.length(), mod->massDelta); }
+}
+
 /**
  * Adds a SeqMod for each modification in the given modified sequence string of the form
  * "_I(ab)AMASEQ_". The modifications string contains the (comma separated) full names of
  * the modifications; the string "Unmodified" can mean no variable modifications are present.
  */
-void MaxQuantReader::addModsToVector(vector<SeqMod>& v, const string& modifications, string modSequence)
+void MaxQuantReader::addModsToVector(vector<SeqMod>& v, const string& modifications, string modSequence, const string& sequence)
 {
     bal::replace_all(modSequence, "pS", "S(ph)");
     bal::replace_all(modSequence, "pT", "T(ph)");
@@ -772,19 +808,7 @@ void MaxQuantReader::addModsToVector(vector<SeqMod>& v, const string& modificati
         }
     }
 
-    // get fixed modifications by position
-    const vector<const MaxQuantModification*>& modsAnywhere = fixedModBank_.find(MaxQuantModification::ANYWHERE)->second;
-    const vector<const MaxQuantModification*>& modsAnyNTerm = fixedModBank_.find(MaxQuantModification::ANY_N_TERM)->second;
     const vector<const MaxQuantModification*>& modsAnyCTerm = fixedModBank_.find(MaxQuantModification::ANY_C_TERM)->second;
-    const vector<const MaxQuantModification*>& modsNotNTerm = fixedModBank_.find(MaxQuantModification::NOT_N_TERM)->second;
-    const vector<const MaxQuantModification*>& modsNotCTerm = fixedModBank_.find(MaxQuantModification::NOT_C_TERM)->second;
-    
-    /* Do not use since we don't know where the peptide is in relation to the Protein N-term/C-term
-    vector<const MaxQuantModification*> modsProteinNTerm;
-    vector<const MaxQuantModification*> modsProteinCTerm;
-    */
-
-    for (const auto& mod : modsAnyNTerm) { if (mod->sites.empty()) v.emplace_back(1, mod->massDelta); }
 
     // iterate over sequence
     int modsFound = 0;
@@ -816,23 +840,12 @@ void MaxQuantReader::addModsToVector(vector<SeqMod>& v, const string& modificati
                 throw BlibException(false, "Illegal character %c found in sequence %s (line %d)", 
                                     modSequence[i], modSequence.c_str(), lineNum_);
             }
-            // check for fixed mods
-            boost::range::insert(v, v.end(), getFixedMods(modSequence[i], i + 1 - modsTotalLength, modsAnywhere));
-            if (i == 0)
-                boost::range::insert(v, v.end(), getFixedMods(modSequence[i], i + 1 - modsTotalLength, modsAnyNTerm));
-            else if (i + 1 == sequenceLength)
-                boost::range::insert(v, v.end(), getFixedMods(modSequence[i], i + 1 - modsTotalLength, modsAnyCTerm));
-
-            if (i > 0)
-                boost::range::insert(v, v.end(), getFixedMods(modSequence[i], i + 1 - modsTotalLength, modsNotNTerm));
-            if (i + 1 < sequenceLength)
-                boost::range::insert(v, v.end(), getFixedMods(modSequence[i], i + 1 - modsTotalLength, modsNotCTerm));
 
             break;
         }
     }
 
-    for (const auto& mod : modsAnyCTerm) { if (mod->sites.empty()) v.emplace_back(sequenceLength - modsTotalLength, mod->massDelta); }
+    addFixedMods(v, sequence, fixedModBank_);
 
     if (modsFound < (int)modNames.size())
     {
@@ -870,22 +883,7 @@ void MaxQuantReader::addLabelModsToVector(vector<SeqMod>& v, const string& rawFi
                                    labelingState, labels->labelingStates.size(), rawFile.c_str());
     }
 
-    const auto& labelState = labels->labelingStates[labelingState];
-    const auto& labelMods = labelState.mods;
-    const auto& modsAnyNTerm = labelState.modsByPosition.find(MaxQuantModification::ANY_N_TERM)->second;
-    const auto& modsAnyCTerm = labelState.modsByPosition.find(MaxQuantModification::ANY_C_TERM)->second;
-
-    for (const auto& mod : modsAnyNTerm) { if (mod->sites.empty()) v.emplace_back(1, mod->massDelta); }
-
-    // iterate over sequence
-    for (int i = 0; i < (int)sequence.length(); i++)
-    {
-        // check for label mods
-        vector<SeqMod> sequenceLabelMods = getFixedMods(sequence[i], i + 1, labelMods);
-        v.insert(v.end(), sequenceLabelMods.begin(), sequenceLabelMods.end());
-    }
-
-    for (const auto& mod : modsAnyCTerm) { if (mod->sites.empty()) v.emplace_back(sequence.length(), mod->massDelta); }
+    addFixedMods(v, sequence, labels->labelingStates[labelingState].modsByPosition);
 }
 
 /**

--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
@@ -869,7 +869,13 @@ void MaxQuantReader::addLabelModsToVector(vector<SeqMod>& v, const string& rawFi
                                    "raw file '%s'.",
                                    labelingState, labels->labelingStates.size(), rawFile.c_str());
     }
-    const vector<const MaxQuantModification*>& labelMods = labels->labelingStates[labelingState].mods;
+
+    const auto& labelState = labels->labelingStates[labelingState];
+    const auto& labelMods = labelState.mods;
+    const auto& modsAnyNTerm = labelState.modsByPosition.find(MaxQuantModification::ANY_N_TERM)->second;
+    const auto& modsAnyCTerm = labelState.modsByPosition.find(MaxQuantModification::ANY_C_TERM)->second;
+
+    for (const auto& mod : modsAnyNTerm) { if (mod->sites.empty()) v.emplace_back(1, mod->massDelta); }
 
     // iterate over sequence
     for (int i = 0; i < (int)sequence.length(); i++)
@@ -878,6 +884,8 @@ void MaxQuantReader::addLabelModsToVector(vector<SeqMod>& v, const string& rawFi
         vector<SeqMod> sequenceLabelMods = getFixedMods(sequence[i], i + 1, labelMods);
         v.insert(v.end(), sequenceLabelMods.begin(), sequenceLabelMods.end());
     }
+
+    for (const auto& mod : modsAnyCTerm) { if (mod->sites.empty()) v.emplace_back(sequence.length(), mod->massDelta); }
 }
 
 /**

--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.h
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.h
@@ -215,10 +215,11 @@ private:
     void collectPsms();
     void storeLine(MaxQuantLine& entry);
     void addDoublesToVector(vector<double>& v, const string& valueList);
-    void addModsToVector(vector<SeqMod>& v, const string& modifications, string modSequence);
+    void addModsToVector(vector<SeqMod>& v, const string& modifications, string modSequence, const string& unmodSequence);
     void addLabelModsToVector(vector<SeqMod>& v, const string& rawFile, const string& sequence, int labelingState);
     SeqMod searchForMod(vector<string>& modNames, const string& modSequence, int& posOpenParen);
     static int getModPosition(const string& modSeq, int posOpenParen);
+    void addFixedMods(vector<SeqMod>& v, const string& seq, const map< MaxQuantModification::MAXQUANT_MOD_POSITION, vector<const MaxQuantModification*> >& modsByPosition);
     vector<SeqMod> getFixedMods(char aa, int aaPosition, const vector<const MaxQuantModification*>& mods);
     void initEvidence();  // optionally parse ion mobility info from evidence.txt
 


### PR DESCRIPTION
Reported by Ida Suppanz

Tested as working on Ida's data (as well as after tweaking their mqpar.xml to use a C-terminal label instead of N-terminal).