### PR TITLE
* switched s3 bucket for SKYLINE_TOOL_TESTING_MIRROR_URL

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
@@ -245,7 +245,7 @@ namespace pwiz.SkylineTestUtil
                 Directory.CreateDirectory(targetFolder);
 
             bool downloadFromS3 = Environment.GetEnvironmentVariable("SKYLINE_DOWNLOAD_FROM_S3") == "1";
-            string s3hostname = @"skyline-perftest.s3-us-west-2.amazonaws.com";
+            string s3hostname = @"mc-tca-01.s3-us-west-2.amazonaws.com";
             string message = string.Empty;
             for (var retry = true; ; retry = false)
             {

--- a/pwiz_tools/Skyline/Util/UtilInstall.cs
+++ b/pwiz_tools/Skyline/Util/UtilInstall.cs
@@ -152,7 +152,7 @@ namespace pwiz.Skyline.Util
         /// <summary>
         /// This custom OpenJDK JRE was created with https://justinmahar.github.io/easyjre/
         /// </summary>
-        static Uri JRE_URL = new Uri($@"https://pwiz-upload.s3.us-west-2.amazonaws.com/skyline_tool_testing_mirror/{JRE_FILENAME}.zip");
+        static Uri JRE_URL = new Uri($@"https://mc-tca-01.s3-us-west-2.amazonaws.com/skyline_tool_testing_mirror/{JRE_FILENAME}.zip");
         public static string JavaDirectory => Path.Combine(ToolDescriptionHelpers.GetToolsDirectory(), JRE_FILENAME);
         public static string JavaBinary => Path.Combine(JavaDirectory, JRE_FILENAME, @"bin", @"java.exe");
 
@@ -165,7 +165,7 @@ namespace pwiz.Skyline.Util
 
     public static class SimpleFileDownloader
     {
-        private static readonly string SKYLINE_TOOL_TESTING_MIRROR_URL = @"https://pwiz-upload.s3.us-west-2.amazonaws.com/skyline_tool_testing_mirror";
+        private static readonly string SKYLINE_TOOL_TESTING_MIRROR_URL = @"https://mc-tca-01.s3-us-west-2.amazonaws.com/skyline_tool_testing_mirror";
 
         public static bool FileAlreadyDownloaded(FileDownloadInfo requiredFile)
         {


### PR DESCRIPTION
Quick fix for change to MacCoss S3. Per discussion with Brian C will later switch to CNAME entry on skyline.ms so it can be redirected without changing code.