### PR TITLE
Fixes a medium size annoyance for developers using parallel test in Skyline Tester…

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/TabTests.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabTests.cs
@@ -29,7 +29,6 @@ namespace SkylineTester
 {
     public class TabTests : TabBase
     {
-        private static int parallelInvocationsCount; // Number of times we've launched parallel tests from here
         public override void Enter()
         {
             MainWindow.DefaultButton = MainWindow.RunTests;
@@ -110,12 +109,6 @@ namespace SkylineTester
                 // CONSIDER: Should we add a checkbox for this?
                 // args.Append(" keepworkerlogs=1"); // For debugging startup issues. Look for TestRunner-docker-worker_#-docker.log files in pwiz root
                 args.AppendFormat(" parallelmode=server workercount={0}", MainWindow.RunParallelWorkerCount.Value);
-                if (parallelInvocationsCount++ > 0)
-                {
-                    // Allows unique naming of workers between runs, helpful if a run is canceled then quickly restarted and
-                    // workers haven't shut down, as often happens when you realize you've forgotten to select certain tests etc
-                    args.AppendFormat(" invocation={0}", parallelInvocationsCount-1); 
-                }
                 try
                 {
                     var dockerImagesOutput = RunTests.RunCommand("docker", $"images {RunTests.DOCKER_IMAGE_NAME}", RunTests.IS_DOCKER_RUNNING_MESSAGE);

--- a/pwiz_tools/Skyline/SkylineTester/TabTests.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabTests.cs
@@ -29,6 +29,7 @@ namespace SkylineTester
 {
     public class TabTests : TabBase
     {
+        private static int parallelInvocationsCount; // Number of times we've launched parallel tests from here
         public override void Enter()
         {
             MainWindow.DefaultButton = MainWindow.RunTests;
@@ -109,6 +110,12 @@ namespace SkylineTester
                 // CONSIDER: Should we add a checkbox for this?
                 // args.Append(" keepworkerlogs=1"); // For debugging startup issues. Look for TestRunner-docker-worker_#-docker.log files in pwiz root
                 args.AppendFormat(" parallelmode=server workercount={0}", MainWindow.RunParallelWorkerCount.Value);
+                if (parallelInvocationsCount++ > 0)
+                {
+                    // Allows unique naming of workers between runs, helpful if a run is canceled then quickly restarted and
+                    // workers haven't shut down, as often happens when you realize you've forgotten to select certain tests etc
+                    args.AppendFormat(" invocation={0}", parallelInvocationsCount-1); 
+                }
                 try
                 {
                     var dockerImagesOutput = RunTests.RunCommand("docker", $"images {RunTests.DOCKER_IMAGE_NAME}", RunTests.IS_DOCKER_RUNNING_MESSAGE);

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -658,8 +658,8 @@ namespace TestRunner
         private static string LaunchDockerWorker(int i, CommandLineArgs commandLineArgs, ref string workerNames, bool bigWorker, long workerBytes, int workerPort, StreamWriter log)
         {
             var pwizRoot = Path.GetDirectoryName(Path.GetDirectoryName(GetSkylineDirectory().FullName));
-            var invocationDetail = GetInvocationDetail(); // Avoids conflicts between this and any previous invocation
-            string workerName = bigWorker ? $"docker_big_worker{invocationDetail}_{i}" : $"docker_worker{invocationDetail}_{i}";
+            // Adding timestamp to worker name voids conflicts between this and any previous invocation
+            string workerName = bigWorker ? $"docker_big_worker{GetTestRunTimeStamp()}_{i}" : $"docker_worker{GetTestRunTimeStamp()}_{i}";
             string dockerRunRedirect = string.Empty;
             string testRunnerLog = @$"c:\AlwaysUpCLT\TestRunner-{workerName}.log";
             if (commandLineArgs.ArgAsBool("keepworkerlogs"))
@@ -699,7 +699,7 @@ namespace TestRunner
         // Avoids conflicts between this and any previous invocation that may not have torn down its workers yet
         // Helps when a run is cancelled then quickly restarted, as often happens when you realize you've forgotten
         // to select certain tests etc
-        private static string GetInvocationDetail()
+        private static string GetTestRunTimeStamp()
         {
             return $"_{_testRunStartTime.ToString("yyyyMMddHHmmss")}";
         }
@@ -880,7 +880,8 @@ namespace TestRunner
                         }
 
                         string testName = testInfo.TestInfo.TestMethod.Name;
-                        var serverWorkerLogName = $"serverWorker{GetInvocationDetail()}.log";
+                        // Adding timestamp to worker name voids conflicts between this and any previous invocation
+                        var serverWorkerLogName = $"serverWorker{GetTestRunTimeStamp()}.log";
                         try
                         {
                             // running RunTestPasses() for GUI tests directly is problematic because we're no longer on the main thread

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -223,7 +223,7 @@ namespace TestRunnerLib
             if (string.IsNullOrEmpty(resultsDir))
                 resultsDir = Path.Combine(GetProjectPath("TestResults"), "TestRunner results");
             else if (IsParallelClient && resultsDir.Contains("TestResults_"))
-                ParallelClientId = resultsDir.Split('_')[1];
+                ParallelClientId = resultsDir.Split('_').Last();
             testContext.Properties["TestDir"] = resultsDir;
             if (Directory.Exists(resultsDir))
                 Try<Exception>(() => Directory.Delete(resultsDir, true), 4, false);


### PR DESCRIPTION
…. I, at least, often realize that I've kicked of the wrong selection of tests. So, Stop the tests, make the selection, then either wait for (or manually kill) the workers so a new set can be spun up. Or forget to wait and get a bunch of errors.

With this change, each round of parallel tests uses unique worker names so this conflict never happens.

![image](https://user-images.githubusercontent.com/1200761/221292102-f1c0311a-86d2-4877-a87d-ffe50ea678a0.png)
