### PR TITLE
* fixed error processing DIA raw files

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ConverterSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ConverterSettingsControl.cs
@@ -312,12 +312,12 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                 diaUmpireConfig.Parameters[kvp.Key] = kvp.Value.Value;
             diaUmpireConfig.UseMzMlSpillFile = UseMzMlSpillFile;
 
-            return new DiaUmpireDdaConverter(ImportPeptideSearch.SearchEngine, _fullScanSettingsControlGetter().IsolationScheme, diaUmpireConfig);
+            return new DiaUmpireDdaConverter(ImportPeptideSearch, _fullScanSettingsControlGetter().IsolationScheme, diaUmpireConfig);
         }
 
         public MsconvertDdaConverter GetMsconvertConverter()
         {
-            return new MsconvertDdaConverter(ImportPeptideSearch.SearchEngine);
+            return new MsconvertDdaConverter(ImportPeptideSearch);
         }
     }
 }

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
@@ -112,6 +112,26 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             return !SimpleFileDownloader.FilesNotAlreadyDownloaded(filesNotAlreadyDownloaded).Any();
         }
 
+        public static bool HasRequiredFilesDownloaded(SearchEngine searchEngine)
+        {
+            FileDownloadInfo[] fileDownloadInfo;
+            switch (searchEngine)
+            {
+                case SearchEngine.MSAmanda:
+                    return true;
+                case SearchEngine.MSGFPlus:
+                    fileDownloadInfo = MsgfPlusSearchEngine.FilesToDownload;
+                    break;
+                case SearchEngine.MSFragger:
+                    fileDownloadInfo = MsFraggerSearchEngine.FilesToDownload;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            return !SimpleFileDownloader.FilesNotAlreadyDownloaded(fileDownloadInfo).Any();
+        }
+
         private AbstractDdaSearchEngine InitSelectedSearchEngine()
         {
             pBLogo.Image = null;

--- a/pwiz_tools/Skyline/Model/AbstractDdaConverter.cs
+++ b/pwiz_tools/Skyline/Model/AbstractDdaConverter.cs
@@ -25,11 +25,11 @@ namespace pwiz.Skyline.Model
     {
         public MsDataFileUri[] OriginalSpectrumSources { get; protected set; }
         public MsDataFileUri[] ConvertedSpectrumSources { get; protected set; }
-        protected AbstractDdaSearchEngine SearchEngine { get; private set; }
+        protected ImportPeptideSearch ImportPeptideSearch { get; private set; }
 
-        public AbstractDdaConverter(AbstractDdaSearchEngine searchEngine)
+        public AbstractDdaConverter(ImportPeptideSearch importPeptideSearch)
         {
-            SearchEngine = searchEngine;
+            ImportPeptideSearch = importPeptideSearch;
         }
 
         // NB: these must match the enum values in pwiz::msdata::MSDataFile::Format,

--- a/pwiz_tools/Skyline/Model/DdaSearch/MsconvertDdaConverter.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MsconvertDdaConverter.cs
@@ -42,7 +42,7 @@ namespace pwiz.Skyline.Model.DdaSearch
         public string MsConvertOutputExtension { get; private set; }
         public string MsConvertOutputFormatParam { get; private set; }
 
-        public MsconvertDdaConverter(AbstractDdaSearchEngine searchEngine) : base(searchEngine)
+        public MsconvertDdaConverter(ImportPeptideSearch importPeptideSearch) : base(importPeptideSearch)
         {
             MsConvertOutputExtension = @".mzML";
             MsConvertOutputFormatParam = @"--mzML";
@@ -136,7 +136,7 @@ namespace pwiz.Skyline.Model.DdaSearch
                 }
 
                 // tell the search engine to search the converted files instead of the original files
-                SearchEngine.SetSpectrumFiles(ConvertedSpectrumSources);
+                ImportPeptideSearch.SearchEngine.SetSpectrumFiles(ConvertedSpectrumSources);
                 return true;
             }
             catch (Exception e)

--- a/pwiz_tools/Skyline/Model/DiaUmpireDdaConverter.cs
+++ b/pwiz_tools/Skyline/Model/DiaUmpireDdaConverter.cs
@@ -42,7 +42,7 @@ namespace pwiz.Skyline.Model
         private IProgressStatus _progressStatus;
         private int _currentSourceIndex;
 
-        public DiaUmpireDdaConverter(AbstractDdaSearchEngine searchEngine, IsolationScheme isolationScheme, DiaUmpire.Config diaUmpireConfig) : base(searchEngine)
+        public DiaUmpireDdaConverter(ImportPeptideSearch importPeptideSearch, IsolationScheme isolationScheme, DiaUmpire.Config diaUmpireConfig) : base(importPeptideSearch)
         {
             var isolationWindows = isolationScheme.PrespecifiedIsolationWindows;
             var windowSizes = isolationWindows.Skip(1).Select(w => Math.Round(w.End - w.Start, 1));
@@ -180,7 +180,7 @@ namespace pwiz.Skyline.Model
                 }
 
                 // tell the search engine to search the converted files instead of the original files
-                SearchEngine.SetSpectrumFiles(ConvertedSpectrumSources);
+                ImportPeptideSearch.SearchEngine.SetSpectrumFiles(ConvertedSpectrumSources);
                 return true;
             }
             catch (Exception e)

--- a/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
@@ -28,7 +28,6 @@ using pwiz.Skyline.Controls;
 using pwiz.Skyline.FileUI;
 using pwiz.Skyline.FileUI.PeptideSearch;
 using pwiz.Skyline.Model;
-using pwiz.Skyline.Model.DdaSearch;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Properties;

--- a/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
@@ -92,6 +92,8 @@ namespace TestPerf
         /// </summary>
         private bool IsRecordMode => false;
 
+        private bool RedownloadTools => !IsRecordMode && !IsRecordAuditLogForTutorials && IsPass0;
+
         private Image _searchLogImage;
 
         protected override void ProcessCoverShot(Bitmap bmp)
@@ -108,7 +110,7 @@ namespace TestPerf
             PrepareDocument("TestDdaTutorial.sky");
 
             // delete downloaded tools if not recording new counts or audit logs
-            if (!IsRecordMode && !IsRecordAuditLogForTutorials)
+            if (RedownloadTools)
                 foreach (var requiredFile in MsFraggerSearchEngine.FilesToDownload)
                     if (requiredFile.Unzip)
                         DirectoryEx.SafeDelete(requiredFile.InstallPath);
@@ -214,7 +216,7 @@ namespace TestPerf
 
             // switch SearchEngine and handle download dialogs if necessary
             SkylineWindow.BeginInvoke(new Action(() => importPeptideSearchDlg.SearchSettingsControl.SelectedSearchEngine = SearchSettingsControl.SearchEngine.MSFragger));
-            if (!IsRecordMode && !IsRecordAuditLogForTutorials)
+            if (RedownloadTools)
             {
                 var msfraggerDownloaderDlg = TryWaitForOpenForm<MsFraggerDownloadDlg>(2000);
                 PauseForScreenShot<ImportPeptideSearchDlg.FastaPage>("Import Peptide Search - Download MSFragger", tutorialPage++);

--- a/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
@@ -93,6 +93,7 @@ namespace TestPerf
         private bool IsRecordMode => false;
 
         private bool RedownloadTools => !IsRecordMode && !IsRecordAuditLogForTutorials && IsPass0;
+        private bool HasMissingDependencies => !SearchSettingsControl.HasRequiredFilesDownloaded(SearchSettingsControl.SearchEngine.MSFragger);
 
         private Image _searchLogImage;
 
@@ -216,18 +217,24 @@ namespace TestPerf
 
             // switch SearchEngine and handle download dialogs if necessary
             SkylineWindow.BeginInvoke(new Action(() => importPeptideSearchDlg.SearchSettingsControl.SelectedSearchEngine = SearchSettingsControl.SearchEngine.MSFragger));
-            if (RedownloadTools)
+            if (RedownloadTools || HasMissingDependencies)
             {
                 var msfraggerDownloaderDlg = TryWaitForOpenForm<MsFraggerDownloadDlg>(2000);
-                PauseForScreenShot<ImportPeptideSearchDlg.FastaPage>("Import Peptide Search - Download MSFragger", tutorialPage++);
-                RunUI(() => msfraggerDownloaderDlg.SetValues("Matt Chambers (testing download from Skyline)", "matt.chambers42@gmail.com", "UW"));
-                OkDialog(msfraggerDownloaderDlg, msfraggerDownloaderDlg.ClickAccept);
+                if (msfraggerDownloaderDlg != null)
+                {
+                    PauseForScreenShot<ImportPeptideSearchDlg.FastaPage>("Import Peptide Search - Download MSFragger", tutorialPage++);
+                    RunUI(() => msfraggerDownloaderDlg.SetValues("Matt Chambers (testing download from Skyline)", "matt.chambers42@gmail.com", "UW"));
+                    OkDialog(msfraggerDownloaderDlg, msfraggerDownloaderDlg.ClickAccept);
+                }
 
                 var downloaderDlg = TryWaitForOpenForm<MultiButtonMsgDlg>(2000);
-                PauseForScreenShot<ImportPeptideSearchDlg.FastaPage>("Import Peptide Search - Download Java and Crux", tutorialPage++);
-                OkDialog(downloaderDlg, downloaderDlg.ClickYes);
-                var waitDlg = WaitForOpenForm<LongWaitDlg>();
-                WaitForClosedForm(waitDlg);
+                if (downloaderDlg != null)
+                {
+                    PauseForScreenShot<ImportPeptideSearchDlg.FastaPage>("Import Peptide Search - Download Java and Crux", tutorialPage++);
+                    OkDialog(downloaderDlg, downloaderDlg.ClickYes);
+                    var waitDlg = WaitForOpenForm<LongWaitDlg>();
+                    WaitForClosedForm(waitDlg);
+                }
             }
 
             RunUI(() =>
@@ -330,7 +337,7 @@ namespace TestPerf
 
             using (new WaitDocumentChange(null, true))
             {
-            OkDialog(emptyProteinsDlg, emptyProteinsDlg.OkDialog);
+                OkDialog(emptyProteinsDlg, emptyProteinsDlg.OkDialog);
             }
 
             FindNode(string.Format("{0:F04}++", IsFullData ? 835.914 : 699.3566));


### PR DESCRIPTION
* fixed error processing DIA raw files from vendor formats with MS-GF+ and MSFragger
* turned off calibrate_mass in TestDdaSearchMsFragger to speed it up
* made downloading of DDA search tools dependent on IsPass0
* fixed TestDiaSearchVariableWindows* tests not able to handle downloading missing tools