### PR TITLE
Checkbox to "Synchronize Peptides" so the same peptide can belong to multiple proteins

### DIFF
--- a/pwiz_tools/Skyline/Model/DocNode.cs
+++ b/pwiz_tools/Skyline/Model/DocNode.cs
@@ -949,7 +949,7 @@ namespace pwiz.Skyline.Model
         /// <param name="childReplace">A child node with an Id that is reference equal to the node to be replaced</param>
         /// <returns>A new parent node</returns>
         /// <exception cref="IdentityNotFoundException"/>
-        public DocNodeParent ReplaceChild(DocNode childReplace)
+        public virtual DocNodeParent ReplaceChild(DocNode childReplace)
         {
             if (Children == null)
                 throw new InvalidOperationException(@"Invalid operation ReplaceChild before children set.");

--- a/pwiz_tools/Skyline/Model/DocSettings/DataSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/DataSettings.cs
@@ -96,6 +96,15 @@ namespace pwiz.Skyline.Model.DocSettings
                 im => im.MetadataRuleSets = ImmutableList.ValueOfOrEmpty(extractedMetadata));
         }
 
+        [TrackChildren]
+        public bool SynchronizeMolecules { get; private set; }
+
+        public DataSettings ChangeSynchronizeMolecules(bool synchronizeMolecules)
+        {
+            return ChangeProp(ImClone(this), im => im.SynchronizeMolecules = synchronizeMolecules);
+        }
+
+
         /// <summary>
         /// True if audit logging is enabled for this document. ModifyDocument calls will generate audit log entries that can be viewed in the
         /// AuditLogForm and are written to a separate file (.skyl) when the document is saved. If audit logging is disabled, no entries are kept
@@ -221,6 +230,7 @@ namespace pwiz.Skyline.Model.DocSettings
             if (!string.IsNullOrEmpty(docGuid))
                 DocumentGuid = docGuid;
             AuditLogging = reader.GetBoolAttribute(Attr.audit_logging);
+            SynchronizeMolecules = reader.GetBoolAttribute(Attr.synchronize_molecules);
 
             var allElements = new List<IXmlSerializable>();
             // Consume tag
@@ -243,7 +253,8 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             panorama_publish_uri,
             document_guid,
-            audit_logging
+            audit_logging,
+            synchronize_molecules
         }
 
         public void WriteXml(XmlWriter writer)
@@ -254,6 +265,7 @@ namespace pwiz.Skyline.Model.DocSettings
             if(!string.IsNullOrEmpty(DocumentGuid))
                 writer.WriteAttributeString(Attr.document_guid, DocumentGuid);
             writer.WriteAttribute(Attr.audit_logging, AuditLogging);
+            writer.WriteAttribute(Attr.synchronize_molecules, SynchronizeMolecules);
             var elements = AnnotationDefs.Cast<IXmlSerializable>()
                 .Concat(GroupComparisonDefs)
                 .Concat(Lists)
@@ -290,7 +302,8 @@ namespace pwiz.Skyline.Model.DocSettings
                    && Equals(AuditLogging, other.AuditLogging)
                    && Equals(DocumentGuid, other.DocumentGuid)
                    && Equals(Lists, other.Lists)
-                   && Equals(MetadataRuleSets, other.MetadataRuleSets);
+                   && Equals(MetadataRuleSets, other.MetadataRuleSets)
+                   && Equals(SynchronizeMolecules, other.SynchronizeMolecules);
         }
 
         public override bool Equals(object obj)
