### PR TITLE
Add missing setting "LastBrowseToFileLocation" to SeeMS Settings.sett…

### DIFF
--- a/pwiz_tools/SeeMS/Properties/Settings.Designer.cs
+++ b/pwiz_tools/SeeMS/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace seems.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -346,18 +346,15 @@ namespace seems.Properties {
                 this["SrmAsSpectra"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("C:\\")]
-        public string LastBrowseToFileLocation
-        {
-            get
-            {
+        public string LastBrowseToFileLocation {
+            get {
                 return ((string)(this["LastBrowseToFileLocation"]));
             }
-            set
-            {
+            set {
                 this["LastBrowseToFileLocation"] = value;
             }
         }

--- a/pwiz_tools/SeeMS/Properties/Settings.settings
+++ b/pwiz_tools/SeeMS/Properties/Settings.settings
@@ -83,5 +83,8 @@
     <Setting Name="SrmAsSpectra" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="LastBrowseToFileLocation" Type="System.String" Scope="User">
+      <Value Profile="(Default)">C:\</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
…ings.

This property was present in the .Designer.cs file, but was missing from the Settings.settings file, and would therefore disappear if the .Designer.cs were regenerated.