### PR TITLE
Code inspection tweaks - please review TeamCity for new failures in Shared/Common

### DIFF
--- a/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
+++ b/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
@@ -299,7 +299,10 @@ namespace pwiz.SkylineTest
 
             foreach (var fileMask in allFileMasks)
             {
-                foreach (var filename in Directory.GetFiles(root, fileMask, SearchOption.AllDirectories))
+                var filenames = Directory.GetFiles(root, fileMask, SearchOption.AllDirectories).ToList();
+                filenames.AddRange(Directory.GetFiles(Path.Combine(root, @"..", @"Shared", @"Common"), fileMask, SearchOption.AllDirectories));
+
+                foreach (var filename in filenames)
                 {
                     if (Equals(filename, thisFile))
                     {

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -82,6 +82,9 @@ namespace TestRunner
             {"TestInstrumentInfo", new ExpandedLeakCheck(LeakCheckIterations * 2, true)}
         };
 
+        //  These tests only need to be run once, regardless of language, so they get turned off in pass 0 after a single invocation
+        public static string[] RunOnceTestNames = { "AaantivirusTestExclusion", "CodeInspection" };
+
         // These tests are allowed to fail the total memory leak threshold, and extra iterations are not done to stabilize a spiky total memory distribution
         public static string[] MutedTotalMemoryLeakTestNames = { "TestMs1Tutorial", "TestGroupedStudiesTutorialDraft" };
 
@@ -580,8 +583,11 @@ namespace TestRunner
                             }
                             continue;
                         }
-                        if (!runTests.Run(test, 0, testNumber, dmpDir, false))
+                        if (!runTests.Run(test, 0, testNumber, dmpDir, false) || // No point in re-running a failed test
+                            RunOnceTestNames.Contains(test.TestMethod.Name)) // No point in running certain tests more than once
+                        {
                             removeList.Add(test);
+                        }
                     }
                     runTests.Skyline.Set("NoVendorReaders", false);
                     runTests.AccessInternet = internet;


### PR DESCRIPTION
- extend code inspection to Skyline/../Shared/Common
- only run code inspection once
- add antivirus exclusion test to the new run-once list