### PR TITLE
Several pwiz fixes

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumList_Filter.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_Filter.cpp
@@ -214,7 +214,11 @@ PWIZ_API_DECL SpectrumList_FilterPredicate_ScanNumberSet::SpectrumList_FilterPre
 
 PWIZ_API_DECL tribool SpectrumList_FilterPredicate_ScanNumberSet::accept(const SpectrumIdentity& spectrumIdentity) const
 {
-    int scanNumber = id::valueAs<int>(spectrumIdentity.id, "scan");
+    int scanNumber = 0;
+    if (bal::starts_with(spectrumIdentity.id, "scan="))
+        scanNumber = id::valueAs<int>(spectrumIdentity.id, "scan");
+    else if (bal::starts_with(spectrumIdentity.id, "index=")) 
+        scanNumber = id::valueAs<int>(spectrumIdentity.id, "index");
     if (scanNumberSet_.hasUpperBound(scanNumber)) eos_ = true;
     bool result = scanNumberSet_.contains(scanNumber);
     return result;

--- a/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummer.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_ScanSummer.cpp
@@ -265,7 +265,7 @@ PWIZ_API_DECL SpectrumList_ScanSummer::SpectrumList_ScanSummer(const SpectrumLis
                 precursorMap.push_back(precursorGroupPtr());
                 continue;
             }
-            double rTime = s->scanList.scans[0].cvParam(MS_scan_start_time).timeInSeconds();
+            double rTime = s->scanList.scans[0].cvParam(MS_scan_start_time).valueAs<double>();
             double ionMobility = s->scanList.scans[0].cvParamValueOrDefault(MS_inverse_reduced_ion_mobility, 0.0);
 
             if (precursorList.empty()) // set some parameters

--- a/pwiz/utility/minimxml/SAXParser.cpp
+++ b/pwiz/utility/minimxml/SAXParser.cpp
@@ -583,7 +583,7 @@ PWIZ_API_DECL void parse(istream& is, Handler& handler)
 
 string xml_root_element(const string& fileheader)
 {
-    const static bxp::sregex e = bxp::sregex::compile("<\\?xml.*?>.*?<([^?!]\\S+?)[\\s>]");
+    const static bxp::sregex e = bxp::sregex::compile("(?:<\\?xml.*?>)?.*?<([^?!]\\S+?)[\\s>]");
 
     // convert Unicode to ASCII
     string asciiheader;
@@ -597,7 +597,7 @@ string xml_root_element(const string& fileheader)
     bxp::smatch m;
     if (bxp::regex_search(asciiheader, m, e))
         return m[1];
-    throw runtime_error("[xml_root_element] Root element not found (header is not well-formed XML)");
+    throw xml_root_error("[xml_root_element] Root element not found (header is not well-formed XML)");
 }
 
 string xml_root_element(istream& is)
@@ -612,7 +612,7 @@ string xml_root_element_from_file(const string& filepath)
 {
     pwiz::util::random_access_compressed_ifstream file(filepath.c_str());
     if (!file)
-        throw runtime_error("[xml_root_element_from_file] Error opening file");
+        throw xml_root_error("[xml_root_element_from_file] Error opening file");
     return xml_root_element(file);
 }
 

--- a/pwiz/utility/minimxml/SAXParser.hpp
+++ b/pwiz/utility/minimxml/SAXParser.hpp
@@ -696,6 +696,12 @@ PWIZ_API_DECL void parse(std::istream& is, Handler& handler);
 } // namespace SAXParser
 
 
+/// Thrown by xml_root_element if the file or string is not XML
+class xml_root_error : public std::runtime_error
+{
+    public: xml_root_error(const std::string& what) : std::runtime_error(what) {}
+};
+
 /// Returns the root element from an XML buffer;
 /// throws runtime_error if no element is found.
 PWIZ_API_DECL std::string xml_root_element(const std::string& fileheader);

--- a/pwiz/utility/minimxml/SAXParserTest.cpp
+++ b/pwiz/utility/minimxml/SAXParserTest.cpp
@@ -536,8 +536,12 @@ void testRootElement()
 
     unit_assert_operator_equal(RootElement, xml_root_element("<?xml?><RootElement>"));
     unit_assert_operator_equal(RootElement, xml_root_element("<?xml?><RootElement name='value'"));
+    unit_assert_operator_equal(RootElement, xml_root_element("<?xml?>\r\n<RootElement>"));
+    unit_assert_operator_equal(RootElement, xml_root_element("<?xml?>\r\n<RootElement name='value'"));
+    unit_assert_operator_equal(RootElement, xml_root_element("<RootElement>"));
+    unit_assert_operator_equal(RootElement, xml_root_element("<RootElement name='value'"));
 
-    unit_assert_throws(xml_root_element("not-xml"), runtime_error);
+    unit_assert_throws(xml_root_element("not-xml"), xml_root_error);
 }
 
 


### PR DESCRIPTION
- fixed xml_root_element to be able to handle XML files without an XML declaration "<?xml ...?>"; reported by Bruna
- fixed scanSumming filter not to change times to seconds when calculating scan time for summed spectra; reported by Amey
- changed scan number filter to fall back to index if there is no scan= in the nativeId
* changed xml_root_element to throw a new exception type xml_root_error instead of runtime_error (finally I can ignore those exceptions when debugging without turning off all runtime_errors!)