### PR TITLE
* fixed reading mzXML from mzML parentFile

### DIFF
--- a/pwiz/data/msdata/Serializer_mzXML.cpp
+++ b/pwiz/data/msdata/Serializer_mzXML.cpp
@@ -889,6 +889,7 @@ CVID translateSourceFileTypeToNativeIdFormat(CVID sourceFileType)
         case MS_SCIEX_TOF_TOF_T2D_format:
         case MS_Waters_raw_format:
         case MS_Micromass_PKL_format:
+        case MS_mzML_format:
             return MS_scan_number_only_nativeID_format;
 
         // in other cases, assume the source file doesn't contain instrument data


### PR DESCRIPTION
There's no way to know the correct nativeID type so just fall back to scan number only.

Closes #1954