### PR TITLE
Skyline (22.2): Fix intermittent failure in TestExistingExperimentsTutorial

### DIFF
--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -1024,6 +1024,7 @@ namespace pwiz.Skyline.FileUI
         public class DocumentChecked
         {
             public SrmDocument Document;
+            public Dictionary<string, FastaSequence> ProteinAssociations;
             public IdentityPath SelectPath;
             public List<MeasuredRetentionTime> IrtPeptides;
             public List<SpectrumMzInfo> LibrarySpectra;
@@ -1204,10 +1205,13 @@ namespace pwiz.Skyline.FileUI
                         CheckMoleculeColumns();
                     }
 
+                    insertionParams.ProteinAssociations = checkBoxAssociateProteins.Checked && Importer.RowReader.Indices.ProteinColumn == 0
+                        ? _dictNameSeq
+                        : new Dictionary<string, FastaSequence>();
                     insertionParams.Document = _docCurrent.ImportMassList(_inputs, Importer, progressMonitor,
                         _insertPath, out insertionParams.SelectPath, out insertionParams.IrtPeptides,
                         out insertionParams.LibrarySpectra, out testErrorList, out insertionParams.PeptideGroups, insertionParams.ColumnHeaderList, GetRadioType(), hasHeaders, 
-                        checkBoxAssociateProteins.Checked && Importer.RowReader.Indices.ProteinColumn == 0 ? _dictNameSeq : new Dictionary<string, FastaSequence>());
+                        insertionParams.ProteinAssociations);
                     errorCheckCanceled = progressMonitor.IsCanceled;
                 });
             }

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -1945,6 +1945,7 @@ namespace pwiz.Skyline
             List<string> columnPositions = null;
             var docCurrent = DocumentUI;
             SrmDocument docNew = null;
+            Dictionary<string, FastaSequence> proteinAssociations = null;
             MassListImporter importer = null;
             var analyzingMessage = string.Format(Resources.SkylineWindow_ImportMassList_Analyzing_input__0_, inputs.InputFilename ?? string.Empty);
             using (var longWaitDlg0 = new LongWaitDlg(this)
@@ -1991,6 +1992,7 @@ namespace pwiz.Skyline
 
                     var insParams = columnDlg.InsertionParams;
                     docNew = insParams.Document;
+                    proteinAssociations = insParams.ProteinAssociations;
                     selectPath = insParams.SelectPath;
                     irtPeptides = insParams.IrtPeptides;
                     librarySpectra = insParams.LibrarySpectra;
@@ -2101,7 +2103,8 @@ namespace pwiz.Skyline
                     // If the document was changed during the operation, try all the changes again
                     // using the information given by the user.
                     docCurrent = DocumentUI;
-                    doc = doc.ImportMassList(inputs, importer, insertPath, out selectPath, columnPositions, hasHeaders);
+                    doc = doc.ImportMassList(inputs, importer, null, insertPath, out selectPath, out _, out _, out _,
+                        out _, columnPositions, SrmDocument.DOCUMENT_TYPE.none, hasHeaders, proteinAssociations);
                     if (irtInputs != null)
                     {
                         var iRTimporter = doc.PreImportMassList(irtInputs, null, false);

--- a/pwiz_tools/Skyline/TestTutorial/ExistingExperimentsTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/ExistingExperimentsTutorialTest.cs
@@ -109,6 +109,9 @@ namespace pwiz.SkylineTestTutorial
 
         private void DoMrmerTest()
         {
+            if (!IsPauseForScreenShots)
+                AllowInternetAccess = false;    // Keep the background proteome from getting updated from the web
+
             // Preparing a Document to Accept a Transition List, p. 2
             var peptideSettingsUI = ShowDialog<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI);
             var editListUI =
@@ -147,8 +150,10 @@ namespace pwiz.SkylineTestTutorial
             var docBeforePeptideSettings = SkylineWindow.Document;
             OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
             var docBeforeTrans = WaitForDocumentChangeLoaded(docBeforePeptideSettings);
+            WaitForBackgroundProteomeLoaderCompleted();
 
             // Inserting a Transition List With Associated Proteins, p. 6
+            // using (new DocChangeLogger("ShowInsertTransitionListDlg"))
             using (new CheckDocumentState(24, 44, 88, 296))
             {
                 var importDialog = ShowDialog<InsertTransitionListDlg>(SkylineWindow.ShowPasteTransitionListDlg);
@@ -163,7 +168,8 @@ namespace pwiz.SkylineTestTutorial
                 OkDialog(colDlg, colDlg.OkDialog);
             }
 
-            Assert.IsTrue(SkylineWindow.Document.Children.All(c => c.Id is FastaSequence));
+            Assert.IsTrue(SkylineWindow.Document.Children.All(c => c.Id is FastaSequence),
+                string.Format("Found {0} proteins without FASTA information", SkylineWindow.Document.Children.Count(c => !(c.Id is FastaSequence))));
 
             RunUI(() =>
             {


### PR DESCRIPTION
- Use WaitForBackgroundProteomeLoaderCompleted() to avoid unexpected document change
- Fix SkylineWindow.ImportMassList() to preserve protein associations from the ImportTransitionListColumnSelectDlg when document changes before ModifyDocument() can commit the change