### PR TITLE
Update WIFF2 SDK to support all(?) instruments

### DIFF
--- a/pwiz/data/msdata/SpectrumListBase.cpp
+++ b/pwiz/data/msdata/SpectrumListBase.cpp
@@ -24,6 +24,7 @@
 
 #include "SpectrumListBase.hpp"
 #include "pwiz/utility/misc/String.hpp"
+#include "pwiz/utility/misc/Stream.hpp"
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
 
@@ -36,7 +37,7 @@ PWIZ_API_DECL void pwiz::msdata::SpectrumListBase::warn_once(const char * msg) c
 {
     boost::lock_guard<boost::mutex> g(m);
     if (warn_msg_hashes_.insert(hash(msg)).second) // .second is true iff value is new
-        std::cerr << msg << std::endl;
+        cerr << msg << std::endl;
 }
 
 

--- a/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
@@ -268,6 +268,14 @@ PWIZ_API_DECL void SpectrumList_ABI::createIndex() const
             ExperimentPtr msExperiment = experimentsMap_.find(pair<int, int>(period, experiment))->second;
 
             ExperimentType experimentType = msExperiment->getExperimentType();
+
+            if (bal::iends_with(wifffile_->getWiffPath(), "wiff2") &&
+                (experimentType == MRM || experimentType == SIM))
+            {
+                warn_once("WARNING: the WIFF2 reader does not support SIM/MRM chromatograms or spectra; point at the WIFF file instead");
+                continue;
+            }
+
             if ((experimentType == MRM && !config_.srmAsSpectra) ||
                 (experimentType == SIM && !config_.simAsSpectra))
                 continue;

