### PR TITLE
Restore and improve my previous attempt at finding forms that aren't …

### DIFF
--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -863,9 +863,9 @@ namespace TestRunnerLib
                 if (type.IsClass && HasAttribute(type, "TestClassAttribute"))
                 {
                     if (!DerivesFromAbstractUnitTest(type))
-// ReSharper disable LocalizableElement
-                        Console.WriteLine("WARNING: " + type.Name + " does not derive from AbstractUnitTest!");
-// ReSharper restore LocalizableElement
+                    {
+                        Console.WriteLine($@"ERROR: {type.Name} does not derive from AbstractUnitTest!"); 
+                    }
                     MethodInfo testInitializeMethod = null;
                     MethodInfo testCleanupMethod = null;
                     var methods = type.GetMethods();


### PR DESCRIPTION
…using FormEx, this time avoiding assemblies that aren't needed (and which can cause trouble due to brittle load order issues etc).

Also change the "WARNING: {test name} does not derive from AbstractUnitTest!" message in TestRunner to say "ERROR" = even though it doesn't actually show as an error in our test stats, it should be harder to ignore.