### PR TITLE
Reduce size of class "TransitionGroupChromInfo".

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -1033,11 +1033,12 @@ namespace pwiz.Skyline.Model.Results
         private readonly float _backgroundArea;
         private readonly float _height;
         private readonly float _fwhm;
-        private uint _flagBits;
+        private FlagValues _flagValues;
+        private short _massError;
         private readonly short _pointsAcross;
 
         [Flags]
-        public enum FlagValues
+        public enum FlagValues : ushort
         {
             degenerate_fwhm =       0x0001,
             forced_integration =    0x0002,
@@ -1048,7 +1049,6 @@ namespace pwiz.Skyline.Model.Results
             used_id_alignment =     0x0040,
 
             // This is the last available flag
-            // The high word of the flags is reserved for delta-mass-error
             mass_error_known =      0x8000,
         }
 
@@ -1201,7 +1201,7 @@ namespace pwiz.Skyline.Model.Results
             _backgroundArea = 0;
             _pointsAcross = (short)Math.Min(pointsAcrossThePeak, ushort.MaxValue);
             _retentionTime = (float) apexTime;
-            _flagBits = 0;
+            _flagValues = flagValues;
             if (halfMaxStart.HasValue)
             {
                 _fwhm = (float) (halfMaxEnd - halfMaxStart);
@@ -1212,15 +1212,18 @@ namespace pwiz.Skyline.Model.Results
             }
             if (null != timeIntensities.MassErrors && totalArea > 0)
             {
-                flagValues |= FlagValues.mass_error_known;
-                FlagBits = ((uint)To10x(totalMassError / totalArea)) << 16;
+                _flagValues |= FlagValues.mass_error_known;
+                _massError = To10x(totalMassError / totalArea);
+            }
+            else
+            {
+                _flagValues &= ~FlagValues.mass_error_known;
+                _massError = 0;
             }
 
-
-            FlagBits |= (uint) flagValues;
             if (fwhmDegenerate)
             {
-                FlagBits |= (uint) FlagValues.degenerate_fwhm;
+                _flagValues |= FlagValues.degenerate_fwhm;
             }
         }
 
@@ -1273,20 +1276,23 @@ namespace pwiz.Skyline.Model.Results
             _fwhm = (float) (peak.Fwhm * interval);
             if (float.IsNaN(Fwhm))
                 _fwhm = 0;
+            _flagValues = flags;
             if (peak.FwhmDegenerate)
-                flags |= FlagValues.degenerate_fwhm;
+                _flagValues |= FlagValues.degenerate_fwhm;
 
             // Calculate peak truncation as a peak extent at either end of the
             // recorded values, where the intensity is higher than the other extent
             // by more than 1% of the peak height.
-            flags |= FlagValues.peak_truncation_known;
+            _flagValues |= FlagValues.peak_truncation_known;
             const double truncationTolerance = 0.01;
             double deltaIntensityExtents = (intensities[peak.EndIndex] - intensities[peak.StartIndex]) / Height;
             if ((peak.StartIndex == 0 && deltaIntensityExtents < -truncationTolerance) ||
                 (peak.EndIndex == times.Count - 1 && deltaIntensityExtents > truncationTolerance))
             {
-                flags |= FlagValues.peak_truncated;
+                _flagValues |= FlagValues.peak_truncated;
             }
+
+            _massError = 0;
             if (massErrors != null)
             {
                 // Mass error is mean of mass errors in the peak, weighted by intensity
@@ -1307,11 +1313,10 @@ namespace pwiz.Skyline.Model.Results
                 // Only if intensity exceded the background at least once
                 if (totalIntensity > 0)
                 {
-                    flags |= FlagValues.mass_error_known;
-                    FlagBits = ((uint)To10x(massError)) << 16;
+                    _flagValues |= FlagValues.mass_error_known;
+                    _massError = To10x(massError);
                 }
             }
-            FlagBits |= (uint) flags;
             if (rawTimes != null)
             {
                 int startIndex = CollectionUtil.BinarySearch(rawTimes, StartTime);
@@ -1339,7 +1344,6 @@ namespace pwiz.Skyline.Model.Results
         public float BackgroundArea { get { return _backgroundArea; } }
         public float Height { get { return _height; } }
         public float Fwhm { get { return _fwhm; } }
-        public uint FlagBits { get { return _flagBits; } private set { _flagBits = value; } }
         public short? PointsAcross { get { return _pointsAcross == 0 ? (short?)null : _pointsAcross; } }
 
         public override string ToString()
@@ -1352,7 +1356,7 @@ namespace pwiz.Skyline.Model.Results
             get
             {
                 // Mask off mass error bits
-                return (FlagValues) (FlagBits & 0xFFFF);
+                return _flagValues;
             }
         }
 
