### PR TITLE
Skyline/work/20220127 missing text in transition list error dlg

### DIFF
--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -543,7 +543,8 @@ namespace pwiz.Skyline.FileUI
             List<TransitionImportErrorInfo> testErrorList1 = null;
             insertionParams.Document = _docCurrent.ImportMassList(input, Importer, null,
                 _insertPath, out insertionParams.SelectPath, out insertionParams.IrtPeptides,
-                out insertionParams.LibrarySpectra, out testErrorList1, out insertionParams.PeptideGroups);
+                out insertionParams.LibrarySpectra, out testErrorList1, out insertionParams.PeptideGroups,
+                null, SrmDocument.DOCUMENT_TYPE.none, false);
 
             var allError = ReferenceEquals(insertionParams.Document, _docCurrent);
             // If all transitions are errors, reset the columns to the detected columns

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.Designer.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.Designer.cs
@@ -35,14 +35,14 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
             this.bindingSourceGrid = new System.Windows.Forms.BindingSource(this.components);
             this.dataGridViewErrors = new pwiz.Skyline.Controls.DataGridViewEx();
-            this.buttonOk = new System.Windows.Forms.Button();
-            this.buttonCancel = new System.Windows.Forms.Button();
-            this.labelErrors = new System.Windows.Forms.Label();
-            this.cbShowText = new System.Windows.Forms.CheckBox();
             this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.LineText = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.buttonOk = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.labelErrors = new System.Windows.Forms.Label();
+            this.cbShowText = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.bindingSourceGrid)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewErrors)).BeginInit();
             this.SuspendLayout();
@@ -64,32 +64,6 @@
             this.dataGridViewErrors.Name = "dataGridViewErrors";
             this.dataGridViewErrors.ReadOnly = true;
             this.dataGridViewErrors.RowHeadersVisible = false;
-            // 
-            // buttonOk
-            // 
-            resources.ApplyResources(this.buttonOk, "buttonOk");
-            this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOk.Name = "buttonOk";
-            this.buttonOk.UseVisualStyleBackColor = true;
-            // 
-            // buttonCancel
-            // 
-            resources.ApplyResources(this.buttonCancel, "buttonCancel");
-            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Name = "buttonCancel";
-            this.buttonCancel.UseVisualStyleBackColor = true;
-            // 
-            // labelErrors
-            // 
-            resources.ApplyResources(this.labelErrors, "labelErrors");
-            this.labelErrors.Name = "labelErrors";
-            // 
-            // cbShowText
-            // 
-            resources.ApplyResources(this.cbShowText, "cbShowText");
-            this.cbShowText.Name = "cbShowText";
-            this.cbShowText.UseVisualStyleBackColor = true;
-            this.cbShowText.CheckedChanged += new System.EventHandler(this.cbShowText_CheckedChanged);
             // 
             // dataGridViewTextBoxColumn1
             // 
@@ -127,6 +101,32 @@
             resources.ApplyResources(this.LineText, "LineText");
             this.LineText.Name = "LineText";
             this.LineText.ReadOnly = true;
+            // 
+            // buttonOk
+            // 
+            resources.ApplyResources(this.buttonOk, "buttonOk");
+            this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOk.Name = "buttonOk";
+            this.buttonOk.UseVisualStyleBackColor = true;
+            // 
+            // buttonCancel
+            // 
+            resources.ApplyResources(this.buttonCancel, "buttonCancel");
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            // 
+            // labelErrors
+            // 
+            resources.ApplyResources(this.labelErrors, "labelErrors");
+            this.labelErrors.Name = "labelErrors";
+            // 
+            // cbShowText
+            // 
+            resources.ApplyResources(this.cbShowText, "cbShowText");
+            this.cbShowText.Name = "cbShowText";
+            this.cbShowText.UseVisualStyleBackColor = true;
+            this.cbShowText.CheckedChanged += new System.EventHandler(this.cbShowText_CheckedChanged);
             // 
             // ImportTransitionListErrorDlg
             // 

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.cs
@@ -48,11 +48,18 @@ namespace pwiz.Skyline.FileUI
             // If all of the transitions were errors, canceling and accepting are the same
             // so give a different message and disable the cancel button
             string errorListMessage;
