### PR TITLE
Removed the unintended 32767 character limit for pasting transition lists from the clipboard into the Edit > Insert > Transition List dialog.

### DIFF
--- a/pwiz_tools/Skyline/FileUI/InsertTransitionListDlg.resx
+++ b/pwiz_tools/Skyline/FileUI/InsertTransitionListDlg.resx
@@ -159,6 +159,9 @@
   <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 27</value>
   </data>
+  <data name="textBox1.MaxLength" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="textBox1.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>


### PR DESCRIPTION
Reported by user Kaitlyn

Developer note: no automated test for this as it's only reproducible by an actual user paste action. Per https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.textboxbase.maxlength?view=netframework-4.7.2 "In code, you can set the value of the Text property to a value that has a length greater than the value specified by the MaxLength property. This property only affects text entered into the control at run time."