### PR TITLE
Added a new standard report "Small Molecule Peak Boundaries" …

### DIFF
--- a/pwiz_tools/Shared/Common/SystemUtil/LocalizationHelper.cs
+++ b/pwiz_tools/Shared/Common/SystemUtil/LocalizationHelper.cs
@@ -87,16 +87,20 @@ namespace pwiz.Common.SystemUtil
     public class CurrentCultureSetter : IDisposable
     {
         private CultureInfo PreviousCulture { get; }
+        private CultureInfo PreviousUICulture { get; }
 
         public CurrentCultureSetter(CultureInfo newCultureInfo)
         {
             PreviousCulture = Thread.CurrentThread.CurrentCulture;
+            PreviousUICulture = Thread.CurrentThread.CurrentUICulture;
             Thread.CurrentThread.CurrentCulture = newCultureInfo;
+            Thread.CurrentThread.CurrentUICulture = newCultureInfo;
         }
 
         public void Dispose()
         {
             Thread.CurrentThread.CurrentCulture = PreviousCulture;
+            Thread.CurrentThread.CurrentUICulture = PreviousUICulture;
         }
     }
 }

--- a/pwiz_tools/Skyline/Controls/Databinding/ExportLiveReportDlg.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/ExportLiveReportDlg.cs
@@ -215,6 +215,7 @@ namespace pwiz.Skyline.Controls.Databinding
                 Text = Resources.ExportLiveReportDlg_ShowPreview_Preview__ + viewInfo.Name,
                 ShowViewsMenu = false,
             };
+            form.GetModeUIHelper().IgnoreModeUI = true; // Don't want any "peptide"=>"molecule" translation in title etc
             form.BindingListSource.SetViewContext(viewContext, viewInfo);
             form.Show(Owner);
         }