@@ -305,14 +318,15 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             unchecked
             {
-                int result = _annotationDefs.GetHashCodeDeep();
-                result = result*397 + _groupComparisonDefs.GetHashCodeDeep();
-                result = result*397 + ViewSpecList.GetHashCode();
-                result = result*397 + (PanoramaPublishUri == null ? 0 : PanoramaPublishUri.GetHashCode());
-                result = result*397 + (AuditLogging ? 1 : 0);
-                result = result*397 + (DocumentGuid == null ? 0 : DocumentGuid.GetHashCode());
-                result = result*397 + Lists.GetHashCode();
-                result = result*397 + MetadataRuleSets.GetHashCode();
+                int result = _annotationDefs.GetHashCode();
+                result = result * 397 ^ _groupComparisonDefs.GetHashCode();
+                result = result * 397 ^ ViewSpecList.GetHashCode();
+                result = result * 397 ^ (PanoramaPublishUri == null ? 0 : PanoramaPublishUri.GetHashCode());
+                result = result * 397 ^ AuditLogging.GetHashCode();
+                result = result * 397 ^ (DocumentGuid == null ? 0 : DocumentGuid.GetHashCode());
+                result = result * 397 ^ Lists.GetHashCode();
+                result = result * 397 ^ MetadataRuleSets.GetHashCode();
+                result = result * 397 ^ SynchronizeMolecules.GetHashCode();
                 return result;
             }
         }

--- a/pwiz_tools/Skyline/Model/DocSettings/DataSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/DataSettings.cs
@@ -96,7 +96,7 @@ namespace pwiz.Skyline.Model.DocSettings
                 im => im.MetadataRuleSets = ImmutableList.ValueOfOrEmpty(extractedMetadata));
         }
 
-        [TrackChildren]
+        [Track]
         public bool SynchronizeMolecules { get; private set; }
 
         public DataSettings ChangeSynchronizeMolecules(bool synchronizeMolecules)

--- a/pwiz_tools/Skyline/Model/MoleculeIdLookup.cs
+++ b/pwiz_tools/Skyline/Model/MoleculeIdLookup.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace pwiz.Skyline.Model
+{
+    public class MoleculeIdLookup
+    {
+    }
+}

--- a/pwiz_tools/Skyline/Model/MoleculeSynchronizer.cs
+++ b/pwiz_tools/Skyline/Model/MoleculeSynchronizer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace pwiz.Skyline.Model
 {
@@ -17,7 +18,12 @@ namespace pwiz.Skyline.Model
             return molecule.SequenceKey;
         }
 
