### PR TITLE
Add msconvert.exe to Administrator Installer

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/ABI/Jamfile.jam
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/Jamfile.jam
@@ -53,7 +53,7 @@ rule vendor-api-requirements ( properties * )
         result += <assembly>$(dll_location)/Sciex.Data.XYData.dll ;
         result += <assembly>$(dll_location)/SCIEX.Apis.Data.v1.dll ;
         result += <assembly-dependency>$(dll_location)/$(PLATFORM)/SQLite.Interop.dll ;
-        result += <assembly>$(PWIZ_LIBRARIES_PATH)/SQLite/$(PLATFORM)/System.Data.SQLite.DLL ;
+        result += <assembly>$(PWIZ_LIBRARIES_PATH)/SQLite/$(PLATFORM)/System.Data.SQLite.dll ;
 
         result += <assembly-dependency>$(dll_location)/Clearcore2.Compression.dll ;
         result += <assembly-dependency>$(dll_location)/Clearcore2.Data.Wiff2.dll ;
@@ -71,7 +71,7 @@ rule vendor-api-requirements ( properties * )
         result += <assembly-dependency>$(dll_location)/Sciex.Clearcore.FMan.dll ;
         result += <assembly-dependency>$(dll_location)/Sciex.FMan.dll ;
         result += <assembly-dependency>$(dll_location)/Sciex.Wiff.dll ;
-        result += <assembly-dependency>$(dll_location)/Sciex.Data.Processing.DLL ;
+        result += <assembly-dependency>$(dll_location)/Sciex.Data.Processing.dll ;
         result += <assembly-dependency>$(dll_location)/Sciex.Data.SimpleTypes.dll ;
 
         result += <include>$(dll_location) ;

--- a/pwiz_tools/Skyline/Executables/Installer/FileList64-template.txt
+++ b/pwiz_tools/Skyline/Executables/Installer/FileList64-template.txt
@@ -170,6 +170,7 @@ Microsoft.Practices.Unity.Configuration.dll (included automatically from ProteoW
 Microsoft.Practices.Unity.dll (included automatically from ProteoWizard; DO NOT ADD TO THE WXS TEMPLATE!)
 MIDAC.dll (included automatically from ProteoWizard; DO NOT ADD TO THE WXS TEMPLATE!)
 modifications.xml
+msconvert.exe
 MSGraph.dll
 MSGraph.pdb
 MSMSDBCntl.dll (included automatically from ProteoWizard; DO NOT ADD TO THE WXS TEMPLATE!)

--- a/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
+++ b/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
@@ -208,6 +208,9 @@
       <Component Id="modifications.xml">
         <File Source="$(var.Skyline.TargetDir)/modifications.xml" KeyPath="yes"/>
       </Component>
+      <Component Id="msconvert.exe">
+        <File Source="$(var.Skyline.TargetDir)/msconvert.exe" KeyPath="yes"/>
+      </Component>
       <Component Id="MSGraph.dll">
         <File Source="$(var.Skyline.TargetDir)/MSGraph.dll" KeyPath="yes"/>
       </Component>

--- a/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
+++ b/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
@@ -92,7 +92,7 @@
       <Directory Id="sv_directory" Name="sv"/>
       <Directory Id="tr_directory" Name="tr"/>
       <Directory Id="zh_CHS_directory" Name="zh-CHS"/>
-      <Directory Id="zh_tw_directory" Name="zh-tw"/>
+      <Directory Id="zh_tw_directory" Name="zh-TW"/>
       
       <Directory Id="Method_directory" Name="Method">
         <Directory Id="Method_AbSciex_directory" Name="AbSciex">


### PR DESCRIPTION
Fixed missing msconvert.exe from Admin Installer (reported by Dilip)
Also, change capitalization of a couple of dll's and "zh-TW" folder to be consistent between admin installer and the regular installer.
