### PR TITLE
SeeMS detail tooltips and filter multiselect

### DIFF
--- a/pwiz_tools/SeeMS/Dialogs/SpectrumListForm.Designer.cs
+++ b/pwiz_tools/SeeMS/Dialogs/SpectrumListForm.Designer.cs
@@ -103,7 +103,6 @@ namespace seems
             this.IsolationWindows,
             this.ScanInfo,
             this.IonMobility} );
-            this.gridView.Cursor = System.Windows.Forms.Cursors.Hand;
             this.gridView.DataSource = this.spectraSource;
             this.gridView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gridView.Location = new System.Drawing.Point( 0, 0 );

--- a/pwiz_tools/SeeMS/Dialogs/SpectrumListForm.cs
+++ b/pwiz_tools/SeeMS/Dialogs/SpectrumListForm.cs
@@ -25,16 +25,12 @@ using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using DigitalRune.Windows.Docking;
 using pwiz.CLI.cv;
 using pwiz.CLI.data;
 using pwiz.CLI.msdata;
-using pwiz.CLI.analysis;
-using pwiz.Common.SystemUtil;
 using seems.Misc;
-using pwiz.vendor_api.UNIFI;
 using Spectrum = pwiz.CLI.msdata.Spectrum;
 
 namespace seems

--- a/pwiz_tools/SeeMS/Dialogs/SpectrumListForm.cs
+++ b/pwiz_tools/SeeMS/Dialogs/SpectrumListForm.cs
@@ -32,7 +32,10 @@ using pwiz.CLI.cv;
 using pwiz.CLI.data;
 using pwiz.CLI.msdata;
 using pwiz.CLI.analysis;
+using pwiz.Common.SystemUtil;
 using seems.Misc;
+using pwiz.vendor_api.UNIFI;
+using Spectrum = pwiz.CLI.msdata.Spectrum;
 
 namespace seems
 {
@@ -43,8 +46,10 @@ namespace seems
 	public partial class SpectrumListForm : DockableForm
 	{
         Dictionary<int, MassSpectrum> spectrumList; // indexable by MassSpectrum.Index
+        TreeViewForm treeViewTooltip;
+        Timer hoverTimer;
 
-		public DataGridView GridView { get { return gridView; } }
+        public DataGridView GridView { get { return gridView; } }
 
 		public event SpectrumListCellClickHandler CellClick;
 		public event SpectrumListCellDoubleClickHandler CellDoubleClick;
@@ -73,7 +78,35 @@ namespace seems
 			InitializeComponent();
 
             initializeGridView( nativeIdFormat );
-		}
+
+            treeViewTooltip = new TreeViewForm();
+            hoverTimer = new Timer { Interval = 3000 };
+
+            hoverTimer.Tick += (sender, args) =>
+            {
+                treeViewTooltip.Hide();
+                hoverTimer.Stop();
+            };
+            treeViewTooltip.TreeView.MouseHover += (sender, args) => hoverTimer.Stop();
+            treeViewTooltip.TreeView.MouseLeave += (sender, args) => hoverTimer.Start();
+
+            var columnHasDetailTooltip = new SortedSet<int>
+            {
+                IcId.Index,
+                DpId.Index,
+                PrecursorInfo.Index,
+                IsolationWindows.Index,
+                ScanInfo.Index
+            };
+
+            gridView.CellMouseMove += (sender, args) =>
+            {
+                if (columnHasDetailTooltip.Contains(args.ColumnIndex))
+                    Cursor = Cursors.Hand;
+                else
+                    Cursor = Cursors.Arrow;
+            };
+        }
 
         private CVID nativeIdFormat = CVID.CVID_Unknown;
         public CVID NativeIdFormat { get { return nativeIdFormat; } }
@@ -422,7 +455,7 @@ namespace seems
 
 		private void gridView_CellMouseClick( object sender, DataGridViewCellMouseEventArgs e )
 		{
-            if( e.RowIndex > -1 && gridView.Columns[e.ColumnIndex] is DataGridViewLinkColumn )
+            if( e.RowIndex > -1 )
                 gridView_ShowCellToolTip( gridView[e.ColumnIndex, e.RowIndex] );
 			OnCellClick( e );
 		}
@@ -460,17 +493,21 @@ namespace seems
                     continue;
 
                 string nodeText;
