### PR TITLE
Skyline: Find and replace dlg.OkDialog() inside RunUI(() => {...})

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
@@ -282,15 +282,11 @@ namespace pwiz.SkylineTestFunctional
                 var expectedMsg = string.Format(Resources.MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty, editServerDlg.GetTextServerUrlControlLabel());
                 Assert.AreEqual(expectedMsg, errorMsg);
             }
-            RunUI(() =>
-                      {
-                          messageDlg.OkDialog();
-                          editServerDlg.CancelButton.PerformClick();
-                          editServerListDlg.OkDialog();
-                      });
-            WaitForClosedForm(editServerDlg);
-            WaitForClosedForm(editServerListDlg);
-            Assert.AreEqual(expectedServerCount, Settings.Default.ServerList.Count);
+            OkDialog(messageDlg, messageDlg.OkDialog);
+            OkDialog(editServerDlg, editServerDlg.CancelDialog);
+            OkDialog(editServerListDlg, editServerListDlg.OkDialog);
+            TryWaitForConditionUI(() => expectedServerCount == Settings.Default.ServerList.Count);
+            RunUI(() => Assert.AreEqual(expectedServerCount, Settings.Default.ServerList.Count));
         }
 
         private void CheckServerInfoSuccess(TestPanoramaClient testClient, int expectedServerCount)
@@ -303,12 +299,11 @@ namespace pwiz.SkylineTestFunctional
                           editServerDlg.URL = testClient.Server;
                           editServerDlg.Username = testClient.Username;
                           editServerDlg.Password = testClient.Password;
-                          editServerDlg.OkDialog();
-                          editServerListDlg.OkDialog();
                       });
-            WaitForClosedForm(editServerDlg);
-            WaitForClosedForm(editServerListDlg);
-            Assert.AreEqual(expectedServerCount, Settings.Default.ServerList.Count);
+            OkDialog(editServerDlg, editServerDlg.OkDialog);
+            OkDialog(editServerListDlg, editServerListDlg.OkDialog);
+            TryWaitForConditionUI(() => expectedServerCount == Settings.Default.ServerList.Count);
+            RunUI(() => Assert.AreEqual(expectedServerCount, Settings.Default.ServerList.Count));
         }
 
         private void TestPanoramaServerUrls()

--- a/pwiz_tools/Skyline/TestFunctional/DetectionsPlotTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DetectionsPlotTest.cs
@@ -75,12 +75,8 @@ namespace pwiz.SkylineTestFunctional
             });
 
             //verify data correct for 2 q-values
-            RunUI(() =>
-            {
-                propDialog.SetQValueTo(0.003f);
-                propDialog.OkDialog();
-            });
-            WaitForClosedForm(propDialog);
+            RunUI(() => propDialog.SetQValueTo(0.003f));
+            OkDialog(propDialog, propDialog.OkDialog);
             WaitForCondition(() => (DetectionsGraphController.Settings.QValueCutoff == 0.003f));
             AssertDataCorrect(pane, 0, 0.003f);
 
@@ -89,12 +85,8 @@ namespace pwiz.SkylineTestFunctional
             {
                 toolbar.pbProperties_Click(graph.GraphControl, new EventArgs());
             });
-            RunUI(() =>
-            {
-                propDialog.SetQValueTo(0.001f);
-                propDialog.OkDialog();
-            });
-            WaitForClosedForm(propDialog);
+            RunUI(() => propDialog.SetQValueTo(0.001f));
+            OkDialog(propDialog, propDialog.OkDialog);
             WaitForCondition(() => (DetectionsGraphController.Settings.QValueCutoff == 0.001f));
             AssertDataCorrect(pane, 2, 0.001f);
 

--- a/pwiz_tools/Skyline/TestFunctional/DocumentSizeErrorTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DocumentSizeErrorTest.cs
@@ -64,8 +64,8 @@ namespace pwiz.SkylineTestFunctional
                     Assert.IsTrue(errorDlg.Message.Contains(String.Format(
                         Resources.PeptideGroupDocNode_ChangeSettings_The_current_document_settings_would_cause_the_number_of_targeted_transitions_to_exceed__0_n0___The_document_settings_must_be_more_restrictive_or_add_fewer_proteins_,
                         SrmDocument.MaxTransitionCount)));
-                    errorDlg.OkDialog();
                 });
+                OkDialog(errorDlg, errorDlg.OkDialog);
             }
             finally
             {

--- a/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
@@ -268,9 +268,7 @@ namespace pwiz.SkylineTestFunctional
                 editMoleculeDlgA.IonMobilityUnits = eIonMobilityUnits.none; // Simulate user forgets to declare units
                 editMoleculeDlgA.CollisionalCrossSectionSqA = TESTVALUES_GROUP.CollisionalCrossSectionSqA.Value;
             });
