### PR TITLE
Fix mismatch between color of annotations and lines on small molecule library explorer graph

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/SpectrumGraphItem.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SpectrumGraphItem.cs
@@ -141,13 +141,17 @@ namespace pwiz.Skyline.Controls.Graphs
         private FontSpec _fontSpecPrecursor;
         private FontSpec FONT_SPEC_Z { get { return GetFontSpec(IonTypeExtension.GetTypeColor(IonType.z), ref _fontSpecZ); } }
         private FontSpec _fontSpecOtherIons;
-        private FontSpec FONT_SPEC_OTHER_IONS { get { return GetFontSpec(IonTypeExtension.GetTypeColor(IonType.a), ref _fontSpecOtherIons); } } // Small molecule fragments etc
         private FontSpec _fontSpecNone;
         private FontSpec FONT_SPEC_NONE { get { return GetFontSpec(IonTypeExtension.GetTypeColor(null), ref _fontSpecNone); } }
         private FontSpec _fontSpecSelected;
         private FontSpec FONT_SPEC_SELECTED { get { return GetFontSpec(COLOR_SELECTED, ref _fontSpecSelected); } }
         // ReSharper restore InconsistentNaming
 
+        // The color of small molecule fragments and other non-peptide ions depends upon their library rank
+        private FontSpec GetOtherIonsFontSpec(int rank = 0)
+        {
+            return GetFontSpec(IonTypeExtension.GetTypeColor(IonType.custom, rank), ref _fontSpecOtherIons);
+        }
         protected AbstractSpectrumGraphItem(LibraryRankedSpectrumInfo spectrumInfo)
         {
             SpectrumInfo = spectrumInfo;
@@ -269,7 +273,7 @@ namespace pwiz.Skyline.Controls.Graphs
                     {
                     if (rmi.Rank == 0 && !rmi.HasAnnotations)
                         return null; // Small molecule fragments - only force annotation if ranked
-                    fontSpec = FONT_SPEC_OTHER_IONS;
+                    fontSpec = GetOtherIonsFontSpec(rmi.Rank);
                     }
                     break;
                 case IonType.precursor: fontSpec = FONT_SPEC_PRECURSOR; break;
@@ -293,7 +297,7 @@ namespace pwiz.Skyline.Controls.Graphs
                     yield return GetLabel(rmi);
             }
         }
-       
+
         private string GetLabel(LibraryRankedSpectrumInfo.RankedMI rmi)
         {
             // Show the m/z values in the labels, if multiple should be visible, and

--- a/pwiz_tools/Skyline/Controls/Graphs/SpectrumGraphItem.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SpectrumGraphItem.cs
@@ -297,7 +297,7 @@ namespace pwiz.Skyline.Controls.Graphs
                     yield return GetLabel(rmi);
             }
         }
-
+       
         private string GetLabel(LibraryRankedSpectrumInfo.RankedMI rmi)
         {
             // Show the m/z values in the labels, if multiple should be visible, and

--- a/pwiz_tools/Skyline/Controls/Graphs/SpectrumGraphItem.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SpectrumGraphItem.cs
@@ -147,7 +147,7 @@ namespace pwiz.Skyline.Controls.Graphs
         private FontSpec FONT_SPEC_SELECTED { get { return GetFontSpec(COLOR_SELECTED, ref _fontSpecSelected); } }
         // ReSharper restore InconsistentNaming
 
-        // The color of small molecule fragments and other non-peptide ions depends upon their library rank
+        // Consider the rank of small molecule fragments when selecting the color for the FontSpec
         private FontSpec GetOtherIonsFontSpec(int rank = 0)
         {
             return GetFontSpec(IonTypeExtension.GetTypeColor(IonType.custom, rank), ref _fontSpecOtherIons);

--- a/pwiz_tools/Skyline/TestFunctional/LibraryExplorerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryExplorerTest.cs
@@ -683,7 +683,7 @@ namespace pwiz.SkylineTestFunctional
             foreach (var annotation in from item in graphControl.GraphPane.CurveList let info = item.Tag as IMSGraphItemExtended from pt in (MSPointList) 
                 item.Points select info.AnnotatePoint(pt) into annotation where annotation != null where annotation.ZOrder != null select annotation)
             {
-                Assert.AreEqual(annotation.FontSpec,
+                Assert.AreEqual(annotation.FontSpec.FontColor,
                     IonTypeExtension.GetTypeColor(IonType.custom, annotation.ZOrder.Value));
             }
 

--- a/pwiz_tools/Skyline/TestFunctional/LibraryExplorerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryExplorerTest.cs
@@ -678,7 +678,7 @@ namespace pwiz.SkylineTestFunctional
                 return;
             }
             
-            // Verify that graph items with ranked ions are being annotated with the correct colors
+            // Verify that the color of annotations for ranked ions are being retrieved correctly
             var graphControl = (MSGraphControl)_viewLibUI.Controls.Find("graphControl", true).First();
             foreach (var annotation in from item in graphControl.GraphPane.CurveList let info = item.Tag as IMSGraphItemExtended from pt in (MSPointList) 
                 item.Points select info.AnnotatePoint(pt) into annotation where annotation != null where annotation.ZOrder != null select annotation)

--- a/pwiz_tools/Skyline/TestFunctional/LibraryExplorerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryExplorerTest.cs
@@ -23,6 +23,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.MSGraph;
 using pwiz.Skyline.Alerts;
 using pwiz.Skyline.Controls.SeqNode;
 using pwiz.Skyline.Model;
@@ -676,6 +677,16 @@ namespace pwiz.SkylineTestFunctional
                 WaitForClosedForm(_viewLibUI);
                 return;
             }
+            
+            // Verify that graph items with ranked ions are being annotated with the correct colors
+            var graphControl = (MSGraphControl)_viewLibUI.Controls.Find("graphControl", true).First();
+            foreach (var annotation in from item in graphControl.GraphPane.CurveList let info = item.Tag as IMSGraphItemExtended from pt in (MSPointList) 
+                item.Points select info.AnnotatePoint(pt) into annotation where annotation != null where annotation.ZOrder != null select annotation)
+            {
+                Assert.AreEqual(annotation.FontSpec,
+                    IonTypeExtension.GetTypeColor(IonType.custom, annotation.ZOrder.Value));
+            }
+
             RunUI(() =>
             {
                 libComboBox = (ComboBox)_viewLibUI.Controls.Find("comboLibrary", true)[0];


### PR DESCRIPTION
In the library explorer spectrum graph, ranked small molecule fragments are colored differently than unranked small molecule fragments. However, the annotations were being colored as if all small molecule fragments were unranked. This resulted in a mismatch between the color of the lines on the graph and the color of the annotations. 

This change fixes the mismatch by considering the rank of small molecule fragments when assigning the color of annotations.