-        public static MoleculeSynchronizer MakeMoleculeIndex(IEnumerable<PeptideGroupDocNode> peptideGroups)
+        public static MoleculeSynchronizer MakeMoleculeSynchronizer(SrmDocument document)
+        {
+            return MakeMoleculeSynchronizer(document.MoleculeGroups);
+        }
+
+        public static MoleculeSynchronizer MakeMoleculeSynchronizer(IEnumerable<PeptideGroupDocNode> peptideGroups)
         {
             var lookup = peptideGroups.SelectMany(group => group.Molecules.Select(molecule
                     => Tuple.Create(GetKey(molecule), new IdentityPath(group.PeptideGroup, molecule.Peptide))))
@@ -33,8 +39,8 @@ namespace pwiz.Skyline.Model
         public DocNodeChildren Synchronize(DocNodeChildren moleculeGroups, PeptideGroup peptideGroup, Peptide peptide)
         {
             var sourceIdentityPath = new IdentityPath(peptideGroup, peptide);
-            var sourceDocNode = FindPeptide(moleculeGroups, sourceIdentityPath);
-            var key = GetKey(sourceDocNode);
+            var sourceMoleculeNode = FindPeptide(moleculeGroups, sourceIdentityPath);
+            var key = GetKey(sourceMoleculeNode);
             DocNode[] newChildren = null;
             foreach (var identityPath in _lookup[key])
             {
@@ -51,16 +57,16 @@ namespace pwiz.Skyline.Model
 
                 newChildren = newChildren ?? moleculeGroups.ToArray();
                 var targetMoleculeGroup = (PeptideGroupDocNode) newChildren[targetMoleculeGroupIndex];
-                int childIndex = targetMoleculeGroup.FindNodeIndex(identityPath.GetIdentity(1));
-                if (childIndex < 0)
+                var targetMoleculeNode = (PeptideDocNode) targetMoleculeGroup.FindNode(identityPath.GetIdentity(1));
+                if (targetMoleculeNode == null)
                 {
                     continue;
                 }
 
                 targetMoleculeGroup =
                     (PeptideGroupDocNode) targetMoleculeGroup.ReplaceChild(
-                        sourceDocNode.ChangePeptide((Peptide) identityPath.GetIdentity(1)));
-                newChildren[childIndex] = targetMoleculeGroup;
+                        CopyPeptideIdFrom(sourceMoleculeNode, targetMoleculeNode));
+                newChildren[targetMoleculeGroupIndex] = targetMoleculeGroup;
             }
 
             if (newChildren == null)
@@ -71,11 +77,13 @@ namespace pwiz.Skyline.Model
             return new DocNodeChildren(newChildren, moleculeGroups);
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization)]
         public SrmDocument AfterReplaceChild(SrmDocument document, PeptideGroup peptideGroup)
         {
             var originalChildren = GetChildren(document);
+            int peptideGroupIndex = originalChildren.IndexOf(peptideGroup);
             var newChildren = originalChildren;
-            var peptideGroupDocNode = document.FindPeptideGroup(peptideGroup);
+            var peptideGroupDocNode = (PeptideGroupDocNode) originalChildren[peptideGroupIndex];
             foreach (PeptideDocNode peptideDocNode in peptideGroupDocNode.Children)
             {
                 newChildren = Synchronize(newChildren, peptideGroup, peptideDocNode.Peptide);
@@ -109,6 +117,76 @@ namespace pwiz.Skyline.Model
         public static DocNodeChildren GetChildren(SrmDocument document)
         {
             return document.Children as DocNodeChildren ?? new DocNodeChildren(document.Children, document.Children);
+        }
+
+        private PeptideDocNode CopyPeptideIdFrom(PeptideDocNode copyIdTo, PeptideDocNode copyIdFrom)
+        {
+            IEnumerable<TransitionGroupDocNode> newTransitionGroups;
+            if (IdsMatch(copyIdTo.TransitionGroups, copyIdFrom.TransitionGroups, tg=>RemoveProteinId(tg.TransitionGroup)))
+            {
+                newTransitionGroups = copyIdTo.TransitionGroups.Zip(copyIdFrom.TransitionGroups, CopyTransitionGroupIdFrom);
+            }
+            else
+            {
+                newTransitionGroups = copyIdTo.TransitionGroups.Select(t => t.ChangePeptide(copyIdFrom.Peptide));
+            }
+
+            return copyIdTo.ChangePeptide(copyIdFrom.Peptide, newTransitionGroups);
+        }
+
+        private TransitionGroupDocNode CopyTransitionGroupIdFrom(TransitionGroupDocNode copyIdTo, TransitionGroupDocNode copyIdFrom)
+        {
+            IEnumerable<TransitionDocNode> newTransitions;
+            if (IdsMatch(copyIdTo.Transitions, copyIdFrom.Transitions, t=>RemoveProteinId(t.Transition)))
+            {
+                newTransitions =
+                    copyIdTo.Transitions.Zip(copyIdFrom.Transitions, (t, f) => t.ChangeTransitionId(f.Transition));
+            }
+            else
+            {
+                newTransitions = copyIdTo.Transitions.Select(t => t.ChangeTransitionGroup(copyIdFrom.TransitionGroup));
+            }
+
+            return copyIdTo.ChangeTransitionGroupId(copyIdFrom.TransitionGroup, newTransitions);
+        }
+
+        private Peptide RemoveProteinId(Peptide peptide)
+        {
+            if (peptide.FastaSequence == null)
+            {
+                return peptide;
+            }
+
+            return new Peptide(null, peptide.Sequence, null, null, peptide.MissedCleavages, peptide.IsDecoy);
+        }
+
+        private TransitionGroup RemoveProteinId(TransitionGroup transitionGroup)
+        {
+            var newPeptide = RemoveProteinId(transitionGroup.Peptide);
+            if (ReferenceEquals(newPeptide, transitionGroup.Peptide))
+            {
+                return transitionGroup;
+            }
+
+            return new TransitionGroup(newPeptide, transitionGroup.PrecursorAdduct, transitionGroup.LabelType, true,
+                transitionGroup.DecoyMassShift);
+        }
+
+        private Transition RemoveProteinId(Transition transition)
+        {
+            var newTransitionGroup = RemoveProteinId(transition.Group);
+            if (ReferenceEquals(newTransitionGroup, transition.Group))
+            {
+                return transition;
+            }
+
+            return transition.ChangeTransitionGroup(newTransitionGroup);
+        }
+
+
+        private bool IdsMatch<T>(IEnumerable<T> nodes1, IEnumerable<T> nodes2, Func<T, Identity> getIdentityFunc)
+        {
+            return nodes1.Select(getIdentityFunc).SequenceEqual(nodes2.Select(getIdentityFunc));
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/MoleculeSynchronizer.cs
+++ b/pwiz_tools/Skyline/Model/MoleculeSynchronizer.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace pwiz.Skyline.Model
+{
+    public class MoleculeSynchronizer
+    {
+        private ILookup<PeptideSequenceModKey, IdentityPath> _lookup;
+        public MoleculeSynchronizer(ILookup<PeptideSequenceModKey, IdentityPath> lookup)
+        {
+            _lookup = lookup;
+        }
+
+        public static PeptideSequenceModKey GetKey(PeptideDocNode molecule)
+        {
+            return molecule.SequenceKey;
+        }
+
+        public static MoleculeSynchronizer MakeMoleculeIndex(IEnumerable<PeptideGroupDocNode> peptideGroups)
+        {
+            var lookup = peptideGroups.SelectMany(group => group.Molecules.Select(molecule
+                    => Tuple.Create(GetKey(molecule), new IdentityPath(group.PeptideGroup, molecule.Peptide))))
+                .ToLookup(tuple => tuple.Item1, tuple => tuple.Item2);
+            return new MoleculeSynchronizer(lookup);
+        }
+
+        public IEnumerable<IdentityPath> FindMolecules(PeptideSequenceModKey key)
+        {
+            return _lookup[key];
+        }
+
+        public DocNodeChildren Synchronize(DocNodeChildren moleculeGroups, PeptideGroup peptideGroup, Peptide peptide)
+        {
+            var sourceIdentityPath = new IdentityPath(peptideGroup, peptide);
+            var sourceDocNode = FindPeptide(moleculeGroups, sourceIdentityPath);
+            var key = GetKey(sourceDocNode);
+            DocNode[] newChildren = null;
+            foreach (var identityPath in _lookup[key])
+            {
+                if (Equals(identityPath, sourceIdentityPath))
+                {
+                    continue;
+                }
+
+                int targetMoleculeGroupIndex = moleculeGroups.IndexOf(identityPath.GetIdentity(0));
+                if (targetMoleculeGroupIndex < 0)
+                {
+                    continue;
+                }
+
+                newChildren = newChildren ?? moleculeGroups.ToArray();
+                var targetMoleculeGroup = (PeptideGroupDocNode) newChildren[targetMoleculeGroupIndex];
+                int childIndex = targetMoleculeGroup.FindNodeIndex(identityPath.GetIdentity(1));
+                if (childIndex < 0)
+                {
+                    continue;
+                }
+
+                targetMoleculeGroup =
+                    (PeptideGroupDocNode) targetMoleculeGroup.ReplaceChild(
+                        sourceDocNode.ChangePeptide((Peptide) identityPath.GetIdentity(1)));
+                newChildren[childIndex] = targetMoleculeGroup;
+            }
+
+            if (newChildren == null)
+            {
+                return moleculeGroups;
+            }
+
+            return new DocNodeChildren(newChildren, moleculeGroups);
+        }
+
+        public SrmDocument AfterReplaceChild(SrmDocument document, PeptideGroup peptideGroup)
+        {
+            var originalChildren = GetChildren(document);
+            var newChildren = originalChildren;
+            var peptideGroupDocNode = document.FindPeptideGroup(peptideGroup);
+            foreach (PeptideDocNode peptideDocNode in peptideGroupDocNode.Children)
+            {
+                newChildren = Synchronize(newChildren, peptideGroup, peptideDocNode.Peptide);
+            }
+
+            if (ReferenceEquals(newChildren, originalChildren))
+            {
+                return document;
+            }
+
+            return (SrmDocument) document.ChangeChildren(newChildren);
+        }
+
+        private PeptideGroupDocNode FindMoleculeGroup(DocNodeChildren docNodeChildren, PeptideGroup id)
+        {
+            int index = docNodeChildren.IndexOf(id);
+            if (index < 0)
+            {
+                return null;
+            }
+
+            return (PeptideGroupDocNode) docNodeChildren[index];
+        }
+
+        private PeptideDocNode FindPeptide(DocNodeChildren moleculeGroups, IdentityPath moleculeIdentityPath)
+        {
+            return (PeptideDocNode) FindMoleculeGroup(moleculeGroups,
+                (PeptideGroup) moleculeIdentityPath.GetIdentity(0)).FindNode(moleculeIdentityPath.GetIdentity(1));
+        }
+
+        public static DocNodeChildren GetChildren(SrmDocument document)
+        {
+            return document.Children as DocNodeChildren ?? new DocNodeChildren(document.Children, document.Children);
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Model/PeptideDocNode.cs
+++ b/pwiz_tools/Skyline/Model/PeptideDocNode.cs
@@ -120,11 +120,11 @@ namespace pwiz.Skyline.Model
 
         public Peptide Peptide { get { return (Peptide)Id; } }
 
-        public PeptideDocNode ChangePeptide(Peptide peptide)
+        public PeptideDocNode ChangePeptide(Peptide peptide, IEnumerable<TransitionGroupDocNode> newTransitionGroups)
         {
             var node = (PeptideDocNode) ChangeId(peptide);
-            return (PeptideDocNode) node.ChangeChildren(node.TransitionGroups.Select(tg => tg.ChangePeptide(peptide))
-                .Cast<DocNode>().ToList());
+            node = (PeptideDocNode) node.ChangeChildren(newTransitionGroups.Cast<DocNode>().ToList());
+            return node;
         }
 
         [TrackChildren(ignoreName:true, defaultValues: typeof(DefaultValuesNull))]

--- a/pwiz_tools/Skyline/Model/PeptideDocNode.cs
+++ b/pwiz_tools/Skyline/Model/PeptideDocNode.cs
@@ -120,6 +120,13 @@ namespace pwiz.Skyline.Model
 
         public Peptide Peptide { get { return (Peptide)Id; } }
 
+        public PeptideDocNode ChangePeptide(Peptide peptide)
+        {
+            var node = (PeptideDocNode) ChangeId(peptide);
+            return (PeptideDocNode) node.ChangeChildren(node.TransitionGroups.Select(tg => tg.ChangePeptide(peptide))
+                .Cast<DocNode>().ToList());
+        }
+
         [TrackChildren(ignoreName:true, defaultValues: typeof(DefaultValuesNull))]
         public CustomMolecule CustomMolecule { get { return Peptide.CustomMolecule; } }
 

--- a/pwiz_tools/Skyline/Model/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Transition.cs
@@ -485,7 +485,7 @@ namespace pwiz.Skyline.Model
                                  decoyMassShift.Value);
         }
 
-        private readonly TransitionGroup _group;
+        private TransitionGroup _group;
 
         /// <summary>
         /// Creates a precursor transition
@@ -784,6 +784,13 @@ namespace pwiz.Skyline.Model
                 default:
                     return true;
             }
+        }
+
+        public Transition ChangeTransitionGroup(TransitionGroup transitionGroup)
+        {
+            var transition = (Transition) MemberwiseClone();
+            transition._group = transitionGroup;
+            return transition;
         }
 
 

--- a/pwiz_tools/Skyline/Model/TransitionDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionDocNode.cs
@@ -1124,5 +1124,15 @@ namespace pwiz.Skyline.Model
             get { return TransitionTreeNode.GetLabel(this, string.Empty); }
         }
 
+        public TransitionDocNode ChangeTransitionGroup(TransitionGroup newTransitionGroup)
+        {
+            return ChangeTransitionId(new Transition(newTransitionGroup, Transition.IonType, Transition.CleavageOffset,
+                Transition.MassIndex, Transition.Adduct, Transition.DecoyMassShift, Transition.CustomIon));
+        }
+
+        public TransitionDocNode ChangeTransitionId(Transition transition)
+        {
+            return (TransitionDocNode) ChangeId(transition);
+        }
     }
 }

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -894,14 +894,13 @@ namespace pwiz.Skyline.Model
         {
             var newId = new TransitionGroup(peptide, TransitionGroup.PrecursorAdduct, TransitionGroup.LabelType, true,
                 TransitionGroup.DecoyMassShift);
-            return ChangeTransitionGroupId(newId);
+            return ChangeTransitionGroupId(newId, Transitions.Select(t=>t.ChangeTransitionGroup(newId)));
         }
 
