### PR TITLE
Removed "KeyValuePair`2" from Reports documentation.

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/Documentation/DocumentationGenerator.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Documentation/DocumentationGenerator.cs
@@ -78,7 +78,7 @@ namespace pwiz.Common.DataBinding.Documentation
                     var collectionInfo = DataSchema.GetCollectionInfo(rowType);
                     if (collectionInfo != null)
                     {
-                        columnQueue.Enqueue(ColumnDescriptor.RootColumn(rootColumn.DataSchema, collectionInfo.ElementType, rootColumn.UiMode));
+                        columnQueue.Enqueue(ColumnDescriptor.RootColumn(rootColumn.DataSchema, collectionInfo.ElementValueType, rootColumn.UiMode));
                     }
                     else if (!IsScalar(rowType))
                     {


### PR DESCRIPTION
Removed "KeyValuePair`2" from Reports documentation. (Reported by Brian Pratt)