### PR TITLE
More choices for group comparisons

### DIFF
--- a/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.Designer.cs
@@ -114,8 +114,13 @@
             resources.ApplyResources(this.comboMsLevel, "comboMsLevel");
             this.comboMsLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboMsLevel.FormattingEnabled = true;
+            this.comboMsLevel.Items.AddRange(new object[] {
+            resources.GetString("comboMsLevel.Items"),
+            resources.GetString("comboMsLevel.Items1"),
+            resources.GetString("comboMsLevel.Items2"),
+            resources.GetString("comboMsLevel.Items3"),
+            resources.GetString("comboMsLevel.Items4")});
             this.comboMsLevel.Name = "comboMsLevel";
-            this.comboMsLevel.SelectedIndexChanged += new System.EventHandler(this.comboMsLevel_SelectedIndexChanged);
             // 
             // lblMsLevel
             // 

--- a/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.Designer.cs
@@ -32,6 +32,8 @@
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.panelMain = new System.Windows.Forms.Panel();
+            this.comboMsLevel = new System.Windows.Forms.ComboBox();
+            this.lblMsLevel = new System.Windows.Forms.Label();
             this.btnAdvanced = new System.Windows.Forms.Button();
             this.lblControlAnnotation = new System.Windows.Forms.Label();
             this.comboControlAnnotation = new System.Windows.Forms.ComboBox();
@@ -87,6 +89,8 @@
             // 
             // panelMain
             // 
+            this.panelMain.Controls.Add(this.comboMsLevel);
+            this.panelMain.Controls.Add(this.lblMsLevel);
             this.panelMain.Controls.Add(this.btnAdvanced);
             this.panelMain.Controls.Add(this.lblControlAnnotation);
             this.panelMain.Controls.Add(this.comboControlAnnotation);
@@ -104,6 +108,19 @@
             this.panelMain.Controls.Add(this.lblNormalizationMethod);
             resources.ApplyResources(this.panelMain, "panelMain");
             this.panelMain.Name = "panelMain";
+            // 
+            // comboMsLevel
+            // 
+            resources.ApplyResources(this.comboMsLevel, "comboMsLevel");
+            this.comboMsLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboMsLevel.FormattingEnabled = true;
+            this.comboMsLevel.Name = "comboMsLevel";
+            this.comboMsLevel.SelectedIndexChanged += new System.EventHandler(this.comboMsLevel_SelectedIndexChanged);
+            // 
+            // lblMsLevel
+            // 
+            resources.ApplyResources(this.lblMsLevel, "lblMsLevel");
+            this.lblMsLevel.Name = "lblMsLevel";
             // 
             // btnAdvanced
             // 
@@ -377,5 +394,7 @@
         private System.Windows.Forms.GroupBox groupBoxQValueCutoff;
         private System.Windows.Forms.Button btnAdvanced;
         private System.Windows.Forms.Panel panelAdvanced;
+        private System.Windows.Forms.ComboBox comboMsLevel;
+        private System.Windows.Forms.Label lblMsLevel;
     }
 }

--- a/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.cs
@@ -25,6 +25,7 @@ using System.Windows.Forms;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.AuditLog;
 using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Model.DocSettings.AbsoluteQuantification;
 using pwiz.Skyline.Model.GroupComparison;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
@@ -50,6 +51,8 @@ namespace pwiz.Skyline.Controls.GroupComparison
             }
             _pushChangesToDocument = false;
             tbxName.Text = groupComparisonDef.Name ?? string.Empty;
+            comboMsLevel.Items.Clear();
+            comboMsLevel.Items.AddRange(MsLevelOption.AllOptions.ToArray());
         }
 
         public EditGroupComparisonDlg(FoldChangeBindingSource foldChangeBindingSource)
@@ -111,6 +114,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
             ReplaceComboItems(comboNormalizationMethod, NormalizationMethod.ListNormalizationMethods(GroupComparisonModel.Document), groupComparisonDef.NormalizationMethod);
             ReplaceComboItems(comboSummaryMethod, SummarizationMethod.ListSummarizationMethods(), groupComparisonDef.SummarizationMethod);
             tbxConfidenceLevel.Text = groupComparisonDef.ConfidenceLevelTimes100.ToString(CultureInfo.CurrentCulture);
+            ReplaceComboItems(comboMsLevel, MsLevelOption.AllOptions, groupComparisonDef.MsLevel);
             radioScopeProtein.Checked = groupComparisonDef.PerProtein;
             radioScopePeptide.Checked = !groupComparisonDef.PerProtein;
             cbxUseZeroForMissingPeaks.Checked = groupComparisonDef.UseZeroForMissingPeaks;
@@ -475,6 +479,17 @@ namespace pwiz.Skyline.Controls.GroupComparison
         private void btnAdvanced_Click(object sender, EventArgs e)
         {
             ShowAdvanced(true);
+        }
+
+        private void comboMsLevel_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (_inChangeSettings)
+            {
+                return;
+            }
+
+            GroupComparisonDef =
+                GroupComparisonDef.ChangeMsLevel(comboMsLevel.SelectedItem as MsLevelOption ?? MsLevelOption.ALL);
         }
     }
 }

--- a/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.resx
@@ -189,6 +189,21 @@
   <data name="comboMsLevel.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
     <value>System</value>
   </data>
+  <data name="comboMsLevel.Items" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="comboMsLevel.Items1" xml:space="preserve">
+    <value>Equalize medians</value>
+  </data>
+  <data name="comboMsLevel.Items2" xml:space="preserve">
+    <value>Quantile</value>
+  </data>
+  <data name="comboMsLevel.Items3" xml:space="preserve">
+    <value>Relative to global standards</value>
+  </data>
+  <data name="comboMsLevel.Items4" xml:space="preserve">
+    <value>Relative to internal standard</value>
+  </data>
   <data name="comboMsLevel.Location" type="System.Drawing.Point, System.Drawing">
     <value>217, 223</value>
   </data>
@@ -196,7 +211,7 @@
     <value>94, 21</value>
   </data>
   <data name="comboMsLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
+    <value>14</value>
   </data>
   <data name="&gt;&gt;comboMsLevel.Name" xml:space="preserve">
     <value>comboMsLevel</value>
@@ -223,7 +238,7 @@
     <value>55, 13</value>
   </data>
   <data name="lblMsLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>13</value>
   </data>
   <data name="lblMsLevel.Text" xml:space="preserve">
     <value>MS Level:</value>
@@ -250,7 +265,7 @@
     <value>97, 23</value>
   </data>
   <data name="btnAdvanced.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+    <value>16</value>
   </data>
   <data name="btnAdvanced.Text" xml:space="preserve">
     <value>Advanced &gt;&gt;</value>
@@ -280,7 +295,7 @@
     <value>126, 13</value>
   </data>
   <data name="lblControlAnnotation.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>0</value>
   </data>
   <data name="lblControlAnnotation.Text" xml:space="preserve">
     <value>&amp;Control group annotation:</value>
