### PR TITLE
BlibBuild: Fixes for DIA-NN speclib parsing

### DIFF
--- a/pwiz_tools/BiblioSpec/src/DiaNNSpecLibReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/DiaNNSpecLibReader.cpp
@@ -476,9 +476,15 @@ class Library {
         in.read((char*)&iRT_min, sizeof(double));
         in.read((char*)&iRT_max, sizeof(double));
         read_array(in, entries, version);
+        int i = 0;
         for (auto &e : entries)
         {
             e.lib = this;
+            std::string precursor = precursors[i++];
+            if (!bal::equals(e.name.c_str(), precursor.c_str()))
+            {
+                Verbosity::error("Precursor mismatch between %s and %s in speclib file", e.name.c_str(), precursor.c_str());
+            }
             entryByModPeptideAndCharge.emplace(e.name, std::ref(e));
         }
         if (version <= -1 && in.peek() != std::char_traits<char>::eof()) read_vector(in, elution_groups);
@@ -587,7 +593,7 @@ bool DiaNNSpecLibReader::parseFile()
         impl_->specLib.read(specLibStream);
     }
 
-    typedef io::CSVReader<8, io::trim_chars<' ', ' '>, io::no_quote_escape<'\t'>> ReportReaderType;
+    typedef io::CSVReader<9, io::trim_chars<' ', ' '>, io::no_quote_escape<'\t'>> ReportReaderType;
 
     auto diannReportFilepath = bal::replace_last_copy(string(impl_->specLibFile_), "-lib.tsv.speclib", "-report.tsv");
     /*if (diannReportFilepath == impl_->specLibFile_)
@@ -622,9 +628,9 @@ bool DiaNNSpecLibReader::parseFile()
             if (kvp.first < 1)
                 break;
 
-            io::CSVReader<1, io::trim_chars<' ', ' '>, io::no_quote_escape<'\t'>> reportReader(kvp.second.string().c_str());
-            reportReader.read_header(io::ignore_extra_column | io::ignore_missing_column, "Precursor.Id");
-            if (reportReader.has_column("Precursor.Id"))
+            io::CSVReader<4, io::trim_chars<' ', ' '>, io::no_quote_escape<'\t'>> reportReader(kvp.second.string().c_str());
+            reportReader.read_header(io::ignore_extra_column | io::ignore_missing_column, "Run", "Precursor.Id", "Q.Value", "RT");
+            if (reportReader.has_column("Precursor.Id") && reportReader.has_column("Q.Value") && reportReader.has_column("RT"))
             {
                 diannReportFilepath = kvp.second.string();
                 break;
@@ -645,12 +651,12 @@ bool DiaNNSpecLibReader::parseFile()
     do
     {
         ReportReaderType reportReader(diannReportFilepath.c_str());
-        reportReader.read_header(io::ignore_extra_column, "Run", "Precursor.Id", "Q.Value", "PEP", "RT", "RT.Start", "RT.Stop", "IM");
-        char *run, *precursorId;
-        float qValue, pep, rt, rtStart, rtStop, im;
+        reportReader.read_header(io::ignore_extra_column, "Run", "File.Name", "Protein.Group", "Precursor.Id", "Q.Value", "RT", "RT.Start", "RT.Stop", "IM");
+        char *run, *fileName, *proteinGrp, *precursorId;
+        float qValue, rt, rtStart, rtStop, im;
         string currentRun;
         hasSkippedRuns = false;
-        while (reportReader.read_row(run, precursorId, qValue, pep, rt, rtStart, rtStop, im))
+        while (reportReader.read_row(run, fileName, proteinGrp, precursorId, qValue, rt, rtStart, rtStop, im))
         {
             if (currentRun.empty())
             {
@@ -669,11 +675,16 @@ bool DiaNNSpecLibReader::parseFile()
 
             auto findItr = speclib.entryByModPeptideAndCharge.find(precursorId);
             if (findItr == speclib.entryByModPeptideAndCharge.end())
+            {
+                // skip contaminant proteins if they are not included in the speclib file
+                if (bal::starts_with(proteinGrp, "contaminant_"))
+                    continue;
+
                 throw BlibException(false, "could not find precursorId '%s' in speclib; is '%s' the correct report TSV file?", precursorId, bfs::path(diannReportFilepath).filename().string().c_str());
+            }
 
             auto& speclibEntry = findItr->second.get();
             speclibEntry.curQValue = qValue;
-            speclibEntry.curPEP = pep;
             speclibEntry.curRT = rt;
             speclibEntry.curRTStart = rtStart;
             speclibEntry.curRTStop = rtStop;

--- a/pwiz_tools/BiblioSpec/src/DiaNNSpecLibReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/DiaNNSpecLibReader.cpp
@@ -476,15 +476,15 @@ class Library {
         in.read((char*)&iRT_min, sizeof(double));
         in.read((char*)&iRT_max, sizeof(double));
         read_array(in, entries, version);
-        int i = 0;
+        auto precursorItr = precursors.begin();
         for (auto &e : entries)
         {
             e.lib = this;
-            std::string precursor = precursors[i++];
-            if (!bal::equals(e.name.c_str(), precursor.c_str()))
+            if (e.name != *precursorItr)
             {
-                Verbosity::error("Precursor mismatch between %s and %s in speclib file", e.name.c_str(), precursor.c_str());
+                Verbosity::error("Precursor mismatch between %s and %s in speclib file", e.name.c_str(), precursorItr->c_str());
             }
+            ++precursorItr;
             entryByModPeptideAndCharge.emplace(e.name, std::ref(e));
         }
         if (version <= -1 && in.peek() != std::char_traits<char>::eof()) read_vector(in, elution_groups);
@@ -628,8 +628,8 @@ bool DiaNNSpecLibReader::parseFile()
             if (kvp.first < 1)
                 break;
 
-            io::CSVReader<4, io::trim_chars<' ', ' '>, io::no_quote_escape<'\t'>> reportReader(kvp.second.string().c_str());
-            reportReader.read_header(io::ignore_extra_column | io::ignore_missing_column, "Run", "Precursor.Id", "Q.Value", "RT");
+            io::CSVReader<3, io::trim_chars<' ', ' '>, io::no_quote_escape<'\t'>> reportReader(kvp.second.string().c_str());
+            reportReader.read_header(io::ignore_extra_column | io::ignore_missing_column, "Precursor.Id", "Q.Value", "RT");
             if (reportReader.has_column("Precursor.Id") && reportReader.has_column("Q.Value") && reportReader.has_column("RT"))
             {
                 diannReportFilepath = kvp.second.string();


### PR DESCRIPTION
- may not be ready for merging but hopefully fixes for issues seen at CRG course
- increased robustness by comparing .speclib and .tsv Precursor.IDs to avoid a mix-up situation