### PR TITLE
Associate proteins description fix (#2501)

### DIFF
--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using pwiz.Common.Chemistry;
+using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.ProteomeDatabase.API;
 using pwiz.Skyline.Model.Crosslinking;
@@ -2796,7 +2797,7 @@ namespace pwiz.Skyline.Model
             {
                 BaseName = Name = fastaSequence.Name;
                 Description = fastaSequence.Description;
-                Alternatives = fastaSequence.Alternatives.ToArray();
+                Alternatives = fastaSequence.Alternatives;
             }
             _settings = settings;
             _enzyme = _settings.PeptideSettings.Enzyme;
@@ -2823,33 +2824,14 @@ namespace pwiz.Skyline.Model
             {
                 _customName = true;
                 start++;
-            }
-            // Split ID from description at first space or tab
-            int split = _customName ? -1 : IndexEndId(line);
-            if (split == -1)
-            {
                 BaseName = Name = line.Substring(start);
-                Description = string.Empty;
             }
             else
             {
-                BaseName = Name = line.Substring(start, split - start);
-                string[] descriptions = line.Substring(split + 1).Split((char)1);
-                Description = descriptions[0];
-                var listAlternatives = new List<ProteinMetadata>();
-                for (int i = 1; i < descriptions.Length; i++)
-                {
-                    string alternative = descriptions[i];
-                    split = IndexEndId(alternative);
-                    if (split == -1)
-                        listAlternatives.Add(new ProteinMetadata(alternative, null));
-                    else
-                    {
-                        listAlternatives.Add(new ProteinMetadata(alternative.Substring(0, split),
-                            alternative.Substring(split + 1)));
-                    }
-                }
-                Alternatives = listAlternatives.ToArray();
+                var fastaSequence = FastaData.MakeFastaSequence(line, @"A");
+                BaseName = Name = fastaSequence.Name;
+                Description = fastaSequence.Description;
+                Alternatives = fastaSequence.Alternatives;
             }
             PeptideList = peptideList;
         }
@@ -2858,11 +2840,6 @@ namespace pwiz.Skyline.Model
             : this(line, true, settings, sourceFile, irtTargets)
         {
             _modMatcher = modMatcher;
-        }
-
-        private static int IndexEndId(string line)
-        {
-            return line.IndexOfAny(new[] { TextUtil.SEPARATOR_SPACE, TextUtil.SEPARATOR_TSV });
         }
 
         /// <summary>
@@ -2877,7 +2854,7 @@ namespace pwiz.Skyline.Model
 
         public string Name { get; private set; }
         public string Description { get; private set; }
-        public ProteinMetadata[] Alternatives { get; private set; }
+        public ImmutableList<ProteinMetadata> Alternatives { get; private set; }
         public string AA
         {
             get
@@ -3436,18 +3413,10 @@ namespace pwiz.Skyline.Model
         }
     }
 
