### PR TITLE
Add a couple of Bruker files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,6 +387,8 @@ Reader*Test.data
 /pwiz_aux/msrc/utility/vendor_api/ABI/LicenseKey.h
 /pwiz_aux/msrc/utility/vendor_api/Agilent/x64/
 /pwiz_aux/msrc/utility/vendor_api/Agilent/x86/
+/pwiz_aux/msrc/utility/vendor_api/Bruker/BAF2SQL-README.txt
+/pwiz_aux/msrc/utility/vendor_api/Bruker/BAF2SQL-THIRD-PARTY-LICENSE-README.txt
 /pwiz_aux/msrc/utility/vendor_api/Bruker/x64/
 /pwiz_aux/msrc/utility/vendor_api/Bruker/x86/
 /pwiz_aux/msrc/utility/vendor_api/Bruker/**/*.h

--- a/pwiz_tools/Skyline/Skyline.sln
+++ b/pwiz_tools/Skyline/Skyline.sln
@@ -6,9 +6,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Skyline.vsmdi = Skyline.vsmdi
 		TestSettings_x64.runsettings = TestSettings_x64.runsettings
-		TestSettings_x64.testsettings = TestSettings_x64.testsettings
 		TestSettings_x86.runsettings = TestSettings_x86.runsettings
-		TestSettings_x86.testsettings = TestSettings_x86.testsettings
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skyline", "Skyline.csproj", "{DDA2EA4C-B632-4FDF-94BA-F71E4C152056}"


### PR DESCRIPTION
Add "BAF2SQL-README.txt" and "BAF2SQL-THIRD-PARTY-LICENSE-README.txt" to .gitignore at root of project.

Also remove references to ".testsettings" files from Skyline.sln. Not sure whether these things show up in the Visual Studio UI, but I figured they didn't belong in the .sln file anymore.