### PR TITLE
Fix MSFragger download agreement

### DIFF
--- a/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Matt Chambers <matt.chambers42 .at. gmail.com >
  *
  * Copyright 2021 University of Washington - Seattle, WA
@@ -121,12 +121,15 @@ namespace pwiz.Skyline.Alerts
                     {
                         var postData = new NameValueCollection();
                         postData[@"transfer"] = @"academic";
-                        postData[@"agreement2"] = @"true";
-                        postData[@"agreement3"] = @"true";
+                        postData[@"agreement1"] = @"on";
+                        postData[@"agreement2"] = @"on";
+                        postData[@"agreement3"] = @"on";
                         postData[@"name"] = tbName.Text;
                         postData[@"email"] = tbEmail.Text;
                         postData[@"organization"] = tbInstitution.Text;
                         postData[@"download"] = $@"Release {MsFraggerSearchEngine.MSFRAGGER_VERSION}$zip";
+                        if (cbReceiveUpdateEmails.Checked)
+                            postData[@"receive_email"] = @"on";
 
                         // temporarily disable Expect100Continue to avoid (417) Expectation Failed
                         bool lastExpect100ContinueValue = ServicePointManager.Expect100Continue;


### PR DESCRIPTION
With the MSFragger 3.5 release it seems they tweaked the verification code a bit so a new post variable is needed.

This PR also adds support for the "receive_emails" post variable which Skyline has had a checkbox for, but it didn't do anything.

Reported by Mike