### PR TITLE
Skyline: Update projects with older .NET targets to 4.7.2

### DIFF
--- a/pwiz_tools/Shared/MSGraph/MSGraph.csproj
+++ b/pwiz_tools/Shared/MSGraph/MSGraph.csproj
@@ -15,7 +15,7 @@
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <TargetFrameworkProfile />

--- a/pwiz_tools/Shared/zedgraph/ZedGraph.csproj
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph.csproj
@@ -17,7 +17,7 @@
     </UpgradeBackupLocation>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>ZedGraph.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/pwiz_tools/Skyline/SkylineNightlyShim/SkylineNightlyShim.csproj
+++ b/pwiz_tools/Skyline/SkylineNightlyShim/SkylineNightlyShim.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SkylineNightlyShim</RootNamespace>
     <AssemblyName>SkylineNightlyShim</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/pwiz_tools/Skyline/SkylineTool/SkylineTool.csproj
+++ b/pwiz_tools/Skyline/SkylineTool/SkylineTool.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SkylineTool</RootNamespace>
     <AssemblyName>SkylineTool</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
These 4 projects failed to load on a new machine running Windows 11 and with only Visual Studio 2022 Community Edition. Kaipo said he had to install VS 2017 to get around this. We really want this case to work without requiring VS 2017 and I didn't see any issues when I updated these 4 projects to our standard .NET 4.7.2.