### PR TITLE
Still trying to fix intermittent failure in TestZedGraphClipboard.

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/ZedGraphClipboardTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ZedGraphClipboardTest.cs
@@ -75,11 +75,11 @@ namespace pwiz.SkylineTestFunctional
             {
                 try
                 {
-                    Clipboard.SetText("hello");
+                    Clipboard.SetDataObject("hello");
                 }
-                catch (Exception e)
+                catch (ExternalException e)
                 {
-                    string clipboardMessage = ClipboardHelper.GetCopyErrorMessage();
+                    string clipboardMessage = ClipboardHelper.GetCopyErrorMessage() + " HResult:" + e.HResult;
                     throw new AssertFailedException(clipboardMessage, e);
                 }
 


### PR DESCRIPTION
There was a StackOverflow page that said that maybe calling "Clipboard.SetDataObject" might work more reliably than "Clipboard.SetText".