### PR TITLE
Build system fixes

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -179,7 +179,12 @@ rule without-binary-msdata ( properties * )
    }
 }
 
-if [ modules.peek : NT ]
+local default_build_path = [ MATCH --build-path=(.*) : [ modules.peek : ARGV ] ] ;
+if $(default_build_path)
+{
+    path-constant PWIZ_BUILD_PATH : $(default_build_path) ;
+}
+else if [ modules.peek : NT ]
 {
     path-constant PWIZ_BUILD_PATH : build-nt-x86 ; # force x86 since .NET projects assume that location
 }

--- a/libraries/boost-build/src/tools/msvc.jam
+++ b/libraries/boost-build/src/tools/msvc.jam
@@ -1716,7 +1716,7 @@ local rule configure-really ( version ? : options * )
                     vcvarsall.bat ] ;
             }
 
-            local default-setup-amd64 = vcvarsx86_amd64.bat ;
+            local default-setup-amd64 = vcvars64.bat ;
             local default-setup-i386  = vcvars32.bat ;
             local default-setup-ia64  = vcvarsx86_ia64.bat ;
             local default-setup-arm   = vcvarsx86_arm.bat ;


### PR DESCRIPTION
* added --build-path option to allow overriding PWIZ_BUILD_PATH (using non-default value will still break SeeMS and MSConvertGUI but it's still useful)
* fixed MSVC not using 64-bit tooling on 64-bit hosts (hopefully this will fix the debug build issues happening with VS 2019; it seemed to fix them on my local machine)