### PR TITLE
Fix problem where if "Triggered Acquisition" causes peak areas to be 60 times too small

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -1125,7 +1125,7 @@ namespace pwiz.Skyline.Model.Results
                 if (nextTime > prevTime)
                 {
                     double width = nextTime - prevTime;
-                    double area = intensity * width;
+                    double area = intensity * width * 60;
                     totalArea += area;
                     if (timeIntensities.MassErrors != null)
                     {

--- a/pwiz_tools/Skyline/Model/Results/TimeIntervals.cs
+++ b/pwiz_tools/Skyline/Model/Results/TimeIntervals.cs
@@ -26,6 +26,7 @@ namespace pwiz.Skyline.Model.Results
 {
     public class TimeIntervals
     {
+        public static readonly TimeIntervals EMPTY = FromIntervalsSorted(new KeyValuePair<float, float>[0]);
         public static TimeIntervals FromIntervals(IEnumerable<KeyValuePair<float, float>> intervals)
         {
             return FromIntervalsSorted(MergeIntervals(intervals));
@@ -39,6 +40,10 @@ namespace pwiz.Skyline.Model.Results
                 Starts = ImmutableList.ValueOf(list.Select(kvp => kvp.Key)),
                 Ends = ImmutableList.ValueOf(list.Select(kvp => kvp.Value))
             };
+        }
+
+        private TimeIntervals()
+        {
         }
 
         public ImmutableList<float> Starts { get; private set; }

--- a/pwiz_tools/Skyline/Test/ChromPeakTest.cs
+++ b/pwiz_tools/Skyline/Test/ChromPeakTest.cs
@@ -45,5 +45,25 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(8, chromPeak2.Fwhm);
             Assert.AreEqual(true, chromPeak2.IsFwhmDegenerate);
         }
+
+        [TestMethod]
+        public void TestPeakIntegrator()
+        {
+            var times = Enumerable.Range(0, 12).Select(i => i / 7f).ToList();
+            var timeIntensities = new TimeIntensities(times, Enumerable.Range(0, 12).Select(t => 36f - (t - 6) * (t - 6)), null, null);
+            var peakIntegrator = new PeakIntegrator(timeIntensities);
+            var flagValues = ChromPeak.FlagValues.time_normalized;
+            var peakStartTime = times[1];
+            var peakEndTime = times[times.Count - 2];
+            var peakWithBackground = peakIntegrator.IntegratePeak(peakStartTime, peakEndTime, flagValues);
+            Assert.AreNotEqual(0, peakWithBackground.BackgroundArea);
+
+            // Set the TimeIntervals so the peakIntegrator will use "IntegratePeakWithoutBackground" 
+            peakIntegrator.TimeIntervals = TimeIntervals.EMPTY;
+            var peakWithoutBackground = peakIntegrator.IntegratePeak(peakStartTime, peakEndTime, flagValues);
+            Assert.AreEqual(0, peakWithoutBackground.BackgroundArea);
+            var expectedArea = peakWithBackground.Area + peakWithBackground.BackgroundArea;
+            Assert.AreEqual(expectedArea, peakWithoutBackground.Area, .01);
+        }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/TriggeredAcquisitionTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/TriggeredAcquisitionTest.cs
@@ -102,6 +102,10 @@ namespace pwiz.SkylineTestFunctional
                     var triggeredChromInfo = triggeredTransitionGroup.Results[iReplicate].First();
                     Assert.AreNotEqual(0, untriggeredChromInfo.BackgroundArea);
                     Assert.AreEqual(0, triggeredChromInfo.BackgroundArea);
+
+                    var untriggeredTotalArea = untriggeredChromInfo.Area.Value + untriggeredChromInfo.BackgroundArea.Value;
+                    // The triggered and untriggered area need to be within a factor of 2 of each other.
+                    AssertEx.AreEqual(1.0, triggeredChromInfo.Area / untriggeredTotalArea, .5);
                 }
             }
         }


### PR DESCRIPTION
It "Triggered chromatogram extraction" is checked on the Transition Instrument Settings, the Area values all end up 60 times smaller than they are supposed to be.

The light:heavy ratios would still be correct, so users might not notice.

(Not reported by a user. I ran into this bug while working on a different feature).