### PR TITLE
Prevent duplicate entries in imsdb for crosslinked peptides

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/LibraryKey.cs
+++ b/pwiz_tools/Skyline/Model/Lib/LibraryKey.cs
@@ -792,5 +792,29 @@ namespace pwiz.Skyline.Model.Lib
 
             return true;
         }
+
+        protected bool Equals(CrosslinkLibraryKey other)
+        {
+            return Charge == other.Charge && Equals(PeptideLibraryKeys, other.PeptideLibraryKeys) && Equals(Crosslinks, other.Crosslinks);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((CrosslinkLibraryKey)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Charge;
+                hashCode = (hashCode * 397) ^ (PeptideLibraryKeys != null ? PeptideLibraryKeys.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Crosslinks != null ? Crosslinks.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
     }
 }

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
@@ -263,11 +263,8 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
         {
             if (!File.Exists(path))
             {
-                if (!string.IsNullOrEmpty(path))
-                {
-                    MessageDlg.Show(this, String.Format(Resources.EditIonMobilityLibraryDlg_OpenDatabase_The_file__0__does_not_exist__Click_the_Create_button_to_create_a_new_ion_mobility_library_or_click_the_Open_button_to_find_the_missing_file_,
-                        path));
-                }
+                MessageDlg.Show(this, String.Format(Resources.EditIonMobilityLibraryDlg_OpenDatabase_The_file__0__does_not_exist__Click_the_Create_button_to_create_a_new_ion_mobility_library_or_click_the_Open_button_to_find_the_missing_file_,
+                                                    path));
                 return;
             }
 

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
@@ -263,8 +263,11 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
         {
             if (!File.Exists(path))
             {
-                MessageDlg.Show(this, String.Format(Resources.EditIonMobilityLibraryDlg_OpenDatabase_The_file__0__does_not_exist__Click_the_Create_button_to_create_a_new_ion_mobility_library_or_click_the_Open_button_to_find_the_missing_file_,
-                                                    path));
+                if (!string.IsNullOrEmpty(path))
+                {
+                    MessageDlg.Show(this, String.Format(Resources.EditIonMobilityLibraryDlg_OpenDatabase_The_file__0__does_not_exist__Click_the_Create_button_to_create_a_new_ion_mobility_library_or_click_the_Open_button_to_find_the_missing_file_,
+                        path));
+                }
                 return;
             }
 

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -263,7 +263,7 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
-        protected static void RunDlg<TDlg>(Action show, [InstantHandle] Action<TDlg> act = null, bool pause = false, int millis = -1) where TDlg : Form
+        protected static void RunDlg<TDlg>([InstantHandle] Action show, [InstantHandle] Action<TDlg> act = null, bool pause = false, int millis = -1) where TDlg : Form
         {
             RunDlg(show, false, act, pause, millis);
         }


### PR DESCRIPTION
Fixed bug where ion mobility library entries for crosslinked peptides would be duplicated each time you pressed the "Use Results" button (reported by Juan)
