### PR TITLE
Fix TestMs1Tutorial

### DIFF
--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace pwiz.Skyline.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -17282,15 +17282,6 @@ namespace pwiz.Skyline.Properties {
         public static string IonTypeSelector_SelectAllLossesTooltip {
             get {
                 return ResourceManager.GetString("IonTypeSelector_SelectAllLossesTooltip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Adding peptides.
-        /// </summary>
-        public static string IrtDb_AddPeptides_Adding_peptides {
-            get {
-                return ResourceManager.GetString("IrtDb_AddPeptides_Adding_peptides", resourceCulture);
             }
         }
         
@@ -35493,6 +35484,15 @@ namespace pwiz.Skyline.Properties {
         public static string ViewLibraryDlg_UpdateUI_Failure_loading_spectrum_Library_may_be_corrupted {
             get {
                 return ResourceManager.GetString("ViewLibraryDlg_UpdateUI_Failure_loading_spectrum_Library_may_be_corrupted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File.
+        /// </summary>
+        public static string ViewLibraryDlg_UpdateUI_File {
+            get {
+                return ResourceManager.GetString("ViewLibraryDlg_UpdateUI_File", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace pwiz.Skyline.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace pwiz.Skyline.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -35488,7 +35488,7 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File.
+        ///   Looks up a localized string similar to File: {0}.
         /// </summary>
         public static string ViewLibraryDlg_UpdateUI_File {
             get {

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -3331,7 +3331,7 @@
     <value>ドキュメントノードの検索に失敗しました。</value>
   </data>
   <data name="ViewLibraryDlg_UpdateUI_File" xml:space="preserve">
-    <value>ファイル： </value>
+    <value>ファイル：{0}</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_LoadPeptideSearchLibrary_An_error_occurred_attempting_to_import_the__0__library_" xml:space="preserve">
     <value>{0}ライブラリをインポートしようとした際にエラーが発生しました。</value>
@@ -6775,9 +6775,6 @@
   <data name="ViewLibraryDlg_AddAllPeptides__0__existing" xml:space="preserve">
     <value>{0}既存</value>
   </data>
-  <data name="SkylineViewContext_GetTransitionListReportSpec_Mixed_Transition_List" xml:space="preserve">
-    <value>混合トランジションリスト</value>
-  </data>
   <data name="ResultsGrid_ResultsGrid_Opt_Declustering_Potential" xml:space="preserve">
     <value>最適デクラスタリングポテンシャル</value>
   </data>
@@ -8926,9 +8923,6 @@ Skylineでの列の順序は、列のヘッダーを左右にドラッグする�
   </data>
   <data name="RegressionGraphPane_RegressionGraphPane__0___at__1__points_minimum_" xml:space="preserve">
     <value>{0}（最低{1}点）</value>
-  </data>
-  <data name="IrtDb_AddPeptides_Adding_peptides" xml:space="preserve">
-    <value>ペプチドを追加しています</value>
   </data>
   <data name="BuildBackgroundProteomeDlg_AddFastaFile_The_added_file_included__0__repeated_protein_sequences__Their_names_were_added_as_aliases_to_ensure_the_protein_list_contains_only_one_copy_of_each_sequence_" xml:space="preserve">
     <value>追加されたファイルには、{0}個の反復タンパク質シークエンスが含まれていました。タンパク質リストに各シークエンスのコピーが1つしか含まれないようにするために、これらの名前はエイリアスとして追加されました。</value>

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -3330,6 +3330,9 @@
   <data name="IdentityNotFoundException_IdentityNotFoundException_Failed_to_find_document_node" xml:space="preserve">
     <value>ドキュメントノードの検索に失敗しました。</value>
   </data>
+  <data name="ViewLibraryDlg_UpdateUI_File" xml:space="preserve">
+    <value>ファイル： </value>
+  </data>
   <data name="BuildPeptideSearchLibraryControl_LoadPeptideSearchLibrary_An_error_occurred_attempting_to_import_the__0__library_" xml:space="preserve">
     <value>{0}ライブラリをインポートしようとした際にエラーが発生しました。</value>
   </data>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -3342,7 +3342,7 @@ Are you sure you want to continue?</value>
     <value>Failed to find document node.</value>
   </data>
   <data name="ViewLibraryDlg_UpdateUI_File" xml:space="preserve">
-    <value>File: </value>
+    <value>File: {0}</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_LoadPeptideSearchLibrary_An_error_occurred_attempting_to_import_the__0__library_" xml:space="preserve">
     <value>An error occurred attempting to import the {0} library.</value>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -3341,6 +3341,9 @@ Are you sure you want to continue?</value>
   <data name="IdentityNotFoundException_IdentityNotFoundException_Failed_to_find_document_node" xml:space="preserve">
     <value>Failed to find document node.</value>
   </data>
+  <data name="ViewLibraryDlg_UpdateUI_File" xml:space="preserve">
+    <value>File: </value>
+  </data>
   <data name="BuildPeptideSearchLibraryControl_LoadPeptideSearchLibrary_An_error_occurred_attempting_to_import_the__0__library_" xml:space="preserve">
     <value>An error occurred attempting to import the {0} library.</value>
   </data>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -3330,6 +3330,9 @@
   <data name="IdentityNotFoundException_IdentityNotFoundException_Failed_to_find_document_node" xml:space="preserve">
     <value>未能发现文档节点。</value>
   </data>
+  <data name="ViewLibraryDlg_UpdateUI_File" xml:space="preserve">
+    <value>文件： </value>
+  </data>
   <data name="BuildPeptideSearchLibraryControl_LoadPeptideSearchLibrary_An_error_occurred_attempting_to_import_the__0__library_" xml:space="preserve">
     <value>尝试导入{0}库时出现错误。</value>
   </data>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -3331,7 +3331,7 @@
     <value>未能发现文档节点。</value>
   </data>
   <data name="ViewLibraryDlg_UpdateUI_File" xml:space="preserve">
-    <value>文件： </value>
+    <value>文件：{0}</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_LoadPeptideSearchLibrary_An_error_occurred_attempting_to_import_the__0__library_" xml:space="preserve">
     <value>尝试导入{0}库时出现错误。</value>
@@ -6775,9 +6775,6 @@
   <data name="ViewLibraryDlg_AddAllPeptides__0__existing" xml:space="preserve">
     <value>{0} 个现有的</value>
   </data>
-  <data name="SkylineViewContext_GetTransitionListReportSpec_Mixed_Transition_List" xml:space="preserve">
-    <value>混合离子对列表</value>
-  </data>
   <data name="ResultsGrid_ResultsGrid_Opt_Declustering_Potential" xml:space="preserve">
     <value>最优去簇电压</value>
   </data>
@@ -8926,9 +8923,6 @@
   </data>
   <data name="RegressionGraphPane_RegressionGraphPane__0___at__1__points_minimum_" xml:space="preserve">
     <value>{0}（至少 {1} 点）</value>
-  </data>
-  <data name="IrtDb_AddPeptides_Adding_peptides" xml:space="preserve">
-    <value>添加肽段</value>
   </data>
   <data name="BuildBackgroundProteomeDlg_AddFastaFile_The_added_file_included__0__repeated_protein_sequences__Their_names_were_added_as_aliases_to_ensure_the_protein_list_contains_only_one_copy_of_each_sequence_" xml:space="preserve">
     <value>添加的文件包含 {0} 个重复的蛋白质序列。它们的名称作为别名添加，以确保蛋白质列表只包含每个序列的一个副本。</value>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -855,7 +855,7 @@ namespace pwiz.Skyline.SettingsUI
                             }
                             else
                             {
-                                labelFilename.Text = Resources.ViewLibraryDlg_UpdateUI_File + filename;
+                                labelFilename.Text = string.Format(Resources.ViewLibraryDlg_UpdateUI_File, filename);
                             }
                             if (rt.HasValue)
                             {

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -105,10 +105,10 @@ namespace pwiz.Skyline.SettingsUI
         private bool _hasChromatograms;
         private bool _hasScores;
         private readonly GraphHelper _graphHelper;
+        private string _originalFileLabelText;
+        private string _sourceFile;
 
         private ModFontHolder ModFonts { get; set; }
-
-        private string FileFormat { get; set; }
 
         private string SelectedLibraryName
         {
@@ -158,7 +158,7 @@ namespace pwiz.Skyline.SettingsUI
 
             Icon = Resources.Skyline;
             ModFonts = new ModFontHolder(listPeptide);
-            FileFormat = labelFilename.Text;
+            _originalFileLabelText = labelFilename.Text;
             _peptideImg = Resources.PeptideLib;
             _moleculeImg = Resources.MoleculeLib;
 
@@ -699,6 +699,7 @@ namespace pwiz.Skyline.SettingsUI
 
             labelRT.Text = string.Empty;
             labelFilename.Text = string.Empty;
+            _sourceFile = null;
             bool showComboRedundantSpectra = false; // Careful not to actually hide this responding to a selection change
 
             // Check for appropriate spectrum to load
@@ -841,16 +842,20 @@ namespace pwiz.Skyline.SettingsUI
 
                         graphControl.IsEnableVPan = graphControl.IsEnableVZoom =
                                                     !Settings.Default.LockYAxis;
+                        _sourceFile = spectrumInfo?.FileName;
                         // Update file and retention time indicators
                         if (spectrumInfo != null)
                         {
                             double? rt = libraryChromGroup?.RetentionTime ?? spectrumInfo.RetentionTime;
                             string filename = spectrumInfo.FileName;
 
-                            if (!string.IsNullOrEmpty(filename))
+                            if (showComboRedundantSpectra)
                             {
-                                labelFilename.Text = string.Format(FileFormat,
-                                    !showComboRedundantSpectra ? filename : string.Empty);
+                                labelFilename.Text = _originalFileLabelText;
+                            }
+                            else
+                            {
+                                labelFilename.Text = Resources.ViewLibraryDlg_UpdateUI_File + filename;
                             }
                             if (rt.HasValue)
                             {
@@ -2292,7 +2297,7 @@ namespace pwiz.Skyline.SettingsUI
 
         public string SourceFile
         {
-            get { return GetLabelValue(labelFilename); }
+            get { return _sourceFile; }
         }
 
         public double RetentionTime

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.ja.resx
@@ -315,7 +315,7 @@
     <value>64, 13</value>
   </data>
   <data name="labelFilename.Text" xml:space="preserve">
-    <value>ファイル(&amp;E)： {0}</value>
+    <value>ファイル(&amp;E)：</value>
   </data>
   <data name="comboRedundantSpectra.Location" type="System.Drawing.Point, System.Drawing">
     <value>73, 3</value>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.resx
@@ -1675,6 +1675,6 @@
     <value>ViewLibraryDlg</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=21.2.1.555, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=21.2.1.523, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.resx
@@ -916,7 +916,7 @@
     <value>0</value>
   </data>
   <data name="labelFilename.Text" xml:space="preserve">
-    <value>Fil&amp;e: {0}</value>
+    <value>Fil&amp;e:</value>
   </data>
   <data name="&gt;&gt;labelFilename.Name" xml:space="preserve">
     <value>labelFilename</value>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.resx
@@ -1411,7 +1411,7 @@
     <value>modeUIHandler</value>
   </data>
   <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline-daily, Version=21.2.1.523, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline-daily, Version=21.2.1.555, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAIons.Name" xml:space="preserve">
     <value>btnAIons</value>
@@ -1675,6 +1675,6 @@
     <value>ViewLibraryDlg</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=21.2.1.523, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=21.2.1.555, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
@@ -309,7 +309,7 @@
     <value>54, 13</value>
   </data>
   <data name="labelFilename.Text" xml:space="preserve">
-    <value>文件(&amp;E)： {0}</value>
+    <value>文件(&amp;E)：</value>
   </data>
   <data name="comboRedundantSpectra.Location" type="System.Drawing.Point, System.Drawing">
     <value>63, 3</value>


### PR DESCRIPTION
Here's what I think the fix should be:
1. If showRedundantSpectra is true, then labelFilename should say "Fil&amp;e:"
2. If showRedundantSpectra is false, then labelFilename should say "File: " followed by the filename
3. We should never try to parse the text in labelFilename, and instead. the file name should be stored in "_sourceFile".