### PR TITLE
fix an unhandled exception when attempting to parse an ill-formed adduct description

### DIFF
--- a/pwiz_tools/Skyline/Test/AdductTest.cs
+++ b/pwiz_tools/Skyline/Test/AdductTest.cs
@@ -425,6 +425,7 @@ namespace pwiz.SkylineTest
             mz = BioMassCalc.CalculateIonMass(new TypedMass(massHectochlorin, MassType.Monoisotopic), heavy);
             Assert.AreEqual(2 * (massHectochlorin + 1.23456), mz, .001);
 
+            TestException("", "+M"); // Meaningless, used to cause an exception in our parser
             TestException(Hectochlorin, "M3Cl37+H"); // Trying to label more chlorines than exist in the molecule
             TestException(Hectochlorin, "M-3Cl+H"); // Trying to remove more chlorines than exist in the molecule
             TestException(PENTANE, "M+foo+H"); // Unknown adduct

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -213,7 +213,7 @@ namespace pwiz.Skyline.Util
                 {
                     // No leading + or - : is it because description starts with a label, or because + mode is implied?
                     var limit = input.IndexOfAny(new[] { '+', '-', ']' });
-                    if (limit < 0)
+                    if (limit < posNext)
                     {
                         return null;
                     }


### PR DESCRIPTION
Came in on Exception web without any data, but I was able to repro by feeding the parser a description like "+M" in a new test step.