### PR TITLE
Prevent NaN's in fold change values in PRM tutorial

### DIFF
--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparer.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparer.cs
@@ -489,7 +489,13 @@ namespace pwiz.Skyline.Model.GroupComparison
 
             public double GetLog2Abundance()
             {
-                return Math.Log(Intensity/Denominator)/Math.Log(2.0);
+                double log2Abundance = Math.Log(Intensity/Denominator)/Math.Log(2.0);
+                if (double.IsNaN(log2Abundance) || double.IsInfinity(log2Abundance))
+                {
+                    log2Abundance = 0;
+                }
+
+                return log2Abundance;
             }
         }
 

--- a/pwiz_tools/Skyline/TestPerf/OrbiPrmTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/OrbiPrmTutorialTest.cs
@@ -75,6 +75,7 @@ namespace TestPerf
 //            IsPauseForScreenShots = true;
 //            RunPerfTests = true;
 //            IsCoverShotMode = true;
+//            IsRecordMode = true;
             CoverShotName = "PRM-Obitrap";
 
             LinkPdf = "https://skyline.ms/_webdav/home/software/Skyline/%40files/tutorials/PRM-Orbitrap-21_2.pdf";
@@ -795,7 +796,25 @@ namespace TestPerf
 
             SaveBackup("PRM_Annotated");
         }
-        
+
+        private bool IsRecordMode { get; set; }
+
+        private double[] _g2mVsG1ExpectedValues =
+        {
+            1.4126022125838762, 4.8741132982321638, 5.0424478103497181, 4.8293170158752208, 15.126911528599191,
+            9.1791839486239279, 6.2296345732635485, 3.1161290456155295, 1.8189607341782479, 2.0644594385791533,
+            3.7649084396237988, 6.9299904926539737, 6.4036330881755932, 4.2893196515692162, 1.6064068091869139,
+            1.6281040373632159, 6.5174735762673706, 3.01571908714535, 1.8383738370494354
+        };
+
+        private double[] _sVsG1ExpectedValues =
+        {
+            1.1159764030783934, 1.6314748321839396, 2.3311870386518727, 1.6841367995234979, 4.8909495278818422,
+            3.2275682167523314, 2.3757882463140065, 1.5713835038262798, 1.017217922772327, 1.4498342648347344,
+            1.6399900918403256, 2.9023950735841626, 2.9069057246796444, 1.5243589451007142, 0.71120569210287388,
+            0.96378822722653923, 1.9613259766370852, 1.7862686219978938, 1.0616604140485391
+        };
+
         private void GroupComparison()
         {
             var docBeforeComparison = SkylineWindow.Document;
@@ -821,12 +840,14 @@ namespace TestPerf
 
             var foldChangeGrid1 = ShowDialog<FoldChangeGrid>(() => SkylineWindow.ShowGroupComparisonWindow(comparisonName1));
             WaitForConditionUI(() => 19 == foldChangeGrid1.DataboundGridControl.RowCount);
+            VerifyFoldChangeValues(foldChangeGrid1, _g2mVsG1ExpectedValues, nameof(_g2mVsG1ExpectedValues));
             RunUI(() => foldChangeGrid1.Parent.Parent.Width = 383);
             PauseForScreenShot<FoldChangeGrid>(comparisonName1 + ":Grid", 37);
             OkDialog(foldChangeGrid1, () => foldChangeGrid1.Close());
 
             var foldChangeGrid2 = ShowDialog<FoldChangeGrid>(() => SkylineWindow.ShowGroupComparisonWindow(comparisonName2));
             WaitForConditionUI(() => 19 == foldChangeGrid2.DataboundGridControl.RowCount);
+            VerifyFoldChangeValues(foldChangeGrid2, _sVsG1ExpectedValues, nameof(_sVsG1ExpectedValues));
             RunUI(() => foldChangeGrid2.Parent.Parent.Width = 383);
             PauseForScreenShot<FoldChangeGrid>(comparisonName2 + ":Grid", 37);
             OkDialog(foldChangeGrid2, () => foldChangeGrid2.Close());
@@ -952,6 +973,26 @@ namespace TestPerf
             Assert.IsTrue(SkylineWindow.Document.Settings.DataSettings.ViewSpecList.ViewSpecs
                 .Contains(s => Equals(REPORT_QUANT, s.Name)));
             RunUI(() => SkylineWindow.SaveDocument());
+        }
+
+        private void VerifyFoldChangeValues(FoldChangeGrid foldChangeGrid, double[] expectedValues, string variableName)
+        {
+            RunUI(() =>
+            {
+                var foldChangeRows = foldChangeGrid.FoldChangeBindingSource.GetBindingListSource().Cast<RowItem>()
+                    .Select(rowItem => (FoldChangeBindingSource.FoldChangeRow)rowItem.Value).ToList();
+                double[] actualValues = foldChangeRows.Select(foldChangeResult => foldChangeResult.FoldChangeResult.FoldChange).ToArray();
+                if (IsRecordMode)
+                {
+                    var commaSeparatedValues = string.Join(",",
+                        actualValues.Select(value => value.ToString("R", CultureInfo.InvariantCulture)));
+                    Console.Out.WriteLine("private double[] {0} = {{ {1} }};", variableName, commaSeparatedValues);
+                }
+                else
+                {
+                    CollectionAssert.AreEqual(expectedValues, actualValues);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Fix NaN's that appear in fold change values in PRM tutorial (reported by Brendan)

The bug was originally introduced by the change to GroupComparer.cs in PR #2155.

This is my best guess as to how to fix this bug, but I need to do some more investigation including comparing the results that we get with this fix to what the results were before the bug was introduced.