### PR TITLE
Improve Windows hard-link/copy action

### DIFF
--- a/libraries/boost-build/src/tools/common.jam
+++ b/libraries/boost-build/src/tools/common.jam
@@ -774,9 +774,9 @@ if --verbose in [ modules.peek : ARGV ]
     {
         actions hard-link
         {
-            $(RM) "$(<)" 2$(NULL_OUT) $(NULL_OUT)
+            IF EXIST "$(<)" $(RM) "$(<)" 2$(NULL_OUT)
             $(LN) "$(<)" "$(>)" 2$(NULL_OUT) $(NULL_OUT)
-            IF ERRORLEVEL 1 $(CP) "$(>)" $(WINDOWS-CP-HACK) "$(<)" $(NULL_OUT)
+            IF ERRORLEVEL 1 $(CP) "$(>)" $(WINDOWS-CP-HACK) "$(<)"
         }
     }
     else
@@ -799,9 +799,9 @@ else
     {
         actions quietly hard-link
         {
-            $(RM) "$(<)" 2$(NULL_OUT) $(NULL_OUT)
+            IF EXIST "$(<)" $(RM) "$(<)" 2$(NULL_OUT)
             $(LN) "$(<)" "$(>)" 2$(NULL_OUT) $(NULL_OUT)
-            IF ERRORLEVEL 1 $(CP) "$(>)" $(WINDOWS-CP-HACK) "$(<)" $(NULL_OUT)
+            IF ERRORLEVEL 1 $(CP) "$(>)" $(WINDOWS-CP-HACK) "$(<)"
         }
     }
     else


### PR DESCRIPTION
* changed Windows hard-link/copy action to not hide error output from the fallback copy, to only try deleting if file exists, and not to hide standard error from the delete.