+
+            void HideCancelButton()
+            {
+                buttonCancel.Visible = false;
+                buttonOk.Left = buttonCancel.Right - buttonOk.Width; // Position lower right
+            }
+
             if (isErrorAll)
             {
                 errorListMessage = errorList.Count == 1 ? Resources.ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_The_imported_transition_contains_an_error__Please_check_the_transition_list_and_the_Skyline_settings_and_try_importing_again_ :
                     string.Format(Resources.ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_All__0__transitions_contained_errors___Please_check_the_transition_list_for_errors_and_try_importing_again_, errorList.Count);
-                buttonCancel.Visible = false;
+                HideCancelButton();
                 // In this case, the OK button should close the error dialog but not the column select dialog
                 // Simplest way to do this is to treat it as a cancel button
                 buttonOk.DialogResult = DialogResult.Cancel;
@@ -66,7 +73,7 @@ namespace pwiz.Skyline.FileUI
             {
                 errorListMessage = errorList.Count == 1 ? Resources.ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_A_transition_contained_an_error_ :
                     string.Format(Resources.SkylineWindow_ImportMassList__0__transitions_contained_errors_, errorList.Count);
-                buttonCancel.Visible = false;
+                HideCancelButton();
             }
 
             labelErrors.Text = errorListMessage;
@@ -92,6 +99,11 @@ namespace pwiz.Skyline.FileUI
         public void OkDialog()
         {
             DialogResult = DialogResult.OK;
+        }
+
+        public void ShowLineText(bool show)
+        {
+            cbShowText.Checked = show;
         }
 
         private void cbShowText_CheckedChanged(object sender, System.EventArgs e)

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.resx
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.resx
@@ -166,7 +166,7 @@
     <value>12, 34</value>
   </data>
   <data name="dataGridViewErrors.Size" type="System.Drawing.Size, System.Drawing">
-    <value>740, 290</value>
+    <value>833, 290</value>
   </data>
   <data name="dataGridViewErrors.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -190,7 +190,7 @@
     <value>NoControl</value>
   </data>
   <data name="buttonOk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>770, 34</value>
+    <value>689, 331</value>
   </data>
   <data name="buttonOk.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -217,7 +217,7 @@
     <value>Top, Right</value>
   </data>
   <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>770, 63</value>
+    <value>770, 331</value>
   </data>
   <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>

--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -3361,7 +3361,7 @@ namespace pwiz.Skyline.Model
         }
     }
 
-    public class TransitionImportErrorInfo
+    public class TransitionImportErrorInfo : IEquatable<TransitionImportErrorInfo>
     {
         public long? LineNum { get; private set; }
         public int? Column { get; private set; }
@@ -3374,6 +3374,43 @@ namespace pwiz.Skyline.Model
             LineText = lineText;
             Column = columnIndex + 1;   // 1 based column number for reporting to a user
             LineNum = lineNum;
+        }
+
+        public bool Equals(TransitionImportErrorInfo other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return LineNum == other.LineNum && Column == other.Column && ErrorMessage == other.ErrorMessage && LineText == other.LineText;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TransitionImportErrorInfo)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = LineNum.GetHashCode();
+                hashCode = (hashCode * 397) ^ Column.GetHashCode();
+                hashCode = (hashCode * 397) ^ (ErrorMessage != null ? ErrorMessage.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (LineText != null ? LineText.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(TransitionImportErrorInfo left, TransitionImportErrorInfo right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(TransitionImportErrorInfo left, TransitionImportErrorInfo right)
+        {
+            return !Equals(left, right);
         }
     }
 

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -48,9 +48,13 @@ namespace pwiz.Skyline.Model
 
         private double MzMatchTolerance { get; set; }
 
+        public List<PasteError> ErrorList { get; set; }
+        public bool HasHeaders { get; set; }
+
         protected SmallMoleculeTransitionListReader()
         {
             Rows = new List<Row>();
+            ErrorList = new List<PasteError>();
         }
 
         public class Row
@@ -116,22 +120,30 @@ namespace pwiz.Skyline.Model
                 SortSiblingsByMz();
             }
 
-            _requireProductInfo = GetRequireProductInfo(document);
+            _requireProductInfo = GetRequireProductInfo(document); // Examine the first several lines of the file to determine columns will be needed
+            ErrorList.Clear(); // We're going to reparse, so clear any errors found so far
 
             string defaultPepGroupName = null;
             var docStart = document;
             document = document.BeginDeferSettingsChanges(); // Prevents excessive calls to SetDocumentType etc
+            var rowCount = 0;
+            var rowSuccessCount = 0;
 
             // For each row in the grid, add to or begin MoleculeGroup|Molecule|TransitionList tree
             foreach (var row in Rows)
             {
+                rowCount++;
                 var precursor = ReadPrecursorOrProductColumns(document, row, null, out var hasError); // Get molecule values
                 if (hasError)
-                    return null;
+                {
+                    continue; // This won't succeed, but keep gathering errors
+                }
                 if (_requireProductInfo && ReadPrecursorOrProductColumns(document, row, precursor, out hasError) == null)
                 {
                     if (hasError)
-                        return null;
+                    {
+                        continue; // This won't succeed, but keep gathering errors
+                    }
                 }
 
                 var groupName = GetCellTrimmed(row, INDEX_MOLECULE_GROUP);
@@ -141,14 +153,18 @@ namespace pwiz.Skyline.Model
                 if (string.IsNullOrEmpty(groupName) || !groupNamesSeen.Add(groupName)) // If group name is unique (so far), no need to search document for it
                 {
                     if (ErrorAddingToExistingMoleculeGroup(ref document, precursor, groupName, defaultPepGroupName, precursorNamesSeen, row, ref pepGroupFound))
-                        return null;
+                    {
+                        continue; // This won't succeed, but keep gathering errors
+                    }
                 }
 
                 if (!pepGroupFound)
                 {
                     var node = GetMoleculePeptideGroup(document, row);
                     if (node == null)
-                        return null;
+                    {
+                        continue; // This won't succeed, but keep gathering errors
+                    }
                     IdentityPath first;
                     IdentityPath next;
                     document = document.AddPeptideGroups(new[] {node}, false, to, out first, out next);
@@ -162,6 +178,13 @@ namespace pwiz.Skyline.Model
                         precursorNamesSeen.Add(precursor.Name);
                     groupNamesSeen.Add(node.Name);
                 }
+
+                rowSuccessCount++;
+            }
+
+            if (rowSuccessCount != rowCount)
+            {
+                return null;
             }
 
             document = document.EndDeferSettingsChanges(docStart, null); // Process deferred calls to SetDocumentType etc
@@ -1310,6 +1333,7 @@ namespace pwiz.Skyline.Model
             }
 
             string errMessage = null;
