### PR TITLE
Add support for pressure chromatograms from Thermo

### DIFF
--- a/pwiz/data/vendor_readers/ABI/ChromatogramList_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/ChromatogramList_ABI.cpp
@@ -356,8 +356,10 @@ PWIZ_API_DECL void ChromatogramList_ABI::createIndex() const
         idToIndexMap_[ie.id] = ie.index;
     }
 
-    index_.push_back(IndexEntry());
+    // wiff2 doesn't support BPC for now
+    if (!bal::iends_with(wifffile_->getWiffPath(), ".wiff2"))
     {
+        index_.push_back(IndexEntry());
         IndexEntry& ie = index_.back();
         ie.index = index_.size() - 1;
         ie.id = "BPC";

--- a/pwiz/data/vendor_readers/ABI/Reader_ABI_Test.data/swath.api-sample-centroid.mzML
+++ b/pwiz/data/vendor_readers/ABI/Reader_ABI_Test.data/swath.api-sample-centroid.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="swath.api-sample" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.41" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.99" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -10,7 +10,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="WIFF" name="swath.api.wiff2" location="file://C:\pwiz.git\pwiz\pwiz\data\vendor_readers\ABI\Reader_ABI_Test.data">
+      <sourceFile id="WIFF" name="swath.api.wiff2" location="file://C:\dev\pwiz\pwiz\data\vendor_readers\ABI\Reader_ABI_Test.data">
         <cvParam cvRef="MS" accession="MS:1000770" name="WIFF nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000562" name="ABI WIFF format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="a3ca9764373670629714c86ae63389cf78f0e07f"/>
@@ -21,7 +21,7 @@
     <software id="Analyst" version="unknown">
       <cvParam cvRef="MS" accession="MS:1000551" name="Analyst" value=""/>
     </software>
-    <software id="pwiz_Reader_ABI" version="3.0.20294">
+    <software id="pwiz_Reader_ABI" version="3.0.22272">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -10245,7 +10245,7 @@
         </binaryDataArrayList>
       </spectrum>
     </spectrumList>
-    <chromatogramList count="2" defaultDataProcessingRef="pwiz_Reader_ABI_conversion">
+    <chromatogramList count="1" defaultDataProcessingRef="pwiz_Reader_ABI_conversion">
       <chromatogram index="0" id="TIC" defaultArrayLength="616">
         <cvParam cvRef="MS" accession="MS:1000235" name="total ion current chromatogram" value=""/>
         <binaryDataArrayList count="3">
@@ -10266,29 +10266,6 @@
             <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000786" name="non-standard data array" value="ms level" unitCvRef="UO" unitAccession="UO:0000186" unitName="dimensionless unit"/>
             <binary>eJxjZGBgYCIDM47qG9U3qm9U36i+UX2j+kb1jeqjiT4AZPoEpQ==</binary>
-          </binaryDataArray>
-        </binaryDataArrayList>
-      </chromatogram>
-      <chromatogram index="1" id="BPC" defaultArrayLength="0">
-        <cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" value=""/>
-        <binaryDataArrayList count="3">
-          <binaryDataArray encodedLength="0">
-            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000595" name="time array" value="" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
-            <binary></binary>
-          </binaryDataArray>
-          <binaryDataArray encodedLength="0">
-            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
-            <binary></binary>
-          </binaryDataArray>
-          <binaryDataArray arrayLength="0" encodedLength="0">
-            <cvParam cvRef="MS" accession="MS:1000519" name="32-bit integer" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
-            <cvParam cvRef="MS" accession="MS:1000786" name="non-standard data array" value="ms level" unitCvRef="UO" unitAccession="UO:0000186" unitName="dimensionless unit"/>
-            <binary></binary>
           </binaryDataArray>
         </binaryDataArrayList>
       </chromatogram>

--- a/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.cpp
@@ -246,6 +246,60 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Thermo::chromatogram(size_t index
                 else result->defaultArrayLength = cd->size();
             }
             break;
+
+            case MS_pressure_chromatogram: // ADCard: generate "pressure" chromatogram for entire run
+            {
+                ChromatogramDataPtr cd = rawfile_->getChromatogramData(
+                    Type_ECD, "", 0, 0, 0,
+                    rawfile_->getFirstScanTime(), rawfile_->getLastScanTime());
+                const auto& times = cd->times();
+                const auto& intensities = cd->intensities();
+                int redundantSamples = 0;
+                for (int i = 1; i + 1 < cd->size(); ++i)
+                {
+                    double prevIntensity = intensities[i - 1];
+                    double intensity = intensities[i];
+                    double nextIntensity = intensities[i + 1];
+                    if (intensity == prevIntensity && intensity == nextIntensity)
+                        ++redundantSamples;
+                }
+
+                if (getBinaryData)
+                {
+                    result->setTimeIntensityArrays(vector<double>(), vector<double>(), UO_minute, UO_pascal);
+                    auto& timeArray = result->getTimeArray()->data;
+                    auto& intensityArray = result->getIntensityArray()->data;
+                    timeArray.reserve(cd->size() - redundantSamples);
+                    intensityArray.reserve(cd->size() - redundantSamples);
+
+                    // I observed pressure traces with many redundant data points (same Y value for many X values in a row),
+                    // so I only copy the non-redundant ones
+
+                    // convert bar to pascal (1 bar = 100000 Pa) because there's no bar term in UO
+                    timeArray.push_back(times[0]);
+                    intensityArray.push_back(intensities[0] * 1e5);
+                    for (int i = 1; i+1 < cd->size(); ++i)
+                    {
+                        double prevIntensity = intensities[i - 1];
+                        double intensity = intensities[i];
+                        double nextIntensity = intensities[i + 1];
+                        if (intensity != prevIntensity || intensity != nextIntensity)
+                        {
+                            timeArray.push_back(times[i]);
+                            intensityArray.push_back(intensities[i] * 1e5);
+                        }
+                    }
+                    timeArray.push_back(times.back());
+                    intensityArray.push_back(intensities.back() * 1e5);
+                    result->defaultArrayLength = timeArray.size();
+
+                    // original code that copies all data points including redundant ones
+                    //result->setTimeIntensityArrays(cd->times(), cd->intensities(), UO_minute, UO_pascal);
+                    //boost::range::for_each(result->getIntensityArray()->data, [&](auto& v) {v *= 1e5;});
+                }
+                else result->defaultArrayLength = cd->size() - redundantSamples;
+            }
+            break;
         }
 
         return result;
