### PR TITLE
Seems like we see this at least once a week on ExceptionWeb - I don't know how to repro it but hopefully this is a reasonable fix.…

### DIFF
--- a/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
@@ -439,13 +439,11 @@ namespace pwiz.Skyline.Controls.SeqNode
                 popup.Show(FormEx.GetParentForm(TreeView));
                 popup.Focus();
             }
-
             // Deal with apparent race condition with this timer-driven call and deletion of the associated node
             catch (ObjectDisposedException)
             {
                 return; // Ignore
             }
-
             // Catch exceptions that may be caused trying to read results information from SKYD file
             catch (IOException x)
             {

--- a/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
@@ -435,10 +435,17 @@ namespace pwiz.Skyline.Controls.SeqNode
             Exception exception = null;
             try
             {
-                PopupPickList popup = new PopupPickList(this, ChildHeading, okOnDeactivate) { Location = location };
+                PopupPickList popup = new PopupPickList(this, ChildHeading, okOnDeactivate) {Location = location};
                 popup.Show(FormEx.GetParentForm(TreeView));
                 popup.Focus();
             }
+
+            // Deal with apparent race condition with this timer-driven call and deletion of the associated node
+            catch (ObjectDisposedException)
+            {
+                return; // Ignore
+            }
+
             // Catch exceptions that may be caused trying to read results information from SKYD file
             catch (IOException x)
             {

--- a/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SrmTreeNode.cs
@@ -435,7 +435,7 @@ namespace pwiz.Skyline.Controls.SeqNode
             Exception exception = null;
             try
             {
-                PopupPickList popup = new PopupPickList(this, ChildHeading, okOnDeactivate) {Location = location};
+                PopupPickList popup = new PopupPickList(this, ChildHeading, okOnDeactivate) { Location = location };
                 popup.Show(FormEx.GetParentForm(TreeView));
                 popup.Focus();
             }


### PR DESCRIPTION
…  I'm just tired of seeing it...

Skyline version: 21.1.0.146-9b577b3b8 (64-bit)
Installation ID: 045629dd-0267-441f-a91d-4494bec0101f
Exception type: ObjectDisposedException
Error message: Cannot access a disposed object.
Object name: 'PopupPickList'.

--------------------

System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'PopupPickList'.
   at System.Windows.Forms.Control.CreateHandle()
   at System.Windows.Forms.Form.CreateHandle()
   at System.Windows.Forms.Control.get_Handle()
   at System.Windows.Forms.Form.Show(IWin32Window owner)
   at pwiz.Skyline.Controls.SeqNode.SrmTreeNodeParent.ShowPickList(Point location, Boolean okOnDeactivate) in C:\proj\skyline_21_1_x64\pwiz_tools\Skyline\Controls\SeqNode\SrmTreeNode.cs:line 440
   at pwiz.Skyline.Controls.SequenceTree.ShowPickList(Boolean okOnDeactivate) in C:\proj\skyline_21_1_x64\pwiz_tools\Skyline\Controls\SequenceTree.cs:line 242
   at System.Windows.Forms.Timer.OnTick(EventArgs e)
   at System.Windows.Forms.Timer.TimerNativeWindow.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
Exception caught at:
   at System.Windows.Forms.Application.ThreadContext.OnThreadException(Exception t)
   at System.Windows.Forms.Timer.TimerNativeWindow.OnThreadException(Exception e)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
   at System.Windows.Forms.UnsafeNativeMethods.DispatchMessageW(MSG& msg)
   at System.Windows.Forms.UnsafeNativeMethods.DispatchMessageW(MSG& msg)
   at System.Windows.Forms.Application.ComponentManager.System.Windows.Forms.UnsafeNativeMethods.IMsoComponentManager.FPushMessageLoop(IntPtr dwComponentID, Int32 reason, Int32 pvLoopData)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoopInner(Int32 reason, ApplicationContext context)
   at System.Windows.Forms.Application.ThreadContext.RunMessageLoop(Int32 reason, ApplicationContext context)
   at pwiz.Skyline.Program.Main(String[] args) in C:\proj\skyline_21_1_x64\pwiz_tools\Skyline\Program.cs:line 307