### PR TITLE
Fixed .skyd file corruption problem which can happen if there are mor…

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -581,7 +581,7 @@ namespace pwiz.Skyline.Model.Results
                 readStream.Seek(LocationPeaks + firstPeakIndex * CacheFormat.ChromPeakSize, SeekOrigin.Begin);
                 if (CacheFormat.ChromPeakSize == targetFormat.ChromPeakSize)
                 {
-                    readStream.TransferBytes(writeStream, peakCount * CacheFormat.ChromPeakSize);
+                    readStream.TransferBytes(writeStream, (long) peakCount * CacheFormat.ChromPeakSize);
                     return;
                 }
 

--- a/pwiz_tools/Skyline/Util/UtilIO.cs
+++ b/pwiz_tools/Skyline/Util/UtilIO.cs
@@ -1038,20 +1038,30 @@ namespace pwiz.Skyline.Util
 
     public static class StreamEx
     {
-        public static void TransferBytes(this Stream inStream, Stream outStream, long lenRead)
+        public static void TransferBytes(this Stream inStream, Stream outStream, long bytesToTransfer)
         {
-            inStream.TransferBytes(outStream, lenRead, new byte[0x40000]); // 256K
+            inStream.TransferBytes(outStream, bytesToTransfer, new byte[0x40000]); // 256K
         }
 
-        public static void TransferBytes(this Stream inStream, Stream outStream, long lenRead, byte[] buffer)
+        public static void TransferBytes(this Stream inStream, Stream outStream, long bytesToTransfer, byte[] buffer)
         {
+            long bytesTransferred = 0;
+            long bytesRemaining = bytesToTransfer;
             int len;
-            while (lenRead > 0 && (len = inStream.Read(buffer, 0, (int)Math.Min(lenRead, buffer.Length))) != 0)
+            while (bytesToTransfer > 0 && (len = inStream.Read(buffer, 0, (int)Math.Min(bytesRemaining, buffer.Length))) != 0)
             {
                 outStream.Write(buffer, 0, len);
-                lenRead -= len;
+                bytesRemaining -= len;
+                bytesTransferred += len;
             }
-        }    
+
+            if (bytesTransferred != bytesToTransfer)
+            {
+                throw new InvalidDataException(string.Format(
+                    @"Tried to transfer {0} bytes, but actual byte count transferred was {1}", bytesToTransfer,
+                    bytesTransferred));
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
…e than 60 million candidate peaks (Reported by Haiyan, thanks Nick)

In ChromatogramCache.RawData.TransferPeaks, if the number of peaks multiplied by 36 did not fit in a 32 bit integer, then the .skyd file would become corrupted.