@@ -307,7 +322,7 @@
     <value>486, 21</value>
   </data>
   <data name="comboControlAnnotation.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;comboControlAnnotation.Name" xml:space="preserve">
     <value>comboControlAnnotation</value>
@@ -323,426 +338,6 @@
   </data>
   <data name="groupBoxScope.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>groupBoxScope</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="groupBoxScope.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 249</value>
-  </data>
-  <data name="groupBoxScope.Size" type="System.Drawing.Size, System.Drawing">
-    <value>385, 47</value>
-  </data>
-  <data name="groupBoxScope.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="groupBoxScope.Text" xml:space="preserve">
-    <value>Scope</value>
-  </data>
-  <data name="&gt;&gt;groupBoxScope.Name" xml:space="preserve">
-    <value>groupBoxScope</value>
-  </data>
-  <data name="&gt;&gt;groupBoxScope.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBoxScope.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;groupBoxScope.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="lblPercent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblPercent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblPercent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 226</value>
-  </data>
-  <data name="lblPercent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lblPercent.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="lblPercent.Text" xml:space="preserve">
-    <value>%</value>
-  </data>
-  <data name="&gt;&gt;lblPercent.Name" xml:space="preserve">
-    <value>lblPercent</value>
-  </data>
-  <data name="&gt;&gt;lblPercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPercent.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblPercent.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="comboControlValue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboControlValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 59</value>
-  </data>
-  <data name="comboControlValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 21</value>
-  </data>
-  <data name="comboControlValue.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;comboControlValue.Name" xml:space="preserve">
-    <value>comboControlValue</value>
-  </data>
-  <data name="&gt;&gt;comboControlValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboControlValue.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;comboControlValue.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="tbxConfidenceLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 223</value>
-  </data>
-  <data name="tbxConfidenceLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 20</value>
-  </data>
-  <data name="tbxConfidenceLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;tbxConfidenceLevel.Name" xml:space="preserve">
-    <value>tbxConfidenceLevel</value>
-  </data>
-  <data name="&gt;&gt;tbxConfidenceLevel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbxConfidenceLevel.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;tbxConfidenceLevel.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="lblConfidenceLevel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblConfidenceLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblConfidenceLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 207</value>
-  </data>
-  <data name="lblConfidenceLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 13</value>
-  </data>
-  <data name="lblConfidenceLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="lblConfidenceLevel.Text" xml:space="preserve">
-    <value>Confid&amp;ence level:</value>
-  </data>
-  <data name="&gt;&gt;lblConfidenceLevel.Name" xml:space="preserve">
-    <value>lblConfidenceLevel</value>
-  </data>
-  <data name="&gt;&gt;lblConfidenceLevel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblConfidenceLevel.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblConfidenceLevel.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="lblControlValue.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblControlValue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblControlValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 43</value>
-  </data>
-  <data name="lblControlValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 13</value>
-  </data>
-  <data name="lblControlValue.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="lblControlValue.Text" xml:space="preserve">
-    <value>C&amp;ontrol group value:</value>
-  </data>
-  <data name="&gt;&gt;lblControlValue.Name" xml:space="preserve">
-    <value>lblControlValue</value>
-  </data>
-  <data name="&gt;&gt;lblControlValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblControlValue.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblControlValue.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="lblCompareAgainst.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblCompareAgainst.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblCompareAgainst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 83</value>
-  </data>
-  <data name="lblCompareAgainst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 13</value>
-  </data>
-  <data name="lblCompareAgainst.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="lblCompareAgainst.Text" xml:space="preserve">
-    <value>&amp;Value to compare against:</value>
-  </data>
-  <data name="&gt;&gt;lblCompareAgainst.Name" xml:space="preserve">
-    <value>lblCompareAgainst</value>
-  </data>
-  <data name="&gt;&gt;lblCompareAgainst.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCompareAgainst.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblCompareAgainst.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="comboCaseValue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboCaseValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 99</value>
-  </data>
-  <data name="comboCaseValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 21</value>
-  </data>
-  <data name="comboCaseValue.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;comboCaseValue.Name" xml:space="preserve">
-    <value>comboCaseValue</value>
-  </data>
-  <data name="&gt;&gt;comboCaseValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboCaseValue.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;comboCaseValue.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="comboNormalizationMethod.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboNormalizationMethod.Items" xml:space="preserve">
-    <value>None</value>
-  </data>
-  <data name="comboNormalizationMethod.Items1" xml:space="preserve">
-    <value>Equalize medians</value>
-  </data>
-  <data name="comboNormalizationMethod.Items2" xml:space="preserve">
-    <value>Quantile</value>
-  </data>
-  <data name="comboNormalizationMethod.Items3" xml:space="preserve">
-    <value>Relative to global standards</value>
-  </data>
-  <data name="comboNormalizationMethod.Items4" xml:space="preserve">
-    <value>Relative to internal standard</value>
-  </data>
-  <data name="comboNormalizationMethod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 179</value>
-  </data>
-  <data name="comboNormalizationMethod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 21</value>
-  </data>
-  <data name="comboNormalizationMethod.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;comboNormalizationMethod.Name" xml:space="preserve">
-    <value>comboNormalizationMethod</value>
-  </data>
-  <data name="&gt;&gt;comboNormalizationMethod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboNormalizationMethod.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;comboNormalizationMethod.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 123</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>212, 13</value>
-  </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>I&amp;dentity annotation (for technical replicates):</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="comboIdentityAnnotation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboIdentityAnnotation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 139</value>
-  </data>
-  <data name="comboIdentityAnnotation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 21</value>
-  </data>
-  <data name="comboIdentityAnnotation.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;comboIdentityAnnotation.Name" xml:space="preserve">
-    <value>comboIdentityAnnotation</value>
-  </data>
-  <data name="&gt;&gt;comboIdentityAnnotation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboIdentityAnnotation.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;comboIdentityAnnotation.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="lblNormalizationMethod.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblNormalizationMethod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblNormalizationMethod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 163</value>
-  </data>
-  <data name="lblNormalizationMethod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 13</value>
-  </data>
-  <data name="lblNormalizationMethod.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="lblNormalizationMethod.Text" xml:space="preserve">
-    <value>Nor&amp;malization method:</value>
-  </data>
-  <data name="&gt;&gt;lblNormalizationMethod.Name" xml:space="preserve">
-    <value>lblNormalizationMethod</value>
-  </data>
-  <data name="&gt;&gt;lblNormalizationMethod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNormalizationMethod.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblNormalizationMethod.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="panelMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panelMain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 59</value>
-  </data>
-  <data name="panelMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>515, 349</value>
-  </data>
-  <data name="panelMain.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;panelMain.Name" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;panelMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelMain.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;panelMain.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;radioScopePeptide.Name" xml:space="preserve">
-    <value>radioScopePeptide</value>
-  </data>
-  <data name="&gt;&gt;radioScopePeptide.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioScopePeptide.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;radioScopePeptide.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;radioScopeProtein.Name" xml:space="preserve">
-    <value>radioScopeProtein</value>
-  </data>
-  <data name="&gt;&gt;radioScopeProtein.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioScopeProtein.Parent" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;radioScopeProtein.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
-  </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 28</value>
-  </data>
-  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>groupBoxScope</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="radioScopePeptide.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -803,6 +398,390 @@
   </data>
   <data name="&gt;&gt;radioScopeProtein.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>379, 28</value>
