### PR TITLE
Support for crosslinked peptides in iRT databases

### DIFF
--- a/pwiz_tools/Skyline/Model/Irt/IrtPeptidePicker.cs
+++ b/pwiz_tools/Skyline/Model/Irt/IrtPeptidePicker.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using System.Linq;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
-using pwiz.Skyline.Model.Crosslinking;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Results.Scoring;
 using pwiz.Skyline.Properties;

--- a/pwiz_tools/Skyline/Model/Irt/IrtPeptidePicker.cs
+++ b/pwiz_tools/Skyline/Model/Irt/IrtPeptidePicker.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Linq;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
+using pwiz.Skyline.Model.Crosslinking;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Results.Scoring;
 using pwiz.Skyline.Properties;
@@ -55,7 +56,7 @@ namespace pwiz.Skyline.Model.Irt
                 return Resources.MeasuredPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry;
             if (sequence.IsProteomic)
             {
-                if (!FastaSequence.IsExSequence(sequence.Sequence))
+                if (!FastaSequence.IsValidPeptideSequence(sequence.Sequence))
                     return string.Format(Resources.MeasuredPeptide_ValidateSequence_The_sequence__0__is_not_a_valid_modified_peptide_sequence, sequence);
             }
             return null;

--- a/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.cs
@@ -550,7 +550,7 @@ namespace pwiz.Skyline.SettingsUI.Irt
             {
                 var seqModified = peptide.ModifiedTarget;
                 // CONSIDER: Select the peptide row
-                if (seqModified.IsProteomic && !FastaSequence.IsExSequence(seqModified.Sequence))
+                if (seqModified.IsProteomic && !FastaSequence.IsValidPeptideSequence(seqModified.Sequence))
                 {
                     MessageDlg.Show(this, ModeUIAwareStringFormat(Resources.EditIrtCalcDlg_ValidatePeptideList_The_value__0__is_not_a_valid_modified_peptide_sequence,
                         seqModified));


### PR DESCRIPTION
Enabled using crosslinked peptides in Edit iRT Calculator dialog (reported by Juan)