### PR TITLE
Ion mobility filtering for full scan data should use high energy ion mobility offset values for all acquisition types

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -288,8 +288,8 @@ namespace pwiz.Skyline.Model.Results
                         if (!EnabledMs)
                         {
                             filterCount += filter.AddQ3FilterValues((from TransitionDocNode nodeTran in nodeGroup.Children select nodeTran).
-                                Select(nodeTran => new SpectrumFilterValues(nodeTran.Mz, IsMseData() ?
-                                    nodeTran.ExplicitValues.IonMobilityHighEnergyOffset ?? ionMobilityFilter.HighEnergyIonMobilityOffset ?? 0 : 0)), calcWindowsQ3);
+                                Select(nodeTran => new SpectrumFilterValues(nodeTran.Mz,
+                                    nodeTran.ExplicitValues.IonMobilityHighEnergyOffset ?? ionMobilityFilter.HighEnergyIonMobilityOffset ?? 0)), calcWindowsQ3);
                         }
                         else if (!EnabledMsMs)
                         {
@@ -300,8 +300,8 @@ namespace pwiz.Skyline.Model.Results
                             filterCount += filter.AddQ1FilterValues(GetMS1MzValues(nodeGroup), calcWindowsQ1);
                             filterCount += filter.AddQ3FilterValues((from TransitionDocNode nodeTran in nodeGroup.Children
                                     where !nodeTran.IsMs1 select nodeTran).
-                                Select(nodeTran => new SpectrumFilterValues(nodeTran.Mz, IsMseData() ?
-                                    nodeTran.ExplicitValues.IonMobilityHighEnergyOffset ?? ionMobilityFilter.HighEnergyIonMobilityOffset ?? 0 : 0)), 
+                                Select(nodeTran => new SpectrumFilterValues(nodeTran.Mz,
+                                    nodeTran.ExplicitValues.IonMobilityHighEnergyOffset ?? ionMobilityFilter.HighEnergyIonMobilityOffset ?? 0)), 
                                 calcWindowsQ3);
                         }
                     }

--- a/pwiz_tools/Skyline/TestPerf/PerfHighEnergyIonMobilityOffsetForPRM.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfHighEnergyIonMobilityOffsetForPRM.cs
@@ -1,0 +1,75 @@
+/*
+ * Original author: Brian Pratt <bspratt .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2022 University of Washington - Seattle, WA
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline.Model.DocSettings;
+using pwiz.SkylineTestUtil;
+using System.Linq;
+
+namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the global RunPerfTests flag is set
+{
+    /// <summary>
+    /// Verify use of high energy ion mobility offset values for PRM data - formerly we used it only for All Ions.
+    /// </summary>
+    [TestClass]
+    public class HighEnergyIonMobilityOffsetForPRMTest : AbstractFunctionalTestEx
+    {
+
+        [TestMethod] 
+        public void TestHighEnergyIonMobilityOffsetForPRM()
+        {
+
+            TestFilesZip = GetPerfTestDataURL(@"PerfTestPrmDtOffset.zip");
+
+            RunFunctionalTest();
+            
+        }
+
+        private string GetTestPath(string relativePath)
+        {
+            return TestFilesDirs[0].GetTestPath(relativePath);
+        }
+
+
+        protected override void DoTest()
+        {
+            string skyfile = TestFilesDir.GetTestPath("prm_dt_offset.sky");
+
+            RunUI(() => SkylineWindow.OpenFile(skyfile));
+
+            var doc = WaitForDocumentLoaded();
+            AssertEx.IsDocumentState(doc, null, 1, 1, 1, 2);
+            ImportResults("data.mzML");
+            doc = WaitForDocumentChangeLoaded(doc);
+
+            // Verify that this is PRM data
+            AssertEx.AreEqual(FullScanAcquisitionMethod.PRM, doc.Settings.TransitionSettings.FullScan.AcquisitionMethod);
+
+            // Verify that a high energy ion mobility offset was applied for chromatogram extraction
+            var peptide = SkylineWindow.Document.Molecules.First();
+            var precursor = peptide.TransitionGroups.First();
+            var transitionGroupChromInfo = precursor.Results[0].First();
+            // Without the fix, MS1 and MSMS drift times would be identical
+            AssertEx.AreEqual(22.1, transitionGroupChromInfo.IonMobilityInfo.DriftTimeMS1, .0001);
+            AssertEx.AreEqual(transitionGroupChromInfo.IonMobilityInfo.DriftTimeMS1 - .2, transitionGroupChromInfo.IonMobilityInfo.DriftTimeFragment, .0001);
+
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestPerf/PerfHighEnergyIonMobilityOffsetForPRM.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfHighEnergyIonMobilityOffsetForPRM.cs
@@ -42,12 +42,6 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             
         }
 
-        private string GetTestPath(string relativePath)
-        {
-            return TestFilesDirs[0].GetTestPath(relativePath);
-        }
-
-
         protected override void DoTest()
         {
             string skyfile = TestFilesDir.GetTestPath("prm_dt_offset.sky");
@@ -57,13 +51,13 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             var doc = WaitForDocumentLoaded();
             AssertEx.IsDocumentState(doc, null, 1, 1, 1, 2);
             ImportResults("data.mzML");
-            doc = WaitForDocumentChangeLoaded(doc);
+            doc = SkylineWindow.Document;
 
             // Verify that this is PRM data
             AssertEx.AreEqual(FullScanAcquisitionMethod.PRM, doc.Settings.TransitionSettings.FullScan.AcquisitionMethod);
 
             // Verify that a high energy ion mobility offset was applied for chromatogram extraction
-            var peptide = SkylineWindow.Document.Molecules.First();
+            var peptide = doc.Molecules.First();
             var precursor = peptide.TransitionGroups.First();
             var transitionGroupChromInfo = precursor.Results[0].First();
             // Without the fix, MS1 and MSMS drift times would be identical

--- a/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
+++ b/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
@@ -143,6 +143,7 @@
     <Compile Include="PerfAssociateProteinsTest.cs" />
     <Compile Include="PerfCommandlineCreateImsDbTest.cs" />
     <Compile Include="PerfDetectLockmassFunctionTest.cs" />
+    <Compile Include="PerfHighEnergyIonMobilityOffsetForPRM.cs" />
     <Compile Include="PerfImportBrukerPasefBbCIDTest.cs" />
     <Compile Include="PerfImportHundredsOfReplicatesTest.cs" />
     <Compile Include="HiResMetabolomicsTutorial.cs" />


### PR DESCRIPTION
Formerly we applied it only in All Ions mode, but it is also desirable in PRM etc.

Reported by user Anne