### PR TITLE
Issue 848: Show a better error message if check for Panorama server fails

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
@@ -128,16 +128,15 @@ namespace pwiz.Skyline.FileUI
                     if (ex is WebException || ex is PanoramaServerException)
                     {
                         var error = ex.Message;
-                        if (Resources
-                            .EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server
-                            .Equals(error))
+                        if (error != null && error.Contains(Resources
+                                .EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server))
                         {
                             error = TextUtil.LineSeparate(error, Resources
                                 .PublishDocumentDlg_PublishDocumentDlgLoad_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password_);
 
                         }
 
-                        listErrorServers.Add(new Tuple<Server, string>(server, error));
+                        listErrorServers.Add(new Tuple<Server, string>(server, error ?? string.Empty));
                     }
                     else
                     {

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -12144,20 +12144,20 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} is not a valid email address..
+        /// </summary>
+        public static string EditServerDlg_OkDialog__0__is_not_a_valid_email_address_ {
+            get {
+                return ResourceManager.GetString("EditServerDlg_OkDialog__0__is_not_a_valid_email_address_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The server &apos;{0}&apos; already exists..
         /// </summary>
         public static string EditServerDlg_OkDialog_The_server__0__already_exists_ {
             get {
                 return ResourceManager.GetString("EditServerDlg_OkDialog_The_server__0__already_exists_", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The server {0} is not a Panorama server..
-        /// </summary>
-        public static string EditServerDlg_OkDialog_The_server__0__is_not_a_Panorama_server {
-            get {
-                return ResourceManager.GetString("EditServerDlg_OkDialog_The_server__0__is_not_a_Panorama_server", resourceCulture);
             }
         }
         
@@ -12177,15 +12177,6 @@ namespace pwiz.Skyline.Properties {
             get {
                 return ResourceManager.GetString("EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_" +
                         "the_panorama_server", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unknown error connecting to the server {0}..
-        /// </summary>
-        public static string EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__ {
-            get {
-                return ResourceManager.GetString("EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__", resourceCulture);
             }
         }
         
@@ -15088,6 +15079,24 @@ namespace pwiz.Skyline.Properties {
         public static string GenerateDecoysError_No_peptide_precursor_models_for_decoys_were_found_ {
             get {
                 return ResourceManager.GetString("GenerateDecoysError_No_peptide_precursor_models_for_decoys_were_found_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error: {0}.
+        /// </summary>
+        public static string GenericState_AppendErrorAndUri_Error___0_ {
+            get {
+                return ResourceManager.GetString("GenericState_AppendErrorAndUri_Error___0_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to URL: {0}.
+        /// </summary>
+        public static string GenericState_AppendErrorAndUri_URL___0_ {
+            get {
+                return ResourceManager.GetString("GenericState_AppendErrorAndUri_URL___0_", resourceCulture);
             }
         }
         
@@ -21681,6 +21690,35 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not authenticate user. Response received from server: {0} {1}.
+        /// </summary>
+        public static string PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_ {
+            get {
+                return ResourceManager.GetString("PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_serv" +
+                        "er___0___1_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Server did not return a valid JSON response. {0} is not a Panorama server..
+        /// </summary>
+        public static string PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_ {
+            get {
+                return ResourceManager.GetString("PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_" +
+                        "a_Panorama_server_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unexpected JSON response from the server: {0}.
+        /// </summary>
+        public static string PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_ {
+            get {
+                return ResourceManager.GetString("PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} is not a Panorama folder.
         /// </summary>
         public static string PanoramaUtil_VerifyFolder__0__is_not_a_Panorama_folder {
@@ -27467,6 +27505,15 @@ namespace pwiz.Skyline.Properties {
         public static string ServerList_Title_Edit_Servers {
             get {
                 return ResourceManager.GetString("ServerList_Title_Edit_Servers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to connect to the server {0}..
+        /// </summary>
+        public static string ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__ {
+            get {
+                return ResourceManager.GetString("ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__", resourceCulture);
             }
         }
         
@@ -34864,6 +34911,16 @@ namespace pwiz.Skyline.Properties {
         public static string UpgradeManager_updateCheck_Complete_Upgrading__0_ {
             get {
                 return ResourceManager.GetString("UpgradeManager_updateCheck_Complete_Upgrading__0_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There was an error authenticating user credentials on the server {0}..
+        /// </summary>
+        public static string UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__ {
+            get {
+                return ResourceManager.GetString("UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_t" +
+                        "he_server__0__", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -3212,9 +3212,6 @@
   <data name="RTDetails_gridStatistics_KeyDown_Failed_setting_data_to_clipboard" xml:space="preserve">
     <value>クリップボードへのデータ設定に失敗しました。</value>
   </data>
-  <data name="EditServerDlg_OkDialog_The_server__0__is_not_a_Panorama_server" xml:space="preserve">
-    <value>サーバー{0}はPanoramaサーバーではありません。</value>
-  </data>
   <data name="CommandLine_ExportInstrumentFile_Method__0__exported_successfully_" xml:space="preserve">
     <value>メソッド{0}が正常にエクスポートされました。</value>
   </data>
@@ -4100,9 +4097,6 @@
   </data>
   <data name="SpectrumMzInfo_GetInfoFromLibrary_Library_spectrum_for_sequence__0__is_missing_" xml:space="preserve">
     <value>シークエンスに対するライブラリスペクトルが{0}欠損しています。</value>
-  </data>
-  <data name="EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__" xml:space="preserve">
-    <value>サーバー{0}への接続中の不明なエラー。</value>
   </data>
   <data name="RenameProteinsDlg_OkDialog_Cannot_rename__0__more_than_once__Please_remove_either__1__or__2__" xml:space="preserve">
     <value>{0}の名前を1回以上変更することはできません。{1}または{2}を削除してください</value>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -3215,9 +3215,6 @@ Are you sure you want to continue?</value>
   <data name="RTDetails_gridStatistics_KeyDown_Failed_setting_data_to_clipboard" xml:space="preserve">
     <value>Failed setting data to clipboard.</value>
   </data>
-  <data name="EditServerDlg_OkDialog_The_server__0__is_not_a_Panorama_server" xml:space="preserve">
-    <value>The server {0} is not a Panorama server.</value>
-  </data>
   <data name="CommandLine_ExportInstrumentFile_Method__0__exported_successfully_" xml:space="preserve">
     <value>Method {0} exported successfully.</value>
   </data>
@@ -4103,9 +4100,6 @@ If you prefer you can choose to report anonymously.</value>
   </data>
   <data name="SpectrumMzInfo_GetInfoFromLibrary_Library_spectrum_for_sequence__0__is_missing_" xml:space="preserve">
     <value>Library spectrum for sequence {0} is missing.</value>
-  </data>
-  <data name="EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__" xml:space="preserve">
-    <value>Unknown error connecting to the server {0}.</value>
   </data>
   <data name="RenameProteinsDlg_OkDialog_Cannot_rename__0__more_than_once__Please_remove_either__1__or__2__" xml:space="preserve">
     <value>Cannot rename {0} more than once. Please remove either {1} or {2}</value>
@@ -11867,5 +11861,29 @@ If you do not have the original file, you may build the library with embedded sp
   </data>
   <data name="PeptideSettingsUI_ShowFilterMidasDlg_Failed_loading_MIDAS_library__0__" xml:space="preserve">
       <value>Failed loading MIDAS library {0}.</value>
+  </data>
+  <data name="GenericState_AppendErrorAndUri_Error___0_" xml:space="preserve">
+	  <value>Error: {0}</value>
+  </data>
+  <data name="GenericState_AppendErrorAndUri_URL___0_" xml:space="preserve">
+	  <value>URL: {0}</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
+	  <value>Could not authenticate user. Response received from server: {0} {1}</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
+	  <value>Unexpected JSON response from the server: {0}</value>
+  </data>
+  <data name="UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
+	  <value>There was an error authenticating user credentials on the server {0}.</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
+	  <value>Server did not return a valid JSON response. {0} is not a Panorama server.</value>
+  </data>
+  <data name="EditServerDlg_OkDialog__0__is_not_a_valid_email_address_" xml:space="preserve">
+	  <value>{0} is not a valid email address.</value>
+  </data>
+  <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
+	  <value>Unable to connect to the server {0}.</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -3212,9 +3212,6 @@
   <data name="RTDetails_gridStatistics_KeyDown_Failed_setting_data_to_clipboard" xml:space="preserve">
     <value>向剪切板设定数据失败。</value>
   </data>
-  <data name="EditServerDlg_OkDialog_The_server__0__is_not_a_Panorama_server" xml:space="preserve">
-    <value>服务器{0}不是 Panorama 服务器。</value>
-  </data>
   <data name="CommandLine_ExportInstrumentFile_Method__0__exported_successfully_" xml:space="preserve">
     <value>方法{0}已成功导出。</value>
   </data>
@@ -4100,9 +4097,6 @@
   </data>
   <data name="SpectrumMzInfo_GetInfoFromLibrary_Library_spectrum_for_sequence__0__is_missing_" xml:space="preserve">
     <value>针对序列 {0} 的库谱图丢失。</value>
-  </data>
-  <data name="EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__" xml:space="preserve">
-    <value>连接至服务器{0}出现未知错误。</value>
   </data>
   <data name="RenameProteinsDlg_OkDialog_Cannot_rename__0__more_than_once__Please_remove_either__1__or__2__" xml:space="preserve">
     <value>无法多次重新命名{0}。请删除{1}或{2}</value>

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -3018,12 +3018,12 @@ namespace pwiz.SkylineTestData
 
             // Error: Unknown server
             var serverUri = PanoramaUtil.ServerNameToUri("unknown.server-state.com");
-            var client = new TestPanoramaClient() { MyServerState = ServerState.unknown, ServerUri = serverUri };
+            var client = new TestPanoramaClient() { MyServerState = new ServerState(ServerStateEnum.unknown, null, null), ServerUri = serverUri };
             helper.ValidateServer(client, null, null);
             Assert.IsTrue(
                 buffer.ToString()
                     .Contains(
-                        string.Format(Resources.EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__,
+                        string.Format(Resources.ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__,
                             serverUri.AbsoluteUri)));
             TestOutputHasErrorLine(buffer.ToString());
             buffer.Clear();
@@ -3031,12 +3031,12 @@ namespace pwiz.SkylineTestData
 
             // Error: Not a Panorama Server
             serverUri = PanoramaUtil.ServerNameToUri("www.google.com");
-            client = new TestPanoramaClient() {MyPanoramaState = PanoramaState.other, ServerUri = serverUri};
+            client = new TestPanoramaClient() {MyUserState = new UserState(UserStateEnum.unknown, null, null), ServerUri = serverUri};
             helper.ValidateServer(client, null, null);
             Assert.IsTrue(
                 buffer.ToString()
                     .Contains(
-                        string.Format(Resources.EditServerDlg_OkDialog_The_server__0__is_not_a_Panorama_server,
+                        string.Format(Resources.UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__,
                             serverUri.AbsoluteUri)));
             TestOutputHasErrorLine(buffer.ToString());
             buffer.Clear();
@@ -3044,7 +3044,7 @@ namespace pwiz.SkylineTestData
 
             // Error: Invalid user
             serverUri = PanoramaUtil.ServerNameToUri(PanoramaUtil.PANORAMA_WEB);
-            client = new TestPanoramaClient() { MyUserState = UserState.nonvalid, ServerUri = serverUri };
+            client = new TestPanoramaClient() { MyUserState = new UserState(UserStateEnum.nonvalid, null, null), ServerUri = serverUri };
             helper.ValidateServer(client, "invalid", "user");
             Assert.IsTrue(
                 buffer.ToString()
@@ -3213,26 +3213,19 @@ namespace pwiz.SkylineTestData
             public Uri ServerUri { get; set; }
 
             public ServerState MyServerState { get; set; }
-            public PanoramaState MyPanoramaState { get; set; }
             public UserState MyUserState { get; set; }
             public FolderState MyFolderState { get; set; }
 
             public TestPanoramaClient()
             {
-                MyServerState = ServerState.available;
-                MyPanoramaState = PanoramaState.panorama;
-                MyUserState = UserState.valid;
+                MyServerState = ServerState.VALID;
+                MyUserState = UserState.VALID;
                 MyFolderState = FolderState.valid;
             }
 
             public virtual ServerState GetServerState()
             {
                 return MyServerState;
-            }
-
-            public PanoramaState IsPanorama()
-            {
-                return MyPanoramaState;
             }
 
             public UserState IsValidUser(string username, string password)

--- a/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
@@ -46,20 +46,18 @@ namespace pwiz.SkylineTestFunctional
             RunFunctionalTest();
         }
 
-        private readonly IPanoramaClient _testClient = new TestPanoramaClient(); // Use null for WebClient
         private readonly IPanoramaPublishClient _testPublishClient = new TestPanoramaPublishClient();
-        private const string VALID_USER_NAME = "user";
+        private const string VALID_USER_NAME = "user@user.edu";
         private const string VALID_PASSWORD = "password";
 
         private const string VALID_PANORAMA_SERVER = "https://128.208.10.133:8070/";
-        private const string VALID_NON_PANORAMA_SERVER = "www.google.com";
-        private const string NON_EXISTENT_SERVER = "www.noexist.edu";
-        private const string UNKNOWN_STATE_SERVER = "unknown.server-state.com";
+        private const string VALID_NON_PANORAMA_SERVER = "http://www.google.com";
+        private const string NON_EXISTENT_SERVER = "http://www.noexist.edu";
+        private const string UNKNOWN_STATE_SERVER = "http://unknown.server-state.com";
+        private const string BAD_SERVER_URL = "http://w ww.google.com";
+        private const string EMPTY_SERVER_URL = " ";
 
         private ToolOptionsUI ToolOptionsDlg { get; set; }
-        private static string Server { get; set; }
-        private string Username { get; set; }
-        private string Password { get; set; }
 
         private const string NO_WRITE_NO_TARGETED = "No write permissions/TargetedMS is not active";
         private const string NO_WRITE_TARGETED = "Does not have write permission/TargetedMS active";
@@ -80,47 +78,32 @@ namespace pwiz.SkylineTestFunctional
             ToolOptionsDlg = ShowDialog<ToolOptionsUI>(() => SkylineWindow.ShowToolOptionsUI(ToolOptionsUI.TABS.Panorama));
 
             // Incorrect password.
-            Server = VALID_PANORAMA_SERVER;
-            Username = VALID_USER_NAME;
-            Password = "bad password";
-            CheckServerInfoFailure(0);
+            CheckServerInfoFailure(new TestPanoramaClient(VALID_PANORAMA_SERVER, VALID_USER_NAME, "bad password"),0);
 
-            // Non-existant username.
-            Username = "fake username";
-            CheckServerInfoFailure(0);
+            // Non-existent username.
+            CheckServerInfoFailure(new TestPanoramaClient(VALID_PANORAMA_SERVER, "fake-user@user.edu", "bad password"),0);
 
             // Successful login.
-            Username = VALID_USER_NAME;
-            Password = VALID_PASSWORD;
-            CheckServerInfoSuccess(1);
+            CheckServerInfoSuccess(new TestPanoramaClient(VALID_PANORAMA_SERVER, VALID_USER_NAME, VALID_PASSWORD), 1);
 
             // Existing non-Panorama server
-            Server = VALID_NON_PANORAMA_SERVER;
-            CheckServerInfoFailure(1);
+            CheckServerInfoFailure(new TestPanoramaClient(VALID_NON_PANORAMA_SERVER, VALID_USER_NAME, VALID_PASSWORD), 1);
 
-            // We assume that the first component of the path element is the contex path where LabKey Server is deployed.
+            // We assume that the first component of the path element is the context path where LabKey Server is deployed.
             // Both VALID_PANORAMA_Server and VALID_PANORAMA_SERVER/libkey will be saved as two different servers.
-            Server = VALID_PANORAMA_SERVER + "/libkey";
-            CheckServerInfoSuccess(2);
+            CheckServerInfoSuccess(new TestPanoramaClient(VALID_PANORAMA_SERVER + "/libkey", VALID_USER_NAME, VALID_PASSWORD), 2);
 
             // Non-existent server
-            Server = NON_EXISTENT_SERVER;
-            CheckServerInfoFailure(2);
+            CheckServerInfoFailure(new TestPanoramaClient(NON_EXISTENT_SERVER, VALID_USER_NAME, VALID_PASSWORD), 2);
 
             // Unknown state server
-            if (_testClient != null)
-            {
-                Server = UNKNOWN_STATE_SERVER;
-                CheckServerInfoFailure(2);
-            }
+            CheckServerInfoFailure(new TestPanoramaClient(UNKNOWN_STATE_SERVER, VALID_USER_NAME, VALID_PASSWORD), 2);
 
             // Bad URI Format
-            Server = "w ww.google.com";
-            CheckServerInfoFailure(2);
+            CheckServerInfoFailure(new TestPanoramaClient(BAD_SERVER_URL, VALID_USER_NAME, VALID_PASSWORD), 2);
 
             // No server given
-            Server = " ";
-            CheckServerInfoFailure(2);
+            CheckServerInfoFailure(new TestPanoramaClient(EMPTY_SERVER_URL, VALID_USER_NAME, VALID_PASSWORD), 2);
 
             OkDialog(ToolOptionsDlg, ToolOptionsDlg.OkDialog);
 
@@ -273,46 +256,58 @@ namespace pwiz.SkylineTestFunctional
             OkDialog(publishDocumentDlg, publishDocumentDlg.CancelButton.PerformClick);
         }
 
-        public void CheckServerInfoFailure(int serverCount)
+        public void CheckServerInfoFailure(TestPanoramaClient testClient, int expectedServerCount)
         {
             var editServerListDlg = ShowDialog<EditListDlg<SettingsListBase<Server>, Server>>(ToolOptionsDlg.EditServers);
             var editServerDlg = ShowDialog<EditServerDlg>(editServerListDlg.AddItem);
             RunUI(() =>
                       {
-                          if (_testClient != null)
-                              editServerDlg.PanoramaClient = _testClient;
-                          editServerDlg.URL = Server;
-                          editServerDlg.Username = Username;
-                          editServerDlg.Password = Password;
+                          editServerDlg.PanoramaClient = testClient;
+                          editServerDlg.URL = testClient.Server;
+                          editServerDlg.Username = testClient.Username;
+                          editServerDlg.Password = testClient.Password;
                       });
-            RunDlg<MessageDlg>(editServerDlg.OkDialog, messageDlg => messageDlg.OkDialog());
+            var messageDlg = ShowDialog<MessageDlg>(editServerDlg.OkDialog);
+            var errorMsg = messageDlg.Message;
+            if (testClient.ServerUri != null)
+            {
+                Assert.IsTrue(errorMsg.Contains(testClient.Server));
+            }
+            else if (BAD_SERVER_URL.Equals(testClient.Server))
+            {
+                Assert.IsTrue(errorMsg.Equals(string.Format(Resources.EditServerDlg_OkDialog_The_text__0__is_not_a_valid_server_name_, BAD_SERVER_URL)));
+            }
+            else if (EMPTY_SERVER_URL.Equals(testClient.Server))
+            {
+                Assert.IsTrue(errorMsg.Equals(string.Format(Resources.MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty, "URL (e.g. https://panoramaweb.org/)")));
+            }
             RunUI(() =>
                       {
+                          messageDlg.OkDialog();
                           editServerDlg.CancelButton.PerformClick();
                           editServerListDlg.OkDialog();
                       });
             WaitForClosedForm(editServerDlg);
             WaitForClosedForm(editServerListDlg);
-            Assert.AreEqual(serverCount, Settings.Default.ServerList.Count);
+            Assert.AreEqual(expectedServerCount, Settings.Default.ServerList.Count);
         }
 
-        private void CheckServerInfoSuccess(int serverCount)
+        private void CheckServerInfoSuccess(TestPanoramaClient testClient, int expectedServerCount)
         {
             var editServerListDlg = ShowDialog<EditListDlg<SettingsListBase<Server>, Server>>(ToolOptionsDlg.EditServers);
             var editServerDlg = ShowDialog<EditServerDlg>(editServerListDlg.AddItem);
             RunUI(() =>
                       {
-                          if (_testClient != null)
-                              editServerDlg.PanoramaClient = _testClient;
-                          editServerDlg.URL = Server;
-                          editServerDlg.Username = Username;
-                          editServerDlg.Password = Password;
+                          editServerDlg.PanoramaClient = testClient;
+                          editServerDlg.URL = testClient.Server;
+                          editServerDlg.Username = testClient.Username;
+                          editServerDlg.Password = testClient.Password;
                           editServerDlg.OkDialog();
                           editServerListDlg.OkDialog();
                       });
             WaitForClosedForm(editServerDlg);
             WaitForClosedForm(editServerListDlg);
-            Assert.AreEqual(serverCount, Settings.Default.ServerList.Count);
+            Assert.AreEqual(expectedServerCount, Settings.Default.ServerList.Count);
         }
 
         private void TestPanoramaServerUrls()
@@ -347,37 +342,52 @@ namespace pwiz.SkylineTestFunctional
             Assert.IsFalse(pServer.Redirect("http:/another.server/" + PanoramaUtil.ENSURE_LOGIN_PATH, PanoramaUtil.ENSURE_LOGIN_PATH)); // Not the same host
         }
 
-        private class TestPanoramaClient : IPanoramaClient
+        public class TestPanoramaClient : IPanoramaClient
         {
-            public Uri ServerUri { get { return null; } }
-            
+            public Uri ServerUri { get; set; }
+
+            public string Server { get; }
+            public string Username { get; }
+            public string Password { get; }
+            public TestPanoramaClient(string server, string username, string password)
+            {
+                Server = server;
+                Username = username;
+                Password = password;
+                try
+                {
+                    ServerUri = new Uri(server);
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
+            }
+
             public ServerState GetServerState()
             {
                 if (Server.Contains(VALID_PANORAMA_SERVER) ||
                     string.Equals(Server, VALID_NON_PANORAMA_SERVER))
-                    return ServerState.available;
+                    return ServerState.VALID;
 
-                else if (string.Equals(Server, UNKNOWN_STATE_SERVER))
-                    return ServerState.unknown;
+                else if (string.Equals(Server, NON_EXISTENT_SERVER))
+                    return new ServerState(ServerStateEnum.missing, "Test WebException - NameResolutionFailure", ServerUri);
 
-                return ServerState.missing;
-            }
-
-            public PanoramaState IsPanorama()
-            {
-                if (Server.Contains(VALID_PANORAMA_SERVER))
-                    return PanoramaState.panorama;
-                return PanoramaState.other;
+                return new ServerState(ServerStateEnum.unknown, "Test WebException - unknown failure", ServerUri);
             }
 
             public UserState IsValidUser(string username, string password)
             {
-                if (string.Equals(username, VALID_USER_NAME) &&
-                    string.Equals(password, VALID_PASSWORD))
+                if (Server.Contains(VALID_PANORAMA_SERVER))
                 {
-                    return UserState.valid;
+                    if (string.Equals(username, VALID_USER_NAME) &&
+                        string.Equals(password, VALID_PASSWORD))
+                    {
+                        return UserState.VALID;
+                    }
                 }
-                return UserState.nonvalid;
+
+                return new UserState(UserStateEnum.nonvalid, "Test WebException", ServerUri);
             }
 
             public FolderState IsValidFolder(string folderPath, string username, string password)

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.cs
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Mail;
 using System.Windows.Forms;
 using pwiz.Skyline.Controls;
 using pwiz.Skyline.Properties;
@@ -84,6 +85,19 @@ namespace pwiz.Skyline.ToolsUI
             if (uriServer == null)
             {
                 helper.ShowTextBoxError(textServerURL, Resources.EditServerDlg_OkDialog_The_text__0__is_not_a_valid_server_name_, serverName);
+                return;
+            }
+
+            if (!(helper.ValidateNameTextBox(textUsername, out _) && helper.ValidateNameTextBox(textPassword, out _)))
+                return;
+
+            try
+            {
+                var unused = new MailAddress(textUsername.Text);
+            }
+            catch (Exception)
+            {
+                helper.ShowTextBoxError(textServerURL, Resources.EditServerDlg_OkDialog__0__is_not_a_valid_email_address_, textUsername.Text);
                 return;
             }
 

--- a/pwiz_tools/Skyline/Util/PanoramaUtil.cs
+++ b/pwiz_tools/Skyline/Util/PanoramaUtil.cs
@@ -41,6 +41,7 @@ using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Model.Serialization;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util.Extensions;
+using Formatting = Newtonsoft.Json.Formatting;
 
 namespace pwiz.Skyline.Util
 {
@@ -83,39 +84,16 @@ namespace pwiz.Skyline.Util
         {
             var uriServer = panoramaClient.ServerUri;
 
-            switch (panoramaClient.GetServerState())
+            var serverState = panoramaClient.GetServerState();
+            if (!serverState.IsValid())
             {
-                case ServerState.missing:
-                    throw new PanoramaServerException(string.Format(
-                        Resources.EditServerDlg_VerifyServerInformation_The_server__0__does_not_exist,
-                        uriServer.AbsoluteUri));
-                case ServerState.unknown:
-                    throw new PanoramaServerException(string.Format(
-                        Resources.EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__,
-                        uriServer.AbsoluteUri));
+                throw new PanoramaServerException(serverState.GetErrorMessage(uriServer));
             }
 
-            switch (panoramaClient.IsValidUser(username, password))
+            var userState = panoramaClient.IsValidUser(username, password);
+            if (!userState.IsValid())
             {
-                case UserState.nonvalid:
-                    throw new PanoramaServerException(Resources
-                        .EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server);
-                case UserState.unknown:
-                    throw new PanoramaServerException(string.Format(
-                        Resources.EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__,
-                        uriServer.AbsoluteUri));
-            }
-
-            switch (panoramaClient.IsPanorama())
-            {
-                case PanoramaState.other:
-                    throw new PanoramaServerException(string.Format(
-                        Resources.EditServerDlg_OkDialog_The_server__0__is_not_a_Panorama_server,
-                        uriServer.AbsoluteUri));
-                case PanoramaState.unknown:
-                    throw new PanoramaServerException(string.Format(
-                        Resources.EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__,
-                        uriServer.AbsoluteUri));
+                throw new PanoramaServerException(userState.getErrorMessage(uriServer));
             }
         }
 
@@ -151,13 +129,13 @@ namespace pwiz.Skyline.Util
                     }
                 }
 
-                return UserState.unknown;
+                return new UserState(UserStateEnum.unknown, ex.Message, GetEnsureLoginUri(pServer));
             }
         }
 
         private static UserState EnsureLogin(PanoramaServer pServer)
         {
-            var requestUri = new Uri(pServer.ServerUri, ENSURE_LOGIN_PATH);
+            var requestUri = GetEnsureLoginUri(pServer);
             var request = (HttpWebRequest) WebRequest.Create(requestUri);
             request.Headers.Add(HttpRequestHeader.Authorization,
                 Server.GetBasicAuthHeader(pServer.Username, pServer.Password));
@@ -165,7 +143,33 @@ namespace pwiz.Skyline.Util
             {
                 using (var response = (HttpWebResponse) request.GetResponse())
                 {
-                    return response.StatusCode == HttpStatusCode.OK ? UserState.valid : UserState.unknown;
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        return new UserState(UserStateEnum.nonvalid,
+                            string.Format(Resources.PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_,
+                                response.StatusCode, response.StatusDescription),
+                            requestUri);
+                    }
+
+                    JObject jsonResponse = null;
+                    if (TryGetJsonResponse(response, ref jsonResponse) && IsValidEnsureLoginResponse(jsonResponse, pServer.Username))
+                    {
+                        return UserState.VALID;
+                    }
+                    else if (jsonResponse == null)
+                    {
+                        return new UserState(UserStateEnum.unknown,
+                            string.Format(Resources.PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_, pServer.ServerUri),
+                            requestUri);
+                    }
+                    else
+                    {
+                        var jsonText = jsonResponse.ToString(Formatting.None);
+                        jsonText = jsonText.Replace(@"{", @"{{"); // escape curly braces
+                        return new UserState(UserStateEnum.unknown,
+                            string.Format(Resources.PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_, jsonText),
+                            requestUri);
+                    }
                 }
             }
             catch (WebException ex)
@@ -185,11 +189,66 @@ namespace pwiz.Skyline.Util
                         }
                     }
 
-                    return UserState.nonvalid; // User cannot be authenticated
+                    return new UserState(UserStateEnum.nonvalid, ex.Message, requestUri); // User cannot be authenticated
                 }
 
                 throw;
             }
+        }
+
+        private static bool TryGetJsonResponse(HttpWebResponse response, ref JObject jsonResponse)
+        {
+            using (var stream = response.GetResponseStream())
+            {
+                if (stream != null)
+                {
+                    using (var reader = new StreamReader(stream, Encoding.UTF8))
+                    {
+                        var responseText = reader.ReadToEnd();
+                        try
+                        {
+                            jsonResponse = JObject.Parse(responseText);
+                            return true;
+                        }
+                        catch (JsonReaderException) {}
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsValidEnsureLoginResponse(JObject jsonResponse, string expectedEmail)
+        {
+            // Example JSON response:
+            /*
+             * {
+                  "currentUser" : {
+                    "canUpdateOwn" : "false",
+                    "canUpdate" : "false",
+                    "canDeleteOwn" : "false",
+                    "canInsert" : "false",
+                    "displayName" : "test_user",
+                    "canDelete" : "false",
+                    "id" : 1166,
+                    "isAdmin" : "false",
+                    "email" : "test_user@uw.edu"
+                  }
+                }
+             */
+            jsonResponse.TryGetValue(@"currentUser", out JToken currentUser);
+            if (currentUser != null)
+            {
+                var email = currentUser.Value<string>(@"email");
+                return email != null && email.Equals(expectedEmail);
+            }
+
+            return false;
+        }
+
+        private static Uri GetEnsureLoginUri(PanoramaServer pServer)
+        {
+            return new Uri(pServer.ServerUri, ENSURE_LOGIN_PATH);
         }
 
         private static UserState TryEnsureLogin(PanoramaServer pServer, ref Uri serverUri)
@@ -200,10 +259,10 @@ namespace pwiz.Skyline.Util
                 serverUri = pServer.ServerUri;
                 return userState;
             }
-            catch (WebException)
+            catch (WebException e)
             {
                 // Due to anything other than 401 (Unauthorized), which is handled in EnsureLogin.
-                return UserState.unknown;
+                return new UserState(UserStateEnum.unknown, e.Message, GetEnsureLoginUri(pServer));
             }
         }
 
@@ -466,9 +525,116 @@ namespace pwiz.Skyline.Util
         #endregion
     }
 
-    public enum ServerState { unknown, missing, available }
-    public enum PanoramaState { panorama, other, unknown }
-    public enum UserState { valid, nonvalid, unknown }
+    public abstract class GenericState<T>
+    { 
+        public T State { get; }
+        public string Error { get; }
+        public Uri Uri { get; }
+
+        public abstract bool IsValid();
+
+        protected string AppendErrorAndUri(string stateErrorMessage)
+        {
+            var message = stateErrorMessage;
+
+            if (Error != null || Uri != null)
+            {
+                var sb = new StringBuilder();
+
+                if (Error != null)
+                {
+                    sb.AppendLine(string.Format(Resources.GenericState_AppendErrorAndUri_Error___0_, Error));
+                }
+
+                if (Uri != null)
+                {
+                    sb.AppendLine(string.Format(Resources.GenericState_AppendErrorAndUri_URL___0_, Uri));
+                }
+
+                message = TextUtil.LineSeparate(message, string.Empty, sb.ToString());
+            }
+
+
+            return message;
+        }
+
+        public GenericState(T state, string error, Uri uri)
+        {
+            State = state;
+            Error = error;
+            Uri = uri;
+        }
+    }
+
+    public class ServerState : GenericState<ServerStateEnum>
+    {
+        public static readonly ServerState VALID = new ServerState(ServerStateEnum.available, null, null);
+
+        public ServerState(ServerStateEnum state, string error, Uri uri) : base(state, error, uri)
+        {
+        }
+
+        public override bool IsValid()
+        {
+            return State == ServerStateEnum.available;
+        }
+
+        public string GetErrorMessage(Uri serverUri)
+        {
+            var stateError = string.Empty;
+            switch (State)
+            {
+                case ServerStateEnum.missing:
+                    stateError = string.Format(
+                        Resources.EditServerDlg_VerifyServerInformation_The_server__0__does_not_exist,
+                        serverUri.AbsoluteUri);
+                    break;
+                case ServerStateEnum.unknown:
+                    stateError = string.Format(
+                        Resources.ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__,
+                        serverUri.AbsoluteUri);
+                    break;
+            }
+
+            return AppendErrorAndUri(stateError);
+        }
+    }
+
+    public class UserState : GenericState<UserStateEnum>
+    {
+        public static readonly UserState VALID = new UserState(UserStateEnum.valid, null, null);
+
+        public UserState(UserStateEnum state, string error, Uri uri) : base(state, error, uri)
+        {
+        }
+
+        public override bool IsValid()
+        {
+            return State == UserStateEnum.valid;
+        }
+
+        public string getErrorMessage(Uri serverUri)
+        {
+            var stateError = string.Empty;
+            switch (State)
+            {
+                case UserStateEnum.nonvalid:
+                    stateError = Resources
+                        .EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server;
+                    break;
+                case UserStateEnum.unknown:
+                    stateError = string.Format(
+                        Resources.UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__,
+                        serverUri.AbsoluteUri);
+                    break;
+            }
+
+            return AppendErrorAndUri(stateError);
+        }
+    }
+
+    public enum ServerStateEnum { unknown, missing, available }
+    public enum UserStateEnum { valid, nonvalid, unknown }
     public enum FolderState { valid, notpanorama, nopermission, notfound }
     public enum FolderOperationStatus{OK, notpanorama, nopermission, notfound, alreadyexists, error}
 
@@ -476,7 +642,6 @@ namespace pwiz.Skyline.Util
     {
         Uri ServerUri { get; }
         ServerState GetServerState();
-        PanoramaState IsPanorama();
         UserState IsValidUser(string username, string password);
         FolderState IsValidFolder(string folderPath, string username, string password);
 
@@ -513,7 +678,7 @@ namespace pwiz.Skyline.Util
                 using (var webClient = new WebClient())
                 {
                     webClient.DownloadString(ServerUri);
-                    return ServerState.available;
+                    return ServerState.VALID;
                 }
             }
             catch (WebException ex)
@@ -521,17 +686,17 @@ namespace pwiz.Skyline.Util
                 // Invalid URL
                 if (ex.Status == WebExceptionStatus.NameResolutionFailure)
                 {
-                    return ServerState.missing;
+                    return new ServerState(ServerStateEnum.missing, ex.Message, ServerUri);
                 }
                 else if (tryNewProtocol)
                 {
-                    if (TryNewProtocol(() => TryGetServerState(false) == ServerState.available))
-                        return ServerState.available;
+                    if (TryNewProtocol(() => TryGetServerState(false).IsValid()))
+                        return ServerState.VALID;
 
-                    return ServerState.unknown;
+                    return new ServerState(ServerStateEnum.unknown, ex.Message, ServerUri);
                 }
             }
-            return ServerState.unknown;
+            return new ServerState(ServerStateEnum.unknown, null, ServerUri);
         }
 
         // This function must be true/false returning; no exceptions can be thrown
@@ -557,55 +722,11 @@ namespace pwiz.Skyline.Util
             return false;
         }
 
-        public PanoramaState IsPanorama()
-        {
-            return TryIsPanorama();
-        }
-
-        private PanoramaState TryIsPanorama(bool tryNewProtocol = true)
-        {
-            try
-            {
-                // Use the LabKey AdminController.HealthCheckAction instead of ProjectController.GetContainersAction which does not return the expected
-                // JSON key if the "Home" container on the LabKey Server is not public.
-                // (https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=20686)
-                Uri uri = new Uri(ServerUri, @"admin/home/healthCheck.view");
-                using (var webClient = new UTF8WebClient())
-                {
-                    JObject jsonResponse = webClient.Get(uri);
-                    var panoramaState = jsonResponse.ContainsKey(@"healthy")
-                        ? PanoramaState.panorama
-                        : PanoramaState.other;
-                    return panoramaState;
-                }
-            }
-            catch (WebException ex)
-            {
-                HttpWebResponse response = ex.Response as HttpWebResponse;
-                // Labkey container page should be part of all Panorama servers. 
-                if (response != null && response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    return PanoramaState.other;
-                }
-                else if(tryNewProtocol)
-                {
-                    if (TryNewProtocol(() => TryIsPanorama(false) == PanoramaState.panorama))
-                        return PanoramaState.panorama;
-                }
-            }
-            catch
-            {
-                return PanoramaState.unknown;
-            }
-
-            return PanoramaState.unknown;  
-        }
-
         public UserState IsValidUser(string username, string password)
         {
             var refServerUri = ServerUri;
             var userState = PanoramaUtil.ValidateServerAndUser(ref refServerUri, username, password);
-            if (userState == UserState.valid)
+            if (userState.IsValid())
             {
                 ServerUri = refServerUri;
             }
@@ -926,19 +1047,14 @@ namespace pwiz.Skyline.Util
         {
             var refServerUri = server.URI;
             UserState userState = PanoramaUtil.ValidateServerAndUser(ref refServerUri, server.Username, server.Password);
-            if (userState == UserState.valid)
+            if (userState.IsValid())
             {
                 server.URI = refServerUri;
-                return;
             }
-
-            switch (userState)
+            else
             {
-                case UserState.nonvalid:
-                    throw new PanoramaServerException(Resources.EditServerDlg_OkDialog_The_username_and_password_could_not_be_authenticated_with_the_panorama_server);
-                case UserState.unknown:
-                    throw new PanoramaServerException(string.Format(Resources.EditServerDlg_OkDialog_Unknown_error_connecting_to_the_server__0__, refServerUri.AbsoluteUri));
-            } 
+                throw new PanoramaServerException(userState.getErrorMessage(refServerUri));
+            }
         }
 
         public override JToken GetInfoForFolders(Server server, string folder)
@@ -1294,7 +1410,7 @@ namespace pwiz.Skyline.Util
     }
 
     public class PanoramaServerException : Exception
-    {
+    { 
         public PanoramaServerException(string message) : base(message)
         {
         }


### PR DESCRIPTION
- Removed check for valid Panorama server (AdminController.HealthCheckAction)
- Parse the JSON response from EnsureLogin action to verify that server is a Panorama server
-  Email and Password fields should not be empty in EditServerDlg