### PR TITLE
Fix transition list first line import bug

### DIFF
--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -909,6 +909,7 @@ namespace pwiz.Skyline.FileUI
         private bool CheckForErrors(bool silentSuccess)
         {
             var insertionParams = new DocumentChecked();
+            bool hasHeaders = Importer.RowReader.Indices.Headers != null;
             List<TransitionImportErrorInfo> testErrorList = null;
             var errorCheckCanceled = true;
             insertionParams.ColumnHeaderList = CurrentColumnPositions();
@@ -934,7 +935,7 @@ namespace pwiz.Skyline.FileUI
                     }
                     insertionParams.Document = _docCurrent.ImportMassList(_inputs, Importer, progressMonitor,
                         _insertPath, out insertionParams.SelectPath, out insertionParams.IrtPeptides,
-                        out insertionParams.LibrarySpectra, out testErrorList, out insertionParams.PeptideGroups, insertionParams.ColumnHeaderList, GetRadioType());
+                        out insertionParams.LibrarySpectra, out testErrorList, out insertionParams.PeptideGroups, insertionParams.ColumnHeaderList, GetRadioType(), hasHeaders);
                     errorCheckCanceled = progressMonitor.IsCanceled;
                 });
             }

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -1885,12 +1885,12 @@ namespace pwiz.Skyline.Model
     {
         private readonly DsvFileReader _csvReader;
 
-        public SmallMoleculeTransitionListCSVReader(IList<string> csvText, List<string> columnPositions = null)
+        public SmallMoleculeTransitionListCSVReader(IList<string> csvText, List<string> columnPositions = null, bool hasHeaders = true)
         {
             // Ask MassListInputs to figure out the column and decimal separators
             var inputs = new MassListInputs(csvText);
             _cultureInfo = inputs.FormatProvider;
-            _csvReader = new DsvFileReader(new StringListReader(csvText), inputs.Separator, SmallMoleculeTransitionListColumnHeaders.KnownHeaderSynonyms, columnPositions);
+            _csvReader = new DsvFileReader(new StringListReader(csvText), inputs.Separator, SmallMoleculeTransitionListColumnHeaders.KnownHeaderSynonyms, columnPositions, hasHeaders);
             // Do we recognize all the headers?
             var badHeaders =
                 _csvReader.FieldNames.Where(

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -1396,13 +1396,14 @@ namespace pwiz.Skyline.Model
             MassListImporter importer, 
             IdentityPath to, 
             out IdentityPath firstAdded,
-            List<string> columnPositions = null)
+            List<string> columnPositions = null,
+            bool hasHeaders = true)
         {
             List<MeasuredRetentionTime> irtPeptides;
             List<SpectrumMzInfo> librarySpectra;
             List<TransitionImportErrorInfo> errorList;
             List<PeptideGroupDocNode> peptideGroups;
-            return ImportMassList(inputs, importer, null, to, out firstAdded, out irtPeptides, out librarySpectra, out errorList, out peptideGroups, columnPositions);
+            return ImportMassList(inputs, importer, null, to, out firstAdded, out irtPeptides, out librarySpectra, out errorList, out peptideGroups, columnPositions, DOCUMENT_TYPE.none, hasHeaders);
         }
 
         public SrmDocument ImportMassList(MassListInputs inputs,
@@ -1427,7 +1428,8 @@ namespace pwiz.Skyline.Model
                                           out List<TransitionImportErrorInfo> errorList,
                                           out List<PeptideGroupDocNode> peptideGroups,
                                           List<string> columnPositions = null,
-                                          DOCUMENT_TYPE radioType = DOCUMENT_TYPE.none)
+                                          DOCUMENT_TYPE radioType = DOCUMENT_TYPE.none,
+                                          bool hasHeaders = true)
         {
             irtPeptides = new List<MeasuredRetentionTime>();
             librarySpectra = new List<SpectrumMzInfo>();
@@ -1443,7 +1445,7 @@ namespace pwiz.Skyline.Model
                 try
                 {
                     var lines = inputs.ReadLines(progressMonitor);
-                    var reader = new SmallMoleculeTransitionListCSVReader(lines, columnPositions);
+                    var reader = new SmallMoleculeTransitionListCSVReader(lines, columnPositions, hasHeaders);
                     docNew = reader.CreateTargets(this, to, out firstAdded);
                 }
                 catch (LineColNumberedIoException x)

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -1882,6 +1882,7 @@ namespace pwiz.Skyline
             IdentityPath selectPath = null;
             bool isSmallMoleculeList = true;
             bool useColSelectDlg = true;
+            bool hasHeaders = false;
             List<MeasuredRetentionTime> irtPeptides = new List<MeasuredRetentionTime>();
             List<SpectrumMzInfo> librarySpectra = new List<SpectrumMzInfo>();
             List<TransitionImportErrorInfo> errorList = new List<TransitionImportErrorInfo>();
@@ -1907,7 +1908,7 @@ namespace pwiz.Skyline
                     return;
                 }
             }