--- a/pwiz/utility/bindings/CLI/common/IterationListener.hpp
+++ b/pwiz/utility/bindings/CLI/common/IterationListener.hpp
@@ -34,6 +34,13 @@ namespace CLI {
 namespace util {
 
 
+extern "C" {
+typedef char* (__stdcall* LogCallback)(const wchar_t* info);
+__declspec(dllexport) void SetCerrCallback(LogCallback cb);
+__declspec(dllexport) void SetCoutCallback(LogCallback cb);
+}
+
+
 public ref struct IterationListener
 {
     enum class Status {Ok, Cancel};

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -393,6 +393,7 @@ InstrumentModel WiffFile2Impl::getInstrumentModel() const
         if (modelName->Contains("5500"))            return API5500; // predicted
         if (modelName->Contains("QTRAP6500"))       return API6500QTrap; // predicted
         if (modelName->Contains("6500"))            return API6500; // predicted
+        if (modelName->Contains("TRIPLEQUAD7500"))  return TripleQuad7500;
         if (modelName->Contains("QSTARPULSAR"))     return QStarPulsarI; // also covers variants like "API QStar Pulsar i, 0, Qstar"
         if (modelName->Contains("QSTARXL"))         return QStarXL;
         if (modelName->Contains("QSTARELITE"))      return QStarElite;
@@ -410,6 +411,7 @@ InstrumentModel WiffFile2Impl::getInstrumentModel() const
         if (modelName->Contains("350"))             return API350; // predicted
         if (modelName->Contains("365"))             return API365; // predicted
         if (modelName->Contains("X500QTOF"))        return X500QTOF;
+        if (modelName->Contains("ZENOTOF7600"))     return ZenoTOF7600;
         throw gcnew Exception("unknown instrument type: " + instrumentDetails->DeviceModelName);
     }
     CATCH_AND_FORWARD
@@ -616,6 +618,10 @@ ExperimentType Experiment2Impl::getExperimentType() const
             return ExperimentType::MS;
         if (msExperiment->ScanType == "TOFMSMS")
             return ExperimentType::Product;
+        if (msExperiment->ScanType == "MRM")
+            return ExperimentType::MRM;
+        if (msExperiment->ScanType == "SIM")
+            return ExperimentType::SIM;
 
         return ExperimentType::MS;
 

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -56,7 +56,9 @@ class WiffFile2Impl : public WiffFile
 
     ISampleDataApi^ DataReader() const
     {
-        static gcroot<ISampleDataApi^> dataReader = (gcnew DataApiFactory())->CreateSampleDataApi();
+        IDataApiFactory^ apiFactory = gcnew DataApiFactory();
+        apiFactory->LicenseKey = "<?xml version=\"1.0\" encoding=\"utf-8\"?><license_key><company_name>Proteowizard</company_name><product_name>Sciex Data API</product_name><features /><key_data>t6QaoUk9a7EedqZ/V/WAE98aSv1Z0tgvmnYXSveHSvLNChvDdMXh3A==</key_data></license_key>";
+        static gcroot<ISampleDataApi^> dataReader = apiFactory->CreateSampleDataApi();
         try
         {
             if (!dataReader)

--- a/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
@@ -36,6 +36,8 @@
 #include <iostream>
 #include <fstream>
 
+#pragma warning (push)
+#pragma warning (disable: 4189)
 //#include "MassLynxRawDataFile.h"
 #include "MassLynxRawBase.hpp"
 #include "MassLynxRawScanReader.hpp"
@@ -48,6 +50,7 @@
 #include "MassLynxParameters.hpp"
 //#include "cdtdefs.h"
 //#include "compresseddatacluster.h"
+#pragma warning (pop)
 
 namespace pwiz {
 namespace vendor_api {

--- a/pwiz_tools/MSConvertGUI/MainLogic.cs
+++ b/pwiz_tools/MSConvertGUI/MainLogic.cs
@@ -107,7 +107,7 @@ namespace MSConvertGUI
 
         public bool Canceled => _canceled;
 
-        private readonly ProgressForm.JobInfo _info;
+        public ProgressForm.JobInfo JobInfo { get; }
         private string _errorMessage;
         bool _canceled;
         private Map<string, int> _usedOutputFilenames;
@@ -115,9 +115,9 @@ namespace MSConvertGUI
 
         static Queue<KeyValuePair<MainLogic, Config>> _workQueue = new Queue<KeyValuePair<MainLogic, Config>>();
 
-        public MainLogic(ProgressForm.JobInfo info, Map<string, int> usedOutputFilenames, object calculateSHA1Mutex)
+        public MainLogic(ProgressForm.JobInfo jobInfo, Map<string, int> usedOutputFilenames, object calculateSHA1Mutex)
         {
-            _info = info;
+            JobInfo = jobInfo;
             _canceled = false;
             _usedOutputFilenames = usedOutputFilenames;
             _calculateSHA1Mutex = calculateSHA1Mutex;
@@ -459,10 +459,10 @@ namespace MSConvertGUI
                                                 updateMessage.iterationIndex + 1,
                                                 updateMessage.iterationCount), _info);*/
                     if (updateMessage.message.Any())
-                        StatusUpdate?.Invoke(String.Format("{0}: {1}/{2}", updateMessage.message, updateMessage.iterationIndex + 1, updateMessage.iterationCount), ProgressBarStyle.Continuous, _info);
+                        StatusUpdate?.Invoke(String.Format("{0}: {1}/{2}", updateMessage.message, updateMessage.iterationIndex + 1, updateMessage.iterationCount), ProgressBarStyle.Continuous, JobInfo);
                     else
-                        StatusUpdate?.Invoke(String.Format("{1}/{2}", updateMessage.message, updateMessage.iterationIndex + 1, updateMessage.iterationCount), ProgressBarStyle.Continuous, _info);
-                    PercentageUpdate?.Invoke(updateMessage.iterationIndex + 1, updateMessage.iterationCount, _info);
+                        StatusUpdate?.Invoke(String.Format("{1}/{2}", updateMessage.message, updateMessage.iterationIndex + 1, updateMessage.iterationCount), ProgressBarStyle.Continuous, JobInfo);
+                    PercentageUpdate?.Invoke(updateMessage.iterationIndex + 1, updateMessage.iterationCount, JobInfo);
                 }
                 return Status.Ok;
             }
@@ -482,8 +482,8 @@ namespace MSConvertGUI
                 if (stripCredentialsMatch.Success)
                     msg = msg.Replace(stripCredentialsMatch.Groups[1].Value, "");
 
-                LogUpdate?.Invoke(msg, _info);
-                StatusUpdate?.Invoke(msg, ProgressBarStyle.Marquee, _info);
+                LogUpdate?.Invoke(msg, JobInfo);
+                StatusUpdate?.Invoke(msg, ProgressBarStyle.Marquee, JobInfo);
                 readers.read(filename, msdList, config.ReaderConfig);
 
                 foreach (var msd in msdList)
@@ -493,7 +493,7 @@ namespace MSConvertGUI
                         var outputFilename = config.outputFilename(filename, msd);
                         string deduplicatedFilename = outputFilename;
 
-                        StatusUpdate?.Invoke("Waiting...", ProgressBarStyle.Marquee, _info);
+                        StatusUpdate?.Invoke("Waiting...", ProgressBarStyle.Marquee, JobInfo);
 
                         // only one thread 
                         lock (_calculateSHA1Mutex)
@@ -506,16 +506,16 @@ namespace MSConvertGUI
                                 deduplicatedFilename = deduplicatedFilename.Replace(Path.GetExtension(outputFilename), String.Format(" ({0}).{1}",  usedOutputFilenames[outputFilename] + 1, Path.GetExtension(outputFilename)));
                             ++usedOutputFilenames[outputFilename];
 
-                            LogUpdate?.Invoke("Calculating SHA1 checksum...", _info);
-                            StatusUpdate?.Invoke("Calculating SHA1 checksum...", ProgressBarStyle.Marquee, _info);
+                            LogUpdate?.Invoke("Calculating SHA1 checksum...", JobInfo);
+                            StatusUpdate?.Invoke("Calculating SHA1 checksum...", ProgressBarStyle.Marquee, JobInfo);
                             MSDataFile.calculateSHA1Checksums(msd);
                         }
 
                         var ilr = new IterationListenerRegistry();
                         ilr.addListenerWithTimer(this, 1);
 
-                        LogUpdate?.Invoke("Processing...", _info);
-                        StatusUpdate?.Invoke("Processing...", ProgressBarStyle.Marquee, _info);
+                        LogUpdate?.Invoke("Processing...", JobInfo);
+                        StatusUpdate?.Invoke("Processing...", ProgressBarStyle.Marquee, JobInfo);
 
                         SpectrumListFactory.wrap(msd, config.Filters, ilr);
 
@@ -538,20 +538,20 @@ namespace MSConvertGUI
                             }
                             else
                                 msg = "Note: input contains no spectra or chromatogram data.";
-                            LogUpdate?.Invoke(msg, _info);
-                            StatusUpdate?.Invoke(msg, ProgressBarStyle.Continuous, _info);
+                            LogUpdate?.Invoke(msg, JobInfo);
+                            StatusUpdate?.Invoke(msg, ProgressBarStyle.Continuous, JobInfo);
                         }
 
                         if (StatusUpdate != null && msd.run.spectrumList != null)
                             StatusUpdate(String.Format("Processing ({0} of {1})", 
                                                        DataGridViewProgressCell.MessageSpecialValue.CurrentValue,
                                                        DataGridViewProgressCell.MessageSpecialValue.Maximum),
-                                         ProgressBarStyle.Continuous, _info);
+                                         ProgressBarStyle.Continuous, JobInfo);
 
                         // write out the new data file
                         msg = String.Format("Writing \"{0}\"...", deduplicatedFilename);
