### PR TITLE
Added SendGa4AnalyticsHit() to send an event to GA4

### DIFF
--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -390,15 +390,16 @@ namespace pwiz.Skyline
             // ReSharper restore LocalizableElement
         }
 
-        internal static void SendGa4AnalyticsHit(bool validateEvent = false)
+        internal static string SendGa4AnalyticsHit(bool useDebugUrl = false)
         {
             // ReSharper disable LocalizableElement
             const string measurementId = "G-CQG6T54XQR";
             const string apiSecret = "8_Ci004BQSKdL1bEazPK3A"; // does this need to be kept secret somehow?
-            string analyticsUrl = $"https://www.google-analytics.com/{(validateEvent ? "debug/" : "")}mp/collect?measurement_id={measurementId}&api_secret={apiSecret}";
+            string debugModifier = useDebugUrl ? "debug/" : "";
+            string analyticsUrl = $"https://www.google-analytics.com/{debugModifier}mp/collect?measurement_id={measurementId}&api_secret={apiSecret}";
 
             var postData = new Dictionary<string, object>();
-            postData["client_id"] = validateEvent ? "test" : Settings.Default.InstallationId;
+            postData["client_id"] = useDebugUrl ? "test" : Settings.Default.InstallationId;
             var events = new List<Dictionary<string, object>>();
             postData["events"] = events;
             events.Add(new Dictionary<string, object>
@@ -429,10 +430,10 @@ namespace pwiz.Skyline
             var responseStream = response.GetResponseStream();
             if (null != responseStream)
             {
-                var responseString = new StreamReader(responseStream).ReadToEnd();
-                if (validateEvent)
-                    Assume.AreEqual("{\n  \"validationMessages\": [ ]\n}\n", responseString, "validation errors from analytics test: " + responseString);
+                return new StreamReader(responseStream).ReadToEnd();
             }
+
+            return string.Empty;
             // ReSharper restore LocalizableElement
         }
 

--- a/pwiz_tools/Skyline/Test/AnalyticsTest.cs
+++ b/pwiz_tools/Skyline/Test/AnalyticsTest.cs
@@ -28,7 +28,7 @@ namespace pwiz.SkylineTest
         [TestMethod]
         public void SendGa4AnalyticsHitTest()
         {
-            Program.SendGa4AnalyticsHit(true);
+            Assert.AreEqual("{\n  \"validationMessages\": [ ]\n}\n", Program.SendGa4AnalyticsHit(true));
         }
     }
 }

--- a/pwiz_tools/Skyline/Test/AnalyticsTest.cs
+++ b/pwiz_tools/Skyline/Test/AnalyticsTest.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Original author: Matt Chambers <matt.chambers42 .at. gmail.com >
+ *
+ * Copyright 2022
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTest
+{
+    [TestClass]
+    public class AnalyticsTest : AbstractUnitTest
+    {
+        [TestMethod]
+        public void SendGa4AnalyticsHitTest()
+        {
+            Program.SendGa4AnalyticsHit(true);
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -134,6 +134,7 @@
   <ItemGroup>
     <Compile Include="AddTransitionsTest.cs" />
     <Compile Include="AdductTest.cs" />
+    <Compile Include="AnalyticsTest.cs" />
     <Compile Include="AnnotationUnitTest.cs" />
     <Compile Include="AntivirusExclusionTest.cs" />
     <Compile Include="AuditLogListTest.cs" />


### PR DESCRIPTION
* added SendGa4AnalyticsHit() to send an instance event to the new GA4 property

We continue to send events to UA. I modeled the GA4 event after the UA event, but I'm not sure if there isn't some better way to do it. There's a lot of builtin events in GA4, but none of them seem to fit what we're doing with the custom "Instance" event. The "login" event seemed closest but I wasn't clear whether you're supposed to add custom properties to builtin event types. And it's not really a login anyway.

I am considering whether to make the validation variable dependent on whether it's running as a test. But we'd only want to test it once (could be its own test). Do I need to make it public to call it from a unit test?