### PR TITLE
Skyline: Test fixes based on all night parallel test run failures

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/MultiSampleImportPeakBoundariesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MultiSampleImportPeakBoundariesTest.cs
@@ -91,8 +91,8 @@ namespace pwiz.SkylineTestFunctional
                 importResultsSamplesDlg.ExcludeSample(3);
             });
             OkDialog(importResultsSamplesDlg, importResultsSamplesDlg.OkDialog);
-            WaitForDocumentLoaded();
             WaitForCondition(() => 2 == SkylineWindow.Document.Settings.MeasuredResults.Chromatograms.Count);
+            WaitForDocumentLoaded();
             Assert.AreEqual(2, SkylineWindow.Document.Settings.MeasuredResults.Chromatograms.Count);
 
             // Import the second and third samples from "secondfile.wiff" into a replicate named "ReplicateThree"
@@ -114,8 +114,8 @@ namespace pwiz.SkylineTestFunctional
                 importResultsSamplesDlg.ExcludeSample(1);
             });
             OkDialog(importResultsSamplesDlg, importResultsSamplesDlg.OkDialog);
-            WaitForDocumentLoaded();
             WaitForCondition(() => 3 == SkylineWindow.Document.Settings.MeasuredResults.Chromatograms.Count);
+            WaitForDocumentLoaded();
             Assert.AreEqual(3, SkylineWindow.Document.Settings.MeasuredResults.Chromatograms.Count);
 
             var peakBoundariesFile = TestFilesDir.GetTestPath("PeakBoundaries.tsv");


### PR DESCRIPTION
- ran parallel test all night and got failures in TestTargetedMsMsTutorial and TestMultiSampleImportPeakBoundaries
- also found that parallel testing never passed through the runsmallmoleculeversions argument