### PR TITLE
Fix nightly failure in TestFiguresOfMerit

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/CalibrationCurveFitter.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/CalibrationCurveFitter.cs
@@ -450,7 +450,7 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
                     }
                     double meanPeakArea = peakAreas.Mean();
                     double? backCalculatedConcentration =
-                        GetConcentrationFromXValue(calibrationCurve.GetX(meanPeakArea));
+                        GetConcentrationFromXValue(calibrationCurve.GetXValueForLimitOfDetection(meanPeakArea));
                     if (!backCalculatedConcentration.HasValue)
                     {
                         break;

--- a/pwiz_tools/Skyline/TestFunctional/FiguresOfMeritTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/FiguresOfMeritTest.cs
@@ -215,7 +215,7 @@ namespace pwiz.SkylineTestFunctional
             var actualLoq = peptideEntity.FiguresOfMerit.LimitOfQuantification;
             if (expectedLoq != actualLoq)
             {
-                Assert.AreEqual(expectedLoq, actualLoq);
+                Assert.AreEqual(expectedLoq, actualLoq, "Options: {0}", options);
             }
         }
 
@@ -306,6 +306,12 @@ namespace pwiz.SkylineTestFunctional
             public LodCalculation LodCalculation;
             public double? MaxLoqBias;
             public double? MaxLoqCv;
+
+            public override string ToString()
+            {
+                return string.Format("RegressionFit: {0} LodCalculation: {1} MaxLoqBias: {2} MaxLoqCv: {3}",
+                    RegressionFit, LodCalculation, MaxLoqBias, MaxLoqCv);
+            }
         }
     }
 }


### PR DESCRIPTION
The failure was "intermittent" because to speed up the test, TestFiguresOfMerit only tests a random subset of possible sets of settings. This failure happened when calculating the LOD with Bilinear fit.