### PR TITLE
Fix "Loss-only modifications may not be explicit." error

### DIFF
--- a/pwiz_tools/Skyline/EditUI/EditLinkedPeptidesDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/EditLinkedPeptidesDlg.cs
@@ -470,9 +470,16 @@ namespace pwiz.Skyline.EditUI
             for (int i = 0; i < _peptideRows.Count; i++)
             {
                 var peptideRow = _peptideRows[i];
-                if (i == _peptideRows.Count - 1 && string.IsNullOrEmpty(peptideRow.Sequence))
+                if (string.IsNullOrEmpty(peptideRow.Sequence))
                 {
-                    continue;
+                    if (i == _peptideRows.Count - 1)
+                    {
+                        // ignore the last row if it is blank
+                        continue;
+                    }
+                    MessageDlg.Show(this, Resources.PasteDlg_ListPeptideSequences_The_peptide_sequence_cannot_be_blank);
+                    SetGridFocus(dataGridViewLinkedPeptides, i, colPeptideSequence);
+                    return;
                 }
                 Peptide peptide;
                 try

--- a/pwiz_tools/Skyline/EditUI/EditLinkedPeptidesDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/EditLinkedPeptidesDlg.cs
@@ -465,12 +465,15 @@ namespace pwiz.Skyline.EditUI
         public ExplicitMods ExplicitMods { get; private set; }
         public void OkDialog()
         {
-            var peptideSequences = GetPeptideSequences();
             var linkedPeptides = new List<Peptide>();
             var linkedExplicitMods = new List<ExplicitMods>();
             for (int i = 0; i < _peptideRows.Count; i++)
             {
                 var peptideRow = _peptideRows[i];
+                if (i == _peptideRows.Count - 1 && string.IsNullOrEmpty(peptideRow.Sequence))
+                {
+                    continue;
+                }
                 Peptide peptide;
                 try
                 {

--- a/pwiz_tools/Skyline/Model/DocSettings/Modification.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Modification.cs
@@ -516,8 +516,6 @@ namespace pwiz.Skyline.Model.DocSettings
                         throw new InvalidDataException(Resources.StaticMod_Validate_Modification_must_specify_a_formula_labeled_atoms_or_valid_monoisotopic_and_average_masses);
                     if (IsVariable)
                         throw new InvalidDataException(Resources.StaticMod_Validate_Loss_only_modifications_may_not_be_variable);
-                    if (IsExplicit)
-                        throw new InvalidDataException(Resources.StaticMod_Validate_Loss_only_modifications_may_not_be_explicit);
                 }
             }
             else

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -16013,7 +16013,7 @@ namespace pwiz.Skyline.Properties {
         ///
         ///Multipliers (e.g. the &quot;2&quot; in &quot;[2M+K]&quot;) and isotope labels (e.g. the &quot;2Cl37&quot; in &quot;[M2Cl37+H]&quot;) are supported.
         ///
-        ///Recognized adduct com [rest of string was truncated]&quot;;.
+        ///Recognized adduct components  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string IonInfo_AdductTips_ {
             get {
@@ -20761,7 +20761,7 @@ namespace pwiz.Skyline.Properties {
         ///    
         ///Note that you can adjust column order in Skyline by dragging the column headers left or right.  For molecules, you can also select which columns to enable with the &quot;Columns...&quot; button.
         ///
-        ///Most peptide transition lists can be imported with the &quot;File|Import|Transition List...&quot; menu item or even pasted directly into the Targets window. You can also do this with molecule tra [rest of string was truncated]&quot;;.
+        ///Most peptide transition lists can be imported with the &quot;File|Import|Transition List...&quot; menu item or even pasted directly into the Targets window. You can also do this with molecule transit [rest of string was truncated]&quot;;.
         /// </summary>
         public static string PasteDlg_btnTransitionListHelp_Click_SmallMol_ {
             get {

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -16013,7 +16013,7 @@ namespace pwiz.Skyline.Properties {
         ///
         ///Multipliers (e.g. the &quot;2&quot; in &quot;[2M+K]&quot;) and isotope labels (e.g. the &quot;2Cl37&quot; in &quot;[M2Cl37+H]&quot;) are supported.
         ///
-        ///Recognized adduct components  [rest of string was truncated]&quot;;.
+        ///Recognized adduct com [rest of string was truncated]&quot;;.
         /// </summary>
         public static string IonInfo_AdductTips_ {
             get {
@@ -20761,7 +20761,7 @@ namespace pwiz.Skyline.Properties {
         ///    
         ///Note that you can adjust column order in Skyline by dragging the column headers left or right.  For molecules, you can also select which columns to enable with the &quot;Columns...&quot; button.
         ///
-        ///Most peptide transition lists can be imported with the &quot;File|Import|Transition List...&quot; menu item or even pasted directly into the Targets window. You can also do this with molecule transit [rest of string was truncated]&quot;;.
+        ///Most peptide transition lists can be imported with the &quot;File|Import|Transition List...&quot; menu item or even pasted directly into the Targets window. You can also do this with molecule tra [rest of string was truncated]&quot;;.
         /// </summary>
         public static string PasteDlg_btnTransitionListHelp_Click_SmallMol_ {
             get {
@@ -30788,15 +30788,6 @@ namespace pwiz.Skyline.Properties {
         public static string StaticMod_Validate_Invalid_amino_acid___0___ {
             get {
                 return ResourceManager.GetString("StaticMod_Validate_Invalid_amino_acid___0___", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Loss-only modifications may not be explicit..
-        /// </summary>
-        public static string StaticMod_Validate_Loss_only_modifications_may_not_be_explicit {
-            get {
-                return ResourceManager.GetString("StaticMod_Validate_Loss_only_modifications_may_not_be_explicit", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -1311,9 +1311,6 @@
   <data name="SkylineWindow_ShowExportEspFeaturesDialog_Export_ESP_Features" xml:space="preserve">
     <value>Export ESP Features</value>
   </data>
-  <data name="StaticMod_Validate_Loss_only_modifications_may_not_be_explicit" xml:space="preserve">
-    <value>Loss-only modifications may not be explicit.</value>
-  </data>
   <data name="AddZipToolHelper_ShouldOverwrite_Error__There_is_a_conflicting_tool" xml:space="preserve">
     <value>Error: There is a conflicting tool</value>
   </data>

--- a/pwiz_tools/Skyline/Test/SrmSettingsTest.cs
+++ b/pwiz_tools/Skyline/Test/SrmSettingsTest.cs
@@ -587,7 +587,7 @@ namespace pwiz.SkylineTest
             AssertEx.DeserializeError<StaticMod>("<static_modification name=\"Mod\" variable=\"true\" />");
             // Loss only failures
             AssertEx.DeserializeError<StaticMod>("<static_modification name=\"Loss-only\" aminoacid=\"K, R, Q, N\" variable=\"true\"><potential_loss formula=\"NH3\"/></static_modification>");
-            AssertEx.DeserializeError<StaticMod>("<static_modification name=\"Loss-only\" aminoacid=\"K, R, Q, N\" explicit_decl=\"true\"><potential_loss formula=\"NH3\"/></static_modification>");
+            AssertEx.DeserializeNoError<StaticMod>("<static_modification name=\"Loss-only\" aminoacid=\"K, R, Q, N\" explicit_decl=\"true\"><potential_loss formula=\"NH3\"/></static_modification>", true, true, structuralModificationType);
             AssertEx.DeserializeError<StaticMod>("<static_modification name=\"LossInclusion\" aminoacid=\"T, S\" formula=\"HPO3\"><potential_loss formula=\"HP3O4\" inclusion=\"Sometimes\"/></static_modification>");
         }
 


### PR DESCRIPTION
Now that users are able to add neutral loss modifications to their peptides using the "Modify Peptide" dialog, the error "Loss-only modifications may not be explicit" no longer applies.

(user "jmr" reported this error with a crosslink modification which had zero mass and some neutral losses, but this error can be reproduced with simple neutral loss modifications)

Also, fix an error "Protein sequence may not be empty" that can happen in the Edit Linked Peptides dialog if the focus is in the new row of the peptide sequences grid when you press "OK" on the Edit Linked Peptides dialog when the focus is in an uncommitted new row in the DataGridView.
(also reported by jmr)