-
+            hasHeaders = importer.RowReader.Indices.Headers != null;
             if (importer.InputType == SrmDocument.DOCUMENT_TYPE.small_molecules)
             {
                 List<TransitionImportErrorInfo> testErrorList = new List<TransitionImportErrorInfo>();
@@ -1947,7 +1948,7 @@ namespace pwiz.Skyline
                 {
                     docCurrent = docCurrent.ImportMassList(inputs, importer, null,
                         insertPath, out selectPath, out irtPeptides, out librarySpectra, out errorList,
-                        out peptideGroups, columnPositions);
+                        out peptideGroups, columnPositions, SrmDocument.DOCUMENT_TYPE.none, hasHeaders);
                 }
                
             }
@@ -2029,11 +2030,11 @@ namespace pwiz.Skyline
                     // If the document was changed during the operation, try all the changes again
                     // using the information given by the user.
                     docCurrent = DocumentUI;
-                    doc = doc.ImportMassList(inputs, importer, insertPath, out selectPath, columnPositions);
+                    doc = doc.ImportMassList(inputs, importer, insertPath, out selectPath, columnPositions, hasHeaders);
                     if (irtInputs != null)
                     {
                         var iRTimporter = doc.PreImportMassList(irtInputs, null, false);
-                        doc = doc.ImportMassList(irtInputs, iRTimporter, null, out selectPath, columnPositions);
+                        doc = doc.ImportMassList(irtInputs, iRTimporter, null, out selectPath, columnPositions, hasHeaders);
                     }
                     var newSettings = doc.Settings;
                     if (retentionTimeRegressionStore != null)

--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -110,7 +110,8 @@ namespace pwiz.SkylineTestFunctional
         {
             var docEmpty = NewDocument();
 
-            TestImportAllData();
+            TestImportAllData(true);
+            TestImportAllData(false);
             TestInconsistentMoleculeDescriptions();
             TestProductNeutralLoss();
             TestUnsortedMzPrecursors();
@@ -1732,10 +1733,10 @@ namespace pwiz.SkylineTestFunctional
             //OkDialog(messageDlg, messageDlg.AcceptButton.PerformClick); // Acknowledge the error
         }
 
