### PR TITLE
Skyline: better error handling when trying to read a damaged BiblioSpec file into Skyline

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -1159,10 +1159,19 @@ namespace pwiz.Skyline.Model.Lib
 
         string FormatErrorMessage(Exception x)
         {
+            string details;
+            try
+            {
+                details = LibraryDetails.ToString();
+            }
+            catch (Exception e)
+            {
+                details = e.Message; // File is too messed up to pull details, leave a hint as to why that might be
+            }
             return TextUtil.LineSeparate(
                 string.Format(Resources.BiblioSpecLiteLibrary_Load_Failed_loading_library__0__, FilePath),
                 x.Message,
-                LibraryDetails.ToString());
+                details);
         }
 
         private ImmutableSortedList<int, ExplicitPeakBounds> ReadPeakBoundaries(Stream stream)


### PR DESCRIPTION
Need to handle exceptions when trying to get details on the offending library.