### PR TITLE
Dialog title should be "Import Assay Library: Identify Columns"…

### DIFF
--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -124,7 +124,7 @@ namespace pwiz.Skyline.FileUI
         private List<string> smallMolColPositions;
         private List<string> peptideColPositions;
 
-        public ImportTransitionListColumnSelectDlg(MassListImporter importer, SrmDocument docCurrent, MassListInputs inputs, IdentityPath insertPath)
+        public ImportTransitionListColumnSelectDlg(MassListImporter importer, SrmDocument docCurrent, MassListInputs inputs, IdentityPath insertPath, bool assayLibrary)
         {
             Importer = importer;
             _docCurrent = docCurrent;
@@ -136,6 +136,11 @@ namespace pwiz.Skyline.FileUI
             _proteinTip = new NodeTip(this) { Parent = this };
             previousIndices = new int[Importer.RowReader.Lines[0].ParseDsvFields(Importer.Separator).Length + 1];
             InitializeComponent();
+
+            if (assayLibrary) // Dialog title should be "Import Assay Library: Identify Columns" instead of "Transition List: Identify Columns"
+            {
+                Text = Resources.ImportTransitionListColumnSelectDlg_Import_Assay_Library___Identify_Columns;
+            }
 
             fileLabel.Text = Importer.Inputs.InputFilename;
             InitializeComboBoxes();

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -137,9 +137,9 @@ namespace pwiz.Skyline.FileUI
             previousIndices = new int[Importer.RowReader.Lines[0].ParseDsvFields(Importer.Separator).Length + 1];
             InitializeComponent();
 
-            if (assayLibrary) // Dialog title should be "Import Assay Library: Identify Columns" instead of "Transition List: Identify Columns"
+            if (assayLibrary) // Dialog title should be "Import Assay Library:Identify Columns" instead of "Transition List:Identify Columns"
             {
-                Text = Resources.ImportTransitionListColumnSelectDlg_Import_Assay_Library___Identify_Columns;
+                Text = Resources.ImportTransitionListColumnSelectDlg_Import_Assay_Library__Identify_Columns;
             }
 
             fileLabel.Text = Importer.Inputs.InputFilename;

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.resx
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.resx
@@ -445,7 +445,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Import Transition List:  Identify Columns</value>
+    <value>Import Transition List: Identify Columns</value>
   </data>
   <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
     <value>modeUIHandler</value>

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -16327,6 +16327,15 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Import Assay Library:  Identify Columns.
+        /// </summary>
+        public static string ImportTransitionListColumnSelectDlg_Import_Assay_Library___Identify_Columns {
+            get {
+                return ResourceManager.GetString("ImportTransitionListColumnSelectDlg_Import_Assay_Library___Identify_Columns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Decoy.
         /// </summary>
         public static string ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Decoy {

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -16327,11 +16327,11 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Import Assay Library:  Identify Columns.
+        ///   Looks up a localized string similar to Import Assay Library: Identify Columns.
         /// </summary>
-        public static string ImportTransitionListColumnSelectDlg_Import_Assay_Library___Identify_Columns {
+        public static string ImportTransitionListColumnSelectDlg_Import_Assay_Library__Identify_Columns {
             get {
-                return ResourceManager.GetString("ImportTransitionListColumnSelectDlg_Import_Assay_Library___Identify_Columns", resourceCulture);
+                return ResourceManager.GetString("ImportTransitionListColumnSelectDlg_Import_Assay_Library__Identify_Columns", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -11630,4 +11630,7 @@ If you do not have the original file, you may build the library with embedded sp
   <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Multiple_ion_mobility_declarations" xml:space="preserve">
     <value>Multiple ion mobility declarations</value>
   </data>
+  <data name="ImportTransitionListColumnSelectDlg_Import_Assay_Library___Identify_Columns" xml:space="preserve">
+    <value>Import Assay Library:  Identify Columns</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -11630,7 +11630,7 @@ If you do not have the original file, you may build the library with embedded sp
   <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Multiple_ion_mobility_declarations" xml:space="preserve">
     <value>Multiple ion mobility declarations</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_Import_Assay_Library___Identify_Columns" xml:space="preserve">
-    <value>Import Assay Library:  Identify Columns</value>
+  <data name="ImportTransitionListColumnSelectDlg_Import_Assay_Library__Identify_Columns" xml:space="preserve">
+    <value>Import Assay Library: Identify Columns</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -1969,7 +1969,7 @@ namespace pwiz.Skyline
             if (useColSelectDlg)
             {
                 // Allow the user to assign column types
-                using (var columnDlg = new ImportTransitionListColumnSelectDlg(importer, docCurrent, inputs, insertPath))
+                using (var columnDlg = new ImportTransitionListColumnSelectDlg(importer, docCurrent, inputs, insertPath, assayLibrary))
                 {
                     if (columnDlg.ShowDialog(this) != DialogResult.OK)
                         return;


### PR DESCRIPTION
… instead of "Transition List: Identify Columns" when importing an assay library.