### PR TITLE
Fix several issues in pwiz core

### DIFF
--- a/pwiz/data/identdata/Serializer_pepXML.cpp
+++ b/pwiz/data/identdata/Serializer_pepXML.cpp
@@ -96,7 +96,8 @@ const AnalysisSoftwareTranslation analysisSoftwareTranslationTable[] =
     {MS_Spectrum_Mill_for_MassHunter_Workstation, "Spectrum Mill;SpectrumMill"},
     {MS_Proteios, "Proteios"},
     {MS_MS_GF_, "MS-GF+"},
-    {MS_Comet, "Comet"}
+    {MS_Comet, "Comet"},
+    {MS_Percolator, "Percolator"}
     // TODO: PROBID, InsPecT, Crux, Tide need CV terms
 };
 
@@ -200,7 +201,10 @@ const ScoreTranslation scoreTranslationTable[] =
     {MS_Comet, MS_Comet_deltacnstar, "deltacnstar"},
     {MS_Comet, MS_Comet_sprank, "sprank"},
     {MS_Comet, MS_Comet_spscore, "spscore"},
-    {MS_Comet, MS_Comet_expectation_value, "expect"}
+    {MS_Comet, MS_Comet_expectation_value, "expect"},
+    {MS_Percolator, MS_percolator_score, "percolator_score"},
+    {MS_Percolator, MS_percolator_Q_value, "qvalue;percolator_qvalue"},
+    {MS_Percolator, MS_percolator_PEP, "PEP;percolator_PEP"}
 };
 
 const size_t scoreTranslationTableSize = sizeof(scoreTranslationTable)/sizeof(ScoreTranslation);
@@ -1097,7 +1101,9 @@ struct HandlerSearchSummary : public SAXParser::Handler
         // there's not really a way to avoid hand coding these mappings
 
         // map "decoyprefix" from any search engine; this supports the mzid->pepXML->mzid path
-        const string& decoyPrefix = getValueOrDefault(kvPairs, "decoyprefix", "");
+        string decoyPrefix = getValueOrDefault(kvPairs, "decoyprefix", "");
+        if (decoyPrefix.empty())
+            decoyPrefix = getValueOrDefault(kvPairs, "decoy_prefix", "");
         if (!decoyPrefix.empty())
             _mzid->dataCollection.inputs.searchDatabase[0]->set(MS_decoy_DB_accession_regexp, "^" + decoyPrefix);
 

--- a/pwiz/data/proteome/Serializer_FASTA.cpp
+++ b/pwiz/data/proteome/Serializer_FASTA.cpp
@@ -68,7 +68,7 @@ class ProteinList_FASTA : public ProteinList
         set<string> idSet;
 
         Index::stream_offset indexOffset = 0;
-        while (getlinePortable(*fsPtr_, buf))
+        while (getline(*fsPtr_, buf))
         {
             size_t bufLength = buf.length() + 1; // include newline
             indexOffset += bufLength;
@@ -160,7 +160,7 @@ class ProteinList_FASTA : public ProteinList
         fsPtr_->seekg(entryPtr->offset);
 
         string buf;
-        getlinePortable(*fsPtr_, buf);
+        getline(*fsPtr_, buf);
 
         // test that the index offset is valid
         if (buf.empty() || buf[0] != '>')
@@ -179,7 +179,7 @@ class ProteinList_FASTA : public ProteinList
             fsPtr_->seekg(entryPtr->offset);
 
             string buf;
-            getlinePortable(*fsPtr_, buf);
+            getline(*fsPtr_, buf);
 
             // if the offset is still invalid, throw
             if (buf.empty() || buf[0] != '>')
@@ -208,7 +208,7 @@ class ProteinList_FASTA : public ProteinList
 
         string sequence;
         if (getSequence)
-            while (getlinePortable(*fsPtr_, buf))
+            while (getline(*fsPtr_, buf))
             {
                 if (buf.empty() || buf[0] == '\r') // skip blank lines
                     continue;

--- a/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
@@ -277,7 +277,8 @@ PWIZ_API_DECL void SpectrumList_ABI::createIndex() const
                 msExperiment->getTIC(times, intensities);
 
                 for (int i = 0, end = (int) times.size(); i < end; ++i)
-                    if (!wiff2 || intensities[i] > 0)
+                    if ((!wiff2 || intensities[i] > 0) &&
+                        (experimentType != ABI::Product || wifffile_->getSpectrum(msExperiment, i+1)->getHasPrecursorInfo()))
                         experimentAndCycleByTime.insert(make_pair(times[i], make_pair(msExperiment, i + 1)));
             }
             else

--- a/pwiz_tools/BiblioSpec/Jamfile.jam
+++ b/pwiz_tools/BiblioSpec/Jamfile.jam
@@ -122,7 +122,7 @@ tar.create bibliospec-bin.tar.bz2
     $(PWIZ_LIBRARIES_PATH)/predef
     $(PWIZ_LIBRARIES_PATH)/libsvm-3.0
     $(PWIZ_LIBRARIES_PATH)/SQLite
-    [ path.glob $(PWIZ_LIBRARIES_PATH) : *.bat *.sh *.jam *.dll *.lib *.exe *.cpp libgd*.tar.bz2 libpng*.tar.bz2 freetype*.tar.bz2 zlib*.tar.bz2 hdf5*.tar.bz2 expat*.tar.bz2 ]
+    [ path.glob $(PWIZ_LIBRARIES_PATH) : *.bat *.sh *.h *.jam *.dll *.lib *.exe *.cpp libgd*.tar.bz2 libpng*.tar.bz2 freetype*.tar.bz2 zlib*.tar.bz2 hdf5*.tar.bz2 expat*.tar.bz2 ]
 
     # include the bcp'd boost tarball as if it was really located at "libraries/boost_*.tar.bz2"
     "path-anchor:$(BOOST_SUBSET_PATH)"


### PR DESCRIPTION
- added Percolator terms to Serializer_pepXML's translation tables
- fixed MS2 spectra in WIFF files sometimes missing precursor info
* fixed csv.h missing from BiblioSpec subset tarball
* fixed indexing bug in Serializer_FASTA caused by earlier getlinePortable() change