### PR TITLE
Hopefully a somewhat more informative error message for TestToolService failures in Nightly runs

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/ToolServiceTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ToolServiceTest.cs
@@ -233,11 +233,11 @@ TTDFDGYWVNHNWYSIYEST*
             Assert.AreEqual(0, DocumentChangeCount);
             RunUI(SkylineWindow.EditDelete);
             const int GRACE_PERIOD_MSEC = 5 * 1000; // Normally this takes less than 1/2 second, but not always, esp. under debugger
-            WaitForCondition(GRACE_PERIOD_MSEC, () => 1 == DocumentChangeCount, "timed out waiting for DocumentChangeCount==1");
-            Assert.AreEqual(1, DocumentChangeCount);
+            TryWaitForCondition(GRACE_PERIOD_MSEC, () => 1 == DocumentChangeCount);
+            AssertEx.AreEqual(1, DocumentChangeCount, "timed out waiting for DocumentChangeCount==1");
             RunUI(SkylineWindow.Undo);
-            WaitForCondition(GRACE_PERIOD_MSEC, () => 2 == DocumentChangeCount, "timed out waiting for DocumentChangeCount==2");
-            Assert.AreEqual(2, DocumentChangeCount);
+            TryWaitForCondition(GRACE_PERIOD_MSEC, () => 2 == DocumentChangeCount);
+            AssertEx.AreEqual(2, DocumentChangeCount, "timed out waiting for DocumentChangeCount==2");
         }
 
         private int DocumentChangeCount


### PR DESCRIPTION
It's a pretty common failure, would be nice to understand more about it