### PR TITLE
Guard against possible null value

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/DocNodeChromInfo.cs
@@ -562,7 +562,7 @@ namespace pwiz.Skyline.Model.Results
             RetentionTime = retentionTime;
             StartRetentionTime = startRetentionTime;
             EndRetentionTime = endRetentionTime;
-            IonMobility = ionMobility;
+            IonMobility = ionMobility ?? IonMobilityFilter.EMPTY;
             Area = area;
             BackgroundArea = backgroundArea;
             Height = height;


### PR DESCRIPTION
I can't actually see a control path that would allow this to be set null, but it can't hurt to add a check to make sure it's EMPTY rather than null. 

Not clear that this is actually the problem, but inspired by https://skyline.ms/announcements/home/issues/exceptions/thread.view?entityId=f15c02de-375f-103b-b47c-22f53556c296&_anchor=57340