### PR TITLE
Skyline: Fix a NRE in Edit > Insert > Peptides found by Nick with neutral losses

### DIFF
--- a/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
@@ -1070,7 +1070,7 @@ namespace pwiz.Skyline.Model
             // If no light modifications are present, this code assumes the user wants the 
             // default global light modifications.  Unless not stringPaste, in which case the target
             // static mods must also be empty
-            if (listLightMods.Count == 0 && (stringPaste || targetImplicitMods.StaticModifications.Count == 0))
+            if (listLightMods.Count(m => m.Modification.HasMod) == 0 && (stringPaste || targetImplicitMods.StaticModifications.Count == 0))
                 listLightMods = null;
             else if (stringPaste && ArrayUtil.EqualsDeep(listLightMods.ToArray(), targetImplicitMods.StaticModifications))
                 listLightMods = null;

--- a/pwiz_tools/Skyline/Model/ModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/ModificationMatcher.cs
@@ -190,12 +190,16 @@ namespace pwiz.Skyline.Model
                     var lossMod = lossOnlyMods.FirstOrDefault(m => m.IsLoss(aa, indexAAInSeq, aas.Length));
                     if (lossMod != null)
                     {
-                        yield return new AAModInfo
+                        var info = new AAModInfo
                         {
                             ModKey = new AAModKey { Name = lossMod.Name, AA = aa, Terminus = lossMod.Terminus },
                             IndexAA = indexAA,
                             IndexAAInSeq = indexAAInSeq,
                         };
+                        // Make sure this key finds a modification in the Matches dictionary
+                        if (!Matches.ContainsKey(info.ModKey))
+                            Matches.Add(info.ModKey, new AAModMatch {StructuralMod = lossMod});
+                        yield return info;
                     }
                     else if (includeUnmod)
                     {

--- a/pwiz_tools/Skyline/Test/ModificationMatcherTest.cs
+++ b/pwiz_tools/Skyline/Test/ModificationMatcherTest.cs
@@ -272,6 +272,54 @@ namespace pwiz.SkylineTest
             }
         }
 
+        [TestMethod]
+        public void TestNeutralLossModificationMatcher()
+        {
+            var srmSettings = SrmSettingsList.GetDefault();
+            var staticMods =
+                srmSettings.PeptideSettings.Modifications.StaticModifications
+                    .Append(UniMod.GetModification("Water Loss (D, E, S, T)", true))
+                    .Append(UniMod.GetModification("Oxidation (M)", true).ChangeVariable(true))
+                    .ToList();
+            srmSettings = srmSettings.ChangePeptideSettings(
+                srmSettings.PeptideSettings.ChangeModifications(
+                    srmSettings.PeptideSettings.Modifications.ChangeStaticModifications(staticMods)));
+            var modificationMatcher = new ModificationMatcher();
+            var peptideSequences = new List<string>
+            {
+                "PEPTIDECK", // No explicit mods C should be modified
+                "PEPC[+57]IMEK",    // No need for variable mods because M unmodified
+                "C[+57]EDM[+16]K",  // No explicit losses M variably modified
+                "C[+57]EDS[+80]K",   // Explicit phospho modification on S and losses
+                "CEDM[+16]K",  // Explicitly modified due to no mod on C
+            };
+            modificationMatcher.CreateMatches(srmSettings, peptideSequences, Settings.Default.StaticModList, Settings.Default.HeavyModList);
+            for (int i = 0; i < peptideSequences.Count; i++)
+            {
+                string sequence = peptideSequences[i];
+                var peptideDocNode = modificationMatcher.GetModifiedNode(sequence);
+                Assert.IsNotNull(peptideDocNode, sequence);
+                if (i < 2)
+                    Assert.IsFalse(peptideDocNode.HasExplicitMods, sequence);
+                else
+                {
+                    if (i < 3)
+                    {
+                        Assert.IsTrue(peptideDocNode.HasVariableMods, sequence);
+                        // Static mods aren't included in the variable mods
+                        Assert.AreEqual(1, peptideDocNode.ExplicitMods.StaticModifications.Count, sequence);
+                    }
+                    else
+                    {
+                        Assert.IsTrue(peptideDocNode.HasExplicitMods && !peptideDocNode.HasVariableMods, sequence);
+                        Assert.IsTrue(peptideDocNode.ExplicitMods.HasNeutralLosses);
+                        Assert.AreEqual(sequence.Count(c => c == '[' || c == 'E' || c == 'D'),
+                            peptideDocNode.ExplicitMods.StaticModifications.Count, sequence);
+                    }
+                }
+            }
+        }
+
         private const string ZIP_FILE = @"Test\ModMatch.zip";
 
         private static void UpdateMatcherFail(string seq)


### PR DESCRIPTION
- It seems my last PR caused some problems in wider use than our automated tests
- New automated test added to cover more cases, including the one that caused the NRE