### PR TITLE
Attempt to fix clickonce installer error "The element 'assembly' has invalid child element 'SignedInfo'".

### DIFF
--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/Properties/app.manifest
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/Properties/app.manifest
@@ -27,9 +27,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
-
       <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
 

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/Properties/app.manifest
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/Properties/app.manifest
@@ -27,9 +27,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
-
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
 

--- a/pwiz_tools/Skyline/Properties/app.manifest
+++ b/pwiz_tools/Skyline/Properties/app.manifest
@@ -29,9 +29,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
-
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
 

--- a/pwiz_tools/Skyline/Properties/app.manifest
+++ b/pwiz_tools/Skyline/Properties/app.manifest
@@ -29,9 +29,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
-
       <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
 

--- a/pwiz_tools/Skyline/SkylineCmd/Properties/app.manifest
+++ b/pwiz_tools/Skyline/SkylineCmd/Properties/app.manifest
@@ -30,9 +30,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
-
       <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
 

--- a/pwiz_tools/Skyline/SkylineCmd/Properties/app.manifest
+++ b/pwiz_tools/Skyline/SkylineCmd/Properties/app.manifest
@@ -30,9 +30,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
-
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
 

--- a/pwiz_tools/Skyline/SkylineTester/Properties/app.manifest
+++ b/pwiz_tools/Skyline/SkylineTester/Properties/app.manifest
@@ -27,9 +27,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
-
       <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
 

--- a/pwiz_tools/Skyline/SkylineTester/Properties/app.manifest
+++ b/pwiz_tools/Skyline/SkylineTester/Properties/app.manifest
@@ -27,9 +27,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
-
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
 

--- a/pwiz_tools/Skyline/TestRunner/app.manifest
+++ b/pwiz_tools/Skyline/TestRunner/app.manifest
@@ -27,9 +27,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows Vista -->
-      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
-
       <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
 

--- a/pwiz_tools/Skyline/TestRunner/app.manifest
+++ b/pwiz_tools/Skyline/TestRunner/app.manifest
@@ -27,9 +27,6 @@
            and is designed to work with. Uncomment the appropriate elements
            and Windows will automatically select the most compatible environment. -->
 
-      <!-- Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
-
       <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
 


### PR DESCRIPTION
This error is the same as mentioned on this StackOverflow page:
https://stackoverflow.com/questions/27106385/clickonce-manifest-has-invalid-children-but-xml-matches-old-published-manifest
where they said the solution is to remove the Vista line from the application compatibility section.
From testing on my Windows 11 machine, it appeared to be necessary to remove both the Windows 7 and Windows Vista GUIDs.