### PR TITLE
Fix the "Install" class so that it can be used in unit tests.

### DIFF
--- a/pwiz_tools/Skyline/Util/Install.cs
+++ b/pwiz_tools/Skyline/Util/Install.cs
@@ -18,6 +18,7 @@
  */
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
@@ -25,30 +26,66 @@ namespace pwiz.Skyline.Util
 {
     public static class Install
     {
+        static Install()
+        {
+            var assembly = typeof(Program).Assembly;
+            try
+            {
+                string productVersion;
+                var versionAttribute = assembly.GetCustomAttributes(false)
+                    .OfType<AssemblyInformationalVersionAttribute>().FirstOrDefault();
+                if (versionAttribute != null)
+                {
+                    productVersion = versionAttribute.InformationalVersion;
+                    if (productVersion.Contains(@"(developer build)"))
+                    {
+                        IsDeveloperInstall = true;
+                        productVersion = productVersion.Replace(@"(developer build)", "").Trim();
+                    }
+                    else if (productVersion.Contains(@"(automated build)"))
+                    {
+                        IsAutomatedBuild = true;
+                        productVersion = productVersion.Replace(@"(automated build)", "").Trim();
+                    }
+                }
+                else
+                {
+                    // win32 version info
+                    productVersion = FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion?.Trim();
+                }
+
+                Version = productVersion;
+            }
+            catch (Exception)
+            {
+                Version = string.Empty;
+            }
+
+        }
         public enum InstallType { release, daily, developer }
 
         public static InstallType Type
         {
             get
             {
-                return IsDeveloperInstall
-                        ? InstallType.developer
-                        : (Build == 0)
-                              ? InstallType.release
-                              : InstallType.daily;
+                if (IsDeveloperInstall)
+                {
+                    return InstallType.developer;
+                }
+                return Build == 0 ? InstallType.release : InstallType.daily;
             }
         }
 
-        public static bool IsDeveloperInstall { get; private set; }
+        public static bool IsDeveloperInstall { get; }
         public static bool IsAutomatedBuild { get; private set; }
 
         public static bool Is64Bit
         {
             get
             {
-                var myAssemplyLocation = Assembly.GetExecutingAssembly().Location;
+                var myAssemblyLocation = Assembly.GetExecutingAssembly().Location;
                 // ReSharper disable once AssignNullToNotNullAttribute
-                var myAssemblyName = AssemblyName.GetAssemblyName(myAssemplyLocation);
+                var myAssemblyName = AssemblyName.GetAssemblyName(myAssemblyLocation);
                 return ProcessorArchitecture.MSIL == myAssemblyName.ProcessorArchitecture;
             }
         }
@@ -87,54 +124,9 @@ namespace pwiz.Skyline.Util
             }
         }
 
-        private static string _version;
-
-        private static string GetVersion()
-        {
-            // mostly copied from System.Windows.Forms.Application.ProductVersion reference source
-            try
-            {
-                string productVersion = null;
-
-                Assembly entryAssembly = Assembly.GetEntryAssembly();
-                if (entryAssembly != null)
-                {
-                    // custom attribute
-                    object[] attrs = entryAssembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
-                    // Play it safe with a null check no matter what ReSharper thinks
-                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                    if (attrs != null && attrs.Length > 0)
-                    {
-                        productVersion = ((AssemblyInformationalVersionAttribute)attrs[0]).InformationalVersion;
-                        if (productVersion.Contains(@"(developer build)"))
-                        {
-                            IsDeveloperInstall = true;
-                            productVersion = productVersion.Replace(@"(developer build)", "").Trim();
-                        }
-                        else if (productVersion.Contains(@"(automated build)"))
-                        {
-                            IsAutomatedBuild = true;
-                            productVersion = productVersion.Replace(@"(automated build)", "").Trim();
-                        }
-                    }
-                    else
-                    {
-                        // win32 version info
-                        productVersion = FileVersionInfo.GetVersionInfo(entryAssembly.Location).ProductVersion?.Trim();
-                    }
-                }
-
-                return productVersion ?? string.Empty;
-            }
-            catch (Exception)
-            {
-                return string.Empty;
-            }
-        }
-
         public static string Version
         {
-            get { return _version ?? (_version = GetVersion()); }
+            get;
         }
 
         private static int VersionPart(int index)


### PR DESCRIPTION
I wanted to use the class "Install" in pull request #1981, but the class did not work during unit tests.

The class was looking at "Assembly.GetExecutingAssembly()" instead of the Skyline executable, which ends up returning something not useful when running as a unit test.
Also, moved the initializing code into a static initializer. It used to be that "Install.Type" would not return the correct value until after the property "Install.Version" was first queried.