### PR TITLE
Add branch specification for non-Skyline builds in vcs_trigger_and_paths_config.py

### DIFF
--- a/scripts/misc/smartBuildTrigger.py
+++ b/scripts/misc/smartBuildTrigger.py
@@ -117,7 +117,7 @@ for tuple in matchPaths:
 # match changed file paths to triggers
 triggers = {}
 if (current_branch == "master" or current_branch.startswith("skyline_")) and len(changed_files) == 0:
-    print("Empty change list on master branch; this is some merge I don't know how to get a reliable change list for yet. Building everything!")
+    print(f"Empty change list on {current_branch} branch; this is some merge I don't know how to get a reliable change list for yet. Building everything!")
     for target in targets['All']:
         if target not in triggers:
             isBaseBranchDict = isinstance(tuple[1][target], dict) # these targets were promoted into top-level above

--- a/scripts/misc/vcs_trigger_and_paths_config.py
+++ b/scripts/misc/vcs_trigger_and_paths_config.py
@@ -2,9 +2,16 @@
 targets = {}
 targets['CoreWindowsRelease'] = \
 {
-    "bt83": "Core Windows x86_64"
-    ,"bt36": "Core Windows x86"
-    ,"bt143": "Core Windows x86_64 (no vendor DLLs)"
+    'master':
+    {
+        "bt83": "Core Windows x86_64"
+        ,"bt36": "Core Windows x86"
+        ,"bt143": "Core Windows x86_64 (no vendor DLLs)"
+    },
+    'release':
+    {
+        # bt83 will be triggered by ProteoWizard_ProteoWizardAndSkylineReleaseBranchDockerContainerWineX8664
+    }
 }
 #targets['CoreWindowsDebug'] = \
 #{
@@ -13,7 +20,7 @@ targets['CoreWindowsRelease'] = \
 #}
 #targets['CoreWindows'] = merge(targets['CoreWindowsRelease'], targets['CoreWindowsDebug'])
 targets['CoreWindows'] = targets['CoreWindowsRelease']
-targets['CoreLinux'] = {"bt17": "Core Linux x86_64"}
+targets['CoreLinux'] = {'master': {"bt17": "Core Linux x86_64"}}
 
 targets['SkylineRelease'] = \
 {
@@ -53,10 +60,13 @@ targets['Container'] = \
 
 targets['BumbershootRelease'] = \
 {
-    "Bumbershoot_Windows_X86_64": "Bumbershoot Windows x86_64"
-    ,"ProteoWizard_Bumbershoot_Windows_X86": "Bumbershoot Windows x86"
+    'master':
+    {
+        "Bumbershoot_Windows_X86_64": "Bumbershoot Windows x86_64"
+        ,"ProteoWizard_Bumbershoot_Windows_X86": "Bumbershoot Windows x86"
+    }
 }
-targets['BumbershootLinux'] = {"ProteoWizard_Bumbershoot_Linux_x86_64": "Bumbershoot Linux x86_64"}
+targets['BumbershootLinux'] = {'master': {"ProteoWizard_Bumbershoot_Linux_x86_64": "Bumbershoot Linux x86_64"}}
 targets['Bumbershoot'] = merge(targets['BumbershootRelease'], targets['BumbershootLinux'])
 
 targets['Core'] = merge(targets['CoreWindows'], targets['CoreLinux'])


### PR DESCRIPTION
* added branch specification for non-Skyline builds in vcs_trigger_and_paths_config.pyd_paths_config.py so they don't get triggered for "build everything" builds on Skyline's release branch