### PR TITLE
Fixed a problem handling transition lists with missing product m/z in…

### DIFF
--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -1544,7 +1544,7 @@ namespace pwiz.Skyline.Model
                     int iPrecursor = prec.PrecursorMzIdex;
                     int iProduct = FindProduct(fieldsFirstRow, prec.Sequence, prec.TransitionExps, prec.SequenceIndex, prec.PrecursorMzIdex,
                         tolerance, provider, settings);
-                    if (iProduct == -1)
+                    if (iProduct == -1 && !tolerateErrors)
                         throw new MzMatchException(Resources.GeneralRowReader_Create_No_valid_product_m_z_column_found, 1, -1);
 
                     int iProt = indices.ProteinColumn;

--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -1219,9 +1219,8 @@ namespace pwiz.SkylineTestFunctional
                 }
                 var errText = string.Format(Resources.PasteDlg_ValidateEntry_Error_on_line__0___Product_needs_values_for_any_two_of__Formula__m_z_or_Charge_, 1);
                 Assert.IsTrue(allErrorText.Contains(errText),
-                    string.Format(
-                        "Unexpected value in paste dialog error window:\r\nexpected \"{0}\"\r\ngot \"{1}\"",
-                        errText, errDlg.ErrorList));
+                    "Unexpected value in paste dialog error window:\r\nexpected \"{0}\"\r\ngot \"{1}\"",
+                    errText, errDlg.ErrorList);
             });
             OkDialog(errDlg, errDlg.Close);
             OkDialog(columnSelectDlg, columnSelectDlg.CancelDialog);

--- a/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
@@ -18,6 +18,7 @@
  */
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -55,7 +56,9 @@ namespace pwiz.SkylineTestFunctional
         }
 
         protected override void DoTest()
-        { 
+        {
+            TestMissingFragmentMz();
+
             RunUI(() => SkylineWindow.NewDocument());
 
             WaitForDocumentLoaded();
@@ -313,6 +316,34 @@ namespace pwiz.SkylineTestFunctional
             }); // Let it initialize
 
             RunUI(() => documentGrid.Close());
+        }
+
+        private void TestMissingFragmentMz()
+        {
+            // Make sure we properly handle missing fragment mz info
+            var saveColumnOrder = Settings.Default.CustomMoleculeTransitionInsertColumnsList;
+            var text =  "Peptide Modified Sequence\tPrecursor m/z\tFragment Name\tProduct Charge\nPEPTIDER\t478.738\ty1\t1\nPEPTIDER\t478.738\ty2\t1";
+            var importDialog = ShowDialog<InsertTransitionListDlg>(SkylineWindow.ShowPasteTransitionListDlg);
+            var columnSelectDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => importDialog.textBox1.Text =
+                text.Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator));
+
+            var errDlg = ShowDialog<MessageDlg>(columnSelectDlg.CheckForErrors);
+            RunUI(() =>
+            {
+                Assert.IsTrue(errDlg.Message.Contains(Resources.ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_) &&
+                              errDlg.Message.Contains(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z),
+                    string.Format(
+                        "Unexpected value in paste dialog error window:\r\nexpected \"{0}\"\r\ngot \"{1}\"",
+                        Resources.ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_ +
+                        Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z,
+                        errDlg.Message));
+            });
+            OkDialog(errDlg, errDlg.Close);
+
+            OkDialog(columnSelectDlg, columnSelectDlg.CancelDialog);
+            WaitForClosedForm(importDialog);
+
+            RunUI(() => Settings.Default.CustomMoleculeTransitionInsertColumnsList = saveColumnOrder);
         }
 
     }

--- a/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
@@ -332,11 +332,10 @@ namespace pwiz.SkylineTestFunctional
             {
                 Assert.IsTrue(errDlg.Message.Contains(Resources.ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_) &&
                               errDlg.Message.Contains(Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z),
-                    string.Format(
-                        "Unexpected value in paste dialog error window:\r\nexpected \"{0}\"\r\ngot \"{1}\"",
-                        Resources.ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_ +
-                        Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z,
-                        errDlg.Message));
+                    "Unexpected value in paste dialog error window:\r\nexpected \"{0}\"\r\ngot \"{1}\"",
+                    Resources.ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_ +
+                    Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z,
+                    errDlg.Message);
             });
             OkDialog(errDlg, errDlg.Close);
 


### PR DESCRIPTION
…formation (ref  https://skyline.ms/announcements/home/issues/exceptions/thread.view?rowId=54002). This would cause an exception during the initial inspection of the data to determine its format, but during the inspection phase no exception should be thrown.