### PR TITLE
For chromatogram graph display purposes, change the "^2" in "Vs/cm^2"…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/ChromGraphItem.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ChromGraphItem.cs
@@ -863,7 +863,8 @@ namespace pwiz.Skyline.Controls.Graphs
         {
             var imString = ionMobilityFilter.IonMobility.HasValue
                 ? string.Format(@"{0:F02} {1}",
-                    ionMobilityFilter.IonMobility.Mobility, IonMobilityValue.GetUnitsString(ionMobilityFilter.IonMobilityUnits))
+                    ionMobilityFilter.IonMobility.Mobility, 
+                    IonMobilityValue.GetUnitsString(ionMobilityFilter.IonMobilityUnits).Replace(@"^2", @"²")) // Make "Vs/cm^2" into "Vs/cm²" to agree with CCS "Å²"
                 : @"IM unknown"; // Should never happen
             return imString;
         }


### PR DESCRIPTION
… to a superscript 2 so as to agree with the CCS display, which has a superscript 2 for "angstroms squared". Leaving it alone elsewhere as the "^2" form is less likely to cause issues with exported reports etc, as it is easily represented as simple ASCII.

So instead of a display like
![image](https://user-images.githubusercontent.com/1200761/137189776-b9966f5f-b2aa-449d-86e7-5fef9b97854a.png)
we have something like this instead (these examples are not using the same data set, obviously)
![image](https://user-images.githubusercontent.com/1200761/137189801-b32f5c49-602f-44c3-a040-253c0cbb8877.png)
