### PR TITLE
* fixed Thermo precursorSpectrumRef

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -948,7 +948,14 @@ PWIZ_API_DECL size_t SpectrumList_Thermo::findPrecursorSpectrumIndex(RawFile* ra
         if (masterScan > -1)
         {
             if (masterScan == ie.scan)
-                return index;
+            {
+                if (static_cast<int>(ie.msOrder) == precursorMsLevel)
+                    return index;
+
+                // master scan is a non-precursor triggering scan (e.g. ETD triggers HCD of the same MS level)
+                masterScan = -1;
+                continue;
+            }
 
             // master scan not in index (i.e. SIM scan without simAsSpectra)
             if (masterScan > ie.scan)


### PR DESCRIPTION
* fixed Thermo precursorSpectrumRef pointing when Master Scan attribute points to a triggering scan from the same MS level

Reported Felipe.

Fixes issue #1216 (probably)