### PR TITLE
Fix irt tests

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.Designer.cs
@@ -297,8 +297,6 @@
             this.MinimizeBox = false;
             this.Name = "CalibrateIrtDlg";
             this.ShowInTaskbar = false;
-            this.Load += new System.EventHandler(this.OnLoad);
-            this.Shown += new System.EventHandler(this.CalibrateIrtDlg_Shown);
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceStandard)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.gridViewCalibrate)).EndInit();
             this.grpRegressionEquation.ResumeLayout(false);

--- a/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.cs
@@ -45,7 +45,6 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
         private readonly CalibrationGridViewDriver _gridViewDriver;
         private bool FireStandardsChanged { get; set; }
-        public bool IsShown { get; private set; }
 
         private IrtStandard _standard;
         private readonly IEnumerable<IrtStandard> _existing;
@@ -145,18 +144,16 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
         private List<StandardPeptide> _recalibrationPeptides;
 
-        private void OnLoad(object sender, EventArgs e)
+        protected override void OnLoad(EventArgs e)
         {
+            base.OnLoad(e);
+
             // If you set this in the Designer, DataGridView has a defect that causes it to throw an
             // exception if the the cursor is positioned over the record selector column during loading.
             gridViewCalibrate.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
-        }
 
-        private void CalibrateIrtDlg_Shown(object sender, EventArgs e)
-        {
             FireStandardsChanged = true;
-            UpdateEquation(sender, e);
-            IsShown = true;
+            UpdateEquation(null, e);
         }
 
         public void OkDialog()

--- a/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.cs
@@ -45,6 +45,7 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
         private readonly CalibrationGridViewDriver _gridViewDriver;
         private bool FireStandardsChanged { get; set; }
+        public bool IsShown { get; private set; }
 
         private IrtStandard _standard;
         private readonly IEnumerable<IrtStandard> _existing;
@@ -155,6 +156,7 @@ namespace pwiz.Skyline.SettingsUI.Irt
         {
             FireStandardsChanged = true;
             UpdateEquation(sender, e);
+            IsShown = true;
         }
 
         public void OkDialog()

--- a/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
@@ -413,7 +413,6 @@ namespace pwiz.SkylineTestFunctional
             //Calc dialog -> calibrate standard
             RunDlg<CalibrateIrtDlg>(irtDlg2.Calibrate, calibrateDlg2 =>
             {
-                WaitForCondition(() => calibrateDlg2.IsShown);
                 //Get 11 peptides from the document (all of them) and go back to calculator dialog
                 calibrateDlg2.Recalculate(SkylineWindow.Document, 11);
                 calibrateDlg2.StandardName = "Document2";

--- a/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
@@ -413,10 +413,9 @@ namespace pwiz.SkylineTestFunctional
             //Calc dialog -> calibrate standard
             RunDlg<CalibrateIrtDlg>(irtDlg2.Calibrate, calibrateDlg2 =>
             {
+                WaitForCondition(() => calibrateDlg2.IsShown);
                 //Get 11 peptides from the document (all of them) and go back to calculator dialog
                 calibrateDlg2.Recalculate(SkylineWindow.Document, 11);
-                calibrateDlg2.WriteFixedPointPeptides(); // diagnostic
-                WaitForCondition(() => calibrateDlg2.NumFixedPointOptions == 11);
                 calibrateDlg2.StandardName = "Document2";
                 calibrateDlg2.OkDialog();
             });

--- a/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
@@ -278,7 +278,6 @@ namespace pwiz.SkylineTestTutorial
             RunDlg<RefineDlg>(SkylineWindow.ShowRefineDlg, refineDlg =>
                     {
                         refineDlg.RefineLabelType = IsotopeLabelType.heavy;
-                        WaitForCondition(() => refineDlg.RefineLabelType == IsotopeLabelType.heavy);
                         refineDlg.OkDialog();
                     });
             var docLightOnly = WaitForDocumentChange(docHumanAndStandard);

--- a/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
@@ -167,7 +167,6 @@ namespace pwiz.SkylineTestTutorial
                       });
             {
                 var calibrateDlg = ShowDialog<CalibrateIrtDlg>(editIrtCalc1.Calibrate);
-                WaitForConditionUI(() => calibrateDlg.IsShown);
                 RunUI(() =>
                 {
                     calibrateDlg.StandardName = "Biognosys (30 min cal)";
@@ -279,6 +278,7 @@ namespace pwiz.SkylineTestTutorial
             RunDlg<RefineDlg>(SkylineWindow.ShowRefineDlg, refineDlg =>
                     {
                         refineDlg.RefineLabelType = IsotopeLabelType.heavy;
+                        WaitForCondition(() => refineDlg.RefineLabelType == IsotopeLabelType.heavy);
                         refineDlg.OkDialog();
                     });
             var docLightOnly = WaitForDocumentChange(docHumanAndStandard);

--- a/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
@@ -167,13 +167,12 @@ namespace pwiz.SkylineTestTutorial
                       });
             {
                 var calibrateDlg = ShowDialog<CalibrateIrtDlg>(editIrtCalc1.Calibrate);
+                WaitForConditionUI(() => calibrateDlg.IsShown);
                 RunUI(() =>
                 {
                     calibrateDlg.StandardName = "Biognosys (30 min cal)";
                     calibrateDlg.UseResults();
                     Assert.AreEqual(11, calibrateDlg.StandardPeptideCount);
-                    calibrateDlg.WriteFixedPointPeptides(); // diagnostic
-                    WaitForCondition(() => calibrateDlg.NumFixedPointOptions == 11);
                     calibrateDlg.SetFixedPoints(1, 10);
                     for (int i = 0; i < calibrateDlg.StandardPeptideCount; i++)
                     {


### PR DESCRIPTION
So I think the actual problem was that the test was doing stuff with the form, but sometimes before the Form.Shown event handler had executed.
I'm not 100% sure here but I ran it a bunch of times on Brian's machine and didn't get any failures with this fix.