### PR TITLE
Add OFX.Core.Contracts.dll to ClickOnce installer. (#2115)

### DIFF
--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -5575,6 +5575,16 @@
       <IncludeHash>True</IncludeHash>
       <FileType>File</FileType>
     </PublishFile>
+    <PublishFile Include="OFX.Core.Contracts">
+      <Visible>False</Visible>
+      <Group>
+      </Group>
+      <TargetPath>
+      </TargetPath>
+      <PublishState>Include</PublishState>
+      <IncludeHash>True</IncludeHash>
+      <FileType>Assembly</FileType>
+    </PublishFile>
     <PublishFile Include="ProteomeDb.pdb">
       <Visible>False</Visible>
       <Group>


### PR DESCRIPTION
Fixed error about missing "OFX.Core.Contracts.dll" when importing SCIEX 6500 QQQ wiff file (reported by Matt)  (no, not that Matt, a different Matt on the support board)