### PR TITLE
Set menuStrip.ShowToolTips to true

### DIFF
--- a/pwiz_tools/Skyline/Skyline.Designer.cs
+++ b/pwiz_tools/Skyline/Skyline.Designer.cs
@@ -1683,6 +1683,7 @@ namespace pwiz.Skyline
             this.helpToolStripMenuItem});
             resources.ApplyResources(this.menuMain, "menuMain");
             this.menuMain.Name = "menuMain";
+            this.menuMain.ShowItemToolTips = true;
             // 
             // fileToolStripMenuItem
             // 


### PR DESCRIPTION
The tooltips on the menu items "Remove Repeated Peptides" and "Remove Duplicate Peptides" are not showing up.
This can be fixed by setting "ShowToolTips" to true on the Skyline menu strip.
I do not know why this worked back in Skyline 20.2, but it did, even though back then "ShowToolTips" was false. It must be that moving the menu items to the separate RefineMenu control caused a change in behavior.

These two menu items are the only menu items in Skyline that are supposed to have a tooltip.

There is also sometimes a tooltip on the recent files at the bottom of the File menu. Those tooltips never stopped working.

(Reported by Deanna)