### PR TITLE
Fix NRE in PeptideChromInfoListCalculator.AddChromInfoList

### DIFF
--- a/pwiz_tools/Skyline/Model/PeptideDocNode.cs
+++ b/pwiz_tools/Skyline/Model/PeptideDocNode.cs
@@ -1522,7 +1522,7 @@ namespace pwiz.Skyline.Model
 
             public void AddChromInfoList(TransitionGroupDocNode nodeGroup, TransitionDocNode nodeTran)
             {
-                var listInfo = nodeTran.Results[ResultsIndex];
+                var listInfo = nodeTran.GetSafeChromInfo(ResultsIndex);
                 if (listInfo.IsEmpty)
                     return;
 


### PR DESCRIPTION
Fixed error that could happen if a particular precursor did not have any results. (Reported by Bob)