+  </data>
+  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>groupBoxScope</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="groupBoxScope.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 249</value>
+  </data>
+  <data name="groupBoxScope.Size" type="System.Drawing.Size, System.Drawing">
+    <value>385, 47</value>
+  </data>
+  <data name="groupBoxScope.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="groupBoxScope.Text" xml:space="preserve">
+    <value>Scope</value>
+  </data>
+  <data name="&gt;&gt;groupBoxScope.Name" xml:space="preserve">
+    <value>groupBoxScope</value>
+  </data>
+  <data name="&gt;&gt;groupBoxScope.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxScope.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;groupBoxScope.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblPercent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblPercent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblPercent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 226</value>
+  </data>
+  <data name="lblPercent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lblPercent.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="lblPercent.Text" xml:space="preserve">
+    <value>%</value>
+  </data>
+  <data name="&gt;&gt;lblPercent.Name" xml:space="preserve">
+    <value>lblPercent</value>
+  </data>
+  <data name="&gt;&gt;lblPercent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPercent.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblPercent.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="comboControlValue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboControlValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 59</value>
+  </data>
+  <data name="comboControlValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>486, 21</value>
+  </data>
+  <data name="comboControlValue.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;comboControlValue.Name" xml:space="preserve">
+    <value>comboControlValue</value>
+  </data>
+  <data name="&gt;&gt;comboControlValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboControlValue.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboControlValue.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tbxConfidenceLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 223</value>
+  </data>
+  <data name="tbxConfidenceLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>90, 20</value>
+  </data>
+  <data name="tbxConfidenceLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;tbxConfidenceLevel.Name" xml:space="preserve">
+    <value>tbxConfidenceLevel</value>
+  </data>
+  <data name="&gt;&gt;tbxConfidenceLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbxConfidenceLevel.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;tbxConfidenceLevel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="lblConfidenceLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblConfidenceLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblConfidenceLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 207</value>
+  </data>
+  <data name="lblConfidenceLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 13</value>
+  </data>
+  <data name="lblConfidenceLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="lblConfidenceLevel.Text" xml:space="preserve">
+    <value>Confid&amp;ence level:</value>
+  </data>
+  <data name="&gt;&gt;lblConfidenceLevel.Name" xml:space="preserve">
+    <value>lblConfidenceLevel</value>
+  </data>
+  <data name="&gt;&gt;lblConfidenceLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblConfidenceLevel.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblConfidenceLevel.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="lblControlValue.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblControlValue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblControlValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 43</value>
+  </data>
+  <data name="lblControlValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 13</value>
+  </data>
+  <data name="lblControlValue.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblControlValue.Text" xml:space="preserve">
+    <value>C&amp;ontrol group value:</value>
+  </data>
+  <data name="&gt;&gt;lblControlValue.Name" xml:space="preserve">
+    <value>lblControlValue</value>
+  </data>
+  <data name="&gt;&gt;lblControlValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblControlValue.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblControlValue.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="lblCompareAgainst.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblCompareAgainst.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblCompareAgainst.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 83</value>
+  </data>
+  <data name="lblCompareAgainst.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 13</value>
+  </data>
+  <data name="lblCompareAgainst.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="lblCompareAgainst.Text" xml:space="preserve">
+    <value>&amp;Value to compare against:</value>
+  </data>
+  <data name="&gt;&gt;lblCompareAgainst.Name" xml:space="preserve">
+    <value>lblCompareAgainst</value>
+  </data>
+  <data name="&gt;&gt;lblCompareAgainst.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCompareAgainst.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblCompareAgainst.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="comboCaseValue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboCaseValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 99</value>
+  </data>
+  <data name="comboCaseValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>486, 21</value>
+  </data>
+  <data name="comboCaseValue.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;comboCaseValue.Name" xml:space="preserve">
+    <value>comboCaseValue</value>
+  </data>
+  <data name="&gt;&gt;comboCaseValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboCaseValue.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboCaseValue.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="comboNormalizationMethod.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboNormalizationMethod.Items" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="comboNormalizationMethod.Items1" xml:space="preserve">
+    <value>Equalize medians</value>
+  </data>
+  <data name="comboNormalizationMethod.Items2" xml:space="preserve">
+    <value>Quantile</value>
+  </data>
+  <data name="comboNormalizationMethod.Items3" xml:space="preserve">
+    <value>Relative to global standards</value>
+  </data>
+  <data name="comboNormalizationMethod.Items4" xml:space="preserve">
+    <value>Relative to internal standard</value>
+  </data>
+  <data name="comboNormalizationMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 179</value>
+  </data>
+  <data name="comboNormalizationMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>486, 21</value>
+  </data>
+  <data name="comboNormalizationMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;comboNormalizationMethod.Name" xml:space="preserve">
+    <value>comboNormalizationMethod</value>
+  </data>
+  <data name="&gt;&gt;comboNormalizationMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboNormalizationMethod.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboNormalizationMethod.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 123</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>212, 13</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>I&amp;dentity annotation (for technical replicates):</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="comboIdentityAnnotation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboIdentityAnnotation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 139</value>
+  </data>
+  <data name="comboIdentityAnnotation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>486, 21</value>
+  </data>
+  <data name="comboIdentityAnnotation.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;comboIdentityAnnotation.Name" xml:space="preserve">
+    <value>comboIdentityAnnotation</value>
+  </data>
+  <data name="&gt;&gt;comboIdentityAnnotation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboIdentityAnnotation.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboIdentityAnnotation.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="lblNormalizationMethod.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblNormalizationMethod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblNormalizationMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 163</value>
+  </data>
+  <data name="lblNormalizationMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>111, 13</value>
+  </data>
+  <data name="lblNormalizationMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="lblNormalizationMethod.Text" xml:space="preserve">
+    <value>Nor&amp;malization method:</value>
+  </data>
+  <data name="&gt;&gt;lblNormalizationMethod.Name" xml:space="preserve">
+    <value>lblNormalizationMethod</value>
+  </data>
+  <data name="&gt;&gt;lblNormalizationMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNormalizationMethod.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblNormalizationMethod.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="panelMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelMain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 59</value>
+  </data>
+  <data name="panelMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>515, 349</value>
+  </data>
+  <data name="panelMain.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;panelMain.Name" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;panelMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelMain.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelMain.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="groupBoxQValueCutoff.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.resx
@@ -183,8 +183,68 @@
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="comboMsLevel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboMsLevel.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="comboMsLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>217, 223</value>
+  </data>
+  <data name="comboMsLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 21</value>
+  </data>
+  <data name="comboMsLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;comboMsLevel.Name" xml:space="preserve">
+    <value>comboMsLevel</value>
+  </data>
+  <data name="&gt;&gt;comboMsLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboMsLevel.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboMsLevel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblMsLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblMsLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblMsLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>221, 207</value>
+  </data>
+  <data name="lblMsLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>55, 13</value>
+  </data>
+  <data name="lblMsLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="lblMsLevel.Text" xml:space="preserve">
+    <value>MS Level:</value>
+  </data>
+  <data name="&gt;&gt;lblMsLevel.Name" xml:space="preserve">
+    <value>lblMsLevel</value>
+  </data>
+  <data name="&gt;&gt;lblMsLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblMsLevel.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblMsLevel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnAdvanced.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
   <data name="btnAdvanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 296</value>
