### PR TITLE
Per Brendan's request, make the use of tabs instead of spaces a ReSharper code inspection Warning.

### DIFF
--- a/pwiz_tools/Shared/Common/Collections/ImmutableSortedList.cs
+++ b/pwiz_tools/Shared/Common/Collections/ImmutableSortedList.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -288,7 +288,7 @@ namespace pwiz.Common.Collections
 
 
         #region object overrides
-		public bool Equals(ImmutableSortedList<TKey, TValue> other)
+        public bool Equals(ImmutableSortedList<TKey, TValue> other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;

--- a/pwiz_tools/Shared/Common/Collections/ImmutableSortedList.cs
+++ b/pwiz_tools/Shared/Common/Collections/ImmutableSortedList.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Shared/Common/Graph/DataColumn.cs
+++ b/pwiz_tools/Shared/Common/Graph/DataColumn.cs
@@ -82,7 +82,7 @@ namespace pwiz.Common.Graph
         }
 
         #region object overrides
-		public bool Equals(DataColumn<T> other)
+        public bool Equals(DataColumn<T> other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -104,6 +104,6 @@ namespace pwiz.Common.Graph
                 return (Cells.GetHashCode()*397) ^ (Title != null ? Title.GetHashCode() : 0);
             }
         }
- 	    #endregion    
+         #endregion    
     }
 }

--- a/pwiz_tools/Shared/ProteomeDb/API/ProteomeDb.cs
+++ b/pwiz_tools/Shared/ProteomeDb/API/ProteomeDb.cs
@@ -696,7 +696,7 @@ namespace pwiz.ProteomeDatabase.API
             // If we're here, it's because the background loader is done digesting and has moved on to protein metadata,
             // or because the PeptideSettingsUI thread needs to have protein metadata resolved for uniqueness purposes before
             // it can proceed.   Either way, we should be working on a temp copy and be the only one needing write access, so get a lock now
-            using (ISession session = OpenWriteSession())	// We may update the protdb file with web search results
+            using (ISession session = OpenWriteSession()) // We may update the protdb file with web search results
             {
                 if (!UpdateProgressAndCheckForCancellation(progressMonitor, ref status, Resources.ProteomeDb_LookupProteinMetadata_looking_for_unresolved_protein_details, 0))
                 {

--- a/pwiz_tools/Shared/ProteomeDb/Fasta/WebEnabledFastaImporter.cs
+++ b/pwiz_tools/Shared/ProteomeDb/Fasta/WebEnabledFastaImporter.cs
@@ -446,9 +446,9 @@ namespace pwiz.ProteomeDatabase.Fasta
             @"tpd", //  third-party DDBJ  tpd|accession|name
             @"tpe", //  third-party EMBL  tpe|accession|name
             @"tpg", //  third-party GenBank  tpg|accession|name
-            @"bbm", //  GenInfo backbone moltype	bbm|integer
-            @"bbs", //  GenInfo backbone seqid	bbs|integer
-            @"gim", //  GenInfo import ID	gim|integer
+            @"bbm", //  GenInfo backbone moltype  bbm|integer
+            @"bbs", //  GenInfo backbone seqid  bbs|integer
+            @"gim", //  GenInfo import ID gim|integer
         };
 
         // basic Regex.Replace expression for returning the info we want - some regexes may want to augment

--- a/pwiz_tools/Skyline/Alerts/PasteFilteredPeptidesDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/PasteFilteredPeptidesDlg.cs
@@ -45,8 +45,8 @@ namespace pwiz.Skyline.Alerts
                 var listSizing = new List<string>(_peptides);
                 if (listSizing.Count > MAX_LINES)
                     listSizing.RemoveRange(MAX_LINES, listSizing.Count - MAX_LINES);
- 				labelList.Text = TextUtil.LineSeparate(listSizing);                
-				Height += labelList.Height - panelList.Height;
+                labelList.Text = TextUtil.LineSeparate(listSizing);                
+                Height += labelList.Height - panelList.Height;
                 labelList.Text = TextUtil.LineSeparate(_peptides);
                 if (_peptides.Count > 1)
                 {

--- a/pwiz_tools/Skyline/Controls/CustomTip.cs
+++ b/pwiz_tools/Skyline/Controls/CustomTip.cs
@@ -509,11 +509,11 @@ namespace pwiz.Skyline.Controls
 
         private static bool PerformWmNcHitTest(ref Message m)
         {
-//			POINT point1;
-//			Point p = Control.MousePosition;
-//			point1.x = p.X;
-//			point1.y = p.Y;
-//			point1 = MousePositionToClient(point1);
+//          POINT point1;
+//          Point p = Control.MousePosition;
+//          point1.x = p.X;
+//          point1.y = p.Y;
+//          point1 = MousePositionToClient(point1);
 
             m.Result = (IntPtr) (-1);
             return true;

--- a/pwiz_tools/Skyline/Controls/Graphs/MassErrorHistogram2DGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/MassErrorHistogram2DGraphPane.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Alex MacLean <alexmaclean2000 .at. gmail.com>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Controls/Graphs/MassErrorHistogram2DGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/MassErrorHistogram2DGraphPane.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Alex MacLean <alexmaclean2000 .at. gmail.com>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -47,8 +47,8 @@ namespace pwiz.Skyline.Controls.Graphs
         public void Update(SrmDocument document, int resultIndex, PointsTypeMassError pointsType)
         {
             var bestResults = ShowReplicate == ReplicateDisplay.best;
-			if (Data == null || !Data.IsCurrent(document, resultIndex, bestResults, pointsType))
-				Data = new GraphData(document, Data, resultIndex, bestResults, pointsType);
+            if (Data == null || !Data.IsCurrent(document, resultIndex, bestResults, pointsType))
+                Data = new GraphData(document, Data, resultIndex, bestResults, pointsType);
         }
 
         public void Clear()
@@ -121,11 +121,11 @@ namespace pwiz.Skyline.Controls.Graphs
         /// </summary>
         sealed class GraphData : Immutable
         {
-			// Cache variables for this data. Data only valid for this state
-	        private readonly SrmDocument _document;	// Active document when data was created
-	        private readonly int _resultIndex;	// Index to active replicate or -1 for everything
-	        private readonly ReplicateDisplay _replicateDisplay; // Replicate display when data was created
-	        private readonly DisplayTypeMassError _displayType; // Display type when data was created
+            // Cache variables for this data. Data only valid for this state
+            private readonly SrmDocument _document;    // Active document when data was created
+            private readonly int _resultIndex;    // Index to active replicate or -1 for everything
+            private readonly ReplicateDisplay _replicateDisplay; // Replicate display when data was created
+            private readonly DisplayTypeMassError _displayType; // Display type when data was created
 
             public readonly HeatMapData _heatMapData;
             private readonly int _maxCount;
@@ -144,9 +144,9 @@ namespace pwiz.Skyline.Controls.Graphs
             public GraphData(SrmDocument document, GraphData dataPrevious, int resultIndex,
                 bool bestResult, PointsTypeMassError pointsType)
             {
-	            _document = document;
-	            _resultIndex = resultIndex;
-	            _replicateDisplay = ShowReplicate;
+                _document = document;
+                _resultIndex = resultIndex;
+                _replicateDisplay = ShowReplicate;
 
                 int[,] counts2D = EMPTY_COUNTS;
                 _displayType = MassErrorGraphController.HistogramDisplayType;
@@ -255,20 +255,20 @@ namespace pwiz.Skyline.Controls.Graphs
                 }
             }
 
-	        public bool IsCurrent(SrmDocument document, int resultIndex, bool bestResults, PointsTypeMassError pointsType)
-	        {
-		        return document != null && _document != null &&
-		               ReferenceEquals(document.Children, _document.Children) &&
-		               (bestResults || resultIndex == _resultIndex) &&
-		               pointsType == _pointsType &&
-		               Settings.Default.MassErorrHistogramBinSize == _binSizePpm &&
-		               MassErrorGraphController.Histogram2DXAxis == _xAxis &&
-		               MassErrorGraphController.HistogramDisplayType == _displayType &&
-		               MassErrorGraphController.HistogramTransiton == _transition &&
-		               ShowReplicate == _replicateDisplay;
-	        }
+            public bool IsCurrent(SrmDocument document, int resultIndex, bool bestResults, PointsTypeMassError pointsType)
+            {
+                return document != null && _document != null &&
+                       ReferenceEquals(document.Children, _document.Children) &&
+                       (bestResults || resultIndex == _resultIndex) &&
+                       pointsType == _pointsType &&
+                       Settings.Default.MassErorrHistogramBinSize == _binSizePpm &&
+                       MassErrorGraphController.Histogram2DXAxis == _xAxis &&
+                       MassErrorGraphController.HistogramDisplayType == _displayType &&
+                       MassErrorGraphController.HistogramTransiton == _transition &&
+                       ShowReplicate == _replicateDisplay;
+            }
 
-			public void Graph(MassErrorHistogram2DGraphPane graphPane, PeptideDocNode nodeSelected)
+            public void Graph(MassErrorHistogram2DGraphPane graphPane, PeptideDocNode nodeSelected)
             {
                 graphPane.Title.Text = string.Empty;
                 graphPane.YAxis.Title.Text = Resources.MassErrorReplicateGraphPane_UpdateGraph_Mass_Error;

--- a/pwiz_tools/Skyline/Controls/Graphs/MassErrorHistogramGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/MassErrorHistogramGraphPane.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Alex MacLean <alexmaclean2000 .at. gmail.com>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Controls/Graphs/MassErrorHistogramGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/MassErrorHistogramGraphPane.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Alex MacLean <alexmaclean2000 .at. gmail.com>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -102,8 +102,8 @@ namespace pwiz.Skyline.Controls.Graphs
         sealed class GraphData : Immutable
         {
             // Cache variables for this data. Data only valid for this state
-            private readonly SrmDocument _document;	// Active document when data was created
-            private readonly int _resultIndex;	// Index to active replicate or -1 for everything
+            private readonly SrmDocument _document; // Active document when data was created
+            private readonly int _resultIndex; // Index to active replicate or -1 for everything
             private readonly DisplayTypeMassError _displayType; // Display type when data was created
             private readonly ReplicateDisplay _replicateDisplay; // Replicate dsiaply when data was created
 

--- a/pwiz_tools/Skyline/Controls/Graphs/MassErrorReplicateGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/MassErrorReplicateGraphPane.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Alex MacLean <alexmaclean2000 .at. gmail.com>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Controls/Graphs/MassErrorReplicateGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/MassErrorReplicateGraphPane.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Alex MacLean <alexmaclean2000 .at. gmail.com>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -208,7 +208,7 @@ namespace pwiz.Skyline.Controls.Graphs
                });
            }
 
-	        XAxis.Scale.MinAuto = XAxis.Scale.MaxAuto = selectionChanged;
+            XAxis.Scale.MinAuto = XAxis.Scale.MaxAuto = selectionChanged;
             YAxis.Scale.MinAuto = YAxis.Scale.MaxAuto = true;
             if (Settings.Default.MinMassError != 0)
                 YAxis.Scale.Min = Settings.Default.MinMassError;

--- a/pwiz_tools/Skyline/Controls/TreeViewMS.cs
+++ b/pwiz_tools/Skyline/Controls/TreeViewMS.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Controls/TreeViewMS.cs
+++ b/pwiz_tools/Skyline/Controls/TreeViewMS.cs
@@ -32,11 +32,11 @@ using ZedGraph;
 
 namespace pwiz.Skyline.Controls
 {
-	/// <summary>
+    /// <summary>
     /// A MultiSelect TreeView.
     /// <para>
     /// Inspired by the example at http://www.codeproject.com/KB/tree/treeviewms.aspx for details.</para>
-	/// </summary>
+    /// </summary>
     public abstract class TreeViewMS : TreeView
     {
         // Length of the horizontal dashed lines representing each branch of the tree
@@ -47,14 +47,14 @@ namespace pwiz.Skyline.Controls
         protected internal const int IMG_WIDTH = 16;
 
         private TreeNodeMS _anchorNode;
-	    private bool _inRightClick;
+        private bool _inRightClick;
 
-	    private const int DEFAULT_ITEM_HEIGHT = 16;
-	    private const float DEFAULT_FONT_SIZE = (float) 8.25;
+        private const int DEFAULT_ITEM_HEIGHT = 16;
+        private const float DEFAULT_FONT_SIZE = (float) 8.25;
 
         public const double DEFAULT_TEXT_FACTOR = 1;
-	    public const double LRG_TEXT_FACTOR = 1.25;
-	    public const double XLRG_TEXT_FACTOR = 1.5;
+        public const double LRG_TEXT_FACTOR = 1.25;
+        public const double XLRG_TEXT_FACTOR = 1.5;
 
         protected TreeViewMS()
         {
@@ -84,7 +84,7 @@ namespace pwiz.Skyline.Controls
         public ICollection<TreeNodeMS> SelectedNodes { get; private set; }
 
         // If true, disjoint select is enabled.
-	    private bool _allowDisjoint;
+        private bool _allowDisjoint;
 
         /// <summary>
         /// For functional testing of multiple selection code.
@@ -188,9 +188,9 @@ namespace pwiz.Skyline.Controls
             }
         }
 
-	    protected abstract bool IsParentNode(TreeNode node);
+        protected abstract bool IsParentNode(TreeNode node);
 
-	    protected abstract int EnsureChildren(TreeNode node);
+        protected abstract int EnsureChildren(TreeNode node);
 
         public bool RestoredFromPersistentString { get; set; }
         private TreeViewStateRestorer TreeStateRestorer { get; set; }
@@ -378,7 +378,7 @@ namespace pwiz.Skyline.Controls
             }
         }
 
-	    private int _updateLockCount;
+        private int _updateLockCount;
 
         public bool IsInUpdate { get { return _updateLockCount > 0; } }
 

--- a/pwiz_tools/Skyline/EditUI/PasteDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Nick Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/EditUI/PasteDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Nick Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -1243,11 +1243,11 @@ namespace pwiz.Skyline.EditUI
                         row.Cells[column.Index].Value = valueEnumerator.Current;
                     }
                 }
