### PR TITLE
Fix DiaUmpire crashes from CLI bindings

### DIFF
--- a/pwiz/utility/bindings/CLI/analysis/spectrum_processing.cpp
+++ b/pwiz/utility/bindings/CLI/analysis/spectrum_processing.cpp
@@ -54,6 +54,7 @@ SpectrumListWrapper::SpectrumListWrapper(SpectrumList^ inner)
 {
     base_ = new SpectrumListWrapperDefault(*inner->base_);
     SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
 }
 
 
@@ -85,6 +86,9 @@ void SpectrumListFactory::wrap(msdata::MSData^ msd, System::String^ wrapper)
 void SpectrumListFactory::wrap(msdata::MSData^ msd, System::String^ wrapper, util::IterationListenerRegistry^ ilr)
 {
     b::SpectrumListFactory::wrap(msd->base(), ToStdString(wrapper), ilr ? &ilr->base() : nullptr);
+    System::GC::KeepAlive(ilr);
+    System::GC::KeepAlive(wrapper);
+    System::GC::KeepAlive(msd);
 }
 
 void SpectrumListFactory::wrap(msdata::MSData^ msd, System::Collections::Generic::IList<System::String^>^ wrappers)
@@ -98,6 +102,9 @@ void SpectrumListFactory::wrap(msdata::MSData^ msd, System::Collections::Generic
     for each(System::String^ wrapper in wrappers)
         nativeWrappers.push_back(ToStdString(wrapper));
     b::SpectrumListFactory::wrap(msd->base(), nativeWrappers, ilr ? &ilr->base() : nullptr);
+    System::GC::KeepAlive(ilr);
+    System::GC::KeepAlive(wrappers);
+    System::GC::KeepAlive(msd);
 }
 
 System::String^ SpectrumListFactory::usage()
