### PR TITLE
Fix ArgumentOutOfRangeException pasting into empty document grid

### DIFF
--- a/pwiz_tools/Skyline/Util/DataGridViewPasteHandler.cs
+++ b/pwiz_tools/Skyline/Util/DataGridViewPasteHandler.cs
@@ -123,8 +123,13 @@ namespace pwiz.Skyline.Util
             try
             {
                 Settings.Default.ResultsGridSynchSelection = false;
-                var cellAddress = DataGridView.CurrentCellAddress;
                 DataGridView.Enabled = false;
+                var cellAddress = DataGridView.CurrentCellAddress;
+                if (cellAddress.Y < 0 || cellAddress.Y >= DataGridView.RowCount ||
+                    cellAddress.X < 0 || cellAddress.X >= DataGridView.ColumnCount)
+                {
+                    return false;
+                }
                 DataGridView.CurrentCell = DataGridView.Rows[cellAddress.Y].Cells[cellAddress.X];
                 lock (skylineDataSchema.SkylineWindow.GetDocumentChangeLock())
                 {


### PR DESCRIPTION
Fixed unhandled error when trying to paste into the Document Grid when it is empty (reported anonymously, thanks Nick)