### PR TITLE
Prevent the "ThreadAbortException" from being written to the console …

### DIFF
--- a/pwiz_tools/Topograph/TopographApp/TopographApp.csproj
+++ b/pwiz_tools/Topograph/TopographApp/TopographApp.csproj
@@ -94,6 +94,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <EnableSecurityDebugging>false</EnableSecurityDebugging>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/pwiz_tools/Topograph/TopographTestProject/ChromatogramGeneratorTest.cs
+++ b/pwiz_tools/Topograph/TopographTestProject/ChromatogramGeneratorTest.cs
@@ -113,6 +113,7 @@ namespace pwiz.Topograph.Test
             var chromatogramDatas = peptideFileAnalysis.GetChromatograms();
             Assert.IsFalse(chromatogramDatas.Chromatograms.Count == 0);
             chromatogramGenerator.Stop();
+            workspace.ResultCalculator?.Stop();
             while (chromatogramGenerator.IsThreadAlive)
             {
                 Thread.Sleep(100);

--- a/pwiz_tools/Topograph/TopographTestProject/PrecursorPoolTest.cs
+++ b/pwiz_tools/Topograph/TopographTestProject/PrecursorPoolTest.cs
@@ -48,6 +48,7 @@ namespace pwiz.Topograph.Test
             var precursorEnrichment = turnoverCalculator.ComputePrecursorEnrichmentAndTurnover(dict, out turnover, out turnoverScore, out bestMatch);
             Assert.AreEqual(.7, turnover);
             Assert.AreEqual(58, precursorEnrichment["Tracer"]);
+            workspace.ResultCalculator?.Stop();
         }
     }
 }


### PR DESCRIPTION
…when running the Topograph unit tests.

Also, prevent the message about security debugging when launching Topograph.