### PR TITLE
Hide molecule-specific reports in proteomics mode

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/AbstractViewContext.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/AbstractViewContext.cs
@@ -141,11 +141,6 @@ namespace pwiz.Common.DataBinding
 
         protected abstract void SaveViewSpecList(ViewGroupId viewGroupId, ViewSpecList viewSpecList);
 
-        protected RowSourceInfo FindRowSourceInfo(ViewInfo viewInfo)
-        {
-            return FindRowSourceInfo(viewInfo.ParentColumn.PropertyType);
-        }
-
         public ViewInfo GetViewInfo(ViewGroup viewGroup, ViewSpec viewSpec)
         {
             var rowSourceInfo = GetRowSourceInfo(viewSpec);
@@ -170,7 +165,7 @@ namespace pwiz.Common.DataBinding
             return GetViewInfo(FindGroup(viewName.Value.GroupId), viewSpec);
         }
 
-        protected RowSourceInfo GetRowSourceInfo(ViewSpec viewSpec)
+        public RowSourceInfo GetRowSourceInfo(ViewSpec viewSpec)
         {
             return RowSources.FirstOrDefault(rowSource => rowSource.Name == viewSpec.RowSource);
         }
@@ -706,5 +701,10 @@ namespace pwiz.Common.DataBinding
         // SkylineViewContext overrides and uses this event 
 #pragma warning disable 67
         public virtual event Action ViewsChanged;
+
+        public virtual bool CanDisplayView(ViewSpec viewSpec)
+        {
+            return null != GetRowSourceInfo(viewSpec);
+        }
     }
 }

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ChooseViewsControl.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ChooseViewsControl.cs
@@ -86,7 +86,7 @@ namespace pwiz.Common.DataBinding.Controls.Editor
                         newGroups.Add(listViewGroup);
                         foreach (var viewSpec in ViewContext.GetViewSpecList(group.Id).ViewSpecs)
                         {
-                            bool validRowSource = null != ViewContext.GetViewInfo(new ViewName(group.Id, viewSpec.Name));
+                            bool validRowSource = ViewContext.CanDisplayView(viewSpec);
                             if (FilterRowSources && !validRowSource)
                             {
                                 continue;

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ManageViewsForm.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ManageViewsForm.cs
@@ -175,8 +175,7 @@ namespace pwiz.Common.DataBinding.Controls.Editor
         public void UpdateButtons()
         {
             btnCopy.Enabled = btnShare.Enabled = btnRemove.Enabled = chooseViewsControl1.SelectedViews.Any();
-            ViewInfo selectedViewInfo = chooseViewsControl1.ViewContext.GetViewInfo(chooseViewsControl1.SelectedViewName);
-            btnEdit.Enabled = null != selectedViewInfo;
+            btnEdit.Enabled = CanEdit(chooseViewsControl1.SelectedViewName);
         }
 
         private void btnCopy_Click(object sender, EventArgs e)
@@ -184,10 +183,20 @@ namespace pwiz.Common.DataBinding.Controls.Editor
             ShowCopyContextMenu();
         }
 
+        private bool CanEdit(ViewName? viewName)
+        {
+            if (!viewName.HasValue)
+            {
+                return false;
+            }
+            var viewContext = chooseViewsControl1.ViewContext;
+            var viewSpec = viewContext.GetViewSpecList(viewName.Value.GroupId)?.GetView(viewName.Value.Name);
+            return viewSpec != null && viewContext.GetRowSourceInfo(viewSpec) != null;
+        }
+
         public void ShowCopyContextMenu()
         {
-            openViewEditorContextMenuItem.Enabled = 
-                null != chooseViewsControl1.ViewContext.GetViewInfo(chooseViewsControl1.SelectedViewName);
+            openViewEditorContextMenuItem.Enabled = CanEdit(chooseViewsControl1.SelectedViewName);
             copyToGroupContextMenuItem.DropDownItems.Clear();
             foreach (var group in ViewContext.ViewGroups)
             {

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/NavBar.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/NavBar.cs
@@ -194,11 +194,12 @@ namespace pwiz.Common.DataBinding.Controls
                     }
                     foreach (var viewSpec in viewSpecList.ViewSpecs)
                     {
-                        var item = NewChooseViewItem(group, viewSpec);
-                        if (null != item)
+                        if (!ViewContext.CanDisplayView(viewSpec))
                         {
-                            items.Add(item);
+                            continue;
                         }
+
+                        items.Add(NewChooseViewItem(group, viewSpec));
                     }
                     if (!items.Any())
                     {
@@ -251,11 +252,6 @@ namespace pwiz.Common.DataBinding.Controls
 
         ToolStripItem NewChooseViewItem(ViewGroup viewGroup, ViewSpec viewSpec)
         {
-            var viewInfo = ViewContext.GetViewInfo(new ViewName(viewGroup.Id, viewSpec.Name));
-            if (null == viewInfo)
-            {
-                return null;
-            }
             Image image = null;
             int imageIndex = ViewContext.GetImageIndex(viewSpec);
             if (imageIndex >= 0)

--- a/pwiz_tools/Shared/Common/DataBinding/IViewContext.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/IViewContext.cs
@@ -42,6 +42,11 @@ namespace pwiz.Common.DataBinding
         IRowSource GetRowSource(ViewInfo viewInfo);
         ViewInfo GetViewInfo(ViewGroup viewGroup, ViewSpec viewSpec);
         ViewInfo GetViewInfo(ViewName? viewName);
+        RowSourceInfo GetRowSourceInfo(ViewSpec viewSpec);
+        /// <summary>
+        /// Returns true if this view is able to be displayed in this ViewContext.
+        /// </summary>
+        bool CanDisplayView(ViewSpec viewSpec);
         void Export(Control owner, BindingListSource bindingListSource);
         void CopyAll(Control owner, BindingListSource bindingListSource);
         ViewSpec NewView(Control owner, ViewGroup viewGroup);

--- a/pwiz_tools/Skyline/Model/Databinding/SkylineViewContext.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/SkylineViewContext.cs
@@ -900,5 +900,24 @@ namespace pwiz.Skyline.Model.Databinding
                 return UiModes.AvailableModes(SkylineDataSchema.SkylineWindow.ModeUI);
             }
         }
+
+        public override bool CanDisplayView(ViewSpec viewSpec)
+        {
+            if (!base.CanDisplayView(viewSpec))
+            {
+                return false;
+            }
+
+            var reportUiMode = DataSchema.NormalizeUiMode(viewSpec.UiMode);
+            switch (DataSchema.DefaultUiMode)
+            {
+                case UiModes.PROTEOMIC:
+                    return reportUiMode != UiModes.SMALL_MOLECULES;
+                case UiModes.SMALL_MOLECULES:
+                    return reportUiMode != UiModes.PROTEOMIC;
+            }
+
+            return true;
+        }
     }
 }