+    <value>3, 319</value>
   </data>
   <data name="btnAdvanced.Size" type="System.Drawing.Size, System.Drawing">
     <value>97, 23</value>
@@ -205,7 +265,7 @@
     <value>panelMain</value>
   </data>
   <data name="&gt;&gt;btnAdvanced.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="lblControlAnnotation.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -235,7 +295,7 @@
     <value>panelMain</value>
   </data>
   <data name="&gt;&gt;lblControlAnnotation.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="comboControlAnnotation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -259,10 +319,430 @@
     <value>panelMain</value>
   </data>
   <data name="&gt;&gt;comboControlAnnotation.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="groupBoxScope.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>groupBoxScope</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="groupBoxScope.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 249</value>
+  </data>
+  <data name="groupBoxScope.Size" type="System.Drawing.Size, System.Drawing">
+    <value>385, 47</value>
+  </data>
+  <data name="groupBoxScope.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="groupBoxScope.Text" xml:space="preserve">
+    <value>Scope</value>
+  </data>
+  <data name="&gt;&gt;groupBoxScope.Name" xml:space="preserve">
+    <value>groupBoxScope</value>
+  </data>
+  <data name="&gt;&gt;groupBoxScope.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxScope.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;groupBoxScope.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblPercent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblPercent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblPercent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 226</value>
+  </data>
+  <data name="lblPercent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 13</value>
+  </data>
+  <data name="lblPercent.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="lblPercent.Text" xml:space="preserve">
+    <value>%</value>
+  </data>
+  <data name="&gt;&gt;lblPercent.Name" xml:space="preserve">
+    <value>lblPercent</value>
+  </data>
+  <data name="&gt;&gt;lblPercent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblPercent.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblPercent.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="comboControlValue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboControlValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 59</value>
+  </data>
+  <data name="comboControlValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>486, 21</value>
+  </data>
+  <data name="comboControlValue.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;comboControlValue.Name" xml:space="preserve">
+    <value>comboControlValue</value>
+  </data>
+  <data name="&gt;&gt;comboControlValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboControlValue.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboControlValue.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tbxConfidenceLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 223</value>
+  </data>
+  <data name="tbxConfidenceLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>90, 20</value>
+  </data>
+  <data name="tbxConfidenceLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;tbxConfidenceLevel.Name" xml:space="preserve">
+    <value>tbxConfidenceLevel</value>
+  </data>
+  <data name="&gt;&gt;tbxConfidenceLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbxConfidenceLevel.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;tbxConfidenceLevel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="lblConfidenceLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblConfidenceLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblConfidenceLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 207</value>
+  </data>
+  <data name="lblConfidenceLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 13</value>
+  </data>
+  <data name="lblConfidenceLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="lblConfidenceLevel.Text" xml:space="preserve">
+    <value>Confid&amp;ence level:</value>
+  </data>
+  <data name="&gt;&gt;lblConfidenceLevel.Name" xml:space="preserve">
+    <value>lblConfidenceLevel</value>
+  </data>
+  <data name="&gt;&gt;lblConfidenceLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblConfidenceLevel.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblConfidenceLevel.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="lblControlValue.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblControlValue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblControlValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 43</value>
+  </data>
+  <data name="lblControlValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 13</value>
+  </data>
+  <data name="lblControlValue.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblControlValue.Text" xml:space="preserve">
+    <value>C&amp;ontrol group value:</value>
+  </data>
+  <data name="&gt;&gt;lblControlValue.Name" xml:space="preserve">
+    <value>lblControlValue</value>
+  </data>
+  <data name="&gt;&gt;lblControlValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblControlValue.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblControlValue.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="lblCompareAgainst.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblCompareAgainst.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblCompareAgainst.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 83</value>
+  </data>
+  <data name="lblCompareAgainst.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 13</value>
+  </data>
+  <data name="lblCompareAgainst.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="lblCompareAgainst.Text" xml:space="preserve">
+    <value>&amp;Value to compare against:</value>
+  </data>
+  <data name="&gt;&gt;lblCompareAgainst.Name" xml:space="preserve">
+    <value>lblCompareAgainst</value>
+  </data>
+  <data name="&gt;&gt;lblCompareAgainst.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblCompareAgainst.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblCompareAgainst.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="comboCaseValue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboCaseValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 99</value>
+  </data>
+  <data name="comboCaseValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>486, 21</value>
+  </data>
+  <data name="comboCaseValue.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;comboCaseValue.Name" xml:space="preserve">
+    <value>comboCaseValue</value>
+  </data>
+  <data name="&gt;&gt;comboCaseValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboCaseValue.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboCaseValue.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="comboNormalizationMethod.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboNormalizationMethod.Items" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="comboNormalizationMethod.Items1" xml:space="preserve">
+    <value>Equalize medians</value>
+  </data>
+  <data name="comboNormalizationMethod.Items2" xml:space="preserve">
+    <value>Quantile</value>
+  </data>
+  <data name="comboNormalizationMethod.Items3" xml:space="preserve">
+    <value>Relative to global standards</value>
+  </data>
+  <data name="comboNormalizationMethod.Items4" xml:space="preserve">
+    <value>Relative to internal standard</value>
+  </data>
+  <data name="comboNormalizationMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 179</value>
+  </data>
+  <data name="comboNormalizationMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>486, 21</value>
+  </data>
+  <data name="comboNormalizationMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;comboNormalizationMethod.Name" xml:space="preserve">
+    <value>comboNormalizationMethod</value>
+  </data>
+  <data name="&gt;&gt;comboNormalizationMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboNormalizationMethod.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboNormalizationMethod.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 123</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>212, 13</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>I&amp;dentity annotation (for technical replicates):</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="comboIdentityAnnotation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboIdentityAnnotation.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 139</value>
+  </data>
+  <data name="comboIdentityAnnotation.Size" type="System.Drawing.Size, System.Drawing">
+    <value>486, 21</value>
+  </data>
+  <data name="comboIdentityAnnotation.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;comboIdentityAnnotation.Name" xml:space="preserve">
+    <value>comboIdentityAnnotation</value>
+  </data>
+  <data name="&gt;&gt;comboIdentityAnnotation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comboIdentityAnnotation.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;comboIdentityAnnotation.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="lblNormalizationMethod.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblNormalizationMethod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblNormalizationMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 163</value>
+  </data>
+  <data name="lblNormalizationMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>111, 13</value>
+  </data>
+  <data name="lblNormalizationMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="lblNormalizationMethod.Text" xml:space="preserve">
+    <value>Nor&amp;malization method:</value>
+  </data>
+  <data name="&gt;&gt;lblNormalizationMethod.Name" xml:space="preserve">
+    <value>lblNormalizationMethod</value>
+  </data>
+  <data name="&gt;&gt;lblNormalizationMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblNormalizationMethod.Parent" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;lblNormalizationMethod.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="panelMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelMain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 59</value>
+  </data>
+  <data name="panelMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>515, 349</value>
+  </data>
+  <data name="panelMain.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;panelMain.Name" xml:space="preserve">
+    <value>panelMain</value>
+  </data>
+  <data name="&gt;&gt;panelMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelMain.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelMain.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;radioScopePeptide.Name" xml:space="preserve">
+    <value>radioScopePeptide</value>
+  </data>
+  <data name="&gt;&gt;radioScopePeptide.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioScopePeptide.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;radioScopePeptide.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;radioScopeProtein.Name" xml:space="preserve">
+    <value>radioScopeProtein</value>
+  </data>
+  <data name="&gt;&gt;radioScopeProtein.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;radioScopeProtein.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;radioScopeProtein.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>379, 28</value>
+  </data>
+  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>groupBoxScope</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="radioScopePeptide.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -324,392 +804,56 @@
   <data name="&gt;&gt;radioScopeProtein.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
