### PR TITLE
Workaround DiaUmpire spill file leak

### DIFF
--- a/pwiz/analysis/dia_umpire/DiaUmpire.cpp
+++ b/pwiz/analysis/dia_umpire/DiaUmpire.cpp
@@ -1035,9 +1035,12 @@ namespace DiaUmpire {
 
                 MSData spillFile;
                 spillFile.id = spillFile.run.id = msd_.id + " DIA window " + diaWindowId;
+                spillFile.instrumentConfigurationPtrs = msd_.instrumentConfigurationPtrs;
+                spillFile.softwarePtrs = msd_.softwarePtrs;
+                spillFile.cvs = msd_.cvs;
                 auto outputScans = boost::make_shared<SpectrumListSimple>();
                 spillFile.run.spectrumListPtr = outputScans;
-                auto spillFilepathPtr = boost::make_shared<TemporaryFile>(".mz5");
+                auto spillFilepathPtr = boost::make_shared<TemporaryFile>(".tmp_spill");
 
                 vector<PseudoMsMsKey> localPseudoMsMs;
                 for (const auto& pseudoScan : LocalScanList)
@@ -1108,7 +1111,7 @@ namespace DiaUmpire {
                 }
 
                 {
-                    MSDataFile::WriteConfig writeConfig(MSDataFile::Format_MZ5);
+                    MSDataFile::WriteConfig writeConfig(config_.spillFileFormat);
                     writeConfig.useWorkerThreads = false;
                     writeConfig.binaryDataEncoderConfig.precision = BinaryDataEncoder::Precision_32;
 

--- a/pwiz/analysis/dia_umpire/DiaUmpire.hpp
+++ b/pwiz/analysis/dia_umpire/DiaUmpire.hpp
@@ -27,7 +27,7 @@
 #define _DIAUMPIRE_HPP_
 
 #include "pwiz/utility/misc/Export.hpp"
-#include "pwiz/data/msdata/MSData.hpp"
+#include "pwiz/data/msdata/MSDataFile.hpp"
 #include "pwiz/utility/misc/IterationListener.hpp"
 #include "pwiz/utility/misc/Filesystem.hpp"
 #include "InstrumentParameter.hpp"
@@ -67,6 +67,8 @@ struct PWIZ_API_DECL Config
 
     int maxThreads = 0; // 0 = # of cores
     bool multithreadOverWindows = true;
+
+    pwiz::msdata::MSDataFile::Format spillFileFormat = pwiz::msdata::MSDataFile::Format_MZ5;
 
     Config(const std::string& paramsFilepath = "");
 };

--- a/pwiz/utility/bindings/CLI/analysis/spectrum_processing.hpp
+++ b/pwiz/utility/bindings/CLI/analysis/spectrum_processing.hpp
@@ -29,7 +29,7 @@
 //#include "SpectrumListWrapper.hpp"
 
 #ifdef PWIZ_BINDINGS_CLI_COMBINED
-    #include "../msdata/MSData.hpp"
+    #include "../msdata/MSDataFile.hpp"
     #include "../common/IterationListener.hpp"
 #else
     #include "../common/SharedCLI.hpp"
@@ -630,6 +630,10 @@ public ref class SpectrumList_DiaUmpire : public msdata::SpectrumList
         DEFINE_SIMPLE_PRIMITIVE_PROPERTY(bool, exportMs1ClusterTable);
         DEFINE_SIMPLE_PRIMITIVE_PROPERTY(bool, exportMs2ClusterTable);
         DEFINE_SIMPLE_PRIMITIVE_PROPERTY(bool, exportSeparateQualityMGFs);
+
+        DEFINE_SIMPLE_PRIMITIVE_PROPERTY(int, maxThreads);
+        DEFINE_SIMPLE_PRIMITIVE_PROPERTY(bool, multithreadOverWindows);
+        DEFINE_PRIMITIVE_PROPERTY(pwiz::msdata::MSDataFile::Format, pwiz::CLI::msdata::MSDataFile::Format, spillFileFormat);
     };
 
     SpectrumList_DiaUmpire(pwiz::CLI::msdata::MSData^ msd, pwiz::CLI::msdata::SpectrumList^ inner, Config^ config);

--- a/pwiz_tools/Shared/ProteowizardWrapper/DiaUmpire.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/DiaUmpire.cs
@@ -52,6 +52,7 @@ namespace pwiz.ProteowizardWrapper
         public class Config
         {
             public IDictionary<string, object> Parameters { get; }
+            public bool UseMzMlSpillFile { get; set; }
 
             public Config()
             {
@@ -174,6 +175,8 @@ namespace pwiz.ProteowizardWrapper
                             throw new InvalidDataException(@"unexpected type in SpectrumList_DiaUmpire.Config.InstrumentParameter");
                     }
                 }
+
+                config.spillFileFormat = UseMzMlSpillFile ? MSDataFile.Format.Format_mzML : MSDataFile.Format.Format_MZ5;
 
                 return config;
             }

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ConverterSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ConverterSettingsControl.cs
@@ -302,11 +302,14 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             set { cbEstimateBg.Checked = value; }
         }
 
+        public bool UseMzMlSpillFile { get; set; }
+
         public DiaUmpireDdaConverter GetDiaUmpireConverter()
         {
             var diaUmpireConfig = DiaUmpire.Config.GetDefaultsForInstrument(InstrumentPreset);
             foreach (var kvp in AdditionalSettings)
                 diaUmpireConfig.Parameters[kvp.Key] = kvp.Value.Value;
+            diaUmpireConfig.UseMzMlSpillFile = UseMzMlSpillFile;
 
             return new DiaUmpireDdaConverter(ImportPeptideSearch.SearchEngine, _fullScanSettingsControlGetter().IsolationScheme, diaUmpireConfig);
         }

--- a/pwiz_tools/Skyline/Jamfile.jam
+++ b/pwiz_tools/Skyline/Jamfile.jam
@@ -228,7 +228,7 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
         IF ERRORLEVEL 1 exit %ERRORLEVEL%
 
         echo Testing subset of Skyline's leak checking (pass1) in $(CONFIGURATION:L) configuration...
-        $(OUTPUT_PATH)/TestRunner.exe log=TestPass1Subset.log buildcheck=1 pass1=on pass2=off test=TestInstrumentInfo,TestQcTraces,TestTicChromatogram $(.teamcity-test-decoration)
+        $(OUTPUT_PATH)/TestRunner.exe log=TestPass1Subset.log buildcheck=1 pass1=on pass2=off test=TestInstrumentInfo,TestQcTraces,TestTicChromatogram,TestDiaSearchFixedWindows $(.teamcity-test-decoration)
         set status=%ERRORLEVEL%
         exit %status%
     }

--- a/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
@@ -272,6 +272,7 @@ namespace pwiz.SkylineTestFunctional
 
                 importPeptideSearchDlg.ConverterSettingsControl.InstrumentPreset = DiaUmpire.Config.InstrumentPreset.TripleTOF;
                 importPeptideSearchDlg.ConverterSettingsControl.EstimateBackground = false;
+                importPeptideSearchDlg.ConverterSettingsControl.UseMzMlSpillFile = true; // mz5 spill file leaks
                 importPeptideSearchDlg.ConverterSettingsControl.AdditionalSettings =
                     new Dictionary<string, AbstractDdaSearchEngine.Setting>
                     {


### PR DESCRIPTION
* made DiaUmpire spill file format to be configurable; the mz5 format leaks some memory so Skyline needs to use a stable format for leak checking
* added TestDiaSearchFixedWindows to Pass1Subset test