### PR TITLE
Fix failure in TestImportHighPrecTransitionList and TestPrecursorIon …

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/ImportTransitionListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ImportTransitionListTest.cs
@@ -43,6 +43,7 @@ namespace pwiz.SkylineTestFunctional
         {
             RunUI(()=>SkylineWindow.OpenFile(TestFilesDir.GetTestPath("ImportHighPrecTranList.sky")));
             ImportTransitionListSkipColumnSelect(TestFilesDir.GetTestPath("ThermoTransitionList.csv"));
+            WaitForCondition(() => 0 != SkylineWindow.Document.MoleculeCount);
             var documentGrid = ShowDialog<DocumentGridForm>(() => SkylineWindow.ShowDocumentGrid(true));
             RunUI(() => documentGrid.ChooseView("PeptideModSeqFullNames"));
             VerifyExpectedPeptides(documentGrid);
@@ -85,6 +86,10 @@ namespace pwiz.SkylineTestFunctional
         private void Filter(DataboundGridControl databoundGridControl, PropertyPath propertyPath, string filterValue)
         {
             WaitForConditionUI(() => databoundGridControl.IsComplete);
+            if (0 == databoundGridControl.RowCount)
+            {
+                System.Diagnostics.Debugger.Break();
+            }
             var filterDlg = ShowDialog<QuickFilterForm>(() =>
             {
                 databoundGridControl.QuickFilter(databoundGridControl.FindColumn(propertyPath));

--- a/pwiz_tools/Skyline/TestFunctional/ImportTransitionListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ImportTransitionListTest.cs
@@ -86,10 +86,6 @@ namespace pwiz.SkylineTestFunctional
         private void Filter(DataboundGridControl databoundGridControl, PropertyPath propertyPath, string filterValue)
         {
             WaitForConditionUI(() => databoundGridControl.IsComplete);
-            if (0 == databoundGridControl.RowCount)
-            {
-                System.Diagnostics.Debugger.Break();
-            }
             var filterDlg = ShowDialog<QuickFilterForm>(() =>
             {
                 databoundGridControl.QuickFilter(databoundGridControl.FindColumn(propertyPath));

--- a/pwiz_tools/Skyline/TestFunctional/PrecursorTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PrecursorTest.cs
@@ -140,6 +140,7 @@ namespace pwiz.SkylineTestFunctional
             // Paste the transition list
             SetClipboardTextUI(File.ReadAllText(tranListPath));
             PasteTransitionListSkipColumnSelect();
+            WaitForCondition(() => 0 != SkylineWindow.Document.MoleculeCount);
             Assert.AreEqual(2, GetPrecursorTranstionCount());
             Assert.AreEqual(docCurrent.PeptideTransitionCount, SkylineWindow.Document.PeptideTransitionCount);
             Assert.AreEqual(IonType.precursor, new List<TransitionDocNode>(docCurrent.PeptideTransitions)[0].Transition.IonType,


### PR DESCRIPTION
…in code coverage builds on TeamCity.

The problem is that PasteTransitionListSkipColumnSelect returns as soon as the column select dialog goes away.
However, there is still some work that gets done inside of a LongWaitDlg.

There might be a better way to fix this, where PasteTransitionListSkipColumnSelect would wait until the operation was completely finished, but I couldn't think of a way to do that.