### PR TITLE
* fixed using declaration for bnw::system causing VS2019 error

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -351,6 +351,9 @@ project pwiz
         <toolset>clang:<cxxflags>-Wno-unused-local-typedef
         <toolset>darwin:<cxxflags>-Wno-unused-local-typedef
 
+        # avoid unused parameter warnings (especially annoying for stub functions)
+        <toolset>clang:<cxxflags>-Wunused-parameter
+
         # avoid C++1x deprecation warnings
         <toolset>gcc:<cxxflags>-Wno-deprecated-declarations
         <toolset>clang:<cxxflags>-Wno-deprecated-declarations
@@ -503,7 +506,7 @@ version-tag = $(numeric-version-tag) $(PWIZ_GIT_REV) ;
 constant PWIZ_NUMERIC_VERSION_TAG : $(numeric-version-tag:J=.) ;
 constant PWIZ_VERSION_TAG : $(version-tag:J=.) ;
 
-echo ProteoWizard $(version-tag:J=.) $(PWIZ_GIT_BRANCH) $(PLATFORM) $(PROCESSOR_ARCHITECTURE) ;
+echo ProteoWizard $(version-tag:J=.) $(PWIZ_GIT_BRANCH) $(PLATFORM) $(PROCESSOR_ARCHITECTURE) $(.os) ;
 
 import generate-version ;
 generate-version.cpp $(PWIZ_ROOT_PATH)/pwiz/data/msdata/Version.cpp : pwiz msdata : $(PWIZ_MAJOR) : $(PWIZ_MINOR) : $(PWIZ_BUILD_TIMESTAMP) : $(PWIZ_GIT_REV) : $(PWIZ_GIT_BRANCH) ;

--- a/libraries/boost-build/src/tools/zlib.jam
+++ b/libraries/boost-build/src/tools/zlib.jam
@@ -28,7 +28,7 @@ header = zlib.h ;
 names = z zlib zll zdll ;
 
 sources = adler32.c compress.c
-     crc32.c deflate.c gzclose.c gzio.c gzlib.c gzread.c gzwrite.c
+     crc32.c deflate.c gzclose.c gzlib.c gzread.c gzwrite.c
      infback.c inffast.c inflate.c inftrees.c trees.c uncompr.c zutil.c
      contrib/minizip/ioapi.c contrib/minizip/unzip.c ;
 

