### PR TITLE
Fix NullReferenceException displaying tooltip on Fold Change Volcano …

### DIFF
--- a/pwiz_tools/Skyline/Model/ProteomicSequence.cs
+++ b/pwiz_tools/Skyline/Model/ProteomicSequence.cs
@@ -30,6 +30,10 @@ namespace pwiz.Skyline.Model
         public static ProteomicSequence GetProteomicSequence(SrmSettings settings, Peptide peptide,
             ExplicitMods explicitMods, IsotopeLabelType labelType)
         {
+            if (peptide.IsCustomMolecule)
+            {
+                return null;
+            }
             if (explicitMods == null || !explicitMods.HasCrosslinks)
             {
                 return ModifiedSequence.GetModifiedSequence(settings, peptide.Sequence, explicitMods, labelType);


### PR DESCRIPTION
…plot if document has small molecules.

(Reported on exception web. This bug happened to be introduced as part of the new crosslinking work this version)