--- a/pwiz_tools/Skyline/Model/PersistedViews.cs
+++ b/pwiz_tools/Skyline/Model/PersistedViews.cs
@@ -112,7 +112,7 @@ namespace pwiz.Skyline.Model
         }
 
         public int RevisionIndex { get; private set; }
-        public int RevisionIndexCurrent { get { return 10; } }
+        public int RevisionIndexCurrent { get { return 11; } }
         public override void ReadXml(XmlReader reader)
         {
             RevisionIndex = reader.GetIntAttribute(Attr.revision);
@@ -166,6 +166,11 @@ namespace pwiz.Skyline.Model
                 reportStrings.Add(REPORTS_V10);
             }
 
+            if (revisionIndex >= 11)
+            {
+                reportStrings.Add(REPORTS_V11);
+            }
+
             var list = new List<KeyValuePair<ViewGroupId, ViewSpec>>();
             var xmlSerializer = new XmlSerializer(typeof(ViewSpecList));
             foreach (var reportString in reportStrings)
@@ -182,6 +187,8 @@ namespace pwiz.Skyline.Model
                 {"Peptide Transition List", MainGroup.Id.ViewName(Resources.SkylineViewContext_GetTransitionListReportSpec_Peptide_Transition_List)},
                 {"Mixed Transition List", MainGroup.Id.ViewName(Resources.SkylineViewContext_GetTransitionListReportSpec_Mixed_Transition_List)},
                 {"Small Molecule Transition List", MainGroup.Id.ViewName(Resources.SkylineViewContext_GetTransitionListReportSpec_Small_Molecule_Transition_List)},