-				if (enumerateProteins)
-				{
-					EnumerateProteins(dataGridView, row.Index, keepAllPeptides, ref numUnmatched, ref numMulitpleMatches,
-						ref numFiltered, listPepSeqs, associateHelper);
-				}
+                if (enumerateProteins)
+                {
+                    EnumerateProteins(dataGridView, row.Index, keepAllPeptides, ref numUnmatched, ref numMulitpleMatches,
+                        ref numFiltered, listPepSeqs, associateHelper);
+                }
             }
         }
 

--- a/pwiz_tools/Skyline/Model/DdaSearch/MsgfPlusSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MsgfPlusSearchEngine.cs
@@ -194,27 +194,27 @@ namespace pwiz.Skyline.Model.DdaSearch
         {
             /*  # Mass or CompositionStr, Residues, ModType, Position, Name (all the five fields are required).
                 # CompositionStr (C[Num]H[Num]N[Num]O[Num]S[Num]P[Num]Br[Num]Cl[Num]Fe[Num])
-                # 	- C (Carbon), H (Hydrogen), N (Nitrogen), O (Oxygen), S (Sulfur), P (Phosphorus), Br (Bromine), Cl (Chlorine), Fe (Iron), and Se (Selenium) are allowed.
-                # 	- Negative numbers are allowed.
-                # 	- E.g. C2H2O1 (valid), H2C1O1 (invalid) 
+                #   - C (Carbon), H (Hydrogen), N (Nitrogen), O (Oxygen), S (Sulfur), P (Phosphorus), Br (Bromine), Cl (Chlorine), Fe (Iron), and Se (Selenium) are allowed.
+                #   - Negative numbers are allowed.
+                #   - E.g. C2H2O1 (valid), H2C1O1 (invalid) 
                 # Mass can be used instead of CompositionStr. It is important to specify accurate masses (integer masses are insufficient).
-                # 	- E.g. 15.994915 
+                #   - E.g. 15.994915 
                 # Residues: affected amino acids (must be upper letters)
-                # 	- Must be upper letters or *
-                # 	- Use * if this modification is applicable to any residue. 
-                # 	- * should not be "anywhere" modification (e.g. "15.994915, *, opt, any, Oxidation" is not allowed.) 
-                # 	- E.g. NQ, *
+                #   - Must be upper letters or *
+                #   - Use * if this modification is applicable to any residue. 
+                #   - * should not be "anywhere" modification (e.g. "15.994915, *, opt, any, Oxidation" is not allowed.) 
+                #   - E.g. NQ, *
                 # ModType: "fix" for fixed modifications, "opt" for variable modifications, "custom" for custom amino acids (case insensitive)
                 # Position: position in the peptide where the modification can be attached. 
-                # 	- One of the following five values should be used:
-                # 	- any (anywhere), N-term (peptide N-term), C-term (peptide C-term), Prot-N-term (protein N-term), Prot-C-term (protein C-term) 
-                # 	- Case insensitive
-                # 	- "-" can be omitted
-                # 	- E.g. any, Any, Prot-n-Term, ProtNTerm => all valid
+                #   - One of the following five values should be used:
+                #   - any (anywhere), N-term (peptide N-term), C-term (peptide C-term), Prot-N-term (protein N-term), Prot-C-term (protein C-term) 
+                #   - Case insensitive
+                #   - "-" can be omitted
+                #   - E.g. any, Any, Prot-n-Term, ProtNTerm => all valid
                 # Name: name of the modification (Unimod PSI-MS name)
-                # 	- For proper mzIdentML output, this name should be the same as the Unimod PSI-MS name
-                # 	- E.g. Phospho, Acetyl
-                # 	- Visit http://www.unimod.org to get PSI-MS names.
+                #   - For proper mzIdentML output, this name should be the same as the Unimod PSI-MS name
+                #   - E.g. Phospho, Acetyl
+                #   - Visit http://www.unimod.org to get PSI-MS names.
              */
             using (var modsFileStream = new StreamWriter(modsFile, false))
             {

--- a/pwiz_tools/Skyline/Model/DdaSearch/MsgfPlusSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MsgfPlusSearchEngine.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Matt Chambers <matt.chambers42 .at. gmail.com >
  *
  * Copyright 2020 University of Washington - Seattle, WA

--- a/pwiz_tools/Skyline/Model/ExportChromatograms.cs
+++ b/pwiz_tools/Skyline/Model/ExportChromatograms.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Dario Amodei <damodei .at. stanford.edu>,
  *                  Mallick Lab, Department of Radiology, Stanford University
  *

--- a/pwiz_tools/Skyline/Model/ExportChromatograms.cs
+++ b/pwiz_tools/Skyline/Model/ExportChromatograms.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Dario Amodei <damodei .at. stanford.edu>,
  *                  Mallick Lab, Department of Radiology, Stanford University
  *
@@ -35,15 +35,15 @@ namespace pwiz.Skyline.Model
     public class ChromatogramExporter
     {
         public SrmDocument Document { get; private set; }
-	    
+        
         public ChromatogramExporter(SrmDocument document)
-	    {
+        {
             Document = document;
             _settings = Document.Settings;
             _measuredResults = _settings.MeasuredResults;
             _matchTolerance = (float)_settings.TransitionSettings.Instrument.MzMatchTolerance;
             _chromatogramSets = _measuredResults.Chromatograms;
-	    }
+        }
 
         public const char MAIN_SEPARATOR = TextUtil.SEPARATOR_TSV;
 

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Dario Amodei <damodei .at. stanford.edu>,
  *                  Mallick Lab, Department of Radiology, Stanford University
  *

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Dario Amodei <damodei .at. stanford.edu>,
  *                  Mallick Lab, Department of Radiology, Stanford University
  *
@@ -46,15 +46,15 @@ namespace pwiz.Skyline.Model
         public HashSet<string> UnrecognizedPeptides { get; private set; }
         public HashSet<string> UnrecognizedFiles { get; private set; }
         public HashSet<UnrecognizedChargeState> UnrecognizedChargeStates { get; private set; } 
-	    
+        
         public PeakBoundaryImporter(SrmDocument document)
-	    {
+        {
             Document = document;
             AnnotationsAdded = new List<string>();
             UnrecognizedFiles = new HashSet<string>();
             UnrecognizedPeptides = new HashSet<string>();
             UnrecognizedChargeStates = new HashSet<UnrecognizedChargeState>();
-	    }
+        }
 
         public struct UnrecognizedChargeState
         {

--- a/pwiz_tools/Skyline/Model/Lib/Library.cs
+++ b/pwiz_tools/Skyline/Model/Lib/Library.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Model/Lib/Library.cs
+++ b/pwiz_tools/Skyline/Model/Lib/Library.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -644,7 +644,7 @@ namespace pwiz.Skyline.Model.Lib
         /// <summary>
         /// Some details for the library. 
         /// This can be the library revision, program version, 
-		/// build date or a hyperlink to the library source 
+        /// build date or a hyperlink to the library source 
         /// (e.g. http://peptide.nist.gov/ for NIST libraries)
         /// </summary>
         public abstract LibraryDetails LibraryDetails { get; }

--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -1795,8 +1795,8 @@ namespace pwiz.Skyline.Model.Results
                 if (configInfo == null || configInfo.IsEmpty)
                     continue;
 
-				if (infoString.Length > 0)
-	                infoString.Append('\n');
+                if (infoString.Length > 0)
+                    infoString.Append('\n');
 
                 // instrument model
                 if(!string.IsNullOrWhiteSpace(configInfo.Model))

--- a/pwiz_tools/Skyline/Model/Results/ResultNameMap.cs
+++ b/pwiz_tools/Skyline/Model/Results/ResultNameMap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Linq;
 using System.Collections.Generic;
@@ -180,7 +180,7 @@ namespace pwiz.Skyline.Model.Results
         }
 
         #region Object Overrides
-		public bool Equals(ResultNameMap<T> other)
+        public bool Equals(ResultNameMap<T> other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;

--- a/pwiz_tools/Skyline/Model/Results/ResultNameMap.cs
+++ b/pwiz_tools/Skyline/Model/Results/ResultNameMap.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Linq;
 using System.Collections.Generic;

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeSource.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeSource.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Nick Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeSource.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeSource.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Nick Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -44,7 +44,7 @@ namespace pwiz.Skyline.Model.RetentionTimes
         public string Library { get; private set; }
 
         #region object overrides
-		public bool Equals(RetentionTimeSource other)
+        public bool Equals(RetentionTimeSource other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -65,7 +65,7 @@ namespace pwiz.Skyline.Model.RetentionTimes
                 return (base.GetHashCode()*397) ^ (Library != null ? Library.GetHashCode() : 0);
             }
         }
-	    #endregion
+        #endregion
         #region Implementation of IXmlSerializable
         private enum Attr
         {

--- a/pwiz_tools/Skyline/Model/SequenceUtil.cs
+++ b/pwiz_tools/Skyline/Model/SequenceUtil.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -1321,7 +1321,7 @@ namespace pwiz.Skyline.Model
             _aminoMasses['b'] = _aminoMasses['B'] =
                 (_massCalc.CalculateMassFromFormula(@"C4H5NO3") + _massCalc.CalculateMassFromFormula(@"C4H6N2O2")) / 2;
             _aminoMasses['j'] = _aminoMasses['J'] = 0.0;
-            _aminoMasses['x'] = _aminoMasses['X'] = 111.060000;	// Why?
+            _aminoMasses['x'] = _aminoMasses['X'] = 111.060000;    // Why?
             // Wikipedia says Glutamic acid or Glutamine
             _aminoMasses['z'] = _aminoMasses['Z'] =
                 (_massCalc.CalculateMassFromFormula(@"C5H6ON2") + _massCalc.CalculateMassFromFormula(@"C5H8N2O2")) / 2;

--- a/pwiz_tools/Skyline/Model/SequenceUtil.cs
+++ b/pwiz_tools/Skyline/Model/SequenceUtil.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -236,7 +236,7 @@ namespace pwiz.Skyline.Model
             get { return TextUtil.FileDialogFilter(Resources.SrmDocument_FILTER_DOC_Skyline_Documents, EXT); }
         }
 
-		public static string FILTER_DOC_AND_SKY_ZIP
+        public static string FILTER_DOC_AND_SKY_ZIP
         {
             // Used only in the open file dialog.
             get

--- a/pwiz_tools/Skyline/SettingsUI/EditRTDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditRTDlg.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/SettingsUI/EditRTDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditRTDlg.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -468,8 +468,8 @@ namespace pwiz.Skyline.SettingsUI
         /// <summary>
         /// This function will update the calculator to the one given, or to the one with the best score for the document 
         /// peptides. It will then return the peptides chosen by that calculator for regression.
-		/// Todo: split this function into one that chooses and returns the calculator and one that returns the peptides
-		/// todo: chosen by that calculator
+        /// Todo: split this function into one that chooses and returns the calculator and one that returns the peptides
+        /// todo: chosen by that calculator
         /// </summary>
         private IList<MeasuredRetentionTime> UpdateCalculator(RetentionScoreCalculatorSpec calculator, IList<MeasuredRetentionTime> activePeptides = null)
         {
@@ -524,7 +524,7 @@ namespace pwiz.Skyline.SettingsUI
                 return null;
             }
             
-			//This "if" is to keep from getting into infinite loops
+            //This "if" is to keep from getting into infinite loops
             if (calcInitiallyNull)
                 comboCalculator.SelectedItem = calculator.Name;
 

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Tahmina Jahan <tabaker .at. u.washington.edu>,
  *                  Alana Killeen <killea .at. u.washington.edu>,
  *                  UWPR, Department of Genome Sciences, UW

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Tahmina Jahan <tabaker .at. u.washington.edu>,
  *                  Alana Killeen <killea .at. u.washington.edu>,
  *                  UWPR, Department of Genome Sciences, UW
@@ -195,7 +195,7 @@ namespace pwiz.Skyline.SettingsUI
         /// </summary>
         private void InitializeMatchCategoryComboBox()
         {
-        	// Clear the combo box of any items left over from a previous library
+            // Clear the combo box of any items left over from a previous library
             comboFilterCategory.Items.Clear();
             
             // Add localized names for fields like Formula, Precursor m/z

--- a/pwiz_tools/Skyline/Skyline.sln.DotSettings
+++ b/pwiz_tools/Skyline/Skyline.sln.DotSettings
@@ -88,6 +88,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEverywhere/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEvident/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TabsAndSpacesMismatch/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TabsAreDisallowed/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=TryCastAlwaysSucceeds/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	

--- a/pwiz_tools/Skyline/SkylineNightly/Program.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Don Marsh <donmarsh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -82,7 +82,7 @@ namespace SkylineNightly
 
                 switch (command)
                 {
-					case @"run":
+                    case @"run":
                     {
                         switch (args.Length)
                         {
@@ -95,10 +95,10 @@ namespace SkylineNightly
                             {
                                 PerformTests((Nightly.RunMode) Enum.Parse(typeof(Nightly.RunMode), args[1]),
                                     (Nightly.RunMode) Enum.Parse(typeof(Nightly.RunMode), args[2]),
-									args[1] + @" then " + args[2]);
+                                    args[1] + @" then " + args[2]);
                                 break;
                             }
-							default: throw new Exception(@"Wrong number of run modes specified, has to be 1 or 2");
+                            default: throw new Exception(@"Wrong number of run modes specified, has to be 1 or 2");
                         }
 
                         break;
@@ -114,13 +114,13 @@ namespace SkylineNightly
                     case @"/?":
                     {
                         nightly = new Nightly(Nightly.RunMode.trunk);
-						string commands = string.Join(@" | ",
+                        string commands = string.Join(@" | ",
                             SkylineNightly.RunModes.Select(r => r.ToString()).ToArray());
                         message = string.Format(@"Usage: SkylineNightly run [{0}] [{1}]", commands, commands);
                         nightly.Finish(message, errMessage);
                         break;
                     }
-					case @"parse":
+                    case @"parse":
                     {
                         nightly = new Nightly(Nightly.RunMode.parse);
                         message = string.Format(@"Parse and post log {0}", nightly.GetLatestLog());
@@ -131,7 +131,7 @@ namespace SkylineNightly
                         nightly.Finish(message, errMessage);
                         break;
                     }
-					case @"post":
+                    case @"post":
                     {
                         nightly = new Nightly(Nightly.RunMode.post);
                         message = string.Format(@"Post existing XML for {0}", nightly.GetLatestLog());
@@ -168,7 +168,7 @@ namespace SkylineNightly
             }
             catch (Exception ex)
             {
-				MessageBox.Show(@"Exception Caught: " + ex.Message, @"SkylineNightly.exe");
+                MessageBox.Show(@"Exception Caught: " + ex.Message, @"SkylineNightly.exe");
             }
         }
     }

--- a/pwiz_tools/Skyline/SkylineNightly/Program.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Program.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Don Marsh <donmarsh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Don Marsh <donmarsh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -149,7 +149,7 @@ namespace SkylineNightly
         public string RunType(out int durationHours)
         {
             durationHours = 0;
-			string result = @"run ";
+            string result = @"run ";
 
             int[] hours =
             {
@@ -162,7 +162,7 @@ namespace SkylineNightly
 
             if (comboBoxOptions2.SelectedIndex != RunModes.Length && comboBoxOptions2.SelectedIndex != -1) //!= none && != not selected
             {
-				result += @" " + RunModes[comboBoxOptions2.SelectedIndex];
+                result += @" " + RunModes[comboBoxOptions2.SelectedIndex];
                 durationHours += hours[comboBoxOptions2.SelectedIndex];
             }
 

--- a/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Don Marsh <donmarsh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/TestFunctional/RetentionTimeAlignmentTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/RetentionTimeAlignmentTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Nick Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -84,7 +84,7 @@ namespace pwiz.SkylineTestFunctional
             var alignedTo10 = documentRetentionTimes.FileAlignments.Find("S_10");
             var af10To1 = alignedTo1.RetentionTimeAlignments.Find("S_10");
             var af1To10 = alignedTo10.RetentionTimeAlignments.Find("S_1");
-		    // Verify that the slopes and intercepts are reciprocals of each other.
+            // Verify that the slopes and intercepts are reciprocals of each other.
             // We can only verify this with very coarse precision
             Assert.AreEqual(af10To1.RegressionLine.Slope, 1/af1To10.RegressionLine.Slope, .03);
             Assert.AreEqual(af10To1.RegressionLine.Intercept, -af1To10.RegressionLine.Intercept * af10To1.RegressionLine.Slope, 1);

--- a/pwiz_tools/Skyline/TestFunctional/RetentionTimeAlignmentTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/RetentionTimeAlignmentTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Nick Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
@@ -31,8 +31,8 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
 {
     /// <summary>
     /// Verify operation of UI when working with large protdb files that may need 
-	/// processing before the settings can be changed.  In particular verify the 
-	/// interaction of the UI with the background loader, and behaviour on cancellation.
+    /// processing before the settings can be changed.  In particular verify the 
+    /// interaction of the UI with the background loader, and behaviour on cancellation.
     /// </summary>
     [TestClass]
     public class PerfUniquePeptidesTest : AbstractFunctionalTest

--- a/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brian Pratt <bspratt .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/TestPerf/SmallMolLibrariesTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/SmallMolLibrariesTutorialTest.cs
@@ -1,4 +1,4 @@
-/*
+Ôªø/*
  * Original author: Brian Pratt <bspratt .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -77,20 +77,20 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
         {
             RunUI(() => SkylineWindow.SetUIMode(SrmDocument.DOCUMENT_TYPE.small_molecules));
 
-            //   ï On the Settings menu, click Default.
-            //   ï Click No on the form asking if you want to save the current settings.
+            //   ‚Ä¢ On the Settings menu, click Default.
+            //   ‚Ä¢ Click No on the form asking if you want to save the current settings.
             RunUI(() => SkylineWindow.ResetDefaultSettings());
 
             var doc = SkylineWindow.Document;
 
-            //   ï On the Settings menu, click Transition Settings.
-            //   ï Click the Filter tab.
+            //   ‚Ä¢ On the Settings menu, click Transition Settings.
+            //   ‚Ä¢ Click the Filter tab.
             var transitionSettingsUI = ShowDialog<TransitionSettingsUI>(() =>
                 SkylineWindow.ShowTransitionSettingsUI(TransitionSettingsUI.TABS.Filter));
 
-            //   ï This data was collected in negative ionization mode so [M+H] and[M +] can be removed from the Precursor Adducts and Fragment Adducts fields. However, they are harmless if left as is since the library we will use has only negative ion mode entries.
-            //   ï In the Precursor Adducts field, enter ì[M-H], [M+HCOO], [M+CH3COO]î. 
-            //   ï In the Fragment Adducts field, enter ì[M-]î.
+            //   ‚Ä¢ This data was collected in negative ionization mode so [M+H] and[M +] can be removed from the Precursor Adducts and Fragment Adducts fields. However, they are harmless if left as is since the library we will use has only negative ion mode entries.
+            //   ‚Ä¢ In the Precursor Adducts field, enter ‚Äú[M-H], [M+HCOO], [M+CH3COO]‚Äù. 
+            //   ‚Ä¢ In the Fragment Adducts field, enter ‚Äú[M-]‚Äù.
             RunUI(() =>
             {
                 transitionSettingsUI.SmallMoleculePrecursorAdducts = "[M-H], [M+HCOO], [M+CH3COO]";
@@ -98,66 +98,66 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 transitionSettingsUI.SmallMoleculeFragmentTypes = "f, p";
                 transitionSettingsUI.Left = SkylineWindow.Right + 20;
             });
-            //   ï The Transition Settings form should now look like this:
+            //   ‚Ä¢ The Transition Settings form should now look like this:
             PauseForScreenShot<TransitionSettingsUI.FilterTab>("Transition Settings: Filter", 3);
 
             RunUI(() =>
             {
-                //   ï Click the Full-Scan tab in the Transition Settings form.
+                //   ‚Ä¢ Click the Full-Scan tab in the Transition Settings form.
                 transitionSettingsUI.SelectedTab = TransitionSettingsUI.TABS.FullScan;
-                //   ï  In the MS1 filtering section, set the Isotope peaks included field to Count.
+                //   ‚Ä¢  In the MS1 filtering section, set the Isotope peaks included field to Count.
                 transitionSettingsUI.PrecursorIsotopesCurrent = FullScanPrecursorIsotopes.Count;
-                //   ï Set the Precursor mass analyzer field to TOF.
+                //   ‚Ä¢ Set the Precursor mass analyzer field to TOF.
                 transitionSettingsUI.PrecursorMassAnalyzer = FullScanMassAnalyzerType.tof;
-                //   ï Enter ì20,000î in the Resolving power field.
+                //   ‚Ä¢ Enter ‚Äú20,000‚Äù in the Resolving power field.
                 transitionSettingsUI.PrecursorRes = 20000;
-                //   ï In the MS/MS filtering section, set the Acquisition method field to DIA.
+                //   ‚Ä¢ In the MS/MS filtering section, set the Acquisition method field to DIA.
                 transitionSettingsUI.AcquisitionMethod = FullScanAcquisitionMethod.DIA;
-                //   ï Set the Isolation scheme field to All Ions.
+                //   ‚Ä¢ Set the Isolation scheme field to All Ions.
                 transitionSettingsUI.IsolationSchemeName = IsolationScheme.SpecialHandlingType.ALL_IONS;
-                //   ï Enter ì20,000î in the Resolving power field.
+                //   ‚Ä¢ Enter ‚Äú20,000‚Äù in the Resolving power field.
                 transitionSettingsUI.ProductRes = 20000;
-                //   ï Check Use high-selectivity extraction.
+                //   ‚Ä¢ Check Use high-selectivity extraction.
                 transitionSettingsUI.UseSelectiveExtraction = true;
             });
 
             //   The Transition Settings form should look like this:
             PauseForScreenShot<TransitionSettingsUI.FullScanTab>("Transition Settings - Full-Scan", 4);
-            //   ï Click the OK button.
+            //   ‚Ä¢ Click the OK button.
             OkDialog(transitionSettingsUI, transitionSettingsUI.OkDialog);
             doc = WaitForDocumentChange(doc);
 
             //   Adding and Exploring a Spectral Library
             // Before you can explore the library, Skyline must be directed to its location by adding your library of interest to the global list of libraries for document editing.
             //   To get started with the small molecule library containing Drosophila lipids perform the following steps:
-            //   ï From the Settings menu, click Molecule Settings.
-            //   ï Click the Library tab.
+            //   ‚Ä¢ From the Settings menu, click Molecule Settings.
+            //   ‚Ä¢ Click the Library tab.
             var peptideSettingsUI = ShowDialog<PeptideSettingsUI>(() =>
                 SkylineWindow.ShowPeptideSettingsUI(PeptideSettingsUI.TABS.Library));
-            //   ï Click the Edit List button.
+            //   ‚Ä¢ Click the Edit List button.
             var libListDlg =
                 ShowDialog<EditListDlg<SettingsListBase<LibrarySpec>, LibrarySpec>>(peptideSettingsUI.EditLibraryList);
-            //   ï Click the Add button in the Edit Libraries form.
+            //   ‚Ä¢ Click the Add button in the Edit Libraries form.
             var addLibDlg = ShowDialog<EditLibraryDlg>(libListDlg.AddItem);
             var drosophilaLipids = "Drosophila Lipids";
             RunUI(() =>
             {
-                //   ï Enter ìDrosophila Lipidsî in the Name field of the Edit Library form.
+                //   ‚Ä¢ Enter ‚ÄúDrosophila Lipids‚Äù in the Name field of the Edit Library form.
                 addLibDlg.LibraryName = drosophilaLipids;
-                //   ï Click the Browse button.
-                //   ï Navigate to the SmallMoleculeLibraries folder created earlier.
-                //   ï Select the ìDrosophila_Lipids_Neg.blibî file.
+                //   ‚Ä¢ Click the Browse button.
+                //   ‚Ä¢ Navigate to the SmallMoleculeLibraries folder created earlier.
+                //   ‚Ä¢ Select the ‚ÄúDrosophila_Lipids_Neg.blib‚Äù file.
                 addLibDlg.LibraryPath = GetFullDataPath("Drosophila_Lipids_Neg.blib");
             });
-            //   ï Click the Open button.
-            //   ï Click the OK button in the Edit Library form.
+            //   ‚Ä¢ Click the Open button.
+            //   ‚Ä¢ Click the OK button in the Edit Library form.
             OkDialog(addLibDlg, addLibDlg.OkDialog);
-            //   ï Click the OK button in the Edit Libraries form.
+            //   ‚Ä¢ Click the OK button in the Edit Libraries form.
             OkDialog(libListDlg, libListDlg.OkDialog);
 
             //   The Libraries list in the Molecule Settings form should now contain the Drosophila Lipids library you just created.
-            //   ï Check the Drosophila Lipids checkbox to tell Skyline to use this library in the current document.
-            //   ï If you have any other libraries in this list checked, uncheck them now.
+            //   ‚Ä¢ Check the Drosophila Lipids checkbox to tell Skyline to use this library in the current document.
+            //   ‚Ä¢ If you have any other libraries in this list checked, uncheck them now.
             RunUI(() =>
             {
                 peptideSettingsUI.PickedLibraries = new[] {drosophilaLipids};
@@ -165,12 +165,12 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             });
             //   The Molecule Settings form should now look like:
             PauseForScreenShot<PeptideSettingsUI.LibraryTab>("Molecule Settings - Library", 6);
-            //   ï Click the OK button in the Molecule Settings form.
+            //   ‚Ä¢ Click the OK button in the Molecule Settings form.
             OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
             doc = WaitForDocumentChangeLoaded(doc);
 
             //   To open the library explorer and view the contents of the library you just added, do the following: 
-            //   ï From the View menu, click Spectral Libraries.
+            //   ‚Ä¢ From the View menu, click Spectral Libraries.
             var viewLibUI = ShowDialog<ViewLibraryDlg>(SkylineWindow.ViewSpectralLibraries);
             RunUI(() =>
             {
@@ -182,8 +182,8 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             PauseForScreenShot("Library Explorer (probably need to resize wider)", 7);
 
             //  To add all the molecules in the library to your target list:
-            //   ï Click the Add All button.
-            //   ï A popup window will then notify you that you will add 34 molecules, 38 precursors, and 246 transitions to the document. Click Add All.
+            //   ‚Ä¢ Click the Add All button.
+            //   ‚Ä¢ A popup window will then notify you that you will add 34 molecules, 38 precursors, and 246 transitions to the document. Click Add All.
             var confirmAddDlg = ShowDialog<AlertDlg>(viewLibUI.AddAllPeptides);
             using (new CheckDocumentState(1, 34, 38, 246))
             {
@@ -191,7 +191,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 doc = WaitForDocumentChangeLoaded(doc);
             }
 
-            //   ï Close the Spectral Library Explorer window.
+            //   ‚Ä¢ Close the Spectral Library Explorer window.
             OkDialog(viewLibUI, viewLibUI.CancelDialog);
 
             //   Your Skyline window should now resemble:
@@ -200,17 +200,17 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
 
             //Importing Results Chromatogram.Data
             //    In this section, you will import the Drosophila data without utilizing IMS filtering. This is an initial look at the data to see the impact of interference among lipids and their shared fragments. To import the data, perform the following steps:
-            //   ï On the File menu, click Save (Ctrl+S).
-            //   ï Save this document in the tutorial folder you created.
+            //   ‚Ä¢ On the File menu, click Save (Ctrl+S).
+            //   ‚Ä¢ Save this document in the tutorial folder you created.
             RunUI(() => SkylineWindow.SaveDocument(TestFilesDirs[0].GetTestPath("Tutorial.sky")));
 
-            //   ï From the File menu, choose Import and click Results.
+            //   ‚Ä¢ From the File menu, choose Import and click Results.
             using (new WaitDocumentChange(null, true))
             {
                 var askDecoysDlg = ShowDialog<MultiButtonMsgDlg>(SkylineWindow.ImportResults);
                 var importResultsDlg1 = ShowDialog<ImportResultsDlg>(askDecoysDlg.ClickNo);
-                //   ï Set the Files to import simultaneously field to Many.
-                //   ï Check Show chromatograms during import.
+                //   ‚Ä¢ Set the Files to import simultaneously field to Many.
+                //   ‚Ä¢ Check Show chromatograms during import.
                 //   The Import Results form will appear as follows:
                 RunUI(() =>
                 {
@@ -220,9 +220,9 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 PauseForScreenShot<ImportResultsDlg>("Import Results", 9);
                 var openDataSourceDialog1 = ShowDialog<OpenDataSourceDialog>(() => importResultsDlg1.NamedPathSets =
                     importResultsDlg1.GetDataSourcePathsFile(null));
-                //   ï Click the OK button.
+                //   ‚Ä¢ Click the OK button.
                 //   The Import Results Files form will now show the.d files you have extracted into the tutorial folder:
-                //   ï Select both .d files.
+                //   ‚Ä¢ Select both .d files.
                 RunUI(() =>
                 {
                     var path = Path.GetDirectoryName(GetFullDataPath(Flies_M));
@@ -234,8 +234,8 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 PauseForScreenShot<OpenDataSourceDialog>("Import Results Files selection form", 10);
                 OkDialog(openDataSourceDialog1, openDataSourceDialog1.Open);
 
-                //   ï Click the Open button.
-                //   ï The Import Results window will ask if you would like to remove the common prefix and suffix to shorten the file names used in Skyline.Click OK to accept the names ìF_A_018î and ìM_A_001î.
+                //   ‚Ä¢ Click the Open button.
+                //   ‚Ä¢ The Import Results window will ask if you would like to remove the common prefix and suffix to shorten the file names used in Skyline.Click OK to accept the names ‚ÄúF_A_018‚Äù and ‚ÄúM_A_001‚Äù.
                 //This should start the import and cause Skyline to show the Importing Results progress form:
                 var importResultsNameDlg = ShowDialog<ImportResultsNameDlg>(importResultsDlg1.OkDialog);
                 OkDialog(importResultsNameDlg, importResultsNameDlg.OkDialog);
@@ -254,16 +254,16 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             //    Once the files are imported, you can examine the chromatograms to evaluate interference from peaks with retention times and m/z values within the tolerance of your target list.
             RunUI(() =>
             {
-                //   ï From the Edit menu, choose Expand All and click Molecules (Ctrl+D).
+                //   ‚Ä¢ From the Edit menu, choose Expand All and click Molecules (Ctrl+D).
                 SkylineWindow.ExpandPeptides();
                 SkylineWindow.SetDisplayTypeChrom(DisplayTypeChrom.all);
-                //   ï From the View menu, choose Arrange Graphs and click Tiled (Ctrl+T).
+                //   ‚Ä¢ From the View menu, choose Arrange Graphs and click Tiled (Ctrl+T).
                 SkylineWindow.ArrangeGraphs(DisplayGraphsType.Row); // With just two panes, Tiled may go either row or column, force row 
-                //   ï Right-click in a chromatogram graph and click Synchronize Zooming(leave if already checked).
+                //   ‚Ä¢ Right-click in a chromatogram graph and click Synchronize Zooming(leave if already checked).
                 SkylineWindow.SynchronizeZooming(true);
-                // ï Right-click in a chromatogram graph and click Legend to hide the legend.
+                // ‚Ä¢ Right-click in a chromatogram graph and click Legend to hide the legend.
                 SkylineWindow.ShowChromatogramLegends(false);
-                //   ï Right-click in a chromatogram graph, choose Transitions and click Split Graph (leave if already checked).
+                //   ‚Ä¢ Right-click in a chromatogram graph, choose Transitions and click Split Graph (leave if already checked).
                 SkylineWindow.ShowSplitChromatogramGraph(true);
                 SkylineWindow.AutoZoomBestPeak();
                 SkylineWindow.Size = new Size(1487, 786);
@@ -274,7 +274,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 propDlg.TimeRange = 7; // minutes
                 propDlg.OkDialog();
             });
-            //  ï Select the molecule PC(16:0_18:1) and your spectra should appear as: 
+            //  ‚Ä¢ Select the molecule PC(16:0_18:1) and your spectra should appear as: 
             FindNode("PC(16:0_18:1)");
             PauseForScreenShot("Chromatograms - prtsc-paste-edit", 12);
 
@@ -284,19 +284,19 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             PauseForScreenShot("Library Match", 13);
 
             //Since there are only 38 precursors in this document, you may want to review all 38 to get an overall feel for how the XIC look prior to IMS filtering.Before starting this review, do the following:
-            //   ï On the View menu, choose Retention Times and click Replicate Comparison (F8).
-            //   ï Attach the Retention Times view to the left of the Library Match view by clicking in the title bar and dragging until the mouse cursor is inside the left-side docking icon.
+            //   ‚Ä¢ On the View menu, choose Retention Times and click Replicate Comparison (F8).
+            //   ‚Ä¢ Attach the Retention Times view to the left of the Library Match view by clicking in the title bar and dragging until the mouse cursor is inside the left-side docking icon.
             RunUI(() =>
             {
                 SkylineWindow.ShowGraphRetentionTime(true, GraphTypeSummary.replicate);
-                //   ï Right-click in the Retention Times view and click Legend to hide the legend in this graph.
+                //   ‚Ä¢ Right-click in the Retention Times view and click Legend to hide the legend in this graph.
                 SkylineWindow.ShowRTLegend(false);
             });
 
-            //   ï From the View menu, choose Peak Areas and click Replicate Comparison (F7).
+            //   ‚Ä¢ From the View menu, choose Peak Areas and click Replicate Comparison (F7).
             RestoreViewOnScreen(14);
 
-            //   ï Attach the Peak Areas view above the Retention Times view by clicking in the title bar and dragging until the mouse cursor is inside the up-side docking icon.
+            //   ‚Ä¢ Attach the Peak Areas view above the Retention Times view by clicking in the title bar and dragging until the mouse cursor is inside the up-side docking icon.
             //    You should end up with a similar layout to that below:
             RunUI(() =>
             {
@@ -321,8 +321,8 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
 
             //Understanding and Utilizing the IMS Separation
             //To this point, we have ignored the IMS dimension in this data.To better understand the IMS separation, you need to look at the underlying spectra from which these chromatograms were extracted by doing the following:
-            //   ï On the View menu, choose Auto-Zoom and click Best Peak (F11).
-            //   ï Select the molecule PE(16:1_18:3).
+            //   ‚Ä¢ On the View menu, choose Auto-Zoom and click Best Peak (F11).
+            //   ‚Ä¢ Select the molecule PE(16:1_18:3).
             FindNode("PE(16:1_18:3)");
             WaitForGraphs();
             RunDlg<ChromChartPropertyDlg>(SkylineWindow.ShowChromatogramProperties, propDlg =>
@@ -334,29 +334,29 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             WaitForGraphs();
             PauseForScreenShot("Chromatogram", 15);
 
-            //   ï Hover the mouse cursor over the precursor chromatogram peak apex until a blue circle appears that tracks the mouse movement, and click on it.
+            //   ‚Ä¢ Hover the mouse cursor over the precursor chromatogram peak apex until a blue circle appears that tracks the mouse movement, and click on it.
             ClickChromatogram(F_A_018, 14.81, 162.1E3, PaneKey.PRECURSORS);
             //   This should bring up the Full-Scan view showing a familiar two-dimensional spectrum in profile mode:
             RunUI(() => SkylineWindow.GraphFullScan.SetSpectrum(true));
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
             PauseForScreenShot("2D plot", 16);
 
-            //   ï Click the Show 2D Spectrum button  to change the plot to a three-dimensional spectrum with drift time.
+            //   ‚Ä¢ Click the Show 2D Spectrum button  to change the plot to a three-dimensional spectrum with drift time.
             RunUI(() => SkylineWindow.GraphFullScan.SetSpectrum(false));
             PauseForScreenShot("3D plot", 16);
 
-            //   ï Click the Zoom to Selection button to see the entire 3D MS1 spectrum at the selected retention time.
+            //   ‚Ä¢ Click the Zoom to Selection button to see the entire 3D MS1 spectrum at the selected retention time.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(false));
             PauseForScreenShot("3D plot full range", 17);
 
             //    This is a fairly typical MS1 spectrum for IMS-MS lipidomics data.You can get a better sense of the data by zooming into multiple areas on this plot.You can also select other lipids and click on the blue circle at the apex of each precursor chromatogram peak to see how this plot can differ with retention time. An interesting example is PE(O-18:0/16:1), which has distinct ion distributions showing correlations between m/z and drift time for different lipid classes.
             //    To inspect a relevant MS/MS spectrum:
-            //   ï Re-select the molecule PE(16:1_18:3) if you navigated away from it to view other MS1 spectra.
+            //   ‚Ä¢ Re-select the molecule PE(16:1_18:3) if you navigated away from it to view other MS1 spectra.
             FindNode("PE(16:1_18:3)");
-            //   ï Click on the Zoom to Selection button to zoom back in.
+            //   ‚Ä¢ Click on the Zoom to Selection button to zoom back in.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
             WaitForGraphs();
-            //   ï Hover the mouse over the FA 18:3(+O) fragment chromatogram peak apex until a teal colored circle appears that tracks the mouse movement, and click on it.
+            //   ‚Ä¢ Hover the mouse over the FA 18:3(+O) fragment chromatogram peak apex until a teal colored circle appears that tracks the mouse movement, and click on it.
             ClickChromatogram(F_A_018, 14.83, 120.5E3, PaneKey.PRODUCTS);
             //   The Full-Scan graph should change to:
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
@@ -364,7 +364,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
 
 
             //You can see that at least three visible ions are contributing to the extracted intensities at 33, 37, and 44 ms.This goes back to the nature of lipid fragmentation as previously discussed, where most lipids with an 18:3 fatty acyl chain will share this fragment.The complexity is increased for fatty acyl chains fragments with fewer double bonds, such as 18:2 at m/z 279, which may have multiple ions as well as isotopic overlap from the abundant 18:3 fragment at m/z 277 contributing to the extracted intensity.A similar observation can be made with the FA 16:1(+O) fragment.
-            //   ï Click the Zoom to Selection button again to see the entire 3D MS/MS spectrum.
+            //   ‚Ä¢ Click the Zoom to Selection button again to see the entire 3D MS/MS spectrum.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(false));
             PauseForScreenShot("3D plot MSMS full range", 18);
 
@@ -372,19 +372,19 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             //    Reimporting Data with Drift Time Filtering
 
             // Prior to changing the settings and reimporting the data, you may want to save the current Skyline document and create a second file in order to compare the data before and after IMS filtering. To do so:
-            //    ï On the File menu, click Save As...
-            //    ï Save the file with a different name than your original Skyline document, such as ìDrosophila_Lipids_Neg_IMS_Filteredî, in the tutorial folder you created.
+            //    ‚Ä¢ On the File menu, click Save As...
+            //    ‚Ä¢ Save the file with a different name than your original Skyline document, such as ‚ÄúDrosophila_Lipids_Neg_IMS_Filtered‚Äù, in the tutorial folder you created.
             RunUI(() => SkylineWindow.SaveDocument(TestFilesDirs[0].GetTestPath(@"Drosophila_Lipids_Neg_IMS_Filtered.sky")));
             RunUI(() => SkylineWindow.Width -= 300);
 
-            //   ï From the Settings menu, click Transition Settings.
-            //   ï Click the Ion Mobility tab.
+            //   ‚Ä¢ From the Settings menu, click Transition Settings.
+            //   ‚Ä¢ Click the Ion Mobility tab.
             transitionSettingsUI = ShowDialog<TransitionSettingsUI>(() =>
                 SkylineWindow.ShowTransitionSettingsUI(TransitionSettingsUI.TABS.IonMobility));
 
-            //   ï Check Use spectral library ion mobility values when present.
-            //   ï Set the Window Type field to Resolving power.
-            //   ï In the Resolving power field, enter ì50î.
+            //   ‚Ä¢ Check Use spectral library ion mobility values when present.
+            //   ‚Ä¢ Set the Window Type field to Resolving power.
+            //   ‚Ä¢ In the Resolving power field, enter ‚Äú50‚Äù.
             RunUI(() =>
             {
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
@@ -394,20 +394,20 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                     IonMobilityWindowWidthCalculator.IonMobilityWindowWidthType.resolving_power;
                 transitionSettingsUI.Left = SkylineWindow.Right + 20;
             });
-            //   ï The Transition Settings form should now look like this:
+            //   ‚Ä¢ The Transition Settings form should now look like this:
             PauseForScreenShot<TransitionSettingsUI.IonMobilityTab>("Transition Settings: IonMobility", 20);            //The Transition Settings should now look like:
 
 
-            //   ï Click the OK button.
+            //   ‚Ä¢ Click the OK button.
             OkDialog(transitionSettingsUI, transitionSettingsUI.OkDialog);
             WaitForDocumentChange(doc);
 
             //   The results must now be reimported with the newly applied IMS settings.
-            //   ï From the Edit menu, click Manage Results.
-            //   ï Click the Re-import button. ì*î Should appear to the left of F_A_018.
-            //   ï Select M_A_001 in the Manage Results view.
-            //   ï Click the Re-import button. ì*î Should appear to the left of M_A_001.
-            //   ï Click the OK button.
+            //   ‚Ä¢ From the Edit menu, click Manage Results.
+            //   ‚Ä¢ Click the Re-import button. ‚Äú*‚Äù Should appear to the left of F_A_018.
+            //   ‚Ä¢ Select M_A_001 in the Manage Results view.
+            //   ‚Ä¢ Click the Re-import button. ‚Äú*‚Äù Should appear to the left of M_A_001.
+            //   ‚Ä¢ Click the OK button.
             doc = SkylineWindow.Document;
             RunDlg<ManageResultsDlg>(SkylineWindow.ManageResults, manageDlg =>
             {
@@ -418,14 +418,14 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             //   This should start the re-import and cause Skyline to show the Importing Results progress form.
             WaitForDocumentChangeLoaded(doc);
 
-            //   ï Click any other lipid in the Target list and re-select PE(16:1_18:3) to update the chromatograms.
+            //   ‚Ä¢ Click any other lipid in the Target list and re-select PE(16:1_18:3) to update the chromatograms.
             FindNode("PC(16:0_18:1)");
             WaitForGraphs();
             FindNode("PE(16:1_18:3)");
             WaitForGraphs();
             //   To explore the filtered data, perform the following:
-            //   ï Click on the apex of the blue precursor chromatogram to show the Full-Scan graph.
-            //   ï Click the Zoom to Selection button.
+            //   ‚Ä¢ Click on the apex of the blue precursor chromatogram to show the Full-Scan graph.
+            //   ‚Ä¢ Click the Zoom to Selection button.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
             //   The Full-Scan graph should now look something like this:
             ClickChromatogram(F_A_018, 14.807, 152.0E3, PaneKey.PRECURSORS);
@@ -442,7 +442,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             PauseForScreenShot("Full scan graph with IM filtering", 21);
 
             // Note that if you were interested in lipids that are not present in the current spectral library, you can add to it manually or using LipidCreator. To access the LipidCreator plugin, do the following:
-            //   ï From the Tools menu, click Tool Store.
+            //   ‚Ä¢ From the Tools menu, click Tool Store.
             if (IsPauseForScreenShots)
             {
                 RunUI(() =>
@@ -451,7 +451,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                     SkylineWindow.Width -= 300;
                 });
                 var configureToolsDlg = ShowDialog<ConfigureToolsDlg>(SkylineWindow.ShowConfigureToolsDlg);
-                //   ï Select LipidCreator.
+                //   ‚Ä¢ Select LipidCreator.
                 var pick = ShowDialog<ToolStoreDlg>(configureToolsDlg.AddFromWeb);
                 RunUI(() =>
                 {
@@ -461,12 +461,12 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 PauseForScreenShot("LipidCreator in tool store", 22);
                 RunUI(() => pick.CancelDialog());
                 OkDialog(configureToolsDlg, configureToolsDlg.Cancel);
-                //   ï Click the Install button.
+                //   ‚Ä¢ Click the Install button.
             }
 
             //   The following steps can be taken to easily export an updated spectral library:
-            //   ï From the File menu, choose Export and click Spectral Library.
-            //   ï Enter a file name and click Save.
+            //   ‚Ä¢ From the File menu, choose Export and click Spectral Library.
+            //   ‚Ä¢ Enter a file name and click Save.
 
         }
     }

--- a/pwiz_tools/Skyline/TestPerf/SmallMolLibrariesTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/SmallMolLibrariesTutorialTest.cs
@@ -77,20 +77,20 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
         {
             RunUI(() => SkylineWindow.SetUIMode(SrmDocument.DOCUMENT_TYPE.small_molecules));
 
-            //   •	On the Settings menu, click Default.
-            //   •	Click No on the form asking if you want to save the current settings.
+            //   • On the Settings menu, click Default.
+            //   • Click No on the form asking if you want to save the current settings.
             RunUI(() => SkylineWindow.ResetDefaultSettings());
 
             var doc = SkylineWindow.Document;
 
-            //   •	On the Settings menu, click Transition Settings.
-            //   •	Click the Filter tab.
+            //   • On the Settings menu, click Transition Settings.
+            //   • Click the Filter tab.
             var transitionSettingsUI = ShowDialog<TransitionSettingsUI>(() =>
                 SkylineWindow.ShowTransitionSettingsUI(TransitionSettingsUI.TABS.Filter));
 
-            //   •	This data was collected in negative ionization mode so [M+H] and[M +] can be removed from the Precursor Adducts and Fragment Adducts fields. However, they are harmless if left as is since the library we will use has only negative ion mode entries.
-            //   •	In the Precursor Adducts field, enter “[M-H], [M+HCOO], [M+CH3COO]”. 
-            //   •	In the Fragment Adducts field, enter “[M-]”.
+            //   • This data was collected in negative ionization mode so [M+H] and[M +] can be removed from the Precursor Adducts and Fragment Adducts fields. However, they are harmless if left as is since the library we will use has only negative ion mode entries.
+            //   • In the Precursor Adducts field, enter “[M-H], [M+HCOO], [M+CH3COO]”. 
+            //   • In the Fragment Adducts field, enter “[M-]”.
             RunUI(() =>
             {
                 transitionSettingsUI.SmallMoleculePrecursorAdducts = "[M-H], [M+HCOO], [M+CH3COO]";
@@ -98,66 +98,66 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 transitionSettingsUI.SmallMoleculeFragmentTypes = "f, p";
                 transitionSettingsUI.Left = SkylineWindow.Right + 20;
             });
-            //   •	The Transition Settings form should now look like this:
+            //   • The Transition Settings form should now look like this:
             PauseForScreenShot<TransitionSettingsUI.FilterTab>("Transition Settings: Filter", 3);
 
             RunUI(() =>
             {
-                //   •	Click the Full-Scan tab in the Transition Settings form.
+                //   • Click the Full-Scan tab in the Transition Settings form.
                 transitionSettingsUI.SelectedTab = TransitionSettingsUI.TABS.FullScan;
-                //   •	 In the MS1 filtering section, set the Isotope peaks included field to Count.
+                //   •  In the MS1 filtering section, set the Isotope peaks included field to Count.
                 transitionSettingsUI.PrecursorIsotopesCurrent = FullScanPrecursorIsotopes.Count;
-                //   •	Set the Precursor mass analyzer field to TOF.
+                //   • Set the Precursor mass analyzer field to TOF.
                 transitionSettingsUI.PrecursorMassAnalyzer = FullScanMassAnalyzerType.tof;
-                //   •	Enter “20,000” in the Resolving power field.
+                //   • Enter “20,000” in the Resolving power field.
                 transitionSettingsUI.PrecursorRes = 20000;
-                //   •	In the MS/MS filtering section, set the Acquisition method field to DIA.
+                //   • In the MS/MS filtering section, set the Acquisition method field to DIA.
                 transitionSettingsUI.AcquisitionMethod = FullScanAcquisitionMethod.DIA;
-                //   •	Set the Isolation scheme field to All Ions.
+                //   • Set the Isolation scheme field to All Ions.
                 transitionSettingsUI.IsolationSchemeName = IsolationScheme.SpecialHandlingType.ALL_IONS;
-                //   •	Enter “20,000” in the Resolving power field.
+                //   • Enter “20,000” in the Resolving power field.
                 transitionSettingsUI.ProductRes = 20000;
-                //   •	Check Use high-selectivity extraction.
+                //   • Check Use high-selectivity extraction.
                 transitionSettingsUI.UseSelectiveExtraction = true;
             });
 
             //   The Transition Settings form should look like this:
             PauseForScreenShot<TransitionSettingsUI.FullScanTab>("Transition Settings - Full-Scan", 4);
-            //   •	Click the OK button.
+            //   • Click the OK button.
             OkDialog(transitionSettingsUI, transitionSettingsUI.OkDialog);
             doc = WaitForDocumentChange(doc);
 
             //   Adding and Exploring a Spectral Library
             // Before you can explore the library, Skyline must be directed to its location by adding your library of interest to the global list of libraries for document editing.
             //   To get started with the small molecule library containing Drosophila lipids perform the following steps:
-            //   •	From the Settings menu, click Molecule Settings.
-            //   •	Click the Library tab.
+            //   • From the Settings menu, click Molecule Settings.
+            //   • Click the Library tab.
             var peptideSettingsUI = ShowDialog<PeptideSettingsUI>(() =>
                 SkylineWindow.ShowPeptideSettingsUI(PeptideSettingsUI.TABS.Library));
-            //   •	Click the Edit List button.
+            //   • Click the Edit List button.
             var libListDlg =
                 ShowDialog<EditListDlg<SettingsListBase<LibrarySpec>, LibrarySpec>>(peptideSettingsUI.EditLibraryList);
-            //   •	Click the Add button in the Edit Libraries form.
+            //   • Click the Add button in the Edit Libraries form.
             var addLibDlg = ShowDialog<EditLibraryDlg>(libListDlg.AddItem);
             var drosophilaLipids = "Drosophila Lipids";
             RunUI(() =>
             {
-                //   •	Enter “Drosophila Lipids” in the Name field of the Edit Library form.
+                //   • Enter “Drosophila Lipids” in the Name field of the Edit Library form.
                 addLibDlg.LibraryName = drosophilaLipids;
-                //   •	Click the Browse button.
-                //   •	Navigate to the SmallMoleculeLibraries folder created earlier.
-                //   •	Select the “Drosophila_Lipids_Neg.blib” file.
+                //   • Click the Browse button.
+                //   • Navigate to the SmallMoleculeLibraries folder created earlier.
+                //   • Select the “Drosophila_Lipids_Neg.blib” file.
                 addLibDlg.LibraryPath = GetFullDataPath("Drosophila_Lipids_Neg.blib");
             });
-            //   •	Click the Open button.
-            //   •	Click the OK button in the Edit Library form.
+            //   • Click the Open button.
+            //   • Click the OK button in the Edit Library form.
             OkDialog(addLibDlg, addLibDlg.OkDialog);
-            //   •	Click the OK button in the Edit Libraries form.
+            //   • Click the OK button in the Edit Libraries form.
             OkDialog(libListDlg, libListDlg.OkDialog);
 
             //   The Libraries list in the Molecule Settings form should now contain the Drosophila Lipids library you just created.
-            //   •	Check the Drosophila Lipids checkbox to tell Skyline to use this library in the current document.
-            //   •	If you have any other libraries in this list checked, uncheck them now.
+            //   • Check the Drosophila Lipids checkbox to tell Skyline to use this library in the current document.
+            //   • If you have any other libraries in this list checked, uncheck them now.
             RunUI(() =>
             {
                 peptideSettingsUI.PickedLibraries = new[] {drosophilaLipids};
@@ -165,12 +165,12 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             });
             //   The Molecule Settings form should now look like:
             PauseForScreenShot<PeptideSettingsUI.LibraryTab>("Molecule Settings - Library", 6);
-            //   •	Click the OK button in the Molecule Settings form.
+            //   • Click the OK button in the Molecule Settings form.
             OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
             doc = WaitForDocumentChangeLoaded(doc);
 
             //   To open the library explorer and view the contents of the library you just added, do the following: 
-            //   •	From the View menu, click Spectral Libraries.
+            //   • From the View menu, click Spectral Libraries.
             var viewLibUI = ShowDialog<ViewLibraryDlg>(SkylineWindow.ViewSpectralLibraries);
             RunUI(() =>
             {
@@ -182,8 +182,8 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             PauseForScreenShot("Library Explorer (probably need to resize wider)", 7);
 
             //  To add all the molecules in the library to your target list:
-            //   •	Click the Add All button.
-            //   •	A popup window will then notify you that you will add 34 molecules, 38 precursors, and 246 transitions to the document. Click Add All.
+            //   • Click the Add All button.
+            //   • A popup window will then notify you that you will add 34 molecules, 38 precursors, and 246 transitions to the document. Click Add All.
             var confirmAddDlg = ShowDialog<AlertDlg>(viewLibUI.AddAllPeptides);
             using (new CheckDocumentState(1, 34, 38, 246))
             {
@@ -191,7 +191,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 doc = WaitForDocumentChangeLoaded(doc);
             }
 
-            //   •	Close the Spectral Library Explorer window.
+            //   • Close the Spectral Library Explorer window.
             OkDialog(viewLibUI, viewLibUI.CancelDialog);
 
             //   Your Skyline window should now resemble:
@@ -200,17 +200,17 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
 
             //Importing Results Chromatogram.Data
             //    In this section, you will import the Drosophila data without utilizing IMS filtering. This is an initial look at the data to see the impact of interference among lipids and their shared fragments. To import the data, perform the following steps:
-            //   •	On the File menu, click Save (Ctrl+S).
-            //   •	Save this document in the tutorial folder you created.
+            //   • On the File menu, click Save (Ctrl+S).
+            //   • Save this document in the tutorial folder you created.
             RunUI(() => SkylineWindow.SaveDocument(TestFilesDirs[0].GetTestPath("Tutorial.sky")));
 
-            //   •	From the File menu, choose Import and click Results.
+            //   • From the File menu, choose Import and click Results.
             using (new WaitDocumentChange(null, true))
             {
                 var askDecoysDlg = ShowDialog<MultiButtonMsgDlg>(SkylineWindow.ImportResults);
                 var importResultsDlg1 = ShowDialog<ImportResultsDlg>(askDecoysDlg.ClickNo);
-                //   •	Set the Files to import simultaneously field to Many.
-                //   •	Check Show chromatograms during import.
+                //   • Set the Files to import simultaneously field to Many.
+                //   • Check Show chromatograms during import.
                 //   The Import Results form will appear as follows:
                 RunUI(() =>
                 {
@@ -220,9 +220,9 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 PauseForScreenShot<ImportResultsDlg>("Import Results", 9);
                 var openDataSourceDialog1 = ShowDialog<OpenDataSourceDialog>(() => importResultsDlg1.NamedPathSets =
                     importResultsDlg1.GetDataSourcePathsFile(null));
-                //   •	Click the OK button.
+                //   • Click the OK button.
                 //   The Import Results Files form will now show the.d files you have extracted into the tutorial folder:
-                //   •	Select both .d files.
+                //   • Select both .d files.
                 RunUI(() =>
                 {
                     var path = Path.GetDirectoryName(GetFullDataPath(Flies_M));
@@ -234,8 +234,8 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 PauseForScreenShot<OpenDataSourceDialog>("Import Results Files selection form", 10);
                 OkDialog(openDataSourceDialog1, openDataSourceDialog1.Open);
 
-                //   •	Click the Open button.
-                //   •	The Import Results window will ask if you would like to remove the common prefix and suffix to shorten the file names used in Skyline.Click OK to accept the names “F_A_018” and “M_A_001”.
+                //   • Click the Open button.
+                //   • The Import Results window will ask if you would like to remove the common prefix and suffix to shorten the file names used in Skyline.Click OK to accept the names “F_A_018” and “M_A_001”.
                 //This should start the import and cause Skyline to show the Importing Results progress form:
                 var importResultsNameDlg = ShowDialog<ImportResultsNameDlg>(importResultsDlg1.OkDialog);
                 OkDialog(importResultsNameDlg, importResultsNameDlg.OkDialog);
@@ -254,16 +254,16 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             //    Once the files are imported, you can examine the chromatograms to evaluate interference from peaks with retention times and m/z values within the tolerance of your target list.
             RunUI(() =>
             {
-                //   •	From the Edit menu, choose Expand All and click Molecules (Ctrl+D).
+                //   • From the Edit menu, choose Expand All and click Molecules (Ctrl+D).
                 SkylineWindow.ExpandPeptides();
                 SkylineWindow.SetDisplayTypeChrom(DisplayTypeChrom.all);
-                //   •	From the View menu, choose Arrange Graphs and click Tiled (Ctrl+T).
+                //   • From the View menu, choose Arrange Graphs and click Tiled (Ctrl+T).
                 SkylineWindow.ArrangeGraphs(DisplayGraphsType.Row); // With just two panes, Tiled may go either row or column, force row 
-                //   •	Right-click in a chromatogram graph and click Synchronize Zooming(leave if already checked).
+                //   • Right-click in a chromatogram graph and click Synchronize Zooming(leave if already checked).
                 SkylineWindow.SynchronizeZooming(true);
-                // •	Right-click in a chromatogram graph and click Legend to hide the legend.
+                // • Right-click in a chromatogram graph and click Legend to hide the legend.
                 SkylineWindow.ShowChromatogramLegends(false);
-                //   •	Right-click in a chromatogram graph, choose Transitions and click Split Graph (leave if already checked).
+                //   • Right-click in a chromatogram graph, choose Transitions and click Split Graph (leave if already checked).
                 SkylineWindow.ShowSplitChromatogramGraph(true);
                 SkylineWindow.AutoZoomBestPeak();
                 SkylineWindow.Size = new Size(1487, 786);
@@ -274,7 +274,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 propDlg.TimeRange = 7; // minutes
                 propDlg.OkDialog();
             });
-            //  •	Select the molecule PC(16:0_18:1) and your spectra should appear as: 
+            //  • Select the molecule PC(16:0_18:1) and your spectra should appear as: 
             FindNode("PC(16:0_18:1)");
             PauseForScreenShot("Chromatograms - prtsc-paste-edit", 12);
 
@@ -284,19 +284,19 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             PauseForScreenShot("Library Match", 13);
 
             //Since there are only 38 precursors in this document, you may want to review all 38 to get an overall feel for how the XIC look prior to IMS filtering.Before starting this review, do the following:
-            //   •	On the View menu, choose Retention Times and click Replicate Comparison (F8).
-            //   •	Attach the Retention Times view to the left of the Library Match view by clicking in the title bar and dragging until the mouse cursor is inside the left-side docking icon.
+            //   • On the View menu, choose Retention Times and click Replicate Comparison (F8).
+            //   • Attach the Retention Times view to the left of the Library Match view by clicking in the title bar and dragging until the mouse cursor is inside the left-side docking icon.
             RunUI(() =>
             {
                 SkylineWindow.ShowGraphRetentionTime(true, GraphTypeSummary.replicate);
-                //   •	Right-click in the Retention Times view and click Legend to hide the legend in this graph.
+                //   • Right-click in the Retention Times view and click Legend to hide the legend in this graph.
                 SkylineWindow.ShowRTLegend(false);
             });
 
-            //   •	From the View menu, choose Peak Areas and click Replicate Comparison (F7).
+            //   • From the View menu, choose Peak Areas and click Replicate Comparison (F7).
             RestoreViewOnScreen(14);
 
-            //   •	Attach the Peak Areas view above the Retention Times view by clicking in the title bar and dragging until the mouse cursor is inside the up-side docking icon.
+            //   • Attach the Peak Areas view above the Retention Times view by clicking in the title bar and dragging until the mouse cursor is inside the up-side docking icon.
             //    You should end up with a similar layout to that below:
             RunUI(() =>
             {
@@ -321,8 +321,8 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
 
             //Understanding and Utilizing the IMS Separation
             //To this point, we have ignored the IMS dimension in this data.To better understand the IMS separation, you need to look at the underlying spectra from which these chromatograms were extracted by doing the following:
-            //   •	On the View menu, choose Auto-Zoom and click Best Peak (F11).
-            //   •	Select the molecule PE(16:1_18:3).
+            //   • On the View menu, choose Auto-Zoom and click Best Peak (F11).
+            //   • Select the molecule PE(16:1_18:3).
             FindNode("PE(16:1_18:3)");
             WaitForGraphs();
             RunDlg<ChromChartPropertyDlg>(SkylineWindow.ShowChromatogramProperties, propDlg =>
@@ -334,29 +334,29 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             WaitForGraphs();
             PauseForScreenShot("Chromatogram", 15);
 
-            //   •	Hover the mouse cursor over the precursor chromatogram peak apex until a blue circle appears that tracks the mouse movement, and click on it.
+            //   • Hover the mouse cursor over the precursor chromatogram peak apex until a blue circle appears that tracks the mouse movement, and click on it.
             ClickChromatogram(F_A_018, 14.81, 162.1E3, PaneKey.PRECURSORS);
             //   This should bring up the Full-Scan view showing a familiar two-dimensional spectrum in profile mode:
             RunUI(() => SkylineWindow.GraphFullScan.SetSpectrum(true));
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
             PauseForScreenShot("2D plot", 16);
 
-            //   •	Click the Show 2D Spectrum button  to change the plot to a three-dimensional spectrum with drift time.
+            //   • Click the Show 2D Spectrum button  to change the plot to a three-dimensional spectrum with drift time.
             RunUI(() => SkylineWindow.GraphFullScan.SetSpectrum(false));
             PauseForScreenShot("3D plot", 16);
 
-            //   •	Click the Zoom to Selection button to see the entire 3D MS1 spectrum at the selected retention time.
+            //   • Click the Zoom to Selection button to see the entire 3D MS1 spectrum at the selected retention time.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(false));
             PauseForScreenShot("3D plot full range", 17);
 
             //    This is a fairly typical MS1 spectrum for IMS-MS lipidomics data.You can get a better sense of the data by zooming into multiple areas on this plot.You can also select other lipids and click on the blue circle at the apex of each precursor chromatogram peak to see how this plot can differ with retention time. An interesting example is PE(O-18:0/16:1), which has distinct ion distributions showing correlations between m/z and drift time for different lipid classes.
             //    To inspect a relevant MS/MS spectrum:
-            //   •	Re-select the molecule PE(16:1_18:3) if you navigated away from it to view other MS1 spectra.
+            //   • Re-select the molecule PE(16:1_18:3) if you navigated away from it to view other MS1 spectra.
             FindNode("PE(16:1_18:3)");
-            //   •	Click on the Zoom to Selection button to zoom back in.
+            //   • Click on the Zoom to Selection button to zoom back in.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
             WaitForGraphs();
-            //   •	Hover the mouse over the FA 18:3(+O) fragment chromatogram peak apex until a teal colored circle appears that tracks the mouse movement, and click on it.
+            //   • Hover the mouse over the FA 18:3(+O) fragment chromatogram peak apex until a teal colored circle appears that tracks the mouse movement, and click on it.
             ClickChromatogram(F_A_018, 14.83, 120.5E3, PaneKey.PRODUCTS);
             //   The Full-Scan graph should change to:
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
@@ -364,7 +364,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
 
 
             //You can see that at least three visible ions are contributing to the extracted intensities at 33, 37, and 44 ms.This goes back to the nature of lipid fragmentation as previously discussed, where most lipids with an 18:3 fatty acyl chain will share this fragment.The complexity is increased for fatty acyl chains fragments with fewer double bonds, such as 18:2 at m/z 279, which may have multiple ions as well as isotopic overlap from the abundant 18:3 fragment at m/z 277 contributing to the extracted intensity.A similar observation can be made with the FA 16:1(+O) fragment.
-            //   •	Click the Zoom to Selection button again to see the entire 3D MS/MS spectrum.
+            //   • Click the Zoom to Selection button again to see the entire 3D MS/MS spectrum.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(false));
             PauseForScreenShot("3D plot MSMS full range", 18);
 
@@ -372,19 +372,19 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             //    Reimporting Data with Drift Time Filtering
 
             // Prior to changing the settings and reimporting the data, you may want to save the current Skyline document and create a second file in order to compare the data before and after IMS filtering. To do so:
-            //    •	On the File menu, click Save As...
-            //    •	Save the file with a different name than your original Skyline document, such as “Drosophila_Lipids_Neg_IMS_Filtered”, in the tutorial folder you created.
+            //    • On the File menu, click Save As...
+            //    • Save the file with a different name than your original Skyline document, such as “Drosophila_Lipids_Neg_IMS_Filtered”, in the tutorial folder you created.
             RunUI(() => SkylineWindow.SaveDocument(TestFilesDirs[0].GetTestPath(@"Drosophila_Lipids_Neg_IMS_Filtered.sky")));
             RunUI(() => SkylineWindow.Width -= 300);
 
-            //   •	From the Settings menu, click Transition Settings.
-            //   •	Click the Ion Mobility tab.
+            //   • From the Settings menu, click Transition Settings.
+            //   • Click the Ion Mobility tab.
             transitionSettingsUI = ShowDialog<TransitionSettingsUI>(() =>
                 SkylineWindow.ShowTransitionSettingsUI(TransitionSettingsUI.TABS.IonMobility));
 
-            //   •	Check Use spectral library ion mobility values when present.
-            //   •	Set the Window Type field to Resolving power.
-            //   •	In the Resolving power field, enter “50”.
+            //   • Check Use spectral library ion mobility values when present.
+            //   • Set the Window Type field to Resolving power.
+            //   • In the Resolving power field, enter “50”.
             RunUI(() =>
             {
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
@@ -394,20 +394,20 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                     IonMobilityWindowWidthCalculator.IonMobilityWindowWidthType.resolving_power;
                 transitionSettingsUI.Left = SkylineWindow.Right + 20;
             });
-            //   •	The Transition Settings form should now look like this:
+            //   • The Transition Settings form should now look like this:
             PauseForScreenShot<TransitionSettingsUI.IonMobilityTab>("Transition Settings: IonMobility", 20);            //The Transition Settings should now look like:
 
 
-            //   •	Click the OK button.
+            //   • Click the OK button.
             OkDialog(transitionSettingsUI, transitionSettingsUI.OkDialog);
             WaitForDocumentChange(doc);
 
             //   The results must now be reimported with the newly applied IMS settings.
-            //   •	From the Edit menu, click Manage Results.
-            //   •	Click the Re-import button. “*” Should appear to the left of F_A_018.
-            //   •	Select M_A_001 in the Manage Results view.
-            //   •	Click the Re-import button. “*” Should appear to the left of M_A_001.
-            //   •	Click the OK button.
+            //   • From the Edit menu, click Manage Results.
+            //   • Click the Re-import button. “*” Should appear to the left of F_A_018.
+            //   • Select M_A_001 in the Manage Results view.
+            //   • Click the Re-import button. “*” Should appear to the left of M_A_001.
+            //   • Click the OK button.
             doc = SkylineWindow.Document;
             RunDlg<ManageResultsDlg>(SkylineWindow.ManageResults, manageDlg =>
             {
@@ -418,14 +418,14 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             //   This should start the re-import and cause Skyline to show the Importing Results progress form.
             WaitForDocumentChangeLoaded(doc);
 
-            //   •	Click any other lipid in the Target list and re-select PE(16:1_18:3) to update the chromatograms.
+            //   • Click any other lipid in the Target list and re-select PE(16:1_18:3) to update the chromatograms.
             FindNode("PC(16:0_18:1)");
             WaitForGraphs();
             FindNode("PE(16:1_18:3)");
             WaitForGraphs();
             //   To explore the filtered data, perform the following:
-            //   •	Click on the apex of the blue precursor chromatogram to show the Full-Scan graph.
-            //   •	Click the Zoom to Selection button.
+            //   • Click on the apex of the blue precursor chromatogram to show the Full-Scan graph.
+            //   • Click the Zoom to Selection button.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
             //   The Full-Scan graph should now look something like this:
             ClickChromatogram(F_A_018, 14.807, 152.0E3, PaneKey.PRECURSORS);
@@ -442,7 +442,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             PauseForScreenShot("Full scan graph with IM filtering", 21);
 
             // Note that if you were interested in lipids that are not present in the current spectral library, you can add to it manually or using LipidCreator. To access the LipidCreator plugin, do the following:
-            //   •	From the Tools menu, click Tool Store.
+            //   • From the Tools menu, click Tool Store.
             if (IsPauseForScreenShots)
             {
                 RunUI(() =>
@@ -451,7 +451,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                     SkylineWindow.Width -= 300;
                 });
                 var configureToolsDlg = ShowDialog<ConfigureToolsDlg>(SkylineWindow.ShowConfigureToolsDlg);
-                //   •	Select LipidCreator.
+                //   • Select LipidCreator.
                 var pick = ShowDialog<ToolStoreDlg>(configureToolsDlg.AddFromWeb);
                 RunUI(() =>
                 {
@@ -461,12 +461,12 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 PauseForScreenShot("LipidCreator in tool store", 22);
                 RunUI(() => pick.CancelDialog());
                 OkDialog(configureToolsDlg, configureToolsDlg.Cancel);
-                //   •	Click the Install button.
+                //   • Click the Install button.
             }
 
             //   The following steps can be taken to easily export an updated spectral library:
-            //   •	From the File menu, choose Export and click Spectral Library.
-            //   •	Enter a file name and click Save.
+            //   • From the File menu, choose Export and click Spectral Library.
+            //   • Enter a file name and click Save.
 
         }
     }

--- a/pwiz_tools/Skyline/TestTutorial/QuasarTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/QuasarTutorialTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -41,7 +41,7 @@ namespace pwiz.SkylineTestTutorial
     {
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
-        const int WM_KEYDOWN	= 0x100;
+        const int WM_KEYDOWN    = 0x100;
         private const int WM_KEYUP = 0x101;
 
         [TestMethod, NoLocalization]

--- a/pwiz_tools/Skyline/TestTutorial/QuasarTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/QuasarTutorialTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Util/BioMassCalc.cs
+++ b/pwiz_tools/Skyline/Util/BioMassCalc.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -480,7 +480,7 @@ namespace pwiz.Skyline.Util
                     continue;
                 }
                 AddMass(entry.Key, entry.Value.AverageMass);
-			}
+            }
 
             // Add entries for isotope synonyms like D (H') and T (H")
             foreach (var kvp in DICT_HEAVYSYMBOL_NICKNAMES) 

--- a/pwiz_tools/Skyline/Util/BioMassCalc.cs
+++ b/pwiz_tools/Skyline/Util/BioMassCalc.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Brendan MacLean <brendanx .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Util/ClipboardEx.cs
+++ b/pwiz_tools/Skyline/Util/ClipboardEx.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Original author: Don Marsh <donmarsh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *

--- a/pwiz_tools/Skyline/Util/ClipboardEx.cs
+++ b/pwiz_tools/Skyline/Util/ClipboardEx.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Don Marsh <donmarsh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *
@@ -27,7 +27,7 @@ namespace pwiz.Skyline.Util
     {
         public const string SKYLINE_FORMAT = "Skyline Format";
 
-	    private static bool _useSystemClipboard = true;
+        private static bool _useSystemClipboard = true;
         private static DataObject _dataObject;
 
         // Set this true to check that the internal clipboard returns the

--- a/pwiz_tools/Skyline/Util/SSRCalc3.cs
+++ b/pwiz_tools/Skyline/Util/SSRCalc3.cs
@@ -1407,18 +1407,18 @@ namespace pwiz.Skyline.Util
         // convert electric to scaler - v 2,3 algorithms
         private static double electric_scale(double v)
         {
-	        double best=1.0;
+            double best=1.0;
 
             // Translator2 Note: this is commented out in the perl source
             // if (NOELECTRIC==1) { return 1.0; }
-        	
-	        foreach (Isoparams p in ISOPARAMS)
-	        {
-		        if (v > p.emin && v < p.emax)
+            
+            foreach (Isoparams p in ISOPARAMS)
+            {
+                if (v > p.emin && v < p.emax)
                     best= p.eK;
-	        }
+            }
 
-	        return best;            
+            return best;            
         }
         */
     }

--- a/pwiz_tools/Skyline/Util/UtilIO.cs
+++ b/pwiz_tools/Skyline/Util/UtilIO.cs
@@ -1179,10 +1179,10 @@ namespace pwiz.Skyline.Util
         /// <param name="fileName">File path to the final destination</param>
         /// <param name="createStream">If true, create a Stream for the temporary file</param>
         /// <throws>IOException</throws>
-		public FileSaver(string fileName, bool createStream = false)
+        public FileSaver(string fileName, bool createStream = false)
             : this(fileName, FileStreamManager.Default, createStream)
-		{
-		}
+        {
+        }
 
         /// <summary>
         /// Construct an instance of <see cref="FileSaver"/> to manage saving to a temporary
@@ -1198,14 +1198,14 @@ namespace pwiz.Skyline.Util
 
             RealName = fileName;
 
-		    string dirName = Path.GetDirectoryName(fileName);
-		    string tempName = _streamManager.GetTempFileName(dirName, TEMP_PREFIX);
+            string dirName = Path.GetDirectoryName(fileName);
+            string tempName = _streamManager.GetTempFileName(dirName, TEMP_PREFIX);
             // If the directory name is returned, then starting path was bogus.
             if (!Equals(dirName, tempName))
                 SafeName = tempName;
             if (createStream)
                 CreateStream();
-		}
+        }
 
         public void CreateStream()
         {
@@ -1283,10 +1283,10 @@ namespace pwiz.Skyline.Util
         public bool Commit(IPooledStream streamDest)
         {
             // This is where the file that got written is renamed to the desired file.
-	        // Dispose() will do any necessary temporary file clean-up.
+            // Dispose() will do any necessary temporary file clean-up.
 
-	        if (string.IsNullOrEmpty(SafeName))
-		        return false;
+            if (string.IsNullOrEmpty(SafeName))
+                return false;
 
             if (_stream != null)
             {
@@ -1302,7 +1302,7 @@ namespace pwiz.Skyline.Util
 //                _streamManager.Commit(baseMatchFile, Path.ChangeExtension(RealName, baseMatchFile.Substring(SafeName.LastIndexOf('.'))), null);
 //            }
 
-        	Dispose();
+            Dispose();
 
             return true;
         }


### PR DESCRIPTION
Only real change here is to the DotSettings file, everything else is cosmetic changes from tab to 4 spaces.

Note that ReSharper does not complain about tab characters inside strings, which is good since a lot of our tests have that (in FASTA data especially)