### PR TITLE
Remove slow code from PeakIntegrator.IntegratePeak

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/PeakIntegrator.cs
+++ b/pwiz_tools/Skyline/Model/Results/PeakIntegrator.cs
@@ -73,13 +73,6 @@ namespace pwiz.Skyline.Model.Results
                 return ChromPeak.EMPTY;
             }
             var foundPeak = PeakFinder.GetPeak(startIndex, endIndex);
-            // Tell Crawdad find peaks in the chromatogram. If Crawdad would not have detected a peak at
-            // that location, then mark the peak as Forced Integration
-            if (PeakFinder.CalcPeaks(-1, Array.Empty<int>())
-                .All(peak => peak.EndIndex < startIndex || peak.StartIndex > endIndex))
-            {
-                flags |= ChromPeak.FlagValues.forced_integration;
-            }
             return new ChromPeak(PeakFinder, foundPeak, flags, InterpolatedTimeIntensities, RawTimeIntensities?.Times);
         }
 

--- a/pwiz_tools/Skyline/Model/Results/PeakIntegrator.cs
+++ b/pwiz_tools/Skyline/Model/Results/PeakIntegrator.cs
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 using System;
-using System.Linq;
 using pwiz.Common.PeakFinding;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Util;


### PR DESCRIPTION
Crawdad peak finder was being invoked for manually integrated peaks in a misguided attempt to set "Coeluting" to a meaningful value for manually integrated peaks. There were some scenarios where this code was much too slow.

Fixed performance problem with manually integrated peaks (reported by Elena)