+            var humanReadableRowIndex = row.Index + (HasHeaders ? 2 : 1);
             if (countValues >= 2) // Do we have at least 2 of charge, mz, formula?
             {
                 TypedMass monoMass;
@@ -1405,7 +1429,7 @@ namespace pwiz.Skyline.Model
                                     errMessage = String.Format(getPrecursorColumns
                                         ? Resources.PasteDlg_ReadPrecursorOrProductColumns_Error_on_line__0___Precursor_m_z__1__does_not_agree_with_value__2__as_calculated_from_ion_formula_and_charge_state__delta____3___Transition_Settings___Instrument___Method_match_tolerance_m_z____4_____Correct_the_m_z_value_in_the_table__or_leave_it_blank_and_Skyline_will_calculate_it_for_you_
                                         : Resources.PasteDlg_ReadPrecursorOrProductColumns_Error_on_line__0___Product_m_z__1__does_not_agree_with_value__2__as_calculated_from_ion_formula_and_charge_state__delta____3___Transition_Settings___Instrument___Method_match_tolerance_m_z____4_____Correct_the_m_z_value_in_the_table__or_leave_it_blank_and_Skyline_will_calculate_it_for_you_,
-                                        row.Index + 1, (float)mz, (float)mzCalc.Value, (float)(mzCalc.Value - mz), (float)document.Settings.TransitionSettings.Instrument.MzMatchTolerance);
+                                        humanReadableRowIndex, (float)mz, (float)mzCalc.Value, (float)(mzCalc.Value - mz), (float)document.Settings.TransitionSettings.Instrument.MzMatchTolerance);
                                     errColumn = indexMz;
                                 }
                                 else
@@ -1413,7 +1437,7 @@ namespace pwiz.Skyline.Model
                                     // No charge state given, and mz makes no sense with formula
                                     errMessage = String.Format(getPrecursorColumns
                                         ? Resources.PasteDlg_ValidateEntry_Error_on_line__0___Precursor_formula_and_m_z_value_do_not_agree_for_any_charge_state_
-                                        : Resources.PasteDlg_ValidateEntry_Error_on_line__0___Product_formula_and_m_z_value_do_not_agree_for_any_charge_state_, row.Index + 1);
+                                        : Resources.PasteDlg_ValidateEntry_Error_on_line__0___Product_formula_and_m_z_value_do_not_agree_for_any_charge_state_, humanReadableRowIndex);
                                     errColumn = indexMz;
                                 }
                             }