-                if( param.value.ToString().Length > 0 )
+                string paramValue = param.value.ToString();
+                if (paramValue.Length > 0 )
                 {
+                    if (double.TryParse(paramValue, out double dblValue))
+                        paramValue = dblValue.ToString("G6");
+
                     // has value
                     if( param.units != CVID.CVID_Unknown )
                     {
                         // has value and units
-                        nodeText = String.Format( "{0}: {1} {2}", param.name, param.value, param.unitsName);
+                        nodeText = String.Format( "{0}: {1} {2}", param.name, paramValue, param.unitsName);
                     } else
                     {
                         // has value but no units
-                        nodeText = String.Format( "{0}: {1}", param.name, param.value);
+                        nodeText = String.Format( "{0}: {1}", param.name, paramValue);
                     }
                 } else
                 {
@@ -508,15 +545,19 @@ namespace seems
 
         private void gridView_ShowCellToolTip( DataGridViewCell cell )
         {
-            MassSpectrum spectrum = cell.OwningRow.Tag as MassSpectrum;
+            MassSpectrum spectrum = GetSpectrum(cell.RowIndex);
             Spectrum s = spectrum.Element;
 
-            TreeViewForm treeViewForm = new TreeViewForm( spectrum );
-            TreeView tv = treeViewForm.TreeView;
+            treeViewTooltip.Hide();
 
-            if( gridView.Columns[cell.ColumnIndex].Name == "PrecursorInfo" )
+            TreeView tv = treeViewTooltip.TreeView;
+            tv.Nodes.Clear();
+
+            string columnName = gridView.Columns[cell.ColumnIndex].Name;
+
+            if (columnName == "PrecursorInfo" || columnName == "IsolationWindows")
             {
-                treeViewForm.Text = "Precursor Details";
+                treeViewTooltip.Text = "Precursor Details";
                 if( s.precursors.Count == 0 )
                     tv.Nodes.Add( "No precursor information available." );
                 else
@@ -561,9 +602,9 @@ namespace seems
                         }
                     }
                 }
-            } else if( gridView.Columns[cell.ColumnIndex].Name == "ScanInfo" )
+            } else if (columnName == "ScanInfo")
             {
-                treeViewForm.Text = "Scan Configuration Details";
+                treeViewTooltip.Text = "Scan Configuration Details";
                 if( s.scanList.empty() )
                     tv.Nodes.Add( "No scan details available." );
                 else
@@ -583,9 +624,9 @@ namespace seems
                         }
                     }
                 }
-            } else if( gridView.Columns[cell.ColumnIndex].Name == "InstrumentConfigurationID" )
+            } else if (columnName == "IcId")
             {
-                treeViewForm.Text = "Instrument Configuration Details";
+                treeViewTooltip.Text = "Instrument Configuration Details";
                 InstrumentConfiguration ic = s.scanList.scans[0].instrumentConfiguration;
                 if( ic == null || ic.empty() )
                     tv.Nodes.Add( "No instrument configuration details available." );
@@ -632,9 +673,9 @@ namespace seems
                         swNode.Nodes.Add( "Version: " + sw.version );
                     }
                 }
-            } else if( gridView.Columns[cell.ColumnIndex].Name == "DataProcessing" )
+            } else if (columnName == "DpId")
             {
-                treeViewForm.Text = "Data Processing Details";
+                treeViewTooltip.Text = "Data Processing Details";
                 DataProcessing dp = s.dataProcessing;
                 if( dp == null || dp.empty() )
                     tv.Nodes.Add( "No data processing details available." );
@@ -657,11 +698,24 @@ namespace seems
                 return;
 
             tv.ExpandAll();
-            treeViewForm.StartPosition = FormStartPosition.CenterParent;
-            treeViewForm.AutoSize = true;
-            //treeViewForm.DoAutoSize();
-            treeViewForm.Show( this.DockPanel );
-            //leaveTimer.Start();
+            treeViewTooltip.DoAutoSize();
+            treeViewTooltip.StartPosition = FormStartPosition.Manual;
+
+            Point tentativeLocation = MousePosition;
+            if (tentativeLocation.X + treeViewTooltip.Width > Screen.FromControl(gridView).WorkingArea.Right)
+                tentativeLocation.Offset(-treeViewTooltip.Width, 0);
+            else
+                tentativeLocation.Offset(Cursor.Size.Width, 0);
+            if (tentativeLocation.Y + treeViewTooltip.Height > Screen.FromControl(gridView).WorkingArea.Bottom)
+                tentativeLocation.Offset(0, -treeViewTooltip.Height);
+            treeViewTooltip.Location = tentativeLocation;
+
+            if (treeViewTooltip.Visible)
+                treeViewTooltip.Refresh();
+            else
+                treeViewTooltip.Show( this );
+            hoverTimer.Stop();
+            hoverTimer.Start();
             this.Focus();
         }
 	}

--- a/pwiz_tools/SeeMS/Dialogs/TreeViewForm.Designer.cs
+++ b/pwiz_tools/SeeMS/Dialogs/TreeViewForm.Designer.cs
@@ -19,6 +19,9 @@
 // limitations under the License.
 //
 