--- a/pwiz_tools/Skyline/Model/DocSettings/TransitionIonMobilityFiltering.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/TransitionIonMobilityFiltering.cs
@@ -1059,9 +1059,8 @@ namespace pwiz.Skyline.Model.DocSettings
             var currentCulture = Thread.CurrentThread.CurrentUICulture;
             try
             {
-                foreach (var culture in new[] {@"en", @"zh-CHS", @"ja"})
+                foreach (var tryCulture in CultureUtil.AvailableDisplayLanguages())
                 {
-                    var tryCulture = new CultureInfo(culture);
                     Thread.CurrentThread.CurrentUICulture = tryCulture;
                     foreach (eIonMobilityUnits u in Enum.GetValues(typeof(eIonMobilityUnits)))
                     {
@@ -1094,9 +1093,8 @@ namespace pwiz.Skyline.Model.DocSettings
             {
                 var result = new List<string>();
                 var currentCulture = Thread.CurrentThread.CurrentUICulture;
-                foreach (var culture in new[] { @"en", @"zh-CHS", @"ja" })
+                foreach (var tryCulture in CultureUtil.AvailableDisplayLanguages())
                 {
-                    var tryCulture = new CultureInfo(culture);
                     Thread.CurrentThread.CurrentUICulture = tryCulture;
                     foreach (eIonMobilityUnits u in Enum.GetValues(typeof(eIonMobilityUnits)))
                     {

--- a/pwiz_tools/Skyline/Model/DocSettings/TransitionIonMobilityFiltering.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/TransitionIonMobilityFiltering.cs
@@ -19,7 +19,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -100,14 +100,28 @@ namespace pwiz.Skyline.Model
 
         // ReSharper disable LocalizableElement
 
-        public static readonly string[] PEPTIDE_SYNONYMS = new[]
+        public static string[] PEPTIDE_SYNONYMS
         {
-            "PeptideModifiedSequence", "ModifiedSequence", "FullPeptideName", "EG.ModifiedSequence", ColumnCaptions.PeptideModifiedSequence, ColumnCaptions.ModifiedSequence
-        };
-        public static readonly string[] MOLECULE_SYNONYMS = new[]
+            get
+            {
+                return new[] 
+                {
+                    "PeptideModifiedSequence", "ModifiedSequence", "FullPeptideName", "EG.ModifiedSequence",
+                    ColumnCaptions.PeptideModifiedSequence, ColumnCaptions.ModifiedSequence
+                };
+            }
+        }
+
+        public static string[] MOLECULE_SYNONYMS
         {
-            "Molecule", "MoleculeName", ColumnCaptions.Molecule, ColumnCaptions.MoleculeName
-        };
+            get
+            {
+                return new[] 
+                {
+                    "Molecule", "MoleculeName", ColumnCaptions.Molecule, ColumnCaptions.MoleculeName
+                };
+            }
+        }
 
         // NOTE: The first name is what appears in error messages about missing required fields
         public static string[][] FIELD_NAMES

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -22,6 +22,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Windows.Forms;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Alerts;
@@ -100,26 +101,57 @@ namespace pwiz.Skyline.Model
 
         // ReSharper disable LocalizableElement
 
+        private static string[] _peptide_synonyms; // Cache for performance reasons (L10N stuff is expensive)
         public static string[] PEPTIDE_SYNONYMS
         {
             get
             {
-                return new[] 
+                if (_peptide_synonyms == null)
                 {
-                    "PeptideModifiedSequence", "ModifiedSequence", "FullPeptideName", "EG.ModifiedSequence",
-                    ColumnCaptions.PeptideModifiedSequence, ColumnCaptions.ModifiedSequence
-                };
+                    var headers = new List<string>()
+                    {
+                        "PeptideModifiedSequence", "ModifiedSequence", "FullPeptideName", "EG.ModifiedSequence",
+                    };
+                    // Also recognize column captions in all supported display languages
+                    var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+                    foreach (var culture in CultureUtil.AvailableDisplayLanguages())
+                    {
+                        Thread.CurrentThread.CurrentUICulture = culture;
+                        headers.Add(ColumnCaptions.PeptideModifiedSequence);
+                        headers.Add(ColumnCaptions.ModifiedSequence);
+                    }
+
+                    Thread.CurrentThread.CurrentUICulture = currentUICulture;
+                    _peptide_synonyms = headers.ToArray();
+                }
+                return _peptide_synonyms;
             }
         }
 
+        private static string[] _molecule_synonyms; // Cache for performance reasons (L10N stuff is expensive)
         public static string[] MOLECULE_SYNONYMS
         {
             get
             {
-                return new[] 
+                if (_molecule_synonyms == null) 
                 {
-                    "Molecule", "MoleculeName", ColumnCaptions.Molecule, ColumnCaptions.MoleculeName
-                };
+                    var headers = new List<string>()
+                    {
+                        "Molecule", "MoleculeName"
+                    };
+                    // Also recognize column captions in all supported display languages
+                    var currentUICulture = Thread.CurrentThread.CurrentUICulture;
+                    foreach (var culture in CultureUtil.AvailableDisplayLanguages())
+                    {
+                        Thread.CurrentThread.CurrentUICulture = culture;
+                        headers.Add(ColumnCaptions.Molecule);
+                        headers.Add(ColumnCaptions.MoleculeName);
+                    }
+
+                    Thread.CurrentThread.CurrentUICulture = currentUICulture;
+                    _molecule_synonyms = headers.ToArray();
+                }
+                return _molecule_synonyms;
             }
         }
 

--- a/pwiz_tools/Skyline/Model/PersistedViews.cs
+++ b/pwiz_tools/Skyline/Model/PersistedViews.cs
@@ -29,8 +29,26 @@ using pwiz.Skyline.Util;
 namespace pwiz.Skyline.Model
 {
     /// <summary>
-    /// Holds all of the Skyline views that get saved in <see cref="Settings.PersistedViews"/>.
+    /// Holds all of the Skyline views (aka "reports") that get saved in <see cref="Settings.PersistedViews"/>, and
+    /// thus appear in the Document Grid "Reports" dropdown button.
+    /// 
     /// This class replaces <see cref="Settings.ViewSpecList"/> and <see cref="Settings.ReportSpecList"/>.
+    ///
+    /// TO ADD OR CHANGE A DEFAULT REPORT
+    ///
+    /// 1) increase the number that is returned by "PersistedViews.RevisionIndexCurrent" (necessary even mid-release-cycle if there has been an official Daily release).
+    /// 2) add a new string constant defining the new or revised report. If there's already a report by that name, the more recent one is what shows up in Skyline.
+    /// 3) change the PersistedViews.GetDefaults(int revisionIndex) method so that it adds the new string to "reportString".
+    /// 
+    /// A convenient way to create the string constant defining a report is to build the report in Skyline, then export the report
+    /// definition with "File > Export > Report > Edit List > Share" (or you can do it from "Manage Views" on the Document Grid).
+    /// Then open the.skyr file in Notepad and replace all of the double quotes with single quotes and paste the contents of the file into
+    /// a @"" string constant. Find the commit in which this comment was added for an example.
+    ///
+    /// Note that if you skip step 1, users who have installed the current Skyline-Daily will not see the new report(s) when they upgrade.
+    /// On your own computer, if you want to see the new reports without increasing the version number, you can go to Tools > Options > Miscellaneous
+    /// and push the "Clear all saved settings" button.
+    /// 
     /// </summary>
     [XmlRoot("persisted_views")]
     public class PersistedViews : SerializableViewGroups
@@ -112,7 +130,7 @@ namespace pwiz.Skyline.Model
         }
 
         public int RevisionIndex { get; private set; }
-        public int RevisionIndexCurrent { get { return 11; } }
+        public int RevisionIndexCurrent { get { return 12; } } // v12 adds small mol peak boundaries report
         public override void ReadXml(XmlReader reader)
         {
             RevisionIndex = reader.GetIntAttribute(Attr.revision);
@@ -171,6 +189,11 @@ namespace pwiz.Skyline.Model
                 reportStrings.Add(REPORTS_V11);
             }
 
+            if (revisionIndex >= 12)
+            {
+                reportStrings.Add(REPORTS_V12); // Including molecule peak boundaries export
+            }
+
             var list = new List<KeyValuePair<ViewGroupId, ViewSpec>>();
             var xmlSerializer = new XmlSerializer(typeof(ViewSpecList));
             foreach (var reportString in reportStrings)
@@ -184,6 +207,7 @@ namespace pwiz.Skyline.Model
                 {"Peptide RT Results", MainGroup.Id.ViewName(Resources.ReportSpecList_GetDefaults_Peptide_RT_Results)},
                 {"Transition Results", MainGroup.Id.ViewName(Resources.ReportSpecList_GetDefaults_Transition_Results)},
                 {"Peak Boundaries", MainGroup.Id.ViewName(Resources.ReportSpecList_GetDefaults_Peak_Boundaries)},
+                {"Molecule Peak Boundaries", MainGroup.Id.ViewName(Resources.ReportSpecList_GetDefaults_Molecule_Peak_Boundaries)},
                 {"Peptide Transition List", MainGroup.Id.ViewName(Resources.SkylineViewContext_GetTransitionListReportSpec_Peptide_Transition_List)},
                 {"Small Molecule Transition List", MainGroup.Id.ViewName(Resources.SkylineViewContext_GetTransitionListReportSpec_Small_Molecule_Transition_List)},
                 {"Molecule Quantification", MainGroup.Id.ViewName(Resources.PersistedViews_GetDefaults_Molecule_Quantification)},
@@ -464,6 +488,17 @@ namespace pwiz.Skyline.Model
     <column name='Results!*.Value.PeptideRetentionTime' />
     <column name='Results!*.Value.RatioToStandard' />
     <column name='Results!*.Value.Quantification' />
+    <filter column='Results!*.Value' opname='isnotnullorblank' />
+  </view>
+</views>";
+
+        private const string REPORTS_V12 = @"<views>
+  <view name='Molecule Peak Boundaries' rowsource='pwiz.Skyline.Model.Databinding.Entities.Precursor' sublist='Results!*' uimode='small_molecules'>
+    <column name='Results!*.Value.PeptideResult.ResultFile.FileName' />
+    <column name='Peptide.MoleculeName' />
+    <column name='Results!*.Value.MinStartTime' />
+    <column name='Results!*.Value.MaxEndTime' />
+    <column name='Adduct' />
     <filter column='Results!*.Value' opname='isnotnullorblank' />
   </view>
 </views>";

--- a/pwiz_tools/Skyline/Model/PersistedViews.cs
+++ b/pwiz_tools/Skyline/Model/PersistedViews.cs
@@ -495,7 +495,7 @@ namespace pwiz.Skyline.Model
         private const string REPORTS_V12 = @"<views>
   <view name='Molecule Peak Boundaries' rowsource='pwiz.Skyline.Model.Databinding.Entities.Precursor' sublist='Results!*' uimode='small_molecules'>
     <column name='Results!*.Value.PeptideResult.ResultFile.FileName' />
-    <column name='Peptide.MoleculeName' />
+    <column name='Peptide' />
     <column name='Results!*.Value.MinStartTime' />
     <column name='Results!*.Value.MaxEndTime' />
     <column name='Adduct' />

--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -379,6 +379,15 @@ namespace pwiz.Skyline.Model.Results
                 {
                     return true;
                 }
+                // Test support - in "AsSmallMolecules" versions of tests where we transform a proteomic document to small molecules,
+                // cached chromatogram textID may be that of the original peptide. In that case, look for "PEPTIDER" instead of "pep_PEPTIDER"
+                if (SrmDocument.IsConvertedFromProteomicTestDocNode(nodePep))
+                {
+                    if (EqualTextIdBytes(nodePep.CustomMolecule.Name.Substring(RefinementSettings.TestingConvertedFromProteomicPeptideNameDecorator.Length), textIdIndex, textIdLen))
+                    {
+                        return true;
+                    }
+                }
                 return false;
             }
             else

--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -381,7 +381,8 @@ namespace pwiz.Skyline.Model.Results
                 }
                 // Test support - in "AsSmallMolecules" versions of tests where we transform a proteomic document to small molecules,
                 // cached chromatogram textID may be that of the original peptide. In that case, look for "PEPTIDER" instead of "pep_PEPTIDER"
