### PR TITLE
Add back lost changes to translated resx files

### DIFF
--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -1604,10 +1604,6 @@
   <data name="ToolMacros__listArguments_Document_Path" xml:space="preserve">
     <value>ドキュメントパス</value>
   </data>
-  <data name="PanoramaHelper_ValidateServer_" xml:space="preserve">
-    <value>Panoramaサーバー情報を検証しようとした際に不明なエラーが発生しました。
-{0}</value>
-  </data>
   <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
     <value>プリカーサー</value>
   </data>
@@ -5159,10 +5155,6 @@
   </data>
   <data name="SkylineWindow_ImportMassList_Finishing_up_import" xml:space="preserve">
     <value>インポートの終了中</value>
-  </data>
-  <data name="PanoramaHelper_ValidateFolder_" xml:space="preserve">
-    <value>サーバー{1}上のPanormaフォルダ{0}へのアクセスを検証しようとした際に不明なエラーが発生しました。
-{2}</value>
   </data>
   <data name="DoconvolutionMethod_NONE_None" xml:space="preserve">
     <value>なし</value>
@@ -10029,10 +10021,6 @@ Skylineにインポートする前に必要に応じてライブラリをフィ�
     <value>Panoramaにアップロードしようとした際に不明なエラーが発生しました。
 {0}</value>
   </data>
-  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
-    <value>ドキュメントをPanormaにアップロードするため必要な以下の引数に値を指定してください：
-{0}</value>
-  </data>
   <data name="SkylineWindow_ShowPublishDlg_The_document_must_be_fully_loaded_before_it_can_be_uploaded_" xml:space="preserve">
     <value>ドキュメントはアップロードする前に、完全に読み込まれている必要があります。</value>
   </data>
@@ -10053,10 +10041,6 @@ Skylineにインポートする前に必要に応じてライブラリをフィ�
   </data>
   <data name="PublishDocumentDlg_btnBrowse_Click_Upload_Document" xml:space="preserve">
     <value>ドキュメントをアップロード</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
-    <value>ドキュメントをPanoramaにアップロードするため必要な以下の引数に値を指定してください：
-{0}</value>
   </data>
   <data name="FullScanAcquisitionMethod_FromName__0__is_not_a_valid_Full_Scan_Acquisition_Method" xml:space="preserve">
     <value>{0}は有効なフルスキャン取得メソッドではありません</value>
@@ -11421,5 +11405,8 @@ Example: Crosslink to PEPTIDE: T [4]</comment>
   <data name="IonMobilityObject_ToString_HEO_" xml:space="preserve">
     <value>HEO：</value>
     <comment>Compact representation of "High Energy Ion Mobility Offset Offset"</comment>
+  </data>
+  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
+    <value>エラー：</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -1604,10 +1604,6 @@
   <data name="ToolMacros__listArguments_Document_Path" xml:space="preserve">
     <value>文档路径</value>
   </data>
-  <data name="PanoramaHelper_ValidateServer_" xml:space="preserve">
-    <value>在尝试验证 Panorama 服务器信息时出现未知错误。
-{0}</value>
-  </data>
   <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
     <value>母离子</value>
   </data>
@@ -5159,10 +5155,6 @@
   </data>
   <data name="SkylineWindow_ImportMassList_Finishing_up_import" xml:space="preserve">
     <value>正在完成导入</value>
-  </data>
-  <data name="PanoramaHelper_ValidateFolder_" xml:space="preserve">
-    <value>尝试验证访问服务器 {1} 上的 Panorama 文件夹 {0} 时发生未知错误。
-{2}</value>
   </data>
   <data name="DoconvolutionMethod_NONE_None" xml:space="preserve">
     <value>无</value>
@@ -10037,10 +10029,6 @@
     <value>尝试上传至 Panorama 时出现未知错误。
 {0}</value>
   </data>
-  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
-    <value>请为向 Panorma 上传文档时需要的以下参数指定一个值：
-{0}</value>
-  </data>
   <data name="SkylineWindow_ShowPublishDlg_The_document_must_be_fully_loaded_before_it_can_be_uploaded_" xml:space="preserve">
     <value>文档必须在可以上传之前完全加载。</value>
   </data>
@@ -10061,10 +10049,6 @@
   </data>
   <data name="PublishDocumentDlg_btnBrowse_Click_Upload_Document" xml:space="preserve">
     <value>上传文档</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
-    <value>请为向 Panorma 上传文档时需要的以下参数指定一个值：
-{0}</value>
   </data>
   <data name="FullScanAcquisitionMethod_FromName__0__is_not_a_valid_Full_Scan_Acquisition_Method" xml:space="preserve">
     <value>{0} 不是有效的全扫描采集方法</value>
@@ -11431,5 +11415,8 @@ Example: Crosslink to PEPTIDE: T [4]</comment>
   <data name="IonMobilityObject_ToString_HEO_" xml:space="preserve">
     <value>HEO：</value>
     <comment>Compact representation of "High Energy Ion Mobility Offset Offset"</comment>
+  </data>
+  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
+    <value>错误：</value>
   </data>
 </root>


### PR DESCRIPTION
Changes added to the Japanese and Chinese resx files with PR 1531 were overwritten with the commit to merge localization changes for 21.1. Adding those changes back:
- Added translated "CommandStatusWriter_WriteLine_Error_"
- Removed PanoramaHelper_ValidateServer_ and PanoramaHelper_ValidateFolder_ (no longer used in the code)
- Removed CommandArgs_PanoramaArgsComplete_plural_ and CommandArgs_PanoramaArgsComplete_. Their value has changed and will have to be translated.