### PR TITLE
Fix duplicate filename extension in BlibBuild.exe error message 

### DIFF
--- a/pwiz_tools/BiblioSpec/src/BuildParser.cpp
+++ b/pwiz_tools/BiblioSpec/src/BuildParser.cpp
@@ -204,9 +204,7 @@ string BuildParser::filesNotFoundMessage(
     if (extensions.empty())
         throw BlibException(false, "empty extensions list for filesNotFoundMessage");
 
-    string extString = extensions.at(0);
-    for (const auto& ext : extensions)
-        extString += ", " + ext;
+    string extString = boost::algorithm::join(extensions, ", ");
 
     string filesPlural = "file";
     string namesPlural = "name";


### PR DESCRIPTION
BiblioSpec was outputting the message "could not find matches for the following basename with any of the supported file extensions (.mz5, .mz5, .mzML, .mzXML, .ms2, .cms2, .bms2, .pms2)..." where ".mz5" appeared twice.

Fixed incorrect repetition of the first filename extension when BiblioSpec says that it canoot find a file (not reported by anyone)