-        void TestImportAllData()
+        void TestImportAllData(bool asFile)
         {
             // Check that we are importing all the data in the case where there is not a header line provided
-            var input =
+            var inputNoHeaders =
                 "Amino Acids B,AlaB,,light,,,225.1,44,-1,-1,3\n" +
                 "Amino Acids B,ArgB,,light,,,310.2,217,-1,-1,19\n" +
                 "Amino Acids,Ala,,light,,,225,44,1,1,3\n" +
@@ -1748,34 +1749,83 @@ namespace pwiz.SkylineTestFunctional
                 "Amino Acids B,ArgB,,light,,,310.2,218,-1,-1,19\n" +
                 "Amino Acids B,ArgB,,heavy,,,312,219,-1,-1,19\n" +
                 "Amino Acids B,ArgB,,heavy,,,312,220,-1,-1,19\n";
-            var docOrig = NewDocument();
-            SetClipboardText(input);
+            for (var pass = 0; pass < 2; pass++) 
+            {
+                var withHeaders = pass == 1;     // Double check that headers work too
 
-            // Paste directly into targets area, which should send us to ColumnSelectDlg
-            var testImportDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => SkylineWindow.Paste());
-            WaitForDocumentLoaded();
-            // Correct the header assignments
-            RunUI(() => {
-                testImportDlg.radioMolecule.PerformClick();
-                var comboBoxes = testImportDlg.ComboBoxes;
-                comboBoxes[0].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_List_Name);
-                comboBoxes[1].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_Name);
-                comboBoxes[2].SelectedIndex = comboBoxes[1].FindStringExact(Resources.PasteDlg_UpdateMoleculeType_Product_Name);
-                comboBoxes[3].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Label_Type);
-                comboBoxes[4].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_headerList_Molecular_Formula);
-                comboBoxes[5].SelectedIndex = comboBoxes[1].FindStringExact(Resources.PasteDlg_UpdateMoleculeType_Product_Formula);
-                comboBoxes[6].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z);
-                comboBoxes[7].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z);
-                comboBoxes[8].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_Charge);
-                comboBoxes[9].SelectedIndex = comboBoxes[1].FindStringExact(Resources.PasteDlg_UpdateMoleculeType_Product_Charge);
-                comboBoxes[10].SelectedIndex = comboBoxes[1].FindStringExact(Resources.PasteDlg_UpdateMoleculeType_Explicit_Retention_Time);
-            });
-            
-            // Import the list
-            OkDialog(testImportDlg, testImportDlg.OkDialog);
-            var pastedDoc = WaitForDocumentChange(docOrig);
-            AssertEx.IsDocumentState(pastedDoc, null, 2, 4, 8, 12);
+                var input = withHeaders ?
+                    string.Join(",", new string[]
+                    {
+                        SmallMoleculeTransitionListColumnHeaders.moleculeGroup,
+                        SmallMoleculeTransitionListColumnHeaders.namePrecursor,
+                        SmallMoleculeTransitionListColumnHeaders.nameProduct,
+                        SmallMoleculeTransitionListColumnHeaders.labelType,
+                        SmallMoleculeTransitionListColumnHeaders.formulaPrecursor,
+                        SmallMoleculeTransitionListColumnHeaders.formulaProduct,
+                        SmallMoleculeTransitionListColumnHeaders.mzPrecursor,
+                        SmallMoleculeTransitionListColumnHeaders.mzProduct,
+                        SmallMoleculeTransitionListColumnHeaders.chargePrecursor,
+                        SmallMoleculeTransitionListColumnHeaders.chargeProduct,
+                        SmallMoleculeTransitionListColumnHeaders.rtPrecursor,
+                    }) + "\n" + inputNoHeaders :
+                    inputNoHeaders; 
+
+                var docOrig = NewDocument();
+
+                var tempFile = TestFilesDir.GetTestPath(string.Format("transitions_tmp{0}.csv", pass));
+                if (asFile)
+                {
+                    File.WriteAllText(tempFile, input);
+                }
+                else
+                {
+                    SetClipboardText(input);
+                }
+
+                if (withHeaders)
+                {
+                    // With headers, should be no need for header selection
+                    if (asFile)
+                    {
+                        RunUI(() => SkylineWindow.ImportMassList(tempFile));
+                    }
+                    else
+                    {
+                        RunUI(() => SkylineWindow.Paste());
+                    }
+                }
+                else
+                {
+                    var testImportDlg = asFile ?
+                        // Import the file, which should send us to ColumnSelectDlg
+                        ShowDialog<ImportTransitionListColumnSelectDlg>(() => SkylineWindow.ImportMassList(tempFile)) :
+                        // Paste directly into targets area, which should send us to ColumnSelectDlg
+                        ShowDialog<ImportTransitionListColumnSelectDlg>(() => SkylineWindow.Paste());
+                    WaitForDocumentLoaded();
+                    // Correct the header assignments
+                    RunUI(() => {
+                        testImportDlg.radioMolecule.PerformClick();
+                        var comboBoxes = testImportDlg.ComboBoxes;
+                        comboBoxes[0].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_List_Name);
+                        comboBoxes[1].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_Name);
+                        comboBoxes[2].SelectedIndex = comboBoxes[1].FindStringExact(Resources.PasteDlg_UpdateMoleculeType_Product_Name);
+                        comboBoxes[3].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Label_Type);
+                        comboBoxes[4].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_headerList_Molecular_Formula);
+                        comboBoxes[5].SelectedIndex = comboBoxes[1].FindStringExact(Resources.PasteDlg_UpdateMoleculeType_Product_Formula);
+                        comboBoxes[6].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z);
+                        comboBoxes[7].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z);
+                        comboBoxes[8].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_Charge);
+                        comboBoxes[9].SelectedIndex = comboBoxes[1].FindStringExact(Resources.PasteDlg_UpdateMoleculeType_Product_Charge);
+                        comboBoxes[10].SelectedIndex = comboBoxes[1].FindStringExact(Resources.PasteDlg_UpdateMoleculeType_Explicit_Retention_Time);
+                    });
+                
+                    // Import the list
+                    OkDialog(testImportDlg, testImportDlg.OkDialog);
+                }
+                var pastedDoc = WaitForDocumentChange(docOrig);
+                AssertEx.IsDocumentState(pastedDoc, null, 2, 4, 8, 12);
+            }
+           
         }
