### PR TITLE
* commented out several apparently unused/unnecessary MSVC runtime DLLs

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -1315,26 +1315,21 @@ searched-lib msparser : : <conditional>@msparser-requirements : : <conditional>@
     Microsoft.VC140.CRT/x86/api-ms-win-crt-string-l1-1-0.dll 
     Microsoft.VC140.CRT/x86/api-ms-win-crt-time-l1-1-0.dll 
     Microsoft.VC140.CRT/x86/api-ms-win-crt-utility-l1-1-0.dll 
-    Microsoft.VC140.CRT/x86/concrt140.dll
-    Microsoft.VC140.CRT/x86/mfc140.dll 
+    #Microsoft.VC140.CRT/x86/concrt140.dll
+    #Microsoft.VC140.CRT/x86/mfc140.dll 
     Microsoft.VC140.CRT/x86/msvcp140.dll 
     Microsoft.VC140.CRT/x86/ucrtbase.dll 
     Microsoft.VC140.CRT/x86/vcomp140.dll 
     Microsoft.VC140.CRT/x86/vcruntime140.dll 
-    Microsoft.VC140.CRT/x86/msvcp140_1.dll
-    Microsoft.VC140.CRT/x86/msvcp140_2.dll
-    Microsoft.VC140.CRT/x86/msvcp140_atomic_wait.dll
-    Microsoft.VC140.CRT/x86/msvcp140_codecvt_ids.dll
-    Microsoft.VC140.CRT/x86/vccorlib140.dll
-    Microsoft.VC90.CRT/x86/msvcm90.dll 
-    Microsoft.VC90.CRT/x86/msvcp90.dll 
-    Microsoft.VC90.CRT/x86/msvcr90.dll 
-    Microsoft.VC90.CRT/x86/vcomp90.dll 
-    Microsoft.VC90.CRT/x86/Microsoft.VC90.CRT.manifest
-    Microsoft.VC90.CRT/x86/Microsoft.VC90.OpenMP.manifest
+    #Microsoft.VC140.CRT/x86/msvcp140_1.dll
+    #Microsoft.VC140.CRT/x86/msvcp140_2.dll
+    #Microsoft.VC140.CRT/x86/msvcp140_atomic_wait.dll
+    #Microsoft.VC140.CRT/x86/msvcp140_codecvt_ids.dll
+    #Microsoft.VC140.CRT/x86/vccorlib140.dll
     Microsoft.VC90.MFC/x86/Microsoft.VC90.MFC.manifest
-    Microsoft.VC90.MFC/x86/mfc90.dll 
     Microsoft.VC90.MFC/x86/mfc90u.dll 
+    Microsoft.VC90.CRT/x86/msvcp90.dll # used by MSFileReader
+    Microsoft.VC90.CRT/x86/msvcr90.dll # used by MSFileReader
     ;
 
 .msvcrt-x64 =
@@ -1383,26 +1378,37 @@ searched-lib msparser : : <conditional>@msparser-requirements : : <conditional>@
     Microsoft.VC140.CRT/x64/api-ms-win-crt-string-l1-1-0.dll
     Microsoft.VC140.CRT/x64/api-ms-win-crt-time-l1-1-0.dll
     Microsoft.VC140.CRT/x64/api-ms-win-crt-utility-l1-1-0.dll
-    Microsoft.VC140.CRT/x64/concrt140.dll
-    Microsoft.VC140.CRT/x64/mfc140.dll
+    #Microsoft.VC140.CRT/x64/concrt140.dll
+    #Microsoft.VC140.CRT/x64/mfc140.dll
     Microsoft.VC140.CRT/x64/msvcp140.dll
     Microsoft.VC140.CRT/x64/ucrtbase.dll
     Microsoft.VC140.CRT/x64/vcomp140.dll
     Microsoft.VC140.CRT/x64/vcruntime140.dll
