### PR TITLE
temporary fix for performance issues around IM filtering in library viewer - just disable for peptides until we address the actual problem

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -421,7 +421,7 @@ namespace pwiz.Skyline.SettingsUI
 
                         var info = new ViewLibraryPepInfo(key, libInfo);
                         // If there are any, set the ion mobility values of entry
-                        return SetIonMobilityCCSValues(info);
+                        return key.IsSmallMoleculeKey ? SetIonMobilityCCSValues(info) : info; // Don't do this for peptides until we have performance issues worked out
                     });
             }
 


### PR DESCRIPTION
User noticed slow load time for large peptide library