### PR TITLE
Restore Skyline's ability to deal with chemical formulas that contain zero counts (e.g. C12N5H0 - that's a zero, not an Oxygen)

### DIFF
--- a/pwiz_tools/Skyline/Model/CustomMolecule.cs
+++ b/pwiz_tools/Skyline/Model/CustomMolecule.cs
@@ -459,7 +459,7 @@ namespace pwiz.Skyline.Model
             get { return _formula; }
             protected set
             {
-                _formula = value ?? string.Empty;
+                _formula = BioMassCalc.MONOISOTOPIC.RegularizeFormula(value ?? string.Empty); // e.g. XeC12N1H0 => XeC12N1
                 var unlabeled = string.IsNullOrEmpty(_formula) ? _formula : BioMassCalc.MONOISOTOPIC.StripLabelsFromFormula(_formula);
                 UnlabeledFormula = Equals(_formula, unlabeled) ? _formula : unlabeled;
             }

--- a/pwiz_tools/Skyline/Test/AdductTest.cs
+++ b/pwiz_tools/Skyline/Test/AdductTest.cs
@@ -85,6 +85,12 @@ namespace pwiz.SkylineTest
         private void TestAdductOperators()
         {
             // Test some underlying formula handling for fanciful user-supplied values
+            AssertEx.AreEqual("COOOHN", BioMassCalc.MONOISOTOPIC.RegularizeFormula("COOOHNS0"));
+            AssertEx.AreEqual("XeC12N1", BioMassCalc.MONOISOTOPIC.RegularizeFormula("XeC12N1H0"));
+            AssertEx.AreEqual("XeC12N1", BioMassCalc.MONOISOTOPIC.RegularizeFormula("XeC12N01H0"));
+            AssertEx.AreEqual("C'3C2H9NO2O\"2S1", BioMassCalc.MONOISOTOPIC.RegularizeFormula("C'3C2H9H'0NO2O\"2S001"));
+            var labels = new Dictionary<string, int>(){{"C'",3},{"O\"",2}}; // Find the C'3O"2 in  C'3C2H9H'0NO2O"2S (yes, H'0 - seen in the wild - but we drop zero counts)
+            AssertEx.AreEqual(labels, BioMassCalc.MONOISOTOPIC.FindIsotopeLabelsInFormula("C'3C2H9H'0NO2O\"2S"));
             AssertEx.AreEqual(Adduct.SINGLY_PROTONATED, Adduct.FromStringAssumeProtonated("(M+H)+") );
             AssertEx.IsTrue(Adduct.FromStringAssumeProtonatedNonProteomic("[M-H2O+H]+").SameEffect(Adduct.FromStringAssumeProtonatedNonProteomic("(M+H)+[-H2O]")));
             Assert.IsTrue(Molecule.AreEquivalentFormulas("C10H30Si5O5H-CH4", "C9H27O5Si5"));

--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -1533,10 +1533,10 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() => SkylineWindow.Paste());
             AssertEx.IsDocumentState(SkylineWindow.Document, null, 1, 5, 5, 5);
             var docMolecules = SkylineWindow.Document.CustomMolecules.Select(mol => mol.CustomMolecule.Formula).ToArray();
-            AssertEx.AreEqual("C28H42N2OXe", docMolecules[0]);
-            AssertEx.AreEqual("C30H46N2OXe", docMolecules[1]);
+            AssertEx.AreEqual("C28H42N2O1Xe", docMolecules[0]);
+            AssertEx.AreEqual("C30H46N2O1Xe", docMolecules[1]);
             AssertEx.AreEqual("C28H41N2OXe", docMolecules[2]);
-            AssertEx.AreEqual("C28N2OXe", docMolecules[3]);
+            AssertEx.AreEqual("C28N2O1Xe", docMolecules[3]);
             AssertEx.AreEqual("C30N2OXeH45", docMolecules[4]); // We intentionally preserve nonstandard order
             NewDocument();
         }

--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -135,7 +135,7 @@ namespace pwiz.SkylineTestFunctional
         protected override void DoTest()
         {
             var docEmpty = NewDocument();
-
+            TestFormulaWithAtomCountZero();
             TestIrregularColumnCounts();
             TestMissingAccessionNumbers();
             TestMzOrderIndependence();
@@ -1514,6 +1514,31 @@ namespace pwiz.SkylineTestFunctional
                     !t.Transition.IsNegative() && Math.Abs(t.Transition.CustomIon.AverageMassMz - 236.1) < 1));
                 NewDocument();
             }
