### PR TITLE
Skyline: Test improvements while working on parallel testing

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -66,7 +66,7 @@ namespace SkylineTester
                 return;
 
             foreach (var runButton in _runButtons)
-                runButton.Text = "Stop";
+                runButton.Text = "&Stop";
             buttonStop.Enabled = true;
             EnableButtonSelectFailedTests(false); // Until we have failures to select
             AcceptButton = null;
@@ -170,7 +170,7 @@ namespace SkylineTester
             _runningTab = null;
 
             foreach (var runButton in _runButtons)
-                runButton.Text = "Run";
+                runButton.Text = "&Run";
             buttonStop.Enabled = false;
             AcceptButton = DefaultButton;
 

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
@@ -581,7 +581,7 @@ namespace SkylineTester
             this.runForms.Name = "runForms";
             this.runForms.Size = new System.Drawing.Size(100, 28);
             this.runForms.TabIndex = 4;
-            this.runForms.Text = "Run";
+            this.runForms.Text = "&Run";
             this.runForms.UseVisualStyleBackColor = true;
             this.runForms.Click += new System.EventHandler(this.RunOrStop_Clicked);
             // 
@@ -928,7 +928,7 @@ namespace SkylineTester
             this.runTutorials.Name = "runTutorials";
             this.runTutorials.Size = new System.Drawing.Size(100, 28);
             this.runTutorials.TabIndex = 1;
-            this.runTutorials.Text = "Run";
+            this.runTutorials.Text = "&Run";
             this.runTutorials.UseVisualStyleBackColor = true;
             this.runTutorials.Click += new System.EventHandler(this.RunOrStop_Clicked);
             // 
@@ -959,7 +959,7 @@ namespace SkylineTester
             this.runTests.Name = "runTests";
             this.runTests.Size = new System.Drawing.Size(100, 28);
             this.runTests.TabIndex = 5;
-            this.runTests.Text = "Run";
+            this.runTests.Text = "&Run";
             this.toolTip1.SetToolTip(this.runTests, "run the selected tests, immediately");
             this.runTests.UseVisualStyleBackColor = true;
             this.runTests.Click += new System.EventHandler(this.RunOrStop_Clicked);
@@ -1519,7 +1519,7 @@ namespace SkylineTester
             this.runBuild.Name = "runBuild";
             this.runBuild.Size = new System.Drawing.Size(100, 28);
             this.runBuild.TabIndex = 22;
-            this.runBuild.Text = "Run";
+            this.runBuild.Text = "&Run";
             this.runBuild.UseVisualStyleBackColor = true;
             this.runBuild.Click += new System.EventHandler(this.RunOrStop_Clicked);
             // 
@@ -2017,7 +2017,7 @@ namespace SkylineTester
             this.runQuality.Name = "runQuality";
             this.runQuality.Size = new System.Drawing.Size(100, 28);
             this.runQuality.TabIndex = 26;
-            this.runQuality.Text = "Run";
+            this.runQuality.Text = "&Run";
             this.runQuality.UseVisualStyleBackColor = true;
             this.runQuality.Click += new System.EventHandler(this.RunOrStop_Clicked);
             // 
@@ -2649,7 +2649,7 @@ namespace SkylineTester
             this.runNightly.Name = "runNightly";
             this.runNightly.Size = new System.Drawing.Size(100, 28);
             this.runNightly.TabIndex = 33;
-            this.runNightly.Text = "Run";
+            this.runNightly.Text = "&Run";
             this.runNightly.UseVisualStyleBackColor = true;
             this.runNightly.Click += new System.EventHandler(this.RunOrStop_Clicked);
             // 
@@ -2805,7 +2805,7 @@ namespace SkylineTester
             this.buttonStop.Name = "buttonStop";
             this.buttonStop.Size = new System.Drawing.Size(100, 28);
             this.buttonStop.TabIndex = 27;
-            this.buttonStop.Text = "Stop";
+            this.buttonStop.Text = "&Stop";
             this.buttonStop.UseVisualStyleBackColor = true;
             this.buttonStop.Click += new System.EventHandler(this.Stop_Clicked);
             // 