-            ShowDialog<MessageDlg>(editMoleculeDlgA.OkDialog);
-            var errorDlg = WaitForOpenForm<MessageDlg>();
-            RunUI(() =>
+            RunDlg<MessageDlg>(editMoleculeDlgA.OkDialog, errorDlg =>
             {
                 Assert.IsTrue(errorDlg.Message.Contains(Resources.EditCustomMoleculeDlg_OkDialog_Please_specify_the_ion_mobility_units_));
                 errorDlg.OkDialog();
@@ -285,16 +283,14 @@ namespace pwiz.SkylineTestFunctional
             {
                 editMoleculeDlgA.IonMobility = -TESTVALUES_GROUP.IonMobility.Value;
             });
-            ShowDialog<MessageDlg>(editMoleculeDlgA.OkDialog);
-            errorDlg = WaitForOpenForm<MessageDlg>();
-            RunUI(() =>
+            RunDlg<MessageDlg>(editMoleculeDlgA.OkDialog, errorDlg =>
             {
                 Assert.IsTrue(errorDlg.Message.Contains(
-                    string.Format(Resources.SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_value__0_, 
+                    string.Format(Resources.SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_value__0_,
                         -TESTVALUES_GROUP.IonMobility.Value)));
                 errorDlg.OkDialog();
-                editMoleculeDlgA.IonMobilityUnits = eIonMobilityUnits.compensation_V; // But negative CoV is allowed
             });
+            RunUI(() => editMoleculeDlgA.IonMobilityUnits = eIonMobilityUnits.compensation_V); // But negative CoV is allowed
             OkDialog(editMoleculeDlgA, editMoleculeDlgA.OkDialog);
             var docB = WaitForDocumentChange(doc);
             // Undo that last change
@@ -872,11 +868,9 @@ namespace pwiz.SkylineTestFunctional
             SelectNode(SrmDocument.Level.TransitionGroups, 0);
             var moleculeDlg = ShowDialog<EditCustomMoleculeDlg>(SkylineWindow.ModifySmallMoleculeTransitionGroup);
             var adduct = moleculeDlg.FormulaBox.Adduct.ChangeIonFormula("-C+2H");
-            RunUI(() =>
-            {
-                moleculeDlg.Adduct = adduct; 
-                moleculeDlg.OkDialog();
-            });
+            RunUI(() => moleculeDlg.Adduct = adduct);
+            OkDialog(moleculeDlg, moleculeDlg.OkDialog);
+
             // The first precursor now has no Carbon - if we try to remove Carbon from parent molecule too that should error out
             SelectNode(SrmDocument.Level.Molecules, 0);
             moleculeDlg = ShowDialog<EditCustomMoleculeDlg>(SkylineWindow.ModifyPeptide);

--- a/pwiz_tools/Skyline/TestFunctional/EditNoteTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditNoteTest.cs
@@ -77,9 +77,8 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() =>
             {
                 Assert.AreEqual(Settings.Default.AnnotationColor, editNoteDlg.ColorIndex);
-                editNoteDlg.OkDialog();
             });
-            WaitForClosedForm(editNoteDlg);
+            OkDialog(editNoteDlg, editNoteDlg.OkDialog);
             // Select just the first protein.
             RunUI(() =>
             {
@@ -99,9 +98,8 @@ namespace pwiz.SkylineTestFunctional
             {
                 editNoteDlg4.ColorIndex = 3;
                 editNoteDlg4.NoteText = "Text";
-                editNoteDlg4.OkDialog();
             });
-            WaitForClosedForm(editNoteDlg4);
+            OkDialog(editNoteDlg4, editNoteDlg4.OkDialog);
             RunDlg<EditNoteDlg>(SkylineWindow.EditNote, editNoteDlg0 =>
             {
                 // Test annotations set correctly.
@@ -138,7 +136,10 @@ namespace pwiz.SkylineTestFunctional
             {
                 editNoteDlg1.ColorIndex = 3;
                 editNoteDlg1.NoteText = "Text";
-                editNoteDlg1.OkDialog();
+            });
+            OkDialog(editNoteDlg1, editNoteDlg1.OkDialog);
+            RunUI(() =>
+            {
                 // Select the first protein again, also keeping the peptide selected.
                 SkylineWindow.SequenceTree.SelectedPaths = new List<IdentityPath>
                 {
@@ -146,7 +147,6 @@ namespace pwiz.SkylineTestFunctional
                     SkylineWindow.Document.GetPathTo((int)SrmDocument.Level.MoleculeGroups, 0)
                 };
             });
-            WaitForClosedForm(editNoteDlg1);
             WaitForDocumentChange(doc);
             RunDlg<EditNoteDlg>(SkylineWindow.EditNote, editNoteDlg2 =>
             {

--- a/pwiz_tools/Skyline/TestFunctional/EditStaticModTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditStaticModTest.cs
@@ -95,9 +95,8 @@ namespace pwiz.SkylineTestFunctional
                 StaticMod uniMod;
                 Assert.IsTrue(UniMod.DictIsotopeModNames.TryGetValue(mod.Name, out uniMod));
                 Assert.AreEqual(mod, uniMod);
-                peptideSettingsUI.OkDialog();
             });
-            WaitForClosedForm(peptideSettingsUI);
+            OkDialog(peptideSettingsUI, peptideSettingsUI.OkDialog);
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/ExportMethodDialogTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExportMethodDialogTest.cs
@@ -907,11 +907,9 @@ namespace pwiz.SkylineTestFunctional
                 editRTDlg.SetSlope(slope.ToString(LocalizationHelper.CurrentCulture));
                 editRTDlg.SetIntercept("0");
                 editRTDlg.SetTimeWindow(10);
-
-                editRTDlg.OkDialog();
             });
-            WaitForClosedForm(editRTDlg);
 
+            OkDialog(editRTDlg, editRTDlg.OkDialog);
             OkDialog(peptideSettingsDlg, peptideSettingsDlg.OkDialog);
         }
 

--- a/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IonMobilityTest.cs
@@ -160,12 +160,8 @@ namespace pwiz.SkylineTestFunctional
             });
             AssertEx.AreEqual(testlibName, ionMobilityLibDlg1.LibraryName);
             // Expect to be warned about multiple conformer
