### PR TITLE
Fix ga4 hit geolocation

### DIFF
--- a/pwiz_tools/Skyline/Test/AnalyticsTest.cs
+++ b/pwiz_tools/Skyline/Test/AnalyticsTest.cs
@@ -28,7 +28,7 @@ namespace pwiz.SkylineTest
         [TestMethod]
         public void SendGa4AnalyticsHitTest()
         {
-            Assert.AreEqual("{\n  \"validationMessages\": [ ]\n}\n", Program.SendGa4AnalyticsHit(true));
+            Assert.AreEqual(204, Program.SendGa4AnalyticsHit(true));
         }
     }
 }


### PR DESCRIPTION
OK, so after fiddling with Puppeteer for a while, looking at what it was sending, and doing a bit more research about what the cryptically named query parameters meant, I decided that maybe we can just fudge it and make direct requests to google-analytics. It seems to be working. The fact it uses a POST method but actually sends the parameters in the URL is odd, but that's the way it does it in the browser too. When useDebugUrl is true, the page_view hit can be seen in [DebugView](https://analytics.google.com/analytics/web/#/m/p318139389/debugview) and when it's false you can see it in [Realtime view](https://analytics.google.com/analytics/web/#/p318139389/realtime/overview) (and this is also the only way you can see the geolocation is working; DebugView doesn't do the geolocation apparently).

The one thing I'm not happy about here is we aren't really testing that the hit is showing up in analytics, just that the status code comes back as 204 (No Content). It gives that status code even if I mess up the parameters in a way that the hit won't be shown. So I'm a bit concerned that if they change gtag.js in the future such that the parameter names change, our analytics might stop working. @bconn-proteinms do you think we can somehow monitor analytics DebugView to make sure we're getting hits there every day (during nightly tests)?