### PR TITLE
Fix RTScheduleGraphPane exceptions (#1551)

### DIFF
--- a/pwiz_tools/Skyline/Controls/Clustering/BoundGraphDataCalculator.cs
+++ b/pwiz_tools/Skyline/Controls/Clustering/BoundGraphDataCalculator.cs
@@ -30,7 +30,8 @@ namespace pwiz.Skyline.Controls.Clustering
     /// </summary>
     public abstract class BoundGraphDataCalculator<TInput, TResults> : GraphDataCalculator<TInput, TResults> where TInput : DataSchemaInput
     {
-        protected BoundGraphDataCalculator(CancellationToken parentCancellationToken, ZedGraphControl zedGraphControl) : base(parentCancellationToken, zedGraphControl)
+        protected BoundGraphDataCalculator(CancellationToken parentCancellationToken, ZedGraphControl zedGraphControl) :
+            base(parentCancellationToken, zedGraphControl, zedGraphControl.GraphPane)
         {
         }
 

--- a/pwiz_tools/Skyline/Controls/Graphs/ExportMethodScheduleGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ExportMethodScheduleGraph.cs
@@ -24,6 +24,7 @@ using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Hibernate;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
+using ZedGraph;
 
 namespace pwiz.Skyline.Controls.Graphs
 {
@@ -72,7 +73,7 @@ namespace pwiz.Skyline.Controls.Graphs
             masterPane.PaneList.Clear();
             masterPane.Border.IsVisible = false;
 
-            _pane = new RTScheduleGraphPane(null, true);
+            _pane = new RTScheduleGraphPane(null, graphControl, true);
             _pane.BrukerMetrics = brukerMetrics;
 
             // Save existing settings
@@ -164,6 +165,11 @@ namespace pwiz.Skyline.Controls.Graphs
                 graphControl.Visible = false;
                 dataGridView.Visible = true;
             }
+        }
+
+        public ZedGraphControl GraphControl
+        {
+            get { return graphControl; }
         }
     }
 }

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphDataCalculator.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphDataCalculator.cs
@@ -38,20 +38,18 @@ namespace pwiz.Skyline.Controls.Graphs
         private Tuple<CancellationTokenSource, PaneProgressBar> _progressTuple;
 
 
-        public GraphDataCalculator(CancellationToken parentCancellationToken, ZedGraphControl zedGraphControl)
+        public GraphDataCalculator(CancellationToken parentCancellationToken, ZedGraphControl zedGraphControl, GraphPane graphPane)
         {
             ParentCancellationToken = parentCancellationToken;
             ZedGraphControl = zedGraphControl;
+            GraphPane = graphPane;
         }
 
         public CancellationToken ParentCancellationToken { get; }
 
-        public ZedGraphControl ZedGraphControl { get; private set; }
+        public ZedGraphControl ZedGraphControl { get; }
 
-        public virtual GraphPane GraphPane
-        {
-            get { return ZedGraphControl.GraphPane; }
-        }
+        public virtual GraphPane GraphPane { get; }
 
         public TInput Input
         {
@@ -99,16 +97,16 @@ namespace pwiz.Skyline.Controls.Graphs
             ActionUtil.RunAsync(() =>
             {
                 var results = CalculateResults(input, cancellationToken);
-                if (Equals(results, default(TResults)))
-                {
-                    return;
-                }
+                    if (Equals(results, default(TResults)))
+                    {
+                        return;
+                    }
                 BeginInvoke(cancellationToken, ()=> {
                     Assume.IsTrue(ReferenceEquals(_progressTuple.Item1, cancellationTokenSource));
                     _progressTuple.Item2.Dispose();
                     _progressTuple = null;
-                    Results = results;
-                    ResultsAvailable();
+                        Results = results;
+                        ResultsAvailable();
                 });
             });
         }

--- a/pwiz_tools/Skyline/Controls/Graphs/RTGraphController.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTGraphController.cs
@@ -207,7 +207,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 case GraphTypeSummary.schedule:
                     if (!(GraphSummary.GraphPanes.FirstOrDefault() is RTScheduleGraphPane))
                     {
-                        GraphSummary.GraphPanes = new[] {new RTScheduleGraphPane(GraphSummary)};
+                        GraphSummary.GraphPanes = new[] {new RTScheduleGraphPane(GraphSummary, GraphSummary.GraphControl)};
                     }
                     break;
             }

--- a/pwiz_tools/Skyline/Controls/Graphs/RTScheduleGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTScheduleGraphPane.cs
@@ -77,12 +77,14 @@ namespace pwiz.Skyline.Controls.Graphs
         public BrukerTimsTofMethodExporter.Metrics BrukerMetrics { get; set; }
 
         private bool _exportMethodDlg;
+        private ZedGraphControl _graphControl;
 
-        public RTScheduleGraphPane(GraphSummary graphSummary, bool isExportMethodDlg = false)
+        public RTScheduleGraphPane(GraphSummary graphSummary, ZedGraphControl graphControl, bool isExportMethodDlg = false)
             : base(graphSummary)
         {
             _exportMethodDlg = isExportMethodDlg;
-            _dataCalculator = new SchedulingDataCalculator(this);
+            _graphControl = graphControl;
+            _dataCalculator = new SchedulingDataCalculator(this, graphControl);
 
             XAxis.Title.Text = Resources.RTScheduleGraphPane_RTScheduleGraphPane_Scheduled_Time;
             YAxis.Scale.MinAuto = false;
@@ -148,7 +150,7 @@ namespace pwiz.Skyline.Controls.Graphs
             }
 
             AxisChange();
