### PR TITLE
ImportTransitionListColumnSelectDlg lags a bit when associate proteins checked…

### DIFF
--- a/pwiz_tools/Shared/ProteomeDb/API/Digestion.cs
+++ b/pwiz_tools/Shared/ProteomeDb/API/Digestion.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NHibernate;
 using pwiz.ProteomeDatabase.DataModel;
 
@@ -40,32 +41,37 @@ namespace pwiz.ProteomeDatabase.API
 
         public List<Protein> GetProteinsWithSequence(String sequence)
         {
-            return GetProteinsWithSequences(new[] { sequence })[sequence];
+            return GetProteinsWithSequences(new[] { sequence }, CancellationToken.None)[sequence];
         }
 
         public List<Protein> GetProteinsWithSequence(IStatelessSession session, String sequence)
         {
-            return GetProteinsWithSequences(session, new[] {sequence})[sequence];
+            return GetProteinsWithSequences(session, new[] {sequence}, CancellationToken.None)[sequence];
         }
 
-        public IDictionary<String, List<Protein>> GetProteinsWithSequences(IEnumerable<string> sequences)
+        public IDictionary<String, List<Protein>> GetProteinsWithSequences(IEnumerable<string> sequences,  CancellationToken cancellationToken)
         {
             using (var session = ProteomeDb.OpenStatelessSession(false))
             {
-                return GetProteinsWithSequences(session, sequences);
+                return GetProteinsWithSequences(session, sequences, cancellationToken);
             }
         }
 
         public IDictionary<String, List<Protein>> GetProteinsWithSequences(IStatelessSession session,
-            IEnumerable<string> sequences)
+            IEnumerable<string> sequences, CancellationToken cancellationToken)
         {
             var sequenceList = sequences.ToArray();
             var proteinIds = GetProteinIdsThatMightHaveSequence(session, sequenceList);
             var results = new Dictionary<string, List<Protein>>();
             var proteins = GetProteinsWithIds(session, proteinIds);
+            var count = 0;
             foreach (var s in sequenceList.Distinct())
             {
                 results.Add(s, proteins.Where(p => p.Sequence.IndexOf(s, StringComparison.Ordinal) >= 0).ToList());
+                if ((count++ % 100) == 0 && cancellationToken.IsCancellationRequested)
+                {
+                    return null;
+                }
             }
             return results;
         }

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
@@ -94,7 +94,11 @@ namespace pwiz.Skyline.EditUI
                     using (var proteomeDb = proteome.OpenProteomeDb(longWaitBroker.CancellationToken))
                     {
                         proteinsWithSequences = proteomeDb.GetDigestion()
-                            .GetProteinsWithSequences(peptidesForMatching.Select(pep => pep.Peptide.Target.Sequence));
+                            .GetProteinsWithSequences(peptidesForMatching.Select(pep => pep.Peptide.Target.Sequence), longWaitBroker.CancellationToken);
+                        if (longWaitBroker.IsCanceled)
+                        {
+                            proteinsWithSequences = null;
+                        }
                     }
                 });
             }

--- a/pwiz_tools/Skyline/EditUI/PasteDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.cs
@@ -776,7 +776,7 @@ namespace pwiz.Skyline.EditUI
             var proteinName = Convert.ToString(row.Cells[proteinIndex].Value);
             var pepModSequence = Convert.ToString(row.Cells[sequenceIndex].Value);
 
-            var associateAction = associateHelper.determineAssociateAction(proteinName, pepModSequence, seenPepSeq, keepAllPeptides);
+            var associateAction = associateHelper.DetermineAssociateAction(proteinName, pepModSequence, seenPepSeq, keepAllPeptides);
             numUnmatched = associateHelper.numUnmatched;
             numMultipleMatches = associateHelper.numMultipleMatches;
             numFiltered = associateHelper.numFiltered;
@@ -848,9 +848,10 @@ namespace pwiz.Skyline.EditUI
             /// <param name="pepModSequence">Modified sequence of the peptide to be associated</param>
             /// <param name="seenPepSeq">Peptide sequences we have already seen in the data</param>
             /// <param name="keepAllPeptides">Keep peptides that have multiple matches or no matches</param>
+            /// <param name="dictSequenceProteins">Optional prefetched mapping of stripped peptides to proteins</param>
             /// <returns></returns>
-            public AssociateAction determineAssociateAction(string proteinName, string pepModSequence, HashSet<string> seenPepSeq, 
-                bool keepAllPeptides)
+            public AssociateAction DetermineAssociateAction(string proteinName, string pepModSequence, HashSet<string> seenPepSeq, 
+                bool keepAllPeptides, IDictionary<string, List<Protein>> dictSequenceProteins = null)
             {
 
                 // Only enumerate the proteins if the user has not specified a protein.
@@ -879,7 +880,14 @@ namespace pwiz.Skyline.EditUI
                     seenPepSeq.Add(peptideSequence);
                 }
 
