### PR TITLE
Switch from in-process DiaUmpire to msconvert

### DIFF
--- a/pwiz/analysis/dia_umpire/PeakCurve.hpp
+++ b/pwiz/analysis/dia_umpire/PeakCurve.hpp
@@ -33,6 +33,7 @@
 #include "InstrumentParameter.hpp"
 #include "ScanData.hpp"
 #include "DiaUmpireMath.hpp"
+#include "pwiz/data/msdata/MSData.hpp"
 
 namespace DiaUmpire {
 
@@ -91,6 +92,7 @@ class PeakCurve
     float MzVar = -1;
     vector<float> RegionRidge;
     const InstrumentParameter& parameter;
+    const pwiz::msdata::MSData& msd;
 
     public:
 
@@ -388,7 +390,7 @@ class PeakCurve
 
         //Generate a peak curve for each detected region
         for (size_t i = 0; i < GetPeakRegionList().size(); i++) {
-            tempArrayList.emplace_back(new PeakCurve(parameter));
+            tempArrayList.emplace_back(new PeakCurve(parameter, msd));
             PeakCurvePtr& peakCurve = tempArrayList.back();
             peakCurve->Index = this->Index;
             peakCurve->RegionRidge = NoRidgeRegion.at(i);
@@ -424,7 +426,7 @@ class PeakCurve
 #ifdef DIAUMPIRE_DEBUG
         if (MsLevel == 1)
         {
-            ofstream peakRegionLog("DiaUmpireCpp-peakRegion.txt", std::ios::app);
+            ofstream peakRegionLog(("DiaUmpireCpp-peakRegion-" + msd.run.id + ".txt").c_str(), std::ios::app);
             boost::format pointFormat(" (%.2f, %.2f, %.2f)");
             boost::format floatFormat(" %.2f");
             peakRegionLog << Index << " PeakRegionList";
@@ -433,12 +435,12 @@ class PeakCurve
             peakRegionLog << "\n";
         }
 
-        ofstream peakComparisonLog("DiaUmpireCpp-peakComparisons.txt", std::ios::app);
+        ofstream peakComparisonLog(("DiaUmpireCpp-peakComparisons-" + msd.run.id + ".txt").c_str(), std::ios::app);
         boost::format pointFormat(" (%.6f, %.6f, %.6f, %d)");
 
         vector<vector<string>> comparisonsByRegion(GetPeakRegionList().size());
 
-        ofstream peakLog("DiaUmpireCpp-ms1-peaks-at-separate-by-region.txt", std::ios::app);
+        ofstream peakLog(("DiaUmpireCpp-ms1-peaks-at-separate-by-region-" + msd.run.id + ".txt").c_str(), std::ios::app);
         boost::format float6Format(" %.6f");
         if (MsLevel == 1)
             peakLog << Index;
@@ -508,7 +510,7 @@ class PeakCurve
         return returnArrayList;
     }
 
-    PeakCurve(const InstrumentParameter& parameter) : parameter(parameter) {}
+    PeakCurve(const InstrumentParameter& parameter, const pwiz::msdata::MSData& msd) : parameter(parameter), msd(msd) {}
 
     float StartInt() const {
         if (startint == 0) {
@@ -673,7 +675,7 @@ class PeakCurve
     void AddPeak(XYZData xYZPoint)
     {
         if (!PeakList.empty() && xYZPoint.getX() < PeakList.back().getX())
-            throw runtime_error("[DiaUmpire::PeakCurve::AddPeak] scan time is not monotonically increasing");
+            throw runtime_error("[DiaUmpire::PeakCurve::AddPeak] scan time is not monotonically increasing: new time " + pwiz::util::toString(xYZPoint.getX()) + " < last added time " + pwiz::util::toString(PeakList.back().getX()));
 
         PeakList.emplace_back(xYZPoint);
         TotalIntMzF += xYZPoint.getY() * xYZPoint.getZ() * xYZPoint.getZ();

--- a/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpire.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpire.cpp
@@ -80,6 +80,14 @@ PWIZ_API_DECL SpectrumList_DiaUmpire::SpectrumList_DiaUmpire(const MSData& msd, 
     for (const auto& kvp : config.instrumentParameters.GetParameterMap())
         method.userParams.emplace_back(kvp.first, kvp.second);
 
+    if (config.diaTargetWindowScheme == DiaUmpire::TargetWindow::Scheme::SWATH_Variable)
+    {
+        string windowStr;
+        for (auto& window : config.diaVariableWindows)
+            windowStr += toString(window.mzRange.begin) + "-" + toString(window.mzRange.end) + " ";
+        method.userParams.emplace_back("VariableWindows", windowStr);
+    }
+
     if (!dp_->processingMethods.empty())
         method.softwarePtr = dp_->processingMethods[0].softwarePtr;
 

--- a/pwiz/utility/bindings/CLI/analysis/spectrum_processing.cpp
+++ b/pwiz/utility/bindings/CLI/analysis/spectrum_processing.cpp
@@ -555,6 +555,7 @@ SpectrumList_DiaUmpire::SpectrumList_DiaUmpire(msdata::MSData^ msd, msdata::Spec
     try { base_ = new b::SpectrumList_DiaUmpire(msd->base(), *inner->base_, config->base(), ilr ? &ilr->base() : nullptr); } CATCH_AND_FORWARD
     msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
     System::GC::KeepAlive(ilr);
+    System::GC::KeepAlive(inner);
     System::GC::KeepAlive(config);
     System::GC::KeepAlive(msd);
 }

--- a/pwiz/utility/misc/String.cpp
+++ b/pwiz/utility/misc/String.cpp
@@ -106,6 +106,7 @@ std::string pwiz::util::toString(double value, RealConvertPolicy policyFlags)
         case RealConvertPolicy::AutoNotation: return generateWithPolicy<double12_policy<double>>(value);
         case RealConvertPolicy::FixedNotation: return generateWithPolicy<double12_policy_fixed<double>>(value);
         case RealConvertPolicy::ScientificNotation: return generateWithPolicy<double12_policy_scientific<double>>(value);
+        default: throw std::runtime_error("[toString] unknown RealConvertPolicy");
     }
 }
 
@@ -122,6 +123,7 @@ std::string pwiz::util::toString(float value, RealConvertPolicy policyFlags)
         case RealConvertPolicy::AutoNotation: return generateWithPolicy<float5_policy<float>>(value);
         case RealConvertPolicy::FixedNotation: return generateWithPolicy<float5_policy_fixed<float>>(value);
         case RealConvertPolicy::ScientificNotation: return generateWithPolicy<float5_policy_scientific<float>>(value);
+        default: throw std::runtime_error("[toString] unknown RealConvertPolicy");
     }
 }
 

--- a/pwiz_tools/Shared/Common/SystemUtil/ProcessRunner.cs
+++ b/pwiz_tools/Shared/Common/SystemUtil/ProcessRunner.cs
@@ -29,9 +29,10 @@ namespace pwiz.Common.SystemUtil
     {
         string StatusPrefix { get; set; }
         string HideLinePrefix { get; set; }
-        void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status);
         void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status,
-                 TextWriter writer);
+            ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal);
+        void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status,
+                 TextWriter writer, ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal);
     }
 
     public class ProcessRunner : IProcessRunner
