### PR TITLE
Fix NRE using Insert Peptides dialog to insert a peptide which has both a neutral loss and an implicit modification.

### DIFF
--- a/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
@@ -1031,10 +1031,25 @@ namespace pwiz.Skyline.Model
             var dictHeavyMods = new Dictionary<IsotopeLabelType, List<ExplicitMod>>();
             foreach (var info in infos)
             {
+                AAModMatch modMatch;
                 var match = GetMatch(info.ModKey);
                 if (match == null)
-                    return null;
-                AAModMatch modMatch = (AAModMatch)match;
+                {
+                    var staticMod = FindModification(info.ModKey);
+                    if (staticMod == null)
+                    {
+                        return null;
+                    }
+                    modMatch = new AAModMatch
+                    {
+                        StructuralMod = staticMod
+                    };
+                }
+                else
+                {
+                    modMatch = (AAModMatch)match;
+                }
+                
                 var lightMod = modMatch.StructuralMod;
                 if (lightMod != null)
                 {

--- a/pwiz_tools/Skyline/Test/ModificationMatcherTest.cs
+++ b/pwiz_tools/Skyline/Test/ModificationMatcherTest.cs
@@ -272,6 +272,34 @@ namespace pwiz.SkylineTest
             }
         }
 
+        [TestMethod]
+        public void TestNeutralLossModificationMatcher()
+        {
+            var srmSettings = SrmSettingsList.GetDefault();
+            var staticMods =
+                srmSettings.PeptideSettings.Modifications.StaticModifications
+                    .Append(UniMod.GetModification("Water Loss (D, E, S, T)", true))
+                    .Append(UniMod.GetModification("Oxidation (M)", true).ChangeVariable(true))
+                    .ToList();
+            srmSettings = srmSettings.ChangePeptideSettings(
+                srmSettings.PeptideSettings.ChangeModifications(
+                    srmSettings.PeptideSettings.Modifications.ChangeStaticModifications(staticMods)));
+            var modificationMatcher = new ModificationMatcher();
+            var peptideSequences = new List<string>
+            {
+                "PEPTIDECK",
+                "CM[+16]K",
+                "CK",
+                "PEPTIDEK",
+            };
+            modificationMatcher.CreateMatches(srmSettings, peptideSequences, Settings.Default.StaticModList, Settings.Default.HeavyModList);
+            foreach (var sequence in peptideSequences)
+            {
+                var peptideDocNode = modificationMatcher.GetModifiedNode(sequence);
+                Assert.IsNotNull(peptideDocNode, sequence);
+            }
+        }
+
         private const string ZIP_FILE = @"Test\ModMatch.zip";
 
         private static void UpdateMatcherFail(string seq)


### PR DESCRIPTION
This seems to fix the NRE that I reported earlier today.

I will keep testing this fix, and will probably commit it along with a different fix that I am working on which makes it so that "PeptideModifiedSequenceFullNames" does not include neutral loss modifications.
