### PR TITLE
Fix failure in "FullScanFilterTest" when running all tests within Visual Studio.

### DIFF
--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -3065,6 +3065,11 @@ namespace pwiz.SkylineTestData
             TestDetectError(true, true, ci);   // both timestamp and memstamp
         }
 
+        /// <summary>
+        /// Tests that "IsErrorLine" works when the commandline is invoked in a particular culture.
+        /// Note that this code uses LocalizationHelper.CallWithCulture instead of the "--culture" commandline
+        /// argument because the latter does not set the culture back to its original value.
+        /// </summary>
         private void TestDetectError(bool timestamp, bool memstamp, CultureInfo cultureInfo)
         {
             Func<string> testFunc = () =>


### PR DESCRIPTION
SkylineRunnerErrorDetectionTest was causing (by means of the "--culture" commandline argument) LocalizationHelper.CurrentUICulture to get changed and not changed back, which caused subsequent tests to fail.

The "--culture" command line argument is only necessary if the test needs to test the commandline in a new process (in which case it does not matter if it cleans itself up).
Since SkylineRunnerErrorDetectionTest is doing its work by calling into the commandline code in this process, it can just use "LocalizationHelper.CallWithCulture" to cause the culture to be set to what it needs to.

The FullScanFilterTest fails if you do "Run All Tests" in Visual Studio. It's also been failing in the Debug code coverage build on TeamCity.