-        public TransitionGroupDocNode ChangeTransitionGroupId(TransitionGroup newId)
+        public TransitionGroupDocNode ChangeTransitionGroupId(TransitionGroup newId, IEnumerable<TransitionDocNode> newTransitions)
         {
             var node = (TransitionGroupDocNode)ChangeId(newId);
-            node = (TransitionGroupDocNode) node.ChangeChildren(Transitions
-                .Select(t => t.ChangeTransitionGroup(newId)).Cast<DocNode>().ToList());
+            node = (TransitionGroupDocNode) node.ChangeChildren(newTransitions.Cast<DocNode>().ToList());
             return node;
         }
 

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -890,6 +890,21 @@ namespace pwiz.Skyline.Model
             return ChangeProp(ImClone(this), im => im.PrecursorConcentration = precursorConcentration);
         }
 
+        public TransitionGroupDocNode ChangePeptide(Peptide peptide)
+        {
+            var newId = new TransitionGroup(peptide, TransitionGroup.PrecursorAdduct, TransitionGroup.LabelType, true,
+                TransitionGroup.DecoyMassShift);
+            return ChangeTransitionGroupId(newId);
+        }
+
+        public TransitionGroupDocNode ChangeTransitionGroupId(TransitionGroup newId)
+        {
+            var node = (TransitionGroupDocNode)ChangeId(newId);
+            node = (TransitionGroupDocNode) node.ChangeChildren(Transitions
+                .Select(t => t.ChangeTransitionGroup(newId)).Cast<DocNode>().ToList());
+            return node;
+        }
+
         public TransitionGroupDocNode ChangeSettings(SrmSettings settingsNew, PeptideDocNode nodePep, ExplicitMods mods, SrmSettingsDiff diff)
         {
             double precursorMz = PrecursorMz;

--- a/pwiz_tools/Skyline/SettingsUI/DocumentSettingsDlg.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/DocumentSettingsDlg.Designer.cs
@@ -57,12 +57,15 @@ namespace pwiz.Skyline.SettingsUI
             this.chooseViewsControl = new pwiz.Common.DataBinding.Controls.Editor.ChooseViewsControl();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOK = new System.Windows.Forms.Button();
+            this.tabPageMisc = new System.Windows.Forms.TabPage();
+            this.cbxSynchronizeMolecules = new System.Windows.Forms.CheckBox();
             this.tabControl.SuspendLayout();
             this.tabPageAnnotations.SuspendLayout();
             this.tabPageResultFileRules.SuspendLayout();
             this.tabPageLists.SuspendLayout();
             this.tabPageGroupComparisons.SuspendLayout();
             this.tabPageReports.SuspendLayout();
+            this.tabPageMisc.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabControl
@@ -73,6 +76,7 @@ namespace pwiz.Skyline.SettingsUI
             this.tabControl.Controls.Add(this.tabPageLists);
             this.tabControl.Controls.Add(this.tabPageGroupComparisons);
             this.tabControl.Controls.Add(this.tabPageReports);
+            this.tabControl.Controls.Add(this.tabPageMisc);
             this.tabControl.Name = "tabControl";
             this.tabControl.SelectedIndex = 0;
             // 
@@ -274,6 +278,20 @@ namespace pwiz.Skyline.SettingsUI
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
             // 
+            // tabPageMisc
+            // 
+            this.tabPageMisc.Controls.Add(this.cbxSynchronizeMolecules);
+            resources.ApplyResources(this.tabPageMisc, "tabPageMisc");
+            this.tabPageMisc.Name = "tabPageMisc";
+            this.tabPageMisc.UseVisualStyleBackColor = true;
+            // 
+            // cbxSynchronizeMolecules
+            // 
+            resources.ApplyResources(this.cbxSynchronizeMolecules, "cbxSynchronizeMolecules");
+            this.cbxSynchronizeMolecules.Name = "cbxSynchronizeMolecules";
+            this.modeUIHandler.SetUIMode(this.cbxSynchronizeMolecules, pwiz.Skyline.Util.Helpers.ModeUIExtender.MODE_UI_HANDLING_TYPE.invariant);
+            this.cbxSynchronizeMolecules.UseVisualStyleBackColor = true;
+            // 
             // DocumentSettingsDlg
             // 
             this.AcceptButton = this.btnOK;
@@ -294,6 +312,8 @@ namespace pwiz.Skyline.SettingsUI
             this.tabPageLists.ResumeLayout(false);
             this.tabPageGroupComparisons.ResumeLayout(false);
             this.tabPageReports.ResumeLayout(false);
+            this.tabPageMisc.ResumeLayout(false);
+            this.tabPageMisc.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -328,5 +348,7 @@ namespace pwiz.Skyline.SettingsUI
         private System.Windows.Forms.Label lblMetadataRulesDescription;
         private System.Windows.Forms.Button btnAddMetadataRuleSet;
         private System.Windows.Forms.Button btnEditMetadataRuleSetList;
+        private System.Windows.Forms.TabPage tabPageMisc;
+        private System.Windows.Forms.CheckBox cbxSynchronizeMolecules;
     }
 }

