### PR TITLE
Use a static variable instead of "Settings.Default.ShowTreeReplicateEnum"

### DIFF
--- a/pwiz_tools/Skyline/Controls/SequenceTree.cs
+++ b/pwiz_tools/Skyline/Controls/SequenceTree.cs
@@ -446,7 +446,7 @@ namespace pwiz.Skyline.Controls
             return i;
         }
 
-        private ReplicateDisplay? _showReplicate;
+        private ReplicateDisplay _showReplicate = ReplicateDisplay.single;
 
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -454,9 +454,7 @@ namespace pwiz.Skyline.Controls
         {
             get
             {
-                if (_showReplicate == null)
-                    _showReplicate = Helpers.ParseEnum(Settings.Default.ShowTreeReplicateEnum, ReplicateDisplay.single);
-                return _showReplicate.Value;
+                return _showReplicate;
             }
 
             set
@@ -464,7 +462,6 @@ namespace pwiz.Skyline.Controls
                 if (ShowReplicate != value)
                 {
                     _showReplicate = value;
-                    Settings.Default.ShowTreeReplicateEnum = value.ToString();
                     UpdateNodeStates();
                 }
             }

--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace pwiz.Skyline.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -1229,18 +1229,6 @@ namespace pwiz.Skyline.Properties {
             }
             set {
                 this["ShowRegressionReplicateEnum"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("single")]
-        public string ShowTreeReplicateEnum {
-            get {
-                return ((string)(this["ShowTreeReplicateEnum"]));
-            }
-            set {
-                this["ShowTreeReplicateEnum"] = value;
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Properties/Settings.settings
@@ -305,9 +305,6 @@
     <Setting Name="ShowRegressionReplicateEnum" Type="System.String" Scope="User">
       <Value Profile="(Default)">all</Value>
     </Setting>
-    <Setting Name="ShowTreeReplicateEnum" Type="System.String" Scope="User">
-      <Value Profile="(Default)">single</Value>
-    </Setting>
     <Setting Name="ShowIonMz" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/pwiz_tools/Skyline/app.config
+++ b/pwiz_tools/Skyline/app.config
@@ -312,9 +312,6 @@
             <setting name="ShowRegressionReplicateEnum" serializeAs="String">
                 <value>all</value>
             </setting>
-            <setting name="ShowTreeReplicateEnum" serializeAs="String">
-                <value>single</value>
-            </setting>
             <setting name="ShowIonMz" serializeAs="String">
                 <value>False</value>
             </setting>


### PR DESCRIPTION
Changed behavior to prevent "Replicates > Best" setting from being remembered after exiting Skyline because it can be very confusing if Skyline is always switching what the current replicate is whenever the currently selected peptide changes (reported most recently by Claudia)