### PR TITLE
Cherry pick test and document sharing fixes from master (#1569, #1570)

### DIFF
--- a/pwiz_tools/Skyline/Model/SrmDocumentSharing.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocumentSharing.cs
@@ -249,7 +249,7 @@ namespace pwiz.Skyline.Model
             }
             else
             {
-                zip.AddFile(DocumentPath);
+                AddDocumentAndAuditLog(zip, DocumentPath);
             }
             Save(zip);
         }
@@ -378,6 +378,12 @@ namespace pwiz.Skyline.Model
             string entryName = GetDocumentFileName();
             string docFilePath = Path.Combine(EnsureTempDir().DirPath, entryName);
             Document.SerializeToFile(docFilePath, docFilePath, ShareType.SkylineVersion ?? SkylineVersion.CURRENT, ProgressMonitor);
+            AddDocumentAndAuditLog(zip, docFilePath);
+        }
+
+        private void AddDocumentAndAuditLog(ZipFileShare zip, string docFilePath)
+        {
+            zip.AddFile(docFilePath);
             zip.AddFile(docFilePath);
             var auditLogPath = SrmDocument.GetAuditLogPath(docFilePath);
             if (File.Exists(auditLogPath))

--- a/pwiz_tools/Skyline/Model/SrmDocumentSharing.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocumentSharing.cs
@@ -384,7 +384,6 @@ namespace pwiz.Skyline.Model
         private void AddDocumentAndAuditLog(ZipFileShare zip, string docFilePath)
         {
             zip.AddFile(docFilePath);
-            zip.AddFile(docFilePath);
             var auditLogPath = SrmDocument.GetAuditLogPath(docFilePath);
             if (File.Exists(auditLogPath))
             {

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -3065,28 +3065,35 @@ namespace pwiz.SkylineTestData
             TestDetectError(true, true, ci);   // both timestamp and memstamp
         }
 
+        /// <summary>
+        /// Tests that "IsErrorLine" works when the commandline is invoked in a particular culture.
+        /// Note that this code uses LocalizationHelper.CallWithCulture instead of the "--culture" commandline
+        /// argument because the latter does not set the culture back to its original value.
+        /// </summary>
         private void TestDetectError(bool timestamp, bool memstamp, CultureInfo cultureInfo)
         {
-            // --timestamp, --memstamp and --culture arguments have to be before the --in argument
-            var listArgs = new List<string>();
-            if (timestamp)
-                listArgs.Add(CommandArgs.ARG_TIMESTAMP.ArgumentText);
-            if (memstamp)
-                listArgs.Add(CommandArgs.ARG_MEMSTAMP.ArgumentText);
-            if (cultureInfo != null)
-                listArgs.Add(CommandArgs.ARG_INTERNAL_CULTURE.GetArgumentTextWithValue(cultureInfo.Name));
-            listArgs.Add(CommandArgs.ARG_IN.ArgumentText);
-            var output = RunCommand(listArgs.ToArray());
+            Func<string> testFunc = () =>
+            {
+                // --timestamp, --memstamp and arguments have to be before the --in argument
+                var command =
+                    $"{(timestamp ? "--timestamp" : "")} " +
+                    $"{(memstamp ? "--memstamp" : "")} " +
+                    "--in";
+                var argsArray = command.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                return RunCommand(argsArray);
+            };
+            string output = cultureInfo == null
+                ? testFunc()
+                : LocalizationHelper.CallWithCulture(cultureInfo, testFunc);
             var errorLine = TestOutputHasErrorLine(output);
 
             // The error should be about the missing value for the --in argument
             var resourceErrString = cultureInfo == null
                 ? Resources.ValueMissingException_ValueMissingException_ // Resource string for the culture that the test is running under
-                : Resources.ResourceManager.GetString(@"ValueMissingException_ValueMissingException_", cultureInfo); // Resource string for the culture that was
-                                                                                                                     // specified with the --culture argument to
-                                                                                                                     // Skyline command line 
+                : Resources.ResourceManager.GetString(@"ValueMissingException_ValueMissingException_", cultureInfo);
+
             Assert.IsNotNull(resourceErrString, "Expected to find a resources string for culture '{0}'.",
-                cultureInfo == null ? CultureInfo.CurrentCulture.Name : cultureInfo.Name);
+                (cultureInfo ?? CultureInfo.CurrentUICulture).Name);
             Assert.IsTrue(errorLine.Contains(string.Format(resourceErrString, "--in")));
         }
 

--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTestEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTestEx.cs
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;


### PR DESCRIPTION
Fix failure in "FullScanFilterTest" when running all tests within Visual Studio. (#1569)

* Fix failure in "FullScanFilterTest" when running all tests within Visual Studio.

SkylineRunnerErrorDetectionTest was causing (by means of the "--culture" commandline argument) LocalizationHelper.CurrentUICulture to get changed and not changed back, which caused subsequent tests to fail.

Fix problem where Audit Log (.skyl) file does not get included in .sky.zip (#1570)

(Reported by Brendan)