-    Microsoft.VC140.CRT/x64/msvcp140_1.dll
-    Microsoft.VC140.CRT/x64/msvcp140_2.dll
-    Microsoft.VC140.CRT/x64/msvcp140_atomic_wait.dll
-    Microsoft.VC140.CRT/x64/msvcp140_codecvt_ids.dll
+    #Microsoft.VC140.CRT/x64/msvcp140_1.dll
+    #Microsoft.VC140.CRT/x64/msvcp140_2.dll
+    #Microsoft.VC140.CRT/x64/msvcp140_atomic_wait.dll
+    #Microsoft.VC140.CRT/x64/msvcp140_codecvt_ids.dll
     Microsoft.VC140.CRT/x64/vcruntime140_1.dll
-    Microsoft.VC140.CRT/x64/vccorlib140.dll
-    Microsoft.VC90.CRT/x64/msvcm90.dll
-    Microsoft.VC90.CRT/x64/msvcp90.dll
-    Microsoft.VC90.CRT/x64/msvcr90.dll
-    Microsoft.VC90.CRT/x64/vcomp90.dll
+    #Microsoft.VC140.CRT/x64/vccorlib140.dll
+    ;
+
+.msvcrt-x86-cxt =    
+    Microsoft.VC90.CRT/x86/msvcm90.dll # used by CompassXtract
+    Microsoft.VC90.CRT/x86/vcomp90.dll # used by CompassXtract
+    Microsoft.VC90.MFC/x86/mfc90.dll # used by CompassXtract
+    Microsoft.VC90.CRT/x86/Microsoft.VC90.CRT.manifest
+    Microsoft.VC90.CRT/x86/Microsoft.VC90.OpenMP.manifest
+    ;
+
+.msvcrt-x64-cxt =
+    Microsoft.VC90.CRT/x64/msvcm90.dll # used by CompassXtract
+    Microsoft.VC90.CRT/x64/msvcp90.dll # used by CompassXtract
+    Microsoft.VC90.CRT/x64/msvcr90.dll # used by CompassXtract
+    Microsoft.VC90.CRT/x64/vcomp90.dll # used by CompassXtract
+    Microsoft.VC90.MFC/x64/mfc90.dll # used by CompassXtract
     Microsoft.VC90.CRT/x64/Microsoft.VC90.CRT.manifest
     Microsoft.VC90.CRT/x64/Microsoft.VC90.OpenMP.manifest
     Microsoft.VC90.MFC/x64/Microsoft.VC90.MFC.manifest
-    Microsoft.VC90.MFC/x64/mfc90.dll
     ;
 
 rule msvc-runtime-dlls ( properties * )
@@ -1410,13 +1416,16 @@ rule msvc-runtime-dlls ( properties * )
     local result ;
     if <toolset>msvc in $(properties)
     {
+        local xbit = "x86" ;
         if <address-model>64 in $(properties)
         {
-            result = <assembly-dependency>$(PWIZ_ROOT_PATH)/pwiz_tools/Shared/Lib/$(.msvcrt-x64) ;
+            xbit = "x64" ;
         }
-        else
+
+        result = <assembly-dependency>$(PWIZ_ROOT_PATH)/pwiz_tools/Shared/Lib/$(.msvcrt-$(xbit)) ;
+        if ! --without-compassxtract in [ modules.peek : ARGV ]
         {
-            result = <assembly-dependency>$(PWIZ_ROOT_PATH)/pwiz_tools/Shared/Lib/$(.msvcrt-x86) ;
+            result += <assembly-dependency>$(PWIZ_ROOT_PATH)/pwiz_tools/Shared/Lib/$(.msvcrt-$(xbit)-cxt) ;
         }
     }
     return $(result) ;
@@ -1427,13 +1436,16 @@ rule install-msvc-runtime-dlls-requirements ( properties * )
     local result ;
     if <toolset>msvc in $(properties)
     {
+        local xbit = "x86" ;
         if <address-model>64 in $(properties)
         {
-            result = <source>$(PWIZ_ROOT_PATH)/pwiz_tools/Shared/Lib/$(.msvcrt-x64) ;
+            xbit = "x64" ;
         }
-        else
+
+        result = <source>$(PWIZ_ROOT_PATH)/pwiz_tools/Shared/Lib/$(.msvcrt-$(xbit)) ;
+        if ! --without-compassxtract in [ modules.peek : ARGV ]
         {
-            result = <source>$(PWIZ_ROOT_PATH)/pwiz_tools/Shared/Lib/$(.msvcrt-x86) ;
+            result += <source>$(PWIZ_ROOT_PATH)/pwiz_tools/Shared/Lib/$(.msvcrt-$(xbit)-cxt) ;
         }
     }
     return $(result) ;

