### PR TITLE
Add a little more information to TestZedGraphClipboard 

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/ZedGraphClipboardTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ZedGraphClipboardTest.cs
@@ -73,7 +73,16 @@ namespace pwiz.SkylineTestFunctional
             ClipboardEx.UseInternalClipboard(false);
             RunUI(() =>
             {
-                Clipboard.SetText("hello");
+                try
+                {
+                    Clipboard.SetText("hello");
+                }
+                catch (Exception e)
+                {
+                    string clipboardMessage = ClipboardHelper.GetCopyErrorMessage();
+                    throw new AssertFailedException(clipboardMessage, e);
+                }
+
                 Assert.IsTrue(HasClipboardFormat(DataFormats.Text));
                 Assert.IsFalse(HasClipboardFormat(DataFormats.Bitmap));
                 Assert.IsFalse(HasClipboardFormat(DataFormats.EnhancedMetafile));


### PR DESCRIPTION
Add information to the exception that gets thrown by TestZedGraphClipboard to try to track down intermittent nightly failure.