-            var warnDlg = ShowDialog<MessageDlg>(() => ionMobilityLibDlg1.DoPasteLibrary());
-            RunUI(() =>
-            {
-                warnDlg.OkDialog();
-                ionMobilityLibDlg1.OkDialog();
-            });
+            RunDlg<MessageDlg>(() => ionMobilityLibDlg1.DoPasteLibrary(), warnDlg => warnDlg.OkDialog());
+            OkDialog(ionMobilityLibDlg1, ionMobilityLibDlg1.OkDialog);
             RunUI(() => transitionSettingsDlg1.IonMobilityControl.WindowWidthType = IonMobilityWindowWidthCalculator.IonMobilityWindowWidthType.resolving_power);
             RunUI(() => transitionSettingsDlg1.IonMobilityControl.SetResolvingPower(50));
             WaitForClosedForm(ionMobilityLibDlg1);
@@ -177,13 +173,8 @@ namespace pwiz.SkylineTestFunctional
 
             // Simulate user picking Edit... from the Ion Mobility Library combo control
             var editIonMobilityLibraryDlg = ShowDialog<EditIonMobilityLibraryDlg>(transitionSettingsDlg2.IonMobilityControl.EditIonMobilityLibrary);
-
-            RunUI(() =>
-            {
-                editIonMobilityLibraryDlg.LibraryName = testlibName2;
-                editIonMobilityLibraryDlg.OkDialog();
-            });
-            WaitForClosedForm(editIonMobilityLibraryDlg);
+            RunUI(() => editIonMobilityLibraryDlg.LibraryName = testlibName2);
+            OkDialog(editIonMobilityLibraryDlg, editIonMobilityLibraryDlg.OkDialog);
 
             var olddoc = SkylineWindow.Document;
             // Set other parameters - name, resolving power
@@ -367,9 +358,8 @@ namespace pwiz.SkylineTestFunctional
             {
                 importSpectralLibDlg.Source = SpectralLibrarySource.file; // Simulate user selecting 2nd radio button
                 importSpectralLibDlg.FilePath = blibPath; // Simulate user entering filename
-                importSpectralLibDlg.OkDialog();
             });
-            WaitForClosedForm(importSpectralLibDlg);
+            OkDialog(importSpectralLibDlg, importSpectralLibDlg.OkDialog);
             WaitForCondition(() => ionMobilityLibraryDlg.LibraryMobilitiesFlatCount > 8); // Let that library load
             OkDialog(ionMobilityLibraryDlg, ionMobilityLibraryDlg.OkDialog);
             OkDialog(transitionSettingsDlg3, transitionSettingsDlg3.OkDialog);
@@ -802,14 +792,9 @@ namespace pwiz.SkylineTestFunctional
                 ionMobilityLibraryDlg.CreateDatabaseFile(databasePath); // Simulate user click on Create button
                 ionMobilityLibraryDlg.SetOffsetHighEnergySpectraCheckbox(true);
                 ionMobilityLibraryDlg.GetIonMobilitiesFromResults();
-                ionMobilityLibraryDlg.OkDialog();
             });
-            WaitForClosedForm(ionMobilityLibraryDlg);
-            RunUI(() =>
-            {
-                transitionSettingsDlg.OkDialog();
-            });
-            WaitForClosedForm(transitionSettingsDlg);
+            OkDialog(ionMobilityLibraryDlg, ionMobilityLibraryDlg.OkDialog);
+            OkDialog(transitionSettingsDlg, transitionSettingsDlg.OkDialog);
             WaitForDocumentChange(doc);
 
             // Now close the document, then reopen to verify imsdb background loader operation
@@ -861,16 +846,8 @@ namespace pwiz.SkylineTestFunctional
                 values[0].IonMobility = expectedDT2+1;
                 ionMobilityLibraryDlg.LibraryMobilitiesFlat = values;
             });
-            RunUI(() =>
-            {
-                ionMobilityLibraryDlg.OkDialog();
-            });
-            WaitForClosedForm(ionMobilityLibraryDlg);
-            RunUI(() =>
-            {
-                transitionSettingsDlg.OkDialog();
-            });
-            WaitForClosedForm(transitionSettingsDlg);
+            OkDialog(ionMobilityLibraryDlg, ionMobilityLibraryDlg.OkDialog);
+            OkDialog(transitionSettingsDlg, transitionSettingsDlg.OkDialog);
             doc = WaitForDocumentChange(doc);
             result = doc.Settings.TransitionSettings.IonMobilityFiltering.IonMobilityLibrary;
             AssertEx.AreEqual(expectedDT2+1, result.GetIonMobilityInfo(key2).First().IonMobility.Mobility.Value, .001);
@@ -901,11 +878,7 @@ namespace pwiz.SkylineTestFunctional
                 });
 
             OkDialog(driftTimePredictorDoomedDlg, driftTimePredictorDoomedDlg.CancelDialog);
-            RunUI(() =>
-            {
-                transitionSettingsDlg.OkDialog();
-            });
-            WaitForClosedForm(transitionSettingsDlg);
+            OkDialog(transitionSettingsDlg, transitionSettingsDlg.OkDialog);
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
@@ -121,12 +121,8 @@ namespace pwiz.SkylineTestFunctional
             var countDlg = ShowDialog<AddIrtStandardsDlg>(calibrateDlg.UseResults);
             RunUI(() => countDlg.StandardCount = CalibrateIrtDlg.MIN_STANDARD_PEPTIDES - 1);
             RunDlg<MessageDlg>(countDlg.OkDialog, messageDlg => messageDlg.OkDialog());