--- a/pwiz_tools/Skyline/Executables/Installer/Jamfile.jam
+++ b/pwiz_tools/Skyline/Executables/Installer/Jamfile.jam
@@ -139,6 +139,7 @@ actions test_msi
       exit %EXIT%
     )
 
+    chcp 437
     set PATH_TMP=%PATH%
     set PATH=
     copy "$(SKYLINE_BUILD_PATH)\*Test*.dll" "$(INSTALL_PATH)" >nul

--- a/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
+++ b/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
@@ -59,6 +59,8 @@
       <ComponentGroupRef Id="Method_Shimadzu_files"/>
       <ComponentGroupRef Id="Method_Thermo_files"/>
       <ComponentGroupRef Id="Method_Waters_files"/>
+      <ComponentGroupRef Id="Microsoft.VC90.MFC_files"/>
+      <ComponentGroupRef Id="Microsoft.VC90.CRT_files"/>
       <ComponentGroupRef Id="percolator_files"/>
       <ComponentGroupRef Id="ApplicationShortcuts"/>
     </Feature>
@@ -104,6 +106,7 @@
         <Directory Id="Method_Waters_directory" Name="Waters"/>
       </Directory>
       <Directory Id="Microsoft.VC90.MFC_directory" Name="Microsoft.VC90.MFC"/>
+      <Directory Id="Microsoft.VC90.CRT_directory" Name="Microsoft.VC90.CRT"/>
       <Directory Id="percolator_directory" Name="percolator"/>
     </DirectoryRef>
   </Fragment>
@@ -632,6 +635,29 @@
       <Component Id="Method_Waters_VerifyESkylineLibrary.dll">
         <File Source="$(var.Skyline.TargetDir)/Method\Waters\VerifyESkylineLibrary.dll" KeyPath="yes"/>
       </Component>
+    </ComponentGroup>
+    <ComponentGroup Id="Microsoft.VC90.MFC_files" Directory="Microsoft.VC90.MFC_directory">
+      <?if $(sys.BUILDARCH) != x64 ?>
+      <Component>
+        <File Id="Microsoft.VC90.MFC_mfc90u.dll" Source="$(var.Skyline.TargetDir)/Microsoft.VC90.MFC\mfc90u.dll" KeyPath="yes"/>
+      </Component>
+      <Component>
+        <File Id="Microsoft.VC90.MFC_Microsoft.VC90.MFC.manifest" Source="$(var.Skyline.TargetDir)/Microsoft.VC90.MFC\Microsoft.VC90.MFC.manifest" KeyPath="yes"/>
+      </Component>
+      <?endif?>
+    </ComponentGroup>
+    <ComponentGroup Id="Microsoft.VC90.CRT_files" Directory="Microsoft.VC90.CRT_directory">
+      <?if $(sys.BUILDARCH) != x64 ?>
+      <Component>
+        <File Id="Microsoft.VC90.CRT_msvcp90.dll" Source="$(var.Skyline.TargetDir)/Microsoft.VC90.CRT\msvcp90.dll" KeyPath="yes"/>
+      </Component>
+      <Component>
+        <File Id="Microsoft.VC90.CRT_msvcr90.dll" Source="$(var.Skyline.TargetDir)/Microsoft.VC90.CRT\msvcr90.dll" KeyPath="yes"/>
+      </Component>
+      <Component>
+        <File Id="Microsoft.VC90.CRT_Microsoft.VC90.CRT.manifest" Source="$(var.Skyline.TargetDir)/Microsoft.VC90.CRT\Microsoft.VC90.CRT.manifest" KeyPath="yes"/>
+      </Component>
+      <?endif?>
     </ComponentGroup>
     <ComponentGroup Id="percolator_files" Directory="percolator_directory">
       <Component Id="percolator_percolator.exe">


### PR DESCRIPTION
* commented out several apparently unused/unnecessary MSVC runtime DLLs and moved CompassXtract-only DLLs to a separate, conditionally included list