### PR TITLE
Skyline: Add a wait for document change and loaded to PerfUniquePepti…

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/AgilentGCEITest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AgilentGCEITest.cs
@@ -46,6 +46,7 @@ namespace pwiz.SkylineTestFunctional
 
             // Read in a small .MSP file describing GC EI data as MS1
             AddToDocumentFromSpectralLibrary("GC EI test", TestFilesDir.GetTestPath(@"test.MSP"));
+            WaitForDocumentLoaded();
 
             // Extract chromatograms from an Agilent file describing GC EI data as MS1
             ImportResults(new[] { TestFilesDir.GetTestPath(@"cmsptc_00000_20230106_SCFA_1.mzML") });

--- a/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
@@ -221,7 +221,20 @@ using (new Assume.DebugOnFail())  // TODO(bspratt) remove then when this intermi
             }
             else
             {
-                OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
+                bool settingsChanged = false;
+                RunUI(() => settingsChanged = peptideSettingsUI.IsSettingsChanged);
+                if (!settingsChanged)
+                {
+                    // Click the OK button but it is not expected to change anything
+                    OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
+                }
+                else
+                {
+                    using (new WaitDocumentChange(null, true))
+                    {
+                        OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
+                    }
+                }
             }
         }
 

--- a/pwiz_tools/Skyline/TestUtil/AbstractFunctionalTestEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractFunctionalTestEx.cs
@@ -813,6 +813,8 @@ namespace pwiz.SkylineTestUtil
         {
             var peptideSettingsUI = ShowDialog<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI);
 
+            RunUI(() => peptideSettingsUI.TabControlSel = PeptideSettingsUI.TABS.Library);
+
             Assert.IsNotNull(peptideSettingsUI);
             var editListUI =
                 ShowDialog<EditListDlg<SettingsListBase<LibrarySpec>, LibrarySpec>>(peptideSettingsUI.EditLibraryList);
@@ -827,7 +829,10 @@ namespace pwiz.SkylineTestUtil
 
             // Make sure the libraries actually show up in the peptide settings dialog before continuing.
             WaitForConditionUI(() => peptideSettingsUI.AvailableLibraries.Length > 0);
+            // Library gets added to the document below by the ViewLibraryDlg form
             RunUI(() => Assert.IsFalse(peptideSettingsUI.IsSettingsChanged));
+
+            OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
 
             // Add all the molecules in the library
             RunUI(() => SkylineWindow.ViewSpectralLibraries());
@@ -845,16 +850,13 @@ namespace pwiz.SkylineTestUtil
             });
             var filterPeptidesDlg = WaitForOpenForm<FilterMatchedPeptidesDlg>();
             ShowAndDismissDlg<MultiButtonMsgDlg>(filterPeptidesDlg.OkDialog, addLibraryPepsDlg => { addLibraryPepsDlg.Btn1Click(); });
-
             OkDialog(filterPeptidesDlg, filterPeptidesDlg.OkDialog);
 
-            var docAfter = WaitForDocumentChange(docBefore);
+            var docAfterAdd = WaitForDocumentChange(docBefore);
 
             OkDialog(viewLibraryDlg, viewLibraryDlg.Close);
-            OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
 
-            docAfter = WaitForDocumentChange(docAfter);
-            return docAfter;
+            return docAfterAdd;
         }
     }
 }


### PR DESCRIPTION
…desTest in an area causing an intermittent failure

- Seems like this at least stands a chance of fixing the failure for which the Assume.DebugOnFail() was added at line 77