### PR TITLE
Fix for Issue 805: "Stopping SkylineTester does not abort the second run of SkylineNightly"

### DIFF
--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -187,7 +187,7 @@ namespace SkylineNightly
 
         public enum RunMode { parse, post, trunk, perf, release, stress, integration, release_perf, integration_perf }
 
-        private string SkylineTesterStoppedByUser = "SkylineTester stopped by user";
+        public static string SkylineTesterStoppedByUser = "SkylineTester stopped by user";
 
         public string RunAndPost()
         {


### PR DESCRIPTION
On a machine set to run, say, trunk then perf, if the user kills the trunk run then we should assume they don't want the perf run either.