### PR TITLE
Fix blank library match when spectrum intensities are all zero

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
@@ -363,7 +363,11 @@ namespace pwiz.Skyline.Controls.Graphs
 
                 if (DisplayedMirrorSpectrum != null)
                     maxIntensity = Math.Max(maxIntensity, DisplayedMirrorSpectrum.Intensities.Max());
-
+                if (maxIntensity == 0)
+                {
+                    // Prevent Scale.Max and Scale.Min being set to the same value because it makes the entire chart disappear
+                    maxIntensity = 1;
+                }
                 maxIntensity *= YMAX_SCALE;
 
                 GraphPane.YAxis.Scale.Max = DisplayedSpectrum == null ? 0.0 : maxIntensity;


### PR DESCRIPTION
Fixed bug where Library Match graph disappears if spectrum being displayed has no intensities that are greater than zero (reported by Rich)

The X and Y axes would disappear from the Library Match graph if all of the intensities of the displayed spectrum were zero. This happens a lot with EncyclopeDIA quant libraries where the peptide was detected in the chromatogram library but had no signal in the quantification runs.

Before fixing the bug:
![image](https://user-images.githubusercontent.com/303203/192907831-40139ad1-c1b7-488c-8d46-1d97b4487a4a.png)
After fixing the bug (note that X and Y axes are visible):
![image](https://user-images.githubusercontent.com/303203/192907904-04c641c1-2ed2-44ca-822d-5424617f931d.png)