-            RunUI(() =>
-            {
-                countDlg.StandardCount = peptideCount;
-                countDlg.OkDialog();
-            });
-            WaitForClosedForm(countDlg);
+            RunUI(() => countDlg.StandardCount = peptideCount);
+            OkDialog(countDlg, countDlg.OkDialog);
 
             Assert.AreEqual(peptideCount, calibrateDlg.StandardPeptideCount);
 
@@ -155,10 +151,8 @@ namespace pwiz.SkylineTestFunctional
                           //and 3 above 100
                           calibrateDlg.SetFixedPoints(3, 7);
                           calibrateDlg.StandardName = "Document1";
-
-                          calibrateDlg.OkDialog();
                       });
-            WaitForClosedForm(calibrateDlg);
+            OkDialog(calibrateDlg, calibrateDlg.OkDialog);
 
             //Now check that the peptides were passed to the EditIrtCalcDlg
             RunUI(() =>
@@ -335,9 +329,8 @@ namespace pwiz.SkylineTestFunctional
                           editRT1.SetRegressionName("iRT Regression");
                           editRT1.AddResults();
                           editRT1.ChooseCalculator(irtCalc);
-                          editRT1.OkDialog();
                       });
-            WaitForClosedForm(editRT1);
+            OkDialog(editRT1, editRT1.OkDialog);
 
             var editRT1A = ShowDialog<EditRTDlg>(peptideSettingsDlg1.AddRTRegression);
 
@@ -351,8 +344,7 @@ namespace pwiz.SkylineTestFunctional
             RunDlg<RTDetails>(editRT1A.ShowDetails, detailsDlg => detailsDlg.Close());
 
             OkDialog(editRT1A, editRT1A.OkDialog);
-            RunUI(peptideSettingsDlg1.CancelButton.PerformClick);
-            WaitForClosedForm(peptideSettingsDlg1);
+            OkDialog(peptideSettingsDlg1, peptideSettingsDlg1.CancelButton.PerformClick);
 
             var docPeptides = new List<MeasuredRetentionTime>();
             RunUI(() =>
@@ -577,12 +569,8 @@ namespace pwiz.SkylineTestFunctional
             var recalibrateDlg2 = ShowDialog<MultiButtonMsgDlg>(addPeptidesDlg.OkDialog);
             OkDialog(recalibrateDlg2, recalibrateDlg2.Btn1Click);
 
-            RunUI(() =>
-                      {
-                          Assert.AreEqual(18, irtDlg3.LibraryPeptideCount);
-                          irtDlg3.OkDialog();
-                      });
-            WaitForClosedForm(irtDlg3);
+            RunUI(() => Assert.AreEqual(18, irtDlg3.LibraryPeptideCount));
+            OkDialog(irtDlg3, irtDlg3.OkDialog);
             
             OkDialog(editCalculator, editCalculator.OkDialog);
 
@@ -591,20 +579,17 @@ namespace pwiz.SkylineTestFunctional
                           editRT3.AddResults();
                           editRT3.ChooseCalculator("iRT Document Calculator");
                           editRT3.SetTimeWindow(2.0);
-                          editRT3.OkDialog();
                       });
-            WaitForClosedForm(editRT3);
+            OkDialog(editRT3, editRT3.OkDialog);
 
             //Then choose the new, document-based regression and turn off prediction
             RunUI(() =>
                       {
                           peptideSettingsDlg3.ChooseRegression("iRT Document Regression");
                           peptideSettingsDlg3.IsUseMeasuredRT = true;
-                          peptideSettingsDlg3.OkDialog();
-
                       });
             
-            WaitForClosedForm(peptideSettingsDlg3);
+            OkDialog(peptideSettingsDlg3, peptideSettingsDlg3.OkDialog);
 
             Assert.IsNull(FindOpenForm<MessageDlg>());
 
@@ -613,12 +598,8 @@ namespace pwiz.SkylineTestFunctional
 
             //Turn on prediction for scheduling
             var peptideSettingsDlg4 = ShowDialog<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI);
-            RunUI(() =>
-                                          {
-                                              peptideSettingsDlg4.IsUseMeasuredRT = false;
-                                              peptideSettingsDlg4.OkDialog();
-                                          });
-            WaitForClosedForm(peptideSettingsDlg4);
+            RunUI(() => peptideSettingsDlg4.IsUseMeasuredRT = false);
+            OkDialog(peptideSettingsDlg4, peptideSettingsDlg4.OkDialog);
 
             //Export the prediction-based transition list 
             ExportMethod(testFilesDir.GetTestPath("PredictionTL.csv"));
@@ -677,8 +658,7 @@ namespace pwiz.SkylineTestFunctional
             //Try to open a file that does not exist: error
             RunDlg<MessageDlg>(() => irtDlg5.OpenDatabase(databasePath), messageDlg => messageDlg.OkDialog());
 
-            RunUI(() => irtDlg5.CancelButton.PerformClick());
-            WaitForClosedForm(irtDlg5);
+            OkDialog(irtDlg5, irtDlg5.CancelDialog);
 
             //In order to export a transition list, we have to set the RT regression to have the iRT Calc.
             //This means that the iRT calc must have its database connected - else the dialog will not let
@@ -694,17 +674,15 @@ namespace pwiz.SkylineTestFunctional
                           editRT5.SetRegressionName("iRT Test Regression");
                           editRT5.AddResults();
                           editRT5.ChooseCalculator(irtCalc);
