### PR TITLE
Undo/Redo from document grid

### DIFF
--- a/pwiz_tools/Skyline/Controls/Databinding/DataboundGridForm.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/DataboundGridForm.cs
@@ -18,9 +18,13 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using pwiz.Common.DataBinding;
 using pwiz.Common.DataBinding.Controls;
+using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.Databinding;
 using pwiz.Skyline.Util;
 
@@ -57,6 +61,103 @@ namespace pwiz.Skyline.Controls.Databinding
         DataboundGridControl IDataboundGridForm.GetDataboundGridControl()
         {
             return DataboundGridControl;
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            var skylineWindow = (BindingListSource.ViewInfo.DataSchema as SkylineDataSchema)?.SkylineWindow;
+            if (skylineWindow != null)
+            {
+                switch (keyData)
+                {
+                    case Keys.Z | Keys.Control:
+                        skylineWindow.Undo();
+                        return true;
+                    case Keys.Y | Keys.Control:
+                        skylineWindow.Redo();
+                        return true;
+                }
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private ViewName? GetCurrentViewName()
+        {
+            var viewInfo = BindingListSource.ViewInfo;
+            return viewInfo?.ViewGroup?.Id.ViewName(viewInfo.Name);
+        }
+
+        public UndoState GetUndoState()
+        {
+            var viewName = GetCurrentViewName();
+            if (!viewName.HasValue)
+            {
+                return null;
+            }
+
+            return new UndoState(viewName.Value, DataGridView.CurrentCellAddress);
+        }
+
+        public void RestoreUndoState(UndoState undoState)
+        {
+            if (!Equals(GetCurrentViewName(), undoState.ViewName))
+            {
+                // If name of the report in the undo state is different than the current report
+                // then do nothing.
+                return;
+            }
+
+            var dataGridView = DataGridView;
+            var cellAddress = undoState.CurrentCellAddress;
+            if (cellAddress.X < 0 || cellAddress.X >= dataGridView.ColumnCount || 
+                cellAddress.Y < 0 || cellAddress.Y >= dataGridView.RowCount)
+            {
+                return;
+            }
+
+            DataGridView.CurrentCell = DataGridView.Rows[cellAddress.Y].Cells[cellAddress.X];
+        }
+
+        public class UndoState
+        {
+            public UndoState(ViewName viewName, Point currentCellAddress)
+            {
+                ViewName = viewName;
+                CurrentCellAddress = currentCellAddress;
+            }
+            public ViewName ViewName { get; }
+            public Point CurrentCellAddress { get; }
+        }
+
+
+        public static IDictionary<DataGridId, UndoState> GetUndoStates()
+        {
+            var dictionary = new Dictionary<DataGridId, UndoState>();
+            foreach (var form in FormUtil.OpenForms.OfType<DataboundGridForm>())
+            {
+                var dataGridId = form.DataGridId;
+                if (dataGridId != null)
+                {
+                    var undoState = form.GetUndoState();
+                    if (undoState != null)
+                    {
+                        dictionary[dataGridId] = undoState;
+                    }
+                }
+            }
+
+            return dictionary;
+        }
+        public static void RestoreUndoStates(IDictionary<DataGridId, UndoState> undoStates)
+        {
+            foreach (var form in FormUtil.OpenForms.OfType<DataboundGridForm>())
+            {
+                var dataGridId = form.DataGridId;
+                if (dataGridId != null && undoStates.TryGetValue(dataGridId, out var undoState))
+                {
+                    form.RestoreUndoState(undoState);
+                }
+            }
         }
 
         #region Methods exposed for testing

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -933,6 +933,7 @@ namespace pwiz.Skyline
             private readonly IdentityPath _treeSelection;
             private readonly IList<IdentityPath> _treeSelections;
             private readonly string _resultName;
+            private IDictionary<DataGridId, DataboundGridForm.UndoState> _gridStates;
 
             public UndoState(SkylineWindow window)
             {
@@ -941,16 +942,18 @@ namespace pwiz.Skyline
                 _treeSelections = window.SequenceTree.SelectedPaths;
                 _treeSelection = window.SequenceTree.SelectedPath;
                 _resultName = ResultNameCurrent;
+                _gridStates = DataboundGridForm.GetUndoStates();
             }
 
             private UndoState(SkylineWindow window, SrmDocument document, IList<IdentityPath> treeSelections,
-                IdentityPath treeSelection, string resultName)
+                IdentityPath treeSelection, string resultName, IDictionary<DataGridId, DataboundGridForm.UndoState> gridStates)
             {
                 _window = window;
                 _document = document;
                 _treeSelections = treeSelections;
                 _treeSelection = treeSelection;
                 _resultName = resultName;
+                _gridStates = gridStates;
             }
 
             private string ResultNameCurrent
@@ -973,6 +976,8 @@ namespace pwiz.Skyline
                 // Get results name
                 string resultName = ResultNameCurrent;
 
+                var gridStates = DataboundGridForm.GetUndoStates();
+
                 // Restore document state
                 SrmDocument docReplaced = _window.RestoreDocument(_document);
 
@@ -988,9 +993,12 @@ namespace pwiz.Skyline
                 if (_resultName != null)
                     _window.ComboResults.SelectedItem = _resultName;
 
+                if (_gridStates != null)
+                    DataboundGridForm.RestoreUndoStates(_gridStates);
+
                 // Return a record that can be used to restore back to the state
                 // before this action.
-                return new UndoState(_window, docReplaced, treeSelections, treeSelection, resultName);
+                return new UndoState(_window, docReplaced, treeSelections, treeSelection, resultName, gridStates);
             }
         }
 

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
Issue 897: Make Ctrl-Z (Undo) and Ctrl-Y (Redo) work in Document Grid
Issue 898: Record the Document Grid selection in the Undo/Redo buffer during Document Grid editing events