### PR TITLE
fix an annoyance in SkylineTester when switching back and forth from parallel mode …

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.Designer.cs
@@ -306,6 +306,7 @@ namespace SkylineTester
             this.radioButton5 = new System.Windows.Forms.RadioButton();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.myTreeView1 = new SkylineTester.MyTreeView();
+            this.labelParallelOffscreenHint = new System.Windows.Forms.Label();
             this.parallelWorkerCount = new System.Windows.Forms.NumericUpDown();
             this.label22 = new System.Windows.Forms.Label();
             this.runParallel = new System.Windows.Forms.RadioButton();
@@ -1065,6 +1066,7 @@ namespace SkylineTester
             // 
             // windowsGroup
             // 
+            this.windowsGroup.Controls.Add(this.labelParallelOffscreenHint);
             this.windowsGroup.Controls.Add(this.offscreen);
             this.windowsGroup.Location = new System.Drawing.Point(11, 240);
             this.windowsGroup.Margin = new System.Windows.Forms.Padding(4);
@@ -3623,5 +3625,6 @@ namespace SkylineTester
         private RadioButton runSerial;
         private ComboBox testSet;
         private Button buttonRunStatsExportCSV;
+        private Label labelParallelOffscreenHint;
     }
 }

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -1941,11 +1941,9 @@ namespace SkylineTester
 
         private void runSerial_CheckedChanged(object sender, EventArgs e)
         {
-            Offscreen.Enabled = runSerial.Checked; // Everything happens offscreen in parallel tests, so don't offer the option if we're not serial mode
-            if (!Offscreen.Enabled)
-            {
-                Offscreen.Checked = true; // If we're not offering the choice of offscreen, it's because we're forcing it
-            }
+            labelParallelOffscreenHint.Location = Offscreen.Location;
+            Offscreen.Visible = runSerial.Checked; // Everything happens offscreen in parallel tests, so don't offer the option if we're not serial mode
+            labelParallelOffscreenHint.Visible = !Offscreen.Visible;
         }
 
         #endregion Control events

--- a/pwiz_tools/Skyline/SkylineTester/TabTests.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabTests.cs
@@ -54,7 +54,7 @@ namespace SkylineTester
             var args = new StringBuilder();
 
             args.Append("offscreen=");
-            args.Append(MainWindow.Offscreen.Checked);
+            args.Append(MainWindow.Offscreen.Checked || MainWindow.RunParallel.Checked);
 
             if (!MainWindow.RunIndefinitely.Checked)
             {


### PR DESCRIPTION
… - formerly the "Offscreen" setting would be forced True. It's left alone now, and its control is replaced with a text hint when parallel mode is selected