### PR TITLE
Fix intermittent failure in TestPeakPerf caused by TransitionGroupDoc…

### DIFF
--- a/pwiz_tools/Shared/Common/Collections/StructSerializer.cs
+++ b/pwiz_tools/Shared/Common/Collections/StructSerializer.cs
@@ -69,10 +69,20 @@ namespace pwiz.Common.Collections
                 return result;
             }
             result = new TItem[count];
-            var buffer = new byte[ItemSizeOnDisk];
+            var buffer = new byte[Math.Max(ItemSizeInMemory, ItemSizeOnDisk)];
+            int countToRead = ItemSizeOnDisk;
+            int offset;
+            if (PadFromStart)
+            {
+                offset = buffer.Length - countToRead;
+            }
+            else
+            {
+                offset = 0;
+            }
             for (int i = 0; i < count; i++)
             {
-                if (stream.Read(buffer, 0, buffer.Length) != buffer.Length)
+                if (stream.Read(buffer, offset, countToRead) != countToRead)
                     throw new InvalidDataException();
                 result[i] = FromByteArray(buffer);
             }

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -1452,7 +1452,7 @@ namespace pwiz.Skyline.Model
                 {
                     // Get all transition chromatogram info for this file.
                     ChromatogramGroupInfo chromGroupInfo = chromGroupInfos[j];
-                    var peakGroupIntegrator = MakePeakGroupIntegrator(settingsNew, chromatograms, chromGroupInfo);
+                    PeakGroupIntegrator peakGroupIntegrator = null;
                     ChromFileInfoId fileId = fileIds[j];
                     PeakFeatureStatistics reintegratePeak = reintegratePeaks != null ? reintegratePeaks[j] : null;
 
@@ -1507,6 +1507,7 @@ namespace pwiz.Skyline.Model
 
                                     if (chromInfoBest != null)
                                     {
+                                        peakGroupIntegrator ??= MakePeakGroupIntegrator(settingsNew, chromatograms, chromGroupInfo);
                                         peak = CalcPeak(settingsNew, peakGroupIntegrator, info, chromInfoBest);
                                         userSet = chromInfoBest.UserSet;
                                     }
@@ -1515,6 +1516,7 @@ namespace pwiz.Skyline.Model
                                 else if (nodePep.HasResults && !HasResults &&
                                     TryGetMatchingGroupInfo(nodePep, chromIndex, fileId, step, out chromGroupInfoMatch))
                                 {
+                                    peakGroupIntegrator ??= MakePeakGroupIntegrator(settingsNew, chromatograms, chromGroupInfo);
                                     peak = CalcMatchingPeak(settingsNew, peakGroupIntegrator, info, chromGroupInfoMatch, reintegratePeak, qcutoff, ref userSet);
                                 }
                                 // Otherwise use the best peak chosen at import time


### PR DESCRIPTION
…Node.CalcResultsForReplicate always reading chromatogram data and therefore sometimes causing WaitForDocumentLoaded to time out.