### PR TITLE
Skyline: Fixes for large transition list / assay library import

### DIFF
--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -47,7 +47,7 @@ namespace pwiz.Skyline.FileUI
 
         public bool WindowShown { get; private set; }
 
-        private bool showIgnoredCols { get; set; }
+        private bool ShowIgnoredCols { get; set; }
 
         // These are only for error checking
         private readonly SrmDocument _docCurrent;
@@ -61,8 +61,9 @@ namespace pwiz.Skyline.FileUI
         private int _originalProteinIndex;
         private int _originalPeptideIndex;
         private string[] _originalColumnIDs;
-        private string[] _columnDropdownNamesAtSuccessfulAssociateProteins; // State of headers at last associate proteins success
-        private string[] _currentColumnDropdownNames => ComboBoxes.Select(c => c.Text).ToArray();
+
+        private string[] _colSelectionsAtSuccessfulAssociateProteins = Array.Empty<string>(); // State of headers at last associate proteins success
+
         // Protein name, FASTA sequence pairs for importing peptides into protein groups
         private Dictionary<string, FastaSequence> _dictNameSeq;
         // Stores the position of proteins for _proteinTip
@@ -125,8 +126,8 @@ namespace pwiz.Skyline.FileUI
         }
 
         // When we switch modes we want to keep the column positions that were set in the mode not being used
-        private List<string> smallMolColPositions;
-        private List<string> peptideColPositions;
+        private List<string> _smallMolColSelections;
+        private List<string> _peptideColSelections;
 
         public ImportTransitionListColumnSelectDlg(MassListImporter importer, SrmDocument docCurrent, MassListInputs inputs, IdentityPath insertPath, bool assayLibrary)
         {
@@ -135,7 +136,7 @@ namespace pwiz.Skyline.FileUI
             _inputs = inputs;
             _insertPath = insertPath;
             _originalLines = Importer.RowReader.Lines.ToArray();
-            showIgnoredCols = true;
+            ShowIgnoredCols = true;
 
             _proteinTip = new NodeTip(this) { Parent = this };
             previousIndices = new int[Importer.RowReader.Lines[0].ParseDsvFields(Importer.Separator).Length + 1];
@@ -382,7 +383,7 @@ namespace pwiz.Skyline.FileUI
             {
                 // Inspect the input for lines with more columns than headers, or more headers than columns
                 _numColumns = 0;
-                for (var index = 0; index < Importer.RowReader.Lines.Count; index++)
+                for (var index = 0; index < Math.Min(Importer.RowReader.Lines.Count, N_DISPLAY_LINES); index++)
                 {
                     var parsedLine = Importer.RowReader.Lines[index].ParseDsvFields(Importer.Separator);
                     _numColumns = Math.Max(_numColumns, parsedLine.Length);
@@ -404,7 +405,8 @@ namespace pwiz.Skyline.FileUI
             var table = new DataTable("TransitionList");
 
             // Create the first row of columns
-            var numColumns = GetColumnCount(true);
+            var numColumns = GetColumnCount(false);
+            Assume.IsTrue(numColumns == ComboBoxes.Count, @"InitializeComboBoxes() must be called before DisplayData()");
             for (var i = 0; i < numColumns; i++)
                 table.Columns.Add().DataType = typeof(string);
 
@@ -463,6 +465,14 @@ namespace pwiz.Skyline.FileUI
                 comboPanelInner.Controls.Add(combo);
                 combo.BringToFront();
             }
+            // The combo boxes index into the previousIndices array. So make sure they match in size.
+            if (previousIndices.Length != ComboBoxes.Count)
+            {
+                var reallocIndices = new int[ComboBoxes.Count];
+                Array.Copy(previousIndices, reallocIndices, Math.Min(ComboBoxes.Count, previousIndices.Length));
+                previousIndices = reallocIndices;
+            }
+
         }
 
         SrmDocument.DOCUMENT_TYPE GetRadioType()
@@ -559,7 +569,7 @@ namespace pwiz.Skyline.FileUI
         private void UseSavedColumnsIfValid()
         {
             // Save the detected columns so if the saved columns are invalid we can revert back
-            var detectedColumns = CurrentColumnPositions();
+            var detectedColumns = CurrentColSelections();
 
             // Accept invariant column names from settings as well as localized
             var headerTypesInvariant = ImportTransitionListColumnSelectDlg.GetKnownHeaderTypesInvariant();
@@ -575,30 +585,42 @@ namespace pwiz.Skyline.FileUI
             }
 
             // Change the column positions to the saved columns so we can check if they produce valid transitions
-            SetColumnPositions(settingsColumns);
+            SetColSelections(settingsColumns);
 
-            // Make a copy of the current transition list with N_DISPLAY_LINES rows or the length of the current transition list (whichever is smaller)
-            var input = new MassListInputs(Importer.RowReader.Lines.Take(N_DISPLAY_LINES).ToArray());
-            // Try importing that list to check for errors
-            var insertionParams = new DocumentChecked();
-            List<TransitionImportErrorInfo> testErrorList1 = null;
-            insertionParams.Document = _docCurrent.ImportMassList(input, Importer, null,
-                _insertPath, out insertionParams.SelectPath, out insertionParams.IrtPeptides,
-                out insertionParams.LibrarySpectra, out testErrorList1, out insertionParams.PeptideGroups,
-                null, SrmDocument.DOCUMENT_TYPE.none, false);
-
-            var allError = ReferenceEquals(insertionParams.Document, _docCurrent);
-            // If all transitions are errors, reset the columns to the detected columns
-            if (allError)
+            if (!IsValidColSelections())
             {
-                SetColumnPositions(detectedColumns);
+                SetColSelections(detectedColumns);
             }
+        }
+
+        private bool IsValidColSelections()
+        {
+            var savedLines = Importer.RowReader.Lines;
+            SrmDocument docImport;
+            try
+            {
+                // Make a copy of the current transition list with N_DISPLAY_LINES rows or the length
+                // of the current transition list (whichever is smaller)
+                Importer.RowReader.Lines = savedLines.Take(N_DISPLAY_LINES).ToArray();
+                // Try importing that list to check for errors
+                docImport = _docCurrent.ImportMassList(Importer.Inputs, Importer, null,
+                    _insertPath, out _, out _, out _, out _, out _, null,
+                    SrmDocument.DOCUMENT_TYPE.none, false);
+            }
+            finally
+            {
+                Importer.RowReader.Lines = savedLines;
+            }
+
+            // If this operation changed the document at all, the the column selections
+            // are considered valid.
+            return !ReferenceEquals(docImport, _docCurrent);
         }
 
         /// <summary>
         /// Returns the current column positions as a list of strings
         /// </summary>