+                {"Molecule Quantification", MainGroup.Id.ViewName(Resources.PersistedViews_GetDefaults_Molecule_Quantification)},
+                {"Molecule Ratio Results", MainGroup.Id.ViewName(Resources.PersistedViews_GetDefaults_Molecule_Ratio_Results)},
                 {"SRM Collider Input", ExternalToolsGroup.Id.ViewName("SRM Collider Input")},
             };
             // ReSharper restore LocalizableElement
@@ -506,6 +513,29 @@ namespace pwiz.Skyline.Model
   </view>
 </views>
 ";
+
+        private const string REPORTS_V11 = @"<views>
+  <view name='Molecule Quantification' rowsource='pwiz.Skyline.Model.Databinding.Entities.Peptide' sublist='Results!*' uimode='small_molecules'>
+    <column name='' />
+    <column name='Protein' />
+    <column name='StandardType' />
+    <column name='InternalStandardConcentration' />
+    <column name='ConcentrationMultiplier' />
+    <column name='NormalizationMethod' />
+    <column name='CalibrationCurve' />
+    <column name='Note' />
+  </view>
+  <view name='Molecule Ratio Results' rowsource='pwiz.Skyline.Model.Databinding.Entities.Peptide' sublist='Results!*' uimode='small_molecules'>
+    <column name='' />
+    <column name='Protein' />
+    <column name='Results!*.Value.ResultFile.Replicate' />
+    <column name='Results!*.Value.PeptidePeakFoundRatio' />
+    <column name='Results!*.Value.PeptideRetentionTime' />
+    <column name='Results!*.Value.RatioToStandard' />
+    <column name='Results!*.Value.Quantification' />
+    <filter column='Results!*.Value' opname='isnotnullorblank' />
+  </view>
+</views>";
 
         // ReSharper restore LocalizableElement
 

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -23669,6 +23669,24 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Molecule Quantification.
+        /// </summary>
+        public static string PersistedViews_GetDefaults_Molecule_Quantification {
+            get {
+                return ResourceManager.GetString("PersistedViews_GetDefaults_Molecule_Quantification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Molecule Ratio Results.
+        /// </summary>
+        public static string PersistedViews_GetDefaults_Molecule_Ratio_Results {
+            get {
+                return ResourceManager.GetString("PersistedViews_GetDefaults_Molecule_Ratio_Results", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Main.
         /// </summary>
         public static string PersistedViews_MainGroup_Main {

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -11639,4 +11639,10 @@ If you do not have the original file, you may build the library with embedded sp
   <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
 	  <value>Product needs values for any two of: Formula, m/z or Charge.</value>
   </data>
+  <data name="PersistedViews_GetDefaults_Molecule_Quantification" xml:space="preserve">
+	  <value>Molecule Quantification</value>
+  </data>
+  <data name="PersistedViews_GetDefaults_Molecule_Ratio_Results" xml:space="preserve">
+	  <value>Molecule Ratio Results</value>
+  </data>
 </root>


### PR DESCRIPTION
, and hide peptide-specific reports when in small molecule mode.

Add new default reports "Molecule Quantification" and "Molecule Ratio Results".
Here's what the Reports dropdown at the top of the Document Grid looks like when you are in Small Molecules mode:
![image](https://user-images.githubusercontent.com/303203/153283563-2a9aa737-1caa-4c8e-8b5d-4107f97243aa.png)

and here's what the Manage Reports dialog looks like:
![image](https://user-images.githubusercontent.com/303203/153283633-3de971f2-ff29-406d-88a5-9f2a38298e4f.png)

The peptide-specific reports are greyed out. You can actually bring up the report editor on them (in case you want to change their UI mode). This screenshot also shows a report from the Results Grid ("My Peptide Results Report") which is greyed out and which you would not be able to edit, since that report is designed to be used with the Results Grid.

This pull request also includes some changes where I changed it to use "GetRowSourceInfo" instead of "GetViewInfo", because GetViewInfo does a lot more work than is necessary when all we want to know is whether the report should be shown in the "Reports" dropdown.

It would be nice to add a "Small Molecule Peak Boundaries" report. Currently, in order to import peak boundaries you really do need to have a column called "Peptide Modified Sequence", even if it is for small molecules. We should probably change "ImportPeakBoundaries.cs" so that it allows a small-molecule-appropriate column name, and then design a Small Molecule Peak Boundaries report which uses that name.