### PR TITLE
Fix Candidate Peak grid bug

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/OnDemandFeatureCalculator.cs
+++ b/pwiz_tools/Skyline/Model/Results/OnDemandFeatureCalculator.cs
@@ -366,12 +366,10 @@ namespace pwiz.Skyline.Model.Results
                         continue;
                     }
                     var rawTimeIntensities = chromatogramInfo.TimeIntensities;
-                    chromatogramInfo.Transform(TransformChrom.interpolated);
-                    var interpolatedTimeIntensities = chromatogramInfo.TimeIntensities;
                     var chromKey = new ChromKey(PeptideDocNode.ModifiedTarget, transitionGroup.PrecursorMz, null,
                         transition.Mz, 0, 0, transition.IsMs1 ? ChromSource.ms1 : ChromSource.fragment,
                         ChromExtractor.summed, true, false);
-                    chromDatas.Add(new ChromData(chromKey, transition, rawTimeIntensities, interpolatedTimeIntensities));
+                    chromDatas.Add(new ChromData(chromKey, transition, rawTimeIntensities, rawTimeIntensities));
                 }
 
                 if (!chromDatas.Any())


### PR DESCRIPTION
Fix "InvalidOperationException: Cannot truncate data set after interpolation" adjusting peak boundaries with Candidate Peak grid showing.

Fixed error adjusting peak boundaries while Candidate Peaks grid was showing with scheduled PRM data. (Reported by Marc on exception web)