### PR TITLE
Skyline: Always output a message beginning with "Error:" when returning a non-zero exit code from CommandLine. (#1531)

### DIFF
--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -999,8 +999,8 @@ namespace pwiz.Skyline
                 var serverUri = PanoramaUtil.ServerNameToUri(PanoramaServerUri);
                 if (serverUri == null)
                 {
-                    WriteLine(Resources.EditServerDlg_OkDialog_The_text__0__is_not_a_valid_server_name_,
-                        PanoramaServerUri);
+                    WriteLine(Resources.CommandLine_GeneralException_Error___0_, 
+                        string.Format(Resources.EditServerDlg_OkDialog_The_text__0__is_not_a_valid_server_name_, PanoramaServerUri));
                     return false;
                 }
 
@@ -1069,11 +1069,11 @@ namespace pwiz.Skyline
                 }
                 catch (PanoramaServerException x)
                 {
-                    _statusWriter.WriteLine(x.Message);
+                    _statusWriter.WriteLine(Resources.PanoramaHelper_ValidateServer_PanoramaServerException_, x.Message);
                 }
                 catch (Exception x)
                 {
-                    _statusWriter.WriteLine(Resources.PanoramaHelper_ValidateServer_, x.Message);
+                    _statusWriter.WriteLine(Resources.PanoramaHelper_ValidateServer_Exception_, x.Message);
                 }
 
                 return null;
@@ -1088,12 +1088,12 @@ namespace pwiz.Skyline
                 }
                 catch (PanoramaServerException x)
                 {
-                    _statusWriter.WriteLine(x.Message);
+                    _statusWriter.WriteLine(Resources.PanoramaHelper_ValidateFolder_PanoramaServerException_, x.Message);
                 }
                 catch (Exception x)
                 {
                     _statusWriter.WriteLine(
-                        Resources.PanoramaHelper_ValidateFolder_,
+                        Resources.PanoramaHelper_ValidateFolder_Exception_,
                         panoramaFolder, panoramaClient.ServerUri,
                         x.Message);
                 }
