### PR TITLE
Fix for reporting query retention times and library retention times now added to report from blib libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -446,3 +446,11 @@ SkylineTester Results
 /pwiz_tools/Skyline/TestRunner/Properties/AssemblyInfo.cs
 /pwiz_tools/Skyline/Executables/Installer/FileList64.txt
 /pwiz_tools/Skyline/TestSettings_x??.testsettings
+/BrowseOnly/.NETFramework,Version=4.7.2.AssemblyAttributes.cpp
+/libraries/boost_aux/tools/bcp/out/build/x64-Debug/.cmake/api/v1/query/client-MicrosoftVS/query.json
+/libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CompilerIdC/CMakeCCompilerId.c
+/libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CompilerIdCXX/CMakeCXXCompilerId.cpp
+/libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CMakeCCompiler.cmake
+/libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CMakeCXXCompiler.cmake
+/libraries/boost_aux/tools/bcp/out/build/x64-Debug
+/x64/BrowseOnly

--- a/.gitignore
+++ b/.gitignore
@@ -407,12 +407,6 @@ SkylineTester Results
 /bs32.bat
 /bso64.bat
 /bso32.bat
-/BrowseOnly/pwiz.tlog/unsuccessfulbuild
-/BrowseOnly/pwiz.tlog/pwiz.lastbuildstate
-/BrowseOnly/pwiz.tlog/metagen.write.1.tlog
-/BrowseOnly/pwiz.tlog/CL.write.1.tlog
-/BrowseOnly/pwiz.tlog/CL.read.1.tlog
-/BrowseOnly/pwiz.tlog/CL.command.1.tlog
 /OnyxTOFMS.试验.wiff.scan
 /160109_Mix1_calcurve_074_raw.skyl
 /160109_Mix1_calcurve_074_raw.skyd
@@ -446,12 +440,6 @@ SkylineTester Results
 /pwiz_tools/Skyline/TestRunner/Properties/AssemblyInfo.cs
 /pwiz_tools/Skyline/Executables/Installer/FileList64.txt
 /pwiz_tools/Skyline/TestSettings_x??.testsettings
-/BrowseOnly/.NETFramework,Version=4.7.2.AssemblyAttributes.cpp
-/libraries/boost_aux/tools/bcp/out/build/x64-Debug/.cmake/api/v1/query/client-MicrosoftVS/query.json
-/libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CompilerIdC/CMakeCCompilerId.c
-/libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CompilerIdCXX/CMakeCXXCompilerId.cpp
-/libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CMakeCCompiler.cmake
-/libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CMakeCXXCompiler.cmake
-/libraries/boost_aux/tools/bcp/out/build/x64-Debug
+/BrowseOnly
 /x64/BrowseOnly
 /qb64.bat

--- a/.gitignore
+++ b/.gitignore
@@ -454,3 +454,4 @@ SkylineTester Results
 /libraries/boost_aux/tools/bcp/out/build/x64-Debug/CMakeFiles/3.19.20122902-MSVC_2/CMakeCXXCompiler.cmake
 /libraries/boost_aux/tools/bcp/out/build/x64-Debug
 /x64/BrowseOnly
+/qb64.bat