-                          editRT5.OkDialog();
                       });
-            WaitForClosedForm(editRT5);
+            OkDialog(editRT5, editRT5.OkDialog);
 
             RunUI(() =>
                       {
                           peptideSettingsDlg5.ChooseRegression("iRT Test Regression");
                           peptideSettingsDlg5.IsUseMeasuredRT = false; //Use prediction
-                          peptideSettingsDlg5.OkDialog();
                       });
-            WaitForClosedForm(peptideSettingsDlg5);
+            OkDialog(peptideSettingsDlg5, peptideSettingsDlg5.OkDialog);
 
             RunUI(() => SkylineWindow.SaveDocument());
 
@@ -719,8 +697,7 @@ namespace pwiz.SkylineTestFunctional
             // Used to cause a message box, but should work now, because iRT databases get loaded once
             RunUI(() => exportTransList.SetMethodType(ExportMethodType.Scheduled));
 
-            RunUI(() => exportTransList.CancelButton.PerformClick());
-            WaitForClosedForm(exportTransList);
+            OkDialog(exportTransList, exportTransList.CancelDialog);
 
             // Used to cause a message box, but should work now, because iRT databases get loaded once
             RunUI(() => SkylineWindow.ChooseCalculator(irtCalc));

--- a/pwiz_tools/Skyline/TestFunctional/IsolationSchemeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IsolationSchemeTest.cs
@@ -67,9 +67,8 @@ namespace pwiz.SkylineTestFunctional
                         Assert.IsTrue(editDlg.UseResults);
                         Assert.AreEqual(EditIsolationSchemeDlg.IsolationWidthType.RESULTS, editDlg.IsolationWidthTypeName);
                         editDlg.IsolationSchemeName = "test1"; // Not L10N
-                        editDlg.OkDialog();
                     });
-                WaitForClosedForm(editDlg);
+                OkDialog(editDlg, editDlg.OkDialog);
             }
 
             var editList =
@@ -108,9 +107,8 @@ namespace pwiz.SkylineTestFunctional
                         editDlg.IsolationSchemeName = "test2"; // Not L10N
                         editDlg.IsolationWidthTypeName = EditIsolationSchemeDlg.IsolationWidthType.FIXED;
                         editDlg.PrecursorFilter = 50;
-                        editDlg.OkDialog();
                     });
-                WaitForClosedForm(editDlg);
+                OkDialog(editDlg, editDlg.OkDialog);
             }
 
             RunUI(() => editList.SelectItem("test2")); // Not L10N
@@ -126,9 +124,8 @@ namespace pwiz.SkylineTestFunctional
                         Assert.AreEqual(50, editDlg.PrecursorFilter);
                         editDlg.IsolationWidthTypeName = EditIsolationSchemeDlg.IsolationWidthType.RESULTS_WITH_MARGIN;
                         editDlg.PrecursorFilter = 0.5;
-                        editDlg.OkDialog();
                     });
-                WaitForClosedForm(editDlg);
+                OkDialog(editDlg, editDlg.OkDialog);
             }
 
             RunUI(() => editList.SelectItem("test2")); // Not L10N
@@ -143,9 +140,8 @@ namespace pwiz.SkylineTestFunctional
                     Assert.AreEqual(EditIsolationSchemeDlg.IsolationWidthType.RESULTS_WITH_MARGIN, editDlg.IsolationWidthTypeName);
                     Assert.AreEqual(0.5, editDlg.PrecursorFilter);
                     editDlg.IsolationWidthTypeName = EditIsolationSchemeDlg.IsolationWidthType.RESULTS;
-                    editDlg.OkDialog();
                 });
-                WaitForClosedForm(editDlg);
+                OkDialog(editDlg, editDlg.OkDialog);
             }
 
             RunUI(() => editList.SelectItem("test2")); // Not L10N
@@ -319,9 +315,8 @@ namespace pwiz.SkylineTestFunctional
                         editDlg.IsolationWindowGrid.SetCellValue(100);
                         editDlg.IsolationWindowGrid.SelectCell(EditIsolationSchemeDlg.COLUMN_END, 0);
                         editDlg.IsolationWindowGrid.SetCellValue(500);
-                        editDlg.OkDialog();
                     });
-                WaitForClosedForm(editDlg);
+                OkDialog(editDlg, editDlg.OkDialog);
             }
 
             RunUI(() => editList.SelectItem("test2"));
@@ -338,9 +333,8 @@ namespace pwiz.SkylineTestFunctional
                             {
                                 new double?[] { 100.0, 500.0 }
                             });
-                        editDlg.OkDialog();
                     });
-                WaitForClosedForm(editDlg);
+                OkDialog(editDlg, editDlg.OkDialog);
             }
 
             RunUI(() => editList.SelectItem("test2"));
@@ -408,12 +402,8 @@ namespace pwiz.SkylineTestFunctional
                     });
 
                 // Test windows per scan without special handling.
-                RunUI(() =>
-                    {
-                        editDlg.SpecialHandling = IsolationScheme.SpecialHandlingType.NONE;
-                        editDlg.OkDialog();
-                    });
-                WaitForClosedForm(editDlg);
+                RunUI(() => editDlg.SpecialHandling = IsolationScheme.SpecialHandlingType.NONE);
+                OkDialog(editDlg, editDlg.OkDialog);
             }
 
             RunUI(() => editList.SelectItem("test2"));

