### PR TITLE
Fix tooltips on "Remove Repeated Peptides" and "Remove Duplicate Peptides" (#1574)

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
@@ -373,6 +373,7 @@ namespace pwiz.Skyline.Controls.Graphs
             }
             else
             {
+                GraphObjList.Clear();
                 var nodeTree = GraphSummary.StateProvider.SelectedNode as SrmTreeNode;
                 var nodePeptide = nodeTree as PeptideTreeNode;
                 while (nodePeptide == null && nodeTree != null)

--- a/pwiz_tools/Skyline/Skyline.Designer.cs
+++ b/pwiz_tools/Skyline/Skyline.Designer.cs
@@ -1683,6 +1683,7 @@ namespace pwiz.Skyline
             this.helpToolStripMenuItem});
             resources.ApplyResources(this.menuMain, "menuMain");
             this.menuMain.Name = "menuMain";
+            this.menuMain.ShowItemToolTips = true;
             // 
             // fileToolStripMenuItem
             // 


### PR DESCRIPTION
Tooltips are not showing up because MenuStrip.ShowItemTooltips was false.
Not sure why this was not an issue in earlier versions of Skyline, but the tooltips stopped showing up sometime after Skyline 20.2.

(Reported by Deanna)

Fix problem where progress bar on RTLinearRegressionGraphPane sometimes does not disappear. (#1578)

(not reported by anyone)