--- a/pwiz_tools/BiblioSpec/src/LibReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/LibReader.cpp
@@ -171,7 +171,7 @@ int LibReader::getSpecInMzRange(double minMz,
         int numBytes2 = sqlite3_column_bytes(statement, 8);
         Byte* comprI = (Byte*)sqlite3_column_blob(statement, 8);
 
-		tmpSpec->setRetentionTime(sqlite3_column_double(statement, 9));
+        tmpSpec->setRetentionTime(sqlite3_column_double(statement, 9));
 
         tmpSpec->setRawPeaks(getUncompressedPeaks(numPeaks, numBytes1, comprM, 
                                                  numBytes2, comprI));
@@ -241,7 +241,7 @@ int LibReader::getSpecInMzRange(double minMz,
         int numBytes2 = sqlite3_column_bytes(statement, 8);
         Byte* comprI = (Byte*)sqlite3_column_blob(statement, 8);
 
-		tmpSpec->setRetentionTime(sqlite3_column_double(statement, 9));
+        tmpSpec->setRetentionTime(sqlite3_column_double(statement, 9));
 
         tmpSpec->setRawPeaks(getUncompressedPeaks(numPeaks, numBytes1, comprM, 
                                                  numBytes2, comprI));

--- a/pwiz_tools/BiblioSpec/src/LibReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/LibReader.cpp
@@ -134,7 +134,7 @@ int LibReader::getSpecInMzRange(double minMz,
     sprintf(sqlStmtBuffer,
             "SELECT id, peptideSeq, precursorMZ, precursorCharge, "
             "peptideModSeq, copies, numPeaks, peakMZ, "
-            "peakIntensity FROM RefSpectra, RefSpectraPeaks "
+            "peakIntensity, retentionTime FROM RefSpectra, RefSpectraPeaks "
             "WHERE precursorMZ >= %f and precursorMZ <= %f "
             "AND numPeaks > %d "
             "AND id = RefSpectraId",
@@ -171,6 +171,8 @@ int LibReader::getSpecInMzRange(double minMz,
         int numBytes2 = sqlite3_column_bytes(statement, 8);
         Byte* comprI = (Byte*)sqlite3_column_blob(statement, 8);
 
+		tmpSpec->setRetentionTime(sqlite3_column_double(statement, 9));
+
         tmpSpec->setRawPeaks(getUncompressedPeaks(numPeaks, numBytes1, comprM, 
                                                  numBytes2, comprI));
 
@@ -200,7 +202,7 @@ int LibReader::getSpecInMzRange(double minMz,
     sprintf(sqlStmtBuffer,
             "SELECT id, peptideSeq, precursorMZ, precursorCharge, "
             "peptideModSeq, copies, numPeaks, peakMZ, "
-            "peakIntensity FROM RefSpectra, RefSpectraPeaks "
+            "peakIntensity, retentionTime FROM RefSpectra, RefSpectraPeaks "
             "WHERE precursorMZ > %f and precursorMZ <= %f "
             "AND numPeaks > %d "
             "AND id = RefSpectraId",
@@ -238,6 +240,8 @@ int LibReader::getSpecInMzRange(double minMz,
         Byte* comprM = (Byte*)sqlite3_column_blob(statement, 7);
         int numBytes2 = sqlite3_column_bytes(statement, 8);
         Byte* comprI = (Byte*)sqlite3_column_blob(statement, 8);
+
+		tmpSpec->setRetentionTime(sqlite3_column_double(statement, 9));
 
         tmpSpec->setRawPeaks(getUncompressedPeaks(numPeaks, numBytes1, comprM, 
                                                  numBytes2, comprI));
@@ -553,7 +557,7 @@ vector<RefSpectrum> LibReader::getRefSpecsInRange(int lowLibID, int highLibID)
 {
 
     char szSqlStmt[8192];
-    sprintf(szSqlStmt, "select id, peptideSeq, precursorMZ,precursorCharge, "
+    sprintf(szSqlStmt, "select id, peptideSeq, precursorMZ, precursorCharge, "
             "peptideModSeq, prevAA, nextAA, copies, numPeaks, peakMZ, peakIntensity, retentionTime "
             "from RefSpectra,RefSpectraPeaks where "
             "id >= %d and id <=%d AND id=RefSpectraID",

--- a/pwiz_tools/BiblioSpec/src/PwizReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PwizReader.cpp
@@ -413,7 +413,7 @@ void PwizReader::transferSpec(BiblioSpec::SpecData& returnData,
     
     returnData.id = specInfo->scanNumber;
     returnData.retentionTime = specInfo->retentionTime/60;  // seconds to minutes
-	returnData.mz = specInfo->precursors[0].mz;
+    returnData.mz = specInfo->precursors[0].mz;
     returnData.numPeaks = specInfo->data.size();
     
     if( returnData.numPeaks > 0 ){
@@ -440,7 +440,7 @@ void PwizReader::transferSpectrum(BiblioSpec::Spectrum& returnSpectrum,
     returnSpectrum.setScanNumber(specInfo->scanNumber);
     returnSpectrum.setMz(specInfo->precursors[0].mz);
     addCharges(returnSpectrum, foundSpec);
-	returnSpectrum.setRetentionTime(specInfo->retentionTime/60);
+    returnSpectrum.setRetentionTime(specInfo->retentionTime/60);
     
     if( specInfo->data.size() > 0 ){
         vector<BiblioSpec::PEAK_T> peaks;

--- a/pwiz_tools/BiblioSpec/src/PwizReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PwizReader.cpp
@@ -413,7 +413,7 @@ void PwizReader::transferSpec(BiblioSpec::SpecData& returnData,
     
     returnData.id = specInfo->scanNumber;
     returnData.retentionTime = specInfo->retentionTime/60;  // seconds to minutes
-    returnData.mz = specInfo->precursors[0].mz;
+	returnData.mz = specInfo->precursors[0].mz;
     returnData.numPeaks = specInfo->data.size();
     
     if( returnData.numPeaks > 0 ){
@@ -440,6 +440,7 @@ void PwizReader::transferSpectrum(BiblioSpec::Spectrum& returnSpectrum,
     returnSpectrum.setScanNumber(specInfo->scanNumber);
     returnSpectrum.setMz(specInfo->precursors[0].mz);
     addCharges(returnSpectrum, foundSpec);
+	returnSpectrum.setRetentionTime(specInfo->retentionTime/60);
     
     if( specInfo->data.size() > 0 ){
         vector<BiblioSpec::PEAK_T> peaks;

--- a/pwiz_tools/BiblioSpec/src/Reportfile.cpp
+++ b/pwiz_tools/BiblioSpec/src/Reportfile.cpp
@@ -88,7 +88,14 @@ void Reportfile::writeHeader()
     "bp-raw\t"
     "lbp-mz-raw\t"
     "num-peaks\t" 
-    "matched-ions";
+    "matched-ions\t"
+	//New additions to support/enhance small molecule blibs
+	"query-rt\t"
+	"lib-molecule-name\t"
+	"lib-chemical-formula\t"
+	"lib-adduct\t"
+	"lib-inchikey\t"
+	"lib-otherkeys";
   /*
   //"TIC-proc\t"
   //"bp-proc\t"
@@ -224,6 +231,12 @@ void Reportfile::writeMatches(const vector<Match>& results)
         file_ << "\t" << refSpec->getNumRawPeaks();
         */
         file_ << "\t" << curMatch.getScore(MATCHED_IONS);
+		file_ << "\t" << querySpec->getRetentionTime();
+		file_ << "\t" << refSpec->getMoleculeName();
+		file_ << "\t" << refSpec->getChemicalFormula();
+		file_ << "\t" << refSpec->getAdduct();
+		file_ << "\t" << refSpec->getInchiKey();
+		file_ << "\t" << refSpec->getotherKeys();
         file_ << endl;
         
     }// next match

--- a/pwiz_tools/BiblioSpec/src/Reportfile.cpp
+++ b/pwiz_tools/BiblioSpec/src/Reportfile.cpp
@@ -89,8 +89,9 @@ void Reportfile::writeHeader()
     "lbp-mz-raw\t"
     "num-peaks\t" 
     "matched-ions\t"
-	//New additions to support/enhance small molecule blibs
+	//New additions to support/enhance small molecule blibs and report retention times
 	"query-rt\t"
+	"lib-rt\t"
 	"lib-molecule-name\t"
 	"lib-chemical-formula\t"
 	"lib-adduct\t"
@@ -234,6 +235,7 @@ void Reportfile::writeMatches(const vector<Match>& results)
         */
         file_ << "\t" << curMatch.getScore(MATCHED_IONS);
 		file_ << "\t" << querySpec->getRetentionTime();
+		file_ << "\t" << refSpec->getRetentionTime();
 		file_ << "\t" << refSpec->getMoleculeName();
 		file_ << "\t" << refSpec->getChemicalFormula();
 		file_ << "\t" << refSpec->getAdduct();

--- a/pwiz_tools/BiblioSpec/src/Reportfile.cpp
+++ b/pwiz_tools/BiblioSpec/src/Reportfile.cpp
@@ -89,16 +89,16 @@ void Reportfile::writeHeader()
     "lbp-mz-raw\t"
     "num-peaks\t" 
     "matched-ions\t"
-	//New additions to support/enhance small molecule blibs and report retention times
-	"query-rt\t"
-	"lib-rt\t"
-	"lib-molecule-name\t"
-	"lib-chemical-formula\t"
-	"lib-adduct\t"
-	"lib-inchikey\t"
-	"lib-otherkeys\t"
-	"query-ion-mobility\t"
-	"query-ion-mobility-type";
+    //New additions to support/enhance small molecule blibs and report retention times
+    "query-rt\t"
+    "lib-rt\t"
+    "lib-molecule-name\t"
+    "lib-chemical-formula\t"
+    "lib-adduct\t"
+    "lib-inchikey\t"
+    "lib-otherkeys\t"
+    "query-ion-mobility\t"
+    "query-ion-mobility-type";
   /*
   //"TIC-proc\t"
   //"bp-proc\t"
@@ -234,15 +234,15 @@ void Reportfile::writeMatches(const vector<Match>& results)
         file_ << "\t" << refSpec->getNumRawPeaks();
         */
         file_ << "\t" << curMatch.getScore(MATCHED_IONS);
-		file_ << "\t" << querySpec->getRetentionTime();
-		file_ << "\t" << refSpec->getRetentionTime();
-		file_ << "\t" << refSpec->getMoleculeName();
-		file_ << "\t" << refSpec->getChemicalFormula();
-		file_ << "\t" << refSpec->getAdduct();
-		file_ << "\t" << refSpec->getInchiKey();
-		file_ << "\t" << refSpec->getotherKeys();
-		file_ << "\t" << querySpec->getIonMobility();
-		file_ << "\t" << querySpec->getIonMobilityType();
+        file_ << "\t" << querySpec->getRetentionTime();
+        file_ << "\t" << refSpec->getRetentionTime();
+        file_ << "\t" << refSpec->getMoleculeName();
+        file_ << "\t" << refSpec->getChemicalFormula();
+        file_ << "\t" << refSpec->getAdduct();
+        file_ << "\t" << refSpec->getInchiKey();
+        file_ << "\t" << refSpec->getotherKeys();
+        file_ << "\t" << querySpec->getIonMobility();
+        file_ << "\t" << querySpec->getIonMobilityType();
         file_ << endl;
         
     }// next match

--- a/pwiz_tools/BiblioSpec/src/Reportfile.cpp
+++ b/pwiz_tools/BiblioSpec/src/Reportfile.cpp
@@ -95,7 +95,9 @@ void Reportfile::writeHeader()
 	"lib-chemical-formula\t"
 	"lib-adduct\t"
 	"lib-inchikey\t"
-	"lib-otherkeys";
+	"lib-otherkeys\t"
+	"query-ion-mobility\t"
+	"query-ion-mobility-type";
   /*
   //"TIC-proc\t"
   //"bp-proc\t"
@@ -237,6 +239,8 @@ void Reportfile::writeMatches(const vector<Match>& results)
 		file_ << "\t" << refSpec->getAdduct();
 		file_ << "\t" << refSpec->getInchiKey();
 		file_ << "\t" << refSpec->getotherKeys();
+		file_ << "\t" << querySpec->getIonMobility();
+		file_ << "\t" << querySpec->getIonMobilityType();
         file_ << endl;
         
     }// next match

--- a/pwiz_tools/BiblioSpec/src/SearchLibrary.cpp
+++ b/pwiz_tools/BiblioSpec/src/SearchLibrary.cpp
@@ -522,7 +522,7 @@ bool SearchLibrary::checkCharge(const vector<int>& queryCharges, int libCharge){
     }
 
     for(size_t i = 0; i < queryCharges.size(); i++){
-		if (libCharge == queryCharges[i] || libCharge == -queryCharges[i]) {
+            if (libCharge == queryCharges[i] || libCharge == -queryCharges[i]) {
             return true;
         }
     }

--- a/pwiz_tools/BiblioSpec/src/SearchLibrary.cpp
+++ b/pwiz_tools/BiblioSpec/src/SearchLibrary.cpp
@@ -522,7 +522,7 @@ bool SearchLibrary::checkCharge(const vector<int>& queryCharges, int libCharge){
     }
 
     for(size_t i = 0; i < queryCharges.size(); i++){
-        if( libCharge == queryCharges[i] ){
+		if (libCharge == queryCharges[i] || libCharge == -queryCharges[i]) {
             return true;
         }
     }

--- a/pwiz_tools/BiblioSpec/src/SearchLibrary.cpp
+++ b/pwiz_tools/BiblioSpec/src/SearchLibrary.cpp
@@ -522,7 +522,7 @@ bool SearchLibrary::checkCharge(const vector<int>& queryCharges, int libCharge){
     }
 
     for(size_t i = 0; i < queryCharges.size(); i++){
-            if (libCharge == queryCharges[i] || libCharge == -queryCharges[i]) {
+            if ( libCharge == queryCharges[i] ) {
             return true;
         }
     }

--- a/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
@@ -373,6 +373,7 @@ namespace pwiz.Skyline.Controls.Graphs
             }
             else
             {
+                GraphObjList.Clear();
                 var nodeTree = GraphSummary.StateProvider.SelectedNode as SrmTreeNode;
                 var nodePeptide = nodeTree as PeptideTreeNode;
                 while (nodePeptide == null && nodeTree != null)

--- a/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
@@ -304,6 +304,7 @@ namespace pwiz.SkylineTestFunctional
                         {"RTOverlap", new AbstractDdaSearchEngine.Setting("RTOverlap", 0.05, 0, 10)},
                         {"CorrThreshold", new AbstractDdaSearchEngine.Setting("CorrThreshold", 0.1, 0, 10)},
                         {"DeltaApex", new AbstractDdaSearchEngine.Setting("DeltaApex", 0.6, 0, 10)},
+                        {"Thread", new AbstractDdaSearchEngine.Setting("Thread", 1, 0, 64)},
                     };
                 Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
             });


### PR DESCRIPTION
- Query retention times were being reported as 0 instead of the actual value
- Library/reference spectrum retention times were not being recorded in the report file.