### PR TITLE
Fix NullReferenceException in GraphChromatogram.DisplayPeptides

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -2159,14 +2159,18 @@ namespace pwiz.Skyline.Controls.Graphs
                     {
                         bestPeakInfo = new TransitionChromInfo(startRetentionTime, endRetentionTime);
                         var retentionTimeValues = RetentionTimeValues.FromTransitionChromInfo(bestPeakInfo);
-                        if (firstPeak == null || firstPeak.StartRetentionTime > retentionTimeValues.StartRetentionTime)
+                        if (retentionTimeValues != null)
                         {
-                            firstPeak = retentionTimeValues;
-                        }
+                            if (firstPeak == null ||
+                                firstPeak.StartRetentionTime > retentionTimeValues.StartRetentionTime)
+                            {
+                                firstPeak = retentionTimeValues;
+                            }
 
-                        if (lastPeak == null || lastPeak.EndRetentionTime < retentionTimeValues.EndRetentionTime)
-                        {
-                            lastPeak = retentionTimeValues;
+                            if (lastPeak == null || lastPeak.EndRetentionTime < retentionTimeValues.EndRetentionTime)
+                            {
+                                lastPeak = retentionTimeValues;
+                            }
                         }
                     }
                 }

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeValues.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeValues.cs
@@ -79,8 +79,7 @@ namespace pwiz.Skyline.Model.RetentionTimes
 
         public static RetentionTimeValues FromTransitionChromInfo(TransitionChromInfo transitionChromInfo)
         {
-            if (null == transitionChromInfo || transitionChromInfo.StartRetentionTime == 0 ||
-                transitionChromInfo.EndRetentionTime == 0)
+            if (null == transitionChromInfo || transitionChromInfo.IsEmpty)
             {
                 return null;
             }


### PR DESCRIPTION
Fixed error displaying multiple peptide chromatogram graph if any of the chosen peaks has a start retention time equal to zero. (Reported by Yasmine)