### PR TITLE
Revert "* changed DiaSearchTests to use only 1 thread for DiaUmpire"

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
@@ -305,7 +305,6 @@ namespace pwiz.SkylineTestFunctional
                         {"RTOverlap", new AbstractDdaSearchEngine.Setting("RTOverlap", 0.05, 0, 10)},
                         {"CorrThreshold", new AbstractDdaSearchEngine.Setting("CorrThreshold", 0.1, 0, 10)},
                         {"DeltaApex", new AbstractDdaSearchEngine.Setting("DeltaApex", 0.6, 0, 10)},
-                        {"Thread", new AbstractDdaSearchEngine.Setting("Thread", 1, 0, 64)},
                     };
                 Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
             });


### PR DESCRIPTION
Reverts ProteoWizard/pwiz#1575

Should not be necessary anymore with the DiaUmpire sorting fix and it made the Skyline x86 debug tests start taking at least 7 minutes longer and passing the 1h build timeout (I could lengthen the timeout but reducing build/test time is a better option if it works).