### PR TITLE
Fix an error that could happen when merging .skyd created by differen…

### DIFF
--- a/pwiz_tools/Shared/Common/Collections/StructSerializer.cs
+++ b/pwiz_tools/Shared/Common/Collections/StructSerializer.cs
@@ -37,8 +37,8 @@ namespace pwiz.Common.Collections
     /// <typeparam name="TItem"></typeparam>
     public interface IDirectSerializer<TItem>
     {
-        TItem[] ReadArray(SafeHandle safeHandle, int count);
-        bool WriteArray(SafeHandle safeHandle, TItem[] items);
+        TItem[] ReadArray(FileStream fileStream, int count);
+        bool WriteArray(FileStream fileStream, TItem[] items);
     }
 
     
@@ -162,7 +162,7 @@ namespace pwiz.Common.Collections
             {
                 return null;
             }
-            return DirectSerializer.ReadArray(fileStream.SafeFileHandle, count);
+            return DirectSerializer.ReadArray(fileStream, count);
         }
 
         protected bool TryFastWrite(Stream stream, TItem[] items)
@@ -180,7 +180,7 @@ namespace pwiz.Common.Collections
             {
                 return false;
             }
-            return DirectSerializer.WriteArray(fileStream.SafeFileHandle, items);
+            return DirectSerializer.WriteArray(fileStream, items);
         }
     }
 

--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -742,52 +742,6 @@ namespace pwiz.Skyline.Model.Results
         }
 
         /// <summary>
-        /// A 2x slower version of ReadArray than <see cref="ReadArray(SafeHandle,int)"/>
-        /// that does not require a file handle.  This one is covered in Randy Kern's blog,
-        /// but is originally from Eric Gunnerson:
-        /// <para>
-        /// http://blogs.msdn.com/ericgu/archive/2004/04/13/112297.aspx
-        /// </para>
-        /// </summary>
-        /// <param name="stream">Stream to from which to read the elements</param>
-        /// <param name="count">Number of elements to read</param>
-        /// <returns>New array of elements</returns>
-        public static unsafe ChromTransition5[] ReadArray(Stream stream, int count)
-        {
-            // Use fast version, if this is a file
-            var fileStream = stream as FileStream;
-            if (fileStream != null)
-            {
-                try
-                {
-                    return ReadArray(fileStream.SafeFileHandle, count);
-                }
-                catch (BulkReadException)
-                {
-                    // Fall through and attempt to read the slow way
-                }
-            }
-
-            // CONSIDER: Probably faster in this case to read the entire block,
-            //           and convert from bytes to single float values.
-            ChromTransition5[] results = new ChromTransition5[count];
-            int size = sizeof (ChromTransition5);
-            byte[] buffer = new byte[size];
-            for (int i = 0; i < count; ++i)
-            {
-                if (stream.Read(buffer, 0, size) != size)
-                    throw new InvalidDataException();
-
-                fixed (byte* pBuffer = buffer)
-                {
-                    results[i] = *(ChromTransition5*) pBuffer;
-                }
-            }
-
-            return results;
-        }
-
-        /// <summary>
         /// Direct read of an entire array throw p-invoke of Win32 WriteFile.  This seems
         /// to coexist with FileStream reading that the write version, but its use case
         /// is tightly limited.


### PR DESCRIPTION
…t versions of Skyline with different sizes of the ChromPeak data structure.

When we use the "FastWrite" API to write out a list of ChromPeaks, the original FileStream would not know to be positioned at the new end of the file. If we then tried to use an ordinary FileStream to write some more data, then FileStream.VerifyOSHandlePosition would throw an error:
The OS handle's position is not what FileStream expected. Do not use a handle simultaneously in one FileStream and in Win32 code or another FileStream. This may cause data loss.
This would only happen if the joining of .skyd files involved where the first .skyd file being joined had been made by the current version of Skyline and the second .skyd file being joined had been created by an older version of Skyline which used a different size for the ChromPeak structure.

(Also, remove unused overload of function "ReadArray" in ChromTransition5)