### PR TITLE
Remove hack that was added to make ConsoleAddSkyrTest.

### DIFF
--- a/pwiz_tools/Skyline/Model/Databinding/ReportSharing.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/ReportSharing.cs
@@ -55,15 +55,17 @@ namespace pwiz.Skyline.Model.Databinding
 
         public static bool ImportSkyrFile(string fileName, Func<IList<string>, IList<string>> whichToNotOverWrite)
         {
+            var targetGroup = PersistedViews.MainGroup;
             var reportOrViewSpecList = new ReportOrViewSpecList();
-            reportOrViewSpecList.AddRange(GetExistingReports().Values);
+            reportOrViewSpecList.AddRange(GetExistingReports()
+                .Where(kvp => targetGroup.Id.Equals(kvp.Key.GroupId)).Select(kvp => kvp.Value));
             if (!reportOrViewSpecList.ImportFile(fileName, whichToNotOverWrite))
             {
                 return false;
             }
             foreach (var item in reportOrViewSpecList)
             {
-                SaveReport(PersistedViews.MainGroup, item);
+                SaveReport(targetGroup, item);
             }
             return true;
         }

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -2735,7 +2735,7 @@ namespace pwiz.SkylineTestData
             File.WriteAllText(overwriteFile, File.ReadAllText(skyrFile).Replace(">Description<", ">Name<"));
             string output = RunCommand("--report-add=" + skyrFile);
             existingReports = ReportSharing.GetExistingReports();
-            Assert.AreEqual(initialNumber+2, existingReports.Count);    // TODO(NickSh): Needs to pass with 1
+            Assert.AreEqual(initialNumber+1, existingReports.Count);
             Assert.IsTrue(existingReports.ContainsKey(viewName));
             AssertEx.Contains(output, string.Format(Resources.CommandLine_ImportSkyr_Success__Imported_Reports_from__0_, Path.GetFileName(skyrFile)));
             var skyrAdded = existingReports[viewName].ViewSpecLayout;


### PR DESCRIPTION
Fixed bug where "--report-add" commandline argument would cause all reports from "External Tools" group to be copied to the "Main" group.