### PR TITLE
Skyline/work/20220212 asym chrom opt fix 21 2

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -1297,7 +1297,8 @@ namespace pwiz.Skyline.Controls.Graphs
                         int numStepsExpected = chromatograms.OptimizationFunction.StepCount*2 + 1;
                         if (arrayChromInfo.Length != numStepsExpected)
                         {
-                            arrayChromInfo = ResizeArrayChromInfo(arrayChromInfo, numStepsExpected);
+                            int centerInfo = TransitionGroupDocNode.FindCenterInfo(nodeTranSelected, arrayChromInfo);
+                            arrayChromInfo = ResizeArrayChromInfo(arrayChromInfo, centerInfo, numStepsExpected);
                             allowEmpty = true;
                         }
                     }
@@ -1742,7 +1743,10 @@ namespace pwiz.Skyline.Controls.Graphs
                 // no matter what, so that chromatogram colors will match up with peak
                 // area charts.
                 if (infos.Length != totalOptCount)
-                    infos = ResizeArrayChromInfo(infos, totalOptCount);
+                {
+                    int centerInfo = TransitionGroupDocNode.FindCenterInfo(nodeTran, infos);
+                    infos = ResizeArrayChromInfo(infos, centerInfo, totalOptCount);
+                }
 
                 listChromInfoSets.Add(infos);
                 var transitionChromInfos = new TransitionChromInfo[totalOptCount];
@@ -1839,7 +1843,7 @@ namespace pwiz.Skyline.Controls.Graphs
             {
                 var graphData = listGraphData[i];
 
-                if (graphData.InfoPrimary != null)
+                if (graphData.InfoPrimary != null || totalSteps > 0)    // Show everything for optimization runs
                 {
                     int step = i - totalSteps;
                     int width = lineWidth;
@@ -1881,19 +1885,23 @@ namespace pwiz.Skyline.Controls.Graphs
             return chromGraphItems;
         }
 
-        private static ChromatogramInfo[] ResizeArrayChromInfo(ChromatogramInfo[] arrayChromInfo, int numStepsExpected)
+        private static ChromatogramInfo[] ResizeArrayChromInfo(ChromatogramInfo[] arrayChromInfo, int centerInfo, int numStepsExpected)
         {
             int numStepsFound = arrayChromInfo.Length;
             var arrayChromInfoNew = new ChromatogramInfo[numStepsExpected];
             if (numStepsFound < numStepsExpected)
             {
+                // Position a smaller set inside a larger array
+                int destinationIndex = numStepsExpected / 2 - centerInfo;
+                int length = Math.Min(numStepsFound, numStepsExpected - destinationIndex);
                 Array.Copy(arrayChromInfo, 0,
-                           arrayChromInfoNew, (numStepsExpected - numStepsFound) / 2, numStepsFound);
+                    arrayChromInfoNew, destinationIndex, length);
             }
             else
             {
-                Array.Copy(arrayChromInfo, (numStepsFound - numStepsExpected) / 2,
-                           arrayChromInfoNew, 0, numStepsExpected);
+                // Position as much as will fit of a larger set into a smaller array
+                Array.Copy(arrayChromInfo, centerInfo - numStepsExpected / 2,
+                    arrayChromInfoNew, 0, numStepsExpected);
             }
             arrayChromInfo = arrayChromInfoNew;
             return arrayChromInfo;

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -1608,7 +1608,7 @@ namespace pwiz.Skyline.Model
         /// <summary>
         /// Returns the <see cref="ChromatogramInfo"/> with the closest m/z value to the given transition.
         /// </summary>
-        private int FindCenterInfo(TransitionDocNode nodeTran, IList<ChromatogramInfo> listChromInfo)
+        public static int FindCenterInfo(TransitionDocNode nodeTran, IList<ChromatogramInfo> listChromInfo)
         {
             // The list is assumed to be sorted by m/z. So, m/z values should get closer and closer
             // until they start getting farther and farther.

--- a/pwiz_tools/Skyline/TestTutorial/SmallMolMethodDevCEOptTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/SmallMolMethodDevCEOptTutorial.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -38,6 +39,8 @@ using pwiz.Skyline.SettingsUI;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
 using pwiz.SkylineTestUtil;
+using ZedGraph;
+using SampleType = pwiz.Skyline.Model.DocSettings.AbsoluteQuantification.SampleType;
 
 namespace pwiz.SkylineTestTutorial
 {
@@ -464,6 +467,8 @@ namespace pwiz.SkylineTestTutorial
                 });
                 PauseForScreenShot<SkylineWindow>("No legend", 34);
 
+                TestAsymmetricOptimization();
+
                 // Show Pentose-P
                 SelectNode(SrmDocument.Level.Molecules, 6);
                 PauseForScreenShot<SkylineWindow>("Pentose-P", 35);
@@ -500,6 +505,66 @@ namespace pwiz.SkylineTestTutorial
                     PauseForScreenShot<SchedulingOptionsDlg>("Final Scheduling", 37);
                     OkDialog(scheduleDlg, scheduleDlg.OkDialog);
                 }
+            }
+        }
+
+        private void TestAsymmetricOptimization()
+        {
+            SelectNode(SrmDocument.Level.TransitionGroups, 1);
+            WaitForGraphs();
+            TestSelectedAsymOpt(0.95);
+            SelectNode(SrmDocument.Level.TransitionGroups, 2);
+            WaitForGraphs();
+            TestSelectedAsymOpt(0.99);
+            SelectNode(SrmDocument.Level.Transitions, 2);
+            WaitForGraphs();
+            TestSelectedAsymOpt(0.99);
+
+            // Close the opened second molecule node.
+            RunUI(() => SkylineWindow.SequenceTree.Nodes[0].Nodes[1].Collapse());
+        }
+
+        private void TestSelectedAsymOpt(double expectedMinCorr)
+        {
+            RunUI(() =>
+            {
+                var chromPoints = SkylineWindow.GraphChromatograms.Last().CurveList;
+                Assert.AreEqual(11, chromPoints.Count);
+                AreaReplicateGraphPane pane;
+                SkylineWindow.GraphPeakArea.TryGetGraphPane(out pane);
+                var areaPoints = pane.CurveList;
+                Assert.AreEqual(chromPoints.Count, areaPoints.Count);
+                var chromIntensities = new List<double>();
+                var areaIntensities = new List<double>();
+                for (int i = 0; i < chromPoints.Count; i++)
+                {
+                    var chrom = chromPoints[i];
+                    var area = areaPoints[i];
+                    Assert.AreEqual(chrom.Label.Text, area.Label.Text);
+                    chromIntensities.Add(ToIntensities(chrom.Points).Max());
+                    areaIntensities.Add(ToIntensities(area.Points).Last());
+                }
+
+                var statChrom = new Statistics(chromIntensities);
+                var statArea = new Statistics(areaIntensities);
+                double corr = statChrom.R(statArea);
+                Assert.IsTrue(corr >= expectedMinCorr, "Correlation between chromatogram and area intensities {0} expected to be >= {1}",
+                    corr, expectedMinCorr);
+            });
+        }
+
+        private IEnumerable<double> ToIntensities(IPointList points)
+        {
+            // Return at least a single zero point even if there are no points
+            if (points.Count == 0)
+                yield return 0;
+
+            for (int i = 0; i < points.Count; i++)
+            {
+                if (points[i].IsMissing)
+                    yield return 0;
+                else
+                    yield return points[i].Y;
             }
         }
 


### PR DESCRIPTION
Skyline (21.2): Fix asymmetric optimization data in GraphChromatogram display