### PR TITLE
Add "Assume.AreEqual" to PeptideGroupDocNode.ChangeProteinMetadata

### DIFF
--- a/pwiz_tools/Skyline/Model/PeptideGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/PeptideGroupDocNode.cs
@@ -158,6 +158,11 @@ namespace pwiz.Skyline.Model
                 newMetadata = newMetadata.ChangeName(null); // no actual override
             if (Equals(PeptideGroup.Description, newMetadata.Description))
                 newMetadata = newMetadata.ChangeDescription(null); // no actual override
+            var group = PeptideGroup as FastaSequenceGroup;
+            if (group != null)
+            {
+                Assume.AreEqual(group.FastaSequenceList.Count, proteinMetadata.ProteinMetadataList.Count);
+            }
             return ChangeProp(ImClone(this), im => im._proteinMetadata = newMetadata);
         }
 


### PR DESCRIPTION
Add Assume.AreEqual(group.FastaSequenceList.Count, proteinMetadata.ProteinMetadataList.Count) to make sure single protein metadata is never assigned to a FastaSequenceGroup.
(This will be helpful when we come up with a fix for a bug that was reported by Rich)