### PR TITLE
Find scan/index hack and path too long error

### DIFF
--- a/pwiz/data/msdata/MSDataFile.cpp
+++ b/pwiz/data/msdata/MSDataFile.cpp
@@ -77,6 +77,8 @@ void calculateSourceFilePtrSHA1(const SourceFilePtr& sourceFilePtr)
 PWIZ_API_DECL MSDataFile::MSDataFile(const string& filename, const Reader* reader,
                                      bool calculateSourceFileChecksum)
 {
+    check_path_length(filename);
+
     // peek at head of file 
     string head = read_file_header(filename, 512);
 
@@ -219,6 +221,8 @@ void MSDataFile::write(const MSData& msd,
                        const WriteConfig& config,
                        const IterationListenerRegistry* iterationListenerRegistry)
 {
+    check_path_length(filename);
+
     switch (config.format)
     {
         case MSDataFile::Format_MZ5:

--- a/pwiz/data/msdata/Reader.cpp
+++ b/pwiz/data/msdata/Reader.cpp
@@ -75,6 +75,8 @@ Reader::Config::Config(const Config& rhs)
 // default implementation; most Readers don't need to worry about multi-run input files
 PWIZ_API_DECL void Reader::readIds(const string& filename, const string& head, vector<string>& results, const Config& config) const
 {
+    check_path_length(filename);
+
     MSData data;
     read(filename, head, data);
     results.push_back(data.id);
@@ -89,6 +91,8 @@ PWIZ_API_DECL std::string ReaderList::identify(const string& filename) const
 
 PWIZ_API_DECL std::string ReaderList::identify(const string& filename, const string& head) const
 {
+    check_path_length(filename);
+
 	std::string result;
     for (const_iterator it=begin(); it!=end(); ++it)
 	{
@@ -110,6 +114,8 @@ PWIZ_API_DECL void ReaderList::read(const string& filename, MSData& result, int 
 
 PWIZ_API_DECL void ReaderList::read(const string& filename, const string& head, MSData& result, int sampleIndex /* = 0 */, const Config& config) const
 {
+    check_path_length(filename);
+
     for (const_iterator it=begin(); it!=end(); ++it)
         if ((*it)->accept(filename, head))
         {
@@ -129,6 +135,8 @@ PWIZ_API_DECL void ReaderList::read(const string& filename, vector<MSDataPtr>& r
 
 PWIZ_API_DECL void ReaderList::read(const string& filename, const string& head, vector<MSDataPtr>& results, const Config& config) const
 {
+    check_path_length(filename);
+
     for (const_iterator it=begin(); it!=end(); ++it)
         if ((*it)->accept(filename, head))
         {
@@ -148,6 +156,8 @@ PWIZ_API_DECL void ReaderList::readIds(const string& filename, vector<string>& r
 
 PWIZ_API_DECL void ReaderList::readIds(const string& filename, const string& head, vector<string>& results, const Config& config) const
 {
+    check_path_length(filename);
+
     for (const_iterator it=begin(); it!=end(); ++it)
         if ((*it)->accept(filename, head))
         {
@@ -244,6 +254,8 @@ PWIZ_API_DECL ReaderList operator +(const ReaderPtr& lhs, const ReaderPtr& rhs)
 
 PWIZ_API_DECL ReaderPtr ReaderList::identifyAsReader(const std::string& filepath) const
 {
+    check_path_length(filepath);
+
     try
     {
         string head = read_file_header(filepath, 512);

--- a/pwiz/data/msdata/SpectrumList_MGF_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_MGF_Test.cpp
@@ -98,6 +98,11 @@ void test()
     unit_assert(sl->find("index=1") == 1);
     unit_assert(sl->find("index=2") == 2);
 
+    // check that hack works when looking up MGF spectra by scan
+    unit_assert(sl->find("scan=1") == 0);
+    unit_assert(sl->find("scan=2") == 1);
+    unit_assert(sl->find("scan=3") == 2);
+
     // find the second spectrum by TITLE field
     IndexList list = sl->findSpotID("small.pwiz.0004.0004.2");
     unit_assert(list.size() == 1);

--- a/pwiz/data/msdata/SpectrumList_mzML_Test.cpp
+++ b/pwiz/data/msdata/SpectrumList_mzML_Test.cpp
@@ -83,7 +83,8 @@ void test(bool indexed)
 
     unit_assert(sl.get());
     unit_assert(sl->size() == 5);
-    unit_assert(sl->find ("scan=19") == 0);
+    unit_assert(sl->find("scan=19") == 0);
+    unit_assert(sl->find("index=18") == 0);
     IndexList indexList = sl->findNameValue("scan", "19");
     unit_assert(indexList.size()==1 && indexList[0]==0);
     unit_assert(sl->find("scan=20") == 1);

--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -713,6 +713,16 @@ PWIZ_API_DECL string read_file_header(const string& filepath, size_t length)
 }
 
 
+PWIZ_API_DECL void check_path_length(const string& path)
+{
+#ifdef WIN32
+    std::wstring wide_path = boost::locale::conv::utf_to_utf<wchar_t>(bfs::absolute(path).string());
+    if (wide_path.length() > 250)
+        throw std::invalid_argument("path is too long (must be 250 characters or less): " + bfs::absolute(path).string());
+#endif
+}
+
+
 PWIZ_API_DECL TemporaryFile::TemporaryFile(const string& extension)
 {
     filepath = bfs::temp_directory_path() / bfs::unique_path("%%%%%%%%%%%%%%%%" + extension);

--- a/pwiz/utility/misc/Filesystem.hpp
+++ b/pwiz/utility/misc/Filesystem.hpp
@@ -123,6 +123,9 @@ PWIZ_API_DECL bool isHTTP(const std::string& filepath);
 
 PWIZ_API_DECL std::string read_file_header(const std::string& filepath, size_t length = 512);
 
+/// on non-Windows platforms, this does nothing; on Windows it throws an invalid_argument exception if the given path is longer than 250 characters
+PWIZ_API_DECL void check_path_length(const string & path);
+
 
 /// creates a unique named file in the user temp directory
 PWIZ_API_DECL class TemporaryFile

--- a/pwiz_tools/BiblioSpec/src/PwizReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PwizReader.cpp
@@ -74,7 +74,7 @@ void PwizReader::openFile(const char* filename, bool mzSort){
         BiblioSpec::Verbosity::debug("Found %d spectra in %s.",
                                      allSpectra_->size(), filename);
         nativeIdFormat_ = id::getDefaultNativeIDFormat(*fileReader_);
-        if (nativeIdFormat_ == MS_no_nativeID_format)   // This never works
+        if (nativeIdFormat_ == MS_no_nativeID_format || nativeIdFormat_ == CVID_Unknown) // These never work
             nativeIdFormat_ = MS_scan_number_only_nativeID_format;
         
         const auto& nativeIdFormatInfo = cvTermInfo(nativeIdFormat_);


### PR DESCRIPTION
* added hack to find() for trying index=123 if scan=124 is looked for and not found, and vice versa
* fixed BiblioSpec not handling CVID_Unknown from getDefaultNativeIDFormat()
* added pwiz::util::check_path_length() to throw an exception on Windows for paths that are too long
- added checks on Windows for paths which exceed 250 characters; now trying to read/write these paths should give a sensible error message instead of a mysterious crash (I used 250 instead of the actual Windows limit of 260 because RawFileReader was failing for paths longer than 250)

BiblioSpec issue reported by Karl-Heinz.

Closes #1790 