+        }
+
+        private void TestFormulaWithAtomCountZero()
+        {
+            // Make sure that H'0 doesn't cause trouble - throws "System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary."
+            // in StripLabelsFromFormula() in pwiz_tools\Skyline\Util\BioMassCalc.cs if not fixed.
+            var text =
+                "MoleculeGroup,PrecursorName,PrecursorFormula,PrecursorAdduct,PrecursorMz,PrecursorCharge,ProductName,ProductFormula,ProductAdduct,ProductMz,ProductCharge\n" +
+                "AMPP_FA,AMPP_16:0_1.04,C28H42N2O1XeH'0,[M]1+,,1,AMPP_16:0_precursor,C28H42N2O1H'0,[M]1+,,1\n" + // Data from the wild
+                "AMPP_FA,AMPP_18:0_1.04,C30H46N2O1XeH'0,[M]1+,,1,AMPP_18:0_precursor,C30H46N2O1H'0,[M]1+,,1\n" + // Data from the wild
+                "AMPP_FA,AMPP_17:0_1.04,C28H0N2O1XeH'41,[M]1+,,1,AMPP_17:0_precursor,C28H0N2O1XeH'41,[M]1+,,1\n" + // Made up values
+                "AMPP_FA,AMPP_14:0_1.04,C28H0N2O1XeH'0,[M]1+,,1,AMPP_14:0_precursor,C28H0N2O1XeH'0,[M]1+,,1\n" + // Made up values
+                "AMPP_FA,AMPP_19:0_1.04,C30N2O1XeH'45,[M]1+,,1,AMPP_19:0_precursor,C30N2O1XeH'45,[M]1+,,1\n"; // Made up values
+
+            SetClipboardText(text);
+            // Paste directly into targets area - no interaction expected
+            RunUI(() => SkylineWindow.Paste());
+            AssertEx.IsDocumentState(SkylineWindow.Document, null, 1, 5, 5, 5);
+            var docMolecules = SkylineWindow.Document.CustomMolecules.Select(mol => mol.CustomMolecule.Formula).ToArray();
+            AssertEx.AreEqual("C28H42N2OXe", docMolecules[0]);
+            AssertEx.AreEqual("C30H46N2OXe", docMolecules[1]);
+            AssertEx.AreEqual("C28H41N2OXe", docMolecules[2]);
+            AssertEx.AreEqual("C28N2OXe", docMolecules[3]);
+            AssertEx.AreEqual("C30N2OXeH45", docMolecules[4]); // We intentionally preserve nonstandard order
+            NewDocument();
         }
 
         private void TestNegativeModeLabels()

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -897,12 +897,13 @@ namespace TestRunner
                     }
                 }, TaskCreationOptions.LongRunning));
 
-                Console.WriteLine("Running {0}{1} tests{2}{3} in parallel with {4} workers...\r\n",
+                Console.WriteLine("Running {0}{1} tests{2}{3} in parallel with {4} workers...",
                     testList.Count,
                     testList.Count < unfilteredTestList.Count ? "/" + unfilteredTestList.Count : "",
                     (loop <= 0) ? " forever" : (loop == 1) ? "" : " in " + loop + " loops",
                     "", /*(repeat <= 1) ? "" : ", repeated " + repeat + " times each per language",*/
                     workerCount);
+                Console.WriteLine("(If prompted to \"Allow TestRunner to communicate on these networks\", be sure to check BOTH public and private options.)\r\n");
 
                 // main thread listens for workers to connect
                 while (!cts.IsCancellationRequested)

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -61,6 +61,23 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
+        public static void AreEqual<TKey,TValue>(IDictionary<TKey,TValue> expected, IDictionary<TKey, TValue> actual, string message = null)
+        {
+            AreEqual(expected.Count, actual.Count, message);
+
+            foreach (var keyValuePairExpected in expected)
+            {
+                if (!actual.TryGetValue(keyValuePairExpected.Key, out var valueActual ))
+                {
+                    AreEqual(keyValuePairExpected.Key.ToString(), null, message);
+                }
+                else
+                {
+                    AreEqual(keyValuePairExpected.Value, valueActual, message);
+                }
+            }
+        }
+
         public static void AreEqual<T>(T expected, T actual, string message = null)
         {
             if (!Equals(expected, actual))

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -833,10 +833,12 @@ namespace pwiz.Skyline.Util
             } 
             return ChangeIsotopeLabels(
                 isotopes == null || isotopes.Count == 0 ? string.Empty : isotopes.Aggregate(string.Empty,
-                        (current, pair) => current + string.Format(CultureInfo.InvariantCulture, @"{0}{1}",
-                            (pair.Value > 1) ? pair.Value.ToString() : string.Empty,
-                            // If label was described (for example) as Cl' in dict, look up Cl37 and use that
-                            DICT_ADDUCT_ISOTOPE_NICKNAMES.FirstOrDefault(x => x.Value == pair.Key).Key ?? pair.Key))); 
+                    (current, pair) => current +
+                                       ((pair.Value == 0) ? string.Empty : // We see things like H'0 (that's a zero) in the wild
+                                           (string.Format(CultureInfo.InvariantCulture, @"{0}{1}",
+                                               (pair.Value > 1) ? pair.Value.ToString() : string.Empty,
+                                               // If label was described (for example) as Cl' in dict, look up Cl37 and use that
+                                               DICT_ADDUCT_ISOTOPE_NICKNAMES.FirstOrDefault(x => x.Value == pair.Key).Key ?? pair.Key))))); 
         }
 
         // Sometimes all we know is that two analytes have same name but different masses - describe isotope label as a mass


### PR DESCRIPTION
This is a strange construction but we used to allow it, I broke that recently.

Reported by Phil