-            GraphSummary.GraphControl.Invalidate();
+            _graphControl.Invalidate();
         }
 
         public void AddSchedulingCurve(string label, IPointList points, Color color)
@@ -250,12 +252,14 @@ namespace pwiz.Skyline.Controls.Graphs
 
         private class SchedulingDataCalculator : GraphDataCalculator<InputData, Results>
         {
-            public SchedulingDataCalculator(RTScheduleGraphPane graphPane) : base(CancellationToken.None, graphPane.GraphSummary.GraphControl)
+            public SchedulingDataCalculator(RTScheduleGraphPane graphPane, ZedGraphControl graphControl) : base(CancellationToken.None, graphControl, graphPane)
             {
-                GraphPane = graphPane;
             }
 
-            public new RTScheduleGraphPane GraphPane { get; }
+            public new RTScheduleGraphPane GraphPane
+            {
+                get { return (RTScheduleGraphPane) base.GraphPane; }
+            }
 
             protected override Results CalculateResults(InputData input, CancellationToken cancellationToken)
             {
@@ -295,9 +299,18 @@ namespace pwiz.Skyline.Controls.Graphs
                     }
                     else
                     {
-                        BrukerTimsTofMethodExporter.GetScheduling(document,
-                            new ExportDlgProperties(new ExportMethodDlg(document, ExportFileType.Method), new CancellationToken()) { MethodType = ExportMethodType.Scheduled },
-                            input.BrukerTemplateFileValue, new SilentProgressMonitor(cancellationToken), out brukerPoints);
+                        try
+                        {
+                            BrukerTimsTofMethodExporter.GetScheduling(document,
+                                new ExportDlgProperties(new ExportMethodDlg(document, ExportFileType.Method),
+                                    new CancellationToken()) {MethodType = ExportMethodType.Scheduled},
+                                input.BrukerTemplateFileValue, new SilentProgressMonitor(cancellationToken),
+                                out brukerPoints);
+                        }
+                        catch (Exception)
+                        {
+                            // ignore "Scheduling failure (no points)" error
+                        }
                     }
 
                     return brukerPoints;
@@ -355,7 +368,7 @@ namespace pwiz.Skyline.Controls.Graphs
             public static IEnumerable<KeyValuePair<double, double>> GetOverlapCounts(
                 IEnumerable<PrecursorScheduleBase> schedules, double minTime, double maxTime, double stepSize)
             {
-                if (maxTime < minTime)
+                if (maxTime < minTime || double.IsNaN(maxTime) || double.IsNaN(minTime))
                 {
                     return Enumerable.Empty<KeyValuePair<double, double>>();
                 }

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.cs
@@ -1938,6 +1938,11 @@ namespace pwiz.Skyline.FileUI
         
         private void btnGraph_Click(object sender, EventArgs e)
         {
+            ShowSchedulingGraph();
+        }
+
+        public void ShowSchedulingGraph()
+        {
             var brukerTemplate = Equals(InstrumentType, ExportInstrumentType.BRUKER_TIMSTOF)
                 ? textTemplateFile.Text
                 : null;

--- a/pwiz_tools/Skyline/TestFunctional/ExportMethodDialogTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExportMethodDialogTest.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Alerts;
+using pwiz.Skyline.Controls.Graphs;
 using pwiz.Skyline.FileUI;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
@@ -132,7 +133,11 @@ namespace pwiz.SkylineTestFunctional
                         Assert.IsFalse(exportMethodDlg.IsRunLengthVisible);
                         Assert.IsFalse(exportMethodDlg.IsDwellTimeVisible);
                     });
-
+                var exportMethodScheduleGraph =
+                    ShowDialog<ExportMethodScheduleGraph>(exportMethodDlg.ShowSchedulingGraph);
+                WaitForConditionUI(() => exportMethodScheduleGraph.GraphControl.GraphPane.CurveList.Count > 0);
+                OkDialog(exportMethodScheduleGraph, exportMethodScheduleGraph.Close);
+                
                 RunDlg<MessageDlg>(() => exportMethodDlg.MethodType = ExportMethodType.Triggered,
                     dlg =>
                     {

--- a/pwiz_tools/Skyline/TestRunnerLib/TestRunnerFormLookup.csv
+++ b/pwiz_tools/Skyline/TestRunnerLib/TestRunnerFormLookup.csv
@@ -84,7 +84,7 @@ ExportLiveReportDlg,TestReportSummary
 ExportMethodDlg.IsolationListView,TestExportDiaList
 ExportMethodDlg.MethodView,TestExportDiaList
 ExportMethodDlg.TransitionListView,TestExportMethodDlg
-ExportMethodScheduleGraph,TODO (KaipoT)
+ExportMethodScheduleGraph,TestExportMethodDlg
 FilterMatchedPeptidesDlg,TestInsert
 FilterMidasLibraryDlg,TestMidas
 FindColumnDlg,TestFindColumn


### PR DESCRIPTION
Fix Exception "Scheduling failure (no targets?)" displaying RTScheduleGraphPane if Bruker template file is specified and the document is empty.
(Reported on the exception web)

Fix NullReferenceException trying to display Scheduling Graph from Export Method dialog.
(Discovered by Kaipo)

Fix Overflow exception if user sets the scheduling window to "NaN" (not a number).
(Found by Nick. I'll do a separate PR to make it so that MessageBoxHelper prevents the user from being able to type NaN into a DecimalListTextBox).

Also, added a step to TestExportMethodDlg which brings up ExportMethodScheduleGraph