### PR TITLE
Skyline:  Tester fixes

### DIFF
--- a/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/Nightly.cs
@@ -781,21 +781,44 @@ namespace SkylineNightly
                 _endMatchType = FindEndMatch(log);
             }
 
+            private static EndType LAST_BEST_END_TYPE = EndType.none;
+
             private EndType FindEndMatch(string log)
             {
-                // Enumerate through possible formats, starting with the most recent first
                 var regexes = new[] { END_TEST_HEAPS, END_TEST_HANDLES, END_TEST_OLD };
-                for (int i = 0; i < regexes.Length; i++)
+                int beyondSart = _startMatch.Index + _startMatch.Length;
+                // First see if the last matching type matches within this line
+                if (LAST_BEST_END_TYPE != EndType.none)
                 {
-                    var match = regexes[i].Match(log, _startMatch.Index);
-                    if (match.Success)
+                    var match = regexes[(int)LAST_BEST_END_TYPE].Match(log, beyondSart);
+                    int nextNewline = log.IndexOf('\n', beyondSart);
+                    if (match.Success && match.Index < nextNewline)
                     {
                         _endMatch = match;
-                        return (EndType) i;
+                        return LAST_BEST_END_TYPE;
+                    }
+                }
+                // Enumerate through possible formats, starting with the most recent first
+                Match bestMatch = null;
+                var bestEndType = EndType.none;
+                for (int i = 0; i < regexes.Length; i++)
+                {
+                    var match = regexes[i].Match(log, beyondSart);
+                    // The closest matching type is the best. Otherwise there may be a match many lines away.
+                    if (match.Success && (bestMatch == null || bestMatch.Index > match.Index))
+                    {
+                        bestMatch = match;
+                        bestEndType = (EndType) i;
                     }
                 }
 
-                return EndType.none;
+                if (bestMatch != null)
+                {
+                    _endMatch = bestMatch;
+                    LAST_BEST_END_TYPE = bestEndType;
+                }
+
+                return bestEndType;
             }
 
             public string Timestamp { get { return _startMatch.Groups[1].Value; } }
@@ -825,6 +848,9 @@ namespace SkylineNightly
 
         private int ParseTests(string log, bool storeXml = true)
         {
+            // Expecting:
+            // <time> <pass> <test-name> <language> [test-output]<failure-count> failures, <memory-counts> MB, <handle-counts> handles, <seconds> secs.
+            // Match first 4 elements and the trailing space
             var startTest = new Regex(@"\r\n\[(\d\d:\d\d)\] +(\d+).(\d+) +(\S+) +\((\w\w)\) ", RegexOptions.Compiled);
 
             string lastPass = null;

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -875,13 +875,15 @@ namespace SkylineTester
 
             var testNumber = line.Substring(8, 7).Trim();
             var testName = line.Substring(16, 46).TrimEnd();
+            // Expecting:
+            // <time> <pass> <test-name> <language> [test-output]<failure-count> failures, <memory-counts> MB, <handle-counts> handles, <seconds> secs.
             var parts = Regex.Split(line, "\\s+");
-            var partsIndex = memoryGraphType ? 6 : 8;
+            var partsIndex = parts.Length - (memoryGraphType ? 6 : 4);
             var unitsIndex = partsIndex + 1;
             var units = memoryGraphType ? LABEL_UNITS_MEMORY : LABEL_UNITS_HANDLE;
             double minorMemory = 0, majorMemory = 0;
             double? middleMemory = null;
-            if (unitsIndex < parts.Length && parts[unitsIndex].Equals(units + ",", StringComparison.InvariantCultureIgnoreCase))
+            if (6 < parts.Length && parts[unitsIndex].Equals(units + ",", StringComparison.InvariantCultureIgnoreCase))
             {
                 try
                 {

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -483,7 +483,9 @@ namespace TestRunnerLib
 
             TeamCityFinishTest(test, message + '\n' + stackTrace);
 
-            Log("{0,3} failures, {1:F2}/{2:F2}/{3:F1} MB, {4}/{5} handles, {6} sec.\r\n\r\n!!! {7} FAILED\r\n{8}\r\n{9}\r\n!!!\r\n\r\n",
+            Log(ReportSystemHeaps
+                    ? "{0,3} failures, {1:F2}/{2:F2}/{3:F1} MB, {4}/{5} handles, {6} sec.\r\n\r\n!!! {7} FAILED\r\n{8}\r\n{9}\r\n!!!\r\n\r\n"
+                    : "{0,3} failures, {1:F2}/{3:F1} MB, {4}/{5} handles, {6} sec.\r\n\r\n!!! {7} FAILED\r\n{8}\r\n{9}\r\n!!!\r\n\r\n",
                 FailureCount,
                 ManagedMemory,
                 CommittedMemory,


### PR DESCRIPTION
- Fix Nightly parsing of perf tests to avoid assigning memory values of the first failure to all prior tests
- Fix TestRunner to avoid reporting 0.0 heap value during perf tests
- Fix SkylineTester parsing to avoid graphing zero memory values when lines contain unexpected output