-
     }
 }

--- a/pwiz_tools/Skyline/Util/Extensions/Text.cs
+++ b/pwiz_tools/Skyline/Util/Extensions/Text.cs
@@ -719,9 +719,9 @@ namespace pwiz.Skyline.Util.Extensions
             Initialize(reader, separator, hasHeaders);
         }
 
-        public DsvFileReader(TextReader reader, char separator, IReadOnlyDictionary<string, string> headerSynonyms, List<string> columnPositions = null)
+        public DsvFileReader(TextReader reader, char separator, IReadOnlyDictionary<string, string> headerSynonyms, List<string> columnPositions = null, bool hasHeaders = true)
         {
-            Initialize(reader, separator, true, headerSynonyms, columnPositions);
+            Initialize(reader, separator, hasHeaders, headerSynonyms, columnPositions);
         }
 
         public void Initialize(TextReader reader, char separator, bool hasHeaders = true, IReadOnlyDictionary<string, string> headerSynonyms = null, List<string> columnPositions = null)
@@ -731,8 +731,9 @@ namespace pwiz.Skyline.Util.Extensions
             FieldNames = new List<string>();
             FieldDict = new Dictionary<string, int>();
             _titleLine = _reader.ReadLine(); // we will re-use this if it's not actually a header line
+            string saveTitleLine = _titleLine; // because we can overwrite the first line and might want to use it later, save it
             _rereadTitleLine = !hasHeaders; // tells us whether or not to reuse the supposed header line on first read
-            if (columnPositions != null && !_rereadTitleLine)
+            if (columnPositions != null)
             {
                 userHeaders = TextUtil.TextSeparate(separator.ToString(), columnPositions);
                 // userHeaders = userHeaders.Replace(@" ", string.Empty);
@@ -740,7 +741,7 @@ namespace pwiz.Skyline.Util.Extensions
             }
             var fields = _titleLine.ParseDsvFields(separator);
             NumberOfFields = fields.Length;
-            if (!hasHeaders)
+            if (!hasHeaders && columnPositions == null)
             {
                 // that wasn't really the header line, we just used it to get column count
                 // replace with made up column names
@@ -769,6 +770,7 @@ namespace pwiz.Skyline.Util.Extensions
                     }
                 }
             }
+            _titleLine = saveTitleLine;
         }
 
         /// <summary>


### PR DESCRIPTION
A fix for a bug where the first line of a transition list was not imported in the case where the transition list did not contain a header row