### PR TITLE
Maybe fix the intermittent DiaUmpire failures causing the out o…

### DIFF
--- a/pwiz/analysis/dia_umpire/InstrumentParameter.hpp
+++ b/pwiz/analysis/dia_umpire/InstrumentParameter.hpp
@@ -8,21 +8,21 @@ namespace DiaUmpire {
 
 struct InstrumentParameter
 {
-    int Resolution;
-    float MS1PPM;
-    float MS2PPM;
-    float SN;
-    float MinMSIntensity;
-    float MinMSMSIntensity;
+    int Resolution = 0;
+    float MS1PPM = 0;
+    float MS2PPM = 0;
+    float SN = 0;
+    float MinMSIntensity = 0;
+    float MinMSMSIntensity = 0;
     int NoPeakPerMin = 150;
-    float MinRTRange;
+    float MinRTRange = 0;
     int StartCharge = 2;
     int EndCharge = 5;
     int MS2StartCharge = 2;
     int MS2EndCharge = 4;
     float MaxCurveRTRange = 2;
-    float RTtol;
-    float MS2SN;
+    float RTtol = 0;
+    float MS2SN = 0;
     int MaxNoPeakCluster = 4;
     int MinNoPeakCluster = 2;
     int MaxMS2NoPeakCluster = 3;

--- a/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpireTest.data/diaumpire_se_6600_64var.params
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpireTest.data/diaumpire_se_6600_64var.params
@@ -38,7 +38,7 @@ SE.MinPrecursorMass = 400
 SE.MaxPrecursorMass = 5000
 
 #Report peak
-ExportPrecursorPeak = true
+#ExportPrecursorPeak = true
 #ExportFragmentPeak = false
 
 


### PR DESCRIPTION
Maybe fix the intermittent DiaUmpire failures causing the out of order peak time exceptions. Seems to have been caused by uninitialized config variables which do get initialized to 0 in debug builds and apparently usually get allocated in zero-initialized space in release builds.