@@ -2967,21 +2967,21 @@ namespace SkylineTester
             this.exitToolStripMenuItem2});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            this.fileToolStripMenuItem.Text = "File";
+            this.fileToolStripMenuItem.Text = "&File";
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this.openToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.openToolStripMenuItem.Text = "Open...";
+            this.openToolStripMenuItem.Text = "&Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.open_Click);
             // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
             this.saveToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.saveToolStripMenuItem.Text = "Save as...";
+            this.saveToolStripMenuItem.Text = "Save &as...";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.save_Click);
             // 
             // exitToolStripMenuItem1
@@ -2993,7 +2993,7 @@ namespace SkylineTester
             // 
             this.createInstallerZipFileToolStripMenuItem.Name = "createInstallerZipFileToolStripMenuItem";
             this.createInstallerZipFileToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.createInstallerZipFileToolStripMenuItem.Text = "Save zip file installer...";
+            this.createInstallerZipFileToolStripMenuItem.Text = "Save &zip file installer...";
             this.createInstallerZipFileToolStripMenuItem.Click += new System.EventHandler(this.SaveZipFileInstaller);
             // 
             // toolStripSeparator1
@@ -3005,7 +3005,7 @@ namespace SkylineTester
             // 
             this.exitToolStripMenuItem2.Name = "exitToolStripMenuItem2";
             this.exitToolStripMenuItem2.Size = new System.Drawing.Size(188, 22);
-            this.exitToolStripMenuItem2.Text = "Exit";
+            this.exitToolStripMenuItem2.Text = "E&xit";
             this.exitToolStripMenuItem2.Click += new System.EventHandler(this.exit_Click);
             // 
             // findToolStripMenuItem
@@ -3016,14 +3016,14 @@ namespace SkylineTester
             this.findToolStripMenuItem.Name = "findToolStripMenuItem";
             this.findToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.findToolStripMenuItem.Size = new System.Drawing.Size(42, 20);
-            this.findToolStripMenuItem.Text = "Find";
+            this.findToolStripMenuItem.Text = "Fi&nd";
             // 
             // findTestToolStripMenuItem
             // 
             this.findTestToolStripMenuItem.Name = "findTestToolStripMenuItem";
             this.findTestToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
             this.findTestToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
-            this.findTestToolStripMenuItem.Text = "Find...";
+            this.findTestToolStripMenuItem.Text = "&Find...";
             this.findTestToolStripMenuItem.Click += new System.EventHandler(this.findTestToolStripMenuItem_Click);
             // 
             // findNextToolStripMenuItem
@@ -3031,7 +3031,7 @@ namespace SkylineTester
             this.findNextToolStripMenuItem.Name = "findNextToolStripMenuItem";
             this.findNextToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.findNextToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
-            this.findNextToolStripMenuItem.Text = "Find next";
+            this.findNextToolStripMenuItem.Text = "Find &Next";
             this.findNextToolStripMenuItem.Click += new System.EventHandler(this.findNextToolStripMenuItem_Click);
             // 
             // selectBuildMenuItem
@@ -3047,7 +3047,7 @@ namespace SkylineTester
             this.zip64Bit});
             this.selectBuildMenuItem.Name = "selectBuildMenuItem";
             this.selectBuildMenuItem.Size = new System.Drawing.Size(80, 20);
-            this.selectBuildMenuItem.Text = "Select build";
+            this.selectBuildMenuItem.Text = "Select &Build";
             this.selectBuildMenuItem.DropDownOpening += new System.EventHandler(this.selectBuildMenuOpening);
             // 
             // bin32Bit
@@ -3120,14 +3120,14 @@ namespace SkylineTester
             this.accessInternet});
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
             this.optionsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
-            this.optionsToolStripMenuItem.Text = "Options";
+            this.optionsToolStripMenuItem.Text = "&Options";
             // 
             // accessInternet
             // 
             this.accessInternet.CheckOnClick = true;
             this.accessInternet.Name = "accessInternet";
             this.accessInternet.Size = new System.Drawing.Size(154, 22);
