### PR TITLE
Waters fixes and MSAmanda fix

### DIFF
--- a/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
+++ b/pwiz/data/vendor_readers/Waters/SpectrumList_Waters.cpp
@@ -143,7 +143,7 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Waters::spectrum(size_t index, DetailLeve
     double collisionEnergy = 0;
     string collisionEnergyStr = isMS ? rawdata_->GetScanStat(ie.function, scanStatIndex, MassLynxScanItem::COLLISION_ENERGY) : "";
     if (!collisionEnergyStr.empty())
-        collisionEnergy = lexical_cast<double>(collisionEnergyStr);
+        collisionEnergy = abs(lexical_cast<double>(collisionEnergyStr));
 
     // heuristic to detect high-energy MSe function (must run for DetailLevel_InstantMetadata so that msLevel is the same at all detail levels)
     if (msLevel == 1 && ie.function == 1 && collisionEnergy > 0)

--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSpectrumParser.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSpectrumParser.cs
@@ -111,7 +111,7 @@ namespace pwiz.Skyline.Model.DdaSearch
             consideredCharges = charges;
             spectrumFileReader = new MsDataFileImpl(file,
                 requireVendorCentroidedMS2: MsDataFileImpl.SupportsVendorPeakPicking(file),
-                ignoreZeroIntensityPoints: true, trimNativeId: false);
+                acceptZeroLengthSpectra: false, ignoreZeroIntensityPoints: true, trimNativeId: false);
             useMonoIsotopicMass = mono;
 
             msdataRunPath = new MSDataRunPath(file);


### PR DESCRIPTION
- fixed Waters (HD)MSe high energy functions not being marked as MS2 data in negative polarity mode
- fixed UNIFI reader breaking on combined functions (isRetentionData=false)
- fixed MSAmanda search failing on DDA WIFF files