-                        LogUpdate?.Invoke(msg, _info);
-                        StatusUpdate?.Invoke(msg, ProgressBarStyle.Continuous, _info);
+                        LogUpdate?.Invoke(msg, JobInfo);
+                        StatusUpdate?.Invoke(msg, ProgressBarStyle.Continuous, JobInfo);
                         MSDataFile.write(msd, deduplicatedFilename, config.WriteConfig, ilr);
                         ilr.removeListener(this);
                     }
@@ -604,7 +604,7 @@ namespace MSConvertGUI
 
         public void QueueWork(Config config)
         {
-            if (StatusUpdate != null) StatusUpdate("Waiting...", ProgressBarStyle.Continuous, _info);
+            if (StatusUpdate != null) StatusUpdate("Waiting...", ProgressBarStyle.Continuous, JobInfo);
 
             _canceled = false;
 
@@ -649,7 +649,8 @@ namespace MSConvertGUI
                 var LogUpdate = logic.LogUpdate;
                 var StatusUpdate = logic.StatusUpdate;
                 var PercentageUpdate = logic.PercentageUpdate;
-                var _info = logic._info;
+                var _info = logic.JobInfo;
+                _info.Started = true;
 
                 try
                 {
@@ -681,6 +682,8 @@ namespace MSConvertGUI
                         //probably nothing left to report to
                     }
                 }
+
+                _info.Finished = true;
             }
         }
     }

--- a/pwiz_tools/MSConvertGUI/ProgressForm.cs
+++ b/pwiz_tools/MSConvertGUI/ProgressForm.cs
@@ -21,10 +21,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
@@ -39,6 +36,9 @@ namespace MSConvertGUI
             public MainLogic workProcess;
             public TextBox updateTextbox;
             public DataGridViewRow rowShown;
+
+            public bool Started { get; set; }
+            public bool Finished { get; set; }
         }
 
         private IEnumerable<object> _filesToProcess;
@@ -129,9 +129,25 @@ namespace MSConvertGUI
             info.updateTextbox.Visible = true;
         }
 
+        private StringBuilder _stderrBuffer = new StringBuilder();
+        private void ShowStderr(object sender, string stderr)
+        {
+            _stderrBuffer.Append(stderr);
+            if (!stderr.EndsWith("\n"))
+                return;
+
+            // TODO: handle stderr coming from different threads when converting in parallel
+            foreach (var item in _tasksRunningList.Where(t => t.JobInfo.Started && !t.JobInfo.Finished))
+                UpdateLog(_stderrBuffer.ToString(), item.JobInfo);
+
+            _stderrBuffer.Clear();
+        }
+
         private void ProgressForm_Load(object sender, EventArgs e)
         {
             var boxShown = false;
+
+            Program.StderrCaptured += ShowStderr;
 
             foreach (var item in _filesToProcess)
             {


### PR DESCRIPTION
I don't know if it's really ALL instruments that can make WIFF2s, but it's a lot more than just the X500 now.

Although the new SDK can read MRM chromatograms, it can't tell you the Q3 mass for the chromatograms it gives you. I have reported that defect to Sciex. In the meantime I added a warning that WIFF2 MRM/SIM data should point at the WIFF file instead, which led me to discover that MSConvertGUI wasn't displaying the stderr warnings that msconvert.exe shows. I spent a lot of time trying to read the stderr on the .NET side without modifying the C++ side; it might be possible but I couldn't figure it out, so there's a new C function in the binding that will redirect cerr/cout output to a callback function. This might also be useful in Skyline when importing results.