### PR TITLE
Precursor charge state wasn't being recognized in small molecule transition list import

### DIFF
--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -463,7 +463,7 @@ namespace pwiz.Skyline.FileUI
             SetComboBoxText(columns.KEGGColumn, @"KEGG");
             SetComboBoxText(columns.InChiColumn, @"InChi");
             SetComboBoxText(columns.InChiKeyColumn, @"InChiKey");
-            // SetComboBoxText(columns.PrecursorChargeColumn, Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_Charge);
+            SetComboBoxText(columns.PrecursorChargeColumn, Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_Charge);
             var headers = Importer.RowReader.Indices.Headers;
             // Checks if the headers of the current list are the same as the headers of the previous list,
             // because if they are then we want to prioritize user headers

--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -121,6 +121,7 @@ namespace pwiz.SkylineTestFunctional
         {
             var docEmpty = NewDocument();
 
+            TestRecognizeChargeState();
             TestLabelsNoFormulas();
             TestHeavyLightPairs();
             TestHeavyPrecursorNoFormulas();
@@ -1181,6 +1182,21 @@ namespace pwiz.SkylineTestFunctional
             var columnSelectDlg1 = ShowDialog<ImportTransitionListColumnSelectDlg>(() => SkylineWindow.Paste());
             Assert.IsFalse(columnSelectDlg1.radioMolecule.Checked);
             OkDialog(columnSelectDlg1, columnSelectDlg1.CancelDialog);
+        }
+
+        private void TestRecognizeChargeState()
+        {
+            // Make sure we are properly recognizing these common header types
+            var text = "Molecular Formula, Precursor Charge,Product Formula, Product Charge\nH2O10,1,HO10,1\nH2O10,1,HO6,1";
+            var docOrig = NewDocument();
+            var importDialog = ShowDialog<InsertTransitionListDlg>(SkylineWindow.ShowPasteTransitionListDlg);
+            var columnSelectDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => importDialog.textBox1.Text = text);
+            OkDialog(columnSelectDlg, columnSelectDlg.OkDialog);
+            WaitForClosedForm(importDialog);
+
+            var pastedDoc = WaitForDocumentChange(docOrig);
+            AssertEx.IsDocumentState(pastedDoc, null, 1, 1, 1, 2);
+            NewDocument();
         }
 
         private void TestLabelsNoFormulas()


### PR DESCRIPTION
Thanks to Nick for catching this. Too many of our tests set the columns explicitly and we missed this failure to set that column based on input text alone.