@@ -1490,7 +1514,7 @@ namespace pwiz.Skyline.Model
                 {
                     errMessage = string.Format(getPrecursorColumns
                             ? Resources.PasteDlg_ValidateEntry_Error_on_line__0___Precursor_needs_values_for_any_two_of__Formula__m_z_or_Charge_
-                            : Resources.PasteDlg_ValidateEntry_Error_on_line__0___Product_needs_values_for_any_two_of__Formula__m_z_or_Charge_, row.Index + 1);
+                            : Resources.PasteDlg_ValidateEntry_Error_on_line__0___Product_needs_values_for_any_two_of__Formula__m_z_or_Charge_, humanReadableRowIndex);
                 }
                 else
                 {
@@ -1902,6 +1926,7 @@ namespace pwiz.Skyline.Model
             // Ask MassListInputs to figure out the column and decimal separators
             var inputs = new MassListInputs(csvText);
             _cultureInfo = inputs.FormatProvider;
+            HasHeaders = hasHeaders;
             _csvReader = new DsvFileReader(new StringListReader(csvText), inputs.Separator, SmallMoleculeTransitionListColumnHeaders.KnownHeaderSynonyms, columnPositions, hasHeaders);
             // Do we recognize all the headers?
             var badHeaders =
@@ -2008,22 +2033,7 @@ namespace pwiz.Skyline.Model
 
         public override void ShowTransitionError(PasteError error)
         {
-            if (error.Column >= 0)
-            {
-                throw new LineColNumberedIoException(
-                    string.Format(
-                        Resources.InsertSmallMoleculeTransitionList_InsertSmallMoleculeTransitionList_Error_on_line__0___column_1____2_,
-                        error.Line + 1, error.Column + 1, error.Message),
-                    error.Line + 1, error.Column);
-            }
-            else
-            {
-                throw new LineColNumberedIoException(
-                    string.Format(
-                        Resources.InsertSmallMoleculeTransitionList_InsertSmallMoleculeTransitionList_Error_on_line__0__1_,
-                        error.Line + 1, error.Message),
-                    error.Line + 1, error.Column);
-            }
+            ErrorList.Add(error);
         }
 
         public override int ColumnIndex(string columnName)

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -53,6 +53,7 @@ using System.Threading;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using MathNet.Numerics.Interpolation;
 using pwiz.Common.Chemistry;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Controls.Graphs;
@@ -1453,16 +1454,26 @@ namespace pwiz.Skyline.Model
             // Is this a small molecule transition list, or trying to be?
             if (((importer != null && importer.InputType == DOCUMENT_TYPE.small_molecules) && radioType == DOCUMENT_TYPE.none) || radioType == DOCUMENT_TYPE.small_molecules)
             {
+                IList<string> lines = null;
                 try
                 {
-                    var lines = inputs.ReadLines(progressMonitor);
+                    lines = inputs.ReadLines(progressMonitor);
                     var reader = new SmallMoleculeTransitionListCSVReader(lines, columnPositions, hasHeaders);
                     docNew = reader.CreateTargets(this, to, out firstAdded);
+                    foreach (var error in reader.ErrorList)
+                    {
+                        var lineIndex  = error.Line + (hasHeaders ? 1 : 0); // Account for parser not including header in its line count
+                        var line =
+                            ((lineIndex >= 0 && lineIndex < lines.Count) ? lines[lineIndex] : null)?.Replace(
+                                TextUtil.SEPARATOR_TSV_STR, @" ");
+                        errorList.Add(new TransitionImportErrorInfo(error.Message, error.Column, lineIndex + 1, line)); // Show line number as 1 based
+                    }
                 }
                 catch (LineColNumberedIoException x)
                 {
-                    // TODO(brianp): Better to return a complete list of all rows with errors and allow skipping
-                    errorList.Add(new TransitionImportErrorInfo(x.PlainMessage, x.ColumnIndex, x.LineNumber, null));  // CONSIDER: worth the effort to pull row and column info from error message?
+                    var line = (lines != null && x.LineNumber >=0 && x.LineNumber < lines.Count ? lines[(int)x.LineNumber] : null)?.
+                        Replace(TextUtil.SEPARATOR_TSV_STR, @" ");
+                    errorList.Add(new TransitionImportErrorInfo(x.PlainMessage, x.ColumnIndex, x.LineNumber + 1, line));  // CONSIDER: worth the effort to pull row and column info from error message?
                 }
             }
             else


### PR DESCRIPTION
Fixed a few problems with the error dialog for small molecule transition lists:

1) Only the first error was shown. This was irritating when dealing with long, messy transition lists that needed repeated editing.
2) The "Show / hide line text" checkbox had no effect (i.e. the original line data did not appear even though the column was shown)
3) Line numbers were incorrect.
4) The placement of the "OK" button was not making good use of screen real estate.

was:
![image](https://user-images.githubusercontent.com/1200761/151637631-e04c68ee-a0b5-47f2-9d0d-cb83a54dd743.png)

is now:
![image](https://user-images.githubusercontent.com/1200761/151637592-98360119-130d-48ef-9af5-c4efaffb2873.png)