-    public class FastaData
+    public static class FastaData
     {
-        private FastaData(string name, string sequence)
-        {
-            Name = name;
-            Sequence = sequence;
-        }
-
-        public string Name { get; private set; }
-        public string Sequence { get; private set; }
-
-        public static void AppendSequence(StringBuilder sequence, string line)
+        private static string EMPTY_PROTEIN_SEQUENCE = @"EMPTY";
+        private static void AppendSequence(StringBuilder sequence, string line)
         {
             var seq = FastaSequence.StripModifications(line);
             // Get rid of whitespace
@@ -3458,10 +3427,16 @@ namespace pwiz.Skyline.Model
             sequence.Append(seq);
         }
 
-        public static IEnumerable<FastaData> ParseFastaFile(TextReader reader, bool readNamesOnly = false)
+        public static bool IsValidFastaChar(char c)
+        {
+            return c >= 0x20 && c <= 0x7E ||
+                   c == '\t' || c == 0x01;
+        }
+
+        public static IEnumerable<FastaSequence> ParseFastaFile(TextReader reader, bool readNamesOnly = false)
         {
             string line;
-            string name = string.Empty;
+            string fastaDescriptionLine = string.Empty;
             StringBuilder sequence = new StringBuilder();
             int lineNum = 0;
 
@@ -3473,15 +3448,12 @@ namespace pwiz.Skyline.Model
                     
                 if (line.StartsWith(@">"))
                 {
-                    if (!string.IsNullOrEmpty(name))
+                    if (!string.IsNullOrEmpty(fastaDescriptionLine))
                     {
-                        yield return new FastaData(name, sequence.ToString());
-
+                        yield return MakeFastaSequence(fastaDescriptionLine, sequence.ToString());
                         sequence.Clear();
                     }
-                    var split = line.Split(TextUtil.SEPARATOR_SPACE);
-                    // Remove the '>'
-                    name = split[0].Remove(0, 1).Trim();
+                    fastaDescriptionLine = line;
                 }
                 else if (!readNamesOnly)
                 {
@@ -3490,8 +3462,54 @@ namespace pwiz.Skyline.Model
             }
 
             // Add the last fasta sequence
-            if (!string.IsNullOrEmpty(name))
-                yield return new FastaData(name, sequence.ToString());
+            if (!string.IsNullOrEmpty(fastaDescriptionLine))
+                yield return MakeFastaSequence(fastaDescriptionLine, sequence.ToString());
+        }
+
+        public static FastaSequence MakeFastaSequence(string fastaDescriptionLine, string sequence)
+        {
+            int start = fastaDescriptionLine.StartsWith(@">") ? 1 : 0;
+            int split = IndexEndId(fastaDescriptionLine);
+            string name;
+            string description;
+            ImmutableList<ProteinMetadata> alternatives;
+            if (split < 0)
+            {
+                name = fastaDescriptionLine.Substring(start);
+                description = string.Empty;
+                alternatives = ImmutableList<ProteinMetadata>.EMPTY;
+            }
+            else
+            {
+                name = fastaDescriptionLine.Substring(start, split - start);
+                string[] descriptions = fastaDescriptionLine.Substring(split + 1).Split((char)1);
+                description = descriptions[0];
+                var listAlternatives = new List<ProteinMetadata>();
+                for (int i = 1; i < descriptions.Length; i++)
+                {
+                    string alternative = descriptions[i];
+                    split = IndexEndId(alternative);
+                    if (split == -1)
+                        listAlternatives.Add(new ProteinMetadata(alternative, null));
+                    else
+                    {
+                        listAlternatives.Add(new ProteinMetadata(alternative.Substring(0, split),
+                            alternative.Substring(split + 1)));
+                    }
+                }
+                alternatives = ImmutableList.ValueOf(listAlternatives);
+            }
+
+            if (string.IsNullOrEmpty(sequence))
+            {
+                sequence = EMPTY_PROTEIN_SEQUENCE;
+            }
+            return new FastaSequence(name, string.IsNullOrEmpty(description) ? null : description, alternatives, sequence);
+        }
+
+        private static int IndexEndId(string line)
+        {
+            return line.IndexOfAny(new[] { TextUtil.SEPARATOR_SPACE, TextUtil.SEPARATOR_TSV });
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/Proteome/ProteinAssociation.cs
+++ b/pwiz_tools/Skyline/Model/Proteome/ProteinAssociation.cs
@@ -892,7 +892,7 @@ namespace pwiz.Skyline.Model.Proteome
             long streamLength = stream.Length;
             foreach (var fastaData in FastaData.ParseFastaFile(new StreamReader(stream)))
             {
-                yield return new FastaRecord(index, (int) (stream.Position * 100 / streamLength), new FastaSequence(fastaData.Name, null, null, fastaData.Sequence));
+                yield return new FastaRecord(index, (int) (stream.Position * 100 / streamLength), fastaData);
                 index++;
             }
         }


### PR DESCRIPTION
Fix bug where protein descriptions assigned by "Associate Proteins" would disappear when the document was saved and reloaded (reported by Mike)