### PR TITLE
Fix ChromSource AssumptionException in UpdateScanProvider

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -319,7 +319,7 @@ namespace pwiz.Skyline.Controls.Graphs
             var clickedItem = (ChromGraphItem) _closestCurve.Tag;
             if (clickedItem.TransitionNode == null)
                 return;
-            var chromatogramGroupInfo = clickedItem.Chromatogram;
+            var chromatogramInfo = clickedItem.Chromatogram;
 
             double displayTime = graphPane.CurveList[FULLSCAN_TRACKING_INDEX][0].X;
             var retentionTime = clickedItem.GetValidPeakBoundaryTime(displayTime);
@@ -335,9 +335,9 @@ namespace pwiz.Skyline.Controls.Graphs
             {
                 curveList = GetCurveList(graphPane);
             }
-            int scanIndex = MsDataFileScanHelper.FindScanIndex(chromatogramGroupInfo, retentionTime.MeasuredTime);
+            int scanIndex = MsDataFileScanHelper.FindScanIndex(chromatogramInfo, retentionTime.MeasuredTime);
             var transitions = new List<TransitionFullScanInfo>(curveList.Count);
-            int transitionIndex = 0;
+            int? transitionIndex = null;
             foreach (var curve in curveList)
             {
                 var graphItem = (ChromGraphItem) curve.Tag;
@@ -357,12 +357,18 @@ namespace pwiz.Skyline.Controls.Graphs
                     Id = graphItem.TransitionNode.Id
                 });
             }
+
+            if (!transitionIndex.HasValue)
+            {
+                // Curve that they clicked on is no longer in CurveList
+                return;
+            }
             var measuredResults = DocumentUI.Settings.MeasuredResults;
             IScanProvider scanProvider = new ScanProvider(_documentContainer.DocumentFilePath, FilePath, 
-                chromatogramGroupInfo.Source, chromatogramGroupInfo.Times, transitions.ToArray(), measuredResults);
+                chromatogramInfo.Source, chromatogramInfo.Times, transitions.ToArray(), measuredResults);
             var e = new ClickedChromatogramEventArgs(
                 scanProvider,
-                transitionIndex, 
+                transitionIndex.Value, 
                 scanIndex);
             if (ClickedChromatogram != null)    // For ReSharper
                 ClickedChromatogram(this, e);


### PR DESCRIPTION
Fixed error in full scan spectrum viewer that could happen if you rapidly click multiple times on the chromatogram graph. (Reported by Lauren)