@@ -1399,11 +1403,11 @@ namespace pwiz.Skyline.Model.Results
         {
             get
             {
-                if ((FlagBits & (uint) FlagValues.mass_error_known) == 0)
+                if ((_flagValues & FlagValues.mass_error_known) == 0)
                     return null;
                 // Mass error is stored in the high 16 bits of the Flags
                 // as 10x the calculated mass error in PPM.
-                return ((short)(FlagBits >> 16))/10f;
+                return _massError / 10f;
             }
         }
 
@@ -1415,7 +1419,8 @@ namespace pwiz.Skyline.Model.Results
         public ChromPeak RemoveMassError()
         {
             var copy = this;
-            copy.FlagBits = (uint) (Flags & ~FlagValues.mass_error_known);
+            copy._flagValues = Flags & ~FlagValues.mass_error_known;
+            copy._massError = 0;
             return copy;
         }
 

--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -1355,7 +1355,6 @@ namespace pwiz.Skyline.Model.Results
         {
             get
             {
-                // Mask off mass error bits
                 return _flagValues;
             }
         }
@@ -1405,8 +1404,7 @@ namespace pwiz.Skyline.Model.Results
             {
                 if ((_flagValues & FlagValues.mass_error_known) == 0)
                     return null;
-                // Mass error is stored in the high 16 bits of the Flags
-                // as 10x the calculated mass error in PPM.
+                // Mass error is stored as 10x the calculated mass error in PPM.
                 return _massError / 10f;
             }
         }

--- a/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
@@ -188,7 +188,6 @@ namespace pwiz.Skyline.Model.Results
             HasIsotopeDotProduct = 8192,
             HasQValue = 16384,
             HasZScore = 32768,
-
         }
 
         private Flags _flags;
@@ -246,8 +245,8 @@ namespace pwiz.Skyline.Model.Results
         public short OptimizationStep { get; private set; }
 
         public float PeakCountRatio { get; private set; }
-        private float _retentionTime;
 
+        private float _retentionTime;
         public float? RetentionTime
         {
             get { return GetOptional(_retentionTime, Flags.HasRetentionTime); }
@@ -262,7 +261,6 @@ namespace pwiz.Skyline.Model.Results
         }
 
         private float _endRetentionTime;
-
         public float? EndRetentionTime
         {
             get { return GetOptional(_endRetentionTime, Flags.HasEndRetentionTime); }
@@ -301,7 +299,6 @@ namespace pwiz.Skyline.Model.Results
         }
 
         private float _backgroundArea;