--- a/pwiz_tools/Skyline/TestFunctional/LabelPeakPickingTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LabelPeakPickingTest.cs
@@ -284,11 +284,8 @@ namespace pwiz.SkylineTestFunctional
         public void RemoveHeavyPeptides()
         {
             var refineDlg = ShowDialog<RefineDlg>(SkylineWindow.ShowRefineDlg);
-            RunUI(() =>
-            {
-                refineDlg.RefineLabelType = IsotopeLabelType.heavy;
-                refineDlg.OkDialog();
-            });
+            RunUI(() => refineDlg.RefineLabelType = IsotopeLabelType.heavy);
+            OkDialog(refineDlg, refineDlg.OkDialog);
             WaitForDocumentLoaded();
         }
 

--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -287,11 +287,8 @@ namespace pwiz.SkylineTestFunctional
             Assert.AreEqual(heavyRPeptide, nodePepTree.DocNode.Peptide.Sequence);
             // Set the Heavy R modification explicitly
             var editPepModsDlg = ShowDialog<EditPepModsDlg>(SkylineWindow.ModifyPeptide);
-            RunUI(() =>
-            {
-                editPepModsDlg.SetModification(heavyRPeptide.Length - 1, IsotopeLabelType.heavy, heavyR);
-                editPepModsDlg.OkDialog();
-            });
+            RunUI(() => editPepModsDlg.SetModification(heavyRPeptide.Length - 1, IsotopeLabelType.heavy, heavyR));
+            OkDialog(editPepModsDlg, editPepModsDlg.OkDialog);
             WaitForCondition(() => (SkylineWindow.Document.Molecules.First().TransitionGroupCount == 2));
 
             // The peptide should now match the spectrum in the library, and have
@@ -344,11 +341,8 @@ namespace pwiz.SkylineTestFunctional
             // Try filtering for only charge 3 spectra
             var transitionSettingsUI = ShowDialog<TransitionSettingsUI>(
                 SkylineWindow.ShowTransitionSettingsUI);
-            RunUI(() =>
-                {
-                    transitionSettingsUI.PrecursorCharges = "3";
-                    transitionSettingsUI.OkDialog();
-                });
+            RunUI(() => transitionSettingsUI.PrecursorCharges = "3");
+            OkDialog(transitionSettingsUI, transitionSettingsUI.OkDialog);
 
             PastePeptideList(idpList, false, idpCount - idpCount3 + 1 /* missing cleavage*/, 0);
 
@@ -378,8 +372,8 @@ namespace pwiz.SkylineTestFunctional
                 transitionSettingsCpas.ProductCharges = "1,2,3";
                 transitionSettingsCpas.FragmentTypes = "y,b";
                 transitionSettingsCpas.InstrumentMaxMz = 2000;
-                transitionSettingsCpas.OkDialog();
             });
+            OkDialog(transitionSettingsCpas, transitionSettingsCpas.OkDialog);
 
             EnsurePeptideSettings();
 
@@ -387,8 +381,8 @@ namespace pwiz.SkylineTestFunctional
                 {
                     // Turn off carbamidomethyl cys, since not in these searches
                     PeptideSettingsUI.PickedStaticMods = new string[0];
-                    PeptideSettingsUI.OkDialog();
                 });
+            OkDialog(PeptideSettingsUI, PeptideSettingsUI.OkDialog);
 
             // Get the set of peptides to paste from the library, since there
             // are a lot.

--- a/pwiz_tools/Skyline/TestFunctional/ManageResultsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ManageResultsTest.cs
@@ -128,12 +128,8 @@ namespace pwiz.SkylineTestFunctional
 
             var renameDlg = ShowDialog<RenameResultDlg>(manageResultsDlg.RenameResult);
             const string newName = "Test this name";
-            RunUI(() =>
-            {
-                renameDlg.ReplicateName = newName;
-                renameDlg.OkDialog();
-            });
-            WaitForClosedForm(renameDlg);
+            RunUI(() => renameDlg.ReplicateName = newName);
+            OkDialog(renameDlg, renameDlg.OkDialog);
 
             OkDialog(manageResultsDlg, manageResultsDlg.OkDialog);
 
@@ -194,12 +190,8 @@ namespace pwiz.SkylineTestFunctional
             var missingFileMessage = ShowDialog<MessageDlg>(manageResultsDlg2.ReimportResults);
             Assert.IsTrue(missingFileMessage.Message.Contains(
                 docRename.Settings.MeasuredResults.Chromatograms[0].MSDataFilePaths.ToArray()[0].ToString()));
-            RunUI(() =>
-            {
-                missingFileMessage.OkDialog();
-                manageResultsDlg2.OkDialog();
-            });
-            WaitForClosedForm(manageResultsDlg2);
+            OkDialog(missingFileMessage, missingFileMessage.OkDialog);
+            OkDialog(manageResultsDlg2, manageResultsDlg2.OkDialog);
 
             // Reimport data for a replicate
             RunDlg<ManageResultsDlg>(SkylineWindow.ManageResults, dlg =>

--- a/pwiz_tools/Skyline/TestFunctional/PythonInstallerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PythonInstallerTest.cs
@@ -227,12 +227,8 @@ namespace pwiz.SkylineTestFunctional
         private static void TestPackagesUnselected()
         {
             var pythonInstaller = FormatPackageInstallerBothTypes(false, true, true, true);
-            RunUI(() =>
-                {
-                    pythonInstaller.UncheckAllPackages();
-                    pythonInstaller.OkDialog();
-                });
-            WaitForClosedForm(pythonInstaller);
+            RunUI(() => pythonInstaller.UncheckAllPackages());
+            OkDialog(pythonInstaller, pythonInstaller.OkDialog);
         }
 
         private static void TestPackagesSourceOnly()

--- a/pwiz_tools/Skyline/TestFunctional/ReintegrateDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ReintegrateDlgTest.cs
@@ -183,9 +183,8 @@ namespace pwiz.SkylineTestFunctional
                 reintegrateDlgCutoff.ReintegrateAll = false;
                 reintegrateDlgCutoff.Cutoff = 1.0;
                 reintegrateDlgCutoff.OverwriteManual = true;
-                reintegrateDlgCutoff.OkDialog();
             });