--- a/pwiz_tools/Skyline/SettingsUI/DocumentSettingsDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/DocumentSettingsDlg.cs
@@ -54,6 +54,7 @@ namespace pwiz.Skyline.SettingsUI
                 viewSpec => PersistedViews.MainGroup.Id.ViewName(viewSpec.Name));
             _metadataRuleSetsListBoxDriver = new SettingsListBoxDriver<MetadataRuleSet>(checkedListBoxRuleSets, Settings.Default.MetadataRuleSets);
             _metadataRuleSetsListBoxDriver.LoadList(dataSettings.MetadataRuleSets);
+            cbxSynchronizeMolecules.Checked = dataSettings.SynchronizeMolecules;
             _originalSettings = dataSettings;
         }
 
@@ -70,7 +71,8 @@ namespace pwiz.Skyline.SettingsUI
                 .ChangeGroupComparisonDefs(_groupComparisonsListBoxDriver.Chosen)
                 .ChangeViewSpecList(viewSpecs)
                 .ChangeListDefs(_listsListBoxDriver.Chosen)
-                .ChangeExtractedMetadata(_metadataRuleSetsListBoxDriver.Chosen);
+                .ChangeExtractedMetadata(_metadataRuleSetsListBoxDriver.Chosen)
+                .ChangeSynchronizeMolecules(cbxSynchronizeMolecules.Checked);
         }
 
         private void btnAddAnnotation_Click(object sender, System.EventArgs e)