-
         public float? BackgroundArea
         {
             get { return GetOptional(_backgroundArea, Flags.HasBackgroundArea); }
@@ -345,6 +342,7 @@ namespace pwiz.Skyline.Model.Results
 
         public PeakIdentification Identified { get; private set; }
         public bool IsIdentified { get { return Identified != PeakIdentification.FALSE; } }
+
         private float _libraryDotProduct;
         public float? LibraryDotProduct
         {
@@ -367,7 +365,6 @@ namespace pwiz.Skyline.Model.Results
         }
 
         private float _zScore;
-
         public float? ZScore
         {
             get { return GetOptional(_zScore, Flags.HasZScore); }

--- a/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
@@ -169,6 +169,30 @@ namespace pwiz.Skyline.Model.Results
     /// </summary>
     public sealed class TransitionGroupChromInfo : ChromInfo
     {
+        [Flags]
+        private enum Flags
+        {
+            HasRetentionTime = 1,
+            HasStartRetentionTime = 2,
+            HasEndRetentionTime = 4,
+            HasFwhm = 8,
+            HasArea = 16,
+            HasAreaMs1 = 32,
+            HasAreaFragment = 64,
+            HasBackgroundArea = 128,
+            HasBackgroundAreaMs1 = 256,
+            HasBackgroundAreaFragment = 512,
+            HasHeight = 1024,
+            HasMassError = 2048,
+            HasLibraryDotProduct = 4096,
+            HasIsotopeDotProduct = 8192,
+            HasQValue = 16384,
+            HasZScore = 32768,
+
+        }
+
+        private Flags _flags;
+
         public TransitionGroupChromInfo(ChromFileInfoId fileId,
                                         int optimizationStep,
                                         float peakCountRatio,
@@ -195,7 +219,7 @@ namespace pwiz.Skyline.Model.Results
                                         UserSet userSet)
             : base(fileId)
         {
-            OptimizationStep = optimizationStep;
+            OptimizationStep = Convert.ToInt16(optimizationStep);
             PeakCountRatio = peakCountRatio;
             RetentionTime = retentionTime;
             StartRetentionTime = startTime;
@@ -219,30 +243,137 @@ namespace pwiz.Skyline.Model.Results
             Annotations = annotations;
             UserSet = userSet;
         }
-
-        public int OptimizationStep { get; private set; }
+        public short OptimizationStep { get; private set; }
 
         public float PeakCountRatio { get; private set; }
-        public float? RetentionTime { get; private set; }
-        public float? StartRetentionTime { get; private set; }
-        public float? EndRetentionTime { get; private set; }
+        private float _retentionTime;
+
+        public float? RetentionTime
+        {
+            get { return GetOptional(_retentionTime, Flags.HasRetentionTime); }
+            set { _retentionTime = SetOptional(value, Flags.HasRetentionTime); }
+        }
+
+        private float _startRetentionTime;
+        public float? StartRetentionTime
+        {
+            get { return GetOptional(_startRetentionTime, Flags.HasStartRetentionTime); }
+            set { _startRetentionTime = SetOptional(value, Flags.HasStartRetentionTime); }
+        }
+
+        private float _endRetentionTime;
+
+        public float? EndRetentionTime
+        {
+            get { return GetOptional(_endRetentionTime, Flags.HasEndRetentionTime); }
+            set { _endRetentionTime = SetOptional(value, Flags.HasEndRetentionTime); }
+        }
+
         public TransitionGroupIonMobilityInfo IonMobilityInfo { get; private set; }
-        public float? Fwhm { get; private set; }
-        public float? Area { get; private set; }
-        public float? AreaMs1 { get; private set; }
-        public float? AreaFragment { get; private set; }
-        public float? BackgroundArea { get; private set; }
-        public float? BackgroundAreaMs1 { get; private set; }
-        public float? BackgroundAreaFragment { get; private set; }
-        public float? Height { get; private set; }
-        public float? MassError { get; private set; }
-        public int? Truncated { get; private set; }
+        private float _fwhm;
+
+        public float? Fwhm
+        {
+            get { return GetOptional(_fwhm, Flags.HasFwhm); }
+            set { _fwhm = SetOptional(value, Flags.HasFwhm); }
+        }
+
+        private float _area;
+        public float? Area
+        {
+            get { return GetOptional(_area, Flags.HasArea);}
+            private set { _area = SetOptional(value, Flags.HasArea); }
+        }
+
+        private float _areaMs1;
+        public float? AreaMs1
+        {
+            get { return GetOptional(_areaMs1, Flags.HasAreaMs1);}
+
+            private set { _areaMs1 = SetOptional(value, Flags.HasAreaMs1); }
+        }
+
+        private float _areaFragment;
+        public float? AreaFragment
+        {
+            get { return GetOptional(_areaFragment, Flags.HasAreaFragment); }
+            private set { _areaFragment = SetOptional(value, Flags.HasAreaFragment); }
+        }
+
+        private float _backgroundArea;
+
+        public float? BackgroundArea
+        {
+            get { return GetOptional(_backgroundArea, Flags.HasBackgroundArea); }
+            private set { _backgroundArea = SetOptional(value, Flags.HasBackgroundArea); }
+        }
+
+        private float _backgroundAreaMs1;
+        public float? BackgroundAreaMs1
+        {
+            get { return GetOptional(_backgroundAreaMs1, Flags.HasBackgroundAreaMs1); }
+            private set { _backgroundAreaMs1 = SetOptional(value, Flags.HasBackgroundAreaMs1); }
+        }
+
+        private float _backgroundAreaFragment;
+        public float? BackgroundAreaFragment 
+        {
+            get { return GetOptional(_backgroundAreaFragment, Flags.HasBackgroundAreaFragment); }
+            private set { _backgroundAreaFragment = SetOptional(value, Flags.HasBackgroundAreaFragment); }
+        }
+
+        private float _height;
+        public float? Height 
+        { 
+            get { return GetOptional(_height, Flags.HasHeight); }
+            private set { _height = SetOptional(value, Flags.HasHeight); }
+        }
+
+        private float _massError;
+        public float? MassError 
+        { 
+            get { return GetOptional(_massError, Flags.HasMassError); }
+            private set { _massError = SetOptional(value, Flags.HasMassError); }
+        }
+
+        private int _truncated;
+        public int? Truncated
+        {
+            get { return _truncated >= 0 ? _truncated : (int?) null; }
+            private set { _truncated = value ?? -1; }
+        }
+
         public PeakIdentification Identified { get; private set; }
         public bool IsIdentified { get { return Identified != PeakIdentification.FALSE; } }
-        public float? LibraryDotProduct { get; private set; }
-        public float? IsotopeDotProduct { get; private set; }
-        public float? QValue { get; private set; }
-        public float? ZScore { get; private set; }
+        private float _libraryDotProduct;
+        public float? LibraryDotProduct
+        {
+            get { return GetOptional(_libraryDotProduct, Flags.HasLibraryDotProduct);}
+            private set { _libraryDotProduct = SetOptional(value, Flags.HasLibraryDotProduct); }
+        }
+
+        private float _isotopeDotProduct;
+        public float? IsotopeDotProduct
+        {
+            get { return GetOptional(_isotopeDotProduct, Flags.HasIsotopeDotProduct); }
+            private set { _isotopeDotProduct = SetOptional(value, Flags.HasIsotopeDotProduct); }
+        }
+
+        private float _qValue;
+        public float? QValue
+        {
+            get { return GetOptional(_qValue, Flags.HasQValue); }
+            private set { _qValue = SetOptional(value, Flags.HasQValue); }
+        }
+
+        private float _zScore;
+
+        public float? ZScore
+        {
+            get { return GetOptional(_zScore, Flags.HasZScore); }
+            private set { _zScore = SetOptional(value, Flags.HasZScore); }
+        }
+
         public Annotations Annotations { get; private set; }
 
         /// <summary>
@@ -257,6 +388,34 @@ namespace pwiz.Skyline.Model.Results
         public bool IsUserSetMatched { get { return UserSet == UserSet.MATCHED; }}
 
         public bool IsUserModified { get { return IsUserSetManual || !Annotations.IsEmpty; } }
+
+        private bool GetFlag(Flags flag)
+        {
+            return 0 != (_flags & flag);
+        }
+
+        private void SetFlag(Flags flag, bool b)
+        {
+            if (b)
+            {
+                _flags |= flag;
+            }
+            else
+            {
+                _flags &= ~flag;
+            }
+        }
+
+        private T? GetOptional<T>(T field, Flags flag) where T:struct
+        {
+            return GetFlag(flag) ? field : (T?) null;
+        }
+
+        private T SetOptional<T>(T? value, Flags flag) where T : struct
+        {
+            SetFlag(flag, value.HasValue);
+            return value ?? default(T);
+        }
 
         #region Property change methods
 

--- a/pwiz_tools/Skyline/Model/Results/Scoring/IPeakScoringModel.cs
+++ b/pwiz_tools/Skyline/Model/Results/Scoring/IPeakScoringModel.cs
@@ -642,7 +642,7 @@ namespace pwiz.Skyline.Model.Results.Scoring
     }
 
     // ReSharper disable InconsistentNaming
-    public enum PeakIdentification { FALSE, TRUE, ALIGNED }
+    public enum PeakIdentification : byte { FALSE, TRUE, ALIGNED }
     // ReSharper restore InconsistentNaming
 
     public static class PeakIdentificationFastLookup

--- a/pwiz_tools/Skyline/Test/ObjectSizeTest.cs
+++ b/pwiz_tools/Skyline/Test/ObjectSizeTest.cs
@@ -53,6 +53,11 @@ namespace pwiz.SkylineTest
         {
             DumpTypeAndFields(typeof(TransitionChromInfo));
         }
+        [TestMethod]
+        public void TestTransitionGroupChromInfoSize()
+        {
+            DumpTypeAndFields(typeof(TransitionGroupChromInfo));
+        }
 
         private void DumpTypeAndFields(Type type)
         {

--- a/pwiz_tools/Skyline/TestData/Results/StructSizeTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/StructSizeTest.cs
@@ -41,7 +41,8 @@ namespace pwiz.SkylineTestData.Results
             Assert.AreEqual((IntPtr)16, Marshal.OffsetOf<ChromPeak>("_backgroundArea"));
             Assert.AreEqual((IntPtr)20, Marshal.OffsetOf<ChromPeak>("_height"));
             Assert.AreEqual((IntPtr)24, Marshal.OffsetOf<ChromPeak>("_fwhm"));
-            Assert.AreEqual((IntPtr)28, Marshal.OffsetOf<ChromPeak>("_flagBits"));
+            Assert.AreEqual((IntPtr)28, Marshal.OffsetOf<ChromPeak>("_flagValues"));
+            Assert.AreEqual((IntPtr)30, Marshal.OffsetOf<ChromPeak>("_massError"));
             Assert.AreEqual((IntPtr)32, Marshal.OffsetOf<ChromPeak>("_pointsAcross"));
             Assert.AreEqual(32, ChromPeak.GetStructSize(CacheFormatVersion.Eleven));
             Assert.AreEqual(36, ChromPeak.GetStructSize(CacheFormatVersion.Twelve));


### PR DESCRIPTION
I was planning on adding some new fields to TransitionGroupChromInfo, but before I did so, I thought it would be a good idea to make that class smaller.
Currently instances of this class are 192 bytes
With these changes the class is 120 bytes.
Most of the size reduction comes from changing "float?" fields (which are 8 bytes) to just a "float" (4 bytes) combined with one bit in "_flags".
Before these changes:
![image](https://user-images.githubusercontent.com/303203/154591392-f2100c46-e818-4a60-8c59-b0463b07af45.png)

With these changes:
![image](https://user-images.githubusercontent.com/303203/154591344-4ca3003d-509b-4260-8095-363cd26bae52.png)
