### PR TITLE
Skyline/work/20220328 dda peak picking

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/PeptideChromData.cs
+++ b/pwiz_tools/Skyline/Model/Results/PeptideChromData.cs
@@ -77,6 +77,8 @@ namespace pwiz.Skyline.Model.Results
 
         public IList<ChromDataSet> DataSets { get { return _dataSets; } }
 
+        public bool IsDelayedWrite { get; set; }
+
         public RetentionTimePrediction PredictedRetentionTime { set { _predictedRetentionTime = value; }}
 
         public double[] RetentionTimes { set { _retentionTimes = value; } }

--- a/pwiz_tools/Skyline/Model/Results/PeptideChromData.cs
+++ b/pwiz_tools/Skyline/Model/Results/PeptideChromData.cs
@@ -996,6 +996,7 @@ namespace pwiz.Skyline.Model.Results
 
         public IList<ITransitionPeakData<IDetailedPeakData>> Ms1TranstionPeakData { get; private set; }
         public IList<ITransitionPeakData<IDetailedPeakData>> Ms2TranstionPeakData { get; private set; }
+        public IList<ITransitionPeakData<IDetailedPeakData>> Ms2TranstionDotpData { get; private set; }
         public IList<ITransitionPeakData<IDetailedPeakData>> DefaultTranstionPeakData
         {
             get { return Ms2TranstionPeakData.Count > 0 ? Ms2TranstionPeakData : Ms1TranstionPeakData; }
@@ -1023,13 +1024,14 @@ namespace pwiz.Skyline.Model.Results
                 else
                 {
                     Ms1TranstionPeakData = TransitionPeakData.Where(t => t.NodeTran != null && t.NodeTran.IsMs1).ToArray();
+                    Ms2TranstionDotpData = TransitionPeakData.Where(t => t.NodeTran != null && !t.NodeTran.IsMs1).ToArray();
                     if (Data.FullScanAcquisitionMethod == FullScanAcquisitionMethod.DDA)
                     {
                         Ms2TranstionPeakData = ChromDataPeakList.EMPTY;
                     }
                     else
                     {
-                        Ms2TranstionPeakData = TransitionPeakData.Where(t => t.NodeTran != null && !t.NodeTran.IsMs1).ToArray();
+                        Ms2TranstionPeakData = Ms2TranstionDotpData;
                     }
                 }
             }

--- a/pwiz_tools/Skyline/Model/Results/Scoring/IPeakScoringModel.cs
+++ b/pwiz_tools/Skyline/Model/Results/Scoring/IPeakScoringModel.cs
@@ -540,6 +540,7 @@ namespace pwiz.Skyline.Model.Results.Scoring
             TransitionPeakData = ConvertTransitionPeakDatas(_groupPeakData.TransitionPeakData);
             Ms1TranstionPeakData = ConvertTransitionPeakDatas(_groupPeakData.Ms1TranstionPeakData);
             Ms2TranstionPeakData = ConvertTransitionPeakDatas(_groupPeakData.Ms2TranstionPeakData);
+            Ms2TranstionDotpData = ConvertTransitionPeakDatas(_groupPeakData.Ms2TranstionDotpData);
         }
 
         private readonly ITransitionGroupPeakData<TData> _groupPeakData;
@@ -553,6 +554,8 @@ namespace pwiz.Skyline.Model.Results.Scoring
         public IList<ITransitionPeakData<ISummaryPeakData>> Ms1TranstionPeakData { get; private set; }
 
         public IList<ITransitionPeakData<ISummaryPeakData>> Ms2TranstionPeakData { get; private set; }
+
+        public IList<ITransitionPeakData<ISummaryPeakData>> Ms2TranstionDotpData { get; private set; }
 
         public IList<ITransitionPeakData<ISummaryPeakData>> DefaultTranstionPeakData
         {
@@ -618,6 +621,8 @@ namespace pwiz.Skyline.Model.Results.Scoring
         IList<ITransitionPeakData<TData>> Ms1TranstionPeakData { get; }
 
         IList<ITransitionPeakData<TData>> Ms2TranstionPeakData { get; }
+
+        IList<ITransitionPeakData<TData>> Ms2TranstionDotpData { get; }
 
         IList<ITransitionPeakData<TData>> DefaultTranstionPeakData { get; }
     }

