### PR TITLE
Fix retry code in ZedGraphClipboardTest so that it closes the error m…

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/ZedGraphClipboardTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ZedGraphClipboardTest.cs
@@ -134,6 +134,7 @@ namespace pwiz.SkylineTestFunctional
                 var alertDlg = FindOpenForm<AlertDlg>();
                 Assert.IsNotNull(alertDlg);
                 Console.Out.WriteLine("Failed, found message {0}, Retry #{1}", alertDlg.Message, retry);
+                OkDialog(alertDlg, alertDlg.OkDialog);
             }
         }
 


### PR DESCRIPTION
…essage dialog before retrying the action.