### PR TITLE
Prevent the Targets tree from displaying "iRank" for crosslinked frag…

### DIFF
--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
@@ -85,6 +85,13 @@ namespace pwiz.Skyline.Model.Crosslinking
                 transitionQuantInfo = transitionQuantInfo.ChangeIsotopeDistInfo(new TransitionIsotopeDistInfo(
                     isotopeDist.GetRankI(chargedIon.MassIndex), isotopeDist.GetProportionI(chargedIon.MassIndex)));
             }
+            else
+            {
+                if (null != transitionQuantInfo.IsotopeDistInfo)
+                {
+                    transitionQuantInfo = transitionQuantInfo.ChangeIsotopeDistInfo(null);
+                }
+            }
             return new TransitionDocNode(chargedIon, annotations, productMass, transitionQuantInfo, explicitTransitionValues, results);
         }
 


### PR DESCRIPTION
…ment ions that are not actually precursors.

(Reported by Yu)