### PR TITLE
Skyline: Fix spectrum graph title to contain source library name like…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
@@ -964,7 +964,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                     _spectrum.Name, _mirrorSpectrum.Name);
                             GraphPane.Title.Text = TextUtil.LineSeparate(
                                 libraryStr,
-                                SpectrumGraphItem.GetTitle(selection.Peptide, _mirrorSpectrum.Precursor, _mirrorSpectrum.LabelType),
+                                SpectrumGraphItem.GetTitle(null, selection.Peptide, _mirrorSpectrum.Precursor, _mirrorSpectrum.LabelType),
                                 prositEx.Message);
                             graphControl.Refresh();
                             return;
@@ -1029,7 +1029,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                     GraphPane.Title.Text = TextUtil.LineSeparate(
                                         string.Format(PrositResources.GraphSpectrum_UpdateUI__0__vs___1_,
                                             GraphItem.LibraryName, mirrorSpectrum.Name),
-                                        GraphItem.Title,
+                                        SpectrumGraphItem.RemoveLibraryPrefix(GraphItem.Title, GraphItem.LibraryName),
                                         string.Format(@"dotp: {0:0.0000}", dotp));
                                 }
                                 else
@@ -1048,7 +1048,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                     GraphPane.Title.Text = TextUtil.LineSeparate(
                                         string.Format(PrositResources.GraphSpectrum_UpdateUI__0__vs___1_,
                                             GraphItem.LibraryName, SpectrumInfoProsit.NAME),
-                                        GraphItem.Title,
+                                        SpectrumGraphItem.RemoveLibraryPrefix(GraphItem.Title, GraphItem.LibraryName),
                                         prositEx.Message);
                                 }
                                 else

--- a/pwiz_tools/Skyline/Controls/Graphs/SpectrumGraphItem.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SpectrumGraphItem.cs
@@ -55,11 +55,22 @@ namespace pwiz.Skyline.Controls.Graphs
             return ((TransitionNode != null) && (predictedMz == TransitionNode.Mz));
         }
 
-        public static string GetTitle(PeptideDocNode peptideDocNode, TransitionGroupDocNode transitionGroupDocNode, IsotopeLabelType labelType)
+        public static string GetLibraryPrefix(string libraryName)
         {
-            string libraryNamePrefix = string.Empty;
-            //if (!string.IsNullOrEmpty(libraryNamePrefix))
-            //    libraryNamePrefix += @" - ";
+            return !string.IsNullOrEmpty(libraryName) ? libraryName + @" - " : string.Empty;
+        }
+
+        public static string RemoveLibraryPrefix(string title, string libraryName)
+        {
+            string libraryNamePrefix = GetLibraryPrefix(libraryName);
+            if (!string.IsNullOrEmpty(libraryNamePrefix) && title.StartsWith(libraryNamePrefix))
+                return title.Substring(libraryNamePrefix.Length);
+            return title;
+        }
+
+        public static string GetTitle(string libraryName, PeptideDocNode peptideDocNode, TransitionGroupDocNode transitionGroupDocNode, IsotopeLabelType labelType)
+        {
+            string libraryNamePrefix = GetLibraryPrefix(libraryName);
 
             TransitionGroup transitionGroup = transitionGroupDocNode.TransitionGroup;
             string sequence;
@@ -90,7 +101,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
         public override string Title
         {
-            get { return GetTitle(PeptideDocNode, TransitionGroupNode, SpectrumInfo.LabelType); }
+            get { return GetTitle(LibraryName, PeptideDocNode, TransitionGroupNode, SpectrumInfo.LabelType); }
         }
     }
     

--- a/pwiz_tools/Skyline/TestTutorial/MethodEditTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/MethodEditTutorialTest.cs
@@ -250,6 +250,9 @@ namespace pwiz.SkylineTestTutorial
                     () =>
                         SkylineWindow.Document.Settings.PeptideSettings.Libraries.IsLoaded &&
                             SkylineWindow.Document.Settings.PeptideSettings.Libraries.Libraries.Count > 0));
+                // The tutorial tells the reader they can see the library name in the spectrum graph title
+                VerifyPrecursorLibrary(12, YEAST_GPM);
+                VerifyPrecursorLibrary(13, YEAST_ATLAS);
             }
 
             using (new CheckDocumentState(35, 47, 47, 223, 2, true))    // Wait for change loaded, and expect 2 document revisions.
@@ -485,6 +488,16 @@ namespace pwiz.SkylineTestTutorial
                 }
             }
         }
+
+        private void VerifyPrecursorLibrary(int indexPrecursor, string libraryName)
+        {
+            RunUI(() => SkylineWindow.SelectPath(
+                SkylineWindow.DocumentUI.GetPathTo((int)SrmDocument.Level.TransitionGroups, indexPrecursor)));
+            WaitForGraphs();
+            RunUI(() => Assert.IsTrue(SkylineWindow.GraphSpectrum.GraphTitle.StartsWith(libraryName),
+                string.Format("Graph title '{0}' does not start with {1}", SkylineWindow.GraphSpectrum.GraphTitle, libraryName)));
+        }
+
         private void ShowNodeTip(string nodeText)
         {
             RunUI(() =>


### PR DESCRIPTION
… it used to (reported by Skyline Online)