### PR TITLE
Fix alglib assertion in pca plot

### DIFF
--- a/pwiz_tools/Skyline/Controls/Clustering/PcaPlot.cs
+++ b/pwiz_tools/Skyline/Controls/Clustering/PcaPlot.cs
@@ -568,7 +568,7 @@ namespace pwiz.Skyline.Controls.Clustering
 
             public PcaChoice ConstrainComponents(int numberOfDimensions)
             {
-                if (XComponent < numberOfDimensions || YComponent < numberOfDimensions)
+                if (XComponent < numberOfDimensions && YComponent < numberOfDimensions)
                 {
                     return this;
                 }


### PR DESCRIPTION
Fixed error that can happen showing the PCA plot when the total number of principal components for the dataset is one. (reported most recently by Chris on the exception web)