### PR TITLE
Speed up calculating "Shape Correlation" for Transition Results

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromDataSet.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataSet.cs
@@ -781,7 +781,7 @@ namespace pwiz.Skyline.Model.Results
                         if (intervalIndex >= 0 && intervalIndex < intersectedTimeIntervals.Count)
                         {
                             startTime = Math.Max(startTime, intersectedTimeIntervals.Starts[intervalIndex]);
-                            endTime = Math.Min(endTime, intersectedTimeIntervals.Ends[intervalIndex]);
+                            endTime = Math.Max(startTime, Math.Min(endTime, intersectedTimeIntervals.Ends[intervalIndex]));
                         }
 
                         var chromPeak = ChromPeak.IntegrateWithoutBackground(peak.Data.RawTimeIntensities, startTime, endTime, flags, peakGroupIntegrator.GetMedianChromatogram(startTime, endTime));

--- a/pwiz_tools/Skyline/Model/Results/PeakIntegrator.cs
+++ b/pwiz_tools/Skyline/Model/Results/PeakIntegrator.cs
@@ -118,7 +118,7 @@ namespace pwiz.Skyline.Model.Results
                 if (intervalIndex >= 0 && intervalIndex < TimeIntervals.Count)
                 {
                     startTime = Math.Max(startTime, TimeIntervals.Starts[intervalIndex]);
-                    endTime = Math.Min(endTime, TimeIntervals.Ends[intervalIndex]);
+                    endTime = Math.Max(startTime, Math.Min(endTime, TimeIntervals.Ends[intervalIndex]));
                 }
             }
             return ChromPeak.IntegrateWithoutBackground(RawTimeIntensities ?? InterpolatedTimeIntensities, startTime,

--- a/pwiz_tools/Skyline/Model/Results/TimeIntensities.cs
+++ b/pwiz_tools/Skyline/Model/Results/TimeIntensities.cs
@@ -480,6 +480,10 @@ namespace pwiz.Skyline.Model.Results
 
         public float MaxIntensityInRange(float startTime, float endTime)
         {
+            if (startTime > endTime)
+            {
+                return 0;
+            }
             int index = -1;
             float max = GetInterpolatedIntensity(startTime, ref index);
             index = Math.Max(index, 0);

--- a/pwiz_tools/Skyline/TestData/Results/TimeIntensitiesTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/TimeIntensitiesTest.cs
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Collections;
@@ -51,6 +52,47 @@ namespace pwiz.SkylineTestData.Results
             Assert.AreEqual(oddTimes.Times, addedToOdds.Times);
             var addedToEvens = evenTimes.AddIntensities(oddTimes);
             Assert.AreEqual(evenTimes.Times, addedToEvens.Times);
+        }
+
+        [TestMethod]
+        public void TestGetInterpolatedIntensity()
+        {
+            var timeIntensities = new TimeIntensities(new[] { 1f, 3f, 4.5f }, new[] { 4f, 5, 3 });
+            Assert.AreEqual(4f, timeIntensities.GetInterpolatedIntensity(0));
+            Assert.AreEqual(4.5f, timeIntensities.GetInterpolatedIntensity(2));
+            Assert.AreEqual(3, timeIntensities.GetInterpolatedIntensity(5));
+        }
+
+        [TestMethod]
+        public void TestMaxIntensityInRange()
+        {
+            var timeIntensities = new TimeIntensities(new[] { 1f, 3f, 4.5f }, new[] { 4f, 5, 3 });
+            Assert.AreEqual(4f, timeIntensities.MaxIntensityInRange(0, .5f));
+            Assert.AreEqual(4.5f, timeIntensities.MaxIntensityInRange(0, 2));
+
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="TimeIntensities.GetInterpolatedIntensities"/> returns the same thing as
+        /// repeatedly calling <see cref="TimeIntensities.GetInterpolatedIntensity"/>.
+        /// </summary>
+        [TestMethod]
+        public void TestGetInterpolatedIntensities()
+        {
+            var random = new Random(0);
+            for (int nPoints = 0; nPoints < 1000; nPoints = nPoints * 2 + 1)
+            {
+                var times = Enumerable.Range(0, nPoints).Select(i => (float) random.NextDouble()).OrderBy(t=>t).ToList();
+                var intensities = Enumerable.Range(0, nPoints).Select(i => (float) random.NextDouble()).ToList();
+                var timeIntensities = new TimeIntensities(times, intensities);
+
+                var interpolatedTimes = Enumerable.Range(0, 100).Select(i => (float)(.1 + i * .8)).ToList();
+                var interpolatedIntensities = timeIntensities.GetInterpolatedIntensities(interpolatedTimes).ToList();
+                for (int i = 0; i < interpolatedIntensities.Count; i++)
+                {
+                    Assert.AreEqual(interpolatedIntensities[i], timeIntensities.GetInterpolatedIntensity(interpolatedTimes[i]), "nPoints: {0} index: {1}", nPoints, i);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fix error if SRM chromatogram has zero points in it (reported by Regine)

Fix performance problem calculating the "Shape Correlation" value for Transition Results:
1. Reduce number of calls to "BinarySearch" in "TimeIntensities.GetInterpolatedIntensity" by remembering the last index.
2. Use static method "Statistics.QNthItem" in "MedianPeakShape.GetMedianPeakShape" to calculate medians without having to construct new Statistics objects.