### PR TITLE
Some bug fixes

### DIFF
--- a/pwiz_tools/Skyline/Alerts/AlertDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/AlertDlg.cs
@@ -145,8 +145,7 @@ namespace pwiz.Skyline.Alerts
 
         public void CopyMessage()
         {
-            Clipboard.Clear();
-            Clipboard.SetText(GetTitleAndMessageDetail());
+            ClipboardHelper.SetSystemClipboardText(this, GetTitleAndMessageDetail());
         }
 
         public override string DetailedMessage

--- a/pwiz_tools/Skyline/Alerts/ReportErrorDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/ReportErrorDlg.cs
@@ -20,7 +20,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Deployment.Application;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -129,10 +128,6 @@ namespace pwiz.Skyline.Alerts
 
         public void OkDialog()
         {
-            if (!Equals(Settings.Default.StackTraceListVersion, Install.Version))
-            {
-                Settings.Default.StackTraceListVersion = Install.Version;
-            }
             using (var detailedReportErrorDlg = new DetailedReportErrorDlg())
             {
                 if (detailedReportErrorDlg.ShowDialog(this) == DialogResult.OK)
@@ -201,13 +196,10 @@ namespace pwiz.Skyline.Alerts
                 if (!String.IsNullOrEmpty(_message))
                     sb.Append(@"User comments:").AppendLine().AppendLine(_message).AppendLine();
                 
-                if (ApplicationDeployment.IsNetworkDeployed)
-                {
-                    sb.Append(@"Skyline version: ").Append(Install.Version);
-                    if (Install.Is64Bit)
-                        sb.Append(@" (64-bit)");
-                    sb.AppendLine();
-                }
+                sb.Append(@"Skyline version: ").Append(Install.Version);
+                if (Install.Is64Bit)
+                    sb.Append(@" (64-bit)");
+                sb.AppendLine();
 
                 sb.Append(@"Installation ID: ").AppendLine(UserGuid);
                 sb.Append(@"Exception type: ").AppendLine(_exceptionType);
@@ -236,7 +228,7 @@ namespace pwiz.Skyline.Alerts
 
         private void btnClipboard_Click(object sender, EventArgs e)
         {
-            ClipboardEx.SetText(MessageBody);
+            ClipboardHelper.SetClipboardText(this, MessageBody);
         }
 
         private void btnOK_Click(object sender, EventArgs e)

--- a/pwiz_tools/Skyline/Controls/AuditLog/AuditLogExtraInfoForm.cs
+++ b/pwiz_tools/Skyline/Controls/AuditLog/AuditLogExtraInfoForm.cs
@@ -55,7 +55,7 @@ namespace pwiz.Skyline.Controls.AuditLog
 
         private void copyButton_Click(object sender, EventArgs e)
         {
-            ClipboardEx.SetText(extraInfoTextBox.Text);
+            ClipboardHelper.SetClipboardText(this, extraInfoTextBox.Text);
         }
 
         // Test Support

--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -1486,18 +1486,6 @@ namespace pwiz.Skyline.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string StackTraceListVersion {
-            get {
-                return ((string)(this["StackTraceListVersion"]));
-            }
-            set {
-                this["StackTraceListVersion"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         public global::System.Collections.Specialized.StringCollection CustomFinders {
             get {
                 return ((global::System.Collections.Specialized.StringCollection)(this["CustomFinders"]));

--- a/pwiz_tools/Skyline/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Properties/Settings.settings
@@ -368,9 +368,6 @@
     <Setting Name="InstallationId" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="StackTraceListVersion" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
-    </Setting>
     <Setting Name="CustomFinders" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)" />
     </Setting>

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -2293,6 +2293,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\Graphs\DetectionsToolbar.ja.resx">
       <DependentUpon>DetectionsToolbar.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\Graphs\DetectionsToolbar.zh-CHS.resx">
       <DependentUpon>DetectionsToolbar.cs</DependentUpon>

--- a/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
+++ b/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
@@ -136,6 +136,11 @@ namespace pwiz.SkylineTest
                 "new System.Windows.Forms.DataGridView()", false,
                 "Must use subclass CommonDataGridView or DataGridViewEx instead of DataGridView.");
 
+            AddTextInspection("*.cs", Inspection.Forbidden, Level.Error,
+                new[] {"TestFunctional", "TestTutorial", "TestPerf", "Executables", "UtilUIExtra.cs", "ClipboardEx.cs"}, 
+                null, "Clipboard(Ex)?\\.SetText", true, 
+                "Use ClipboardHelper.SetClipboardText instead since it handles exceptions");
+
             // A few lines of fake tests that can be useful in development of this mechanism
             // AddInspection(@"*.Designer.cs", Inspection.Required, Level.Error, null, "Windows Form Designer generated code", @"DetectionsToolbar", @"fake, debug purposes only"); // Uncomment for debug purposes
             // AddInspection(@"*.cs", Inspection.Forbidden, Level.Error, null, string.Empty, @"DetectionsToolbar", @"fake, debug purposes only"); // Uncomment for debug purposes
@@ -645,7 +650,7 @@ namespace pwiz.SkylineTest
             public Pattern(string patternString, bool isRegEx, string patternExceptionString)
             {
                 PatternString = patternString;
-                RegExPattern = isRegEx ? new Regex(patternString, RegexOptions.CultureInvariant | RegexOptions.CultureInvariant) : null;
+                RegExPattern = isRegEx ? new Regex(patternString, RegexOptions.CultureInvariant | RegexOptions.CultureInvariant | RegexOptions.Compiled) : null;
                 PatternExceptionString = patternExceptionString;
             }
 

--- a/pwiz_tools/Skyline/Util/UtilUIExtra.cs
+++ b/pwiz_tools/Skyline/Util/UtilUIExtra.cs
@@ -417,6 +417,23 @@ EndSelection:<<<<<<<3
             }
         }
 
+        /// <summary>
+        /// Sets the text on the system clipboard. Use this method for functionality that should
+        /// use the real clipboard regardless of whether a functional test is running.
+        /// </summary>
+        public static void SetSystemClipboardText(Control owner, string text)
+        {
+            try
+            {
+                Clipboard.Clear();
+                Clipboard.SetText(text);
+            }
+            catch (ExternalException)
+            {
+                MessageDlg.Show(FormUtil.FindTopLevelOwner(owner), GetCopyErrorMessage());
+            }
+        }
+
         public static void SetClipboardData(Control owner, DataObject data, bool copy)
         {
             try

--- a/pwiz_tools/Skyline/app.config
+++ b/pwiz_tools/Skyline/app.config
@@ -375,9 +375,6 @@
             <setting name="InstallationId" serializeAs="String">
                 <value />
             </setting>
-            <setting name="StackTraceListVersion" serializeAs="String">
-                <value />
-            </setting>
             <setting name="RTCalculatorName" serializeAs="String">
                 <value />
             </setting>


### PR DESCRIPTION
Prevented clipboard error pressing "Copy" button on message dialog (reported on Exception Web)

Also:
Change a few other places that were using "Clipboard.SetText" to use ClipboardHelper.SetClipboardText
Remove unused setting "StackTraceListVersion"
Always include product version in body of exception posts (used to leave it off if not ClickOnce install)
Add code inspection to prevent using Clipboard.SetText outside of test code.
Change CodeInspectionTest to use compiled regular expression because it's faster