### PR TITLE
Skyline: the unzoomed view of an ion mobility heatmap had a fixed lower value of zero…

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -53,6 +53,7 @@ namespace pwiz.Skyline.Controls.Graphs
         private HeatMapData _heatMapData;
         private double _maxMz;
         private double _maxIntensity;
+        private double _minIonMobility;
         private double _maxIonMobility;
         private bool _zoomXAxis;
         private bool _zoomYAxis;
@@ -151,7 +152,7 @@ namespace pwiz.Skyline.Controls.Graphs
             _maxMz = 0;
             _maxIntensity = 0;
             GetMaxMzIntensity(out _maxMz, out _maxIntensity);
-            GetMaxMobility(out _maxIonMobility);
+            GetIonMobilityRange(out _minIonMobility, out _maxIonMobility);
             
             _requestedRange = new MzRange(0, _maxMz * 1.1);
             if (Settings.Default.SyncMZScale)
@@ -876,11 +877,13 @@ namespace pwiz.Skyline.Controls.Graphs
             }
         }
 
-        private void GetMaxMobility(out double maxIonMobility)
+        private void GetIonMobilityRange(out double minIonMobility, out double maxIonMobility)
         {
+            minIonMobility = double.MaxValue;
             maxIonMobility = 0;
             foreach (var spectrum in _msDataFileScanHelper.MsDataSpectra)
             {
+                var spectrumMinMobility = Math.Abs(spectrum.MinIonMobility ?? spectrum.IonMobility.Mobility ?? 0);
                 var spectrumMaxMobility = Math.Abs(spectrum.MaxIonMobility ?? spectrum.IonMobility.Mobility ?? 0);
                 if (_msDataFileScanHelper.IsWatersSonarData)
                 {
@@ -889,8 +892,13 @@ namespace pwiz.Skyline.Controls.Graphs
                     var sonarBinToPrecursorMz = _msDataFileScanHelper.ScanProvider.SonarBinToPrecursorMz(bin);
                     Assume.IsTrue(sonarBinToPrecursorMz.HasValue, @"error determining m/z value for SONAR bin #" + bin);
                     spectrumMaxMobility = sonarBinToPrecursorMz.Value;
+                    bin = (int)spectrumMinMobility;
+                    sonarBinToPrecursorMz = _msDataFileScanHelper.ScanProvider.SonarBinToPrecursorMz(bin);
+                    Assume.IsTrue(sonarBinToPrecursorMz.HasValue, @"error determining m/z value for SONAR bin #" + bin);
+                    spectrumMinMobility = sonarBinToPrecursorMz.Value;
                 }
-                maxIonMobility = Math.Max(_maxIonMobility, spectrumMaxMobility);
+                minIonMobility = Math.Min(minIonMobility, spectrumMinMobility);
+                maxIonMobility = Math.Max(maxIonMobility, spectrumMaxMobility);
             }
         }
 
@@ -1046,8 +1054,9 @@ namespace pwiz.Skyline.Controls.Graphs
             }
             else if (!filterBtn.Checked && !magnifyBtn.Checked)
             {
-                yScale.Min = 0;
-                yScale.Max = _maxIonMobility * 1.1;
+                var margin = 0.1 * (_maxIonMobility - _minIonMobility);
+                yScale.Min = _minIonMobility - margin;
+                yScale.Max = _maxIonMobility + margin;
             }
             else
             {


### PR DESCRIPTION
…, which made for a lot of useless whitespace. With this change, we now use the actual range of values instead for the default view.

So you'd formerly get this view:
![image](https://user-images.githubusercontent.com/1200761/137377192-4a48a4e6-1206-40ae-a403-5f27e68d0eda.png)
when this view makes more sense
![image](https://user-images.githubusercontent.com/1200761/137377700-6811c15f-e437-42fa-aca1-3a5c3fb338fe.png)

