### PR TITLE
Fixed a minor display issue where the "Cancel" buttons on multi-file …

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -499,7 +499,7 @@ namespace pwiz.Skyline.Controls.Graphs
             bool first = true;
             var width = flowFileStatus.Width - 2 - // Avoid clipping the cancel/retry button when we need a vertical scrollbar
                         (flowFileStatus.VerticalScroll.Visible || 
-                         status.ProgressList.Count > 8  // If scrollbar isn't visible already, it's about to be
+                         status.ProgressList.Count > (panelFileList.Height / (new FileProgressControl()).Height)  // If scrollbar isn't visible already, it's about to be
                             ? SystemInformation.VerticalScrollBarWidth
                             : 0);
             List<FileProgressControl> controlsToAdd = new List<FileProgressControl>();

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -497,8 +497,9 @@ namespace pwiz.Skyline.Controls.Graphs
 
             // Match each file status with a progress control.
             bool first = true;
-            var width = flowFileStatus.Width - 2 -
-                        (flowFileStatus.VerticalScroll.Visible
+            var width = flowFileStatus.Width - 2 - // Avoid clipping the cancel/retry button when we need a vertical scrollbar
+                        (flowFileStatus.VerticalScroll.Visible || 
+                         status.ProgressList.Count > 8  // If scrollbar isn't visible already, it's about to be
                             ? SystemInformation.VerticalScrollBarWidth
                             : 0);
             List<FileProgressControl> controlsToAdd = new List<FileProgressControl>();


### PR DESCRIPTION
…Import Results progress display could be partially obscured. Reported by Brendan.

There was actually code in there already that tried to anticipate this, but it was timing dependent, so this is a very simple fix.

The problem can be seen here:
![image](https://user-images.githubusercontent.com/1200761/149035406-c5f5561c-9b6c-4b10-ae82-3b1721b59a5c.png)
The corrected code:
![image](https://user-images.githubusercontent.com/1200761/149035439-77226108-56c0-46e9-8d1f-84b4b50a3c70.png)

