### PR TITLE
Handle a case where matcher.GetModifiedNode(pepModSequence, fastaSequence) returns null…

### DIFF
--- a/pwiz_tools/Skyline/EditUI/PasteDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.cs
@@ -383,8 +383,18 @@ namespace pwiz.Skyline.EditUI
                     }
                 }
                 // Create node using ModificationMatcher.
-                nodePepNew = matcher.GetModifiedNode(pepModSequence, fastaSequence).ChangeSettings(document.Settings,
-                                                                                                  SrmSettingsDiff.ALL);
+                nodePepNew = matcher.GetModifiedNode(pepModSequence, fastaSequence);
+                if (nodePepNew == null)
+                {
+                    ShowPeptideError(new PasteError
+                    {
+                        Column = colPeptideSequence.Index,
+                        Line = i,
+                        Message = Resources.PasteDlg_AddPeptides_Unable_to_interpret_peptide_modifications
+                    });
+                    return null;
+                }
+                nodePepNew = nodePepNew.ChangeSettings(document.Settings, SrmSettingsDiff.ALL);
                 // Avoid adding an existing peptide a second time.
                 if (!peptides.Contains(nodePep => Equals(nodePep.Key, nodePepNew.Key)))
                 {


### PR DESCRIPTION
…, as reported in https://skyline.ms/announcements/home/issues/exceptions/thread.view?entityId=eac5f03f-728c-103b-985e-22f53556f4ee&_anchor=57867

No data for repro, so no test. But this is some very old code so it seems like it's probably a rare condition.

Reported anonymously via exception web.