### PR TITLE
Prevent disconnected crosslinked fragment ions

### DIFF
--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
@@ -311,7 +311,7 @@ namespace pwiz.Skyline.Model.Crosslinking
 
             foreach (var complexFragmentIon in complexFragmentIons)
             {
-                if (complexFragmentIon.IsEmpty)
+                if (!complexFragmentIon.IsConnected(PeptideStructure))
                 {
                     continue;
                 }

--- a/pwiz_tools/Skyline/Model/Crosslinking/NeutralFragmentIon.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/NeutralFragmentIon.cs
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/pwiz_tools/Skyline/Model/Crosslinking/NeutralFragmentIon.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/NeutralFragmentIon.cs
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -74,12 +75,57 @@ namespace pwiz.Skyline.Model.Crosslinking
             }
         }
 
-        public bool IsEmpty
+        /// <summary>
+        /// Returns true if all of the peptides in this fragment ion are connected to each other by
+        /// at least one crosslinker.
+        /// </summary>
+        public bool IsConnected(PeptideStructure peptideStructure)
         {
-            get
+            var peptideIndexes =
+                Enumerable.Range(0, IonChain.Count).Where(i => !IonChain[i].IsEmpty).ToHashSet();
+            if (peptideIndexes.Count == 0)
             {
-                return IonChain.IsEmpty;
+                // Empty
+                return false;
             }
+
+            var containedCrosslinks = new List<Crosslink>();
+            foreach (var crosslink in peptideStructure.Crosslinks)
+            {
+                bool? isContained = ContainsCrosslink(peptideStructure, crosslink.Sites);
+                if (!isContained.HasValue)
+                {
+                    return false;
+                }
+
+                if (isContained.Value)
+                {
+                    containedCrosslinks.Add(crosslink);
+                }
+            }
+            var peptideIndexQueue = new Queue<int>();
+            var visitedPeptideIndexes = new HashSet<int>();
+            peptideIndexQueue.Enqueue(peptideIndexes.Min());
+            while (peptideIndexQueue.Count > 0)
+            {
+                var peptideIndex = peptideIndexQueue.Dequeue();
+                visitedPeptideIndexes.Add(peptideIndex);
+                foreach (var crosslink in containedCrosslinks)
+                {
+                    if (crosslink.Sites.PeptideIndexes.Contains(peptideIndex))
+                    {
+                        foreach (var site in crosslink.Sites)
+                        {
+                            if (visitedPeptideIndexes.Add(site.PeptideIndex))
+                            {
+                                peptideIndexQueue.Enqueue(site.PeptideIndex);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return visitedPeptideIndexes.SetEquals(peptideIndexes);
         }
 
         public bool IsOrphan
@@ -174,6 +220,8 @@ namespace pwiz.Skyline.Model.Crosslinking
         /// This method only considers CrosslinkSites whose PeptideIndex is less than IonType.Count.
         /// This is to enable filtering out impossible partial ions while constructing larger ions using
         /// <see cref="SingleFragmentIon.Prepend"/>.
+        /// Note that this does not check whether all of the fragment ions are actually connected to each other.
+        /// For that, you would need to also check <see cref="IsConnected"/>.
         /// </summary>
         public bool IsAllowed(PeptideStructure peptideStructure)
         {

--- a/pwiz_tools/Skyline/Test/CrosslinkModTest.cs
+++ b/pwiz_tools/Skyline/Test/CrosslinkModTest.cs
@@ -409,5 +409,45 @@ namespace pwiz.SkylineTest
                 AssertEx.AreEqual(peptide.ExplicitMods.CrosslinkStructure, roundTripExplicitMods.CrosslinkStructure);
             }
         }
+
+        [TestMethod]
+        public void TestIsConnectedFragmentIon()
+        {
+            var mainPeptide = new Peptide("MERCURY");
+            var linkedPeptide1 = new Peptide("ARSENIC");
+            var linkedPeptide2 = new Peptide("CALCIUM");
+
+
+            var crosslinkMod = new StaticMod("disulfide", null, null, "-H2");
+            var explicitMods = new ExplicitMods(mainPeptide, null, Array.Empty<TypedExplicitModifications>())
+                .ChangeCrosslinkStructure(new CrosslinkStructure(new[] { linkedPeptide1, linkedPeptide2 },
+                    new Crosslink[]
+                    {
+                        new Crosslink(crosslinkMod, new []{new CrosslinkSite(0, 3), new CrosslinkSite(2, 0)}),
+                        new Crosslink(crosslinkMod, new []{new CrosslinkSite(1, 6), new CrosslinkSite(2, 3)})
+                    }));
+
+
+            var peptideStructure = new PeptideStructure(mainPeptide, explicitMods);
+            var b4_b2 = new NeutralFragmentIon(new[] { new IonOrdinal(IonType.b, 4), IonOrdinal.Empty, new IonOrdinal(IonType.b, 2) }, null);
+            AssertEx.IsTrue(b4_b2.IsAllowed(peptideStructure));
+            AssertEx.IsTrue(b4_b2.IsConnected(peptideStructure));
+            var b2b2_= new NeutralFragmentIon(new[] { new IonOrdinal(IonType.b, 2), new IonOrdinal(IonType.b, 2), IonOrdinal.Empty},
+                null);
+            AssertEx.IsTrue(b2b2_.IsAllowed(peptideStructure));
+            AssertEx.IsFalse(b2b2_.IsConnected(peptideStructure));
+            var _y2y4 = new NeutralFragmentIon(
+                new[] { IonOrdinal.Empty, new IonOrdinal(IonType.y, 2), new IonOrdinal(IonType.y, 4) }, null);
+            AssertEx.IsTrue(_y2y4.IsAllowed(peptideStructure));
+            AssertEx.IsTrue(_y2y4.IsConnected(peptideStructure));
+            var b2y2y4 = new NeutralFragmentIon(new[] { new IonOrdinal(IonType.b, 2), new IonOrdinal(IonType.y, 2), 
+                new IonOrdinal(IonType.y, 4) }, null);
+            AssertEx.IsTrue(b2y2y4.IsAllowed(peptideStructure));
+            AssertEx.IsFalse(b2y2y4.IsConnected(peptideStructure));
+            var b4y2p = new NeutralFragmentIon(
+                new[] { new IonOrdinal(IonType.b, 4), new IonOrdinal(IonType.y, 2), IonOrdinal.Precursor }, null);
+            AssertEx.IsTrue(b4y2p.IsAllowed(peptideStructure));
+            AssertEx.IsTrue(b4y2p.IsConnected(peptideStructure));
+        }
     }
 }

--- a/pwiz_tools/Skyline/Test/CrosslinkModTest.cs
+++ b/pwiz_tools/Skyline/Test/CrosslinkModTest.cs
@@ -421,10 +421,10 @@ namespace pwiz.SkylineTest
             var crosslinkMod = new StaticMod("disulfide", null, null, "-H2");
             var explicitMods = new ExplicitMods(mainPeptide, null, Array.Empty<TypedExplicitModifications>())
                 .ChangeCrosslinkStructure(new CrosslinkStructure(new[] { linkedPeptide1, linkedPeptide2 },
-                    new Crosslink[]
+                    new[]
                     {
-                        new Crosslink(crosslinkMod, new []{new CrosslinkSite(0, 3), new CrosslinkSite(2, 0)}),
-                        new Crosslink(crosslinkMod, new []{new CrosslinkSite(1, 6), new CrosslinkSite(2, 3)})
+                        new Crosslink(crosslinkMod, new[] { new CrosslinkSite(0, 3), new CrosslinkSite(2, 0) }),
+                        new Crosslink(crosslinkMod, new[] { new CrosslinkSite(1, 6), new CrosslinkSite(2, 3) })
                     }));
 
 

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -150,14 +150,14 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
-        public static void IsTrue(bool expected, string message = null)
+        public static void IsTrue(bool actual, string message = null)
         {
-            AreEqual(expected, true, message);
+            AreEqual(true, actual, message);
         }
 
-        public static void IsFalse(bool expected, string message = null)
+        public static void IsFalse(bool actual, string message = null)
         {
-            AreEqual(expected, false, message);
+            AreEqual(false, actual, message);
         }
 
         public static void IsNull(object obj, string message = null)


### PR DESCRIPTION
Fixed problem where Skyline would allow transitions which contained multiple crosslink fragment ions which were not actually attached to each other (reported by Bob, thanks Nick)