### PR TITLE
mzML binary data arrays for metadata detail levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Core code and libraries are under the Apache open source license; the vendor lib
 
 | OS      | Status |
 | ------- | ------ |
-| Windows | ![Windows status](https://img.shields.io/teamcity/http/teamcity.labkey.org/s/bt83.svg?label=VS%202017) |
+| Windows | ![Windows status](https://img.shields.io/teamcity/http/teamcity.labkey.org/s/bt83.svg?label=VS%202019) |
 | Native Linux | ![Linux status](https://img.shields.io/teamcity/http/teamcity.labkey.org/s/bt17.svg?label=GCC%204.9) |
 | Wine Linux | ![Docker-Wine status](https://img.shields.io/teamcity/http/teamcity.labkey.org/s/ProteoWizardAndSkylineDockerContainerWineX8664.svg?label=Docker-Wine) |
 

--- a/pwiz/data/msdata/ChromatogramList_mzML_Test.cpp
+++ b/pwiz/data/msdata/ChromatogramList_mzML_Test.cpp
@@ -79,7 +79,7 @@ void test(bool indexed)
     ChromatogramPtr s = sl->chromatogram(0); // read without binary data
     unit_assert(s.get());
     unit_assert(s->id == "tic");
-    unit_assert(s->binaryDataArrayPtrs.empty());
+    unit_assert(s->binaryDataArrayPtrs[0]->data.empty());
 
     unit_assert(sl->chromatogramIdentity(0).index == 0);
     unit_assert(sl->chromatogramIdentity(0).id == "tic");

--- a/pwiz/data/msdata/IO.cpp
+++ b/pwiz/data/msdata/IO.cpp
@@ -1727,12 +1727,16 @@ struct HandlerBinaryDataArray : public HandlerParamContainer
     ParamContainer paramContainer;
     DataProcessingPtr dataProcessingPtr;
     CVID cvidBinaryDataType;
+    BinaryDataFlag binaryDataFlag;
+    BinaryDataArray* binaryDataArray;
+    IntegerDataArray* integerDataArray;
 
-    HandlerBinaryDataArray(std::vector<BinaryDataArrayPtr>* binaryDataArrayPtrs = 0, std::vector<IntegerDataArrayPtr>* integerDataArrayPtrs = 0, const MSData* _msd = 0)
+    HandlerBinaryDataArray(std::vector<BinaryDataArrayPtr>* binaryDataArrayPtrs = 0, std::vector<IntegerDataArrayPtr>* integerDataArrayPtrs = 0, const MSData* _msd = 0, BinaryDataFlag binaryDataFlag = ReadBinaryData)
       : binaryDataArrayPtrs(binaryDataArrayPtrs),
         integerDataArrayPtrs(integerDataArrayPtrs),
         msd(_msd),
         defaultArrayLength(0),
+        binaryDataFlag(binaryDataFlag),
         arrayLength_(0),
         encodedLength_(0)
     {
@@ -1766,27 +1770,62 @@ struct HandlerBinaryDataArray : public HandlerParamContainer
             else if (name == "binary")
             {
                 if (msd) References::resolve(paramContainer, *msd);
+
                 config = getConfig();
+
+                CVID binaryArrayType;
+                if (binaryDataFlag == ReadBinaryDataOnly)
+                    binaryArrayType = paramContainer.cvParamChild(MS_binary_data_array).cvid;
 
                 switch (cvidBinaryDataType)
                 {
                     case MS_32_bit_float:
                     case MS_64_bit_float:
                     {
+                        if (binaryDataFlag == ReadBinaryDataOnly)
+                        {
+                            binaryDataArray = nullptr;
+                            for (const auto& arrayPtr : *binaryDataArrayPtrs)
+                                if (arrayPtr->hasCVParam(binaryArrayType))
+                                {
+                                    binaryDataArray = &*arrayPtr;
+                                    break;
+                                }
+
+                            if (binaryDataArray != nullptr)
+                                return Status::Ok;
+                        }
+
                         BinaryDataArrayPtr binaryDataArray = boost::make_shared<BinaryDataArray>();
                         binaryDataArrayPtrs->emplace_back(binaryDataArray);
                         swap(static_cast<ParamContainer&>(*binaryDataArray), paramContainer);
                         binaryDataArray->dataProcessingPtr = dataProcessingPtr;
+                        this->binaryDataArray = &*binaryDataArrayPtrs->back();
                     }
                     break;
 
                     case MS_32_bit_integer:
                     case MS_64_bit_integer:
                     {
+                        if (binaryDataFlag == ReadBinaryDataOnly)
+                        {
+                            integerDataArray = nullptr;
+                            for (const auto& arrayPtr : *integerDataArrayPtrs)
+                                if (arrayPtr->hasCVParam(binaryArrayType))
+                                {
+                                    integerDataArray = &*arrayPtr;
+                                    break;
+                                }
+
+                            if (integerDataArray != nullptr)
+                                return Status::Ok;
+                        }
+
                         IntegerDataArrayPtr binaryDataArray = boost::make_shared<IntegerDataArray>();
                         integerDataArrayPtrs->emplace_back(binaryDataArray);
                         swap(static_cast<ParamContainer&>(*binaryDataArray), paramContainer);
                         binaryDataArray->dataProcessingPtr = dataProcessingPtr;
+                        this->integerDataArray = &*integerDataArrayPtrs->back();
                     }
                     break;
 
@@ -1807,6 +1846,9 @@ struct HandlerBinaryDataArray : public HandlerParamContainer
     virtual Status characters(const SAXParser::saxstring& text,
                               stream_offset position)
     {
+        if (binaryDataFlag == IgnoreBinaryData)
+            return Status::Ok;
+
         BinaryDataEncoder encoder(config);
 
         switch (cvidBinaryDataType)
@@ -1814,7 +1856,6 @@ struct HandlerBinaryDataArray : public HandlerParamContainer
             case MS_32_bit_float:
             case MS_64_bit_float:
                 {
-                    auto& binaryDataArray = binaryDataArrayPtrs->back();
                     encoder.decode(text.c_str(), text.length(), binaryDataArray->data);
 
                     if (binaryDataArray->data.size() != arrayLength_)
@@ -1826,15 +1867,11 @@ struct HandlerBinaryDataArray : public HandlerParamContainer
             case MS_32_bit_integer:
             case MS_64_bit_integer:
                 {
-                    auto& binaryDataArray = integerDataArrayPtrs->back();
-                    encoder.decode(text.c_str(), text.length(), binaryDataArray->data);
+                    encoder.decode(text.c_str(), text.length(), integerDataArray->data);
 
-                    if (binaryDataArray->data.size() != arrayLength_)
+                    if (integerDataArray->data.size() != arrayLength_)
                         throw runtime_error((format("[IO::HandlerBinaryDataArray] At position %d: expected array of size %d, but decoded array is actually size %d.")
-                            % position % arrayLength_ % binaryDataArray->data.size()).str());
-
-                    swap(static_cast<ParamContainer&>(*binaryDataArray), paramContainer);
-                    binaryDataArray->dataProcessingPtr = dataProcessingPtr;
+                            % position % arrayLength_ % integerDataArray->data.size()).str());
                 }
                 break;
 
@@ -2154,13 +2191,11 @@ struct HandlerSpectrum : public HandlerParamContainer
             }
             else if (name == "binaryDataArray")
             {
-                if (binaryDataFlag == IgnoreBinaryData)
-                    return Status::Done;
-
                 handlerBinaryDataArray_.binaryDataArrayPtrs = &spectrum->binaryDataArrayPtrs;
                 handlerBinaryDataArray_.integerDataArrayPtrs = &spectrum->integerDataArrayPtrs;
                 handlerBinaryDataArray_.defaultArrayLength = spectrum->defaultArrayLength;
                 handlerBinaryDataArray_.msd = msd;
+                handlerBinaryDataArray_.binaryDataFlag = binaryDataFlag;
                 return Status(Status::Delegate, &handlerBinaryDataArray_);
             }
             else if (name == "binaryDataArrayList")
@@ -2303,12 +2338,10 @@ struct HandlerChromatogram : public HandlerParamContainer
         }
         else if (name == "binaryDataArray")
         {
-            if (binaryDataFlag == IgnoreBinaryData)
-                return Status::Done;
-
             handlerBinaryDataArray_.binaryDataArrayPtrs = &chromatogram->binaryDataArrayPtrs;
             handlerBinaryDataArray_.integerDataArrayPtrs = &chromatogram->integerDataArrayPtrs;
             handlerBinaryDataArray_.defaultArrayLength = chromatogram->defaultArrayLength;
+            handlerBinaryDataArray_.binaryDataFlag = binaryDataFlag;
             return Status(Status::Delegate, &handlerBinaryDataArray_);
         }
         else if (name == "binaryDataArrayList")

--- a/pwiz/data/msdata/IOTest.cpp
+++ b/pwiz/data/msdata/IOTest.cpp
@@ -581,10 +581,11 @@ void testSpectrum()
     Spectrum c;
     iss.seekg(0);
     IO::read(iss, c); // default = IgnoreBinaryData
-    unit_assert(c.binaryDataArrayPtrs.empty());
+    unit_assert(c.binaryDataArrayPtrs[0]->data.empty());
     unit_assert(c.sourceFilePosition == 0); // not -1
 
-    a.binaryDataArrayPtrs.clear();
+    for (auto& bda : a.binaryDataArrayPtrs)
+        bda->data.clear();
     diff(a, c);
     unit_assert(!diff);
 }
@@ -635,10 +636,11 @@ void testChromatogram()
     Chromatogram c;
     iss.seekg(0);
     IO::read(iss, c); // default = IgnoreBinaryData
-    unit_assert(c.binaryDataArrayPtrs.empty());
+    unit_assert(c.binaryDataArrayPtrs[0]->data.empty());
     unit_assert(c.sourceFilePosition == 0); // not -1
 
-    a.binaryDataArrayPtrs.clear();
+    for (auto& bda : a.binaryDataArrayPtrs)
+        bda->data.clear();
     diff(a, c);
     unit_assert(!diff);
 }

--- a/pwiz/data/msdata/SpectrumList_mzML_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_mzML_Test.cpp
@@ -115,7 +115,7 @@ void test(bool indexed)
     unit_assert(s->id == "scan=19");
     unit_assert(s->spotID.empty());
     unit_assert(s->cvParam(MS_ms_level).valueAs<int>() == 1);
-    unit_assert(s->binaryDataArrayPtrs.empty());
+    unit_assert(s->binaryDataArrayPtrs[0]->data.empty());
 
     unit_assert(sl->spectrumIdentity(0).index == 0);
     unit_assert(sl->spectrumIdentity(0).id == "scan=19");

--- a/pwiz_tools/SeeMS/Dialogs/SpectrumListForm.cs
+++ b/pwiz_tools/SeeMS/Dialogs/SpectrumListForm.cs
@@ -244,8 +244,10 @@ namespace seems
 
             if (row.IonMobility > 0)
                 row.IonMobilityType = SpectrumDataSet.IonMobilityType_SingleValue;
-            else if (s.id.Contains("frame=") || s.id.Contains("block="))
+            else if (s.id.Contains("frame=") || s.id.Contains("block=") || s.GetIonMobilityArray() != null)
                 row.IonMobilityType = SpectrumDataSet.IonMobilityType_Array;
+            else
+                row.IonMobilityType = SpectrumDataSet.IonMobilityType_None;
 
             row.SpotId = s.spotID;
             row.SpectrumType = s.cvParamChild( CVID.MS_spectrum_type ).name;


### PR DESCRIPTION
- changed mzML binary data array behavior when DetailLevel < FullData: now the BDAs will be created, but the arrays are left empty; this allows metadata readers (like SeeMS) to tell that it's a 3-array combined IMS spectrum