-                if (SrmDocument.IsConvertedFromProteomicTestDocNode(nodePep))
+                if (SrmDocument.IsConvertedFromProteomicTestDocNode(nodePep) &&
+                    nodePep.CustomMolecule.Name.StartsWith(RefinementSettings.TestingConvertedFromProteomicPeptideNameDecorator))
                 {
                     if (EqualTextIdBytes(nodePep.CustomMolecule.Name.Substring(RefinementSettings.TestingConvertedFromProteomicPeptideNameDecorator.Length), textIdIndex, textIdLen))
                     {

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -2146,10 +2146,10 @@ namespace pwiz.Skyline.Model
             var currentCulture = Thread.CurrentThread.CurrentCulture;
             var currentUICulture = Thread.CurrentThread.CurrentUICulture;
             var knownColumnHeadersAllCultures = KnownHeaders.ToDictionary( hdr => hdr, hdr => hdr);
-            foreach (var culture in new[] { @"en", @"zh-CHS", @"ja" })
+            foreach (var culture in CultureUtil.AvailableDisplayLanguages())
             {
                 Thread.CurrentThread.CurrentUICulture =
-                    Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+                    Thread.CurrentThread.CurrentCulture = culture;
                 foreach (var pair in new[] {
                     // ReSharper disable StringLiteralTypo
                     Tuple.Create(moleculeGroup, Resources.PasteDlg_UpdateMoleculeType_Molecule_List_Name),

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -25440,6 +25440,15 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Molecule Peak Boundaries.
+        /// </summary>
+        public static string ReportSpecList_GetDefaults_Molecule_Peak_Boundaries {
+            get {
+                return ResourceManager.GetString("ReportSpecList_GetDefaults_Molecule_Peak_Boundaries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Peak Boundaries.
         /// </summary>
         public static string ReportSpecList_GetDefaults_Peak_Boundaries {

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -1446,8 +1446,11 @@
   <data name="CommandLine_ExportInstrumentFile_No_method_will_be_exported_" xml:space="preserve">
     <value>No method will be exported.</value>
   </data>
-  <data name="ReportSpecList_GetDefaults_Peak_Boundaries" xml:space="preserve">
+..<data name="ReportSpecList_GetDefaults_Peak_Boundaries" xml:space="preserve">
     <value>Peak Boundaries</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Molecule_Peak_Boundaries" xml:space="preserve">
+    <value>Molecule Peak Boundaries</value>
   </data>
   <data name="MQuestStandardWeightedCoElutionCalc_Name_Standard_co_elution__weighted_" xml:space="preserve">
     <value>Standard co-elution (weighted)</value>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -1446,7 +1446,7 @@
   <data name="CommandLine_ExportInstrumentFile_No_method_will_be_exported_" xml:space="preserve">
     <value>No method will be exported.</value>
   </data>
-..<data name="ReportSpecList_GetDefaults_Peak_Boundaries" xml:space="preserve">
+  <data name="ReportSpecList_GetDefaults_Peak_Boundaries" xml:space="preserve">
     <value>Peak Boundaries</value>
   </data>
   <data name="ReportSpecList_GetDefaults_Molecule_Peak_Boundaries" xml:space="preserve">

--- a/pwiz_tools/Skyline/Properties/Settings.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.cs
@@ -3069,6 +3069,10 @@ namespace pwiz.Skyline.Properties
 
     public class ReportSpecList : SerializableSettingsList<ReportSpec>, IItemEditor<ReportSpec>
     {
+        /// <summary>
+        /// OBSOLETE: replaced by  <see cref="Settings.PersistedViews"></see> for reports management/>
+        /// </summary>
+
         public const string EXT_REPORTS = ".skyr";
         // CONSIDER: Consider localizing tool report names which is not possible at the moment.
         public static string SRM_COLLIDER_REPORT_NAME

--- a/pwiz_tools/Skyline/Test/PeakBoundaryTest.cs
+++ b/pwiz_tools/Skyline/Test/PeakBoundaryTest.cs
@@ -22,10 +22,12 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.DataBinding;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model;
-using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Model.Databinding;
 using pwiz.Skyline.Model.DocSettings.Extensions;
 using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Results.Scoring;
@@ -37,8 +39,9 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTest
 {
     [TestClass]
-    public class PeakBoundaryTest : AbstractUnitTest
+    public class PeakBoundaryTest : AbstractUnitTestEx
     {
+        private bool AsSmallMolecules;
         const PeakIdentification FALSE = PeakIdentification.FALSE;
         const PeakIdentification TRUE = PeakIdentification.TRUE;
         
@@ -82,7 +85,7 @@ namespace pwiz.SkylineTest
         private readonly double?[] _idAreas1 = {4060, 1927, 16954, 16314, 4188, 23038, 28701, 354,
                                                2063, 21784, 8775, 18019, 19579, 11013, 58116, 26262};
 
-        private readonly string[] _peptides = { "VLVLDTDYK", "TPEVDDEALEK", "FFVAPFPEVFGK", "YLGYLEQLLR" };
+        private string[] _peptides = { "VLVLDTDYK", "TPEVDDEALEK", "FFVAPFPEVFGK", "YLGYLEQLLR" };
         private readonly string[] _peptidesId ={ "LGGLRPESPESLTSVSR", "ALVEFESNPEETREPGSPPSVQR", "YGPADVEDTTGSGATDSKDDDDIDLFGSDDEEESEEAKR",
                                                     "ESEDKPEIEDVGSDEEEEKKDGDK", "GVVDSEDLPLNISR", "DMESPTKLDVTLAK",
                                                     "VGSLDNVGHLPAGGAVK","KTGSYGALAEITASK","TGSYGALAEITASK","IVRGDQPAASGDSDDDEPPPLPR",
@@ -99,6 +102,32 @@ namespace pwiz.SkylineTest
         [TestMethod]
         public void TestImportPeakBoundary()
         {
+            DoTest();
+        }
+
+        /// <summary>
+        /// Tests File > Import > Peak Boundaries support for small molecules
+        /// </summary>
+        [TestMethod]
+        public void TestImportPeakBoundaryAsSmallMolecules()
+        {
+            if (!RunSmallMoleculeTestVersions)
+            {
+                Console.Write(MSG_SKIPPING_SMALLMOLECULE_TEST_VERSION);
+                return;
+            }
+
+            AsSmallMolecules = true;
+            for (var i = 0; i < _peptides.Length; i++)
+            {
+                _peptides[i] = RefinementSettings.TestingConvertedFromProteomicPeptideNameDecorator + _peptides[i];
+            }
+
+            DoTest();
+        }
+
+        private void DoTest()
+        {
             // Load the SRM document and relevant files            
             var testFilesDir = new TestFilesDir(TestContext, TEST_ZIP_PATH);
             bool isIntl = (TextUtil.CsvSeparator != TextUtil.SEPARATOR_CSV);
@@ -111,6 +140,12 @@ namespace pwiz.SkylineTest
                                                                    : "PeakBoundaryUS.csv");
             var peakBoundaryDoc = testFilesDir.GetTestPath("Chrom05.sky");
             SrmDocument doc = ResultsUtil.DeserializeDocument(peakBoundaryDoc);
+            if (AsSmallMolecules)
+            {
+                // Turn this proteomic doc into a small molecules doc
+                var refine = new RefinementSettings();
+                doc = refine.ConvertToSmallMolecules(doc, peakBoundaryDoc);
+            }
 
             var cult = LocalizationHelper.CurrentCulture;
             var cultI = CultureInfo.InvariantCulture;
@@ -138,16 +173,16 @@ namespace pwiz.SkylineTest
                     _csvMinTime2, _csvMaxTime2, _csvIdentified2, _csvAreas2, _peptides, 1, precursorMzs, annote);
 
                 // Test that importing same file twice leads to no change to document the second time
-                var docNew = ImportFileToDoc(docResults, peakBoundaryFileTsv);
-                var docNewSame = ImportFileToDoc(docNew, peakBoundaryFileTsv);
+                var docNew = ImportFileToDoc(docResults, ref peakBoundaryFileTsv);
+                var docNewSame = ImportFileToDoc(docNew, ref peakBoundaryFileTsv);
                 Assert.AreSame(docNew, docNewSame);
                 Assert.AreNotSame(docNew, docResults);
 
                 // Test that exporting peak boundaries and then importing them leads to no change
                 string peakBoundaryExport = testFilesDir.GetTestPath("TestRoundTrip.csv");
-                ReportSpec reportSpec = MakeReportSpec();
-                ReportToCsv(reportSpec, docNew, peakBoundaryExport);
-                var docRoundTrip = ImportFileToDoc(docNew, peakBoundaryExport);
+                var reportSpec = MakeReportSpec();
+                ReportToCsv(reportSpec, docNew, peakBoundaryExport, LocalizationHelper.CurrentCulture);
+                var docRoundTrip = ImportFileToDoc(docNew, ref peakBoundaryExport);
                 Assert.AreSame(docNew, docRoundTrip);
 
 
@@ -269,6 +304,11 @@ namespace pwiz.SkylineTest
                 // Note: Importing with all 7 columns is tested as part of MProphetResultsHandlerTest
             }
 
+            if (AsSmallMolecules)
+            {
+                return; // The rest of the test concerns peptide modification descriptions, we don't care about that in small mol version
+            }
+
             // Now check a file that has peptide ID's, and see that they're properly ported
             var peptideIdPath = testFilesDir.GetTestPath("Template_MS1Filtering_1118_2011_3-2min.sky");
             SrmDocument docId = ResultsUtil.DeserializeDocument(peptideIdPath);
@@ -319,16 +359,10 @@ namespace pwiz.SkylineTest
             }
         }
 
-        private static ReportSpec MakeReportSpec()
-        {
-            var specList = new ReportSpecList();
-            var defaults = specList.GetDefaults();
-            return defaults.First(spec => spec.Name == Resources.ReportSpecList_GetDefaults_Peak_Boundaries);
-        }
-
-        private static void ImportThrowsException(SrmDocument docResults, string importText, string message, bool isMinutes = true, bool removeMissing = false, bool changePeaks = true)
+        private void ImportThrowsException(SrmDocument docResults, string importText, string message, bool isMinutes = true, bool removeMissing = false, bool changePeaks = true)
         {
             var peakBoundaryImporter = new PeakBoundaryImporter(docResults);
+            importText = UpdateReportForTestMode(importText);
             using (var readerPeakBoundaries = new StringReader(importText))
             {
                 long lineCount = Helpers.CountLinesInString(importText);
@@ -336,9 +370,10 @@ namespace pwiz.SkylineTest
             }
         }
 
-        private static void ImportNoException(SrmDocument docResults, string importText, bool isMinutes = true, bool removeMissing = false, bool changePeaks = true)
+        private void ImportNoException(SrmDocument docResults, string importText, bool isMinutes = true, bool removeMissing = false, bool changePeaks = true)
         {
             var peakBoundaryImporter = new PeakBoundaryImporter(docResults);
+            importText = UpdateReportForTestMode(importText);
             using (var readerPeakBoundaries = new StringReader(importText))
             {
                 long lineCount = Helpers.CountLinesInString(importText);
@@ -346,17 +381,93 @@ namespace pwiz.SkylineTest
             }
         }
 
-        private static SrmDocument ImportFileToDoc(SrmDocument docOld, string importFile)
+        private string UpdateReportForTestMode(string textIn)
         {
+            var text = textIn;
+            if (AsSmallMolecules)
+            {
+                if (!PeakBoundaryImporter.MOLECULE_SYNONYMS.Any(s => text.Contains(s))) // Generated by report during test?
+                {
+                    foreach (var hdr in PeakBoundaryImporter.PEPTIDE_SYNONYMS)
+                    {
+                        text = text.Replace(hdr, PeakBoundaryImporter.MOLECULE_SYNONYMS.First());
+                    }
+
+                    var headerLine = text.Split('\n')[0];
+                    foreach (var sep in new[] {"\t", ";", ",", " "})
+                    {
+                        if (headerLine.Contains(sep))
+                        {
+                            foreach (var charge in new[] {1, 2, 3})
+                            {
+                                text = text.Replace(sep + charge.ToString() + sep,
+                                    sep + "[M+" + charge.ToString() + "H]" + sep);
+                            }
+
+                            // Replace occurrences of (for example) "PEPTIDER" with "pep_PEPTIDER"
+                            foreach (var peptide in _peptides)
+                            {
+                                var undecorated =
+                                    peptide.Replace(RefinementSettings.TestingConvertedFromProteomicPeptideNameDecorator,
+                                        string.Empty);
+                                text = text.Replace(undecorated, peptide);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return text;
+        }
+
+        private SrmDocument ImportFileToDoc(SrmDocument docOld, ref string importFile)
+        {
+            var pep_decorator = "_pep.";
+            if (AsSmallMolecules)
+            {
+                // Massage the peptide-oriented test artifact as needed for small molecule version of test
+                if (!importFile.Contains(pep_decorator)) // Already converted from peptide test version?
+                {
+                    var text = File.ReadAllText(importFile);
+                    var textUpdated = UpdateReportForTestMode(text);
+                    if (!Equals(textUpdated, text)) // Generated by report during test?
+                    {
+                        var ext = Path.GetExtension(importFile);
+                        importFile = Path.ChangeExtension(importFile, pep_decorator + ext);
+                        // ReSharper disable once AssignNullToNotNullAttribute
+                        File.WriteAllText(importFile, textUpdated);
+                    }
+                }
+            }
             var peakBoundaryImporter = new PeakBoundaryImporter(docOld);
             long lineCount = Helpers.CountLinesInFile(importFile);
             SrmDocument docNew = peakBoundaryImporter.Import(importFile, null, lineCount);
             return docNew;
         }
 
-        public void ReportToCsv(ReportSpec reportSpec, SrmDocument doc, string fileName)
+        private static void ReportToCsv(ViewSpec viewSpec, SrmDocument doc, string fileName, CultureInfo cultureInfo)
         {
-            CheckReportCompatibility.ReportToCsv(reportSpec, doc, fileName, LocalizationHelper.CurrentCulture);
+            var documentContainer = new MemoryDocumentContainer();
+            Assert.IsTrue(documentContainer.SetDocument(doc, documentContainer.Document));
+            var skylineDataSchema = new SkylineDataSchema(documentContainer, new DataSchemaLocalizer(cultureInfo, cultureInfo));
+            var viewContext = new DocumentGridViewContext(skylineDataSchema);
+            using (var writer = new StreamWriter(fileName))
+            {
+                IProgressStatus status = new ProgressStatus();
+                viewContext.Export(CancellationToken.None, new SilentProgressMonitor(), ref status,
+                    viewContext.GetViewInfo(ViewGroup.BUILT_IN, viewSpec), writer, viewContext.GetCsvWriter());
+            }
+        }
+
+        private ViewSpec MakeReportSpec()
+        {
+            var viewName = AsSmallMolecules
+                ? Resources.ReportSpecList_GetDefaults_Molecule_Peak_Boundaries
+                : Resources.ReportSpecList_GetDefaults_Peak_Boundaries;
+            Settings.Default.PersistedViews.ResetDefaults();
+            var view = Settings.Default.PersistedViews.GetViewSpecList(PersistedViews.MainGroup.Id).GetView(viewName);
+            return view;
         }
 
         private void DoFileImportTests(SrmDocument docResults,
@@ -371,28 +482,28 @@ namespace pwiz.SkylineTest
                                        string[] precursorMzs = null,
                                        string annotationName = null)
         {
-            SrmDocument docNew = ImportFileToDoc(docResults, importFile);
+            SrmDocument docNew = ImportFileToDoc(docResults, ref importFile);
             int i = 0;
             // Check peptide nodes are correct
-            foreach (PeptideDocNode peptideNode in docNew.Peptides)
+            foreach (PeptideDocNode peptideNode in docNew.Molecules)
             {
-                Assert.AreEqual(peptideNode.Peptide.Sequence, peptides[i]);
+                AssertEx.AreEqual(peptides[i], AsSmallMolecules ? peptideNode.CustomMolecule.Name : peptideNode.Peptide.Sequence);
                 ++i;
             }
             int j = 0;
-            foreach (TransitionGroupDocNode groupNode in docNew.PeptideTransitionGroups)
+            foreach (TransitionGroupDocNode groupNode in docNew.MoleculeTransitionGroups)
             {
                 var groupChromInfo = groupNode.ChromInfos.ToList()[fileId];
                 // Make sure charge on each transition group is correct
-                Assert.AreEqual(groupNode.TransitionGroup.PrecursorAdduct.AdductCharge, chargeList[j]);
+                AssertEx.AreEqual(groupNode.TransitionGroup.PrecursorAdduct.AdductCharge, chargeList[j]);
                 // Make sure imported retention time boundaries, including nulls, are correct
-                Assert.IsTrue(ApproxEqualNullable(groupChromInfo.StartRetentionTime, minTime[j], RT_TOLERANCE));
-                Assert.IsTrue(ApproxEqualNullable(groupChromInfo.EndRetentionTime, maxTime[j], RT_TOLERANCE));
+                AssertEx.IsTrue(ApproxEqualNullable(groupChromInfo.StartRetentionTime, minTime[j], RT_TOLERANCE));
+                AssertEx.IsTrue(ApproxEqualNullable(groupChromInfo.EndRetentionTime, maxTime[j], RT_TOLERANCE));
                 // Check that peak areas are updated correctly
                 double peakArea = peakAreas[j] ?? 0;
-                Assert.IsTrue(ApproxEqualNullable(groupChromInfo.Area, peakAreas[j], RT_TOLERANCE*peakArea));
+                AssertEx.IsTrue(ApproxEqualNullable(groupChromInfo.Area, peakAreas[j], RT_TOLERANCE*peakArea));
                 // Check that identified values are preserved/updated appropriately
-                Assert.IsTrue(groupChromInfo.Identified == identified[j],
+                AssertEx.IsTrue(groupChromInfo.Identified == identified[j],
                     string.Format("No identification match for {0}  ({1})", groupNode.TransitionGroup.Peptide, j));
                 var annotations = groupChromInfo.Annotations;
                 if (precursorMzs != null)

--- a/pwiz_tools/Skyline/Test/PeakBoundaryTest.cs
+++ b/pwiz_tools/Skyline/Test/PeakBoundaryTest.cs
@@ -28,6 +28,7 @@ using pwiz.Common.DataBinding;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Databinding;
+using pwiz.Skyline.Model.Databinding.Entities;
 using pwiz.Skyline.Model.DocSettings.Extensions;
 using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Results.Scoring;
@@ -390,7 +391,7 @@ namespace pwiz.SkylineTest
                 {
                     foreach (var hdr in PeakBoundaryImporter.PEPTIDE_SYNONYMS)
                     {
-                        text = text.Replace(hdr, PeakBoundaryImporter.MOLECULE_SYNONYMS.First());
+                        text = text.Replace(hdr, ColumnCaptions.Molecule);
                     }
 
                     var headerLine = text.Split('\n')[0];


### PR DESCRIPTION
… for use in export of peak boundaries for small molecule documents, and updated the peak boundary import code to handle small molecule information.