### PR TITLE
Fix audit log tutorial test.

### DIFF
--- a/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
@@ -454,7 +454,10 @@ namespace pwiz.SkylineTestTutorial
             RunUI(() => SkylineWindow.AuditLogForm.Parent.Parent.Height += 10); // Extra for 2-line headers
             PauseForScreenShot<AuditLogForm>("Audit Log with custom view.", 18);
 
-            var registrationDialog = ShowDialog<MultiButtonMsgDlg>(() => SkylineWindow.ShowPublishDlg(null));
+            var confirmSaveDlg = ShowDialog<MultiButtonMsgDlg>(() => SkylineWindow.ShowPublishDlg(null));
+            Assert.AreEqual(Resources.SkylineWindow_CheckSaveDocument_Do_you_want_to_save_changes, confirmSaveDlg.Message);
+            // Consider(nicksh): Do we need to add a screenshot of the confirm save dialog to the tutorial document?
+            var registrationDialog = ShowDialog<MultiButtonMsgDlg>(confirmSaveDlg.ClickYes);
             PauseForScreenShot<MultiButtonMsgDlg>("Upload confirmation dialog.", 19);
 
             var loginDialog = ShowDialog<EditServerDlg>(registrationDialog.ClickNo);


### PR DESCRIPTION
Here's a proposed fix for the Audit Log Tutorial test failure.

I imagine we also need to update "pwiz_tools\Skyline\Documentation\Skyline Audit Logging.docx" so that it mentions the confirm save dialog. Here's what that part of the tutorial currently says:
![image](https://user-images.githubusercontent.com/303203/153451748-9162fa23-122e-42bb-91b2-56112ae9c3c8.png)