@@ -51,12 +52,14 @@ namespace pwiz.Common.SystemUtil
         /// </summary>
         public string HideLinePrefix { get; set; }
 
-        public void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status)
+        public void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status,
+            ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal)
         {
-            Run(psi, stdin, progress,ref status, null);
+            Run(psi, stdin, progress,ref status, null, priorityClass);
         }
 
-        public void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status, TextWriter writer)
+        public void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status, TextWriter writer,
+            ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal)
         {
             // Make sure required streams are redirected.
             psi.RedirectStandardOutput = true;
@@ -70,6 +73,7 @@ namespace pwiz.Common.SystemUtil
             var proc = Process.Start(psi);
             if (proc == null)
                 throw new IOException(string.Format(@"Failure starting {0} command.", psi.FileName));
+            proc.PriorityClass = priorityClass;
             if (stdin != null)
             {
                 try
@@ -176,12 +180,14 @@ namespace pwiz.Common.SystemUtil
             public bool shouldCancel { get; set; }
             public string StatusPrefix { get; set; }
             public string HideLinePrefix { get; set; }
-            public void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status)
+            public void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status,
+                ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal)
             {
-                Run(psi, stdin, progress, ref status, null);
+                Run(psi, stdin, progress, ref status, null, priorityClass);
             }
 
-            public void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status, TextWriter writer)
+            public void Run(ProcessStartInfo psi, string stdin, IProgressMonitor progress, ref IProgressStatus status, TextWriter writer,
+                ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal)
             {
                 if (shouldCancel)
                 {

--- a/pwiz_tools/Shared/ProteowizardWrapper/DiaUmpire.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/DiaUmpire.cs
@@ -163,7 +163,7 @@ namespace pwiz.ProteowizardWrapper
                 using (var configFile = new StreamWriter(filepath))
                 {
                     foreach(var p in Parameters)
-                        configFile.WriteLine($"{p.Key} = {p.Value}");
+                        configFile.WriteLine($"{p.Key} = {Convert.ToString(p.Value, CultureInfo.InvariantCulture)}");
 
                     var windowTypeStrings = new Dictionary<WindowScheme, string>
                     {
@@ -177,7 +177,7 @@ namespace pwiz.ProteowizardWrapper
 
                     configFile.WriteLine(@"==window setting begin");
                     foreach(var window in VariableWindows)
-                        configFile.WriteLine($"{window.Start}\t{window.End}");
+                        configFile.WriteLine($"{window.Start.ToString(CultureInfo.InvariantCulture)}\t{window.End.ToString(CultureInfo.InvariantCulture)}");
                     configFile.WriteLine(@"==window setting end");
                 }
             }

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/DDASearchControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/DDASearchControl.cs
@@ -76,15 +76,18 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             string message = status.IsError ? status.ErrorException.ToString() : status.Message;
 
-            var newEntry = new ProgressEntry(DateTime.Now, message);
-            _progressTextItems.Add(newEntry);
-            txtSearchProgress.AppendText($@"{newEntry.ToString(showTimestampsCheckbox.Checked)}{Environment.NewLine}");
-
             if (status.IsError)
             {
                 MessageDlg.ShowWithException(Program.MainWindow, Resources.CommandLineTest_ConsoleAddFastaTest_Error, status.ErrorException);
                 return;
             }
+
+            if (_progressTextItems.Count > 0 && status.Message == _progressTextItems[_progressTextItems.Count - 1].Message)
+                return;
+
+            var newEntry = new ProgressEntry(DateTime.Now, message);
+            _progressTextItems.Add(newEntry);
+            txtSearchProgress.AppendText($@"{newEntry.ToString(showTimestampsCheckbox.Checked)}{Environment.NewLine}");
 
             int percentComplete = status.PercentComplete;
             if (status.SegmentCount > 0)

--- a/pwiz_tools/Skyline/Jamfile.jam
+++ b/pwiz_tools/Skyline/Jamfile.jam
@@ -363,6 +363,7 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
             <conditional>@msvc-dotnet-requirement
             <assembly>../../pwiz/utility/bindings/CLI//pwiz_data_cli
             <assembly>../../pwiz/utility/bindings/CLI/timstof_prm_scheduler//PrmPasefScheduler
+            <dependency>../../pwiz_tools/commandline//msconvert/<location>$(PWIZ_WRAPPER_PATH)/obj/$(PLATFORM)
             <assembly>TestDiagnostics//TestDiagnostics
             <conditional>@build-location
             <conditional>@install-vendor-api-dependencies

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -4774,6 +4774,14 @@
       <Link>BaseDataAccess.dll.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Condition="'$(Platform)' == 'x86'" Include="..\Shared\ProteowizardWrapper\obj\x86\msconvert.exe">
+      <Link>msconvert.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Condition="'$(Platform)' == 'x64'" Include="..\Shared\ProteowizardWrapper\obj\x64\msconvert.exe">
+      <Link>msconvert.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Condition="'$(Platform)' == 'x86'" Include="..\Shared\BiblioSpec\obj\x86\BlibBuild.exe">
       <Link>BlibBuild.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
@@ -66,10 +66,6 @@ namespace pwiz.SkylineTestFunctional
         [TestMethod]
         public void TestDiaSearchVariableWindows()
         {
-            // TODO(matt.chambers): Fix "Cannot pass a GCHandle across AppDomains" error with MSTest
-            if (IsMsTestRun)
-                return;
-
             TestFilesZip = @"TestFunctional\DiaSearchTest.zip";
 
             _testDetails = new TestDetails
@@ -103,23 +99,21 @@ namespace pwiz.SkylineTestFunctional
         [TestMethod]
         public void TestDiaSearchFixedWindows()
         {
-            // TODO(matt.chambers): Fix "Cannot pass a GCHandle across AppDomains" error with MSTest
-            if (IsMsTestRun)
-                return;
-
             TestFilesZip = @"TestFunctional\DiaSearchTest.zip";
 
             string diaUmpireTestDataPath = TestFilesDir.GetVendorTestData(TestFilesDir.VendorDir.DiaUmpire);
+
             _testDetails = new TestDetails
             {
                 DocumentPath = "TestFixedWindowDiaUmpire.sky",
                 SearchFiles = new[]
                 {
                     // CONSIDER: test automatic fixed window as well as manually calculated?
-                    // Path.Combine(TestFilesDir.GetVendorTestData(TestFilesDir.VendorDir.ABI), "swath.api.wiff2")
+                    //Path.Combine(TestFilesDir.GetVendorTestData(TestFilesDir.VendorDir.ABI), "swath.api.wiff2")
 
-                    Path.Combine(diaUmpireTestDataPath, "Hoofnagle_10xDil_SWATH_01-20130327_Hoofnagle_10xDil_SWATH_1_01.mzXML")
+                    "Hoofnagle_10xDil_SWATH_01-20130327_Hoofnagle_10xDil_SWATH_1_01.mzXML"
                 },
+
                 FastaPath = Path.Combine(diaUmpireTestDataPath, "Hoofnagle_10xDil_SWATH.fasta"),
 
                 Initial = new TestDetails.DocumentCounts { ProteinCount = 268, PeptideCount = 93, PrecursorCount = 94, TransitionCount = 846 },
@@ -184,8 +178,14 @@ namespace pwiz.SkylineTestFunctional
         {
             PrepareDocument(testDetails.DocumentPath);
 
+            // copy files from core to test location (otherwise Skyline's DiaUmpire output will overwrite core test reference files)
+            string diaUmpireTestDataPath = TestFilesDir.GetVendorTestData(TestFilesDir.VendorDir.DiaUmpire);
+            foreach (var sourceName in testDetails.SearchFiles)
+                if (File.Exists(Path.Combine(diaUmpireTestDataPath, sourceName)))
+                    File.Copy(Path.Combine(diaUmpireTestDataPath, sourceName), Path.Combine(TestFilesDir.FullPath, sourceName), true);
+
             // delete -diaumpire files so they get regenerated instead of reused
-            foreach(var file in Directory.GetFiles(TestFilesDir.FullPath, "*-diaumpire.*"))
+            foreach (var file in Directory.GetFiles(TestFilesDir.FullPath, "*-diaumpire.*"))
                 FileEx.SafeDelete(file);
 
             // Launch the wizard
@@ -381,7 +381,7 @@ namespace pwiz.SkylineTestFunctional
                 Assert.IsTrue(importPeptideSearchDlg.ClickNextButton()); // now on search progress
             });
 
-            WaitForConditionUI(60000, () => searchSucceeded.HasValue);
+            WaitForConditionUI(360000, () => searchSucceeded.HasValue);
             RunUI(() => Assert.IsTrue(searchSucceeded.Value, importPeptideSearchDlg.SearchControl.LogText));
 
             RunDlg<PeptidesPerProteinDlg>(importPeptideSearchDlg.ClickNextButtonNoCheck, emptyProteinsDlg =>

--- a/pwiz_tools/Skyline/TestPerf/DiaUmpireTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaUmpireTutorialTest.cs
@@ -385,6 +385,11 @@ namespace TestPerf
             // Add the test xml file to the search files list and try to 
             // build the document library.
             string diaDir = GetTestPath("DIA");
+
+            // delete -diaumpire files so they get regenerated instead of reused
+            foreach (var file in Directory.GetFiles(diaDir, "*-diaumpire.*"))
+                FileEx.SafeDelete(file);
+
             string[] searchFiles = DiaFiles.Select(p => Path.Combine(diaDir, p)).Take(_analysisValues.IsWholeProteome ? DiaFiles.Length : 2).ToArray();
             foreach (var searchFile in searchFiles)
                 Assert.IsTrue(File.Exists(searchFile), string.Format("File {0} does not exist.", searchFile));

--- a/pwiz_tools/Skyline/TestSettings_x64-template.testsettings
+++ b/pwiz_tools/Skyline/TestSettings_x64-template.testsettings
@@ -19,9 +19,9 @@
     <DeploymentItem filename="bin\x64\Debug\zh-CHS\pwiz.Common.resources.dll" outputDirectory="zh-CHS" />
     <DeploymentItem filename="bin\x64\Release\zh-CHS\ZedGraph.resources.dll" outputDirectory="zh-CHS" />
     <DeploymentItem filename="bin\x64\Debug\zh-CHS\ZedGraph.resources.dll" outputDirectory="zh-CHS" />
-    <!-- Vendor readers -->
-    <DeploymentItem filename="..\..\pwiz_aux\msrc\utility\vendor_api\Shimadzu\x64\DataReader.dll" />
+
     <!-- Vendor method building -->
+    <DeploymentItem filename="..\..\pwiz_aux\msrc\utility\vendor_api\Shimadzu\x64\DataReader.dll" />
     <DeploymentItem filename="Method\Agilent\BuildAgilentMethod.exe" outputDirectory="Method\Agilent" />
     <DeploymentItem filename="Method\Agilent\MethodCreator.dll" outputDirectory="Method\Agilent" />
     <DeploymentItem filename="Method\Bruker\BuildBrukerMethod.exe" outputDirectory="Method\Bruker" />
@@ -44,6 +44,7 @@
     <DeploymentItem filename="unimod.xml" />
     <DeploymentItem filename="..\..\pwiz\data\common\unimod.obo" />
     <DeploymentItem filename="..\..\pwiz\data\common\psi-ms.obo" />
+    <DeploymentItem filename="msconvert.exe" />
     <DeploymentItem filename="SkylineCmd.exe" />
     <!-- Prosit gRPC -->
     <DeploymentItem filename="..\Shared\Lib\grpc_csharp_ext.x64.dll" />

--- a/pwiz_tools/Skyline/TestSettings_x86-template.testsettings
+++ b/pwiz_tools/Skyline/TestSettings_x86-template.testsettings
@@ -68,6 +68,7 @@
     <DeploymentItem filename="quantitation_2.xsd" />
     <DeploymentItem filename="..\..\pwiz\data\common\unimod.obo" />
     <DeploymentItem filename="..\..\pwiz\data\common\psi-ms.obo" />
+    <DeploymentItem filename="msconvert.exe" />
     <DeploymentItem filename="SkylineCmd.exe" />
     <!-- Prosit gRPC -->
     <DeploymentItem filename="..\Shared\Lib\grpc_csharp_ext.x86.dll" />


### PR DESCRIPTION
* added extra debug conditional code to DiaUmpire.cpp
* changed DiaUmpire.cpp params file parser to support variable names with or without SE prefix
* added window sizes to DiaUmpire output file's processingMethod userParams for variable size scheme
* moved window scheme into pwiz.ProteowizardWrapper.DiaUmpire.Config
* fixed DDASearchControl to ignore repeated identical progress messages
* added msconvert as a dependency of Skyline (built with same without-cxt setting)
* fixed TestDia*DiaUmpire* tests not deleting previous DiaUmpire output files
* removed MSTest restriction from TestDiaSearch* since it is run out of process now