### PR TITLE
Update install requirements to Net 4.8

### DIFF
--- a/pwiz_tools/Bumbershoot/idpicker/Deploy/Deploy.wxs.template
+++ b/pwiz_tools/Bumbershoot/idpicker/Deploy/Deploy.wxs.template
@@ -30,8 +30,8 @@
       </Condition>-->
 
       <PropertyRef Id='NETFRAMEWORK45'/>
-      <Condition Message="Requires Microsoft .NET 4.7.2 Framework">
-        <![CDATA[Installed OR (NETFRAMEWORK45 >= "#461808")]]>
+      <Condition Message="Requires Microsoft .NET 4.8 Framework">
+        <![CDATA[Installed OR (NETFRAMEWORK45 >= "#528040")]]>
       </Condition>
 
       <UIRef Id="WixUI_InstallDirScoped" />

--- a/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
+++ b/pwiz_tools/Skyline/Executables/Installer/Product-template.wxs
@@ -28,8 +28,8 @@
     <MediaTemplate EmbedCab="yes"/>
     <FeatureRef Id="ProductFeature"/>
     <PropertyRef Id='NETFRAMEWORK45'/>
-    <Condition Message="Requires Microsoft .NET 4.7.2 Framework">
-      <![CDATA[Installed OR (NETFRAMEWORK45 >= "#461808")]]>
+    <Condition Message="Requires Microsoft .NET 4.8 Framework">
+      <![CDATA[Installed OR (NETFRAMEWORK45 >= "#528040")]]>
     </Condition>
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
     <UIRef Id="WixUI_InstallDir" />

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -4508,9 +4508,9 @@
     <EmbeddedResource Include="Skyline.ico" />
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.7.2">
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.7.2 %28x86 and x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.8 %28x86 and x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/scripts/wix/pwiz-setup.wxs.template
+++ b/scripts/wix/pwiz-setup.wxs.template
@@ -48,8 +48,8 @@
       <?endif?>
 
       <PropertyRef Id='NETFRAMEWORK45'/>
-      <Condition Message="Requires Microsoft .NET 4.7.2 Framework">
-          <![CDATA[Installed OR (NETFRAMEWORK45 >= "#461808")]]>
+      <Condition Message="Requires Microsoft .NET 4.8 Framework">
+          <![CDATA[Installed OR (NETFRAMEWORK45 >= "#528040")]]>
       </Condition>
      __CONTEXTMENU_PROPERTIES__
 


### PR DESCRIPTION
Change requirements in Skyline publish to require .Net 4.8 instead of .Net 4.72 Also, update wxs templates so that they require .Net 4.8 instead of 4.72
(Skyline batch's .csproj did not have any framework requirements so I didn't update it)