-                proteinNames = GetProteinNamesForPeptideSequence(peptideSequence, _docCurrent, out var proteinList);
+                if (dictSequenceProteins != null && dictSequenceProteins.TryGetValue(peptideSequence, out var proteinList))
+                {
+                    proteinNames = proteinList.ConvertAll(p => p.Name);
+                }
+                else
+                {
+                    proteinNames = GetProteinNamesForPeptideSequence(peptideSequence, _docCurrent, out proteinList);
+                }
                 proteins = proteinList;
 
                 bool isUnmatched = proteinNames == null || proteinNames.Count == 0;

--- a/pwiz_tools/Skyline/EditUI/UniquePeptidesDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/UniquePeptidesDlg.cs
@@ -349,7 +349,7 @@ namespace pwiz.Skyline.EditUI
                     if (digestion != null)
                     {
                         var peptidesOfInterest = _peptideDocNodes.Select(node => node.Item2.Peptide.Target.Sequence);
-                        var sequenceProteinsDict = digestion.GetProteinsWithSequences(peptidesOfInterest);
+                        var sequenceProteinsDict = digestion.GetProteinsWithSequences(peptidesOfInterest, longWaitBroker.CancellationToken);
                         if (longWaitBroker.IsCanceled)
                         {
                             return;

--- a/pwiz_tools/Skyline/Menus/EditMenu.cs
+++ b/pwiz_tools/Skyline/Menus/EditMenu.cs
@@ -322,11 +322,13 @@ namespace pwiz.Skyline.Menus
             else
             {
                 string text;
-                string textCsv;
                 try
                 {
-                    text = ClipboardEx.GetText().Trim();
-                    textCsv = ClipboardEx.GetText(TextDataFormat.CommaSeparatedValue);
+                    text = ClipboardEx.GetText(TextDataFormat.CommaSeparatedValue);
+                    if (string.IsNullOrEmpty(text))
+                    {
+                        text = ClipboardEx.GetText().Trim();
+                    }
                 }
                 catch (Exception)
                 {
@@ -335,7 +337,7 @@ namespace pwiz.Skyline.Menus
                 }
                 try
                 {
-                    Paste(string.IsNullOrEmpty(textCsv) ? text : textCsv);
+                    Paste(text);
                 }
                 catch (Exception x)
                 {

--- a/pwiz_tools/Skyline/Model/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Transition.cs
@@ -301,8 +301,14 @@ namespace pwiz.Skyline.Model
                 return text;
 
             var sequences = new List<string>();
+            var consecutiveLinesWithoutChargeIndicators = 0;
             foreach (var line in text.Split('\n').Select(seq => seq.Trim()))
             {
+                if (consecutiveLinesWithoutChargeIndicators > 1000)
+                {
+                    sequences.Add(line); // If we haven't seen anything like "PEPTIDER+++" by now, we aren't going to 
+                    continue;
+                }
                 // Allow any run of charge indicators no matter how long, because users guess this might work
                 int chargePos = FindChargeSymbolRepeatStart(line, min, max);
                 if (chargePos == -1)
@@ -326,6 +332,15 @@ namespace pwiz.Skyline.Model
                             chargePos = adductStart;
                         }
                     }
+                }
+
+                if (chargePos == -1)
+                {
+                    consecutiveLinesWithoutChargeIndicators++;
+                }
+                else
+                {
+                    consecutiveLinesWithoutChargeIndicators = 0;
                 }
                 sequences.Add(chargePos == -1 ? line : line.Substring(0, chargePos));
             }

--- a/pwiz_tools/Skyline/TestFunctional/InsertTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/InsertTest.cs
@@ -27,7 +27,6 @@ using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.Extensions;
 using pwiz.Skyline.Model.Proteome;
-using pwiz.Skyline.Properties;
 using pwiz.Skyline.SettingsUI;
 using pwiz.SkylineTestUtil;
 
@@ -106,12 +105,8 @@ namespace pwiz.SkylineTestFunctional
             var pasteText = TransitionsClipboardText;
             var transitionDlg = ShowDialog<InsertTransitionListDlg>(SkylineWindow.ShowPasteTransitionListDlg);
             var windowDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => transitionDlg.textBox1.Text = pasteText);