-  </data>
-  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 28</value>
-  </data>
-  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
-    <value>flowLayoutPanel1</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
-    <value>groupBoxScope</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="groupBoxScope.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 249</value>
-  </data>
-  <data name="groupBoxScope.Size" type="System.Drawing.Size, System.Drawing">
-    <value>385, 47</value>
-  </data>
-  <data name="groupBoxScope.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="groupBoxScope.Text" xml:space="preserve">
-    <value>Scope</value>
-  </data>
-  <data name="&gt;&gt;groupBoxScope.Name" xml:space="preserve">
-    <value>groupBoxScope</value>
-  </data>
-  <data name="&gt;&gt;groupBoxScope.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBoxScope.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;groupBoxScope.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="lblPercent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblPercent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblPercent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 226</value>
-  </data>
-  <data name="lblPercent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
-  </data>
-  <data name="lblPercent.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="lblPercent.Text" xml:space="preserve">
-    <value>%</value>
-  </data>
-  <data name="&gt;&gt;lblPercent.Name" xml:space="preserve">
-    <value>lblPercent</value>
-  </data>
-  <data name="&gt;&gt;lblPercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblPercent.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblPercent.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="comboControlValue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboControlValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 59</value>
-  </data>
-  <data name="comboControlValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 21</value>
-  </data>
-  <data name="comboControlValue.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;comboControlValue.Name" xml:space="preserve">
-    <value>comboControlValue</value>
-  </data>
-  <data name="&gt;&gt;comboControlValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboControlValue.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;comboControlValue.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tbxConfidenceLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 223</value>
-  </data>
-  <data name="tbxConfidenceLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 20</value>
-  </data>
-  <data name="tbxConfidenceLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;tbxConfidenceLevel.Name" xml:space="preserve">
-    <value>tbxConfidenceLevel</value>
-  </data>
-  <data name="&gt;&gt;tbxConfidenceLevel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbxConfidenceLevel.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;tbxConfidenceLevel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="lblConfidenceLevel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblConfidenceLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblConfidenceLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 207</value>
-  </data>
-  <data name="lblConfidenceLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 13</value>
-  </data>
-  <data name="lblConfidenceLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="lblConfidenceLevel.Text" xml:space="preserve">
-    <value>Confid&amp;ence level:</value>
-  </data>
-  <data name="&gt;&gt;lblConfidenceLevel.Name" xml:space="preserve">
-    <value>lblConfidenceLevel</value>
-  </data>
-  <data name="&gt;&gt;lblConfidenceLevel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblConfidenceLevel.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblConfidenceLevel.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="lblControlValue.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblControlValue.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblControlValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 43</value>
-  </data>
-  <data name="lblControlValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 13</value>
-  </data>
-  <data name="lblControlValue.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="lblControlValue.Text" xml:space="preserve">
-    <value>C&amp;ontrol group value:</value>
-  </data>
-  <data name="&gt;&gt;lblControlValue.Name" xml:space="preserve">
-    <value>lblControlValue</value>
-  </data>
-  <data name="&gt;&gt;lblControlValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblControlValue.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblControlValue.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="lblCompareAgainst.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblCompareAgainst.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblCompareAgainst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 83</value>
-  </data>
-  <data name="lblCompareAgainst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 13</value>
-  </data>
-  <data name="lblCompareAgainst.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="lblCompareAgainst.Text" xml:space="preserve">
-    <value>&amp;Value to compare against:</value>
-  </data>
-  <data name="&gt;&gt;lblCompareAgainst.Name" xml:space="preserve">
-    <value>lblCompareAgainst</value>
-  </data>
-  <data name="&gt;&gt;lblCompareAgainst.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblCompareAgainst.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblCompareAgainst.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="comboCaseValue.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboCaseValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 99</value>
-  </data>
-  <data name="comboCaseValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 21</value>
-  </data>
-  <data name="comboCaseValue.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;comboCaseValue.Name" xml:space="preserve">
-    <value>comboCaseValue</value>
-  </data>
-  <data name="&gt;&gt;comboCaseValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboCaseValue.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;comboCaseValue.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="comboNormalizationMethod.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboNormalizationMethod.Items" xml:space="preserve">
-    <value>None</value>
-  </data>
-  <data name="comboNormalizationMethod.Items1" xml:space="preserve">
-    <value>Equalize medians</value>
-  </data>
-  <data name="comboNormalizationMethod.Items2" xml:space="preserve">
-    <value>Quantile</value>
-  </data>
-  <data name="comboNormalizationMethod.Items3" xml:space="preserve">
-    <value>Relative to global standards</value>
-  </data>
-  <data name="comboNormalizationMethod.Items4" xml:space="preserve">
-    <value>Relative to internal standard</value>
-  </data>
-  <data name="comboNormalizationMethod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 179</value>
-  </data>
-  <data name="comboNormalizationMethod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 21</value>
-  </data>
-  <data name="comboNormalizationMethod.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;comboNormalizationMethod.Name" xml:space="preserve">
-    <value>comboNormalizationMethod</value>
-  </data>
-  <data name="&gt;&gt;comboNormalizationMethod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboNormalizationMethod.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;comboNormalizationMethod.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 123</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>212, 13</value>
-  </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>I&amp;dentity annotation (for technical replicates):</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="comboIdentityAnnotation.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboIdentityAnnotation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 139</value>
-  </data>
-  <data name="comboIdentityAnnotation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 21</value>
-  </data>
-  <data name="comboIdentityAnnotation.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;comboIdentityAnnotation.Name" xml:space="preserve">
-    <value>comboIdentityAnnotation</value>
-  </data>
-  <data name="&gt;&gt;comboIdentityAnnotation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboIdentityAnnotation.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;comboIdentityAnnotation.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="lblNormalizationMethod.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblNormalizationMethod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblNormalizationMethod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 163</value>
-  </data>
-  <data name="lblNormalizationMethod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 13</value>
-  </data>
-  <data name="lblNormalizationMethod.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="lblNormalizationMethod.Text" xml:space="preserve">
-    <value>Nor&amp;malization method:</value>
-  </data>
-  <data name="&gt;&gt;lblNormalizationMethod.Name" xml:space="preserve">
-    <value>lblNormalizationMethod</value>
-  </data>
-  <data name="&gt;&gt;lblNormalizationMethod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblNormalizationMethod.Parent" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;lblNormalizationMethod.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="panelMain.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panelMain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 59</value>
-  </data>
-  <data name="panelMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>515, 322</value>
-  </data>
-  <data name="panelMain.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;panelMain.Name" xml:space="preserve">
-    <value>panelMain</value>
-  </data>
-  <data name="&gt;&gt;panelMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelMain.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;panelMain.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="groupBoxQValueCutoff.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
+  </data>
+  <data name="&gt;&gt;tbxQValueCutoff.Name" xml:space="preserve">
+    <value>tbxQValueCutoff</value>
+  </data>
+  <data name="&gt;&gt;tbxQValueCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbxQValueCutoff.Parent" xml:space="preserve">
+    <value>groupBoxQValueCutoff</value>
+  </data>
+  <data name="&gt;&gt;tbxQValueCutoff.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;lblQValueCutoff.Name" xml:space="preserve">
+    <value>lblQValueCutoff</value>
+  </data>
+  <data name="&gt;&gt;lblQValueCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblQValueCutoff.Parent" xml:space="preserve">
+    <value>groupBoxQValueCutoff</value>
+  </data>
+  <data name="&gt;&gt;lblQValueCutoff.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="groupBoxQValueCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 70</value>
+  </data>
+  <data name="groupBoxQValueCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>483, 65</value>
+  </data>
+  <data name="groupBoxQValueCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="groupBoxQValueCutoff.Text" xml:space="preserve">
+    <value>Q-value cutoff</value>
+  </data>
+  <data name="&gt;&gt;groupBoxQValueCutoff.Name" xml:space="preserve">
+    <value>groupBoxQValueCutoff</value>
+  </data>
+  <data name="&gt;&gt;groupBoxQValueCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxQValueCutoff.Parent" xml:space="preserve">
+    <value>panelAdvanced</value>
+  </data>
+  <data name="&gt;&gt;groupBoxQValueCutoff.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="tbxQValueCutoff.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 38</value>
@@ -758,30 +902,6 @@
   </data>
   <data name="&gt;&gt;lblQValueCutoff.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="groupBoxQValueCutoff.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 70</value>
