### PR TITLE
Fix CodeInspectionTest

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/DocumentFileLockingTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DocumentFileLockingTest.cs
@@ -54,7 +54,7 @@ namespace pwiz.SkylineTestFunctional
                 var alertDlg = ShowDialog<AlertDlg>(() => Program.StartWindow.OpenFile(versionTooHigh1));
                 // Verify that the file can be deleted while the message is showing
                 File.Delete(versionTooHigh1);
-                // Careful about using RunUI() and OkDialog() here because they can
+                // Careful about using RunUI and OkDialog here because they can
                 // end up accessing a disposed StartPage
                 startWindow.Invoke((Action)alertDlg.OkDialog);
             }


### PR DESCRIPTION
CodeInspectionTest was finding "RunUI()" and "OkDialog" inside of a comment. Removing the parentheses enabled the test to pass.