-            RunUI(() => {
-                var comboBoxes = windowDlg.ComboBoxes;
-                comboBoxes[0].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence);
-                comboBoxes[1].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z);
-                comboBoxes[2].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z);
-            });
+            var associateProteinsDlg = ShowDialog<FilterMatchedPeptidesDlg>(() => windowDlg.checkBoxAssociateProteins.Checked = true ); // // Enable Associate Proteins, but some peptides aren't in background proteome
+            OkDialog(associateProteinsDlg, associateProteinsDlg.OkDialog);
             var errDlg = ShowDialog<ImportTransitionListErrorDlg>(windowDlg.OkDialog);
             RunUI(() =>
             {
@@ -146,15 +141,14 @@ namespace pwiz.SkylineTestFunctional
             var pasteText2 = "LGPGRPLPTFPTSEC[+57]TS[+80]DVEPDTR[+10]\t907.081803\t1387.566968\tDDX54_CL02".Replace(".", LocalizationHelper.CurrentCulture.NumberFormat.NumberDecimalSeparator);
             var transitionDlg2 = ShowDialog<InsertTransitionListDlg>(SkylineWindow.ShowPasteTransitionListDlg);
             var windowDlg2 = ShowDialog<ImportTransitionListColumnSelectDlg>(() => transitionDlg2.textBox1.Text = pasteText2);
-            RunUI(() => {
-                var comboBoxes = windowDlg2.ComboBoxes;
-                comboBoxes[0].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence);
-                comboBoxes[1].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z);
-                comboBoxes[2].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z);
-                comboBoxes[3].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Protein_Name);
-            });
-            // This data was recognized by an error when put into PasteDlg but does not meet the criteria for an error here
-            RunUI(windowDlg2.CancelDialog);
+            associateProteinsDlg = ShowDialog<FilterMatchedPeptidesDlg>(() => windowDlg2.checkBoxAssociateProteins.Checked = true); // // Enable Associate Proteins, but some peptides aren't in background proteome
+            OkDialog(associateProteinsDlg, associateProteinsDlg.OkDialog);
+
+            var noErrDlg = ShowDialog<MessageDlg>(() => windowDlg2.CheckForErrors());
+            Assert.AreEqual(Skyline.Properties.Resources.PasteDlg_ShowNoErrors_No_errors, noErrDlg.Message);
+            OkDialog(noErrDlg, noErrDlg.OkDialog);
+            RunUI(() => windowDlg2.CancelDialog());
+            WaitForClosedForm(windowDlg2);
         }
 
         private static void PastePeptides(PasteDlg pasteDlg, BackgroundProteome.DuplicateProteinsFilter duplicateProteinsFilter, 

--- a/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
@@ -272,13 +272,9 @@ namespace pwiz.SkylineTestFunctional
 
             SetClipboardText(File.ReadAllText(TestFilesDir.GetTestPath("PeptideTransitionList.csv")));
             dlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => SkylineWindow.Paste());
-
-            RunUI(() => {
-                dlg.radioPeptide.PerformClick();
+            RunUI(() => { // Disable the peptide column
                 var comboBoxes = dlg.ComboBoxes;
-                comboBoxes[1].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence);
                 comboBoxes[1].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column);
-                comboBoxes[2].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z);
             });
             // As long as the message tells us that we are missing "Peptide Modified Sequence" and not "Molecule Molecule", then everything is working how we want it to
             var msg = ShowDialog<MessageDlg>(dlg.buttonCheckForErrors.PerformClick);

--- a/pwiz_tools/Skyline/TestTutorial/ExistingExperimentsTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/ExistingExperimentsTutorialTest.cs
@@ -158,15 +158,9 @@ namespace pwiz.SkylineTestTutorial
             var filePath = GetTestPath(@"MRMer\silac_1_to_4.xls"); // Not L10N
             string text1 = GetExcelFileText(filePath, "Fixed", 3, false); // Not L10N
             var colDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => importDialog.textBox1.Text = text1);
-
+            PauseForScreenShot<ImportTransitionListColumnSelectDlg>("Insert Transition List column selection form", 9);
             RunUI(() => {
-                colDlg.radioPeptide.PerformClick();
-                var comboBoxes = colDlg.ComboBoxes;
-                comboBoxes[0].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence);
-                comboBoxes[1].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z);
-                comboBoxes[2].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z);
-
-                colDlg.checkBoxAssociateProteins.Checked = true;
+                colDlg.checkBoxAssociateProteins.Checked = true; // Enable Associate Proteins
             });
 
             OkDialog(colDlg, colDlg.OkDialog);

--- a/pwiz_tools/Skyline/TestTutorial/SRMTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/SRMTutorialTest.cs
@@ -347,10 +347,6 @@ namespace pwiz.SkylineTestTutorial
             var col4Dlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => importDialog3.textBox1.Text = impliedLabeled);
             
             RunUI(() => {
-                var comboBoxes = col4Dlg.ComboBoxes;
-                comboBoxes[0].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence);
-                comboBoxes[1].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z);
-                comboBoxes[2].SelectedIndex = comboBoxes[1].FindStringExact(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z);
                 col4Dlg.checkBoxAssociateProteins.Checked = true;
             });
 


### PR DESCRIPTION
…, per https://skyline.ms/issues/home/issues/details.view?issueId=857  implementing a quick fix:

 default to Associate Proteins *not* checked
 some performance improvements by batching up the protdb peptide search (was one query per unique peptide)
 make operation cancelable

to be followed by a more complete fix:
  default to checked, but only operate on the handful of visible peptides in the dialog
  defer the full task to when user hits "check for errors" or "OK" (retain result if done in "check for errors")
  add progress indicator to the cancelation mechanism (probably means breaking the search into chunks)