-  </data>
-  <data name="groupBoxQValueCutoff.Size" type="System.Drawing.Size, System.Drawing">
-    <value>483, 65</value>
-  </data>
-  <data name="groupBoxQValueCutoff.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="groupBoxQValueCutoff.Text" xml:space="preserve">
-    <value>Q-value cutoff</value>
-  </data>
-  <data name="&gt;&gt;groupBoxQValueCutoff.Name" xml:space="preserve">
-    <value>groupBoxQValueCutoff</value>
-  </data>
-  <data name="&gt;&gt;groupBoxQValueCutoff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBoxQValueCutoff.Parent" xml:space="preserve">
-    <value>panelAdvanced</value>
-  </data>
-  <data name="&gt;&gt;groupBoxQValueCutoff.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="lblSummaryMethod.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -979,7 +1099,7 @@
     <value>Bottom</value>
   </data>
   <data name="panelButtons.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 531</value>
+    <value>0, 562</value>
   </data>
   <data name="panelButtons.Size" type="System.Drawing.Size, System.Drawing">
     <value>515, 32</value>
@@ -1003,7 +1123,7 @@
     <value>Top</value>
   </data>
   <data name="panelAdvanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 381</value>
+    <value>0, 408</value>
   </data>
   <data name="panelAdvanced.Size" type="System.Drawing.Size, System.Drawing">
     <value>515, 152</value>
@@ -1030,7 +1150,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>515, 563</value>
+    <value>515, 594</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
@@ -1042,12 +1162,12 @@
     <value>modeUIHandler</value>
   </data>
   <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=19.1.1.295, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline-daily, Version=22.2.1.382, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>EditGroupComparisonDlg</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.FormEx, Skyline, Version=19.1.1.295, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=22.2.1.382, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.resx
@@ -205,7 +205,7 @@
     <value>Relative to internal standard</value>
   </data>
   <data name="comboMsLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>217, 223</value>
+    <value>221, 223</value>
   </data>
   <data name="comboMsLevel.Size" type="System.Drawing.Size, System.Drawing">
     <value>94, 21</value>
@@ -235,13 +235,13 @@
     <value>221, 207</value>
   </data>
   <data name="lblMsLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
+    <value>51, 13</value>
   </data>
   <data name="lblMsLevel.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
   </data>
   <data name="lblMsLevel.Text" xml:space="preserve">
-    <value>MS Level:</value>
+    <value>MS level:</value>
   </data>
   <data name="&gt;&gt;lblMsLevel.Name" xml:space="preserve">
     <value>lblMsLevel</value>
@@ -786,54 +786,6 @@
   <data name="groupBoxQValueCutoff.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="&gt;&gt;tbxQValueCutoff.Name" xml:space="preserve">
