### PR TITLE
SimpleGridViewDriver fixes

### DIFF
--- a/pwiz_tools/Skyline/Model/Irt/DbIrtPeptide.cs
+++ b/pwiz_tools/Skyline/Model/Irt/DbIrtPeptide.cs
@@ -61,7 +61,7 @@ namespace pwiz.Skyline.Model.Irt
             set
             {
                 // Always round-trip the Target to its serialized form, which might truncate the masses for small molecules.
-                _peptideModSeq = Target.FromSerializableString(value.ToSerializableString());
+                _peptideModSeq = value != null ? Target.FromSerializableString(value.ToSerializableString()) : null;
             }
         }
 

--- a/pwiz_tools/Skyline/SettingsUI/EditOptimizationLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditOptimizationLibraryDlg.cs
@@ -404,6 +404,7 @@ namespace pwiz.Skyline.SettingsUI
                                          SortableBindingList<DbOptimization> items, EditOptimizationLibraryDlg form, SrmDocument document, TargetResolver targetResolver)
                 : base(gridView, bindingSource, items)
             {
+                SetRequiredColumns(COLUMN_VALUE);
                 gridView.UserDeletingRow += gridView_UserDeletingRow;
                 gridView.UserDeletedRow += gridView_UserDeletedRow;
                 gridView.CellFormatting += gridView_CellFormatting;

--- a/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.cs
@@ -715,6 +715,7 @@ namespace pwiz.Skyline.SettingsUI.Irt
                 SortableBindingList<DbIrtPeptide> items)
                 : base(gridView, bindingSource, items)
             {
+                SetRequiredColumns(COLUMN_SEQUENCE, COLUMN_TIME);
                 AllowNegativeTime = true;
                 GridView.CellValueChanged += parent.HandleStandardsChanged;
                 Items.ListChanged += parent.HandleStandardsChanged;
@@ -796,6 +797,7 @@ namespace pwiz.Skyline.SettingsUI.Irt
             public LibraryGridViewDriver(DataGridViewEx gridView, BindingSource bindingSource, SortableBindingList<DbIrtPeptide> items)
                 : base(gridView, bindingSource, items)
             {
+                SetRequiredColumns(COLUMN_SEQUENCE, COLUMN_TIME);
                 AllowNegativeTime = true;
                 _newHistories = new Dictionary<Target, double>();
                 GridView.CellValueChanged += FireCellChanged;

--- a/pwiz_tools/Skyline/SettingsUI/PeptideGridViewDriver.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideGridViewDriver.cs
@@ -174,14 +174,14 @@ namespace pwiz.Skyline.SettingsUI
 
         protected Target TryResolveTarget(object targetText, out string errorText)
         {
-            if (targetText == null)
+            var targetStr = targetText?.ToString();
+            if (string.IsNullOrWhiteSpace(targetStr))
             {
-                errorText = Resources
-                    .MeasuredPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry;
+                errorText = Resources.MeasuredPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry;
                 return null;
             }
 
-            return TargetResolver.TryResolveTarget(targetText.ToString(), out errorText);
+            return TargetResolver.TryResolveTarget(targetStr, out errorText);
         }
 
         protected virtual bool DoCellValidating(int rowIndex, int columnIndex, string value)


### PR DESCRIPTION
Fixes some bugs with grid view, e.g. pressing delete/backspace when a cell is selected where the underlying property can't be set to `string.Empty`