+using System.Drawing;
+using System.Windows.Forms;
+
 namespace seems
 {
     partial class TreeViewForm
@@ -49,44 +52,45 @@ namespace seems
         /// </summary>
         private void InitializeComponent()
         {
-            this.treeView = new System.Windows.Forms.TreeView();
+            this.treeView = new NoHScrollTree();
             this.SuspendLayout();
             // 
             // treeView
             // 
-            this.treeView.Anchor = ( (System.Windows.Forms.AnchorStyles) ( ( ( ( System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom )
-                        | System.Windows.Forms.AnchorStyles.Left )
-                        | System.Windows.Forms.AnchorStyles.Right ) ) );
             this.treeView.BackColor = System.Drawing.SystemColors.Info;
-            this.treeView.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.treeView.Location = new System.Drawing.Point( 3, 3 );
+            this.treeView.ForeColor = System.Drawing.SystemColors.InfoText;
+            this.treeView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.treeView.Location = new System.Drawing.Point(0, 0);
             this.treeView.Name = "treeView";
             this.treeView.ShowNodeToolTips = true;
-            this.treeView.Size = new System.Drawing.Size( 91, 43 );
+            this.treeView.Dock = DockStyle.Fill;
+            this.treeView.Margin = new Padding(3);
             this.treeView.TabIndex = 0;
             // 
             // TreeViewForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF( 6F, 13F );
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Info;
-            this.ClientSize = new System.Drawing.Size( 95, 47 );
+            this.ClientSize = new System.Drawing.Size(95, 47);
             this.ControlBox = false;
-            this.Controls.Add( this.treeView );
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Controls.Add(this.treeView);
+            this.DoubleBuffered = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "TreeViewForm";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
+            this.Padding = Padding.Empty;
             this.TopMost = true;
-            this.ResumeLayout( false );
+            this.ResumeLayout(false);
 
         }
 
         #endregion
 
-        private System.Windows.Forms.TreeView treeView;
+        private NoHScrollTree treeView;
     }
 }

--- a/pwiz_tools/SeeMS/Dialogs/TreeViewForm.cs
+++ b/pwiz_tools/SeeMS/Dialogs/TreeViewForm.cs
@@ -20,44 +20,33 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Text;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using DigitalRune.Windows.Docking;
 
 namespace seems
 {
-    public partial class TreeViewForm : DockableForm, IDataView
+    // courtesy of https://stackoverflow.com/a/10052686/638445
+    public class NoHScrollTree : TreeView
     {
-        private GraphItem graphItem;
-
-        #region IDataView Members
-        public IList<ManagedDataSource> Sources
+        protected override CreateParams CreateParams
         {
             get
             {
-                return new List<ManagedDataSource>( new ManagedDataSource[] { graphItem.Source } );
+                CreateParams cp = base.CreateParams;
+                cp.Style |= 0x8000; // TVS_NOHSCROLL
+                return cp;
             }
         }
+    }
 
-        public IList<GraphItem> DataItems
-        {
-            get
-            {
-                return new List<GraphItem>( new GraphItem[] { graphItem } );
-            }
-        }
-        #endregion
-
+    public partial class TreeViewForm : Form
+    {
         public TreeView TreeView { get { return treeView; } }
 
-        public TreeViewForm( GraphItem item )
+        public TreeViewForm( GraphItem item = null )
         {
             InitializeComponent();
-            graphItem = item;
         }
 
         private void updateNodeBounds( TreeNode node, bool expandedOnly, ref Size bounds )
@@ -82,9 +71,9 @@ namespace seems
 
         public void DoAutoSize()
         {
-            Application.DoEvents();
+            //Application.DoEvents();
             Size nodeSize = GetNodeBounds( true );
-            nodeSize = GetNodeBounds( true );
+            //nodeSize = GetNodeBounds( true );
             nodeSize.Height += 3;
             nodeSize.Width += 3;
             treeView.Size = nodeSize;
@@ -92,6 +81,18 @@ namespace seems
             nodeSize.Width += 6;
             this.Size = nodeSize;
             //MessageBox.Show( treeView.Size.ToString() + "\r\n" + Size.ToString() );
+        }
+
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                const int CS_DROPSHADOW = 0x20000;
+                CreateParams cp = base.CreateParams;
+                cp.ClassStyle |= CS_DROPSHADOW;
+                return cp;
+            }
+
         }
     }
 }

--- a/pwiz_tools/SeeMS/Dialogs/TreeViewForm.resx
+++ b/pwiz_tools/SeeMS/Dialogs/TreeViewForm.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>


### PR DESCRIPTION
- added detailed tooltips for several columns in SeeMS, accessed by clicking rather than hovering
- added ability to select multiple values (by holding Ctrl while clicking) in the spectrum/chromatogram column AutoFilter lists