-    <value>tbxQValueCutoff</value>
-  </data>
-  <data name="&gt;&gt;tbxQValueCutoff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbxQValueCutoff.Parent" xml:space="preserve">
-    <value>groupBoxQValueCutoff</value>
-  </data>
-  <data name="&gt;&gt;tbxQValueCutoff.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblQValueCutoff.Name" xml:space="preserve">
-    <value>lblQValueCutoff</value>
-  </data>
-  <data name="&gt;&gt;lblQValueCutoff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblQValueCutoff.Parent" xml:space="preserve">
-    <value>groupBoxQValueCutoff</value>
-  </data>
-  <data name="&gt;&gt;lblQValueCutoff.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="groupBoxQValueCutoff.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 70</value>
-  </data>
-  <data name="groupBoxQValueCutoff.Size" type="System.Drawing.Size, System.Drawing">
-    <value>483, 65</value>
-  </data>
-  <data name="groupBoxQValueCutoff.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="groupBoxQValueCutoff.Text" xml:space="preserve">
-    <value>Q-value cutoff</value>
-  </data>
-  <data name="&gt;&gt;groupBoxQValueCutoff.Name" xml:space="preserve">
-    <value>groupBoxQValueCutoff</value>
-  </data>
-  <data name="&gt;&gt;groupBoxQValueCutoff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBoxQValueCutoff.Parent" xml:space="preserve">
-    <value>panelAdvanced</value>
-  </data>
-  <data name="&gt;&gt;groupBoxQValueCutoff.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="tbxQValueCutoff.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 38</value>
   </data>
@@ -881,6 +833,30 @@
   </data>
   <data name="&gt;&gt;lblQValueCutoff.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="groupBoxQValueCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 70</value>
