### PR TITLE
Tweaks for code coverage speed and stability

### DIFF
--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudiesTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudiesTutorialTest.cs
@@ -47,8 +47,6 @@ namespace pwiz.SkylineTestTutorial
         {
             // Set true to look at tutorial screenshots.
             //IsPauseForScreenShots = true;
-ForceMzml = (DateTime.Now.DayOfYear % 2) == 0;   // TODO(bspratt) remove this once we're convinced that WIFF isn't the source of leaks and hangs
-
 
             TestFilesZipPaths = new[]
                 {
@@ -127,7 +125,7 @@ ForceMzml = (DateTime.Now.DayOfYear % 2) == 0;   // TODO(bspratt) remove this on
                 RunUI(() =>
                 {
                         editIrtCalcDlg.CalcName = irtCalcName;
-                        editIrtCalcDlg.CreateDatabase(GetOcRawTestPath("iRT-OC-Study.irtdb")); // Not L10N
+                        editIrtCalcDlg.CreateDatabase(GetTestPath("iRT-OC-Study.irtdb")); // Not L10N
                         SetTransitionClipboardText(new[] {15, 17}, c =>
                             {
                                 if (string.Equals(c[8], "protein_name"))
@@ -202,19 +200,23 @@ ForceMzml = (DateTime.Now.DayOfYear % 2) == 0;   // TODO(bspratt) remove this on
                 OkDialog(peptideSettingsUI2, peptideSettingsUI2.OkDialog);
             }
 
-            RunUI(() => SkylineWindow.SaveDocument(GetOcRawTestPath("OC-study.sky")));
+            RunUI(() => SkylineWindow.SaveDocument(GetTestPath("OC-study.sky")));
 
             // Importing Data
             ImportResultsFiles(GetOcRawTestPath(), ExtAbWiff,
                 IsFullData ? "R201217" : "R201217_plasma_revision_A", true);
             WaitForCondition(5*60*1000, () =>
                 SkylineWindow.Document.Settings.HasResults && SkylineWindow.Document.Settings.MeasuredResults.IsLoaded);
+            WaitForDocumentLoaded();
+
             ImportResultsFiles(GetOcRawTestPath(), ExtAbWiff,
                 IsFullData ? "R201203" : "R201203_plasma_revision_F", true);
             WaitForCondition(2*60*1000, () =>
                 SkylineWindow.Document.Settings.HasResults && SkylineWindow.Document.Settings.MeasuredResults.IsLoaded);
+            WaitForDocumentLoaded();
 
             PauseForScreenShot();
+            LoadNewDocument(true); // Clean up
         }
 
         private void SetTransitionClipboardText(int[] columnIndices, Func<string[], string[]> convertColumns = null)

--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudiesTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudiesTutorialTest.cs
@@ -216,7 +216,6 @@ namespace pwiz.SkylineTestTutorial
             WaitForDocumentLoaded();
 
             PauseForScreenShot();
-            LoadNewDocument(true); // Clean up
         }
 
         private void SetTransitionClipboardText(int[] columnIndices, Func<string[], string[]> convertColumns = null)

--- a/pwiz_tools/Skyline/TestTutorial/QuasarTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/QuasarTutorialTest.cs
@@ -206,6 +206,10 @@ namespace pwiz.SkylineTestTutorial
                 argsCollector.BeginInvoke(actCancel);
                 WaitForClosedForm(argsCollector);
             }
+
+            // Try to prevent the occasional "The process cannot access the file 'QuaSAR_Tutorial.skyd' because it is being
+            // used by another process" error we sometimes see on exit, especially under code coverage on TeamCity
+            WaitForDocumentLoaded();
         }
 
         private static readonly AnnotationDef SAMPLEGROUP = new AnnotationDef("SampleGroup", // Not L10N

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -1904,8 +1904,8 @@ namespace pwiz.Skyline.Util
             if (RunningResharperAnalysis)
             {
                 DetailedTrace.WriteLine($@"We're running under ReSharper analysis, which may throw off timing - adding some extra sleep time");
-                // Allow up to 60 sec extra time when running code coverage or other analysis
-                milliseconds += (60000 * (loopCount+1)) / maxLoopCount; // Each loop a little more desperate
+                // Allow up to 5 sec extra time when running code coverage or other analysis
+                milliseconds += (5000 * (loopCount+1)) / maxLoopCount; // Each loop a little more desperate
             }
             DetailedTrace.WriteLine(string.Format(@"Sleeping {0} ms then retrying...", milliseconds));
             Thread.Sleep(milliseconds);

--- a/pwiz_tools/Skyline/Util/UtilIO.cs
+++ b/pwiz_tools/Skyline/Util/UtilIO.cs
@@ -954,7 +954,10 @@ namespace pwiz.Skyline.Util
         {
             try
             {
-                Helpers.TryTwice(() => Directory.Delete(path, true), $@"Directory.Delete({path})");
+                if (path != null && Directory.Exists(path)) // Don't waste time trying to delete something that's already deleted
+                {
+                    Helpers.TryTwice(() => Directory.Delete(path, true), $@"Directory.Delete({path})");
+                }
             }
 // ReSharper disable EmptyGeneralCatchClause
             catch (Exception) { }


### PR DESCRIPTION
These changes should fix the problem with InstallToolsTest taking an hour to complete (apparently just noise around trying to delete directories that don't exist), and the occasional failure that seems to be from an interaction of TestGroupedStudiesTutorialDraft and TestGroupedStudies1Tutorial