-            WaitForClosedForm(reintegrateDlgCutoff);
+            OkDialog(reintegrateDlgCutoff, reintegrateDlgCutoff.OkDialog);
             RunUI(() =>
             {
                 ReportToCsv(reportSpec, SkylineWindow.DocumentUI, docNewActual, CultureInfo.CurrentCulture);

--- a/pwiz_tools/Skyline/TestFunctional/TestPeakAreaDotpGraph.cs
+++ b/pwiz_tools/Skyline/TestFunctional/TestPeakAreaDotpGraph.cs
@@ -58,12 +58,12 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() =>
             {
                 propertyDialog.SetDotpCutoffValue(AreaExpectedValue.ratio_to_label, "asdf");
-                propertyDialog.OkDialog();
+                propertyDialog.OkDialog();  // Does not dismiss the form
                 Assert.IsNotNull(propertyDialog.GetRdotpErrorText());
                 propertyDialog.SetShowCutoffProperty(true);
                 propertyDialog.SetDotpCutoffValue(AreaExpectedValue.ratio_to_label, (0.9).ToString(CultureInfo.CurrentCulture));
-                propertyDialog.OkDialog();
             });
+            OkDialog(propertyDialog, propertyDialog.OkDialog);
 
             FindNode((529.2855).ToString(LocalizationHelper.CurrentCulture) + "++");
             WaitForGraphs();
@@ -95,8 +95,8 @@ namespace pwiz.SkylineTestFunctional
                 propertyDialog.SetShowCutoffProperty(true);
                 propertyDialog.SetDotpCutoffValue(AreaExpectedValue.isotope_dist, (0.94).ToString(CultureInfo.CurrentCulture));
                 propertyDialog.SetDotpCutoffValue(AreaExpectedValue.library, (0.85).ToString(CultureInfo.CurrentCulture));
-                propertyDialog.OkDialog();
             });
+            OkDialog(propertyDialog, propertyDialog.OkDialog);
             FindNode((873.9438).ToString(LocalizationHelper.CurrentCulture) + "++");
             WaitForGraphs();
             RunUI(() =>

--- a/pwiz_tools/Skyline/TestPerf/PerfImportAgilentSpectrumMillRampedIMSTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportAgilentSpectrumMillRampedIMSTest.cs
@@ -158,9 +158,8 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                 {
                     transitionSettingsDlg.IonMobilityControl.SetUseSpectralLibraryIonMobilities(false);
                     transitionSettingsDlg.IonMobilityControl.SelectedIonMobilityLibrary = Resources.SettingsList_ELEMENT_NONE_None;
-                    transitionSettingsDlg.OkDialog();
                 });
-                WaitForClosedForm(transitionSettingsDlg);
+                OkDialog(transitionSettingsDlg, transitionSettingsDlg.OkDialog);
             }
 
             
@@ -260,14 +259,9 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                     editIonMobilityLibraryDlg.LibraryName = "test";
                     editIonMobilityLibraryDlg.CreateDatabaseFile(TestFilesDir.GetTestPath(editIonMobilityLibraryDlg.LibraryName + IonMobilityDb.EXT)); // Simulate user clicking Create button
                     editIonMobilityLibraryDlg.GetIonMobilitiesFromResults();
-                    editIonMobilityLibraryDlg.OkDialog();
                 });
-                WaitForClosedForm(editIonMobilityLibraryDlg);
-                RunUI(() =>
-                {
-                    transitionSettingsDlg.OkDialog();
-                });
-                WaitForClosedForm(transitionSettingsDlg);
+                OkDialog(editIonMobilityLibraryDlg, editIonMobilityLibraryDlg.OkDialog);
+                OkDialog(transitionSettingsDlg, transitionSettingsDlg.OkDialog);
 
                 var document = SkylineWindow.Document;
                 var measuredDTs = document.Settings.TransitionSettings.IonMobilityFiltering.IonMobilityLibrary;

--- a/pwiz_tools/Skyline/TestPerf/PerfMeasuredDriftTimes.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfMeasuredDriftTimes.cs
@@ -86,17 +86,9 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                     ionMobilityLibraryDlg.GetIonMobilitiesFromResults();
                 });
                 PauseForScreenShot("values updated");// For a quick demo when you need it
-                RunUI(() =>
-                {
-                    measuredDTs.Add(ionMobilityLibraryDlg.LibraryMobilitiesFlat.ToList());
-                    ionMobilityLibraryDlg.OkDialog();
-                });
-                WaitForClosedForm(ionMobilityLibraryDlg);
-                RunUI(() =>
-                {
-                    transitionSettingsDlg.OkDialog();
-                });
-                WaitForClosedForm(transitionSettingsDlg);
+                RunUI(() => measuredDTs.Add(ionMobilityLibraryDlg.LibraryMobilitiesFlat.ToList()));
+                OkDialog(ionMobilityLibraryDlg, ionMobilityLibraryDlg.OkDialog);
+                OkDialog(transitionSettingsDlg, transitionSettingsDlg.OkDialog);
                 
                 document = SkylineWindow.Document;
                 var count = 0;
