### PR TITLE
* fixed AssociateProteinsDlg's OK button never being enabled

### DIFF
--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
@@ -155,6 +155,8 @@ namespace pwiz.Skyline.EditUI
                 else
                 {
                     DocumentFinal = AddIrtAndDecoys(_document);
+                    UpdateTargetCounts();
+                    btnOk.Enabled = true;
                     return;
                 }
             }
@@ -218,6 +220,15 @@ namespace pwiz.Skyline.EditUI
             set => numMinPeptides.Value = value;
         }
 
+        private void UpdateTargetCounts()
+        {
+            dgvAssociateResults.RowCount = 3;
+            dgvAssociateResults.ClearSelection();
+            dgvAssociateResults.Invalidate();
+
+            lblStatusBarResult.Text = GetStatusBarResultString();
+        }
+
         private void UpdateParsimonyResults()
         {
             DocumentFinal = null;
@@ -239,12 +250,7 @@ namespace pwiz.Skyline.EditUI
             }
 
             DocumentFinal = CreateDocTree(_document);
-
-            dgvAssociateResults.RowCount = 3;
-            dgvAssociateResults.ClearSelection();
-            dgvAssociateResults.Invalidate();
-
-            lblStatusBarResult.Text = GetStatusBarResultString();
+            UpdateTargetCounts();
         }
 
         private void checkBoxParsimony_CheckedChanged(object sender, EventArgs e)

--- a/pwiz_tools/Skyline/TestFunctional/ImportPeptideSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ImportPeptideSearchTest.cs
@@ -630,7 +630,7 @@ namespace pwiz.SkylineTestFunctional
             });
             var peptidesPerProteinDlg = ShowDialog<AssociateProteinsDlg>(importPeptideSearchDlg.ClickNextButtonNoCheck);
             //RunUI(() => peptidesPerProteinDlg.KeepAll = true);
-            WaitForConditionUI(() => peptidesPerProteinDlg.DocumentFinalCalculated);
+            WaitForConditionUI(() => peptidesPerProteinDlg.IsOkEnabled);
             // The AllChromatogramsGraph will immediately show an error because the file being imported is bogus.
             var importResultsDlg = ShowDialog<AllChromatogramsGraph>(peptidesPerProteinDlg.OkDialog);
             doc = WaitForDocumentChangeLoaded(doc);


### PR DESCRIPTION
* fixed OK button never being enabled when AssociateProteinsDlg's PeptideCount == 0
* fixed TestImportPeptideSearch not waiting for OK button to be enabled

I don't know if this will fix the actual intermittent failure but it definitely fixes a usability bug when the FASTA mapping results in no peptide matches.