+  </data>
+  <data name="groupBoxQValueCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>483, 65</value>
+  </data>
+  <data name="groupBoxQValueCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="groupBoxQValueCutoff.Text" xml:space="preserve">
+    <value>Q-value cutoff</value>
+  </data>
+  <data name="&gt;&gt;groupBoxQValueCutoff.Name" xml:space="preserve">
+    <value>groupBoxQValueCutoff</value>
+  </data>
+  <data name="&gt;&gt;groupBoxQValueCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxQValueCutoff.Parent" xml:space="preserve">
+    <value>panelAdvanced</value>
+  </data>
+  <data name="&gt;&gt;groupBoxQValueCutoff.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblSummaryMethod.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/MsLevelOption.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/MsLevelOption.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using pwiz.Common.Collections;
+using pwiz.Common.SystemUtil;
+
+namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
+{
+    public class MsLevelOption : LabeledValues<string>
+    {
+        private MsLevelOption(string name, Func<string> getLabelFunc) : base(name, getLabelFunc)
+        {
+        }
+
+        public static readonly MsLevelOption ALL = new MsLevelOption("", () => QuantificationStrings.MsLevelOption_ALL_All);
+        public static readonly MsLevelOption ONE = new MsLevelOption(@"1", () => 1.ToString());
+        public static readonly MsLevelOption TWO = new MsLevelOption(@"2", () => 2.ToString());
+        public static readonly MsLevelOption DEFAULT = new MsLevelOption(@"default", () => QuantificationStrings.MsLevelOption_DEFAULT_Default);
+
+        public static MsLevelOption ForName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return ALL;
+            }
+
+            return AllOptions.FirstOrDefault(option => option.Name == name) ?? ALL;
+        }
+
+        public static readonly ImmutableList<MsLevelOption> AllOptions = ImmutableList.ValueOf(new[]
+        {
+            DEFAULT, ALL, ONE, TWO
+        });
+
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationStrings.Designer.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class QuantificationStrings {
@@ -454,6 +454,24 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification {
         public static string LodCalculation_TURNING_POINT_Bilinear_turning_point {
             get {
                 return ResourceManager.GetString("LodCalculation_TURNING_POINT_Bilinear_turning_point", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All.
+        /// </summary>
+        public static string MsLevelOption_ALL_All {
+            get {
+                return ResourceManager.GetString("MsLevelOption_ALL_All", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default.
+        /// </summary>
+        public static string MsLevelOption_DEFAULT_Default {
+            get {
+                return ResourceManager.GetString("MsLevelOption_DEFAULT_Default", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationStrings.resx
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationStrings.resx
@@ -330,4 +330,10 @@
     <value>Default ({0})</value>
     <comment>Example: Default (Global Standards)</comment>
   </data>
+  <data name="MsLevelOption_ALL_All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="MsLevelOption_DEFAULT_Default" xml:space="preserve">
+    <value>Default</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonDef.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonDef.cs
@@ -24,6 +24,7 @@ using System.Xml.Serialization;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Model.DocSettings.AbsoluteQuantification;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Util;
 
@@ -126,6 +127,14 @@ namespace pwiz.Skyline.Model.GroupComparison
         }
 
         [Track]
+        public MsLevelOption MsLevel { get; private set; }
+
+        public GroupComparisonDef ChangeMsLevel(MsLevelOption msLevelOption)
+        {
+            return ChangeProp(ImClone(this), im => im.MsLevel = msLevelOption);
+        }
+
+        [Track]
         public bool PerProtein { get; private set; }
 
         public GroupComparisonDef ChangePerProtein(bool value)
@@ -200,6 +209,7 @@ namespace pwiz.Skyline.Model.GroupComparison
             include_interaction_transitions,
             summarization_method,
             confidence_level,
+            ms_level,
             per_protein,
             use_zero_for_missing_peaks,
             q_value_cutoff
@@ -222,6 +232,7 @@ namespace pwiz.Skyline.Model.GroupComparison
             IncludeInteractionTransitions = reader.GetBoolAttribute(ATTR.include_interaction_transitions, false);
             SummarizationMethod = SummarizationMethod.FromName(reader.GetAttribute(ATTR.summarization_method));
             ConfidenceLevelTimes100 = reader.GetDoubleAttribute(ATTR.confidence_level, 95);
+            MsLevel = MsLevelOption.ForName(reader.GetAttribute(ATTR.ms_level));
             PerProtein = reader.GetBoolAttribute(ATTR.per_protein, false);
             UseZeroForMissingPeaks = reader.GetBoolAttribute(ATTR.use_zero_for_missing_peaks, false);
             QValueCutoff = reader.GetNullableDoubleAttribute(ATTR.q_value_cutoff);
@@ -259,6 +270,7 @@ namespace pwiz.Skyline.Model.GroupComparison
             writer.WriteAttribute(ATTR.include_interaction_transitions, IncludeInteractionTransitions, false);
             writer.WriteAttribute(ATTR.summarization_method, SummarizationMethod.Name);
             writer.WriteAttribute(ATTR.confidence_level, ConfidenceLevelTimes100);
+            writer.WriteAttributeIfString(ATTR.ms_level, MsLevel.Name);
             writer.WriteAttribute(ATTR.per_protein, PerProtein, false);
             writer.WriteAttribute(ATTR.use_zero_for_missing_peaks, UseZeroForMissingPeaks, false);
             writer.WriteAttributeNullable(ATTR.q_value_cutoff, QValueCutoff);
@@ -281,6 +293,7 @@ namespace pwiz.Skyline.Model.GroupComparison
                    IncludeInteractionTransitions == other.IncludeInteractionTransitions &&
                    Equals(SummarizationMethod, other.SummarizationMethod) &&
                    ConfidenceLevelTimes100.Equals(other.ConfidenceLevelTimes100) &&
+                   Equals(MsLevel, other.MsLevel) &&
                    PerProtein == other.PerProtein &&
                    UseZeroForMissingPeaks == other.UseZeroForMissingPeaks &&
                    QValueCutoff.Equals(other.QValueCutoff) &&
@@ -308,6 +321,7 @@ namespace pwiz.Skyline.Model.GroupComparison
                 hashCode = (hashCode*397) ^ IncludeInteractionTransitions.GetHashCode();
                 hashCode = (hashCode*397) ^ (SummarizationMethod != null ? SummarizationMethod.GetHashCode() : 0);
                 hashCode = (hashCode*397) ^ ConfidenceLevelTimes100.GetHashCode();
+                hashCode = (hashCode*397) ^ MsLevel.GetHashCode();
                 hashCode = (hashCode*397) ^ PerProtein.GetHashCode();
                 hashCode = (hashCode*397) ^ UseZeroForMissingPeaks.GetHashCode();
                 hashCode = (hashCode*397) ^ QValueCutoff.GetHashCode();

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.Designer.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.Designer.cs
@@ -197,6 +197,15 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Batch Calibration Curve.
+        /// </summary>
+        internal static string EditGroupComparisonDlg_GetNormalizeOptionText_Batch_Calibration_Curve {
+            get {
+                return ResourceManager.GetString("EditGroupComparisonDlg_GetNormalizeOptionText_Batch_Calibration_Curve", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to -Log10(P Value).
         /// </summary>
         internal static string FoldChange__Log10_P_Value_ {

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.resx
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.resx
@@ -362,4 +362,7 @@
 	  <value>Median Normalized {0}</value>
       <comment>Example: Median Normalized Peak Area</comment>
   </data>
+  <data name="EditGroupComparisonDlg_GetNormalizeOptionText_Batch_Calibration_Curve" xml:space="preserve">
+    <value>Batch Calibration Curve</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/GroupComparison/MsLevelOption.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/MsLevelOption.cs
@@ -2,8 +2,9 @@
 using System.Linq;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
+using pwiz.Skyline.Model.DocSettings.AbsoluteQuantification;
 
-namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
+namespace pwiz.Skyline.Model.GroupComparison
 {
     public class MsLevelOption : LabeledValues<string>
     {

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -575,6 +575,7 @@
     <Compile Include="Controls\Databinding\RowActions\RowAction.cs" />
     <Compile Include="Model\DdaSearch\MsFraggerSearchEngine.cs" />
     <Compile Include="Model\DiaUmpireDdaConverter.cs" />
+    <Compile Include="Model\DocSettings\AbsoluteQuantification\MsLevelOption.cs" />
     <Compile Include="Model\DocSettings\AbsoluteQuantification\ValueStatus.cs" />
     <Compile Include="Model\DocSettings\AnnotationCalculator.cs" />
     <Compile Include="Model\DocSettings\AnnotationExpression.cs" />

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -575,7 +575,7 @@
     <Compile Include="Controls\Databinding\RowActions\RowAction.cs" />
     <Compile Include="Model\DdaSearch\MsFraggerSearchEngine.cs" />
     <Compile Include="Model\DiaUmpireDdaConverter.cs" />
-    <Compile Include="Model\DocSettings\AbsoluteQuantification\MsLevelOption.cs" />
+    <Compile Include="Model\GroupComparison\MsLevelOption.cs" />
     <Compile Include="Model\DocSettings\AbsoluteQuantification\ValueStatus.cs" />
     <Compile Include="Model\DocSettings\AnnotationCalculator.cs" />
     <Compile Include="Model\DocSettings\AnnotationExpression.cs" />
@@ -2417,6 +2417,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\GroupComparison\EditGroupComparisonDlg.resx">
       <DependentUpon>EditGroupComparisonDlg.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\GroupComparison\EditGroupComparisonDlg.zh-CHS.resx">
       <DependentUpon>EditGroupComparisonDlg.cs</DependentUpon>

--- a/pwiz_tools/Skyline/TestPerf/OrbiPrmTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/OrbiPrmTutorialTest.cs
@@ -909,8 +909,8 @@ namespace TestPerf
                 Assert.IsTrue(editGroupComparisonDlg.ComboCaseValue.Items.Contains(caseValue));
                 editGroupComparisonDlg.ComboIdentityAnnotation.SelectedItem = identityAnnotation;
                 Assert.IsTrue(editGroupComparisonDlg.ComboIdentityAnnotation.Items.Contains(identityAnnotation));
-                editGroupComparisonDlg.ComboNormalizationMethod.SelectedItem =
-                    NormalizationMethod.FromIsotopeLabelTypeName("heavy");
+                editGroupComparisonDlg.NormalizeOption =
+                    NormalizeOption.FromNormalizationMethod(NormalizationMethod.FromIsotopeLabelTypeName("heavy"));
                 editGroupComparisonDlg.TextBoxConfidenceLevel.Text = 95.ToString(CultureInfo.CurrentCulture);
                 editGroupComparisonDlg.RadioScopePerProtein.Checked = true;
                 editGroupComparisonDlg.ShowAdvanced(true);

--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
@@ -1347,7 +1347,7 @@ namespace pwiz.SkylineTestTutorial
                 Assert.IsTrue(editGroupComparisonDlg.ComboCaseValue.Items.Contains(caseValue));
                 editGroupComparisonDlg.ComboIdentityAnnotation.SelectedItem = identityAnnotation;
                 Assert.IsTrue(editGroupComparisonDlg.ComboIdentityAnnotation.Items.Contains(identityAnnotation));
-                editGroupComparisonDlg.ComboNormalizationMethod.SelectedItem = NormalizationMethod.GLOBAL_STANDARDS;
+                editGroupComparisonDlg.NormalizeOption = NormalizeOption.GLOBAL_STANDARDS;
                 editGroupComparisonDlg.TextBoxConfidenceLevel.Text = 99.ToString(CultureInfo.CurrentCulture);
                 editGroupComparisonDlg.RadioScopePerProtein.Checked = true;
             });


### PR DESCRIPTION
Features requested by Mike:
1. Allow specifying MS Level for group comparison. Choices are "Default" (i.e. use whatever is specified in Peptide Settings > Quantification"), "All", "1" and "2".
2. More options for "Normalization Method":
"Default": use whatever is in "Peptide Settings > Quantification"
"Batch Calibration Curve" if there is a calibration curve, and any replicates have the "Batch Name" set, then use the calibration curve to get the number for quantification.
![image](https://user-images.githubusercontent.com/303203/213303914-88f07f2a-ba9c-4124-98a0-db2992609881.png)

![image](https://user-images.githubusercontent.com/303203/213303935-638ac290-2730-49c4-b1d0-9838faea2518.png)
