### PR TITLE
Make find box on Document Grid case insensitive by default

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/Controls/NavBar.Designer.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/NavBar.Designer.cs
@@ -149,9 +149,7 @@
             // 
             // navBarButtonMatchCase
             // 
-            this.navBarButtonMatchCase.Checked = true;
             this.navBarButtonMatchCase.CheckOnClick = true;
-            this.navBarButtonMatchCase.CheckState = System.Windows.Forms.CheckState.Checked;
             this.navBarButtonMatchCase.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             resources.ApplyResources(this.navBarButtonMatchCase, "navBarButtonMatchCase");
             this.navBarButtonMatchCase.Name = "navBarButtonMatchCase";


### PR DESCRIPTION
Changed so that the find box on the Document Grid starts out case insensitive (requested by Mike)