### PR TITLE
Fix intermittent failure in GroupedStudies1TutorialTest 

### DIFF
--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
@@ -1397,6 +1397,7 @@ namespace pwiz.SkylineTestTutorial
             foldChangeGrid = WaitForOpenForm<FoldChangeGrid>();
             if (!IsCoverShotMode)
                 RunUI(() => foldChangeGraph.Show(foldChangeGraph.DockPanel, DockState.Floating));
+            WaitForConditionUI(() => foldChangeGrid.DataboundGridControl.IsComplete);
             RunUI(() =>
             {
                 var foldChangeResultColumn =


### PR DESCRIPTION
Fix Intermittent failure in TestGroupedStudies1Tutorial:
ArgumentNullException in DataGridView.Sort