-        public List<string> CurrentColumnPositions()
+        public List<string> CurrentColSelections()
         {
             return ComboBoxes.Select(combo => combo.Text).ToList();
         }
@@ -608,7 +630,7 @@ namespace pwiz.Skyline.FileUI
         /// </summary>
         public List<string> CurrentColumnPositionsInvariant()
         {
-            return ColumnNamesInvariant(CurrentColumnPositions());
+            return ColumnNamesInvariant(CurrentColSelections());
         }
         public static List<string> ColumnNamesInvariant(IEnumerable<string> local)
         {
@@ -653,7 +675,7 @@ namespace pwiz.Skyline.FileUI
         /// <summary>
         /// Set the combo boxes and column indices given a list of column positions
         /// </summary>
-        private void SetColumnPositions(IList<string> columnPositions)
+        private void SetColSelections(IList<string> columnPositions)
         {
             for (int i = 0; i < columnPositions.Count; i++)
             {
@@ -672,7 +694,7 @@ namespace pwiz.Skyline.FileUI
             var activeColumnIndexes = new List<int>();
             for (var i = 0; i < dataGrid.Columns.Count; i++)
             {
-                if (!(!showIgnoredCols && Equals(ComboBoxes[i].Text,
+                if (!(!ShowIgnoredCols && Equals(ComboBoxes[i].Text,
                     Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column)))
                 {
                     activeColumnIndexes.Add(i);
@@ -796,8 +818,8 @@ namespace pwiz.Skyline.FileUI
             if (Equals(comboBox.Text, Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column))
             {
                 var comboBoxIndex = ComboBoxes.IndexOf(comboBox);
-                dataGrid.Columns[comboBoxIndex].Visible = showIgnoredCols;
-                comboBox.Visible = showIgnoredCols;
+                dataGrid.Columns[comboBoxIndex].Visible = ShowIgnoredCols;
+                comboBox.Visible = ShowIgnoredCols;
             }
         }
 
@@ -971,10 +993,8 @@ namespace pwiz.Skyline.FileUI
 
             Assume.IsTrue(isAssociated || !isAssociateProteins, @"expected a complete associate proteins preview");
 
-            // Check for errors is expensive with associate proteins, so don't re-run if associate proteins is known good
-            if (InsertionParams == null || // Haven't checked yet
-                _associateProteinsMode == AssociateProteinsMode.preview || // Either no associate proteins, or we didn't do the full input set
-                !_currentColumnDropdownNames.SequenceEqual(_columnDropdownNamesAtSuccessfulAssociateProteins)) // Something changed in headers selection since last association
+            // Check for errors is expensive with associate proteins, if a known good check exists
+            if (IsCheckForErrorsNecessary(isAssociateProteins)) // Something changed in headers selection since last association
             {
                 if (CheckForErrors(true)) // Look for errors, be silent on success
                     return;
@@ -985,6 +1005,24 @@ namespace pwiz.Skyline.FileUI
                 return; // User canceled out of associate proteins dialog, wait and see what they do next
             }
             DialogResult = DialogResult.OK;
+        }
+
+        private bool IsCheckForErrorsNecessary(bool isAssociateProteins)
+        {
+            if (InsertionParams == null)
+                return true;    // Haven't checked yet
+            var currentColumnSelections = CurrentColSelections();
+            if (!currentColumnSelections.SequenceEqual(InsertionParams.ColSelections))
+                return true;    // Columns selections changed since check
+            if (isAssociateProteins)
+            {
+                if (_associateProteinsMode == AssociateProteinsMode.preview)
+                    return true;    // Either no associate proteins, or we didn't do the full input set
+                if (!currentColumnSelections.SequenceEqual(_colSelectionsAtSuccessfulAssociateProteins))
+                    return true;    // Columns changes since protein associations
+            }
+
+            return false;
         }
 
         private void ButtonCheckForErrors_Click(object sender, EventArgs e)
@@ -1029,7 +1067,7 @@ namespace pwiz.Skyline.FileUI
             public List<MeasuredRetentionTime> IrtPeptides;
             public List<SpectrumMzInfo> LibrarySpectra;
             public List<PeptideGroupDocNode> PeptideGroups;
-            public List<string> ColumnHeaderList;
+            public List<string> ColSelections;
             public bool IsSmallMoleculeList;
         }
 
@@ -1110,17 +1148,17 @@ namespace pwiz.Skyline.FileUI
             if (radioPeptide.Checked)
             {
                 // Set the column headers to what they were last time we were in peptide mode
-                if (peptideColPositions != null)
+                if (_peptideColSelections != null)
                 {
-                    SetColumnPositions(peptideColPositions);
+                    SetColSelections(_peptideColSelections);
                 }
             }
             else
             {
                 // Set the column headers to what they were last time we were in small molecule mode
-                if (smallMolColPositions != null)
+                if (_smallMolColSelections != null)
                 {
-                    SetColumnPositions(smallMolColPositions);
+                    SetColSelections(_smallMolColSelections);
                 }
             }
         }
@@ -1132,6 +1170,7 @@ namespace pwiz.Skyline.FileUI
             {
                 if (comboBox.Text == string.Empty)
                 {
+                    Assume.IsTrue(comboBox.Items.Count > 0);
                     comboBox.SelectedIndex = 0;
                 }
                 
@@ -1174,7 +1213,7 @@ namespace pwiz.Skyline.FileUI
             bool hasHeaders = Importer.RowReader.Indices.Headers != null;
             List<TransitionImportErrorInfo> testErrorList = null;
             var errorCheckCanceled = true;
-            insertionParams.ColumnHeaderList = CurrentColumnPositions();
+            insertionParams.ColSelections = CurrentColSelections();
 
             if (checkBoxAssociateProteins.Checked)
             {
@@ -1212,7 +1251,7 @@ namespace pwiz.Skyline.FileUI
                         : new Dictionary<string, FastaSequence>();
                     insertionParams.Document = _docCurrent.ImportMassList(_inputs, Importer, progressMonitor,
                         _insertPath, out insertionParams.SelectPath, out insertionParams.IrtPeptides,
-                        out insertionParams.LibrarySpectra, out testErrorList, out insertionParams.PeptideGroups, insertionParams.ColumnHeaderList, GetRadioType(), hasHeaders, 
+                        out insertionParams.LibrarySpectra, out testErrorList, out insertionParams.PeptideGroups, insertionParams.ColSelections, GetRadioType(), hasHeaders, 
                         insertionParams.ProteinAssociations);
                     errorCheckCanceled = progressMonitor.IsCanceled;
                 });
@@ -1262,7 +1301,7 @@ namespace pwiz.Skyline.FileUI
                 MessageDlg.Show(this, Resources.PasteDlg_ShowNoErrors_No_errors);
             }
             
-            insertionParams.ColumnHeaderList = CurrentColumnPositions();
+            insertionParams.ColSelections = CurrentColSelections();
             insertionParams.IsSmallMoleculeList = !radioPeptide.Checked;
             InsertionParams = insertionParams;
             return false; // No errors
@@ -1343,7 +1382,7 @@ namespace pwiz.Skyline.FileUI
 
         private void checkBox1_CheckedChanged(object sender, EventArgs e)
         {
-            showIgnoredCols = CheckShowUnusedColumns.Checked;
+            ShowIgnoredCols = CheckShowUnusedColumns.Checked;
 
             // Goes through each comboBox and sets their visibility if they are an Ignore Column
             foreach (var comboBox in ComboBoxes)
@@ -1360,7 +1399,7 @@ namespace pwiz.Skyline.FileUI
         {
             if (radioPeptide.Checked)
             {
-                smallMolColPositions = CurrentColumnPositions();
+                _smallMolColSelections = CurrentColSelections();
             }
             else
             {
@@ -1371,7 +1410,7 @@ namespace pwiz.Skyline.FileUI
                     checkBoxAssociateProteins.Checked = false;
                 }
 
-                peptideColPositions = CurrentColumnPositions();
+                _peptideColSelections = CurrentColSelections();
             }
             foreach (var comboBox in ComboBoxes)
             {
@@ -1388,18 +1427,18 @@ namespace pwiz.Skyline.FileUI
         /// </summary>
         private void ReverseAssociateProteins()
         {
-            var oldPositions = CurrentColumnPositions();
+            var oldColSelections = CurrentColSelections();
             dataGrid.Columns[0].HeaderText = null;
             // Show the original transition list without the protein names we have added
             Importer.RowReader.Lines = _originalLines;
             Importer.RowReader.Indices.Headers = _originalColumnIDs;
-            _columnDropdownNamesAtSuccessfulAssociateProteins = Array.Empty<string>();
+            _colSelectionsAtSuccessfulAssociateProteins = Array.Empty<string>();
             isAssociated = false;
 
             UpdateForm();
-            oldPositions.RemoveAt(0);
+            oldColSelections.RemoveAt(0);
             dataGrid.Columns[0].DefaultCellStyle.Font = new Font(dataGrid.DefaultCellStyle.Font, FontStyle.Regular);
-            SetColumnPositions(oldPositions);
+            SetColSelections(oldColSelections);
             // Make sure we set the "Protein Name" column back to it's original index
             if (_originalProteinIndex != -1 && _originalProteinIndex != 0)
             {
@@ -1430,7 +1469,7 @@ namespace pwiz.Skyline.FileUI
         /// <returns>True if not canceled by user</returns>
         private bool UpdateProteinAssociationState(AssociateProteinsMode mode)
         {
-            var oldPositions = CurrentColumnPositions();
+            var originalColSelections = CurrentColSelections();
             var proteinName = Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Protein_Name;
             var canceled = false;
             if (checkBoxAssociateProteins.Checked)
@@ -1441,7 +1480,8 @@ namespace pwiz.Skyline.FileUI
                     return true; // Not canceled
                 }
 
-                if (isAssociated && Equals(mode, AssociateProteinsMode.preview) && Equals(_columnDropdownNamesAtSuccessfulAssociateProteins, _currentColumnDropdownNames))
+                if (isAssociated && Equals(mode, AssociateProteinsMode.preview) &&
+                    originalColSelections.SequenceEqual(_colSelectionsAtSuccessfulAssociateProteins))
                 {
                     return true; // We have already handled the first bunch of visible peptides
                 }
@@ -1449,7 +1489,7 @@ namespace pwiz.Skyline.FileUI
                 if (mode == AssociateProteinsMode.preview)
                 {
                     // Newly ticked checkbox
-                    _columnDropdownNamesAtSuccessfulAssociateProteins = Array.Empty<string>();
+                    _colSelectionsAtSuccessfulAssociateProteins = Array.Empty<string>();
                     _originalColumnIDs = Importer.RowReader.Indices.Headers;
                     _originalProteinIndex = Importer.RowReader.Indices.ProteinColumn;
                 }
@@ -1488,17 +1528,17 @@ namespace pwiz.Skyline.FileUI
                         // If there was an existing protein name box, set its value to "Ignore Column"
                         if (_originalProteinIndex != -1)
                         {
-                            oldPositions[_originalProteinIndex] =
+                            originalColSelections[_originalProteinIndex] =
                                 Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column;
                         }
 
-                        oldPositions.Insert(0, proteinName);
+                        originalColSelections.Insert(0, proteinName);
                     }
 
-                    SetColumnPositions(oldPositions);
+                    SetColSelections(originalColSelections);
                     if (mode != AssociateProteinsMode.preview)
                     {
-                        _columnDropdownNamesAtSuccessfulAssociateProteins = _currentColumnDropdownNames;
+                        _colSelectionsAtSuccessfulAssociateProteins = CurrentColSelections().ToArray();
                     }
                     isAssociated = true;
                 }

--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -2759,45 +2759,6 @@ namespace pwiz.Skyline.Model
         { }
     }
 
-    public class LineColNumberedIoException : IOException
-    {
-        public LineColNumberedIoException(string message, long lineNum, int colIndex)
-            : base(FormatMessage(message, lineNum, colIndex))
-        {
-            PlainMessage = message;
-            LineNumber = lineNum;
-            ColumnIndex = colIndex;
-        }
-
-        public LineColNumberedIoException(string message, string suggestion, long lineNum, int colIndex)
-            : base(TextUtil.LineSeparate(FormatMessage(message, lineNum, colIndex), suggestion))
-        {
-            PlainMessage = TextUtil.LineSeparate(message, suggestion);
-            LineNumber = lineNum;
-            ColumnIndex = colIndex;
-        }
-
-        public LineColNumberedIoException(string message, long lineNum, int colIndex, Exception inner)
-            : base(FormatMessage(message, lineNum, colIndex), inner)
-        {
-            PlainMessage = message;
-            LineNumber = lineNum;
-            ColumnIndex = colIndex;
-        }
-
-        private static string FormatMessage(string message, long lineNum, int colIndex)
-        {
-            if (colIndex == -1)
-                return string.Format(Resources.LineColNumberedIoException_FormatMessage__0___line__1__, message, lineNum);
-            else
-                return string.Format(Resources.LineColNumberedIoException_FormatMessage__0___line__1___col__2__, message, lineNum, colIndex + 1);
-        }
-
-        public string PlainMessage { get; private set; }
-        public long LineNumber { get; private set; }
-        public int ColumnIndex { get; private set; }
-    }
-
     public class PeptideGroupBuilder
     {
         // filename to use if no file has been specified

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -1462,8 +1462,9 @@ namespace pwiz.Skyline.Model
                                           out List<TransitionImportErrorInfo> errorList,
                                           out List<PeptideGroupDocNode> peptideGroups,
                                           List<string> columnPositions = null,
-                                          DOCUMENT_TYPE radioType = DOCUMENT_TYPE.none,
-                                          bool hasHeaders = true, Dictionary<string, FastaSequence> dictNameSeq = null)
+                                          DOCUMENT_TYPE forceDocType = DOCUMENT_TYPE.none,
+                                          bool hasHeaders = true,
+                                          Dictionary<string, FastaSequence> dictNameSeq = null)
         {
             irtPeptides = new List<MeasuredRetentionTime>();
             librarySpectra = new List<SpectrumMzInfo>();
@@ -1474,7 +1475,8 @@ namespace pwiz.Skyline.Model
             firstAdded = null;
 
             // Is this a small molecule transition list, or trying to be?
-            if (((importer != null && importer.InputType == DOCUMENT_TYPE.small_molecules) && radioType == DOCUMENT_TYPE.none) || radioType == DOCUMENT_TYPE.small_molecules)
+            if (forceDocType == DOCUMENT_TYPE.small_molecules || 
+                (forceDocType == DOCUMENT_TYPE.none && importer != null && importer.InputType == DOCUMENT_TYPE.small_molecules))
             {
                 IList<string> lines = null;
                 try
@@ -1507,11 +1509,12 @@ namespace pwiz.Skyline.Model
                     if (importer != null)
                     {
                         IdentityPath nextAdd;
-                        //peptideGroups = importer.Import(progressMonitor, out irtPeptides, out librarySpectra, out errorList).ToList();
                         if (dictNameSeq == null)
                         {
                             dictNameSeq = new Dictionary<string, FastaSequence>();
                         }
+
+                        Assume.IsTrue(ReferenceEquals(inputs, importer.Inputs));    // DoImport assumes this
 
                         var imported = importer.DoImport(progressMonitor, dictNameSeq, irtPeptides, librarySpectra, errorList);
                         if (progressMonitor != null && progressMonitor.IsCanceled)

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -2002,7 +2002,7 @@ namespace pwiz.Skyline
                     isAssociateProteins = columnDlg.checkBoxAssociateProteins.Checked;
 
                     // Store the text for the audit log if it didn't come from a file
-                    if (inputs.InputFilename == null)
+                    if (string.IsNullOrEmpty(inputs.InputFilename))
                     {
                         // Grab the final grid contents (may have been altered by Associate Proteins, or user additions/deletions
                         var sb = new StringBuilder();
@@ -2139,6 +2139,7 @@ namespace pwiz.Skyline
                 object[] args;
 
                 // Log the column assignments
+                // CONSIDER(brendanx): It would be better to use an object that subclasses AuditLogOperationSettings
                 var columnsUsed = (colSelections == null || colSelections.Count == 0)
                     ? null
                     : string.Format(Resources.SkylineWindow_ImportMassList_Columns_identified_as__0_, TextUtil.ToCsvLine(colSelections.Select(s => $@"'{s}'")));
@@ -2155,7 +2156,7 @@ namespace pwiz.Skyline
                 extraInfo.Add(columnsUsed);
 
                 // Imported from file
-                if (inputs.InputFilename != null)
+                if (!string.IsNullOrEmpty(inputs.InputFilename))
                 {
                     msgType = assayLibrary ? MessageType.imported_assay_library_from_file : MessageType.imported_transition_list_from_file;
                     args = new object[] { AuditLogPath.Create(inputs.InputFilename) };
@@ -2165,11 +2166,10 @@ namespace pwiz.Skyline
                 else
                 {
                     msgType = assayLibrary ? MessageType.imported_assay_library : MessageType.imported_transition_list;
-                    args = new object[0];
+                    args = Array.Empty<object>();
                     extraInfo.Add(gridValues ?? inputs.InputText);
                 }
 
-                // CONSIDER: This doesn't seem like enough, because it doesn't store the column selections and protein association
                 return AuditLogEntry.CreateSingleMessageEntry(new MessageInfo(msgType, docPair.NewDocumentType, args), 
                     TextUtil.LineSeparate(extraInfo.Where(s => !string.IsNullOrEmpty(s)))).Merge(docPair, entryCreators);
             });

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -1942,7 +1942,7 @@ namespace pwiz.Skyline
             List<SpectrumMzInfo> librarySpectra = new List<SpectrumMzInfo>();
             List<TransitionImportErrorInfo> errorList = new List<TransitionImportErrorInfo>();
             List<PeptideGroupDocNode> peptideGroups = new List<PeptideGroupDocNode>();
-            List<string> columnPositions = null;
+            List<string> colSelections = null;
             var docCurrent = DocumentUI;
             SrmDocument docNew = null;
             Dictionary<string, FastaSequence> proteinAssociations = null;
@@ -1997,24 +1997,28 @@ namespace pwiz.Skyline
                     irtPeptides = insParams.IrtPeptides;
                     librarySpectra = insParams.LibrarySpectra;
                     peptideGroups = insParams.PeptideGroups;
-                    columnPositions = insParams.ColumnHeaderList;
+                    colSelections = insParams.ColSelections;
                     isSmallMoleculeList = insParams.IsSmallMoleculeList;
                     isAssociateProteins = columnDlg.checkBoxAssociateProteins.Checked;
 
-                    // Grab the final grid contents (may have been altered by Associate Proteins, or user additions/deletions
-                    var sb = new StringBuilder();
-                    if (columnDlg.Importer.RowReader.Indices.Headers != null &&
-                        columnDlg.Importer.RowReader.Indices.Headers.Any())
+                    // Store the text for the audit log if it didn't come from a file
+                    if (inputs.InputFilename == null)
                     {
-                        // Show the headers as the user sees them
-                        sb.AppendLine(string.Join(columnDlg.Importer.RowReader.Separator.ToString(), columnDlg.Importer.RowReader.Indices.Headers));
+                        // Grab the final grid contents (may have been altered by Associate Proteins, or user additions/deletions
+                        var sb = new StringBuilder();
+                        if (columnDlg.Importer.RowReader.Indices.Headers != null &&
+                            columnDlg.Importer.RowReader.Indices.Headers.Any())
+                        {
+                            // Show the headers as the user sees them
+                            sb.AppendLine(string.Join(columnDlg.Importer.RowReader.Separator.ToString(), columnDlg.Importer.RowReader.Indices.Headers));
+                        }
+                        foreach (var line in columnDlg.Importer.RowReader.Lines.Where(l => !string.IsNullOrEmpty(l)))
+                        {
+                            // Show the input lines as the user sees them
+                            sb.AppendLine(line);
+                        }
+                        gridValues = sb.ToString();
                     }
-                    foreach (var line in columnDlg.Importer.RowReader.Lines.Where(l => !string.IsNullOrEmpty(l)))
-                    {
-                        // Show the input lines as the user sees them
-                        sb.AppendLine(line);
-                    }
-                    gridValues = sb.ToString();
                 }
             }
 
@@ -2023,7 +2027,7 @@ namespace pwiz.Skyline
                 // We should have all the column header info we need, proceed with the import
                 docCurrent = docCurrent.ImportMassList(inputs, importer, null,
                     insertPath, out selectPath, out irtPeptides, out librarySpectra, out errorList,
-                    out peptideGroups, columnPositions, SrmDocument.DOCUMENT_TYPE.none, hasHeaders);
+                    out peptideGroups, colSelections, SrmDocument.DOCUMENT_TYPE.none, hasHeaders);
             }
             if (importer.InputType == SrmDocument.DOCUMENT_TYPE.small_molecules)
             {
@@ -2104,11 +2108,11 @@ namespace pwiz.Skyline
                     // using the information given by the user.
                     docCurrent = DocumentUI;
                     doc = doc.ImportMassList(inputs, importer, null, insertPath, out selectPath, out _, out _, out _,
-                        out _, columnPositions, SrmDocument.DOCUMENT_TYPE.none, hasHeaders, proteinAssociations);
+                        out _, colSelections, SrmDocument.DOCUMENT_TYPE.none, hasHeaders, proteinAssociations);
                     if (irtInputs != null)
                     {
                         var iRTimporter = doc.PreImportMassList(irtInputs, null, false);
-                        doc = doc.ImportMassList(irtInputs, iRTimporter, null, out selectPath, columnPositions, hasHeaders);
+                        doc = doc.ImportMassList(irtInputs, iRTimporter, null, out selectPath, colSelections, hasHeaders);
                     }
                     var newSettings = doc.Settings;
                     if (retentionTimeRegressionStore != null)
@@ -2135,9 +2139,9 @@ namespace pwiz.Skyline
                 object[] args;
 
                 // Log the column assignments
-                var columnsUsed = (columnPositions == null || columnPositions.Count == 0)
+                var columnsUsed = (colSelections == null || colSelections.Count == 0)
                     ? null
-                    : string.Format(Resources.SkylineWindow_ImportMassList_Columns_identified_as__0_, TextUtil.ToCsvLine(columnPositions.Select(s => $@"'{s}'")));
+                    : string.Format(Resources.SkylineWindow_ImportMassList_Columns_identified_as__0_, TextUtil.ToCsvLine(colSelections.Select(s => $@"'{s}'")));
 
                 var extraInfo = new List<string>
                 {
@@ -2155,7 +2159,8 @@ namespace pwiz.Skyline
                 {
                     msgType = assayLibrary ? MessageType.imported_assay_library_from_file : MessageType.imported_transition_list_from_file;
                     args = new object[] { AuditLogPath.Create(inputs.InputFilename) };
-                    extraInfo.Add(gridValues);
+                    // Showing the full text of the file may be too much, even causing out of memory error.
+                    // extraInfo.Add(gridValues);
                 }
                 else
                 {
@@ -2164,6 +2169,7 @@ namespace pwiz.Skyline
                     extraInfo.Add(gridValues ?? inputs.InputText);
                 }
 
+                // CONSIDER: This doesn't seem like enough, because it doesn't store the column selections and protein association
                 return AuditLogEntry.CreateSingleMessageEntry(new MessageInfo(msgType, docPair.NewDocumentType, args), 
                     TextUtil.LineSeparate(extraInfo.Where(s => !string.IsNullOrEmpty(s)))).Merge(docPair, entryCreators);
             });

--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -987,66 +987,69 @@ namespace pwiz.SkylineTestFunctional
         private void TestIrregularColumnCounts()
         {
             var header = GetAminoAcidsTransitionListText(out var textCSV) + "\n";
+            var lineEnd = @",-1,3";
 
-            for (var loop = 0; loop < 2; loop++)
+            TestIrregularColumnCountCases(textCSV, lineEnd, false);
+
+            // Now check again when the anomaly is past the end of the lines that get shown to the user
+            textCSV = textCSV.Replace(header, string.Empty);
+            var chunk = textCSV.Replace(lineEnd, @",-2,4").Split('\n');
+            var bigText = header;
+            int lineCount = 1;
+            while (lineCount < ImportTransitionListColumnSelectDlg.N_DISPLAY_LINES)
             {
-                var docOrig = SkylineWindow.Document;
-                TestError(textCSV, null, null); // That should just work
-                WaitForDocumentChange(docOrig);
-                NewDocument();
-
-                // Now see what happens when we remove the trailing field in the header
-                var shortHeader =
-                    textCSV.Replace(@"," + SmallMoleculeTransitionListColumnHeaders.rtPrecursor, string.Empty);
-                AssertEx.AreNotEqual(shortHeader, textCSV, "did something change in the test code?");
-                docOrig = SkylineWindow.Document;
-                TestError(shortHeader, null, null); 
-                WaitForDocumentChange(docOrig);
-                NewDocument();
-
-                // Now see what happens when we remove the trailing field in a data line (so fewer columns in line than in header)
-                var lineEnd = @",-1,3";
-                var shortData = textCSV.Replace(lineEnd, @",-1");
-                AssertEx.AreNotEqual(shortData, textCSV, "did something change in the test code?");
-                docOrig = SkylineWindow.Document;
-                TestError(shortData, null, null);
-                WaitForDocumentChange(docOrig);
-                NewDocument();
-
-                // Now see what happens when we add an extra trailing field in a data line (so more columns in line than in header)
-                const string suffixField = @",paintball";
-                var longData = textCSV.Replace(lineEnd, lineEnd + suffixField);
-                AssertEx.AreNotEqual(longData, textCSV, "did something change in the test code?");
-                docOrig = SkylineWindow.Document;
-                string expectedError = null;
-                if (loop == 1)
+                foreach (var lineText in chunk.Where(l => !string.IsNullOrEmpty(l)))
                 {
-                    // When the user can't see the field to use in making column decisions, an error is shown
-                    var lineText = ToLocalText(longData.Split('\n').First(l => l.EndsWith(suffixField)));
-                    expectedError =
-                        string.Format(Resources.DsvFileReader_ReadLine_Line__0__has__1__fields_when__2__expected_, lineText, 12, 11);
-                }
-                TestError(longData, expectedError, null);
-                if (expectedError == null)
-                    WaitForDocumentChange(docOrig);
-                NewDocument();
-
-                if (loop == 0)
-                {
-                    // Now check all that when the anomaly is well past the 100 or so lines that we normally show
-                    textCSV = textCSV.Replace(header, string.Empty);
-                    var chunk = textCSV.Replace(lineEnd, @",-2,4").Split('\n');
-                    var bigText = header;
-                    for (var i = 0; i++ < ImportTransitionListColumnSelectDlg.N_DISPLAY_LINES;)
-                    {
-                        foreach (var line in chunk.Where(l => !string.IsNullOrEmpty(l)))
-                        {
-                            bigText += i.ToString() + line + "\n";
-                        }
-                    }
-                    textCSV = bigText + textCSV;
+                    bigText += lineCount + lineText + "\n";
+                    lineCount++;
                 }
             }
+            textCSV = bigText + textCSV;
+
+            TestIrregularColumnCountCases(textCSV, lineEnd, true);
+        }
+
+        private void TestIrregularColumnCountCases(string textCSV, string lineEnd, bool withDsvReaderError)
+        {
+            var docOrig = SkylineWindow.Document;
+            TestError(textCSV, null, null); // That should just work
+            WaitForDocumentChange(docOrig);
+            NewDocument();
+
+            // Now see what happens when we remove the trailing field in the header
+            var shortHeader =
+                textCSV.Replace(@"," + SmallMoleculeTransitionListColumnHeaders.rtPrecursor, string.Empty);
+            AssertEx.AreNotEqual(shortHeader, textCSV, "did something change in the test code?");
+            docOrig = SkylineWindow.Document;
+            TestError(shortHeader, null, null);
+            WaitForDocumentChange(docOrig);
+            NewDocument();
+
+            // Now see what happens when we remove the trailing field in a data line (so fewer columns in line than in header)
+            var shortData = textCSV.Replace(lineEnd, @",-1");
+            AssertEx.AreNotEqual(shortData, textCSV, "did something change in the test code?");
+            docOrig = SkylineWindow.Document;
+            TestError(shortData, null, null);
+            WaitForDocumentChange(docOrig);
+            NewDocument();
+
+            // Now see what happens when we add an extra trailing field in a data line (so more columns in line than in header)
+            const string suffixField = @",paintball";
+            var longData = textCSV.Replace(lineEnd, lineEnd + suffixField);
+            AssertEx.AreNotEqual(longData, textCSV, "did something change in the test code?");
+            docOrig = SkylineWindow.Document;
+            // When the user can't see the field to use in making column decisions, an error is shown
+            string expectedError = withDsvReaderError ? GetDsvReaderError(longData, suffixField) : null;
+            TestError(longData, expectedError, null);
+            if (expectedError == null)
+                WaitForDocumentChange(docOrig);
+            NewDocument();
+        }
+
+        private static string GetDsvReaderError(string longData, string suffixField)
+        {
+            var lineText = ToLocalText(longData.Split('\n').First(l => l.EndsWith(suffixField)));
+            return string.Format(Resources.DsvFileReader_ReadLine_Line__0__has__1__fields_when__2__expected_, lineText, 12, 11);
         }
 
         private void TestToolServiceAccess()

--- a/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
@@ -77,7 +77,7 @@ namespace pwiz.SkylineTestFunctional
                 int covCol = 0;
                 RunUI(() =>
                 {
-                    var thermBoxes = therm.CurrentColumnPositions();
+                    var thermBoxes = therm.CurrentColSelections();
                     // Checks that automatically assigning column headers works properly
                     AssertEx.AreEqual(protName, thermBoxes[0]);
                     AssertEx.AreEqual(peptide, thermBoxes[1]);
@@ -164,7 +164,7 @@ namespace pwiz.SkylineTestFunctional
             WaitForDocumentLoaded();
             RunUI(() =>
             {
-                var peptideBoxes = peptideTransitionList.CurrentColumnPositions();
+                var peptideBoxes = peptideTransitionList.CurrentColSelections();
                 // Column positions are only saved if at least one combobox is changed, so
                 // change a couple in order to trigger column saving
                 peptideBoxes[14] = ignoreColumn;
@@ -184,7 +184,7 @@ namespace pwiz.SkylineTestFunctional
             WaitForDocumentLoaded();
             RunUI(() => 
             {
-                Assert.AreEqual(labelType, peptideTransitionList1.CurrentColumnPositions()[4]);
+                Assert.AreEqual(labelType, peptideTransitionList1.CurrentColSelections()[4]);
                 peptideTransitionList1.CancelDialog();
             });
 
@@ -196,7 +196,7 @@ namespace pwiz.SkylineTestFunctional
             LoadNewDocument(true);
             RunUI(() =>
             {
-                var diffPeptideBoxes = peptideTransitionListDiffHeaders.CurrentColumnPositions();
+                var diffPeptideBoxes = peptideTransitionListDiffHeaders.CurrentColSelections();
                 // Checks that the program did not use the saved indices
                 Assert.AreNotEqual(diffPeptideBoxes[4], 1);
 
@@ -214,11 +214,11 @@ namespace pwiz.SkylineTestFunctional
                 // Checks that two comboboxes cannot have the same header (unless it is Ignore Column)
                 dlg.SetSelectedColumnTypes(dlg.SupportedColumnTypes[1]); // Set 1st column
                 dlg.SetSelectedColumnTypes(null, dlg.SupportedColumnTypes[1]); // Leave 1st column alone, try to set 2nd column to same value
-                var columnTypes = dlg.CurrentColumnPositions();
+                var columnTypes = dlg.CurrentColSelections();
                 Assert.AreNotEqual(columnTypes[0], columnTypes[1]);
 
                 dlg.SetSelectedColumnTypes(null, null, ignoreColumn, ignoreColumn); // Leave first two columns alone, set next two to "ignore"
-                columnTypes = dlg.CurrentColumnPositions();
+                columnTypes = dlg.CurrentColSelections();
                 Assert.AreEqual(columnTypes[2], columnTypes[3]);
                 // Checks resizing of comboboxes 
                 var oldBoxWidth = dlg.ColumnTypeControlWidths[0];
@@ -261,7 +261,7 @@ namespace pwiz.SkylineTestFunctional
             
             RunUI(() =>
             {
-                var transitions1Boxes = transitions1.CurrentColumnPositions();
+                var transitions1Boxes = transitions1.CurrentColSelections();
                 Assert.AreNotEqual(transitions1Boxes[0], Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column);
                 Assert.AreNotEqual(transitions1Boxes[1], Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column);
                 Assert.AreNotEqual(transitions1Boxes[3], Resources.ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column);
@@ -298,7 +298,7 @@ namespace pwiz.SkylineTestFunctional
             // Verify that we did not use the saved position of "precursor m/z"
             RunUI(() =>
             {
-                var pep1Boxes = pep1.CurrentColumnPositions();
+                var pep1Boxes = pep1.CurrentColSelections();
                 Assert.AreNotEqual(pep1Boxes[2], pep1.SupportedColumnTypes[6]);
                 // Verify that we did use the detected values instead
                 Assert.AreEqual(pep1Boxes[4], pep1.SupportedColumnTypes[8]);

--- a/pwiz_tools/Skyline/Util/Extensions/Text.cs
+++ b/pwiz_tools/Skyline/Util/Extensions/Text.cs
@@ -749,6 +749,7 @@ namespace pwiz.Skyline.Util.Extensions
         private string userHeaders;
         private bool _rereadTitleLine; // set true for first readline if the file didn't actually have a header line
         private TextReader _reader;
+        private int _linesRead;
         
         public int NumberOfFields { get; private set; }
         public Dictionary<string, int> FieldDict { get; private set; }
@@ -829,10 +830,12 @@ namespace pwiz.Skyline.Util.Extensions
             _rereadTitleLine = false; // we no longer need to re-use that first line
             if (line == null)
                 return null;
+            _linesRead++;
             _currentFields = line.ParseDsvFields(_separator);
             if (_currentFields.Length > NumberOfFields)
             {
-                throw new IOException(string.Format(Resources.DsvFileReader_ReadLine_Line__0__has__1__fields_when__2__expected_, line, _currentFields.Length, NumberOfFields));
+                throw new LineColNumberedIoException(string.Format(Resources.DsvFileReader_ReadLine_Line__0__has__1__fields_when__2__expected_,
+                    line, _currentFields.Length, NumberOfFields), _linesRead, 0);
             }
             else if (_currentFields.Length < NumberOfFields)
             {
@@ -895,5 +898,44 @@ namespace pwiz.Skyline.Util.Extensions
             _reader.Dispose();
         }
 
+    }
+
+    public class LineColNumberedIoException : IOException
+    {
+        public LineColNumberedIoException(string message, long lineNum, int colIndex)
+            : base(FormatMessage(message, lineNum, colIndex))
+        {
+            PlainMessage = message;
+            LineNumber = lineNum;
+            ColumnIndex = colIndex;
+        }
+
+        public LineColNumberedIoException(string message, string suggestion, long lineNum, int colIndex)
+            : base(TextUtil.LineSeparate(FormatMessage(message, lineNum, colIndex), suggestion))
+        {
+            PlainMessage = TextUtil.LineSeparate(message, suggestion);
+            LineNumber = lineNum;
+            ColumnIndex = colIndex;
+        }
+
+        public LineColNumberedIoException(string message, long lineNum, int colIndex, Exception inner)
+            : base(FormatMessage(message, lineNum, colIndex), inner)
+        {
+            PlainMessage = message;
+            LineNumber = lineNum;
+            ColumnIndex = colIndex;
+        }
+
+        private static string FormatMessage(string message, long lineNum, int colIndex)
+        {
+            if (colIndex == -1)
+                return string.Format(Resources.LineColNumberedIoException_FormatMessage__0___line__1__, message, lineNum);
+            else
+                return string.Format(Resources.LineColNumberedIoException_FormatMessage__0___line__1___col__2__, message, lineNum, colIndex + 1);
+        }
+
+        public string PlainMessage { get; private set; }
+        public long LineNumber { get; private set; }
+        public int ColumnIndex { get; private set; }
     }
 }


### PR DESCRIPTION
Bruker reported an OutOfMemoryException trying to import a large assay library from PaSER. Testing with 6,000,000 line file (5x the Pan Human library) exposed a number of areas broken in this handling by changes in ImportTransitionListColumnSelectDlg with the introduction of small molecule support and a fix to handle non-rectangular data provided by a user.

These fixes now only support showing columns for long lines in the first 100 rows that we show in the form. Otherwise, the first unexpectedly long line now produces a normal error giving the line number with the line containing extra fields.

Attempting to restore save column selections also read the entire file and information derived from clicking "Check For Errors" was always discarded.