### PR TITLE
Skyline: Simplify use of ImportTransitionListColumnSelectDlg in tests

### DIFF
--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.Designer.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.Designer.cs
@@ -7,19 +7,6 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>
@@ -153,7 +140,7 @@
             this.Name = "ImportTransitionListColumnSelectDlg";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
-            this.Shown += new System.EventHandler(this.OnColumnsShown);
+            this.Shown += new System.EventHandler(this.form_Shown);
             this.Resize += new System.EventHandler(this.form_Resize);
             this.comboPanelOuter.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGrid)).EndInit();

--- a/pwiz_tools/Skyline/TestFunctional/InsertTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/InsertTest.cs
@@ -107,7 +107,6 @@ namespace pwiz.SkylineTestFunctional
                 var pasteText = TransitionsClipboardText;
                 var transitionDlg = ShowDialog<InsertTransitionListDlg>(SkylineWindow.ShowPasteTransitionListDlg);
                 var columnSelectDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => transitionDlg.TransitionListText = pasteText);
-                // WaitForConditionUI(() => columnSelectDlg.WindowShown); // Avoids possible race condition in code coverage tests
                 var associateProteinsDlg = ShowDialog<FilterMatchedPeptidesDlg>(columnSelectDlg.OkDialog); // Some peptides aren't in background proteome
                 var errDlg = ShowDialog<ImportTransitionListErrorDlg>(associateProteinsDlg.OkDialog);
                 RunUI(() =>
@@ -140,12 +139,12 @@ namespace pwiz.SkylineTestFunctional
                         doc.ChangeSettings(doc.Settings.ChangePeptideModifications(mods => new PeptideModifications(mods.StaticModifications, heavyMod))));
                     SkylineWindow.Document.Settings.UpdateDefaultModifications(true);
                 });
-                WaitForDocumentChange(document);
+                document = WaitForDocumentChange(document);
+                Assert.IsTrue(document.IsLoaded);
 
                 var pasteText = "LGPGRPLPTFPTSEC[+57]TS[+80]DVEPDTR[+10]\t907.081803\t1387.566968\tDDX54_CL02".Replace(".", LocalizationHelper.CurrentCulture.NumberFormat.NumberDecimalSeparator);
                 var transitionDlg = ShowDialog<InsertTransitionListDlg>(SkylineWindow.ShowPasteTransitionListDlg);
                 var columnSelectDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => transitionDlg.TransitionListText = pasteText);
-                // WaitForConditionUI(() => columnSelectDlg.WindowShown); // Avoids possible race condition in code coverage tests
                 var associateProteinsDlg = ShowDialog<FilterMatchedPeptidesDlg>(() => columnSelectDlg.CheckForErrors()); // Some peptides aren't in background proteome
                 var noErrDlg = ShowDialog<MessageDlg>(associateProteinsDlg.OkDialog);
                 Assert.AreEqual(Skyline.Properties.Resources.PasteDlg_ShowNoErrors_No_errors, noErrDlg.Message);

--- a/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
@@ -257,7 +257,7 @@ namespace pwiz.SkylineTestFunctional
             // Paste in the same list and verify that the invalid column positions were not saved
             LoadNewDocument(true);
             var transitions1 = ShowDialog<ImportTransitionListColumnSelectDlg>(() => SkylineWindow.Paste());
-            WaitForConditionUI(() => transitions1.WindowShown);
+            transitions1.WaitForShown();
             
             RunUI(() =>
             {

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2112,7 +2112,6 @@ namespace pwiz.SkylineTestUtil
             if (expectColumnSelectDialog)
             {
                 var columnSelectDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => SkylineWindow.Paste());
-                WaitForConditionUI(() => columnSelectDlg.WindowShown); // Avoids possible race condition in code coverage tests
                 OkDialog(columnSelectDlg, columnSelectDlg.OkDialog);
             }
             else
@@ -2126,7 +2125,6 @@ namespace pwiz.SkylineTestUtil
             if (expectColumnSelectDialog)
             {
                 var columnSelectDlg = ShowDialog<ImportTransitionListColumnSelectDlg>(() => SkylineWindow.Paste(text));
-                WaitForConditionUI(() => columnSelectDlg.WindowShown); // Avoids possible race condition in code coverage tests
                 OkDialog(columnSelectDlg, columnSelectDlg.OkDialog);
             }
             else


### PR DESCRIPTION
- Add ManualResetEvent and remove WindowShown boolean to reduce need for tests to add waiting
- Hopefully fix intermittent failures in TestInsert