### PR TITLE
Added "[M+]" and "[M-]" to the cascading dropdown control for composing ion formulas…

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/EditCustomMoleculeDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditCustomMoleculeDlg.cs
@@ -94,7 +94,6 @@ namespace pwiz.Skyline.SettingsUI
                                        usageMode == UsageMode.fragment;
             var enableAdductEditing = usageMode == UsageMode.moleculeNew || usageMode == UsageMode.precursor ||
                                       usageMode == UsageMode.fragment;
-            var suggestOnlyAdductsWithMass = usageMode != UsageMode.fragment;
             var needExplicitTransitionValues = usageMode == UsageMode.fragment;
             var needExplicitTransitionGroupValues = usageMode == UsageMode.moleculeNew || usageMode == UsageMode.precursor;
 
@@ -245,8 +244,7 @@ namespace pwiz.Skyline.SettingsUI
                     labelAverage,
                     labelMono,
                     defaultCharge,
-                    editMode,
-                    suggestOnlyAdductsWithMass)
+                    editMode)
                 {
                     NeutralFormula = defaultFormula,
                     AverageMass = averageMass,

--- a/pwiz_tools/Skyline/SettingsUI/FormulaBox.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FormulaBox.cs
@@ -59,8 +59,7 @@ namespace pwiz.Skyline.SettingsUI
         /// <param name="labelMonoText">Label text for the monoisotopic mass or m/z textedit control</param>
         /// <param name="adduct">If non-null, treat the average and monoisotopic textedits as describing m/z instead of mass</param>
         /// <param name="mode">Controls editing of the formula and/or adduct edit</param>
-        /// <param name="suggestOnlyAdductsWithMass">If presenting an adduct dropdown menu, do we include things like "[M+]"?</param>
-        public FormulaBox(bool isProteomic, string labelFormulaText, string labelAverageText, string labelMonoText, Adduct adduct, EditMode mode = EditMode.formula_only, bool suggestOnlyAdductsWithMass = true)
+        public FormulaBox(bool isProteomic, string labelFormulaText, string labelAverageText, string labelMonoText, Adduct adduct, EditMode mode = EditMode.formula_only)
         {
             InitializeComponent();
             if (isProteomic)
@@ -82,7 +81,7 @@ namespace pwiz.Skyline.SettingsUI
             {
                 case EditMode.adduct_only:
                 case EditMode.formula_and_adduct:
-                    TransitionSettingsUI.AppendAdductMenus(contextFormula, suggestOnlyAdductsWithMass, adductStripMenuItem_Click);
+                    TransitionSettingsUI.AppendAdductMenus(contextFormula, adductStripMenuItem_Click);
                     break;
             }
 

--- a/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.cs
@@ -82,8 +82,8 @@ namespace pwiz.Skyline.SettingsUI
             _transitionSettings = _parent.DocumentUI.Settings.TransitionSettings;
 
             // Populate the small mol adduct filter helper menu
-            AppendAdductMenus(contextMenuStripPrecursorAdduct, true, precursorAdductStripMenuItem_Click);
-            AppendAdductMenus(contextMenuStripFragmentAdduct, false, fragmentAdductStripMenuItem_Click);
+            AppendAdductMenus(contextMenuStripPrecursorAdduct, precursorAdductStripMenuItem_Click);
+            AppendAdductMenus(contextMenuStripFragmentAdduct, fragmentAdductStripMenuItem_Click);
             Bitmap bm = Resources.PopupBtn;
             bm.MakeTransparent(Color.Fuchsia);
             btnPrecursorAdduct.Image = bm;
@@ -1152,7 +1152,7 @@ namespace pwiz.Skyline.SettingsUI
         }
 
         // Append adduct picker submenus, one per charge 1,2,3,-1,-2,-3
-        public static void AppendAdductMenus(ContextMenuStrip menuParent, bool showOnlyAdductsWithMass, EventHandler adductStripMenuItem_Click)
+        public static void AppendAdductMenus(ContextMenuStrip menuParent, EventHandler adductStripMenuItem_Click)
         {
             var insertOffset = menuParent.Items.Count == 0 ? 0 : 1; // Leave Help as last item
 
@@ -1170,14 +1170,11 @@ namespace pwiz.Skyline.SettingsUI
                 };
                 menuParent.Items.Insert(menuParent.Items.Count - insertOffset, menuItem);
                 var cascadeTop = menuItem;
-                if (!showOnlyAdductsWithMass)
+                // Charge-only adducts first
+                foreach (var adduct in AdductMenuOrder(Adduct.COMMON_CHARGEONLY_ADDUCTS, charge))
                 {
-                    // Charge-only adducts first
-                    foreach (var adduct in AdductMenuOrder(Adduct.COMMON_CHARGEONLY_ADDUCTS, charge))
-                    {
-                        AddAdductMenuItem(menuItem, adduct.ToString(), adductStripMenuItem_Click);
-                        adductsInMenu.Add(adduct);
-                    }
+                    AddAdductMenuItem(menuItem, adduct.ToString(), adductStripMenuItem_Click);
+                    adductsInMenu.Add(adduct);
                 }
                 // All the adducts from Fiehn lab list
                 foreach (var adduct in AdductMenuOrder(Adduct.DEFACTO_STANDARD_ADDUCTS, charge))


### PR DESCRIPTION
… in the "Modify..." right-click menu item in the Targets tree for small molecules. These were already available for fragment ions but they are also useful for precursors.

Not requested by any user, observed in a Skyline training.