### PR TITLE
Save the document before uploading to Panorama but only if it is "dirty"

### DIFF
--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -3193,12 +3193,13 @@ namespace pwiz.Skyline
             }
 
             // Issue 866: Provide option in Skyline to upload a minimized library to Panorama
-            // Changed from SaveDocument() to CheckSaveDocument() so that the user has to save changes first rather than silently
-            // saving in the current format even if there are no changes.  If the user is uploading an older document with a newer
+            // Save the document but only if it is "dirty". If the user is uploading an older document with a newer
             // version of Skyline they may want to preserve the version in the .sky file. The version is preserved only with a 
             // "complete" share, however. 
-            if (!CheckSaveDocument())
-                return;
+            if (Dirty)
+            {
+                SaveDocument();
+            }
 
             var servers = Settings.Default.ServerList;
             if (servers.Count == 0)


### PR DESCRIPTION
This fixes the TestAuditLogTutorial failure