### PR TITLE
Fix choosing peak by clicking on retention time above found peak

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -2839,7 +2839,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
         private ScaledRetentionTime GetRetentionTimeOfZeroOptStep(ChromGraphItem graphItem, ScaledRetentionTime peakTime)
         {
-            if (graphItem.OptimizationStep == 0)
+            if ((graphItem.OptimizationStep ?? 0) == 0)
             {
                 return peakTime;
             }


### PR DESCRIPTION
Fixed selecting peak by clicking on retention time number above candidate peak (reported by Juan)