### PR TITLE
* disabled nightly smart trigger for Skyline code coverage build

### DIFF
--- a/scripts/misc/nightly_trigger_and_paths_config.py
+++ b/scripts/misc/nightly_trigger_and_paths_config.py
@@ -5,8 +5,8 @@ targets['Skyline'] = \
 {
     'master':
     {
-        "bt210": "Skyline master and PRs (Windows x86_64 debug, with code coverage)"
-        ,"ProteoWizard_SkylinePrPerfAndTutorialTestsWindowsX8664": "Skyline PR Perf and Tutorial tests (Windows x86_64)"
+        #"bt210": "Skyline master and PRs (Windows x86_64 debug, with code coverage)",
+        "ProteoWizard_SkylinePrPerfAndTutorialTestsWindowsX8664": "Skyline PR Perf and Tutorial tests (Windows x86_64)"
     },
     'release':
     {


### PR DESCRIPTION
* disabled nightly smart trigger for Skyline code coverage build because there's currently no way in the smart trigger code to only trigger for PR merges and not for PR commits

Instead I will re-enable the nightly VCS trigger on TeamCity.