### PR TITLE
SkylineTester: add a couple of UI hints encouraging the use of the Tests tab for demos instead of the Tutorials tab…

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
@@ -871,7 +871,8 @@ namespace SkylineTester
             this.tutorialsDemoMode.Name = "tutorialsDemoMode";
             this.tutorialsDemoMode.Size = new System.Drawing.Size(82, 17);
             this.tutorialsDemoMode.TabIndex = 6;
-            this.tutorialsDemoMode.Text = "Demo mode";
+            this.tutorialsDemoMode.Text = "Demo mode (deprecated, use Tests tab)";
+            this.toolTip1.SetToolTip(this.tutorialsDemoMode, "Use the Tests tab's 'Tutorials only', 'Mode', and 'Run indefinitely' settings for more fine-grained control of demos");
             this.tutorialsDemoMode.UseVisualStyleBackColor = true;
             // 
             // label5


### PR DESCRIPTION
… , which has fewer options. 

Nick and I both were confused by this when trying to get a rolling multi-language demo going. Arguably we should just rip that control out but it's presumably there for a reason.