### PR TITLE
DiaUmpire optimizations

### DIFF
--- a/pwiz/analysis/dia_umpire/DiaUmpire.cpp
+++ b/pwiz/analysis/dia_umpire/DiaUmpire.cpp
@@ -124,7 +124,15 @@ namespace DiaUmpire {
             if (!ilr_)
                 return false;
 
-            string msgWithStep = "[step " + lexical_cast<string>(int(step)) + " of " + lexical_cast<string>(int(DiaUmpireStep::Count)-1) + "] " + msg;
+            int stepNum = int(step);
+            int stepCount = int(DiaUmpireStep::Count) - 1;
+
+            if (!config_.multithreadOverWindows)
+            {
+                stepNum += windowsProcessed * 3;
+                stepCount += diaWindows_.size() * 3;
+            }
+            string msgWithStep = "[step " + lexical_cast<string>(stepNum) + " of " + lexical_cast<string>(stepCount) + "] " + msg;
 
             boost::lock_guard<boost::mutex> g(ilrMutex_);
             canceled_ = canceled_ || IterationListener::Status_Cancel == ilr_->broadcastUpdateMessage(IterationListener::UpdateMessage(index, size, msgWithStep));
@@ -153,6 +161,7 @@ namespace DiaUmpire {
         const pwiz::util::IterationListenerRegistry* ilr_;
         mutable boost::mutex ilrMutex_;
         mutable std::atomic<bool> canceled_;
+        mutable std::atomic<size_t> windowsProcessed = 0;
 
         boost::asio::thread_pool pool_;
         boost::asio::thread_pool nestedPool_;
@@ -160,6 +169,7 @@ namespace DiaUmpire {
         // timing
         struct Timing
         {
+            double total = 0;
             double readSpectra = 0;
             double buildPeakCurves = 0;
             double smoothPeakCurves = 0;
@@ -172,6 +182,7 @@ namespace DiaUmpire {
             {
 #ifdef DIAUMPIRE_TIMING
                 cout << endl << "Times in seconds" << endl
+                    << "  Total: " << total << endl
                     << "  Read spectra: " << readSpectra << endl
                     << "  Build peak curves: " << buildPeakCurves << endl
                     << "  Smooth peak curves: " << smoothPeakCurves << endl
@@ -194,10 +205,16 @@ namespace DiaUmpire {
 
             ~Timer()
             {
+                stop();
+            }
+
+            void stop()
+            {
                 timerToIncrement += boost::chrono::duration<double>(boost::chrono::system_clock::now() - start).count();
             }
 #else
             Timer(double& timerToIncrement) {}
+            void stop() {}
 #endif
         };
 
@@ -208,8 +225,10 @@ namespace DiaUmpire {
     DiaUmpire::Impl::Impl(const MSData& msd, const SpectrumListPtr& spectrumList, const Config& config, const IterationListenerRegistry* ilr)
         : msd_(msd), slp_(spectrumList), sl_(*slp_), config_(config), ilr_(ilr), canceled_(false),
           pool_(config_ .multithreadOverWindows ? config_.maxThreads : 1),
-          nestedPool_(config_.multithreadOverWindows ? min(config_.maxThreads, 4) : config_.maxThreads)
+          nestedPool_(config_.multithreadOverWindows ? config_.maxNestedThreads : config_.maxThreads)
     {
+        Timer total(timing_.total);
+
         isotopePatternMap_ = generateIsotopePatternMap(config_.instrumentParameters);
 
         if (config_.exportSeparateQualityMGFs)
@@ -233,11 +252,15 @@ namespace DiaUmpire {
         if (!MS1PeakDetection()) { if (canceled_) return; else throw runtime_error("error in MS1PeakDetection"); }
         if (!DIAMS2PeakDetection()) { if (canceled_) return; else throw runtime_error("error in DIAMS2PeakDetection"); }
         
-        pool_.join();
+        //pool_.join();
         nestedPool_.join();
 
-        ms1PeakClusters_.clear();
-        ms1PeakCurves_.clear();
+        // clearing all the curves takes a while, so do it on a background thread
+        boost::asio::post(pool_, [&]()
+        {
+            ms1PeakClusters_.clear();
+            ms1PeakCurves_.clear();
+        });
 
         if (config_.exportSeparateQualityMGFs)
         {
@@ -306,6 +329,9 @@ namespace DiaUmpire {
 
             if (msLevel == 1)
                 ++ms1Count_;
+
+            if (scanTime > config_.instrumentParameters.EndRT)
+                break;
 
             if (msLevel < 2)
                 continue;
@@ -1037,7 +1063,6 @@ namespace DiaUmpire {
         bool multithreadWindows = config_.multithreadOverWindows;
 
         boost::mutex m;
-        std::atomic<size_t> windowsProcessed(0);
         string progressMessage = "processing DIA window";
         string progressMessage2 = "generating pseudo-MS/MS spectra";
 
@@ -1086,6 +1111,8 @@ namespace DiaUmpire {
                 {
                     MassDefect MD;
                     //cout << endl << "No. of fragment peaks: " << diaWindow.peakCurves.size() << endl;
+                    vector<PeakCurvePtr> keptCurves;
+                    keptCurves.reserve(diaWindow.peakCurves.size());
                     for (int i = diaWindow.peakCurves.size() - 1; i >= 0; --i)
                     {
                         auto& peakCurve = diaWindow.peakCurves[i];
@@ -1099,9 +1126,10 @@ namespace DiaUmpire {
                                 break;
                             }
                         }
-                        if (remove)
-                            diaWindow.peakCurves.erase(diaWindow.peakCurves.begin() + i);
+                        if (!remove)
+                            keptCurves.emplace_back(peakCurve);
                     }
+                    swap(diaWindow.peakCurves, keptCurves);
                     //cout << "No. of remaining fragment peaks: " << diaWindow.peakCurves.size() << endl;
                 }
 
@@ -1395,7 +1423,7 @@ namespace DiaUmpire {
             {
                 int CorrRank = 0;
                 for (int intidx = 0; intidx < (int) CorrArrayList.size(); intidx++) {
-                    if (CorrArrayList.at(intidx) <= ScoreList.at(fragmentClusterUnit))
+                    if (CorrArrayList[intidx] <= ScoreList[fragmentClusterUnit])
                     {
                         CorrRank = intidx + 1;
                         break;
@@ -1500,7 +1528,7 @@ namespace DiaUmpire {
             {
                 int CorrRank = 0;
                 for (size_t intidx = 0; intidx < CorrArrayList.size(); intidx++) {
-                    if (CorrArrayList.at(intidx) <= ScoreList.at(fragmentClusterUnit))
+                    if (CorrArrayList[intidx] <= ScoreList[fragmentClusterUnit])
                     {
                         CorrRank = intidx + 1;
                         break;
@@ -1567,7 +1595,9 @@ namespace DiaUmpire {
         if (paramsFilepath.empty())
         {
             if (maxThreads == 0)
-                maxThreads = boost::thread::hardware_concurrency();
+                maxThreads = boost::thread::hardware_concurrency() / 2;
+            if (maxNestedThreads == 0)
+                maxNestedThreads = boost::thread::hardware_concurrency();
             return;
         }
 
@@ -1800,6 +1830,10 @@ namespace DiaUmpire {
             {
                 maxThreads = lexical_cast<int>(value);
             }
+            else if (type == "NestedThreads")
+            {
+                maxNestedThreads = lexical_cast<int>(value);
+            }
             else if (type == "MultithreadOverWindows")
             {
                 multithreadOverWindows = lexical_cast<bool>(value);
@@ -1816,7 +1850,9 @@ namespace DiaUmpire {
         }
 
         if (maxThreads == 0)
-            maxThreads = boost::thread::hardware_concurrency();
+            maxThreads = boost::thread::hardware_concurrency() / 2;
+        if (maxNestedThreads == 0)
+            maxNestedThreads = boost::thread::hardware_concurrency();
     }
 
     PWIZ_API_DECL PseudoMsMsKey::PseudoMsMsKey(float scanTime, float targetMz, int charge, pwiz::util::TemporaryFile* spillFilePtr, size_t spillFileIndex)

--- a/pwiz/analysis/dia_umpire/DiaUmpire.cpp
+++ b/pwiz/analysis/dia_umpire/DiaUmpire.cpp
@@ -161,7 +161,7 @@ namespace DiaUmpire {
         const pwiz::util::IterationListenerRegistry* ilr_;
         mutable boost::mutex ilrMutex_;
         mutable std::atomic<bool> canceled_;
-        mutable std::atomic<size_t> windowsProcessed = 0;
+        mutable std::atomic<size_t> windowsProcessed;
 
         boost::asio::thread_pool pool_;
         boost::asio::thread_pool nestedPool_;
@@ -223,7 +223,7 @@ namespace DiaUmpire {
 
 
     DiaUmpire::Impl::Impl(const MSData& msd, const SpectrumListPtr& spectrumList, const Config& config, const IterationListenerRegistry* ilr)
-        : msd_(msd), slp_(spectrumList), sl_(*slp_), config_(config), ilr_(ilr), canceled_(false),
+        : msd_(msd), slp_(spectrumList), sl_(*slp_), config_(config), ilr_(ilr), canceled_(false), windowsProcessed(0),
           pool_(config_ .multithreadOverWindows ? config_.maxThreads : 1),
           nestedPool_(config_.multithreadOverWindows ? config_.maxNestedThreads : config_.maxThreads)
     {

--- a/pwiz/analysis/dia_umpire/DiaUmpire.hpp
+++ b/pwiz/analysis/dia_umpire/DiaUmpire.hpp
@@ -65,7 +65,8 @@ struct PWIZ_API_DECL Config
     bool exportMs2ClusterTable = false;
     bool exportSeparateQualityMGFs = false;
 
-    int maxThreads = 0; // 0 = # of cores, which will be set to the actual count in the ctor
+    int maxThreads = 0; // 0 = # of cores/2, which will be set to the actual count in the ctor
+    int maxNestedThreads = 0; // 0 = # of cores; when multithreading over windows, each window uses a pool of this many threads
     bool multithreadOverWindows = true;
 
     pwiz::msdata::MSDataFile::Format spillFileFormat = pwiz::msdata::MSDataFile::Format_MZ5;

--- a/pwiz/analysis/dia_umpire/Jamfile.jam
+++ b/pwiz/analysis/dia_umpire/Jamfile.jam
@@ -34,6 +34,8 @@ lib pwiz_analysis_diaumpire
     : # requirements
         <library>../../data/msdata//pwiz_data_msdata
         <library>$(PWIZ_ROOT_PATH)/pwiz/data/vendor_readers//pwiz_data_vendor_readers
+        # auto-vectorization
+        <toolset>msvc:<cxxflags>"/arch:AVX2" # /Qvec-report:2"
     : # default-build
     : # usage-requirements
         <library>../../data/msdata//pwiz_data_msdata

--- a/pwiz/analysis/dia_umpire/PeakCurve.hpp
+++ b/pwiz/analysis/dia_umpire/PeakCurve.hpp
@@ -131,16 +131,13 @@ class PeakCurve
     //Detect peak region using CWT based on smoothed peak signals
     void DetectPeakRegion()
     {
-        std::vector<XYData> PeakArrayList;
         std::vector<PeakRidge> PeakRidgeList;
         PeakRegionList.clear();
         NoRidgeRegion.clear();
         if (RTWidth() * parameter.NoPeakPerMin < 1) {
             return;
         }
-        for (int i = 0; i < SmoothData.PointCount(); i++) {
-            PeakArrayList.emplace_back(SmoothData.Data.at(i).getX(), SmoothData.Data.at(i).getY());
-        }
+        std::vector<XYData> PeakArrayList = SmoothData.Data;
         //Start CWT process
         WaveletMassDetector waveletMassDetector(parameter, PeakArrayList, (int)(RTWidth() * parameter.NoPeakPerMin));
         waveletMassDetector.Run();
@@ -567,6 +564,7 @@ class PeakCurve
     XYPointCollection GetPeakCollection() const
     {
         XYPointCollection PtCollection;
+        PtCollection.Data.reserve(SmoothData.Data.size());
 
         for (size_t i = 0; i < SmoothData.Data.size(); i++) {
             PtCollection.AddPoint(SmoothData.Data.at(i).getX(), SmoothData.Data.at(i).getY());
@@ -577,6 +575,7 @@ class PeakCurve
     XYPointCollection GetSmoothPeakCollection(float startRT, float endRT) const
     {
         XYPointCollection PtCollection;
+        PtCollection.Data.reserve(SmoothData.Data.size());
 
         for (int i = 0; i < SmoothData.PointCount(); i++) {
             const XYData& pt = SmoothData.Data.at(i);


### PR DESCRIPTION
- fixed step counts when MultithreadOverWindows is off
* moved peak curve/cluster deallocation to a background thread (this fixes the long delay, with no progress messages, after processing all the DIA windows and before writing spectra)
* added MaxNestedThreads parameter and fixed the default so the nested thread pool will use all cores (the MaxThreads parameter which controls the number of windows processed at a time now defaults to half the number of cores)
* made profiling-guided optimizations in memory allocations and math inner loops; performCWT still takes the most compute time, and it would be great if the inner loop could be vectorized because it's pure math, but I couldn't figure out a reasonably easy way to do it because the index into the Mexican hat wavelet skips around