### PR TITLE
Use <nobr> tags in Command Line documentation HTML instead of non-breaking hyphen &#8209;

### DIFF
--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -2557,10 +2557,32 @@ namespace pwiz.Skyline
                 // ReSharper restore LocalizableElement
             }
 
+            // Regular expression for an argument: a hyphen surrounded by zero or more word characters
+            // (i.e. letters, numbers or punctuation connector) or hyphens
+            private static readonly Regex REGEX_ARGUMENT = new Regex("[\\w-]*-[\\w-]*");
+            /// <summary>
+            /// HTML encodes the string.
+            /// Also, puts &lt;nobr> tags around everything that contains a hyphen so that arguments do not get broken across lines.
+            /// </summary>
             private static string HtmlEncode(string str)
             {
-                string encodedText = HttpUtility.HtmlEncode(str ?? string.Empty);
-                return encodedText.Replace(@"-", @"&#8209;");   // Use non-breaking hyphens
+                str = str ?? string.Empty;
+                var result = new StringBuilder();
+                int charIndex = 0;
+                var matchCollection = REGEX_ARGUMENT.Matches(str);
+                foreach (Match match in matchCollection)
+                {
+                    result.Append(HttpUtility.HtmlEncode(str.Substring(charIndex, match.Index - charIndex)));
+                    // ReSharper disable LocalizableElement
+                    result.Append("<nobr>");
+                    result.Append(HttpUtility.HtmlEncode(match.Value));
+                    result.Append("</nobr>");
+                    // ReSharper restore LocalizableElement
+                    charIndex = match.Index + match.Length;
+                }
+
+                result.Append(HttpUtility.HtmlEncode(str.Substring(charIndex)));
+                return result.ToString();
             }
         }
 

--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -2558,11 +2558,12 @@ namespace pwiz.Skyline
             }
 
             // Regular expression for an argument: a hyphen surrounded by zero or more word characters
-            // (i.e. letters, numbers or punctuation connector) or hyphens
-            private static readonly Regex REGEX_ARGUMENT = new Regex("[\\w-]*-[\\w-]*");
+            // (i.e. letters, numbers or UnicodeCategory.ConnectorPunctuation) or hyphens
+            private static readonly Regex REGEX_ARGUMENT = new Regex("[\\w-]*-[\\w-]*",
+                RegexOptions.Compiled | RegexOptions.CultureInvariant);
             /// <summary>
             /// HTML encodes the string.
-            /// Also, puts &lt;nobr> tags around everything that contains a hyphen so that arguments do not get broken across lines.
+            /// Also, puts &lt;nobr> tags around everything that contains a hyphen so that argument names do not get broken across lines.
             /// </summary>
             private static string HtmlEncode(string str)
             {


### PR DESCRIPTION
When Skyline is displaying the command-line documentation window ("Help > Documentation > Command Line"), Skyline replaces all of the "-" characters with "&amp;#8209;" (non-breaking hyphen "&#8209;") so that the argument names do not wrap when you look at them in the Documentation Viewer window.

This causes problems if you try to use Ctrl+F to find and you are looking for something like "--refine".
Also, if you select all and copy and paste into Notepad++, those non-breaking hyphens turn into boxes.

This change makes it so that the text remains the same, but those argument names get surrounded with "&lt;nobr>&lt;/nobr>".
![image](https://user-images.githubusercontent.com/303203/133872362-9369cf3a-a68a-4f05-877f-9c28719533d7.png)

Here's what a snippet of the HTML looks like:
`<tr><td><nobr>--refine-min-peptides</nobr>=&lt;integer&gt;</td><td>Proteins with fe`

I had to use the &lt;nobr> tag, because using &lt;span style="white-space: nowrap;"> did not work at all.