-            this.accessInternet.Text = "Access internet";
+            this.accessInternet.Text = "&Access Internet";
             // 
             // helpToolStripMenuItem
             // 
@@ -3136,20 +3136,20 @@ namespace SkylineTester
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-            this.helpToolStripMenuItem.Text = "Help";
+            this.helpToolStripMenuItem.Text = "&Help";
             // 
             // documentationToolStripMenuItem
             // 
             this.documentationToolStripMenuItem.Name = "documentationToolStripMenuItem";
             this.documentationToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
-            this.documentationToolStripMenuItem.Text = "Documentation...";
+            this.documentationToolStripMenuItem.Text = "&Documentation...";
             this.documentationToolStripMenuItem.Click += new System.EventHandler(this.documentationToolStripMenuItem_Click);
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
             this.aboutToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
-            this.aboutToolStripMenuItem.Text = "About...";
+            this.aboutToolStripMenuItem.Text = "&About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.about_Click);
             // 
             // radioButton3

--- a/pwiz_tools/Skyline/Test/UtilTest.cs
+++ b/pwiz_tools/Skyline/Test/UtilTest.cs
@@ -164,7 +164,7 @@ namespace pwiz.SkylineTest
 
         }
 
-        [TestMethod, NoParallelTesting]
+        [TestMethod]
         public void SafeDeleteTest()
         {
             // Test ArgumentException.
@@ -187,7 +187,8 @@ namespace pwiz.SkylineTest
             AssertEx.NoExceptionThrown<IOException>(() => FileEx.SafeDelete(pathTooLong, true));
 
             // Test IOException.
-            const string busyFile = "TestBusyDelete.txt"; // Not L10N
+            TestContext.EnsureTestResultsDir();
+            string busyFile = TestContext.GetTestResultsPath("TestBusyDelete.txt"); // Not L10N
             using (File.CreateText(busyFile))
             {
                 AssertEx.ThrowsException<IOException>(() => FileEx.SafeDelete(busyFile));
@@ -196,7 +197,7 @@ namespace pwiz.SkylineTest
             AssertEx.NoExceptionThrown<IOException>(() => FileEx.SafeDelete(busyFile));
 
             // Test UnauthorizedAccessException.
-            const string readOnlyFile = "TestReadOnlyFile.txt"; // Not L10N
+            string readOnlyFile = TestContext.GetTestResultsPath("TestReadOnlyFile.txt"); // Not L10N
 // ReSharper disable LocalizableElement
             File.WriteAllText(readOnlyFile, "Testing read only file delete.\n"); // Not L10N
 // ReSharper restore LocalizableElement

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -664,7 +664,12 @@ namespace TestRunner
 
 
             // paths in testRunnerCmd are in container-space (c:\pwiz is mounted from pwizRoot, c:\downloads is mounted from GetDownloadsPath(), c:\AlwaysUpCLT is not copied to the host)
-            var testRunnerCmd = $@"c:\pwiz\pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe parallelmode=client showheader=0 results=c:\AlwaysUpCLT\TestResults log={testRunnerLog}";
+            var testRunnerExe = Assembly.GetExecutingAssembly().Location;
+            int iRelative = testRunnerExe.IndexOf(@"pwiz_tools\Skyline\bin", StringComparison.CurrentCultureIgnoreCase);
+            testRunnerExe = iRelative != -1
+                ? Path.Combine(@"c:\pwiz", testRunnerExe.Substring(iRelative))
+                : @"c:\pwiz\pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe";
+            var testRunnerCmd = $@"{testRunnerExe} parallelmode=client showheader=0 results=c:\AlwaysUpCLT\TestResults log={testRunnerLog}";
             testRunnerCmd = AddPassThroughArguments(commandLineArgs, testRunnerCmd);
             testRunnerCmd += $" workerport={workerPort}";
 


### PR DESCRIPTION
- Make SafeDeleteTest safe for parallel testing by saving to the TestResults folder
- Fix generating TestRunner.exe call for parallel testing to work with debug builds
- Add some keyboard mnemonics to SkylineTester for quicker runs without using the mouse