### PR TITLE
- added precursor charge state for Bruker BAF files

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/Baf2Sql.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/Baf2Sql.cpp
@@ -123,8 +123,10 @@ Baf2SqlImpl::Baf2SqlImpl(const string& rawpath) : rawpath_(rawpath), bafFilepath
                         "ProfileMzId, ProfileIntensityId, LineMzId, LineIntensityId, "
                         "Parent, Mass, IsolationType, ReactionType, ScanMode "
                         ", IFNULL(iw.Value, 0) AS IsolationWidth "
+                        ", IFNULL(cs.Value, 0) AS ChargeState "
                         "FROM Spectra s, AcquisitionKeys ak "
                         "LEFT JOIN PerSpectrumVariables iw ON iw.Spectrum=s.Id AND iw.Variable=8 "
+                        "LEFT JOIN PerSpectrumVariables cs ON cs.Spectrum=s.Id AND cs.Variable=6 "
                         "LEFT JOIN Steps step ON s.Id=TargetSpectrum "
                         "WHERE ak.Id=s.AcquisitionKey "
                         "ORDER BY Rt");
@@ -168,6 +170,7 @@ Baf2SqlImpl::Baf2SqlImpl(const string& rawpath) : rawpath_(rawpath), bafFilepath
         optional<int> reactionMode(row.get<optional<int> >(++idx));
         int scanMode = row.get<int>(++idx);
         optional<double> isolationWidth(row.get<optional<double> >(++idx));
+        optional<int> precursorCharge(row.get<optional<int> >(++idx));
 
         tic_->times.push_back(rt);
         bpi_->times.push_back(rt);
@@ -186,7 +189,7 @@ Baf2SqlImpl::Baf2SqlImpl(const string& rawpath) : rawpath_(rawpath), bafFilepath
                                                                 msLevel, rt, segment, ak, startMz, endMz,
                                                                 tic, bpi, polarity, scanMode,
                                                                 profileMzId, profileIntensityId, lineMzId, lineIntensityId,
-                                                                parentId, precursorMz, isolationMode, reactionMode, isolationWidth)));
+                                                                parentId, precursorMz, isolationMode, reactionMode, isolationWidth, precursorCharge)));
     }
 
     sqlite::query properties(db, "SELECT Key, Value FROM Properties");
@@ -264,11 +267,12 @@ Baf2SqlSpectrum::Baf2SqlSpectrum(BinaryStoragePtr storage, int index,
                                  const optional<uint64_t>& lineMzarrayId, const optional<uint64_t>& lineIntensityArrayId,
                                  const optional<uint64_t>& parentId, const optional<double>& precursorMz,
                                  const optional<int>& isolationMode, const optional<int>& reactionMode,
-                                 const optional<double>& isolationWidth)
+                                 const optional<double>& isolationWidth,
+                                 const optional<int>& precursorCharge)
     : index_(index), msLevel_(msLevel), rt_(rt), segment_(segment), acqKey_(acqKey), parentId_(parentId), tic_(tic), bpi_(bpi),
       profileMzArrayId_(profileMzArrayId), profileIntensityArrayId_(profileIntensityArrayId),
       lineMzArrayId_(lineMzarrayId), lineIntensityArrayId_(lineIntensityArrayId),
-      polarity_(polarity), scanRange_(startMz, endMz),
+      polarity_(polarity), scanRange_(startMz, endMz), chargeState_(precursorCharge),
       isolationMode_(isolationMode), reactionMode_(reactionMode), precursorMz_(precursorMz), scanMode_(scanMode),
       isolationWidth_(isolationWidth),
       storage_(storage)

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/Baf2Sql.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/Baf2Sql.hpp
@@ -59,7 +59,8 @@ struct PWIZ_API_DECL Baf2SqlSpectrum : public MSSpectrum
                     const optional<uint64_t>& lineMzarrayId, const optional<uint64_t>& lineIntensityArrayId,
                     const optional<uint64_t>& parentId, const optional<double>& precursorMz,
                     const optional<int>& isolationMode, const optional<int>& reactionMode,
-                    const optional<double>& isolationWidth);
+                    const optional<double>& isolationWidth,
+                    const optional<int>& precursorCharge);
 
     virtual ~Baf2SqlSpectrum() {}
 


### PR DESCRIPTION
- added precursor charge state for Bruker BAF files (tested locally but I don't have any small datasets with non-zero charge states to add for an automated test)

Reported by Anna Popova