### PR TITLE
SkylineNightly: after 30 minutes of failing to download SkylineTester .lastFinished build,…

### DIFF
--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -322,12 +322,11 @@ namespace SkylineNightly
                         LogAndThrow("Unable to download SkylineTester");
                     }
 
-                    // After 30 minutes, start alternating between lastFinished and lastSuccessful builds
-                    var initialRetryExceeded = i > 30;
-                    useLastSuccessfulInsteadOfLastFinished = initialRetryExceeded && i % 2 == 0; 
-                    if (initialRetryExceeded)
+                    // After 30 minutes, start trying for lastSuccessful build instead
+                    useLastSuccessfulInsteadOfLastFinished = i > 30; 
+                    if (useLastSuccessfulInsteadOfLastFinished)
                     {
-                        Log("Exception while downloading SkylineTester: " + ex.Message + " (TeamCity outage? Retrying every 60 seconds for an additional 90 minutes, alternating between trying for lastFinished vs lastSuccessful builds.)");
+                        Log("Exception while downloading SkylineTester: " + ex.Message + " (TeamCity outage? Retrying every 60 seconds for an additional 90 minutes, attempting download of lastSuccessful build instead of lastFinished.)");
                     }
                     else
                     {

--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -319,7 +319,7 @@ namespace SkylineNightly
                 {
                     if (i == attempts - 1)
                     {
-                        LogAndThrow("Unable to download SkylineTester");
+                        QuitWithError("Unable to download SkylineTester");
                     }
 
                     // After 30 minutes, start trying for lastSuccessful build instead
@@ -338,7 +338,7 @@ namespace SkylineNightly
 
                 // Install SkylineTester.
                 if (!InstallSkylineTester(skylineTesterZip, _skylineTesterDir))
-                    LogAndThrow("SkylineTester installation failed.");
+                    QuitWithError("SkylineTester installation failed.");
                 try
                 {
                     // Delete zip file.
@@ -368,7 +368,7 @@ namespace SkylineNightly
                     Log("Exception while unzipping SkylineTester: " + ex.Message + " (Probably still being built, will retry every 60 seconds for 30 minutes.)");
                     if (i == attempts - 1)
                     {
-                        LogAndThrow("Unable to identify branch from Version.cpp in SkylineTester");
+                        QuitWithError("Unable to identify branch from Version.cpp in SkylineTester");
                     }
                     Thread.Sleep(60 * 1000);  // one minute
                 }
@@ -381,7 +381,7 @@ namespace SkylineNightly
             {
                 if (stream == null)
                 {
-                    LogAndThrow(result = "Embedded resource is broken");
+                    QuitWithError(result = "Embedded resource is broken");
                     return result; 
                 }
                 using (var reader = new StreamReader(stream))
@@ -431,7 +431,7 @@ namespace SkylineNightly
                 var skylineTesterProcess = Process.Start(processInfo);
                 if (skylineTesterProcess == null)
                 {
-                    LogAndThrow(result = "SkylineTester did not start");
+                    QuitWithError(result = "SkylineTester did not start");
                     return result;
                 }
                 Log("SkylineTester started");
@@ -1156,11 +1156,10 @@ namespace SkylineNightly
             return timestampedMessage;
         }
 
-        private void LogAndThrow(string message)
+        private void QuitWithError(string message)
         {
-            var timestampedMessage = Log(message);
             SaveErrorScreenshot();
-            throw new Exception(timestampedMessage);
+            Finish("Quit with error",message);
         }
 
         private void SaveErrorScreenshot()


### PR DESCRIPTION
…  don't give up as we formerly did but instead go an additional 90 minutes of retrying, alternating between trying for .lastFinished vs .lastSuccessful builds.

By waiting to fail over to the potentially stale .lastSuccessful build, we get some testing done on relatively recent code while still being alerted to a problem thanks to the lower test count.