### PR TITLE
Fix Triggered Chromatogram Acquisition mass error.

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/TimeIntensities.cs
+++ b/pwiz_tools/Skyline/Model/Results/TimeIntensities.cs
@@ -363,7 +363,10 @@ namespace pwiz.Skyline.Model.Results
                     double massError2 = MassErrors[index];
                     double weight1 = intensity1 * (time2 - newTime);
                     double weight2 = intensity2 * (newTime - time1);
-                    newMassError = (weight1 * massError1 + weight2 * massError2) / (weight1 + weight2);
+                    if (weight1 + weight2 > 0)
+                    {
+                        newMassError = (weight1 * massError1 + weight2 * massError2) / (weight1 + weight2);
+                    }
                 }
 
                 if (ScanIds != null)


### PR DESCRIPTION
Fixed bug where mass error would sometimes be reported as zero when "Triggered chromatogram acquisition" is checked (reported by Jeffrey, thanks to Nick)