@@ -176,14 +168,9 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                             item.CollisionalCrossSectionSqA * 1.02, heo *1.02)));
                 }
                 editIonMobilityLibraryDlg.LibraryMobilitiesFlat = revised;
-                editIonMobilityLibraryDlg.OkDialog();
             });
-            WaitForClosedForm(editIonMobilityLibraryDlg);
-            RunUI(() =>
-            {
-                transitionSettingsDlg2.OkDialog();
-            });
-            WaitForClosedForm(transitionSettingsDlg2);
+            OkDialog(editIonMobilityLibraryDlg, editIonMobilityLibraryDlg.OkDialog);
+            OkDialog(transitionSettingsDlg2, transitionSettingsDlg2.OkDialog);
             var docChangedDriftTimePredictor = WaitForDocumentChange(document);
 
             // Reimport data for a replicate - without the fix this will throw

--- a/pwiz_tools/Skyline/TestPerf/PerfMeasuredInverseK0.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfMeasuredInverseK0.cs
@@ -107,16 +107,8 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                 editIonMobilityLibraryDlg.GetIonMobilitiesFromResults();
             });
             // PauseTest(); // Uncomment this to inspect ion mobility finder results
-            RunUI(() =>
-            {
-                editIonMobilityLibraryDlg.OkDialog();
-            });
-            WaitForClosedForm(editIonMobilityLibraryDlg);
-            RunUI(() =>
-            {
-                transitionSettingsDlg.OkDialog();
-            });
-            WaitForClosedForm(transitionSettingsDlg);
+            OkDialog(editIonMobilityLibraryDlg, editIonMobilityLibraryDlg.OkDialog);
+            OkDialog(transitionSettingsDlg, transitionSettingsDlg.OkDialog);
 
             var docChangedDriftTimePredictor = WaitForDocumentChange(document);
 

--- a/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
@@ -311,12 +311,10 @@ namespace pwiz.SkylineTestTutorial
                 PauseForScreenShot<DocumentGridForm>("Adjust the scrollbar so that the first displayed column is \"light Height\" and the last displayed column is \"heavy Product Mz\"", 17);
                 OkDialog(previewReportDlg, previewReportDlg.Close);
             }
-            RunUI(() =>
-            {
-                viewEditor.ChooseColumnsTab.RemoveColumn(PropertyPath.Parse("IsotopeLabelType")); // Not L10N
-                viewEditor.OkDialog();
-                editReportListDlg1.OkDialog();
-            });
+            RunUI(() => viewEditor.ChooseColumnsTab.RemoveColumn(PropertyPath.Parse("IsotopeLabelType")));
+            OkDialog(viewEditor, viewEditor.OkDialog);
+            OkDialog(editReportListDlg1, editReportListDlg1.OkDialog);
+
             PauseForScreenShot<ExportLiveReportDlg>("Export Report form", 18);
 
             OkDialog(exportReportDlg1, exportReportDlg1.CancelClick);

--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudiesTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudiesTutorialTest.cs
@@ -160,9 +160,8 @@ namespace pwiz.SkylineTestTutorial
                     Assert.AreEqual(71, addPeptidesDlg.PeptidesCount);
                     Assert.AreEqual(0, addPeptidesDlg.RunsConvertedCount);
                     Assert.AreEqual(0, addPeptidesDlg.RunsFailedCount);
-                    addPeptidesDlg.OkDialog();
                 });
-                WaitForClosedForm(addPeptidesDlg);
+                OkDialog(addPeptidesDlg, addPeptidesDlg.OkDialog);
 
                 PauseForScreenShot();   // Edit iRT Calculator form
 

--- a/pwiz_tools/Skyline/TestTutorial/SmallMolMethodDevCEOptTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/SmallMolMethodDevCEOptTutorial.cs
@@ -399,9 +399,9 @@ namespace pwiz.SkylineTestTutorial
                     });
                     PauseForScreenShot<EditCEDlg>("Edit Collision Energy Equation form", 26);
 
+                    OkDialog(editCurrentCE, editCurrentCE.OkDialog);
                     RunUI(() =>
                     {
-                        editCurrentCE.OkDialog();
                         transitionSettingsUI.UseOptimized = true;
                         transitionSettingsUI.OptimizeType = OptimizedMethodType.Transition.GetLocalizedString();
                     });

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2308,12 +2308,8 @@ namespace pwiz.SkylineTestUtil
         private static void AddMod(string uniModName, bool isVariable, EditListDlg<SettingsListBase<StaticMod>, StaticMod> editModsDlg)
         {
             var addStaticModDlg = ShowAddModDlg(editModsDlg);
-            RunUI(() =>
-            {
-                addStaticModDlg.SetModification(uniModName, isVariable);
-                addStaticModDlg.OkDialog();
-            });
-            WaitForClosedForm(addStaticModDlg);
+            RunUI(() => addStaticModDlg.SetModification(uniModName, isVariable));
+            OkDialog(addStaticModDlg, addStaticModDlg.OkDialog);
 
             OkDialog(editModsDlg, editModsDlg.OkDialog);
         }


### PR DESCRIPTION
- Many cases were fine with WaitForClosedForm() after the RunUI, but some not
- This increases consistency in using OkDialog(dlg, dlg.OkDialog) and may fix intermittent failures