@@ -1890,7 +1890,7 @@ namespace pwiz.Skyline
             }
             catch (Exception x)
             {
-                // Unexpected behavior, but better to output the error then appear to crash, and
+                // Unexpected behavior, but better to output the error than appear to crash, and
                 // have Windows write it to the application event log.
                 WriteLine(Resources.CommandLine_GeneralException_Error___0_, x.Message);
                 WriteLine(x.StackTrace);

--- a/pwiz_tools/Skyline/Executables/SkylineRunner/ErrorChecker.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineRunner/ErrorChecker.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+
+namespace pwiz.SkylineRunner
+{
+    public class ErrorChecker
+    {
+        // We want to be able to distribute SkylineRunner as a single EXE file. So, requiring
+        // resource DLLs for language translation is not possible.
+        private static readonly string[] INTL_ERROR_PREFIXES =
+        {
+            "エラー：", // ja
+            "错误："    // zh-CHS
+        };
+
+        public static bool IsErrorLine(string line)
+        {
+            // The English prefix can happen in any culture when running Skyline-daily with a new
+            // untranslated error message.
+            if (HasErrorPrefix(line, "Error:", StringComparison.InvariantCulture))
+                return true;
+
+            return INTL_ERROR_PREFIXES.Any(p => HasErrorPrefix(line, p, StringComparison.CurrentCulture));
+        }
+
+
+        private static bool HasErrorPrefix(string line, string prefix, StringComparison comparisonType)
+        {
+            int prefixIndex = line.IndexOf(prefix, comparisonType);
+            if (prefixIndex == -1)
+                return false;
+            // The prefix could start the line or it could be preceded by a tab character
+            // if the output includes a timestamp or memory stamp.
+            return prefixIndex == 0 || line[prefixIndex - 1] == '\t';
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Executables/SkylineRunner/Program.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineRunner/Program.cs
@@ -116,7 +116,7 @@ namespace pwiz.SkylineRunner
                     //While (!done reading)
                     while ((line = sr.ReadLine()) != null)
                     {
-                        if (line.StartsWith("Error:"))
+                        if (ErrorChecker.IsErrorLine(line))   // In case of Skyline-daily with untranslated text
                         {
                             exitCode = 2;
                         }

--- a/pwiz_tools/Skyline/Executables/SkylineRunner/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineRunner/Properties/Resources.Designer.cs
@@ -89,6 +89,15 @@ namespace pwiz.SkylineRunner.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error:.
+        /// </summary>
+        internal static string Program_Run_Error_ {
+            get {
+                return ResourceManager.GetString("Program_Run_Error_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Waiting for Skyline.
         /// </summary>
         internal static string Program_WaitForConnection_Waiting_for_Skyline {

--- a/pwiz_tools/Skyline/Executables/SkylineRunner/SkylineRunner.csproj
+++ b/pwiz_tools/Skyline/Executables/SkylineRunner/SkylineRunner.csproj
@@ -118,6 +118,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ErrorChecker.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -6319,6 +6319,15 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error: Failure occurred. Exiting....
+        /// </summary>
+        public static string CommandLine_Run_Error__Failure_occurred__Exiting___ {
+            get {
+                return ResourceManager.GetString("CommandLine_Run_Error__Failure_occurred__Exiting___", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error: You cannot simultaneously export a transition list and a method.  Neither will be exported. Please change the command line parameters..
         /// </summary>
         public static string CommandLine_Run_Error__You_cannot_simultaneously_export_a_transition_list_and_a_method___Neither_will_be_exported__ {
@@ -6668,6 +6677,15 @@ namespace pwiz.Skyline.Properties {
         public static string CommandProgressMonitor_UpdateProgressInternal_Message__ {
             get {
                 return ResourceManager.GetString("CommandProgressMonitor_UpdateProgressInternal_Message__", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error:.
+        /// </summary>
+        public static string CommandStatusWriter_WriteLine_Error_ {
+            get {
+                return ResourceManager.GetString("CommandStatusWriter_WriteLine_Error_", resourceCulture);
             }
         }
         
@@ -20547,19 +20565,39 @@ namespace pwiz.Skyline.Properties {
         ///   Looks up a localized string similar to An unknown error occurred trying to verify access to Panorama folder {0} on the server {1}.
         ///{2}.
         /// </summary>
-        public static string PanoramaHelper_ValidateFolder_ {
+        public static string PanoramaHelper_ValidateFolder_Exception_ {
             get {
-                return ResourceManager.GetString("PanoramaHelper_ValidateFolder_", resourceCulture);
+                return ResourceManager.GetString("PanoramaHelper_ValidateFolder_Exception_", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An unknown error occurred trying to verify Panorama server information.
+        ///   Looks up a localized string similar to Error: Unable to verify access to Panorama folder.
         ///{0}.
         /// </summary>
-        public static string PanoramaHelper_ValidateServer_ {
+        public static string PanoramaHelper_ValidateFolder_PanoramaServerException_ {
             get {
-                return ResourceManager.GetString("PanoramaHelper_ValidateServer_", resourceCulture);
+                return ResourceManager.GetString("PanoramaHelper_ValidateFolder_PanoramaServerException_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error: An unknown error occurred trying to verify Panorama server information.
+        ///{0}.
+        /// </summary>
+        public static string PanoramaHelper_ValidateServer_Exception_ {
+            get {
+                return ResourceManager.GetString("PanoramaHelper_ValidateServer_Exception_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error: Unable to verify Panorama server information.
+        ///{0}.
+        /// </summary>
+        public static string PanoramaHelper_ValidateServer_PanoramaServerException_ {
+            get {
+                return ResourceManager.GetString("PanoramaHelper_ValidateServer_PanoramaServerException_", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -1607,10 +1607,6 @@
   <data name="ToolMacros__listArguments_Document_Path" xml:space="preserve">
     <value>ドキュメントパス</value>
   </data>
-  <data name="PanoramaHelper_ValidateServer_" xml:space="preserve">
-    <value>Panoramaサーバー情報を検証しようとした際に不明なエラーが発生しました。
-{0}</value>
-  </data>
   <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
     <value>プリカーサー</value>
   </data>
@@ -5156,10 +5152,6 @@
   </data>
   <data name="SkylineWindow_ImportMassList_Finishing_up_import" xml:space="preserve">
     <value>インポートの終了中</value>
-  </data>
-  <data name="PanoramaHelper_ValidateFolder_" xml:space="preserve">
-    <value>サーバー{1}上のPanormaフォルダ{0}へのアクセスを検証しようとした際に不明なエラーが発生しました。
-{2}</value>
   </data>
   <data name="DoconvolutionMethod_NONE_None" xml:space="preserve">
     <value>なし</value>
@@ -10002,10 +9994,6 @@ Skylineにインポートする前に必要に応じてライブラリをフィ�
     <value>Panoramaにアップロードしようとした際に不明なエラーが発生しました。
 {0}</value>
   </data>
-  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
-    <value>ドキュメントをPanormaにアップロードするため必要な以下の引数に値を指定してください：
-{0}</value>
-  </data>
   <data name="SkylineWindow_ShowPublishDlg_The_document_must_be_fully_loaded_before_it_can_be_uploaded_" xml:space="preserve">
     <value>ドキュメントはアップロードする前に、完全に読み込まれている必要があります。</value>
   </data>
@@ -10026,10 +10014,6 @@ Skylineにインポートする前に必要に応じてライブラリをフィ�
   </data>
   <data name="PublishDocumentDlg_btnBrowse_Click_Upload_Document" xml:space="preserve">
     <value>ドキュメントをアップロード</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
-    <value>ドキュメントをPanoramaにアップロードするため必要な以下の引数に値を指定してください：
-{0}</value>
   </data>
   <data name="FullScanAcquisitionMethod_FromName__0__is_not_a_valid_Full_Scan_Acquisition_Method" xml:space="preserve">
     <value>{0}は有効なフルスキャン取得メソッドではありません</value>
@@ -11055,5 +11039,8 @@ Invalid peptide sequence at position 18
   </data>
   <data name="MetadataRuleSetList_Label_Rule_Set" xml:space="preserve">
     <value>ルールセット</value>
+  </data>
+  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
+    <value>エラー：</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -1604,10 +1604,6 @@
   <data name="ToolMacros__listArguments_Document_Path" xml:space="preserve">
     <value>Document Path</value>
   </data>
-  <data name="PanoramaHelper_ValidateServer_" xml:space="preserve">
-    <value>An unknown error occurred trying to verify Panorama server information.
-{0}</value>
-  </data>
   <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
     <value>Precursors</value>
   </data>
@@ -5159,10 +5155,6 @@ If you prefer you can choose to report anonymously.</value>
   </data>
   <data name="SkylineWindow_ImportMassList_Finishing_up_import" xml:space="preserve">
     <value>Finishing up import</value>
-  </data>
-  <data name="PanoramaHelper_ValidateFolder_" xml:space="preserve">
-    <value>An unknown error occurred trying to verify access to Panorama folder {0} on the server {1}.
-{2}</value>
   </data>
   <data name="DoconvolutionMethod_NONE_None" xml:space="preserve">
     <value>None</value>
@@ -10037,10 +10029,6 @@ Recognized isotopes include: {2}</value>
     <value>Unknown error attempting to upload to Panorama.
 {0}</value>
   </data>
-  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
-    <value>Please specify a value for the following arguments required to upload the document to Panorma:
-{0}</value>
-  </data>
   <data name="SkylineWindow_ShowPublishDlg_The_document_must_be_fully_loaded_before_it_can_be_uploaded_" xml:space="preserve">
     <value>The document must be fully loaded before it can be uploaded.</value>
   </data>
@@ -10061,10 +10049,6 @@ Recognized isotopes include: {2}</value>
   </data>
   <data name="PublishDocumentDlg_btnBrowse_Click_Upload_Document" xml:space="preserve">
     <value>Upload Document</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
-    <value>Please specify a value for the following argument required to upload the document to Panorma:
-{0}</value>
   </data>
   <data name="FullScanAcquisitionMethod_FromName__0__is_not_a_valid_Full_Scan_Acquisition_Method" xml:space="preserve">
     <value>{0} is not a valid Full Scan Acquisition Method</value>
@@ -11432,5 +11416,35 @@ Example: Crosslink to PEPTIDE: T [4]</comment>
   <data name="IonMobilityObject_ToString_HEO_" xml:space="preserve">
     <value>HEO:</value>
     <comment>Compact representation of "High Energy Ion Mobility Offset Offset"</comment>
+  </data>
+  <data name="CommandLine_Run_Error__Failure_occurred__Exiting___" xml:space="preserve">
+    <value>Error: Failure occurred. Exiting...</value>
+  </data>
+  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
+    <value>Error:</value>
+  </data>
+  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
+    <value>Error: A value is required for the following argument to upload the document to Panorama:
+{0}</value>
+  </data>
+  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
+    <value>Error: A value is required for the following arguments to upload the document to Panorama:
+{0}</value>
+  </data>
+  <data name="PanoramaHelper_ValidateServer_PanoramaServerException_" xml:space="preserve">
+    <value>Error: Unable to verify Panorama server information.
+{0}</value>
+  </data>
+  <data name="PanoramaHelper_ValidateServer_Exception_" xml:space="preserve">
+    <value>Error: An unknown error occurred trying to verify Panorama server information.
+{0}</value>
+  </data>
+  <data name="PanoramaHelper_ValidateFolder_PanoramaServerException_" xml:space="preserve">
+    <value>Error: Unable to verify access to Panorama folder.
+{0}</value>
+  </data>
+  <data name="PanoramaHelper_ValidateFolder_Exception_" xml:space="preserve">
+    <value>Error: An unknown error occurred trying to verify access to Panorama folder '{0}' on the server {1}.
+{2}</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -1607,10 +1607,6 @@
   <data name="ToolMacros__listArguments_Document_Path" xml:space="preserve">
     <value>文档路径</value>
   </data>
-  <data name="PanoramaHelper_ValidateServer_" xml:space="preserve">
-    <value>在尝试验证 Panorama 服务器信息时出现未知错误。
-{0}</value>
-  </data>
   <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
     <value>母离子</value>
   </data>
@@ -5156,10 +5152,6 @@
   </data>
   <data name="SkylineWindow_ImportMassList_Finishing_up_import" xml:space="preserve">
     <value>正在完成导入</value>
-  </data>
-  <data name="PanoramaHelper_ValidateFolder_" xml:space="preserve">
-    <value>尝试验证访问服务器 {1} 上的 Panorama 文件夹 {0} 时发生未知错误。
-{2}</value>
   </data>
   <data name="DoconvolutionMethod_NONE_None" xml:space="preserve">
     <value>无</value>
@@ -10010,10 +10002,6 @@
     <value>尝试上传至 Panorama 时出现未知错误。
 {0}</value>
   </data>
-  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
-    <value>请为向 Panorma 上传文档时需要的以下参数指定一个值：
-{0}</value>
-  </data>
   <data name="SkylineWindow_ShowPublishDlg_The_document_must_be_fully_loaded_before_it_can_be_uploaded_" xml:space="preserve">
     <value>文档必须在可以上传之前完全加载。</value>
   </data>
@@ -10034,10 +10022,6 @@
   </data>
   <data name="PublishDocumentDlg_btnBrowse_Click_Upload_Document" xml:space="preserve">
     <value>上传文档</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
-    <value>请为向 Panorma 上传文档时需要的以下参数指定一个值：
-{0}</value>
   </data>
   <data name="FullScanAcquisitionMethod_FromName__0__is_not_a_valid_Full_Scan_Acquisition_Method" xml:space="preserve">
     <value>{0} 不是有效的全扫描采集方法</value>
@@ -11062,5 +11046,8 @@ Invalid peptide sequence at position 18
   </data>
   <data name="MetadataRuleSetList_Label_Rule_Set" xml:space="preserve">
     <value>规则集</value>
+  </data>
+  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
+    <value>错误：</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -39,6 +39,7 @@ using pwiz.Skyline.Model.Tools;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
+using pwiz.SkylineRunner;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTestData
@@ -2966,6 +2967,7 @@ namespace pwiz.SkylineTestData
                     .Contains(
                         string.Format(Resources.EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__,
                             serverUri.AbsoluteUri)));
+            TestOutputHasErrorLine(buffer.ToString());
             buffer.Clear();
 
 
@@ -2978,6 +2980,7 @@ namespace pwiz.SkylineTestData
                     .Contains(
                         string.Format(Resources.EditServerDlg_OkDialog_The_server__0__is_not_a_Panorama_server,
                             serverUri.AbsoluteUri)));
+            TestOutputHasErrorLine(buffer.ToString());
             buffer.Clear();
 
 
@@ -2990,6 +2993,7 @@ namespace pwiz.SkylineTestData
                     .Contains(
                         Resources
                             .EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server));
+            TestOutputHasErrorLine(buffer.ToString());
             buffer.Clear();
 
 
@@ -2999,7 +3003,8 @@ namespace pwiz.SkylineTestData
             Assert.IsTrue(
                 buffer.ToString()
                     .Contains(
-                        string.Format(Resources.PanoramaHelper_ValidateServer_, "GetServerState threw an exception")));
+                        string.Format(Resources.PanoramaHelper_ValidateServer_Exception_, "GetServerState threw an exception")));
+            TestOutputHasErrorLine(buffer.ToString());
             buffer.Clear();
 
             
@@ -3014,6 +3019,7 @@ namespace pwiz.SkylineTestData
                         string.Format(
                             Resources.PanoramaUtil_VerifyFolder_Folder__0__does_not_exist_on_the_Panorama_server__1_,
                             folder, client.ServerUri)));
+            TestOutputHasErrorLine(buffer.ToString());
             buffer.Clear();
 
 
@@ -3027,6 +3033,7 @@ namespace pwiz.SkylineTestData
                         string.Format(
                             Resources.PanoramaUtil_VerifyFolder_User__0__does_not_have_permissions_to_upload_to_the_Panorama_folder__1_,
                             "user", folder)));
+            TestOutputHasErrorLine(buffer.ToString());
             buffer.Clear();
 
 
@@ -3038,8 +3045,58 @@ namespace pwiz.SkylineTestData
                 buffer.ToString()
                     .Contains(string.Format(Resources.PanoramaUtil_VerifyFolder__0__is_not_a_Panorama_folder,
                         folder)));
+            TestOutputHasErrorLine(buffer.ToString());
 
+        }
 
+        [TestMethod]
+        public void SkylineRunnerErrorDetectionTest()
+        {
+            TestSkylineRunnerErrorDetection(null);
+            TestSkylineRunnerErrorDetection(new CultureInfo("ja"));
+            TestSkylineRunnerErrorDetection(new CultureInfo("zh-CHS"));
+        }
+
+        private void TestSkylineRunnerErrorDetection(CultureInfo ci)
+        {
+            TestDetectError(false, false, ci); // no timestamp or memstamp
+            TestDetectError(true, false, ci);  // only timestamp
+            TestDetectError(false, true, ci);  // only memstamp
+            TestDetectError(true, true, ci);   // both timestamp and memstamp
+        }
+
+        private void TestDetectError(bool timestamp, bool memstamp, CultureInfo cultureInfo)
+        {
+            // --timestamp, --memstamp and --culture arguments have to be before the --in argument
+            var command =
+                $"{(timestamp ? "--timestamp" : "")} " +
+                $"{(memstamp ? "--memstamp" : "")} " +
+                $"{(cultureInfo != null ? $" --culture={cultureInfo.Name}" : "")} " +
+                "--in";
+            var argsArray = command.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
+            var output = RunCommand(argsArray);
+            var errorLine = TestOutputHasErrorLine(output);
+
+            // The error should be about the missing value for the --in argument
+            var resourceErrString = cultureInfo == null
+                ? Resources.ValueMissingException_ValueMissingException_ // Resource string for the culture that the test is running under
+                : Resources.ResourceManager.GetString(@"ValueMissingException_ValueMissingException_", cultureInfo); // Resource string for the culture that was
+                                                                                                                     // specified with the --culture argument to
+                                                                                                                     // Skyline command line 
+            Assert.IsNotNull(resourceErrString, "Expected to find a resources string for culture '{0}'.",
+                cultureInfo == null ? CultureInfo.CurrentCulture.Name : cultureInfo.Name);
+            Assert.IsTrue(errorLine.Contains(string.Format(resourceErrString, "--in")));
+        }
+
+        private string TestOutputHasErrorLine(string output)
+        {
+            var outputLines = output.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+            // The IsErrorLine method from ErrorChecker.cs in the SkylineRunner project should detect an error
+            var errorLine = outputLines.FirstOrDefault(ErrorChecker.IsErrorLine);
+            Assert.IsFalse(string.IsNullOrEmpty(errorLine),
+                string.Format("Expected to find an error line in output: {0}", output));
+            return errorLine;
         }
 
         private static string GetTitleHelper()

--- a/pwiz_tools/Skyline/TestData/TestData.csproj
+++ b/pwiz_tools/Skyline/TestData/TestData.csproj
@@ -144,6 +144,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Executables\SkylineRunner\ErrorChecker.cs">
+      <Link>ErrorChecker.cs</Link>
+    </Compile>
     <Compile Include="CommandLineNoJoinTest.cs" />
     <Compile Include="CommandLineRefineTest.cs" />
     <Compile Include="CommandLineTest.cs" />


### PR DESCRIPTION
* Skyline: Always output a message beginning with "Error:" when returning a non-zero exit code from CommandLine.
- Attempted improvements at the new logic for SkylineRunner error exit codes
- make SkylineRunner error exit codes more robust to output with --timestamp and --memstamp

Co-authored-by: Brendan MacLean <brendanx67@users.noreply.github.com>
Co-authored-by: brendanx67 <brendanx@proteinms.net>