### PR TITLE
* added clearing of z:\temp to tc-perftests.bat

### DIFF
--- a/pwiz_tools/Bumbershoot/idpicker/IDPicker.csproj
+++ b/pwiz_tools/Bumbershoot/idpicker/IDPicker.csproj
@@ -717,12 +717,13 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>call "$(DevEnvDir)..\Tools\VsDevCmd.bat" &gt;nul
+    <PostBuildEvent>call $(ProjectDir)..\..\..\libraries\msvc_setup_script.bat $(PlatformName) 143
 IF $(PlatformName) NEQ "x64" editbin.exe /nologo /LARGEADDRESSAWARE "$(TargetPath)"
 IF EXIST $(OutDir)setup.exe del $(OutDir)setup.exe
 IF EXIST $(OutDir)Test.passed del $(OutDir)Test.passed</PostBuildEvent>
-    <PreBuildEvent>call "$(DevEnvDir)..\Tools\VsDevCmd.bat" &gt;nul
-rc.exe $(ProjectDir)Resources\Resources.rc &gt;nul</PreBuildEvent>
+    <PreBuildEvent>call $(ProjectDir)..\..\..\libraries\msvc_setup_script.bat $(PlatformName) 143
+rc.exe $(ProjectDir)Resources\Resources.rc &gt;nul
+</PreBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/pwiz_tools/Bumbershoot/idpicker/IDPicker.csproj
+++ b/pwiz_tools/Bumbershoot/idpicker/IDPicker.csproj
@@ -717,11 +717,11 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>call "%25VSAPPIDDIR%25..\Tools\VsDevCmd.bat" &gt;nul
+    <PostBuildEvent>call "$(DevEnvDir)..\Tools\VsDevCmd.bat" &gt;nul
 IF $(PlatformName) NEQ "x64" editbin.exe /nologo /LARGEADDRESSAWARE "$(TargetPath)"
 IF EXIST $(OutDir)setup.exe del $(OutDir)setup.exe
 IF EXIST $(OutDir)Test.passed del $(OutDir)Test.passed</PostBuildEvent>
-    <PreBuildEvent>call "%25VSAPPIDDIR%25..\Tools\VsDevCmd.bat" &gt;nul
+    <PreBuildEvent>call "$(DevEnvDir)..\Tools\VsDevCmd.bat" &gt;nul
 rc.exe $(ProjectDir)Resources\Resources.rc &gt;nul</PreBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/scripts/misc/tc-perftests.bat
+++ b/scripts/misc/tc-perftests.bat
@@ -17,6 +17,7 @@ IF ERRORLEVEL 1 (pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe test=%%I loop
 IF ERRORLEVEL 1 set /a FailedTests += 1
 IF EXIST pwiz_tools\Skyline\TestResults rmdir /s /q pwiz_tools\Skyline\TestResults
 IF EXIST %SKYLINE_DOWNLOAD_PATH% rmdir /s /q %SKYLINE_DOWNLOAD_PATH%
+IF EXIST z:\Temp del /f /s /q z:\Temp\*.* >nul
 )
 
 echo %FailedTests% tests failed.


### PR DESCRIPTION
(I'm not sure why this would be different between the Parag AWS AMI and the MacCoss one, but it's what I noticed taking up space on Z: when I logged in.)