### PR TITLE
* fixed top anchor for FASTA textbox

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tbxFasta.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
+    <value>Top, Left, Right</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="tbxFasta.Location" type="System.Drawing.Point, System.Drawing">


### PR DESCRIPTION
@brendanx67 I did test it. It's a little odd that you saw the bottom anchoring behavior even though it's not bottom anchored; probably due to the alignment shenanigans that it does due to being able to switch between multiline or not.