--- a/pwiz_tools/Skyline/SettingsUI/DocumentSettingsDlg.resx
+++ b/pwiz_tools/Skyline/SettingsUI/DocumentSettingsDlg.resx
@@ -819,6 +819,60 @@
   <data name="&gt;&gt;tabPageReports.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="cbxSynchronizeMolecules.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbxSynchronizeMolecules.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 18</value>
+  </data>
+  <data name="cbxSynchronizeMolecules.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 17</value>
+  </data>
+  <data name="cbxSynchronizeMolecules.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="cbxSynchronizeMolecules.Text" xml:space="preserve">
+    <value>Keep duplicate peptides and/or molecules in sync</value>
+  </data>
+  <data name="&gt;&gt;cbxSynchronizeMolecules.Name" xml:space="preserve">
+    <value>cbxSynchronizeMolecules</value>
+  </data>
+  <data name="&gt;&gt;cbxSynchronizeMolecules.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbxSynchronizeMolecules.Parent" xml:space="preserve">
+    <value>tabPageMisc</value>
+  </data>
+  <data name="&gt;&gt;cbxSynchronizeMolecules.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tabPageMisc.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tabPageMisc.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tabPageMisc.Size" type="System.Drawing.Size, System.Drawing">
+    <value>622, 260</value>
+  </data>
+  <data name="tabPageMisc.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tabPageMisc.Text" xml:space="preserve">
+    <value>Misc</value>
+  </data>
+  <data name="&gt;&gt;tabPageMisc.Name" xml:space="preserve">
+    <value>tabPageMisc</value>
+  </data>
+  <data name="&gt;&gt;tabPageMisc.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPageMisc.Parent" xml:space="preserve">
+    <value>tabControl</value>
+  </data>
+  <data name="&gt;&gt;tabPageMisc.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
   <data name="tabControl.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 12</value>
   </data>