@@ -275,6 +282,8 @@ SpectrumList_Filter::SpectrumList_Filter(msdata::SpectrumList^ inner,
     System::IntPtr predicatePtr = System::Runtime::InteropServices::Marshal::GetFunctionPointerForDelegate(wrapper);
     base_ = new b::SpectrumList_Filter(*inner->base_, SpectrumList_FilterPredicate_Custom(predicatePtr.ToPointer()));
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
+    System::GC::KeepAlive(predicate);
 }
 
 SpectrumList_Filter::SpectrumList_Filter(msdata::SpectrumList^ inner,
@@ -283,6 +292,8 @@ SpectrumList_Filter::SpectrumList_Filter(msdata::SpectrumList^ inner,
 {
     base_ = new b::SpectrumList_Filter(*inner->base_, *impl_->managedPredicate->base_);
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
+    System::GC::KeepAlive(predicate);
 }
 
 
@@ -372,6 +383,8 @@ SpectrumList_PeakPicker::SpectrumList_PeakPicker(msdata::SpectrumList^ inner,
         msLevelSet.insert(i);
     base_ = new b::SpectrumList_PeakPicker(*inner->base_, *algorithm->base_, preferVendorPeakPicking, msLevelSet);
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
+    System::GC::KeepAlive(algorithm);
 }
 
 bool SpectrumList_PeakPicker::accept(msdata::SpectrumList^ inner)
@@ -390,8 +403,9 @@ bool SpectrumList_PeakPicker::supportsVendorPeakPicking(System::String^ rawpath)
 SpectrumList_LockmassRefiner::SpectrumList_LockmassRefiner(msdata::SpectrumList^ inner, double lockmassMzPosScans, double lockmassMzNegScans, double lockmassTolerance)
     : msdata::SpectrumList(0)
 {
-        base_ = new b::SpectrumList_LockmassRefiner(*inner->base_, lockmassMzPosScans, lockmassMzNegScans, lockmassTolerance);
+    base_ = new b::SpectrumList_LockmassRefiner(*inner->base_, lockmassMzPosScans, lockmassMzNegScans, lockmassTolerance);
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
 }
 
 bool SpectrumList_LockmassRefiner::accept(msdata::SpectrumList^ inner)
@@ -417,6 +431,7 @@ SpectrumList_ChargeStateCalculator::SpectrumList_ChargeStateCalculator(
                 minMultipleCharge,
                 intensityFractionBelowPrecursorForSinglyCharged);
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
 }
 
 bool SpectrumList_ChargeStateCalculator::accept(msdata::SpectrumList^ inner)
@@ -441,6 +456,7 @@ SpectrumList_3D::SpectrumList_3D(msdata::SpectrumList^ inner)
 {
     base_ = new b::SpectrumList_3D(*inner->base_);
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
 }
 
 Spectrum3D^ SpectrumList_3D::spectrum3d(double scanStartTime, System::Collections::Generic::IEnumerable<ContinuousInterval>^ ionMobilityRanges)
@@ -474,6 +490,7 @@ SpectrumList_IonMobility::SpectrumList_IonMobility(msdata::SpectrumList^ inner)
 {
     base_ = new b::SpectrumList_IonMobility(*inner->base_);
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
 }
 
 SpectrumList_IonMobility::IonMobilityUnits SpectrumList_IonMobility::getIonMobilityUnits()
@@ -527,13 +544,19 @@ SpectrumList_DiaUmpire::SpectrumList_DiaUmpire(msdata::MSData^ msd, msdata::Spec
 {
     try { base_ = new b::SpectrumList_DiaUmpire(msd->base(), *inner->base_, config->base()); } CATCH_AND_FORWARD
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(inner);
+    System::GC::KeepAlive(config);
+    System::GC::KeepAlive(msd);
 }
 
 SpectrumList_DiaUmpire::SpectrumList_DiaUmpire(msdata::MSData^ msd, msdata::SpectrumList^ inner, Config^ config, util::IterationListenerRegistry^ ilr)
     : msdata::SpectrumList(0)
 {
-    try { base_ = new b::SpectrumList_DiaUmpire(msd->base(), *inner->base_, config->base(), &ilr->base()); } CATCH_AND_FORWARD
+    try { base_ = new b::SpectrumList_DiaUmpire(msd->base(), *inner->base_, config->base(), ilr ? &ilr->base() : nullptr); } CATCH_AND_FORWARD
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+    System::GC::KeepAlive(ilr);
+    System::GC::KeepAlive(config);
+    System::GC::KeepAlive(msd);
 }
 
 
@@ -542,6 +565,7 @@ ChromatogramList_XICGenerator::ChromatogramList_XICGenerator(msdata::Chromatogra
 {
     base_ = new b::ChromatogramList_XICGenerator(*inner->base_);
     msdata::ChromatogramList::base_ = new boost::shared_ptr<pwiz::msdata::ChromatogramList>(base_);
+    System::GC::KeepAlive(inner);
 }
 
 msdata::Chromatogram^ ChromatogramList_XICGenerator::xic(double startTime, double endTime, System::Collections::Generic::IEnumerable<ContinuousInterval>^ massRanges, int msLevel)

--- a/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
+++ b/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
@@ -144,6 +144,8 @@ void MSDataFile::write(MSData^ msd,
         b::MSDataFile::write(msd->base(), ToStdString(filename), config2, ilr == nullptr ? 0 : &ilr->base());
     }
     CATCH_AND_FORWARD
+    GC::KeepAlive(ilr);
+    GC::KeepAlive(msd);
 }
 
 
@@ -173,6 +175,7 @@ void MSDataFile::write(System::String^ filename,
         b::MSDataFile::WriteConfig config2((b::MSDataFile::Format) config->format);
         translateConfig(config,config2);
         base().write(ToStdString(filename), config2, ilr == nullptr ? 0 : &ilr->base());
+        GC::KeepAlive(ilr);
     }
     CATCH_AND_FORWARD
 }
@@ -181,6 +184,7 @@ void MSDataFile::write(System::String^ filename,
 void MSDataFile::calculateSHA1Checksums(MSData^ msd)
 {
     try {b::calculateSHA1Checksums(msd->base());} CATCH_AND_FORWARD
+    GC::KeepAlive(msd);
 }
 
 

--- a/pwiz_tools/Shared/ProteowizardWrapper/DiaUmpire.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/DiaUmpire.cs
@@ -232,11 +232,11 @@ namespace pwiz.ProteowizardWrapper
                 precision = MSDataFile.Precision.Precision_32 // CONSIDER: is 64-bit precision needed for these pseudo-spectra?
             };
 
-            /*var ilr = new IterationListenerRegistry();
+            var ilr = new IterationListenerRegistry();
             if (_ilrMonitor != null)
-                ilr.addListenerWithTimer(_ilrMonitor, 5);*/
+                ilr.addListenerWithTimer(_ilrMonitor, 5);
             _msDataFile.run.spectrumList = SpectrumList;
-            MSDataFile.write(_msDataFile, outputFilepath, config/*, ilr*/);
+            MSDataFile.write(_msDataFile, outputFilepath, config, ilr);
         }
     }
 }


### PR DESCRIPTION
Possibly due to missing KeepAlive calls. Let's see.