### PR TITLE
When TestDocumentFormatSchemaFiles() finds that Skyline_Current.xsd has been changed but DocumentFormat.CURRENT has not…

### DIFF
--- a/pwiz_tools/Skyline/Test/SchemaDocumentsTest.cs
+++ b/pwiz_tools/Skyline/Test/SchemaDocumentsTest.cs
@@ -73,10 +73,11 @@ namespace pwiz.SkylineTest
             var xsdCurrentResourceName = SchemaDocuments.GetSkylineSchemaResourceName(DocumentFormat.CURRENT.ToString()); // Special case, returns "Skyline_Current.xsd"
             var currentXsdContents = GetResourceText(xsdCurrentResourceName); 
             Assert.IsNotNull(currentXsdContents);
-            if (explicitCurrentXsdContents != null && !explicitCurrentXsdContents.Equals(currentXsdContents))
+            if (explicitCurrentXsdContents != null)
             {
-                AssertEx.Fail(string.Format("Expected resource files {0} and {1} to be identical - did you change the contents of Skyline_Current.xsd without incrementing the value of DocumentFormat.CURRENT?",
-                    explicitCurrentResourceName, xsdCurrentResourceName));
+                AssertEx.NoDiff(explicitCurrentXsdContents,currentXsdContents,
+                    string.Format("Expected resource files {0} and {1} to be identical - did you change the contents of Skyline_Current.xsd without incrementing the value of DocumentFormat.CURRENT?",
+                        explicitCurrentResourceName, xsdCurrentResourceName));
             }
 
             // List all the historical values of VERSION_* (located in DocumentFormat.cs)

--- a/pwiz_tools/Skyline/Test/SchemaDocumentsTest.cs
+++ b/pwiz_tools/Skyline/Test/SchemaDocumentsTest.cs
@@ -73,11 +73,10 @@ namespace pwiz.SkylineTest
             var xsdCurrentResourceName = SchemaDocuments.GetSkylineSchemaResourceName(DocumentFormat.CURRENT.ToString()); // Special case, returns "Skyline_Current.xsd"
             var currentXsdContents = GetResourceText(xsdCurrentResourceName); 
             Assert.IsNotNull(currentXsdContents);
-            if (explicitCurrentXsdContents != null)
+            if (explicitCurrentXsdContents != null && !explicitCurrentXsdContents.Equals(currentXsdContents))
             {
-                Assert.AreEqual(currentXsdContents, explicitCurrentXsdContents, 
-                    string.Format("Expected resource files {0} and {1} to be identical - did you change the contents of Skyline_Current.xsd without incrementing the value of DocumentFormat.CURRENT?",
-                        explicitCurrentResourceName, xsdCurrentResourceName));
+                AssertEx.Fail(string.Format("Expected resource files {0} and {1} to be identical - did you change the contents of Skyline_Current.xsd without incrementing the value of DocumentFormat.CURRENT?",
+                    explicitCurrentResourceName, xsdCurrentResourceName));
             }
 
             // List all the historical values of VERSION_* (located in DocumentFormat.cs)


### PR DESCRIPTION
…, just show the error message, rather than dumping the full text of the two xsd files being compared followed by the error message.