--- a/libraries/ext-hdf5.jam
+++ b/libraries/ext-hdf5.jam
@@ -121,7 +121,7 @@ rule init ( version ? : location : options * )
 
 rule H5pubconf-requirements ( properties * )
 {
-    if <toolset>msvc in $(properties)
+    if <target-os>windows in $(properties)
     {
         return <include>$(HDF5_SRC)/src/windows ;
     }
@@ -152,7 +152,7 @@ rule link-requirements ( properties * )
 
 rule hdf5-requirements ( properties * )
 {
-    if <toolset>msvc in $(properties)
+    if <target-os>windows in $(properties)
     {
         return <source>$(HDF5_SRC)/src/H5FDwindows.c
                <conditional>@link-requirements ;
@@ -178,7 +178,7 @@ rule hdf5-requirements ( properties * )
 
 rule hdf5-usage-requirements ( properties * )
 {
-    if <toolset>msvc in $(properties)
+    if <target-os>windows in $(properties)
     {
         return <conditional>@link-requirements ;
     }

--- a/pwiz.vcxproj
+++ b/pwiz.vcxproj
@@ -63,10 +63,8 @@
     <NMakeOutput Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|x64'" />
     <NMakePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|Win32'">PWIZ_READER_THERMO;PWIZ_READER_AGILENT;PWIZ_READER_BRUKER;PWIZ_READER_WATERS;PWIZ_READER_ABI;PWIZ_READER_ABI_T2D;WIN32;USE_RAW_PTR;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
     <NMakePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|x64'">PWIZ_READER_THERMO;PWIZ_READER_AGILENT;PWIZ_READER_BRUKER;PWIZ_READER_WATERS;PWIZ_READER_ABI;PWIZ_READER_ABI_T2D;WIN32;USE_RAW_PTR;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|Win32'">$(SolutionDir);$(SolutionDir)libraries\boost_aux;$(SolutionDir)libraries\boost_1_67_0;$(SolutionDir)libraries\SQLite;$(IncludePath)</IncludePath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|x64'">$(SolutionDir);$(SolutionDir)libraries\boost_aux;$(SolutionDir)libraries\boost_1_67_0;$(SolutionDir)libraries\SQLite;$(IncludePath)</IncludePath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|Win32'">$(SolutionDir);$(SolutionDir)libraries\boost_aux;$(SolutionDir)libraries\boost_1_67_0;$(SolutionDir)libraries\SQLite;$(SolutionDir)libraries\CSpline;$(SolutionDir)libraries\Eigen;$(IncludePath)</IncludePath>
-    <IncludePath Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|x64'">$(SolutionDir);$(SolutionDir)libraries\boost_aux;$(SolutionDir)libraries\boost_1_67_0;$(SolutionDir)libraries\SQLite;$(SolutionDir)libraries\CSpline;$(SolutionDir)libraries\Eigen;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|Win32'">$(SolutionDir);$(SolutionDir)libraries\boost_aux;$(SolutionDir)libraries\boost_1_76_0;$(SolutionDir)libraries\SQLite;$(SolutionDir)libraries\CSpline;$(SolutionDir)libraries\Eigen;$(IncludePath)</IncludePath>
+    <IncludePath Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|x64'">$(SolutionDir);$(SolutionDir)libraries\boost_aux;$(SolutionDir)libraries\boost_1_76_0;$(SolutionDir)libraries\SQLite;$(SolutionDir)libraries\CSpline;$(SolutionDir)libraries\Eigen;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='BrowseOnly|Win32'">
     <BuildLog />
@@ -122,6 +120,8 @@
     <ClCompile Include="pwiz\analysis\demux\PrecursorMaskCodecTest.cpp" />
     <ClCompile Include="pwiz\analysis\demux\SpectrumPeakExtractor.cpp" />
     <ClCompile Include="pwiz\analysis\demux\SpectrumPeakExtractorTest.cpp" />
+    <ClCompile Include="pwiz\analysis\dia_umpire\DiaUmpire.cpp" />
+    <ClCompile Include="pwiz\analysis\dia_umpire\IsotopePatternMap.cpp" />
     <ClCompile Include="pwiz\analysis\frequency\FrequencyEstimatorPhysicalModel.cpp" />
     <ClCompile Include="pwiz\analysis\frequency\FrequencyEstimatorPhysicalModelTest.cpp" />
     <ClCompile Include="pwiz\analysis\frequency\FrequencyEstimatorSimple.cpp" />
@@ -899,6 +899,14 @@
     <ClInclude Include="pwiz\analysis\demux\OverlapDemultiplexer.hpp" />
     <ClInclude Include="pwiz\analysis\demux\PrecursorMaskCodec.hpp" />
     <ClInclude Include="pwiz\analysis\demux\SpectrumPeakExtractor.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\DiaUmpire.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\DiaUmpireMath.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\InstrumentParameter.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\IsotopePatternMap.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\IsotopePatternRange.ipp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\PeakCluster.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\PeakCurve.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\ScanData.hpp" />
     <ClInclude Include="pwiz\analysis\proteome_processing\ProteinListFactory.hpp" />
     <ClInclude Include="pwiz\analysis\proteome_processing\ProteinList_Filter.hpp" />
     <ClInclude Include="pwiz\analysis\spectrum_processing\MS2Deisotoper.hpp" />

--- a/pwiz.vcxproj.filters
+++ b/pwiz.vcxproj.filters
@@ -565,6 +565,8 @@
     <ClCompile Include="pwiz\utility\misc\BinaryDataTest.cpp" />
     <ClCompile Include="pwiz_aux\msrc\utility\vendor_api\UIMF\UIMFReader.cpp" />
     <ClCompile Include="pwiz_aux\msrc\utility\vendor_api\UIMF\UIMFReaderTest.cpp" />
+    <ClCompile Include="pwiz\analysis\dia_umpire\DiaUmpire.cpp" />
+    <ClCompile Include="pwiz\analysis\dia_umpire\IsotopePatternMap.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="libraries\boost_aux\boost\nowide\args.hpp" />
@@ -998,6 +1000,14 @@
     <ClInclude Include="pwiz_tools\BiblioSpec\src\BuildParser.h" />
     <ClInclude Include="pwiz_tools\BiblioSpec\src\mzxmlParser.h" />
     <ClInclude Include="pwiz_tools\BiblioSpec\src\PwizReader.h" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\DiaUmpire.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\DiaUmpireMath.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\InstrumentParameter.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\IsotopePatternMap.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\IsotopePatternRange.ipp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\PeakCluster.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\PeakCurve.hpp" />
+    <ClInclude Include="pwiz\analysis\dia_umpire\ScanData.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Jamroot.jam" />

--- a/pwiz/analysis/dia_umpire/DiaUmpire.cpp
+++ b/pwiz/analysis/dia_umpire/DiaUmpire.cpp
@@ -1569,14 +1569,14 @@ namespace DiaUmpire {
         string line;
         vector<string> tokens;
 
-        while (/*pwiz::util::*/getline(reader, line))
+        while (pwiz::util::getline(reader, line))
         {
             if (line.empty() || line[0] == '#')
                 continue;
 
             if (line == ("==window setting begin"))
             {
-                while (/*pwiz::util::*/getline(reader, line) && line != "==window setting end")
+                while (pwiz::util::getline(reader, line) && line != "==window setting end")
                 {
                     if (line.empty())
                         continue;

--- a/pwiz/analysis/dia_umpire/DiaUmpire.cpp
+++ b/pwiz/analysis/dia_umpire/DiaUmpire.cpp
@@ -1569,14 +1569,14 @@ namespace DiaUmpire {
         string line;
         vector<string> tokens;
 
-        while (pwiz::util::getline(reader, line))
+        while (getlinePortable(reader, line))
         {
             if (line.empty() || line[0] == '#')
                 continue;
 
             if (line == ("==window setting begin"))
             {
-                while (pwiz::util::getline(reader, line) && line != "==window setting end")
+                while (getlinePortable(reader, line) && line != "==window setting end")
                 {
                     if (line.empty())
                         continue;

--- a/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
@@ -406,7 +406,7 @@ SpectrumListPtr filterCreator_ZeroSamples(const MSData& msd, const string& arg, 
     if (!bRemover && ("addMissing"!=action))
         throw user_error("[SpectrumListFactory::filterCreator_ZeroSamples()] unknown mode \"" + action + "\"");
     string msLevelSets;
-    pwiz::util::getline(parser, msLevelSets);
+    getlinePortable(parser, msLevelSets);
     if (""==msLevelSets) msLevelSets="1-"; // default is all msLevels
 
     IntegerSet msLevelsToFilter;
@@ -1369,7 +1369,7 @@ SpectrumListPtr filterCreator_thresholdFilter(const MSData& msd, const string& a
     if (parser)
     {
         string msLevelSets;
-        pwiz::util::getline(parser, msLevelSets);
+        getlinePortable(parser, msLevelSets);
 
         if (!msLevelSets.empty())
         {
@@ -1480,7 +1480,7 @@ SpectrumListPtr filterCreator_thermoScanFilterFilter(const MSData& msd, const st
     string includeArg;
     string matchStringArg;
     parser >> matchExactArg >> includeArg;
-    pwiz::util::getline(parser, matchStringArg);
+    getlinePortable(parser, matchStringArg);
     bal::trim(matchStringArg);
 
     bool matchExact;

--- a/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactory.cpp
@@ -406,7 +406,7 @@ SpectrumListPtr filterCreator_ZeroSamples(const MSData& msd, const string& arg, 
     if (!bRemover && ("addMissing"!=action))
         throw user_error("[SpectrumListFactory::filterCreator_ZeroSamples()] unknown mode \"" + action + "\"");
     string msLevelSets;
-    getline(parser, msLevelSets);
+    pwiz::util::getline(parser, msLevelSets);
     if (""==msLevelSets) msLevelSets="1-"; // default is all msLevels
 
     IntegerSet msLevelsToFilter;
@@ -1369,7 +1369,7 @@ SpectrumListPtr filterCreator_thresholdFilter(const MSData& msd, const string& a
     if (parser)
     {
         string msLevelSets;
-        getline(parser, msLevelSets);
+        pwiz::util::getline(parser, msLevelSets);
 
         if (!msLevelSets.empty())
         {
@@ -1480,7 +1480,7 @@ SpectrumListPtr filterCreator_thermoScanFilterFilter(const MSData& msd, const st
     string includeArg;
     string matchStringArg;
     parser >> matchExactArg >> includeArg;
-    getline(parser, matchStringArg);
+    pwiz::util::getline(parser, matchStringArg);
     bal::trim(matchStringArg);
 
     bool matchExact;

--- a/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpireTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpireTest.cpp
@@ -186,7 +186,7 @@ int main(int argc, char* argv[])
         ifstream testsTxt(rawpaths[0].c_str());
         string line;
         int totalTests = 0, failedTests = 0;
-        while (getline(testsTxt, line))
+        while (pwiz::util::getline(testsTxt, line))
         {
             ++totalTests;
             bal::split(tokens, line, bal::is_any_of("\t"));

--- a/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpireTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpireTest.cpp
@@ -186,7 +186,7 @@ int main(int argc, char* argv[])
         ifstream testsTxt(rawpaths[0].c_str());
         string line;
         int totalTests = 0, failedTests = 0;
-        while (pwiz::util::getline(testsTxt, line))
+        while (getlinePortable(testsTxt, line))
         {
             ++totalTests;
             bal::split(tokens, line, bal::is_any_of("\t"));

--- a/pwiz/data/common/obo.cpp
+++ b/pwiz/data/common/obo.cpp
@@ -82,7 +82,7 @@ string unescape_copy(const string& str)
 
 istream& getcleanline(istream& is, string& buffer)
 {
-    if (pwiz::util::getline(is, buffer))
+    if (getlinePortable(is, buffer))
         bal::trim(buffer);
 
     return is;

--- a/pwiz/data/common/obo.cpp
+++ b/pwiz/data/common/obo.cpp
@@ -82,7 +82,7 @@ string unescape_copy(const string& str)
 
 istream& getcleanline(istream& is, string& buffer)
 {
-    if (getline(is, buffer))
+    if (pwiz::util::getline(is, buffer))
         bal::trim(buffer);
 
     return is;

--- a/pwiz/data/identdata/DelimReader.cpp
+++ b/pwiz/data/identdata/DelimReader.cpp
@@ -177,7 +177,7 @@ void DelimReader::read(const string& filename,
         // Each line is parsed into its fields
         int no=0;
         string line;
-        while(pwiz::util::getline(is, line, pimpl->type->record_sep))
+        while(getlinePortable(is, line, pimpl->type->record_sep))
         {
             vector<string> fields;
             

--- a/pwiz/data/identdata/DelimReader.cpp
+++ b/pwiz/data/identdata/DelimReader.cpp
@@ -177,7 +177,7 @@ void DelimReader::read(const string& filename,
         // Each line is parsed into its fields
         int no=0;
         string line;
-        while(getline(is, line, pimpl->type->record_sep))
+        while(pwiz::util::getline(is, line, pimpl->type->record_sep))
         {
             vector<string> fields;
             

--- a/pwiz/data/identdata/KwCVMap.cpp
+++ b/pwiz/data/identdata/KwCVMap.cpp
@@ -27,6 +27,7 @@
 #include <stdexcept>
 #include <boost/tokenizer.hpp>
 #include <boost/foreach.hpp>
+#include "pwiz/utility/misc/String.hpp"
 #include "KwCVMap.hpp"
 
 namespace pwiz{
@@ -254,7 +255,7 @@ ostream& operator<<(ostream& os, const CVMap* cmp)
 istream& operator>>(istream& is, CVMapPtr& cm)
 {
     string line;
-    getline(is, line);
+    pwiz::util::getline(is, line);
 
     if (!line.size())
         //throw length_error("empty line found where record

--- a/pwiz/data/identdata/KwCVMap.cpp
+++ b/pwiz/data/identdata/KwCVMap.cpp
@@ -255,7 +255,7 @@ ostream& operator<<(ostream& os, const CVMap* cmp)
 istream& operator>>(istream& is, CVMapPtr& cm)
 {
     string line;
-    pwiz::util::getline(is, line);
+    getlinePortable(is, line);
 
     if (!line.size())
         //throw length_error("empty line found where record

--- a/pwiz/data/identdata/Serializer_Text.cpp
+++ b/pwiz/data/identdata/Serializer_Text.cpp
@@ -552,7 +552,7 @@ void Serializer_Text::Impl::read(boost::shared_ptr<istream> is, IdentData& mzid)
     string line;
 
     // Get the header line from the file & split it into fields
-    getline(*is, line);
+    pwiz::util::getline(*is, line);
     split(headers, line, is_any_of("\t"));
 
     // Sort out which fields we can manage.

--- a/pwiz/data/identdata/Serializer_Text.cpp
+++ b/pwiz/data/identdata/Serializer_Text.cpp
@@ -552,7 +552,7 @@ void Serializer_Text::Impl::read(boost::shared_ptr<istream> is, IdentData& mzid)
     string line;
 
     // Get the header line from the file & split it into fields
-    pwiz::util::getline(*is, line);
+    getlinePortable(*is, line);
     split(headers, line, is_any_of("\t"));
 
     // Sort out which fields we can manage.

--- a/pwiz/data/misc/FrequencyDataTest.cpp
+++ b/pwiz/data/misc/FrequencyDataTest.cpp
@@ -41,7 +41,7 @@ void diff(const string& filename1, const string& filename2)
 {
 	ifstream file1(filename1.c_str()), file2(filename2.c_str());
 	string line1, line2;
-	while (getline(file1, line1) && getline(file2, line2))
+	while (std::getline(file1, line1) && std::getline(file2, line2))
 	    unit_assert(line1 == line2);
     if (os_) *os_ << "diff " << filename1 << " " << filename2 << ": success\n";
 }

--- a/pwiz/data/msdata/SpectrumList_MGF.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF.cpp
@@ -159,7 +159,7 @@ class SpectrumList_MGFImpl : public SpectrumList_MGF
         spectrum.setMZIntensityArrays(vector<double>(), vector<double>(), MS_number_of_detector_counts);
         BinaryData<double>& mzArray = spectrum.getMZArray()->data;
         BinaryData<double>& intensityArray = spectrum.getIntensityArray()->data;
-	    while (getline(*is_, lineStr))
+	    while (pwiz::util::getline(*is_, lineStr))
 	    {
             size_t lineBegin = lineStr.find_first_not_of(" \t");
             if (lineBegin == string::npos)
@@ -405,7 +405,7 @@ class SpectrumList_MGFImpl : public SpectrumList_MGF
         vector<SpectrumIdentity>::iterator curIdentityItr;
         map<string, size_t>::iterator curIdToIndexItr;
 
-	    while (getline(*is_, lineStr))
+	    while (std::getline(*is_, lineStr)) // need accurate line length, so do not use pwiz::util convenience wrapper
 	    {
 		    ++lineCount;
 		    if (lineStr.find("BEGIN IONS") == 0)

--- a/pwiz/data/msdata/SpectrumList_MGF.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF.cpp
@@ -159,7 +159,7 @@ class SpectrumList_MGFImpl : public SpectrumList_MGF
         spectrum.setMZIntensityArrays(vector<double>(), vector<double>(), MS_number_of_detector_counts);
         BinaryData<double>& mzArray = spectrum.getMZArray()->data;
         BinaryData<double>& intensityArray = spectrum.getIntensityArray()->data;
-	    while (pwiz::util::getline(*is_, lineStr))
+	    while (getlinePortable(*is_, lineStr))
 	    {
             size_t lineBegin = lineStr.find_first_not_of(" \t");
             if (lineBegin == string::npos)

--- a/pwiz/data/msdata/SpectrumList_MSn.cpp
+++ b/pwiz/data/msdata/SpectrumList_MSn.cpp
@@ -239,7 +239,7 @@ class SpectrumList_MSnImpl : public SpectrumList_MSn
     double precursor_mz = 0;
     
     // start reading the file
-    if( getline(*is_, lineStr) )	// not end of file
+    if(pwiz::util::getline(*is_, lineStr) )	// not end of file
     {
         // confirm that the first line is an S line
         if (lineStr.find("S") != 0)
@@ -278,7 +278,7 @@ class SpectrumList_MSnImpl : public SpectrumList_MSn
     vector< pair<int, double> > chargeMassPairs;
 
     // read in remainder of spectrum
-    while (getline(*is_, lineStr))
+    while (pwiz::util::getline(*is_, lineStr))
     {
         if (lineStr.find("S") == 0) // we are at the next spectrum
         {
@@ -641,7 +641,7 @@ class SpectrumList_MSnImpl : public SpectrumList_MSn
     size_t lineCount = 0;
     map<string, size_t>::iterator curIdToIndexItr;
     
-    while (getline(*is_, lineStr))
+    while (std::getline(*is_, lineStr)) // need accurate line length, so do not use pwiz::util convenience wrapper
     {
       ++lineCount;
       if (lineStr.find("S") == 0)

--- a/pwiz/data/msdata/SpectrumList_MSn.cpp
+++ b/pwiz/data/msdata/SpectrumList_MSn.cpp
@@ -239,7 +239,7 @@ class SpectrumList_MSnImpl : public SpectrumList_MSn
     double precursor_mz = 0;
     
     // start reading the file
-    if(pwiz::util::getline(*is_, lineStr) )	// not end of file
+    if(getlinePortable(*is_, lineStr) )	// not end of file
     {
         // confirm that the first line is an S line
         if (lineStr.find("S") != 0)
@@ -278,7 +278,7 @@ class SpectrumList_MSnImpl : public SpectrumList_MSn
     vector< pair<int, double> > chargeMassPairs;
 
     // read in remainder of spectrum
-    while (pwiz::util::getline(*is_, lineStr))
+    while (getlinePortable(*is_, lineStr))
     {
         if (lineStr.find("S") == 0) // we are at the next spectrum
         {

--- a/pwiz/data/proteome/ProteomeDataFileTest.cpp
+++ b/pwiz/data/proteome/ProteomeDataFileTest.cpp
@@ -205,7 +205,7 @@ class TestReader : public Reader
             return "";
 
         string buf;
-        getline(*uriStreamPtr, buf);
+        pwiz::util::getline(*uriStreamPtr, buf);
         if (buf[0] != '>')
             return "";
 

--- a/pwiz/data/proteome/ProteomeDataFileTest.cpp
+++ b/pwiz/data/proteome/ProteomeDataFileTest.cpp
@@ -205,7 +205,7 @@ class TestReader : public Reader
             return "";
 
         string buf;
-        pwiz::util::getline(*uriStreamPtr, buf);
+        getlinePortable(*uriStreamPtr, buf);
         if (buf[0] != '>')
             return "";
 

--- a/pwiz/data/proteome/Serializer_FASTA.cpp
+++ b/pwiz/data/proteome/Serializer_FASTA.cpp
@@ -68,7 +68,7 @@ class ProteinList_FASTA : public ProteinList
         set<string> idSet;
 
         Index::stream_offset indexOffset = 0;
-        while (getline(*fsPtr_, buf))
+        while (pwiz::util::getline(*fsPtr_, buf))
         {
             size_t bufLength = buf.length() + 1; // include newline
             indexOffset += bufLength;
@@ -160,7 +160,7 @@ class ProteinList_FASTA : public ProteinList
         fsPtr_->seekg(entryPtr->offset);
 
         string buf;
-        getline(*fsPtr_, buf);
+        pwiz::util::getline(*fsPtr_, buf);
 
         // test that the index offset is valid
         if (buf.empty() || buf[0] != '>')
@@ -179,7 +179,7 @@ class ProteinList_FASTA : public ProteinList
             fsPtr_->seekg(entryPtr->offset);
 
             string buf;
-            getline(*fsPtr_, buf);
+            pwiz::util::getline(*fsPtr_, buf);
 
             // if the offset is still invalid, throw
             if (buf.empty() || buf[0] != '>')
@@ -208,7 +208,7 @@ class ProteinList_FASTA : public ProteinList
 
         string sequence;
         if (getSequence)
-            while (getline(*fsPtr_, buf))
+            while (pwiz::util::getline(*fsPtr_, buf))
             {
                 if (buf.empty() || buf[0] == '\r') // skip blank lines
                     continue;

--- a/pwiz/data/proteome/Serializer_FASTA.cpp
+++ b/pwiz/data/proteome/Serializer_FASTA.cpp
@@ -68,7 +68,7 @@ class ProteinList_FASTA : public ProteinList
         set<string> idSet;
 
         Index::stream_offset indexOffset = 0;
-        while (pwiz::util::getline(*fsPtr_, buf))
+        while (getlinePortable(*fsPtr_, buf))
         {
             size_t bufLength = buf.length() + 1; // include newline
             indexOffset += bufLength;
@@ -160,7 +160,7 @@ class ProteinList_FASTA : public ProteinList
         fsPtr_->seekg(entryPtr->offset);
 
         string buf;
-        pwiz::util::getline(*fsPtr_, buf);
+        getlinePortable(*fsPtr_, buf);
 
         // test that the index offset is valid
         if (buf.empty() || buf[0] != '>')
@@ -179,7 +179,7 @@ class ProteinList_FASTA : public ProteinList
             fsPtr_->seekg(entryPtr->offset);
 
             string buf;
-            pwiz::util::getline(*fsPtr_, buf);
+            getlinePortable(*fsPtr_, buf);
 
             // if the offset is still invalid, throw
             if (buf.empty() || buf[0] != '>')
@@ -208,7 +208,7 @@ class ProteinList_FASTA : public ProteinList
 
         string sequence;
         if (getSequence)
-            while (pwiz::util::getline(*fsPtr_, buf))
+            while (getlinePortable(*fsPtr_, buf))
             {
                 if (buf.empty() || buf[0] == '\r') // skip blank lines
                     continue;

--- a/pwiz/utility/chemistry/MZTolerance.cpp
+++ b/pwiz/utility/chemistry/MZTolerance.cpp
@@ -44,7 +44,7 @@ PWIZ_API_DECL istream& operator>>(istream& is, MZTolerance& mzt)
     string temp;
 
     // in order to handle both '10ppm' and '10 ppm', this is easier than istream (which may or may not have skipws flag set)
-    getline(is, temp);
+    pwiz::util::getline(is, temp);
     size_t startOfValue = temp.find_first_of("0123456789.-");
     size_t endOfValue = temp.find_first_not_of("0123456789.-", startOfValue);
     size_t startOfUnits = temp.find_first_not_of(" ", endOfValue);

--- a/pwiz/utility/chemistry/MZTolerance.cpp
+++ b/pwiz/utility/chemistry/MZTolerance.cpp
@@ -44,7 +44,7 @@ PWIZ_API_DECL istream& operator>>(istream& is, MZTolerance& mzt)
     string temp;
 
     // in order to handle both '10ppm' and '10 ppm', this is easier than istream (which may or may not have skipws flag set)
-    pwiz::util::getline(is, temp);
+    getlinePortable(is, temp);
     size_t startOfValue = temp.find_first_of("0123456789.-");
     size_t endOfValue = temp.find_first_not_of("0123456789.-", startOfValue);
     size_t startOfUnits = temp.find_first_not_of(" ", endOfValue);

--- a/pwiz/utility/minimxml/SAXParserTest.cpp
+++ b/pwiz/utility/minimxml/SAXParserTest.cpp
@@ -465,7 +465,7 @@ void testDone()
     parse(is, handler); // parses <AnotherRootElement> and aborts
     
     string buffer;
-    pwiz::util::getline(is, buffer, '<');
+    getlinePortable(is, buffer, '<');
     
     if (os_) *os_ << "buffer: " << buffer << "\n\n";
     unit_assert_operator_equal("The quick brown fox jumps over the lazy dog.", buffer);

--- a/pwiz/utility/minimxml/SAXParserTest.cpp
+++ b/pwiz/utility/minimxml/SAXParserTest.cpp
@@ -465,7 +465,7 @@ void testDone()
     parse(is, handler); // parses <AnotherRootElement> and aborts
     
     string buffer;
-    getline(is, buffer, '<');
+    pwiz::util::getline(is, buffer, '<');
     
     if (os_) *os_ << "buffer: " << buffer << "\n\n";
     unit_assert_operator_equal("The quick brown fox jumps over the lazy dog.", buffer);

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -25,9 +25,10 @@
 
 #include "Filesystem.hpp"
 
-#ifdef WIN32
+#ifdef _MSC_VER
     #define _WIN32_WINNT 0x0600
     #define WIN32_LEAN_AND_MEAN
+    #define NOMINMAX
     #define NOGDI
     #include <windows.h>
     #include <direct.h>

--- a/pwiz/utility/misc/Stream.hpp
+++ b/pwiz/utility/misc/Stream.hpp
@@ -51,8 +51,6 @@ using std::stringstream;
 using std::istringstream;
 using std::ostringstream;
 
-//using pwiz::util::getline; // this will cause ambiguous lookup with ADL because std::getline is always an option when resolving an unqualified "getline()" since its arguments are members of std
-
 using std::streampos;
 using std::streamoff;
 using std::streamsize;

--- a/pwiz/utility/misc/Stream.hpp
+++ b/pwiz/utility/misc/Stream.hpp
@@ -51,14 +51,14 @@ using std::stringstream;
 using std::istringstream;
 using std::ostringstream;
 
-using std::getline;
+//using pwiz::util::getline; // this will cause ambiguous lookup with ADL because std::getline is always an option when resolving an unqualified "getline()" since its arguments are members of std
 
 using std::streampos;
 using std::streamoff;
 using std::streamsize;
 
-// This breaks VS2019 usage
-using bnw::system; // unqualified system() calls will be ambiguous, by intention, to force developers to consider UTF-8 compatibility
+
+//using bnw::system; // TODO: add linting so unqualified system() calls will not be allowed to force developers to consider UTF-8 compatibility
 
 using bnw::cin;
 using bnw::cout;

--- a/pwiz/utility/misc/String.hpp
+++ b/pwiz/utility/misc/String.hpp
@@ -91,7 +91,7 @@ inline std::string::const_iterator findUnicodeBytes(const std::string& str)
 /// Convenience wrapper for std::getline that strips trailing \r from DOS-style text files on any platform (e.g. OSX and Linux)
 /// NB: DO NOT USE THIS IF YOU REQUIRE ACCURATE LINE LENGTH, E.G. FOR INDEXING A FILE!
 template <class _Elem, class _Traits, class _Alloc>
-std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>&& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim)
+std::basic_istream<_Elem, _Traits>& getlinePortable(std::basic_istream<_Elem, _Traits>&& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim)
 { // get characters into string, discard delimiter and trailing \r
     auto& result = std::getline(_Istr, _Str, _Delim);
     if (_Delim == _Istr.widen('\n'))
@@ -102,25 +102,25 @@ std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>&&
 // Convenience wrapper for std::getline that strips trailing \r from DOS-style text files on any platform (e.g. OSX and Linux)
 /// NB: DO NOT USE THIS IF YOU REQUIRE ACCURATE LINE LENGTH, E.G. FOR INDEXING A FILE!
 template <class _Elem, class _Traits, class _Alloc>
-std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>&& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str)
+std::basic_istream<_Elem, _Traits>& getlinePortable(std::basic_istream<_Elem, _Traits>&& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str)
 { // get characters into string, discard newline and trailing \r
-    return pwiz::util::getline(_Istr, _Str, _Istr.widen('\n'));
+    return getlinePortable(_Istr, _Str, _Istr.widen('\n'));
 }
 
 // Convenience wrapper for std::getline that strips trailing \r from DOS-style text files on any platform (e.g. OSX and Linux)
 /// NB: DO NOT USE THIS IF YOU REQUIRE ACCURATE LINE LENGTH, E.G. FOR INDEXING A FILE!
 template <class _Elem, class _Traits, class _Alloc>
-std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim)
+std::basic_istream<_Elem, _Traits>& getlinePortable(std::basic_istream<_Elem, _Traits>& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim)
 { // get characters into string, discard delimiter and trailing \r
-    return pwiz::util::getline(std::move(_Istr), _Str, _Delim);
+    return getlinePortable(std::move(_Istr), _Str, _Delim);
 }
 
 // Convenience wrapper for std::getline that strips trailing \r from DOS-style text files on any platform (e.g. OSX and Linux)
 /// NB: DO NOT USE THIS IF YOU REQUIRE ACCURATE LINE LENGTH, E.G. FOR INDEXING A FILE!
 template <class _Elem, class _Traits, class _Alloc>
-std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str)
+std::basic_istream<_Elem, _Traits>& getlinePortable(std::basic_istream<_Elem, _Traits>& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str)
 { // get characters into string, discard newline and trailing \r
-    return pwiz::util::getline(std::move(_Istr), _Str, _Istr.widen('\n'));
+    return getlinePortable(std::move(_Istr), _Str, _Istr.widen('\n'));
 }
 
 
@@ -142,6 +142,8 @@ std::string toString(int value);
 
 } // namespace util
 } // namespace pwiz
+
+using pwiz::util::getlinePortable;
 
 
 #endif // _STRING_HPP_

--- a/pwiz/utility/misc/String.hpp
+++ b/pwiz/utility/misc/String.hpp
@@ -33,7 +33,6 @@
 #include "pwiz/utility/misc/optimized_lexical_cast.hpp"
 
 using std::string;
-using std::getline;
 using std::stringstream;
 using std::istringstream;
 using std::ostringstream;
@@ -86,6 +85,42 @@ std::string longestCommonPrefix(const SequenceT& strings)
 inline std::string::const_iterator findUnicodeBytes(const std::string& str)
 {
     return std::find_if(str.begin(), str.end(), [](char ch) { return !isprint(static_cast<unsigned char>(ch)) || static_cast<int>(ch) < 0; });
+}
+
+
+/// Convenience wrapper for std::getline that strips trailing \r from DOS-style text files on any platform (e.g. OSX and Linux)
+/// NB: DO NOT USE THIS IF YOU REQUIRE ACCURATE LINE LENGTH, E.G. FOR INDEXING A FILE!
+template <class _Elem, class _Traits, class _Alloc>
+std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>&& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim)
+{ // get characters into string, discard delimiter and trailing \r
+    auto& result = std::getline(_Istr, _Str, _Delim);
+    if (_Delim == _Istr.widen('\n'))
+        bal::trim_right_if(_Str, bal::is_any_of("\r"));
+    return result;
+}
+
+// Convenience wrapper for std::getline that strips trailing \r from DOS-style text files on any platform (e.g. OSX and Linux)
+/// NB: DO NOT USE THIS IF YOU REQUIRE ACCURATE LINE LENGTH, E.G. FOR INDEXING A FILE!
+template <class _Elem, class _Traits, class _Alloc>
+std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>&& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str)
+{ // get characters into string, discard newline and trailing \r
+    return pwiz::util::getline(_Istr, _Str, _Istr.widen('\n'));
+}
+
+// Convenience wrapper for std::getline that strips trailing \r from DOS-style text files on any platform (e.g. OSX and Linux)
+/// NB: DO NOT USE THIS IF YOU REQUIRE ACCURATE LINE LENGTH, E.G. FOR INDEXING A FILE!
+template <class _Elem, class _Traits, class _Alloc>
+std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim)
+{ // get characters into string, discard delimiter and trailing \r
+    return pwiz::util::getline(std::move(_Istr), _Str, _Delim);
+}
+
+// Convenience wrapper for std::getline that strips trailing \r from DOS-style text files on any platform (e.g. OSX and Linux)
+/// NB: DO NOT USE THIS IF YOU REQUIRE ACCURATE LINE LENGTH, E.G. FOR INDEXING A FILE!
+template <class _Elem, class _Traits, class _Alloc>
+std::basic_istream<_Elem, _Traits>& getline(std::basic_istream<_Elem, _Traits>& _Istr, std::basic_string<_Elem, _Traits, _Alloc>& _Str)
+{ // get characters into string, discard newline and trailing \r
+    return pwiz::util::getline(std::move(_Istr), _Str, _Istr.widen('\n'));
 }
 
 

--- a/pwiz/utility/misc/TabReader.cpp
+++ b/pwiz/utility/misc/TabReader.cpp
@@ -263,8 +263,8 @@ bool TabReader::Impl::process(const char* filename)
     {
         th_->open();
         
-        getline(in, line);
-        while(getline(in, line))
+        pwiz::util::getline(in, line);
+        while(pwiz::util::getline(in, line))
         {
             if (isComment(line))
                 continue;

--- a/pwiz/utility/misc/TabReader.cpp
+++ b/pwiz/utility/misc/TabReader.cpp
@@ -263,8 +263,8 @@ bool TabReader::Impl::process(const char* filename)
     {
         th_->open();
         
-        pwiz::util::getline(in, line);
-        while(pwiz::util::getline(in, line))
+        getlinePortable(in, line);
+        while(getlinePortable(in, line))
         {
             if (isComment(line))
                 continue;

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -788,7 +788,7 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
             {
                 ifstream urls(filepath.string().c_str());
                 string url;
-                while (getline(urls, url))
+                while (pwiz::util::getline(urls, url))
                 {
                     if (isPathTestable(url))
                     {

--- a/pwiz/utility/misc/VendorReaderTestHarness.cpp
+++ b/pwiz/utility/misc/VendorReaderTestHarness.cpp
@@ -788,7 +788,7 @@ TestResult testReader(const Reader& reader, const vector<string>& args, bool tes
             {
                 ifstream urls(filepath.string().c_str());
                 string url;
-                while (pwiz::util::getline(urls, url))
+                while (getlinePortable(urls, url))
                 {
                     if (isPathTestable(url))
                     {

--- a/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
@@ -438,7 +438,7 @@ struct PWIZ_API_DECL RawData
             return;
 
         string line;
-        while(getline(in, line))
+        while(pwiz::util::getline(in, line))
         {
             size_t c_pos = line.find(": ");
             if (line.find("$$ ") != 0 || c_pos == string::npos)

--- a/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
@@ -438,7 +438,7 @@ struct PWIZ_API_DECL RawData
             return;
 
         string line;
-        while(pwiz::util::getline(in, line))
+        while(getlinePortable(in, line))
         {
             size_t c_pos = line.find(": ");
             if (line.find("$$ ") != 0 || c_pos == string::npos)

--- a/pwiz_tools/BiblioSpec/src/DelimitedFileReader.h
+++ b/pwiz_tools/BiblioSpec/src/DelimitedFileReader.h
@@ -152,7 +152,7 @@ template <typename STORAGE_TYPE> class DelimitedFileReader {
 
         // parse header
         std::string line;
-        pwiz::util::getline(delimFile_, line);
+        getlinePortable(delimFile_, line);
         curLineNumber_++;
         parseHeader(line);
 
@@ -235,7 +235,7 @@ template <typename STORAGE_TYPE> class DelimitedFileReader {
         std::string errorMsg;
         
         while( ! delimFile_.eof() ){
-            pwiz::util::getline(delimFile_, line);
+            getlinePortable(delimFile_, line);
             curLineNumber_++;
 
             if (line.empty() && delimFile_.eof())

--- a/pwiz_tools/BiblioSpec/src/DelimitedFileReader.h
+++ b/pwiz_tools/BiblioSpec/src/DelimitedFileReader.h
@@ -152,7 +152,7 @@ template <typename STORAGE_TYPE> class DelimitedFileReader {
 
         // parse header
         std::string line;
-        getline(delimFile_, line);
+        pwiz::util::getline(delimFile_, line);
         curLineNumber_++;
         parseHeader(line);
 
@@ -235,7 +235,7 @@ template <typename STORAGE_TYPE> class DelimitedFileReader {
         std::string errorMsg;
         
         while( ! delimFile_.eof() ){
-            getline(delimFile_, line);
+            pwiz::util::getline(delimFile_, line);
             curLineNumber_++;
 
             if (line.empty() && delimFile_.eof())

--- a/pwiz_tools/BiblioSpec/src/TSVReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/TSVReader.cpp
@@ -67,7 +67,7 @@ namespace {
                 optionalColumns_.push_back(optionalColumn);
 
             string line;
-            pwiz::util::getline(tsvFile_, line);
+            getlinePortable(tsvFile_, line);
             LineParser headerLine(line, separator_);
             parseHeader(headerLine, targetColumns_, optionalColumns_);
 
@@ -335,7 +335,7 @@ namespace {
                 optionalColumns_.push_back(optionalColumn);
 
             string line;
-            pwiz::util::getline(tsvFile_, line);
+            getlinePortable(tsvFile_, line);
             LineParser headerLine(line, separator_);
             parseHeader(headerLine, targetColumns_, optionalColumns_);
         }
@@ -481,7 +481,7 @@ boost::shared_ptr<TSVReader> TSVReader::create(BlibBuilder& maker, const char* t
     string line;
     {
         ifstream tsvFile(tsvName);
-        pwiz::util::getline(tsvFile, line);
+        getlinePortable(tsvFile, line);
     }
     LineParser headerLine(line, separator_);
 
@@ -527,12 +527,12 @@ void TSVReader::parseHeader(LineParser& headerLine, vector<TSVColumnTranslator>&
 void TSVReader::collectPsms(map<string, Protein>& proteins) {
     tsvFile_.seekg(0);
     string lineStr;
-    pwiz::util::getline(tsvFile_, lineStr);
+    getlinePortable(tsvFile_, lineStr);
 
     ProgressIndicator progress(bfs::file_size(tsvName_) - lineStr.length()+1);
 
     while (!tsvFile_.eof()) {
-        pwiz::util::getline(tsvFile_, lineStr);
+        getlinePortable(tsvFile_, lineStr);
         lineNum_++;
 
         TSVLine line;

--- a/pwiz_tools/BiblioSpec/src/TSVReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/TSVReader.cpp
@@ -67,7 +67,7 @@ namespace {
                 optionalColumns_.push_back(optionalColumn);
 
             string line;
-            getline(tsvFile_, line);
+            pwiz::util::getline(tsvFile_, line);
             LineParser headerLine(line, separator_);
             parseHeader(headerLine, targetColumns_, optionalColumns_);
 
@@ -335,7 +335,7 @@ namespace {
                 optionalColumns_.push_back(optionalColumn);
 
             string line;
-            getline(tsvFile_, line);
+            pwiz::util::getline(tsvFile_, line);
             LineParser headerLine(line, separator_);
             parseHeader(headerLine, targetColumns_, optionalColumns_);
         }
@@ -481,7 +481,7 @@ boost::shared_ptr<TSVReader> TSVReader::create(BlibBuilder& maker, const char* t
     string line;
     {
         ifstream tsvFile(tsvName);
-        getline(tsvFile, line);
+        pwiz::util::getline(tsvFile, line);
     }
     LineParser headerLine(line, separator_);
 
@@ -527,12 +527,12 @@ void TSVReader::parseHeader(LineParser& headerLine, vector<TSVColumnTranslator>&
 void TSVReader::collectPsms(map<string, Protein>& proteins) {
     tsvFile_.seekg(0);
     string lineStr;
-    getline(tsvFile_, lineStr);
+    pwiz::util::getline(tsvFile_, lineStr);
 
     ProgressIndicator progress(bfs::file_size(tsvName_) - lineStr.length()+1);
 
     while (!tsvFile_.eof()) {
-        getline(tsvFile_, lineStr);
+        pwiz::util::getline(tsvFile_, lineStr);
         lineNum_++;
 
         TSVLine line;

--- a/pwiz_tools/BiblioSpec/src/WatersMseReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/WatersMseReader.cpp
@@ -241,7 +241,7 @@ bool WatersMseReader::parseFile(){
     }
     // read header in first line
     string line;
-    getline(csvFile_, line);
+    pwiz::util::getline(csvFile_, line);
     parseHeader(line);
     
     Verbosity::debug("Collecting Psms.");
@@ -334,7 +334,7 @@ void WatersMseReader::collectPsms(){
     
     // read first non-header line
     string line;
-    getline(csvFile_, line);
+    pwiz::util::getline(csvFile_, line);
     lineNum_++;
     bool parseSuccess = true;
     string errorMsg;
@@ -381,7 +381,7 @@ void WatersMseReader::collectPsms(){
         // store this line's information in the curPSM
         storeLine(entry);
         
-        getline(csvFile_, line);
+        pwiz::util::getline(csvFile_, line);
         lineNum_++;
     } // next line
 

--- a/pwiz_tools/BiblioSpec/src/WatersMseReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/WatersMseReader.cpp
@@ -241,7 +241,7 @@ bool WatersMseReader::parseFile(){
     }
     // read header in first line
     string line;
-    pwiz::util::getline(csvFile_, line);
+    getlinePortable(csvFile_, line);
     parseHeader(line);
     
     Verbosity::debug("Collecting Psms.");
@@ -334,7 +334,7 @@ void WatersMseReader::collectPsms(){
     
     // read first non-header line
     string line;
-    pwiz::util::getline(csvFile_, line);
+    getlinePortable(csvFile_, line);
     lineNum_++;
     bool parseSuccess = true;
     string errorMsg;
@@ -381,7 +381,7 @@ void WatersMseReader::collectPsms(){
         // store this line's information in the curPSM
         storeLine(entry);
         
-        pwiz::util::getline(csvFile_, line);
+        getlinePortable(csvFile_, line);
         lineNum_++;
     } // next line
 

--- a/pwiz_tools/Bumbershoot/directag/adjustScanRankerScoreByGroup.cpp
+++ b/pwiz_tools/Bumbershoot/directag/adjustScanRankerScoreByGroup.cpp
@@ -59,12 +59,12 @@ void getHeader(const string& filename, ScoreInfo *scoreInfo )
         throw invalid_argument( string( "unable to open file \"" ) + filename + "\"" );
 
     string headerLine;
-    getline(fileStream, headerLine); //discard the first header line: H    BestTagScoreMean    BestTagTICMean    TagMzRangeMean    BestTagScoreIQR    BestTagTICIQR    TagMzRangeIQR    numTaggedSpectra
-    getline(fileStream, headerLine); // get second line, e.g.: H    25.4616    7.06014    701.679    12.0654    4.52176    305.127    18587
+    pwiz::util::getline(fileStream, headerLine); //discard the first header line: H    BestTagScoreMean    BestTagTICMean    TagMzRangeMean    BestTagScoreIQR    BestTagTICIQR    TagMzRangeIQR    numTaggedSpectra
+    pwiz::util::getline(fileStream, headerLine); // get second line, e.g.: H    25.4616    7.06014    701.679    12.0654    4.52176    305.127    18587
     stringstream lineStream(headerLine);
     string segments;
     vector<string> v;
-    while(getline(lineStream,segments,'\t'))
+    while(pwiz::util::getline(lineStream,segments,'\t'))
     {
         v.push_back(segments);
     }
@@ -103,7 +103,7 @@ void adjustScore(    const string& filename,
         throw invalid_argument( string( "unable to open file \"" ) + filename + "\"" );
 
     string line;
-    while( getline(fileStream, line))
+    while(pwiz::util::getline(fileStream, line))
     {
         if (line.find("H\tBestTagScoreMean") != string::npos)
         {
@@ -130,7 +130,7 @@ void adjustScore(    const string& filename,
             stringstream lineStream(line);
             string segments;
             vector<string> v;
-            while(getline(lineStream,segments,'\t'))
+            while(pwiz::util::getline(lineStream,segments,'\t'))
             {
                 v.push_back(segments);
             }
@@ -161,13 +161,13 @@ int main( int argc, char* argv[] )
 
     ifstream  groupFile( argv[1] );
     string line;
-    while(getline(groupFile,line))  //work on each group; one line one group, separated with ","
+    while(pwiz::util::getline(groupFile,line))  //work on each group; one line one group, separated with ","
     {
         stringstream  lineStream(line);
         string        file;
         vector<ScoreInfo> scoreInfoVector;
         //cout << "Extracting subscore infomation from metrics files ... \n" << endl;
-        while(getline(lineStream,file,','))  //work on a sigle file in a group, extract mean and IQR from each file 
+        while(pwiz::util::getline(lineStream,file,','))  //work on a sigle file in a group, extract mean and IQR from each file 
         {
             ScoreInfo scoreInfo;
             getHeader( file, &scoreInfo );
@@ -205,7 +205,7 @@ int main( int argc, char* argv[] )
         lineStream.clear(); // reset lineStream for getline()
         lineStream.seekg(0,std::ios::beg);
         cout << "Adjusting ScanRanker scores ...\n" << endl;
-        while(getline(lineStream,file,','))  //work on a sigle file in a group, add adjusted scores 
+        while(pwiz::util::getline(lineStream,file,','))  //work on a sigle file in a group, add adjusted scores 
         {
             adjustScore(    file, 
                             gbBestTagScoreMean,

--- a/pwiz_tools/Bumbershoot/directag/adjustScanRankerScoreByGroup.cpp
+++ b/pwiz_tools/Bumbershoot/directag/adjustScanRankerScoreByGroup.cpp
@@ -59,12 +59,12 @@ void getHeader(const string& filename, ScoreInfo *scoreInfo )
         throw invalid_argument( string( "unable to open file \"" ) + filename + "\"" );
 
     string headerLine;
-    pwiz::util::getline(fileStream, headerLine); //discard the first header line: H    BestTagScoreMean    BestTagTICMean    TagMzRangeMean    BestTagScoreIQR    BestTagTICIQR    TagMzRangeIQR    numTaggedSpectra
-    pwiz::util::getline(fileStream, headerLine); // get second line, e.g.: H    25.4616    7.06014    701.679    12.0654    4.52176    305.127    18587
+    getline(fileStream, headerLine); //discard the first header line: H    BestTagScoreMean    BestTagTICMean    TagMzRangeMean    BestTagScoreIQR    BestTagTICIQR    TagMzRangeIQR    numTaggedSpectra
+    getline(fileStream, headerLine); // get second line, e.g.: H    25.4616    7.06014    701.679    12.0654    4.52176    305.127    18587
     stringstream lineStream(headerLine);
     string segments;
     vector<string> v;
-    while(pwiz::util::getline(lineStream,segments,'\t'))
+    while(getline(lineStream,segments,'\t'))
     {
         v.push_back(segments);
     }
@@ -103,7 +103,7 @@ void adjustScore(    const string& filename,
         throw invalid_argument( string( "unable to open file \"" ) + filename + "\"" );
 
     string line;
-    while(pwiz::util::getline(fileStream, line))
+    while(getline(fileStream, line))
     {
         if (line.find("H\tBestTagScoreMean") != string::npos)
         {
@@ -130,7 +130,7 @@ void adjustScore(    const string& filename,
             stringstream lineStream(line);
             string segments;
             vector<string> v;
-            while(pwiz::util::getline(lineStream,segments,'\t'))
+            while(getline(lineStream,segments,'\t'))
             {
                 v.push_back(segments);
             }
@@ -161,13 +161,13 @@ int main( int argc, char* argv[] )
 
     ifstream  groupFile( argv[1] );
     string line;
-    while(pwiz::util::getline(groupFile,line))  //work on each group; one line one group, separated with ","
+    while(getline(groupFile,line))  //work on each group; one line one group, separated with ","
     {
         stringstream  lineStream(line);
         string        file;
         vector<ScoreInfo> scoreInfoVector;
         //cout << "Extracting subscore infomation from metrics files ... \n" << endl;
-        while(pwiz::util::getline(lineStream,file,','))  //work on a sigle file in a group, extract mean and IQR from each file 
+        while(getline(lineStream,file,','))  //work on a sigle file in a group, extract mean and IQR from each file 
         {
             ScoreInfo scoreInfo;
             getHeader( file, &scoreInfo );
@@ -205,7 +205,7 @@ int main( int argc, char* argv[] )
         lineStream.clear(); // reset lineStream for getline()
         lineStream.seekg(0,std::ios::beg);
         cout << "Adjusting ScanRanker scores ...\n" << endl;
-        while(pwiz::util::getline(lineStream,file,','))  //work on a sigle file in a group, add adjusted scores 
+        while(getline(lineStream,file,','))  //work on a sigle file in a group, add adjusted scores 
         {
             adjustScore(    file, 
                             gbBestTagScoreMean,

--- a/pwiz_tools/Bumbershoot/freicore/BaseRunTimeConfig.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/BaseRunTimeConfig.cpp
@@ -62,7 +62,7 @@ namespace freicore
             istringstream cfgStream(cfgStr);
 
             string line;
-            while (pwiz::util::getline(cfgStream, line))
+            while (getlinePortable(cfgStream, line))
             {
                 ++lineNum;
                 bal::trim(line); // trim whitespace

--- a/pwiz_tools/Bumbershoot/freicore/BaseRunTimeConfig.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/BaseRunTimeConfig.cpp
@@ -62,7 +62,7 @@ namespace freicore
             istringstream cfgStream(cfgStr);
 
             string line;
-            while (getline(cfgStream, line))
+            while (pwiz::util::getline(cfgStream, line))
             {
                 ++lineNum;
                 bal::trim(line); // trim whitespace

--- a/pwiz_tools/Bumbershoot/freicore/BlosumMatrix.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/BlosumMatrix.cpp
@@ -54,7 +54,7 @@ namespace freicore {
         size_t rowIndex = 0;
         while(!fileStream.eof()) {
             // Get the line
-            pwiz::util::getline(fileStream,inputLine);
+            getlinePortable(fileStream,inputLine);
             // If the line is start of a header
             if(inputLine.find("A R N D C")!=string::npos) {
                 // Tokenize the header using white space as delimiter
@@ -69,7 +69,7 @@ namespace freicore {
                 }
 
                 // Skip the line after the header
-                pwiz::util::getline(fileStream, inputLine);
+                getlinePortable(fileStream, inputLine);
                 // We will be parsing log odds right after
                 parsingLogOdds = true;
             } else if(parsingLogOdds) {

--- a/pwiz_tools/Bumbershoot/freicore/BlosumMatrix.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/BlosumMatrix.cpp
@@ -54,7 +54,7 @@ namespace freicore {
         size_t rowIndex = 0;
         while(!fileStream.eof()) {
             // Get the line
-            std::getline(fileStream,inputLine);
+            pwiz::util::getline(fileStream,inputLine);
             // If the line is start of a header
             if(inputLine.find("A R N D C")!=string::npos) {
                 // Tokenize the header using white space as delimiter
@@ -69,7 +69,7 @@ namespace freicore {
                 }
 
                 // Skip the line after the header
-                std::getline(fileStream, inputLine);
+                pwiz::util::getline(fileStream, inputLine);
                 // We will be parsing log odds right after
                 parsingLogOdds = true;
             } else if(parsingLogOdds) {

--- a/pwiz_tools/Bumbershoot/freicore/freicore.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/freicore.cpp
@@ -220,7 +220,7 @@ namespace freicore
         if( fileStream.is_open() )
         {
             string line1;
-            pwiz::util::getline( fileStream, line1 );
+            getlinePortable( fileStream, line1 );
 
             // Is this an XML file?
             if( line1.find( "<?xml" ) == 0 )
@@ -230,7 +230,7 @@ namespace freicore
                 rootElIdx = line1.find( '<', 1 );
                 while( rootElIdx == string::npos || line1[rootElIdx+1] == '?' || line1[rootElIdx+1] == '!' )
                 {
-                    pwiz::util::getline( fileStream, line1 );
+                    getlinePortable( fileStream, line1 );
                     rootElIdx = line1.find( '<' );
                 }
                 string rootEl = line1.substr( rootElIdx+1, line1.find_first_of( " >", rootElIdx+2 )-rootElIdx-1 );

--- a/pwiz_tools/Bumbershoot/freicore/freicore.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/freicore.cpp
@@ -220,7 +220,7 @@ namespace freicore
         if( fileStream.is_open() )
         {
             string line1;
-            std::getline( fileStream, line1 );
+            pwiz::util::getline( fileStream, line1 );
 
             // Is this an XML file?
             if( line1.find( "<?xml" ) == 0 )
@@ -230,7 +230,7 @@ namespace freicore
                 rootElIdx = line1.find( '<', 1 );
                 while( rootElIdx == string::npos || line1[rootElIdx+1] == '?' || line1[rootElIdx+1] == '!' )
                 {
-                    std::getline( fileStream, line1 );
+                    pwiz::util::getline( fileStream, line1 );
                     rootElIdx = line1.find( '<' );
                 }
                 string rootEl = line1.substr( rootElIdx+1, line1.find_first_of( " >", rootElIdx+2 )-rootElIdx-1 );

--- a/pwiz_tools/Bumbershoot/freicore/mapPeptidesToFasta.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/mapPeptidesToFasta.cpp
@@ -156,7 +156,7 @@ void mapPeptidesToFasta(string fastafile, string peptidesfile)
 
     vector<shared_string> keywords;
     string input;
-    while(pwiz::util::getline(reader,input))
+    while(getlinePortable(reader,input))
     {
         bal::trim(input);
         if(input.size()>2)

--- a/pwiz_tools/Bumbershoot/freicore/mapPeptidesToFasta.cpp
+++ b/pwiz_tools/Bumbershoot/freicore/mapPeptidesToFasta.cpp
@@ -156,7 +156,7 @@ void mapPeptidesToFasta(string fastafile, string peptidesfile)
 
     vector<shared_string> keywords;
     string input;
-    while(getline(reader,input))
+    while(pwiz::util::getline(reader,input))
     {
         bal::trim(input);
         if(input.size()>2)

--- a/pwiz_tools/Bumbershoot/greazy/greazy.cpp
+++ b/pwiz_tools/Bumbershoot/greazy/greazy.cpp
@@ -1138,14 +1138,14 @@ Map processConfig(const string & fname)
     if (!file)
     {
         cout << "Unable to open file.";
-        pwiz::util::getline(cin, str);
+        getlinePortable(cin, str);
         cin.get();
         exit(1);
     }
 
     string line, tempLine, pStr;
     Map tempMap;
-    while(pwiz::util::getline(file, line))
+    while(getlinePortable(file, line))
     {
         if (line[line.length()-1] == 'Y')
         {    

--- a/pwiz_tools/Bumbershoot/greazy/greazy.cpp
+++ b/pwiz_tools/Bumbershoot/greazy/greazy.cpp
@@ -1138,14 +1138,14 @@ Map processConfig(const string & fname)
     if (!file)
     {
         cout << "Unable to open file.";
-        getline(cin, str);
+        pwiz::util::getline(cin, str);
         cin.get();
         exit(1);
     }
 
     string line, tempLine, pStr;
     Map tempMap;
-    while(getline(file, line))
+    while(pwiz::util::getline(file, line))
     {
         if (line[line.length()-1] == 'Y')
         {    

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/CommandlineTest.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/CommandlineTest.cpp
@@ -602,10 +602,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-no-quantitation-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(expectedProteinHeader, line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
         
@@ -617,10 +617,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-empty-TMT2plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(expectedProteinHeader, line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -637,10 +637,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-quantified-iTRAQ8plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             //unit_assert_operator_equal(expectedProteinHeader + "\tTMT", line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t') + 24, std::count(line.begin(), line.end(), '\t'));
         }
     }
@@ -679,10 +679,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-no-quantitation-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(expectedProteinHeader, line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -694,10 +694,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-empty-TMT2plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             //unit_assert_operator_equal(expectedProteinHeader + "\tTMT", line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -714,10 +714,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-quantified-iTRAQ8plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             //unit_assert_operator_equal(expectedProteinHeader + "\tTMT", line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t') + 24, std::count(line.begin(), line.end(), '\t'));
         }
     }
@@ -744,10 +744,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-empty-iTRAQ8plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(expectedPeptideHeader, line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedPeptideHeader.begin(), expectedPeptideHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -778,10 +778,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-empty-iTRAQ8plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(expectedModificationHeader, line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedModificationHeader.begin(), expectedModificationHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -853,12 +853,12 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile(quantifiedOutputFilepath.c_str());
             string line;
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             // /201203 Empty,201203-TMT2,201203-TMT3,Empty,201203-TMT5,Reference,201203-TMT7,201203-TMT8,201203-TMT9,201203-TMT10
             // /201208 201208-TMT1,201208-TMT2,201208-TMT3,Empty,201208-TMT5,Reference,201208-TMT7,201208-TMT8,201208-TMT9,Empty
             unit_assert_operator_equal(expectedIsobaricSampleMappingHeader, line);
             // TODO: figure out how to test the output of the second line
-            getline(outputFile, line);
+            pwiz::util::getline(outputFile, line);
             unit_assert_operator_equal(std::count(expectedIsobaricSampleMappingHeader.begin(), expectedIsobaricSampleMappingHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
     }

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/CommandlineTest.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/CommandlineTest.cpp
@@ -602,10 +602,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-no-quantitation-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(expectedProteinHeader, line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
         
@@ -617,10 +617,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-empty-TMT2plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(expectedProteinHeader, line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -637,10 +637,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-quantified-iTRAQ8plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             //unit_assert_operator_equal(expectedProteinHeader + "\tTMT", line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t') + 24, std::count(line.begin(), line.end(), '\t'));
         }
     }
@@ -679,10 +679,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-no-quantitation-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(expectedProteinHeader, line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -694,10 +694,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-empty-TMT2plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             //unit_assert_operator_equal(expectedProteinHeader + "\tTMT", line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -714,10 +714,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-quantified-iTRAQ8plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             //unit_assert_operator_equal(expectedProteinHeader + "\tTMT", line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedProteinHeader.begin(), expectedProteinHeader.end(), '\t') + 24, std::count(line.begin(), line.end(), '\t'));
         }
     }
@@ -744,10 +744,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-empty-iTRAQ8plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(expectedPeptideHeader, line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedPeptideHeader.begin(), expectedPeptideHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -778,10 +778,10 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile((testDataPath / ("merged-empty-iTRAQ8plex-" + groupColumn + ".tsv")).string().c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(expectedModificationHeader, line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedModificationHeader.begin(), expectedModificationHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
 
@@ -853,12 +853,12 @@ void testIdpQuery(const string& idpQonvertPath, const string& idpAssemblePath, c
         {
             ifstream outputFile(quantifiedOutputFilepath.c_str());
             string line;
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             // /201203 Empty,201203-TMT2,201203-TMT3,Empty,201203-TMT5,Reference,201203-TMT7,201203-TMT8,201203-TMT9,201203-TMT10
             // /201208 201208-TMT1,201208-TMT2,201208-TMT3,Empty,201208-TMT5,Reference,201208-TMT7,201208-TMT8,201208-TMT9,Empty
             unit_assert_operator_equal(expectedIsobaricSampleMappingHeader, line);
             // TODO: figure out how to test the output of the second line
-            pwiz::util::getline(outputFile, line);
+            getlinePortable(outputFile, line);
             unit_assert_operator_equal(std::count(expectedIsobaricSampleMappingHeader.begin(), expectedIsobaricSampleMappingHeader.end(), '\t'), std::count(line.begin(), line.end(), '\t'));
         }
     }

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/XIC.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/XIC.cpp
@@ -1002,10 +1002,10 @@ int EmbedMS1ForFile(sqlite::database& idpDb, const string& idpDBFilePath, const 
                 RegDefinedPrecursorInfo info;
 
                 std::string   line;
-                pwiz::util::getline(file, line);
+                getlinePortable(file, line);
                 //bool useAvgMass = config.ChromatogramMzUpperOffset.units != MZTolerance::PPM && config.ChromatogramMzLowerOffset.units != MZTolerance::PPM &&
                 //                  config.ChromatogramMzUpperOffset.value + config.ChromatogramMzLowerOffset.value > 1;
-                while(pwiz::util::getline(file, line))
+                while(getlinePortable(file, line))
                 {
                     istringstream   ss(line);
                     double     scantime1,precursorMZ;

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/XIC.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/XIC.cpp
@@ -1002,10 +1002,10 @@ int EmbedMS1ForFile(sqlite::database& idpDb, const string& idpDBFilePath, const 
                 RegDefinedPrecursorInfo info;
 
                 std::string   line;
-                getline(file, line);
+                pwiz::util::getline(file, line);
                 //bool useAvgMass = config.ChromatogramMzUpperOffset.units != MZTolerance::PPM && config.ChromatogramMzLowerOffset.units != MZTolerance::PPM &&
                 //                  config.ChromatogramMzUpperOffset.value + config.ChromatogramMzLowerOffset.value > 1;
-                while(getline(file, line))
+                while(pwiz::util::getline(file, line))
                 {
                     istringstream   ss(line);
                     double     scantime1,precursorMZ;

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/idpAssemble.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/idpAssemble.cpp
@@ -111,7 +111,7 @@ void embedIsobaricSampleMapping(const string& idpDbFilepath, const string& isoba
     bxp::smatch match;
 
     string line;
-    while (pwiz::util::getline(isobaricSampleMappingFile, line))
+    while (getlinePortable(isobaricSampleMappingFile, line))
     {
         if (line.empty())
             continue;
@@ -164,7 +164,7 @@ void assignSourceGroupHierarchy(const string& idpDbFilepath, const string& assem
     bxp::smatch match;
 
     string line;
-    while (pwiz::util::getline(assembleTxtFile, line))
+    while (getlinePortable(assembleTxtFile, line))
     {
         if (line.empty())
             continue;

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/idpAssemble.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/idpAssemble.cpp
@@ -111,7 +111,7 @@ void embedIsobaricSampleMapping(const string& idpDbFilepath, const string& isoba
     bxp::smatch match;
 
     string line;
-    while (getline(isobaricSampleMappingFile, line))
+    while (pwiz::util::getline(isobaricSampleMappingFile, line))
     {
         if (line.empty())
             continue;
@@ -164,7 +164,7 @@ void assignSourceGroupHierarchy(const string& idpDbFilepath, const string& assem
     bxp::smatch match;
 
     string line;
-    while (getline(assembleTxtFile, line))
+    while (pwiz::util::getline(assembleTxtFile, line))
     {
         if (line.empty())
             continue;

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/idpQonvert.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/idpQonvert.cpp
@@ -171,7 +171,7 @@ int InitProcess( argList_t& args )
 
             ifstream listFile(args[i+1].c_str());
             string line;
-            while (getline(listFile, line))
+            while (pwiz::util::getline(listFile, line))
                 extraFilepaths.push_back(line);
 
             args.erase( args.begin() + i );

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/idpQonvert.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/idpQonvert.cpp
@@ -171,7 +171,7 @@ int InitProcess( argList_t& args )
 
             ifstream listFile(args[i+1].c_str());
             string line;
-            while (pwiz::util::getline(listFile, line))
+            while (getlinePortable(listFile, line))
                 extraFilepaths.push_back(line);
 
             args.erase( args.begin() + i );

--- a/pwiz_tools/Bumbershoot/pepitome/LibraryBabelFish.cpp
+++ b/pwiz_tools/Bumbershoot/pepitome/LibraryBabelFish.cpp
@@ -501,7 +501,7 @@ namespace freicore
 
             //copy original library to merged file, except for last line
             string nextLine;
-            getline(originalLib, nextLine);
+            pwiz::util::getline(originalLib, nextLine);
             while (!originalLib.eof())
             {
                 /*if (nextLine != "")
@@ -512,7 +512,7 @@ namespace freicore
                     continue;
                 }*/
                 mergedLibrary << nextLine << "\n";
-                getline(originalLib, nextLine);
+                pwiz::util::getline(originalLib, nextLine);
             }
             originalLib.close();
 
@@ -615,7 +615,7 @@ namespace freicore
             map<int,string> iTraqMods;
             bool report = false;
 
-            getline(inFile,newLine);
+            pwiz::util::getline(inFile,newLine);
             int writeIndex = 0;
 
             //go through file
@@ -945,7 +945,7 @@ namespace freicore
                         decoyStream << newLine << endl;
                     }
                 }
-                getline(inFile,newLine);
+                pwiz::util::getline(inFile,newLine);
             }
             inFile.close();
             outFile.close();

--- a/pwiz_tools/Bumbershoot/pepitome/LibraryBabelFish.cpp
+++ b/pwiz_tools/Bumbershoot/pepitome/LibraryBabelFish.cpp
@@ -501,7 +501,7 @@ namespace freicore
 
             //copy original library to merged file, except for last line
             string nextLine;
-            pwiz::util::getline(originalLib, nextLine);
+            getlinePortable(originalLib, nextLine);
             while (!originalLib.eof())
             {
                 /*if (nextLine != "")
@@ -512,7 +512,7 @@ namespace freicore
                     continue;
                 }*/
                 mergedLibrary << nextLine << "\n";
-                pwiz::util::getline(originalLib, nextLine);
+                getlinePortable(originalLib, nextLine);
             }
             originalLib.close();
 
@@ -615,7 +615,7 @@ namespace freicore
             map<int,string> iTraqMods;
             bool report = false;
 
-            pwiz::util::getline(inFile,newLine);
+            getlinePortable(inFile,newLine);
             int writeIndex = 0;
 
             //go through file
@@ -945,7 +945,7 @@ namespace freicore
                         decoyStream << newLine << endl;
                     }
                 }
-                pwiz::util::getline(inFile,newLine);
+                getlinePortable(inFile,newLine);
             }
             inFile.close();
             outFile.close();

--- a/pwiz_tools/Bumbershoot/pepitome/spectraStore.h
+++ b/pwiz_tools/Bumbershoot/pepitome/spectraStore.h
@@ -1001,7 +1001,7 @@ namespace pepitome
             size_t numPeaks;
             vector<string> tokens;
 
-            while(getline(library, buf)) 
+            while(pwiz::util::getline(library, buf))
             {
                 size_t bufLength = buf.length()+1;
                 dataOffset += bufLength;
@@ -1082,7 +1082,7 @@ namespace pepitome
                 double parentMass;
                 int charge;
                 size_t numPeaks;
-                while(getline(library,buf)) 
+                while(pwiz::util::getline(library,buf))
                 {
                     size_t bufLength = buf.length()+1;
                     dataOffset += bufLength;

--- a/pwiz_tools/Bumbershoot/pepitome/spectraStore.h
+++ b/pwiz_tools/Bumbershoot/pepitome/spectraStore.h
@@ -1001,7 +1001,7 @@ namespace pepitome
             size_t numPeaks;
             vector<string> tokens;
 
-            while(pwiz::util::getline(library, buf))
+            while(getlinePortable(library, buf))
             {
                 size_t bufLength = buf.length()+1;
                 dataOffset += bufLength;
@@ -1082,7 +1082,7 @@ namespace pepitome
                 double parentMass;
                 int charge;
                 size_t numPeaks;
-                while(pwiz::util::getline(library,buf))
+                while(getlinePortable(library,buf))
                 {
                     size_t bufLength = buf.length()+1;
                     dataOffset += bufLength;

--- a/pwiz_tools/Bumbershoot/quameter/quameterFileReaders.cpp
+++ b/pwiz_tools/Bumbershoot/quameter/quameterFileReaders.cpp
@@ -413,9 +413,9 @@ void ScanRankerReader::extractData()
     ifstream reader(srTextFile.c_str());
     
     string input;
-    getline(reader,input);
+    pwiz::util::getline(reader,input);
     while(boost::starts_with(input,"H"))
-        getline(reader,input);
+        pwiz::util::getline(reader,input);
     do
     {
         if(!input.empty())
@@ -453,7 +453,7 @@ void ScanRankerReader::extractData()
             bestTagTics.insert(make_pair(scanInfo, bestTagTIC));
         }
 
-    }while(getline(reader,input));
+    }while(pwiz::util::getline(reader,input));
 }
 
 }

--- a/pwiz_tools/Bumbershoot/quameter/quameterFileReaders.cpp
+++ b/pwiz_tools/Bumbershoot/quameter/quameterFileReaders.cpp
@@ -413,9 +413,9 @@ void ScanRankerReader::extractData()
     ifstream reader(srTextFile.c_str());
     
     string input;
-    pwiz::util::getline(reader,input);
+    getlinePortable(reader,input);
     while(boost::starts_with(input,"H"))
-        pwiz::util::getline(reader,input);
+        getlinePortable(reader,input);
     do
     {
         if(!input.empty())
@@ -453,7 +453,7 @@ void ScanRankerReader::extractData()
             bestTagTics.insert(make_pair(scanInfo, bestTagTIC));
         }
 
-    }while(pwiz::util::getline(reader,input));
+    }while(getlinePortable(reader,input));
 }
 
 }

--- a/pwiz_tools/commandline/idconvert.cpp
+++ b/pwiz_tools/commandline/idconvert.cpp
@@ -269,7 +269,7 @@ Config parseCommandLine(int argc, const char* argv[])
         while (is)
         {
             string filename;
-            getline(is, filename);
+            pwiz::util::getline(is, filename);
             if (is) config.filenames.push_back(filename);
         }
     }

--- a/pwiz_tools/commandline/idconvert.cpp
+++ b/pwiz_tools/commandline/idconvert.cpp
@@ -269,7 +269,7 @@ Config parseCommandLine(int argc, const char* argv[])
         while (is)
         {
             string filename;
-            pwiz::util::getline(is, filename);
+            getlinePortable(is, filename);
             if (is) config.filenames.push_back(filename);
         }
     }

--- a/pwiz_tools/commandline/msaccess.cpp
+++ b/pwiz_tools/commandline/msaccess.cpp
@@ -81,7 +81,7 @@ void initializeAnalyzers(MSDataAnalyzerContainer& analyzers,
         string name, args;
         istringstream iss(*it);
         iss >> name;
-        pwiz::util::getline(iss, args);
+        getlinePortable(iss, args);
 
         if (supportedAnalyzer(name, analyzer_strings<MetadataReporter>::id()))
         {

--- a/pwiz_tools/commandline/msaccess.cpp
+++ b/pwiz_tools/commandline/msaccess.cpp
@@ -81,7 +81,7 @@ void initializeAnalyzers(MSDataAnalyzerContainer& analyzers,
         string name, args;
         istringstream iss(*it);
         iss >> name;
-        getline(iss, args);
+        pwiz::util::getline(iss, args);
 
         if (supportedAnalyzer(name, analyzer_strings<MetadataReporter>::id()))
         {

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -521,7 +521,7 @@ Config parseCommandLine(int argc, char** argv)
         while (is)
         {
             string filename;
-            getline(is, filename);
+            pwiz::util::getline(is, filename);
             if (is) config.filenames.push_back(filename);
         }
     }

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -521,7 +521,7 @@ Config parseCommandLine(int argc, char** argv)
         while (is)
         {
             string filename;
-            pwiz::util::getline(is, filename);
+            getlinePortable(is, filename);
             if (is) config.filenames.push_back(filename);
         }
     }

--- a/pwiz_tools/commandline/mspicture.cpp
+++ b/pwiz_tools/commandline/mspicture.cpp
@@ -296,7 +296,7 @@ Config parseCommandArgs(int argc, const char* argv[])
         std::ifstream is(config.configFilename.c_str());
         ostringstream oss;
         string line;
-        while(getline(is, line).good())
+        while(pwiz::util::getline(is, line).good())
             oss << line << " ";
 
         config.pseudo2dConfig.process(oss.str());

--- a/pwiz_tools/commandline/mspicture.cpp
+++ b/pwiz_tools/commandline/mspicture.cpp
@@ -296,7 +296,7 @@ Config parseCommandArgs(int argc, const char* argv[])
         std::ifstream is(config.configFilename.c_str());
         ostringstream oss;
         string line;
-        while(pwiz::util::getline(is, line).good())
+        while(getlinePortable(is, line).good())
             oss << line << " ";
 
         config.pseudo2dConfig.process(oss.str());

--- a/pwiz_tools/commandline/peakaboo.cpp
+++ b/pwiz_tools/commandline/peakaboo.cpp
@@ -330,7 +330,7 @@ Config parseCommandLine(int argc, const char* argv[])
         while (is)
         {
             string filename;
-            getline(is, filename);
+            pwiz::util::getline(is, filename);
             if (is) config.filenames.push_back(filename);
         }
     }

--- a/pwiz_tools/commandline/peakaboo.cpp
+++ b/pwiz_tools/commandline/peakaboo.cpp
@@ -330,7 +330,7 @@ Config parseCommandLine(int argc, const char* argv[])
         while (is)
         {
             string filename;
-            pwiz::util::getline(is, filename);
+            getlinePortable(is, filename);
             if (is) config.filenames.push_back(filename);
         }
     }

--- a/pwiz_tools/commandline/tab2mzid.cpp
+++ b/pwiz_tools/commandline/tab2mzid.cpp
@@ -115,7 +115,7 @@ bool loadFile(Config& config)
     {
         string line;
     
-        while(pwiz::util::getline(in, line))
+        while(getlinePortable(in, line))
         {
             record rec;
             boost::char_separator<char> sep("\t");

--- a/pwiz_tools/commandline/tab2mzid.cpp
+++ b/pwiz_tools/commandline/tab2mzid.cpp
@@ -115,7 +115,7 @@ bool loadFile(Config& config)
     {
         string line;
     
-        while(getline(in, line))
+        while(pwiz::util::getline(in, line))
         {
             record rec;
             boost::char_separator<char> sep("\t");

--- a/pwiz_tools/common/MSDataAnalyzerApplication.cpp
+++ b/pwiz_tools/common/MSDataAnalyzerApplication.cpp
@@ -152,7 +152,7 @@ PWIZ_API_DECL MSDataAnalyzerApplication::MSDataAnalyzerApplication(int argc, con
         while (is)
         {
             string filename;
-            getline(is, filename);
+            pwiz::util::getline(is, filename);
             if (is) filenames.push_back(filename);
         }
     }

--- a/pwiz_tools/common/MSDataAnalyzerApplication.cpp
+++ b/pwiz_tools/common/MSDataAnalyzerApplication.cpp
@@ -152,7 +152,7 @@ PWIZ_API_DECL MSDataAnalyzerApplication::MSDataAnalyzerApplication(int argc, con
         while (is)
         {
             string filename;
-            pwiz::util::getline(is, filename);
+            getlinePortable(is, filename);
             if (is) filenames.push_back(filename);
         }
     }

--- a/pwiz_tools/examples/txt2mzml.cpp
+++ b/pwiz_tools/examples/txt2mzml.cpp
@@ -87,7 +87,7 @@ void txt2mzml(const char* filenameIn, const char* filenameOut)
         // parse stream one line at a time 
 
         string buffer;
-        getline(is, buffer);
+        pwiz::util::getline(is, buffer);
 
         // if we're done, flush one last time and break
 

--- a/pwiz_tools/examples/txt2mzml.cpp
+++ b/pwiz_tools/examples/txt2mzml.cpp
@@ -87,7 +87,7 @@ void txt2mzml(const char* filenameIn, const char* filenameOut)
         // parse stream one line at a time 
 
         string buffer;
-        pwiz::util::getline(is, buffer);
+        getlinePortable(is, buffer);
 
         // if we're done, flush one last time and break
 

--- a/pwiz_tools/prototype/peptide2formula.cpp
+++ b/pwiz_tools/prototype/peptide2formula.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
 
     ifstream peptideFile(argv[1]);
     string sequence;
-    while (getline(peptideFile, sequence))
+    while (pwiz::util::getline(peptideFile, sequence))
     {
         Peptide peptide(sequence);
         cout << sequence << '\t' << peptide.formula() << '\n';

--- a/pwiz_tools/prototype/peptide2formula.cpp
+++ b/pwiz_tools/prototype/peptide2formula.cpp
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
 
     ifstream peptideFile(argv[1]);
     string sequence;
-    while (pwiz::util::getline(peptideFile, sequence))
+    while (getlinePortable(peptideFile, sequence))
     {
         Peptide peptide(sequence);
         cout << sequence << '\t' << peptide.formula() << '\n';


### PR DESCRIPTION
* fixed using declaration for bnw::system causing VS2019 ambiguity compile error even with all calls fully qualified (need to switch to a linting technique instead)
* fixed unnecessary inclusion of gzio.c in zlib
* added `pwiz::util::getline()` for convenient handling of DOS-style line endings on *nix; replaced most uses of `std::getline()` with `pwiz::util::getline()` (except where byte counting is important)

@bspratt The line ending thing plagued me when I ran pwiz tests on GCC (via Linux Docker containers running on my Windows 10 PC) on a git repo I checked out on Windows (so auto-CRLF setting gave the non-binary files CRLF endings). I was annoyed at being annoyed by this issue in 2021, so I fixed it everywhere in pwiz. Other than the byte-counting caveat I've documented, can you think of any negative consequences for us of silently dropping `\r` from the end of newline-delimited lines?