### PR TITLE
Skyline/work/20211214 code inspection helpful message for misconfigured visual studio

### DIFF
--- a/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
+++ b/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
@@ -30,6 +30,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;


### PR DESCRIPTION
We encountered an issue running our CodeInspection test in Test Explorer (but not TestRunner) which turned out to be a VS2019 configuration issue. Now the test shows this:

    Test method pwiz.SkylineTest.CodeInspectionTest.CodeInspection threw exception:
    System.Exception: Error in FindForms
    (Perhaps Visual Studio menu item "Test | Configure Run Settings | Select Solution Wide runsettings File" is not set to "TestSettings_x64.runsettings"?)
       at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
       at System.Reflection.RuntimeModule.GetTypes()
       at System.Reflection.Assembly.GetTypes()
       at pwiz.SkylineTest.CodeInspectionTest.FindForms(Type[] inUseFormTypes, Type[] directParentTypes) in C:\Dev\Releases\21.2\pwiz_tools\Skyline\Test\CodeInspectionTest.cs:line 293

    Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.

    Could not load file or assembly 'System.Data.SQLite, Version=1.0.98.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139' or one of its dependencies. An attempt was made to load a program with an incorrect format.

    Could not load file or assembly 'SkylineTool, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. An attempt was made to load a program with an incorrect format.

    Could not load file or assembly 'PrmPasefScheduler, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. An attempt was made to load a program with an incorrect format.

    Could not load file or assembly 'SkylineTool, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. An attempt was made to load a program with an incorrect format.

    Could not load file or assembly 'PrmPasefScheduler, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. An attempt was made to load a program with an incorrect format.

    Could not load file or assembly 'PrmPasefScheduler, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. An attempt was made to load a program with an incorrect format.

    Could not load file or assembly 'PrmPasefScheduler, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. An attempt was made to load a program with an incorrect format.
     ---> System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information.