### PR TITLE
Disable auto-vectorization

### DIFF
--- a/pwiz/analysis/dia_umpire/Jamfile.jam
+++ b/pwiz/analysis/dia_umpire/Jamfile.jam
@@ -35,7 +35,7 @@ lib pwiz_analysis_diaumpire
         <library>../../data/msdata//pwiz_data_msdata
         <library>$(PWIZ_ROOT_PATH)/pwiz/data/vendor_readers//pwiz_data_vendor_readers
         # auto-vectorization
-        <toolset>msvc:<cxxflags>"/arch:AVX2" # /Qvec-report:2"
+        #<toolset>msvc:<cxxflags>"/arch:AVX2" # /Qvec-report:2"
     : # default-build
     : # usage-requirements
         <library>../../data/msdata//pwiz_data_msdata


### PR DESCRIPTION
AVX2, at least, is too new to rely on. This auto-vectorization is not doing anything substantial anyway (because as mentioned in #1834 , I couldn't get the most compute-intensive loop to meet the vectorization constraints).