### PR TITLE
Fix some Unhandled Errors related to crosslinked peptides in Edit > Insert > Peptides:

### DIFF
--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
@@ -240,7 +240,7 @@ namespace pwiz.Skyline.Model.Crosslinking
                 if (Settings.TransitionSettings.FullScan.IsHighResPrecursor)
                 {
                     ms1transitions = ms1transitions.SelectMany(tran =>
-                        ExpandPrecursorIsotopes(tran, isotopeDist, useFilter)).ToList();
+                        RemoveUnmeasurable(precursorMz, ExpandPrecursorIsotopes(tran, isotopeDist, useFilter))).ToList();
                 }
             }
             else

--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkSite.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkSite.cs
@@ -38,11 +38,6 @@ namespace pwiz.Skyline.Model.Crosslinking
             {
                 throw new ArgumentOutOfRangeException(nameof(peptideIndex));
             }
-
-            if (aaIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(aaIndex));
-            }
             PeptideIndex = peptideIndex;
             AaIndex = aaIndex;
         }

--- a/pwiz_tools/Skyline/Model/Lib/LibraryKey.cs
+++ b/pwiz_tools/Skyline/Model/Lib/LibraryKey.cs
@@ -701,6 +701,10 @@ namespace pwiz.Skyline.Model.Lib
             var consumedPeptides = new HashSet<int>();
             foreach (var crosslink in Crosslinks)
             {
+                if (!HasValidIndexes(crosslink))
+                {
+                    return false;
+                }
                 var peptideIndexesWithLinks = ImmutableList.ValueOf(crosslink.PeptideIndexesWithLinks);
                 if (peptideIndexesWithLinks.Count == 1)
                 {
@@ -756,6 +760,28 @@ namespace pwiz.Skyline.Model.Lib
             {
                 return false;
             }
+            return true;
+        }
+
+        private bool HasValidIndexes(Crosslink crosslink)
+        {
+            if (crosslink.Positions.Count > PeptideLibraryKeys.Count)
+            {
+                return false;
+            }
+
+            for (int iPeptide = 0; iPeptide < crosslink.Positions.Count; iPeptide++)
+            {
+                var peptideSequence = PeptideLibraryKeys[iPeptide].UnmodifiedSequence;
+                foreach (var position in crosslink.Positions[iPeptide])
+                {
+                    if (position < 1 || position > peptideSequence.Length)
+                    {
+                        return false;
+                    }
+                }
+            }
+
             return true;
         }
     }

--- a/pwiz_tools/Skyline/Test/CrosslinkSequenceParserTest.cs
+++ b/pwiz_tools/Skyline/Test/CrosslinkSequenceParserTest.cs
@@ -16,10 +16,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Collections;
+using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Crosslinking;
+using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Lib;
+using pwiz.Skyline.Properties;
+using pwiz.Skyline.Util;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTest
@@ -69,12 +75,60 @@ namespace pwiz.SkylineTest
             VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,2,*][-2@2,*,3]", true);
             // One peptide that is not connected to the rest of the peptides.
             VerifySupported("PEPTIDEA-PEPTIDEB-PEPTIDEC-[-2@2,*,3]", false);
+            // Zero is not a valid amino acid position
+            VerifySupported("VTKIFVDEGPSM[+16]K-VTKIFVDEGPSM[+16]K-[DSBU@1,0]", false);
+            VerifySupported("MKKDIHPKYEEITASC[+57]SC[+57]GNVMK-[DSBU@0-2]", false);
+            // Amino acid position greater than peptide sequence length
+            VerifySupported("VTKIFVDEGPSM[+16]K-VTKIFVDEGPSM[+16]K-[DSBU@14,1]", false);
         }
 
         private static void VerifySupported(string libKeyString, bool expectedSupported)
         {
             var libKey = CrosslinkSequenceParser.ParseCrosslinkLibraryKey(libKeyString, 1);
             Assert.AreEqual(expectedSupported, libKey.IsSupportedBySkyline());
+        }
+
+        /// <summary>
+        /// Verifies that when a crosslinked peptide's precursor m/z is close the the MaxMz instrument settings,
+        /// the user only gets the MS1 precursor transitions which are less than the MaxMz.
+        /// </summary>
+        [TestMethod]
+        public void TestCrosslinkedPeptideCloseToMaxMz()
+        {
+            var crosslinkSequence = "DAIATVNKQEDANFSNNAMAEAFK-KGEDVEK-[DSBU@5,1]";
+            var srmSettings = SrmSettingsList.GetDefault();
+            var crosslinkMod =
+                new StaticMod("DSBU", "K", null, "C9O3N2H12").ChangeCrosslinkerSettings(CrosslinkerSettings.EMPTY);
+            var peptideSettings = srmSettings.PeptideSettings;
+            peptideSettings = peptideSettings.ChangeModifications(
+                peptideSettings.Modifications.ChangeStaticModifications(
+                    ImmutableList.ValueOf(peptideSettings.Modifications.StaticModifications.Append(crosslinkMod))));
+            srmSettings = srmSettings.ChangePeptideSettings(peptideSettings);
+            var transitionSettings = srmSettings.TransitionSettings;
+            var transitionFilter = transitionSettings.Filter;
+            transitionFilter = transitionFilter.ChangePeptideIonTypes(new[] {IonType.precursor});
+            transitionSettings = transitionSettings
+                .ChangeFilter(transitionFilter)
+                .ChangeFullScan(transitionSettings.FullScan
+                    .ChangePrecursorIsotopes(FullScanPrecursorIsotopes.Count, 3, IsotopeEnrichmentsList.GetDefault())
+                    .ChangePrecursorResolution(FullScanMassAnalyzerType.tof, 70000, null));
+            foreach (var maxMz in new[] {1800, 1801, 1802})
+            {
+                srmSettings = srmSettings.ChangeTransitionSettings(transitionSettings.ChangeInstrument(transitionSettings.Instrument.ChangeMaxMz(maxMz)));
+                var modificationMatcher = new ModificationMatcher();
+                var defStaticMods = new MappedList<string, StaticMod>();
+                defStaticMods.AddRange(StaticModList.GetDefaultsOn());
+                defStaticMods.Add(crosslinkMod);
+                modificationMatcher.CreateMatches(srmSettings, new[] { crosslinkSequence }, defStaticMods, new MappedList<string, StaticMod>());
+                var peptideDocNode = modificationMatcher.GetModifiedNode(crosslinkSequence);
+                Assert.AreEqual(1, peptideDocNode.TransitionGroupCount);
+                var transitionGroupDocNode = peptideDocNode.TransitionGroups.First();
+                Assert.AreEqual(1799.85, transitionGroupDocNode.Transitions.First().Mz, .01);
+                foreach (var transition in transitionGroupDocNode.Transitions)
+                {
+                    Assert.IsTrue(transition.Mz <= maxMz, "{0} cannot be greater than {1}", transition.Mz, maxMz);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed Unhandled Error when inserting crosslinked peptide sequence which specified "0" as amino acid position. (Reported by Juan)
Fixed Unhandled Error inserting crosslinked peptide whose precursor m/z was very close to Instrument Max Mz setting. (Reported by Juan)