### PR TITLE
Fix NRE in "ElementRefs.GetNodeRef"

### DIFF
--- a/pwiz_tools/Skyline/Model/ElementLocators/ElementRefs.cs
+++ b/pwiz_tools/Skyline/Model/ElementLocators/ElementRefs.cs
@@ -72,6 +72,10 @@ namespace pwiz.Skyline.Model.ElementLocators
                 try
                 {
                     parentNode = (DocNodeParent)Document.FindNode(parentIdentityPath);
+                    if (parentNode == null)
+                    {
+                        return null;
+                    }
                 }
                 catch (IdentityNotFoundException)
                 {


### PR DESCRIPTION
Fixed "Unexpected Error" changing annotation value in document grid when the document had been changed (reported anonymously)