### PR TITLE
Add OFX.Core.Contracts.dll to ClickOnce installer.

### DIFF
--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -5602,6 +5602,16 @@
       <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
+    <PublishFile Include="OFX.Core.Contracts">
+      <Visible>False</Visible>
+      <Group>
+      </Group>
+      <TargetPath>
+      </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
+      <FileType>Assembly</FileType>
+    </PublishFile>
     <PublishFile Include="ProteomeDb.pdb">
       <Visible>False</Visible>
       <Group>


### PR DESCRIPTION
Fixed error about missing "OFX.Core.Contracts.dll" when importing SCIEX 6500 QQQ wiff file (reported by Matt)