### PR TITLE
Speed up "CrosslinkSequenceParser.TryParseCrosslinkLibraryKey". It wa…

### DIFF
--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkSequenceParser.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkSequenceParser.cs
@@ -49,7 +49,8 @@ namespace pwiz.Skyline.Model.Crosslinking
             {
                 return false;
             }
-            return FastaSequence.StripModifications(str).IndexOf('-') >= 0;
+
+            return str.IndexOf(@"-[", StringComparison.Ordinal) >= 0 || str.EndsWith(@"-", StringComparison.Ordinal);
         }
 
         public static CrosslinkLibraryKey ParseCrosslinkLibraryKey(string str, int charge)


### PR DESCRIPTION
…s spending a lot of time in "StripModifications".

Also, speed up ChromatogramCache.ChromatogramIndexesMatching. It was spending a lot of time in ChromatogramSet.ContainsFile.