### PR TITLE
Prevent the red highlighting warning on "Include all matching scans" …

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
@@ -1018,7 +1018,7 @@ namespace pwiz.Skyline.SettingsUI
             {
                 groupBoxRetentionTimeToKeep.Enabled = true;
             }
-            if (radioKeepAllTime.Checked && !disabled)
+            if (radioKeepAllTime.Checked && !disabled && AcquisitionMethod != FullScanAcquisitionMethod.Targeted)
             {
                 radioKeepAllTime.ForeColor = Color.Red;
                 toolTip.SetToolTip(radioKeepAllTime,


### PR DESCRIPTION
…if the AcquisitionMethod is "Targeted".