@@ -403,6 +457,8 @@ PWIZ_API_DECL void ChromatogramList_Thermo::createIndex() const
                 }
                 break; // case Controller_PDA
 
+                case Controller_Analog:
+                case Controller_ADCard:
                 case Controller_UV:
                 {
                     auto instrumentData = rawfile_->getInstrumentData();
@@ -414,12 +470,12 @@ PWIZ_API_DECL void ChromatogramList_Thermo::createIndex() const
                     {
                         addChromatogram("CAD " + lexical_cast<string>(n), (ControllerType)controllerType, n, MS_TIC_chromatogram, "");
                     }
-                    else
+                    else if (bal::icontains(instrumentData.AxisLabelY, "Pressure"))
                     {
-                        // TODO: pressure/flow chromatogram
+                        addChromatogram("Pump Pressure " + lexical_cast<string>(n), (ControllerType)controllerType, n, MS_pressure_chromatogram, "");
                     }
                 }
-                break; // case Controller_UV
+                break; // case Controller_UV Controller_ADCard Controller_Analog
 
                 default:
                     // TODO: are there sensible default chromatograms for other controller types?

--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -739,6 +739,13 @@ namespace pwiz.ProteowizardWrapper
                         intensityList.Add((float) intensityArrayData[i]);
                     }
 
+                    // if there were no MS1 TIC points, add a placeholder so the TIC graph displays an appropriate message
+                    if (timeList.Count == 0)
+                    {
+                        timeList.Add(0);
+                        intensityList.Add(1);
+                    }
+
                     timeArray = timeList.ToArray();
                     intensityArray = intensityList.ToArray();
                 }

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -1116,6 +1116,20 @@ namespace pwiz.Skyline.Controls.Graphs
                     SetGraphItem(new UnavailableChromGraphItem(Helpers.PeptideToMoleculeTextMapper.Translate(message, DocumentUI.DocumentType)));
                 }
             }