--- a/pwiz_tools/Skyline/Model/Results/Scoring/PeakFeatureEnumerator.cs
+++ b/pwiz_tools/Skyline/Model/Results/Scoring/PeakFeatureEnumerator.cs
@@ -510,8 +510,6 @@ namespace pwiz.Skyline.Model.Results.Scoring
                     float mzMatchTolerance = (float)document.Settings.TransitionSettings.Instrument.MzMatchTolerance;
                     foreach (var nodeTran in nodeGroup.Transitions)
                     {
-                        if (isDda && !nodeTran.IsMs1)
-                            continue;
                         var tranInfo = _chromGroupInfo.GetTransitionInfo(nodeTran, mzMatchTolerance, chromatogramSet.OptimizationFunction);
                         if (tranInfo == null)
                             continue;
@@ -530,7 +528,10 @@ namespace pwiz.Skyline.Model.Results.Scoring
                     }
                     TransitionPeakData = listPeakData.ToArray();
                     Ms1TranstionPeakData = GetTransitionTypePeakData(ms1Count, ms2Count, true);
-                    Ms2TranstionPeakData = GetTransitionTypePeakData(ms1Count, ms2Count, false);
+                    Ms2TranstionPeakData = Ms2TranstionDotpData =
+                        GetTransitionTypePeakData(ms1Count, ms2Count, false);
+                    if (isDda)
+                        Ms2TranstionPeakData = Array.Empty<ITransitionPeakData<ISummaryPeakData>>();
                 }
             }
 
@@ -563,6 +564,7 @@ namespace pwiz.Skyline.Model.Results.Scoring
             public IList<ITransitionPeakData<ISummaryPeakData>> TransitionPeakData { get; private set; }
             public IList<ITransitionPeakData<ISummaryPeakData>> Ms1TranstionPeakData { get; private set; }
             public IList<ITransitionPeakData<ISummaryPeakData>> Ms2TranstionPeakData { get; private set; }
+            public IList<ITransitionPeakData<ISummaryPeakData>> Ms2TranstionDotpData { get; private set; }
 
             public IList<ITransitionPeakData<ISummaryPeakData>> DefaultTranstionPeakData
             {

--- a/pwiz_tools/Skyline/Model/Results/TimeIntensities.cs
+++ b/pwiz_tools/Skyline/Model/Results/TimeIntensities.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using System.Linq;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
-using pwiz.Skyline.Util;
 
 namespace pwiz.Skyline.Model.Results
 {

--- a/pwiz_tools/Skyline/Test/ChromPeakTest.cs
+++ b/pwiz_tools/Skyline/Test/ChromPeakTest.cs
@@ -17,12 +17,10 @@
  * limitations under the License.
  */
 
-using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Results;
-using pwiz.Skyline.SettingsUI.Irt;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTest

--- a/pwiz_tools/Skyline/Test/MQuestScoringTest.cs
+++ b/pwiz_tools/Skyline/Test/MQuestScoringTest.cs
@@ -364,7 +364,8 @@ namespace pwiz.SkylineTest
             {
                 TransitionPeakData = transitionPeakData;
                 Ms1TranstionPeakData = TransitionPeakData.Where(t => t.NodeTran != null && t.NodeTran.IsMs1).ToArray();
-                Ms2TranstionPeakData = TransitionPeakData.Where(t => t.NodeTran != null && !t.NodeTran.IsMs1).ToArray();
+                Ms2TranstionPeakData = Ms2TranstionDotpData =
+                    TransitionPeakData.Where(t => t.NodeTran != null && !t.NodeTran.IsMs1).ToArray();
 
                 IsStandard = isStandard;
                 var libInfo = new ChromLibSpectrumHeaderInfo("", 0, null);
@@ -378,6 +379,8 @@ namespace pwiz.SkylineTest
             public IList<ITransitionPeakData<TPeak>> TransitionPeakData { get; private set; }
             public IList<ITransitionPeakData<TPeak>> Ms1TranstionPeakData { get; private set; }
             public IList<ITransitionPeakData<TPeak>> Ms2TranstionPeakData { get; private set; }
+            public IList<ITransitionPeakData<TPeak>> Ms2TranstionDotpData { get; private set; }
+
             public IList<ITransitionPeakData<TPeak>> DefaultTranstionPeakData
             {
                 get { return Ms2TranstionPeakData.Count > 0 ? Ms2TranstionPeakData : Ms1TranstionPeakData; }


### PR DESCRIPTION
- improve peak picking in DDA data to work well with datasets provided by Thermo for AutoQC
- currently just using dotp from MS/MS when it is higher than 0.75
- also a first try at 2-pass iRT training that is currently disabled