@@ -919,12 +973,12 @@
     <value>modeUIHandler</value>
   </data>
   <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline-daily, Version=21.2.1.379, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>DocumentSettingsDlg</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.FormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=21.2.1.379, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -607,6 +607,8 @@
     <Compile Include="Model\Lib\SpectralLibraryExporter.cs" />
     <Compile Include="Model\Lib\SpectrumRanker.cs" />
     <Compile Include="Model\MinimizeResults.cs" />
+    <Compile Include="Model\MoleculeIdLookup.cs" />
+    <Compile Include="Model\MoleculeSynchronizer.cs" />
     <Compile Include="Model\ProteomicSequence.cs" />
     <Compile Include="Model\Results\IntensityAccumulator.cs" />
     <Compile Include="Model\Results\Scoring\FeatureTooltips.Designer.cs">


### PR DESCRIPTION
This adds a checkbox to the Document Settings Dialog to enable you to synchronize changes to peptides that are duplicated across your document.
![image](https://user-images.githubusercontent.com/303203/149647127-2fc3a2bc-76eb-4ba0-b671-19581d42f755.png)
In theory, that will make it so that things are still manageable even when the same peptide belongs to multiple proteins

Then, when you have multiple copies of the same peptide in your document like this:
![image](https://user-images.githubusercontent.com/303203/149647175-06c259f0-3edf-4f16-a677-c26e807cc2f0.png)
You can change a peak boundary, and it updates in all the copies of that peptide (see that the "dotp" value changed from 0.86 to 0.8 in the Targets tree for each K.MLSGFIPLKPTVK.K):
![image](https://user-images.githubusercontent.com/303203/149647216-b786747a-5cbe-4dc5-9278-bab1ed802793.png)

In theory this will make it so that people won't feel the need to Remove Repeated Peptides. Peptides will be able to belong to multiple proteins, and they will participate in Protein level fold changes etc. for all the proteins they belong to.

(Still needs a lot of work, but might be functional enough for us to figure out whether this is the direction we want to go in terms of dealing with protein groups in peptide search results).