+            else if (CurveCount == 1 && CurveList[0].NPts == 1 && CurveList[0].Points[0].X == 0)
+            {
+                string message = null;
+                switch (DisplayType)
+                {
+                    case DisplayTypeChrom.base_peak:
+                        message = Resources.GraphChromatogram_UpdateUI_No_MS1_spectra_found_in_base_peak_chromatogram;
+                        break;
+                    case DisplayTypeChrom.tic:
+                        message = Resources.GraphChromatogram_UpdateUI_No_MS1_spectra_found_in_TIC_chromatogram;
+                        break;
+                }
+                SetGraphItem(new UnavailableChromGraphItem(Helpers.PeptideToMoleculeTextMapper.Translate(message, DocumentUI.DocumentType)));
+            }
             else
             {
                 _graphHelper.FinishedAddingChromatograms(new[] {firstBestPeak, lastBestPeak}, false);
@@ -2466,10 +2480,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                      out bool changedGroupIds)
         {
             bool qcTraceNameMatches = extractor != ChromExtractor.qc ||
-                                      (_arrayChromInfo != null &&
-                                       _arrayChromInfo.Length > 0 &&
-                                       _arrayChromInfo[0].Length > 0 &&
-                                       _arrayChromInfo[0][0].TextId == Settings.Default.ShowQcTraceName);
+                                      _arrayChromInfo?[0]?[0].TextId == Settings.Default.ShowQcTraceName;
 
             if (UpdateGroups(nodeGroups, groupPaths, out changedGroups, out changedGroupIds) &&
                 _extractor == extractor &&

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -15101,6 +15101,24 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No MS1 spectra found in base peak chromatogram.
+        /// </summary>
+        public static string GraphChromatogram_UpdateUI_No_MS1_spectra_found_in_base_peak_chromatogram {
+            get {
+                return ResourceManager.GetString("GraphChromatogram_UpdateUI_No_MS1_spectra_found_in_base_peak_chromatogram", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No MS1 spectra found in TIC chromatogram.
+        /// </summary>
+        public static string GraphChromatogram_UpdateUI_No_MS1_spectra_found_in_TIC_chromatogram {
+            get {
+                return ResourceManager.GetString("GraphChromatogram_UpdateUI_No_MS1_spectra_found_in_TIC_chromatogram", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No precursor ion chromatograms found.
         /// </summary>
         public static string GraphChromatogram_UpdateUI_No_precursor_ion_chromatograms_found {

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -11706,13 +11706,13 @@ If you do not have the original file, you may build the library with embedded sp
     <value>Associate Proteins</value>
   </data>
   <data name="SciexOsMethodExporter_EnsureSciexOs_Waiting_for_SCIEX_OS_to_start" xml:space="preserve">
-	  <value>Waiting for SCIEX OS to start</value>
+      <value>Waiting for SCIEX OS to start</value>
   </data>
   <data name="SciexOsMethodExporter_EnsureSciexOs_Working___" xml:space="preserve">
-	  <value>Working...</value>
+      <value>Working...</value>
   </data>
   <data name="SciexOsMethodExporter_EnsureSciexOs_Failed_to_find_a_valid_SCIEX_OS_installation_" xml:space="preserve">
-	  <value>Failed to find a valid SCIEX OS installation.</value>
+      <value>Failed to find a valid SCIEX OS installation.</value>
   </data>
   <data name="BuildLibraryGridView__colFile_File" xml:space="preserve">
     <value>File</value>
@@ -11854,7 +11854,7 @@ If you do not have the original file, you may build the library with embedded sp
     <value>Shared Peptides</value>
   </data>
   <data name="Properties_Button" type="System.Resources.ResXFileRef, System.Windows.Forms">
-	<value>..\Resources\Properties.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Resources\Properties.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="DuplicatedPeptideFinder_DisplayName_Duplicated_peptides" xml:space="preserve">
     <value>Duplicated peptides</value>
@@ -11875,6 +11875,12 @@ If you do not have the original file, you may build the library with embedded sp
       <value>All targets must have an ion mobility between {0} and {1} as specified in the template method. Either use a different template method, or change the ion mobility values for the following targets:</value>
   </data>
   <data name="SkylineWindow_submitErrorReportMenuItem_Click_Submitting_an_unhandled_error_report" xml:space="preserve">
-	  <value>Submitting an unhandled error report</value>
+      <value>Submitting an unhandled error report</value>
+  </data>
+  <data name="GraphChromatogram_UpdateUI_No_MS1_spectra_found_in_base_peak_chromatogram" xml:space="preserve">
+      <value>No MS1 spectra found in base peak chromatogram</value>
+  </data>
+  <data name="GraphChromatogram_UpdateUI_No_MS1_spectra_found_in_TIC_chromatogram" xml:space="preserve">
+      <value>No MS1 spectra found in TIC chromatogram</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteTransitionListTest.cs
@@ -343,7 +343,7 @@ namespace pwiz.SkylineTestFunctional
                     AssertEx.IsTrue(errDlg.ErrorList.Any(err =>
                         err.ErrorMessage.Contains(Resources
                             .SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Multiple_ion_mobility_declarations)));
-                    RunUI(() => errDlg.Close());
+                    OkDialog(errDlg, errDlg.Close);
                     RunUI(() => therm.ComboBoxes[col].SelectedIndex = 0); // Ignore the 1/K0 and CoV values
                 }
             }


### PR DESCRIPTION
- removed empty BP chromatograms for WIFF2 files
- added pressure trace support for Thermo files
- Skyline: improved message displayed by TIC chromatogram graph if the file has no MS1 spectra

Review requested about the TIC chromatogram message.