### PR TITLE
Add msconvert option to skip spectra/chromatograms that give errors

### DIFF
--- a/pwiz/analysis/chromatogram_processing/ChromatogramListWrapper.hpp
+++ b/pwiz/analysis/chromatogram_processing/ChromatogramListWrapper.hpp
@@ -26,25 +26,26 @@
 #define _CHROMATOGRAMLISTWRAPPER_HPP_ 
 
 
-#include "pwiz/data/msdata/MSData.hpp"
+#include "pwiz/data/msdata/ChromatogramListBase.hpp"
 #include <stdexcept>
 
 
 namespace pwiz {
 namespace analysis {
 
+using namespace msdata;
 
 /// Inheritable pass-through implementation for wrapping a ChromatogramList 
-class PWIZ_API_DECL ChromatogramListWrapper : public msdata::ChromatogramList
+class PWIZ_API_DECL ChromatogramListWrapper : public ChromatogramListBase
 {
     public:
 
     ChromatogramListWrapper(const msdata::ChromatogramListPtr& inner)
-        : inner_(inner),
-          dp_(inner->dataProcessingPtr().get() ? new msdata::DataProcessing(*inner->dataProcessingPtr())
-                                               : new msdata::DataProcessing("pwiz_Chromatogram_Processing"))
+        : inner_(inner)
     {
         if (!inner.get()) throw std::runtime_error("[ChromatogramListWrapper] Null ChromatogramListPtr.");
+        setDataProcessingPtr(inner->dataProcessingPtr().get() ? boost::make_shared<DataProcessing>(*inner->dataProcessingPtr())
+                                                              : boost::make_shared<DataProcessing>("pwiz_Chromatogram_Processing"));
     }
 
     static bool accept(const msdata::ChromatogramListPtr& inner) {return true;}
@@ -55,12 +56,9 @@ class PWIZ_API_DECL ChromatogramListWrapper : public msdata::ChromatogramList
     virtual size_t find(const std::string& id) const {return inner_->find(id);}
     virtual msdata::ChromatogramPtr chromatogram(size_t index, bool getBinaryData = false) const { return inner_->chromatogram(index, getBinaryData); }
 
-    virtual const boost::shared_ptr<const msdata::DataProcessing> dataProcessingPtr() const { return dp_; }
-
     protected:
 
     msdata::ChromatogramListPtr inner_;
-    msdata::DataProcessingPtr dp_;
 };
 
 

--- a/pwiz/data/msdata/ChromatogramListBase.hpp
+++ b/pwiz/data/msdata/ChromatogramListBase.hpp
@@ -26,6 +26,7 @@
 
 
 #include "pwiz/data/msdata/MSData.hpp"
+#include "SpectrumListBase.hpp"
 #include <stdexcept>
 
 
@@ -38,11 +39,14 @@ class PWIZ_API_DECL ChromatogramListBase : public ChromatogramList
 {
     public:
 
-    /// implementation of ChromatogramList
-    virtual const boost::shared_ptr<const DataProcessing> dataProcessingPtr() const {return dp_;}
+    /// issues a warning once per list instance (based on string hash)
+    void warn_once(const char* msg) const { impl_.warn_once(msg); }
+
+    /// implementation of ChromatogramList/SpectrumList
+    const boost::shared_ptr<const DataProcessing> dataProcessingPtr() const { return dp_; }
 
     /// set DataProcessing
-    virtual void setDataProcessingPtr(DataProcessingPtr dp) {dp_ = dp;}
+    void setDataProcessingPtr(DataProcessingPtr dp) { dp_ = dp; }
 
     const char* polarityStringForFilter(CVID polarityType) const
     {
@@ -50,8 +54,10 @@ class PWIZ_API_DECL ChromatogramListBase : public ChromatogramList
     }
 
     protected:
-
     DataProcessingPtr dp_;
+
+    private:
+    ListBase impl_;
 };
 
 

--- a/pwiz/data/msdata/IO.cpp
+++ b/pwiz/data/msdata/IO.cpp
@@ -2379,7 +2379,7 @@ void write(minimxml::XMLWriter& writer, const SpectrumList& spectrumList, const 
            const BinaryDataEncoder::Config& config,
            vector<boost::iostreams::stream_offset>* spectrumPositions,
            const IterationListenerRegistry* iterationListenerRegistry,
-           bool useWorkerThreads)
+           bool useWorkerThreads, bool continueOnError)
 {
     XMLWriter::Attributes attributes;
     attributes.add("count", spectrumList.size());
@@ -2390,7 +2390,7 @@ void write(minimxml::XMLWriter& writer, const SpectrumList& spectrumList, const 
 
     writer.startElement("spectrumList", attributes); // required by schema, even if empty
 
-    SpectrumWorkerThreads spectrumWorkers(spectrumList, useWorkerThreads);
+    SpectrumWorkerThreads spectrumWorkers(spectrumList, useWorkerThreads, continueOnError);
 
     for (size_t i=0; i<spectrumList.size(); i++)
     {
@@ -2412,12 +2412,23 @@ void write(minimxml::XMLWriter& writer, const SpectrumList& spectrumList, const 
 
         // write the spectrum
 
-        //SpectrumPtr spectrum = spectrumList.spectrum(i, true);
-        SpectrumPtr spectrum = spectrumWorkers.processBatch(i);
-        BOOST_ASSERT(spectrum->binaryDataArrayPtrs.empty() ||
-                     spectrum->defaultArrayLength == spectrum->getMZArray()->data.size());
-        if (spectrum->index != i) throw runtime_error("[IO::write(SpectrumList)] Bad index.");
-        write(writer, *spectrum, msd, config);
+        SpectrumPtr spectrum;
+        try
+        {
+            //spectrum = spectrumList.spectrum(i, true);
+            spectrum = spectrumWorkers.processBatch(i);
+            BOOST_ASSERT(spectrum->binaryDataArrayPtrs.empty() ||
+                         spectrum->defaultArrayLength == spectrum->getMZArray()->data.size());
+            if (spectrum->index != i) throw runtime_error("[IO::write(SpectrumList)] Bad index.");
+            write(writer, *spectrum, msd, config);
+        }
+        catch (std::exception& e)
+        {
+            if (continueOnError)
+                cerr << "Skipping spectrum " << i << " \"" << (spectrum ? spectrum->id : spectrumList.spectrumIdentity(i).id) << "\": " << e.what() << endl;
+            else
+                throw;
+        }
     }
 
     writer.endElement();
@@ -2482,7 +2493,8 @@ PWIZ_API_DECL
 void write(minimxml::XMLWriter& writer, const ChromatogramList& chromatogramList,
            const BinaryDataEncoder::Config& config,
            vector<boost::iostreams::stream_offset>* chromatogramPositions,
-           const IterationListenerRegistry* iterationListenerRegistry)
+           const IterationListenerRegistry* iterationListenerRegistry,
+           bool continueOnError)
 {
     if (chromatogramList.empty()) // chromatogramList not required by schema
         return;
@@ -2515,10 +2527,20 @@ void write(minimxml::XMLWriter& writer, const ChromatogramList& chromatogramList
             chromatogramPositions->push_back(writer.positionNext());
 
         // write the chromatogram
-
-        ChromatogramPtr chromatogram = chromatogramList.chromatogram(i, true);
-        if (chromatogram->index != i) throw runtime_error("[IO::write(ChromatogramList)] Bad index.");
-        write(writer, *chromatogram, config);
+        ChromatogramPtr chromatogram;
+        try
+        {
+            chromatogram = chromatogramList.chromatogram(i, true);
+            if (chromatogram->index != i) throw runtime_error("[IO::write(ChromatogramList)] Bad index.");
+            write(writer, *chromatogram, config);
+        }
+        catch (std::exception& e)
+        {
+            if (continueOnError)
+                cerr << "Skipping chromatogram " << i << " \"" << (chromatogram ? chromatogram->id : chromatogramList.chromatogramIdentity(i).id) << "\": " << e.what() << endl;
+            else
+                throw;
+        }
     }
 
     writer.endElement();
@@ -2584,7 +2606,7 @@ void write(minimxml::XMLWriter& writer, const Run& run, const MSData& msd,
            vector<boost::iostreams::stream_offset>* spectrumPositions,
            vector<boost::iostreams::stream_offset>* chromatogramPositions,
            const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-           bool useWorkerThreads)
+           bool useWorkerThreads, bool continueOnError)
 {
     XMLWriter::Attributes attributes;
     attributes.add("id", encode_xml_id_copy(run.id));
@@ -2614,10 +2636,10 @@ void write(minimxml::XMLWriter& writer, const Run& run, const MSData& msd,
     bool hasChromatogramList = run.chromatogramListPtr.get() && run.chromatogramListPtr->size() > 0;
 
     if (hasSpectrumList)
-        write(writer, *run.spectrumListPtr, msd, config, spectrumPositions, iterationListenerRegistry, useWorkerThreads);
+        write(writer, *run.spectrumListPtr, msd, config, spectrumPositions, iterationListenerRegistry, useWorkerThreads, continueOnError);
 
     if (hasChromatogramList)
-        write(writer, *run.chromatogramListPtr, config, chromatogramPositions, iterationListenerRegistry);
+        write(writer, *run.chromatogramListPtr, config, chromatogramPositions, iterationListenerRegistry, continueOnError);
 
     writer.endElement();
 }
@@ -2725,7 +2747,7 @@ void write(minimxml::XMLWriter& writer, const MSData& msd,
            vector<boost::iostreams::stream_offset>* spectrumPositions,
            vector<boost::iostreams::stream_offset>* chromatogramPositions,
            const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-           bool useWorkerThreads)
+           bool useWorkerThreads, bool continueOnError)
 {
     XMLWriter::Attributes attributes;
     attributes.add("xmlns", "http://psi.hupo.org/ms/mzml");
@@ -2768,7 +2790,7 @@ void write(minimxml::XMLWriter& writer, const MSData& msd,
 
     writeList(writer, msd.allDataProcessingPtrs(), "dataProcessingList");
 
-    write(writer, msd.run, msd, config, spectrumPositions, chromatogramPositions, iterationListenerRegistry, useWorkerThreads);
+    write(writer, msd.run, msd, config, spectrumPositions, chromatogramPositions, iterationListenerRegistry, useWorkerThreads, continueOnError);
 
     writer.endElement();
 }

--- a/pwiz/data/msdata/IO.hpp
+++ b/pwiz/data/msdata/IO.hpp
@@ -201,7 +201,7 @@ void write(minimxml::XMLWriter& writer, const SpectrumList& spectrumList, const 
            const BinaryDataEncoder::Config& config = BinaryDataEncoder::Config(),
            std::vector<boost::iostreams::stream_offset>* spectrumPositions = 0,
            const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
-           bool useWorkerThreads = true);
+           bool useWorkerThreads = true, bool continueOnError = false);
 PWIZ_API_DECL void read(std::istream& is, SpectrumListSimple& spectrumListSimple);
 
 
@@ -209,7 +209,8 @@ PWIZ_API_DECL
 void write(minimxml::XMLWriter& writer, const ChromatogramList& chromatogramList, 
            const BinaryDataEncoder::Config& config = BinaryDataEncoder::Config(),
            std::vector<boost::iostreams::stream_offset>* chromatogramPositions = 0,
-           const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0);
+           const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
+           bool continueOnError = false);
 PWIZ_API_DECL void read(std::istream& is, ChromatogramListSimple& chromatogramListSimple);
 
 
@@ -222,7 +223,7 @@ void write(minimxml::XMLWriter& writer, const Run& run, const MSData& msd,
            std::vector<boost::iostreams::stream_offset>* spectrumPositions = 0,
            std::vector<boost::iostreams::stream_offset>* chromatogramPositions = 0,
            const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
-           bool useWorkerThreads = true);
+           bool useWorkerThreads = true, bool continueOnError = false);
 PWIZ_API_DECL
 void read(std::istream& is, Run& run,
           SpectrumListFlag spectrumListFlag = IgnoreSpectrumList);
@@ -234,7 +235,7 @@ void write(minimxml::XMLWriter& writer, const MSData& msd,
            std::vector<boost::iostreams::stream_offset>* spectrumPositions = 0,
            std::vector<boost::iostreams::stream_offset>* chromatogramPositions = 0,
            const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
-           bool useWorkerThreads = true);
+           bool useWorkerThreads = true, bool continueOnError = false);
 PWIZ_API_DECL
 void read(std::istream& is, MSData& msd,
           SpectrumListFlag spectrumListFlag = IgnoreSpectrumList);

--- a/pwiz/data/msdata/MSData.cpp
+++ b/pwiz/data/msdata/MSData.cpp
@@ -1162,11 +1162,6 @@ PWIZ_API_DECL SpectrumPtr SpectrumList::spectrum(size_t index, DetailLevel detai
     return spectrum(index, detailLevel == DetailLevel_FullData);
 }
 
-
-PWIZ_API_DECL void SpectrumList::warn_once(const char *msg) const
-{
-}
-
 PWIZ_API_DECL DetailLevel SpectrumList::min_level_accepted(std::function<boost::tribool(const Spectrum&)> predicate) const
 {
     DetailLevel result = DetailLevel_InstantMetadata;

--- a/pwiz/data/msdata/MSData.hpp
+++ b/pwiz/data/msdata/MSData.hpp
@@ -729,7 +729,7 @@ class PWIZ_API_DECL SpectrumList
     virtual const boost::shared_ptr<const DataProcessing> dataProcessingPtr() const;
 
     /// issues a warning once per SpectrumList instance (based on string hash)
-    virtual void warn_once(const char* msg) const; 
+    virtual void warn_once(const char* msg) const = 0; 
 
     /// returns the minimum DetailLevel for which the given predicate returns true
     /// - if the predicate returns indeterminate, another spectrum will be tried
@@ -762,6 +762,7 @@ struct PWIZ_API_DECL SpectrumListSimple : public SpectrumList
     virtual const SpectrumIdentity& spectrumIdentity(size_t index) const;
     virtual SpectrumPtr spectrum(size_t index, bool getBinaryData) const;
     virtual const boost::shared_ptr<const DataProcessing> dataProcessingPtr() const;
+    virtual void warn_once(const char* msg) const {}
 };
 
 
@@ -821,6 +822,9 @@ class PWIZ_API_DECL ChromatogramList
     /// - may return a null shared pointer
     virtual const boost::shared_ptr<const DataProcessing> dataProcessingPtr() const;
 
+    /// issues a warning once per ChromatogramList instance (based on string hash)
+    virtual void warn_once(const char* msg) const = 0;
+
     virtual ~ChromatogramList(){} 
 };
 
@@ -842,6 +846,7 @@ struct PWIZ_API_DECL ChromatogramListSimple : public ChromatogramList
     virtual const ChromatogramIdentity& chromatogramIdentity(size_t index) const;
     virtual ChromatogramPtr chromatogram(size_t index, bool getBinaryData) const;
     virtual const boost::shared_ptr<const DataProcessing> dataProcessingPtr() const;
+    virtual void warn_once(const char* msg) const {}
 };
 
 

--- a/pwiz/data/msdata/MSDataFile.cpp
+++ b/pwiz/data/msdata/MSDataFile.cpp
@@ -162,7 +162,7 @@ void writeStream(ostream& os, const MSData& msd, const MSDataFile::WriteConfig& 
             serializerConfig.binaryDataEncoderConfig = config.binaryDataEncoderConfig;
             serializerConfig.indexed = config.indexed;
             Serializer_mzML serializer(serializerConfig);
-            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads);
+            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads, config.continueOnError);
             break;
         }
         case MSDataFile::Format_mzXML:
@@ -171,37 +171,37 @@ void writeStream(ostream& os, const MSData& msd, const MSDataFile::WriteConfig& 
             serializerConfig.binaryDataEncoderConfig = config.binaryDataEncoderConfig;
             serializerConfig.indexed = config.indexed;
             Serializer_mzXML serializer(serializerConfig);
-            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads);
+            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads, config.continueOnError);
             break;
         }
         case MSDataFile::Format_MGF:
         {
             Serializer_MGF serializer;
-            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads);
+            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads, config.continueOnError);
             break;
         }
         case MSDataFile::Format_MS1:
         {
             Serializer_MSn serializer(MSn_Type_MS1);
-            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads);
+            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads, config.continueOnError);
             break;
         }
         case MSDataFile::Format_CMS1:
         {
             Serializer_MSn serializer(MSn_Type_CMS1);
-            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads);
+            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads, config.continueOnError);
             break;
         }
         case MSDataFile::Format_MS2:
         {
             Serializer_MSn serializer(MSn_Type_MS2);
-            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads);
+            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads, config.continueOnError);
             break;
         }
         case MSDataFile::Format_CMS2:
         {
             Serializer_MSn serializer(MSn_Type_CMS2);
-            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads);
+            serializer.write(os, msd, iterationListenerRegistry, config.useWorkerThreads, config.continueOnError);
             break;
         }
         case MSDataFile::Format_MZ5:

--- a/pwiz/data/msdata/MSDataFile.hpp
+++ b/pwiz/data/msdata/MSDataFile.hpp
@@ -57,8 +57,12 @@ struct PWIZ_API_DECL MSDataFile : public MSData
 		bool gzipped; // if true, file is written as .gz
         bool useWorkerThreads;
 
-        WriteConfig(Format _format = Format_mzML,bool _gzipped = false)
-        :   format(_format), indexed(true), gzipped(_gzipped), useWorkerThreads(true)
+        /// when true, if an error is seen when enumerating a spectrum or chromatogram, it will be skipped and enumeration will continue;
+        /// when false an error will immediately stop enumeration
+        bool continueOnError;
+
+        WriteConfig(Format _format = Format_mzML, bool _gzipped = false)
+        :   format(_format), indexed(true), gzipped(_gzipped), useWorkerThreads(true), continueOnError(false)
         {}
     };
 

--- a/pwiz/data/msdata/MSDataMerger.cpp
+++ b/pwiz/data/msdata/MSDataMerger.cpp
@@ -24,6 +24,7 @@
 
 
 #include "MSDataMerger.hpp"
+#include "SpectrumListBase.hpp"
 #include "pwiz/utility/misc/Std.hpp"
 #include "pwiz/utility/misc/DateTime.hpp"
 #include "Diff.hpp"
@@ -51,7 +52,7 @@ void mergeParamContainers(ParamContainer& target, const ParamContainer& source)
     }
 }
 
-class SpectrumListMerger : public SpectrumList
+class SpectrumListMerger : public SpectrumListBase
 {
     struct IndexEntry : public SpectrumIdentity
     {

--- a/pwiz/data/msdata/Serializer_MGF.cpp
+++ b/pwiz/data/msdata/Serializer_MGF.cpp
@@ -47,7 +47,7 @@ class Serializer_MGF::Impl
 
     void write(ostream& os, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-               bool useWorkerThreads) const;
+               bool useWorkerThreads, bool continueOnError) const;
 
     void read(shared_ptr<istream> is, MSData& msd) const;
 };
@@ -64,7 +64,7 @@ struct nosci10_policy : boost::spirit::karma::real_policies<T>
 
 void Serializer_MGF::Impl::write(ostream& os, const MSData& msd,
     const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-    bool useWorkerThreads) const
+    bool useWorkerThreads, bool continueOnError) const
 {
     bool titleIsThermoDTA = false;
     if (msd.fileDescription.sourceFilePtrs.size() >= 1)
@@ -76,11 +76,26 @@ void Serializer_MGF::Impl::write(ostream& os, const MSData& msd,
 
     os << std::setprecision(10); // 1234.567890
     SpectrumList& sl = *msd.run.spectrumListPtr;
-    SpectrumWorkerThreads spectrumWorkers(sl, useWorkerThreads);
+    SpectrumWorkerThreads spectrumWorkers(sl, useWorkerThreads, continueOnError);
     for (size_t i=0, end=sl.size(); i < end; ++i)
     {
-        //SpectrumPtr s = sl.spectrum(i, true);
-        SpectrumPtr s = spectrumWorkers.processBatch(i);
+        SpectrumPtr s;
+        try
+        {
+            // s = sl->spectrum(i, true);
+            s = spectrumWorkers.processBatch(i);
+        }
+        catch (std::exception& e)
+        {
+            if (continueOnError)
+            {
+                cerr << "Skipping spectrum " << i << " \"" << (s ? s->id : sl.spectrumIdentity(i).id) << "\": " << e.what() << endl;
+                continue;
+            }
+            else
+                throw;
+        }
+
         Scan* scan = !s->scanList.empty() ? &s->scanList.scans[0] : 0;
 
         if (s->cvParam(MS_ms_level).valueAs<int>() > 1 &&
@@ -208,10 +223,10 @@ PWIZ_API_DECL Serializer_MGF::Serializer_MGF()
 
 PWIZ_API_DECL void Serializer_MGF::write(ostream& os, const MSData& msd,
     const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-    bool useWorkerThreads) const
+    bool useWorkerThreads, bool continueOnError) const
   
 {
-    return impl_->write(os, msd, iterationListenerRegistry, useWorkerThreads);
+    return impl_->write(os, msd, iterationListenerRegistry, useWorkerThreads, continueOnError);
 }
 
 

--- a/pwiz/data/msdata/Serializer_MGF.hpp
+++ b/pwiz/data/msdata/Serializer_MGF.hpp
@@ -45,7 +45,7 @@ class PWIZ_API_DECL Serializer_MGF
     /// iterationListenerRegistry may be used to receive progress updates
     void write(std::ostream& os, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
-               bool useWorkerThreads = true) const;
+               bool useWorkerThreads = true, bool continueOnError = false) const;
 
     /// read in MSData object from an MGF istream 
     /// note: istream may be managed by MSData's SpectrumList, to allow for 

--- a/pwiz/data/msdata/Serializer_MSn.hpp
+++ b/pwiz/data/msdata/Serializer_MSn.hpp
@@ -45,7 +45,7 @@ class PWIZ_API_DECL Serializer_MSn
     /// iterationListenerRegistry may be used to receive progress updates
     void write(std::ostream& os, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
-               bool useWorkerThreads = true) const;
+               bool useWorkerThreads = true, bool continueOnError = false) const;
 
     /// read in MSData object from an MGF istream 
     /// note: istream may be managed by MSData's SpectrumList, to allow for 

--- a/pwiz/data/msdata/Serializer_mz5.cpp
+++ b/pwiz/data/msdata/Serializer_mz5.cpp
@@ -63,7 +63,7 @@ class Serializer_mz5::Impl
      */
     void write(const std::string& filename, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-               bool useWorkerThreads) const;
+               bool useWorkerThreads, bool continueOnError) const;
 
     /**
      * Not supported.
@@ -94,11 +94,11 @@ private:
 void Serializer_mz5::Impl::write(const std::string& filename,
                                  const MSData& msd,
                                  const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-                                 bool useWorkerThreads) const
+                                 bool useWorkerThreads, bool continueOnError) const
 {
     ReferenceWrite_mz5 wref(msd);
     Connection_mz5 con(filename, Connection_mz5::RemoveAndCreate, config_);
-    wref.writeTo(con, iterationListenerRegistry, useWorkerThreads);
+    wref.writeTo(con, iterationListenerRegistry, useWorkerThreads, continueOnError);
 }
 
 void Serializer_mz5::Impl::write(std::ostream& os, const MSData& msd,
@@ -154,9 +154,9 @@ PWIZ_API_DECL Serializer_mz5::Serializer_mz5(const pwiz::msdata::MSDataFile::Wri
 PWIZ_API_DECL
 void Serializer_mz5::write(const std::string& filename, const MSData& msd,
                            const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-                           bool useWorkerThreads) const
+                           bool useWorkerThreads, bool continueOnError) const
 {
-    return impl_->write(filename, msd, iterationListenerRegistry, useWorkerThreads);
+    return impl_->write(filename, msd, iterationListenerRegistry, useWorkerThreads, continueOnError);
 }
 
 PWIZ_API_DECL

--- a/pwiz/data/msdata/Serializer_mz5.hpp
+++ b/pwiz/data/msdata/Serializer_mz5.hpp
@@ -61,7 +61,7 @@ class PWIZ_API_DECL Serializer_mz5
      */
     void write(const std::string& filename, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
-               bool useWorkerThreads = true) const;
+               bool useWorkerThreads = true, bool continueOnError = false) const;
 
     /// This method is not supported by mz5 since mz5 can not write to ostreams.
     void write(std::ostream& os, const MSData& msd,

--- a/pwiz/data/msdata/Serializer_mz5_Test.cpp
+++ b/pwiz/data/msdata/Serializer_mz5_Test.cpp
@@ -98,6 +98,10 @@ void testWriteRead()
             = BinaryDataEncoder::Precision_32;
     testWriteRead(msd, writeConfig);
 
+    //test with error skipping
+    writeConfig.continueOnError = true;
+    testWriteRead(msd, writeConfig);
+
     // TODO: test without compression
 }
 

--- a/pwiz/data/msdata/Serializer_mzML.cpp
+++ b/pwiz/data/msdata/Serializer_mzML.cpp
@@ -52,7 +52,7 @@ class Serializer_mzML::Impl
 
     void write(ostream& os, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-               bool useWorkerThreads) const;
+               bool useWorkerThreads, bool continueOnError) const;
 
     void read(shared_ptr<istream> is, MSData& msd) const;
 
@@ -130,7 +130,7 @@ void writeChromatogramIndex(XMLWriter& xmlWriter,
 
 void Serializer_mzML::Impl::write(ostream& os, const MSData& msd,
     const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-    bool useWorkerThreads) const
+    bool useWorkerThreads, bool continueOnError) const
 {
     // instantiate XMLWriter
 
@@ -161,7 +161,7 @@ void Serializer_mzML::Impl::write(ostream& os, const MSData& msd,
     vector<stream_offset> chromatogramPositions;
     BinaryDataEncoder::Config bdeConfig = config_.binaryDataEncoderConfig;
     bdeConfig.byteOrder = BinaryDataEncoder::ByteOrder_LittleEndian; // mzML always little endian
-    IO::write(xmlWriter, msd, bdeConfig, &spectrumPositions, &chromatogramPositions, iterationListenerRegistry, useWorkerThreads);
+    IO::write(xmlWriter, msd, bdeConfig, &spectrumPositions, &chromatogramPositions, iterationListenerRegistry, useWorkerThreads, continueOnError);
 
     // don't write indexes if writing was cancelled
     if (iterationListenerRegistry && IterationListener::Status_Cancel == iterationListenerRegistry->broadcastUpdateMessage(IterationListener::UpdateMessage(0, 0, "writing indexes")))
@@ -245,10 +245,10 @@ PWIZ_API_DECL Serializer_mzML::Serializer_mzML(const Config& config)
 
 PWIZ_API_DECL void Serializer_mzML::write(ostream& os, const MSData& msd,
     const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-    bool useWorkerThreads) const
+    bool useWorkerThreads, bool continueOnError) const
   
 {
-    return impl_->write(os, msd, iterationListenerRegistry, useWorkerThreads);
+    return impl_->write(os, msd, iterationListenerRegistry, useWorkerThreads, continueOnError);
 }
 
 

--- a/pwiz/data/msdata/Serializer_mzML.hpp
+++ b/pwiz/data/msdata/Serializer_mzML.hpp
@@ -60,7 +60,7 @@ class PWIZ_API_DECL Serializer_mzML
     /// iterationListenerRegistry may be used to receive progress updates
     void write(std::ostream& os, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
-               bool useWorkerThreads = true) const;
+               bool useWorkerThreads = true, bool continueOnError = false) const;
 
     /// read in MSData object from an mzML istream 
     /// note: istream may be managed by MSData's SpectrumList, to allow for 

--- a/pwiz/data/msdata/Serializer_mzXML.cpp
+++ b/pwiz/data/msdata/Serializer_mzXML.cpp
@@ -55,7 +55,7 @@ class Serializer_mzXML::Impl
 
     void write(ostream& os, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-               bool useWorkerThreads) const;
+               bool useWorkerThreads, bool continueOnError) const;
 
     void read(shared_ptr<istream> is, MSData& msd) const;
 
@@ -702,13 +702,13 @@ void write_scans(XMLWriter& xmlWriter, const MSData& msd,
                  const Serializer_mzXML::Config& config, vector<IndexEntry>& index,
                  const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
                  map<InstrumentConfigurationPtr, int>& instrumentIndexByPtr,
-                 bool useWorkerThreads)
+                 bool useWorkerThreads, bool continueOnError)
 {
     SpectrumListPtr sl = msd.run.spectrumListPtr;
     if (!sl.get()) return;
 
     CVID defaultNativeIdFormat = id::getDefaultNativeIDFormat(msd);
-    SpectrumWorkerThreads spectrumWorkers(*sl, useWorkerThreads);
+    SpectrumWorkerThreads spectrumWorkers(*sl, useWorkerThreads, continueOnError);
 
     for (size_t i=0; i<sl->size(); i++)
     {
@@ -723,8 +723,22 @@ void write_scans(XMLWriter& xmlWriter, const MSData& msd,
         if (status == IterationListener::Status_Cancel)
             break;
 
-        //SpectrumPtr spectrum = sl->spectrum(i, true);
-        SpectrumPtr spectrum = spectrumWorkers.processBatch(i);
+        SpectrumPtr spectrum;
+        try
+        {
+            // spectrum = sl->spectrum(i, true);
+            spectrum = spectrumWorkers.processBatch(i);
+        }
+        catch (std::exception& e)
+        {
+            if (continueOnError)
+            {
+                cerr << "Skipping spectrum " << i << " \"" << (spectrum ? spectrum->id : sl->spectrumIdentity(i).id) << "\": " << e.what() << endl;
+                continue;
+            }
+            else
+                throw;
+        }
 
         // Thermo spectra not from "controllerType=0 controllerNumber=1" are ignored
         if (defaultNativeIdFormat == MS_Thermo_nativeID_format &&
@@ -740,7 +754,6 @@ void write_scans(XMLWriter& xmlWriter, const MSData& msd,
 
         // write the spectrum
         index.push_back(write_scan(xmlWriter, defaultNativeIdFormat, *spectrum, msd.run.spectrumListPtr, config, instrumentIndexByPtr));
-
     }
 }
 
@@ -771,7 +784,7 @@ void write_index(XMLWriter& xmlWriter, const vector<IndexEntry>& index)
 
 void Serializer_mzXML::Impl::write(ostream& os, const MSData& msd,
     const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-    bool useWorkerThreads) const
+    bool useWorkerThreads, bool continueOnError) const
 {
     SHA1OutputObserver sha1OutputObserver;
     XMLWriter::Config config;
@@ -790,7 +803,7 @@ void Serializer_mzXML::Impl::write(ostream& os, const MSData& msd,
     write_msInstruments(xmlWriter, msd, cvTranslator_, instrumentIndexByPtr);
     write_dataProcessing(xmlWriter, msd, cvTranslator_);
     vector<IndexEntry> index;
-    write_scans(xmlWriter, msd, config_, index, iterationListenerRegistry, instrumentIndexByPtr, useWorkerThreads);
+    write_scans(xmlWriter, msd, config_, index, iterationListenerRegistry, instrumentIndexByPtr, useWorkerThreads, continueOnError);
     xmlWriter.endElement(); // msRun 
 
     stream_offset indexOffset = xmlWriter.positionNext();
@@ -1400,9 +1413,9 @@ PWIZ_API_DECL Serializer_mzXML::Serializer_mzXML(const Config& config)
 
 PWIZ_API_DECL void Serializer_mzXML::write(ostream& os, const MSData& msd,
     const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-    bool useWorkerThreads) const
+    bool useWorkerThreads, bool continueOnError) const
 {
-    return impl_->write(os, msd, iterationListenerRegistry, useWorkerThreads);
+    return impl_->write(os, msd, iterationListenerRegistry, useWorkerThreads, continueOnError);
 }
 
 

--- a/pwiz/data/msdata/Serializer_mzXML.hpp
+++ b/pwiz/data/msdata/Serializer_mzXML.hpp
@@ -34,7 +34,6 @@
 namespace pwiz {
 namespace msdata {
 
-
 /// MSData <-> mzXML stream serialization
 class PWIZ_API_DECL Serializer_mzXML
 {
@@ -60,7 +59,7 @@ class PWIZ_API_DECL Serializer_mzXML
     /// iterationListenerRegistry may be used to receive progress updates
     void write(std::ostream& os, const MSData& msd,
                const pwiz::util::IterationListenerRegistry* iterationListenerRegistry = 0,
-               bool useWorkerThreads = true) const;
+               bool useWorkerThreads = true, bool continueOnError = false) const;
 
     /// read in MSData object from an mzXML istream 
     /// note: istream may be managed by MSData's SpectrumList, to allow for 

--- a/pwiz/data/msdata/SpectrumListBase.cpp
+++ b/pwiz/data/msdata/SpectrumListBase.cpp
@@ -33,7 +33,7 @@ namespace {
     boost::mutex m;
 }
 
-PWIZ_API_DECL void pwiz::msdata::SpectrumListBase::warn_once(const char * msg) const
+PWIZ_API_DECL void pwiz::msdata::ListBase::warn_once(const char * msg) const
 {
     boost::lock_guard<boost::mutex> g(m);
     if (warn_msg_hashes_.insert(hash(msg)).second) // .second is true iff value is new
@@ -66,7 +66,7 @@ PWIZ_API_DECL size_t pwiz::msdata::SpectrumListBase::checkNativeIdFindResult(siz
             boost::lock_guard<boost::mutex> g(m);
 
             // early exit if warning already issued, to avoid potentially doing these calculations for thousands of ids
-            if (!warn_msg_hashes_.insert(spectrum_id_mismatch_hash_).second)
+            if (!impl_.warn_msg_hashes().insert(spectrum_id_mismatch_hash_).second)
                 return size();
         }
 
@@ -94,7 +94,7 @@ PWIZ_API_DECL size_t pwiz::msdata::SpectrumListBase::checkNativeIdFindResult(siz
     }
 }
 
-size_t pwiz::msdata::SpectrumListBase::hash(const char* msg) const
+size_t pwiz::msdata::ListBase::hash(const char* msg) const
 {
     return boost::hash_range(msg, msg + strlen(msg));
 }

--- a/pwiz/data/msdata/SpectrumListWrapper.hpp
+++ b/pwiz/data/msdata/SpectrumListWrapper.hpp
@@ -56,8 +56,6 @@ class PWIZ_API_DECL SpectrumListWrapper : public SpectrumListBase
 
     virtual SpectrumPtr spectrum(size_t index, DetailLevel detailLevel) const {return spectrum(index, detailLevel == DetailLevel_FullData);}
 
-    virtual const boost::shared_ptr<const DataProcessing> dataProcessingPtr() const {return dp_;}
-
     SpectrumListPtr inner() const {return inner_;}
 
     SpectrumListPtr innermost() const

--- a/pwiz/data/msdata/SpectrumWorkerThreads.hpp
+++ b/pwiz/data/msdata/SpectrumWorkerThreads.hpp
@@ -35,7 +35,7 @@ class SpectrumWorkerThreads
 {
     public:
 
-    SpectrumWorkerThreads(const SpectrumList& sl, bool useWorkerThreads);
+    SpectrumWorkerThreads(const SpectrumList& sl, bool useWorkerThreads, bool continueOnError);
     ~SpectrumWorkerThreads();
     SpectrumPtr processBatch(size_t index, DetailLevel detailLevel = DetailLevel_FullData);
 

--- a/pwiz/data/msdata/mz5/ReferenceWrite_mz5.hpp
+++ b/pwiz/data/msdata/mz5/ReferenceWrite_mz5.hpp
@@ -136,7 +136,7 @@ public:
      */
     void writeTo(Connection_mz5& connection,
                  const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-                 bool useWorkerThreads);
+                 bool useWorkerThreads, bool continueOnError);
 
 private:
     /**
@@ -151,7 +151,8 @@ private:
                     std::vector<BinaryDataMZ5>& bdl,
                     std::vector<SpectrumMZ5>& spl,
                     const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
-                    bool useWorkerThreads);
+                    bool useWorkerThreads,
+                    bool continueOnError);
 
     /**
      * Reads and writes all chromtograms using an existing mz5 connection.
@@ -164,7 +165,8 @@ private:
                     Connection_mz5& connection,
                     std::vector<BinaryDataMZ5>& bdl,
                     std::vector<ChromatogramMZ5>& cpl,
-                    const pwiz::util::IterationListenerRegistry* iterationListenerRegistry);
+                    const pwiz::util::IterationListenerRegistry* iterationListenerRegistry,
+                    bool continueOnError);
 
     /**
      * Internal reference to the MSData object.

--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -144,8 +144,7 @@ InstrumentConfigurationPtr SpectrumList_Thermo::findInstrumentConfiguration(cons
         }
     }
 
-    warn_once(("no matching instrument configuration for analyzer type " + cvTermInfo(massAnalyzerType).shortName()).c_str());
-    return InstrumentConfigurationPtr();
+    throw runtime_error("no matching instrument configuration for analyzer type " + cvTermInfo(massAnalyzerType).shortName());
 }
 
 inline boost::optional<double> getElectronvoltActivationEnergy(const ScanInfo& scanInfo)
@@ -274,14 +273,7 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Thermo::spectrum(size_t index, DetailLeve
         scanInfo = raw->getScanInfo(ie.scan);
         if (!scanInfo.get())
             throw runtime_error("[SpectrumList_Thermo::spectrum()] Error retrieving ScanInfo.");
-    }
-    catch (RawEgg& e)
-    {
-        throw runtime_error(string("[SpectrumList_Thermo::spectrum()] Error retrieving ScanInfo: ") + e.what());
-    }
 
-    try
-    {
         if (scanInfo->isConstantNeutralLoss())
         {
             scan.set(MS_analyzer_scan_offset, scanInfo->analyzerScanOffset(), MS_m_z);

--- a/pwiz/data/vendor_readers/UNIFI/ChromatogramList_UNIFI.cpp
+++ b/pwiz/data/vendor_readers/UNIFI/ChromatogramList_UNIFI.cpp
@@ -100,7 +100,7 @@ PWIZ_API_DECL void ChromatogramList_UNIFI::makeFullFileChromatogram(pwiz::msdata
 
         if (!bxp::regex_match(info.id, what, functionNumberRegex))
         {
-            msd_.run.spectrumListPtr->warn_once(("unable to parse function number from chromatogram name: " + info.id).c_str());
+            warn_once(("unable to parse function number from chromatogram name: " + info.id).c_str());
             continue;
         }
 

--- a/pwiz/utility/bindings/CLI/analysis/spectrum_processing.cpp
+++ b/pwiz/utility/bindings/CLI/analysis/spectrum_processing.cpp
@@ -85,10 +85,13 @@ void SpectrumListFactory::wrap(msdata::MSData^ msd, System::String^ wrapper)
 
 void SpectrumListFactory::wrap(msdata::MSData^ msd, System::String^ wrapper, util::IterationListenerRegistry^ ilr)
 {
-    b::SpectrumListFactory::wrap(msd->base(), ToStdString(wrapper), ilr ? &ilr->base() : nullptr);
-    System::GC::KeepAlive(ilr);
-    System::GC::KeepAlive(wrapper);
-    System::GC::KeepAlive(msd);
+    try
+    {
+        b::SpectrumListFactory::wrap(msd->base(), ToStdString(wrapper), ilr ? &ilr->base() : nullptr);
+        System::GC::KeepAlive(ilr);
+        System::GC::KeepAlive(wrapper);
+        System::GC::KeepAlive(msd);
+    } CATCH_AND_FORWARD
 }
 
 void SpectrumListFactory::wrap(msdata::MSData^ msd, System::Collections::Generic::IList<System::String^>^ wrappers)
@@ -98,13 +101,16 @@ void SpectrumListFactory::wrap(msdata::MSData^ msd, System::Collections::Generic
 
 void SpectrumListFactory::wrap(msdata::MSData^ msd, System::Collections::Generic::IList<System::String^>^ wrappers, util::IterationListenerRegistry^ ilr)
 {
-    std::vector<std::string> nativeWrappers;
-    for each(System::String^ wrapper in wrappers)
-        nativeWrappers.push_back(ToStdString(wrapper));
-    b::SpectrumListFactory::wrap(msd->base(), nativeWrappers, ilr ? &ilr->base() : nullptr);
-    System::GC::KeepAlive(ilr);
-    System::GC::KeepAlive(wrappers);
-    System::GC::KeepAlive(msd);
+    try
+    {
+        std::vector<std::string> nativeWrappers;
+        for each (System::String ^ wrapper in wrappers)
+            nativeWrappers.push_back(ToStdString(wrapper));
+        b::SpectrumListFactory::wrap(msd->base(), nativeWrappers, ilr ? &ilr->base() : nullptr);
+        System::GC::KeepAlive(ilr);
+        System::GC::KeepAlive(wrappers);
+        System::GC::KeepAlive(msd);
+    } CATCH_AND_FORWARD
 }
 
 System::String^ SpectrumListFactory::usage()
@@ -158,51 +164,68 @@ bool SpectrumList_FilterPredicate_Custom::done() const
 
 SpectrumList_FilterPredicate_IndexSet::SpectrumList_FilterPredicate_IndexSet(System::String^ indexSet)
 {
-    IntegerSet parsedIndexSet;
-    parsedIndexSet.parse(ToStdString(indexSet));
-    base_ = new b::SpectrumList_FilterPredicate_IndexSet(parsedIndexSet);
+    try
+    {
+        IntegerSet parsedIndexSet;
+        parsedIndexSet.parse(ToStdString(indexSet));
+        base_ = new b::SpectrumList_FilterPredicate_IndexSet(parsedIndexSet);
+    } CATCH_AND_FORWARD
 }
 
 SpectrumList_FilterPredicate_ScanNumberSet::SpectrumList_FilterPredicate_ScanNumberSet(System::String^ scanNumberSet)
 {
-    IntegerSet parsedIndexSet;
-    parsedIndexSet.parse(ToStdString(scanNumberSet));
-    base_ = new b::SpectrumList_FilterPredicate_ScanNumberSet(parsedIndexSet);
+    try
+    {
+        IntegerSet parsedIndexSet;
+        parsedIndexSet.parse(ToStdString(scanNumberSet));
+        base_ = new b::SpectrumList_FilterPredicate_ScanNumberSet(parsedIndexSet);
+    } CATCH_AND_FORWARD
 }
 
 SpectrumList_FilterPredicate_ScanEventSet::SpectrumList_FilterPredicate_ScanEventSet(System::String^ scanEventSet)
 {
-    IntegerSet parsedIndexSet;
-    parsedIndexSet.parse(ToStdString(scanEventSet));
-    base_ = new b::SpectrumList_FilterPredicate_ScanEventSet(parsedIndexSet);
+    try
+    {
+        IntegerSet parsedIndexSet;
+        parsedIndexSet.parse(ToStdString(scanEventSet));
+        base_ = new b::SpectrumList_FilterPredicate_ScanEventSet(parsedIndexSet);
+    } CATCH_AND_FORWARD
 }
 
 SpectrumList_FilterPredicate_ScanTimeRange::SpectrumList_FilterPredicate_ScanTimeRange(double scanTimeLow, double scanTimeHigh)
 {
-    base_ = new b::SpectrumList_FilterPredicate_ScanTimeRange(scanTimeLow, scanTimeHigh);
+    try { base_ = new b::SpectrumList_FilterPredicate_ScanTimeRange(scanTimeLow, scanTimeHigh); } CATCH_AND_FORWARD
 }
 
 SpectrumList_FilterPredicate_MSLevelSet::SpectrumList_FilterPredicate_MSLevelSet(System::String^ msLevelSet)
 {
-    IntegerSet parsedIndexSet;
-    parsedIndexSet.parse(ToStdString(msLevelSet));
-    base_ = new b::SpectrumList_FilterPredicate_MSLevelSet(parsedIndexSet);
+    {
+        IntegerSet parsedIndexSet;
+        parsedIndexSet.parse(ToStdString(msLevelSet));
+        base_ = new b::SpectrumList_FilterPredicate_MSLevelSet(parsedIndexSet);
+    }
 }
 
 SpectrumList_FilterPredicate_ChargeStateSet::SpectrumList_FilterPredicate_ChargeStateSet(System::String^ chargeStateSet)
 {
-    IntegerSet parsedIndexSet;
-    parsedIndexSet.parse(ToStdString(chargeStateSet));
-    base_ = new b::SpectrumList_FilterPredicate_ChargeStateSet(parsedIndexSet);
+    try
+    {
+        IntegerSet parsedIndexSet;
+        parsedIndexSet.parse(ToStdString(chargeStateSet));
+        base_ = new b::SpectrumList_FilterPredicate_ChargeStateSet(parsedIndexSet);
+    } CATCH_AND_FORWARD
 }
 
 SpectrumList_FilterPredicate_PrecursorMzSet::SpectrumList_FilterPredicate_PrecursorMzSet(System::Collections::Generic::IEnumerable<double>^ precursorMzSet, chemistry::MZTolerance tolerance, FilterMode mode)
 {
     std::set<double> nativeSet;
     for each (double d in precursorMzSet) nativeSet.insert(d);
-    base_ = new b::SpectrumList_FilterPredicate_PrecursorMzSet(nativeSet,
-                                                               pwiz::chemistry::MZTolerance(tolerance.value, (pwiz::chemistry::MZTolerance::Units) tolerance.units),
-                                                               (b::SpectrumList_Filter::Predicate::FilterMode) mode);
+    try
+    {
+        base_ = new b::SpectrumList_FilterPredicate_PrecursorMzSet(nativeSet,
+                                                                   pwiz::chemistry::MZTolerance(tolerance.value, (pwiz::chemistry::MZTolerance::Units) tolerance.units),
+                                                                   (b::SpectrumList_Filter::Predicate::FilterMode) mode);
+    } CATCH_AND_FORWARD
 }
 
 SpectrumList_FilterPredicate_DefaultArrayLengthSet::SpectrumList_FilterPredicate_DefaultArrayLengthSet(System::String^ defaultArrayLengthSet)
@@ -212,28 +235,31 @@ SpectrumList_FilterPredicate_ActivationType::SpectrumList_FilterPredicate_Activa
 {
     std::set<pwiz::cv::CVID> nativeSet;
     for each (CVID d in filterItem) nativeSet.insert((pwiz::cv::CVID) d);
-    base_ = new b::SpectrumList_FilterPredicate_ActivationType(nativeSet, hasNoneOf);
+    try { base_ = new b::SpectrumList_FilterPredicate_ActivationType(nativeSet, hasNoneOf); } CATCH_AND_FORWARD
 }
 
 SpectrumList_FilterPredicate_AnalyzerType::SpectrumList_FilterPredicate_AnalyzerType(System::Collections::Generic::IEnumerable<CVID>^ filterItem, System::String^ msLevelSet)
 {
-    IntegerSet parsedMsLevelSet;
-    parsedMsLevelSet.parse(ToStdString(msLevelSet));
-    std::set<pwiz::cv::CVID> nativeSet;
-    for each (CVID d in filterItem) nativeSet.insert((pwiz::cv::CVID) d);
-    base_ = new b::SpectrumList_FilterPredicate_AnalyzerType(nativeSet, parsedMsLevelSet);
+    try
+    {
+        IntegerSet parsedMsLevelSet;
+        parsedMsLevelSet.parse(ToStdString(msLevelSet));
+        std::set<pwiz::cv::CVID> nativeSet;
+        for each (CVID d in filterItem) nativeSet.insert((pwiz::cv::CVID)d);
+        base_ = new b::SpectrumList_FilterPredicate_AnalyzerType(nativeSet, parsedMsLevelSet);
+    } CATCH_AND_FORWARD
 }
 
 SpectrumList_FilterPredicate_Polarity::SpectrumList_FilterPredicate_Polarity(CVID polarity)
 {
-    base_ = new b::SpectrumList_FilterPredicate_Polarity((pwiz::cv::CVID) polarity);
+    try { base_ = new b::SpectrumList_FilterPredicate_Polarity((pwiz::cv::CVID) polarity); } CATCH_AND_FORWARD
 }
 
 //SpectrumList_FilterPredicate_MzPresent::SpectrumList_FilterPredicate_MzPresent(chemistry::MZTolerance mzt, System::Collections::Generic::Generic::ISet<double> mzSet, ThresholdFilter tf, FilterMode mode);
 
 SpectrumList_FilterPredicate_ThermoScanFilter::SpectrumList_FilterPredicate_ThermoScanFilter(System::String^ matchString, bool matchExact, bool inverse)
 {
-    base_ = new b::SpectrumList_FilterPredicate_ThermoScanFilter(ToStdString(matchString), matchExact, inverse);
+    try { base_ = new b::SpectrumList_FilterPredicate_ThermoScanFilter(ToStdString(matchString), matchExact, inverse); } CATCH_AND_FORWARD
 }
 
 
@@ -281,12 +307,12 @@ SpectrumList_Filter::SpectrumList_Filter(msdata::SpectrumList^ inner,
 : msdata::SpectrumList(0), impl_(gcnew Impl(predicate))
 {
     try {
-    SpectrumList_FilterAcceptSpectrumWrapper^ wrapper = gcnew SpectrumList_FilterAcceptSpectrumWrapper(impl_, &SpectrumList_Filter::Impl::marshal);
-    System::IntPtr predicatePtr = System::Runtime::InteropServices::Marshal::GetFunctionPointerForDelegate(wrapper);
-    base_ = new b::SpectrumList_Filter(*inner->base_, SpectrumList_FilterPredicate_Custom(predicatePtr.ToPointer()));
-    msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
-    System::GC::KeepAlive(inner);
-    System::GC::KeepAlive(predicate);
+        SpectrumList_FilterAcceptSpectrumWrapper^ wrapper = gcnew SpectrumList_FilterAcceptSpectrumWrapper(impl_, &SpectrumList_Filter::Impl::marshal);
+        System::IntPtr predicatePtr = System::Runtime::InteropServices::Marshal::GetFunctionPointerForDelegate(wrapper);
+        base_ = new b::SpectrumList_Filter(*inner->base_, SpectrumList_FilterPredicate_Custom(predicatePtr.ToPointer()));
+        msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+        System::GC::KeepAlive(inner);
+        System::GC::KeepAlive(predicate);
     } CATCH_AND_FORWARD
 }
 
@@ -295,10 +321,10 @@ SpectrumList_Filter::SpectrumList_Filter(msdata::SpectrumList^ inner,
 : msdata::SpectrumList(0), impl_(gcnew Impl(predicate))
 {
     try {
-    base_ = new b::SpectrumList_Filter(*inner->base_, *impl_->managedPredicate->base_);
-    msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
-    System::GC::KeepAlive(inner);
-    System::GC::KeepAlive(predicate);
+        base_ = new b::SpectrumList_Filter(*inner->base_, *impl_->managedPredicate->base_);
+        msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+        System::GC::KeepAlive(inner);
+        System::GC::KeepAlive(predicate);
     } CATCH_AND_FORWARD
 }
 
@@ -389,13 +415,13 @@ SpectrumList_PeakPicker::SpectrumList_PeakPicker(msdata::SpectrumList^ inner,
 : msdata::SpectrumList(0)
 {
     try {
-    pwiz::util::IntegerSet msLevelSet;
-    for each(int i in msLevelsToPeakPick)
-        msLevelSet.insert(i);
-    base_ = new b::SpectrumList_PeakPicker(*inner->base_, *algorithm->base_, preferVendorPeakPicking, msLevelSet);
-    msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
-    System::GC::KeepAlive(inner);
-    System::GC::KeepAlive(algorithm);
+        pwiz::util::IntegerSet msLevelSet;
+        for each(int i in msLevelsToPeakPick)
+            msLevelSet.insert(i);
+        base_ = new b::SpectrumList_PeakPicker(*inner->base_, *algorithm->base_, preferVendorPeakPicking, msLevelSet);
+        msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+        System::GC::KeepAlive(inner);
+        System::GC::KeepAlive(algorithm);
     } CATCH_AND_FORWARD
 }
 
@@ -416,9 +442,9 @@ SpectrumList_LockmassRefiner::SpectrumList_LockmassRefiner(msdata::SpectrumList^
     : msdata::SpectrumList(0)
 {
     try {
-    base_ = new b::SpectrumList_LockmassRefiner(*inner->base_, lockmassMzPosScans, lockmassMzNegScans, lockmassTolerance);
-    msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
-    System::GC::KeepAlive(inner);
+        base_ = new b::SpectrumList_LockmassRefiner(*inner->base_, lockmassMzPosScans, lockmassMzNegScans, lockmassTolerance);
+        msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+        System::GC::KeepAlive(inner);
     } CATCH_AND_FORWARD
 }
 
@@ -439,14 +465,14 @@ SpectrumList_ChargeStateCalculator::SpectrumList_ChargeStateCalculator(
 : msdata::SpectrumList(0)
 {
     try {
-    base_ = new b::SpectrumList_ChargeStateCalculator(
-                *inner->base_, 
-                overrideExistingChargeState,
-                maxMultipleCharge,
-                minMultipleCharge,
-                intensityFractionBelowPrecursorForSinglyCharged);
-    msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
-    System::GC::KeepAlive(inner);
+        base_ = new b::SpectrumList_ChargeStateCalculator(
+                    *inner->base_, 
+                    overrideExistingChargeState,
+                    maxMultipleCharge,
+                    minMultipleCharge,
+                    intensityFractionBelowPrecursorForSinglyCharged);
+        msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+        System::GC::KeepAlive(inner);
     } CATCH_AND_FORWARD
 }
 
@@ -471,9 +497,9 @@ SpectrumList_3D::SpectrumList_3D(msdata::SpectrumList^ inner)
     : msdata::SpectrumList(0)
 {
     try {
-    base_ = new b::SpectrumList_3D(*inner->base_);
-    msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
-    System::GC::KeepAlive(inner);
+        base_ = new b::SpectrumList_3D(*inner->base_);
+        msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+        System::GC::KeepAlive(inner);
     } CATCH_AND_FORWARD
 }
 
@@ -507,9 +533,9 @@ SpectrumList_IonMobility::SpectrumList_IonMobility(msdata::SpectrumList^ inner)
     : msdata::SpectrumList(0)
 {
     try {
-    base_ = new b::SpectrumList_IonMobility(*inner->base_);
-    msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
-    System::GC::KeepAlive(inner);
+        base_ = new b::SpectrumList_IonMobility(*inner->base_);
+        msdata::SpectrumList::base_ = new boost::shared_ptr<pwiz::msdata::SpectrumList>(base_);
+        System::GC::KeepAlive(inner);
     } CATCH_AND_FORWARD
 }
 

--- a/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
+++ b/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
@@ -111,6 +111,7 @@ static void translateConfig(MSDataFile::WriteConfig^ config, b::MSDataFile::Writ
     config2.gzipped = config->gzipped;
     config2.indexed = config->indexed;
     config2.useWorkerThreads = config->useWorkerThreads;
+    config2.continueOnError = config->continueOnError;
     config2.binaryDataEncoderConfig.precision = (b::BinaryDataEncoder::Precision) config->precision;
     config2.binaryDataEncoderConfig.byteOrder = (b::BinaryDataEncoder::ByteOrder) config->byteOrder;
     config2.binaryDataEncoderConfig.compression = (b::BinaryDataEncoder::Compression) config->compression;

--- a/pwiz/utility/bindings/CLI/msdata/MSDataFile.hpp
+++ b/pwiz/utility/bindings/CLI/msdata/MSDataFile.hpp
@@ -93,6 +93,12 @@ public ref class MSDataFile : public MSData
         property bool gzipped;
         property bool useWorkerThreads;
 
+        /// <summary>
+        /// when true, if an error is seen when enumerating a spectrum or chromatogram, it will be skipped and enumeration will continue;
+        /// when false an error will immediately stop enumeration
+        /// </summary>
+        property bool continueOnError;
+
         WriteConfig()
         {
             format = Format::Format_mzML;
@@ -104,6 +110,7 @@ public ref class MSDataFile : public MSData
 			numpressLinearAbsMassAcc = -1.0;
 			indexed = true;
             useWorkerThreads = true;
+            continueOnError = false;
         }
     };
 

--- a/pwiz/utility/misc/cpp_cli_utilities.hpp
+++ b/pwiz/utility/misc/cpp_cli_utilities.hpp
@@ -186,7 +186,7 @@ void ToBinaryData(cli::array<managed_value_type>^ managedArray, BinaryData<nativ
 {
     typedef System::Runtime::InteropServices::GCHandle GCHandle;
 
-    if (managedArray->Length == 0)
+    if (managedArray == nullptr || managedArray->Length == 0)
     {
         binaryData.clear();
         return;

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -584,7 +584,7 @@ void RawFileImpl::setCurrentController(ControllerType type, long controllerNumbe
     }
     CATCH_AND_FORWARD
 #else
-    raw_->SelectInstrument((Thermo::Device) type, controllerNumber);
+    try { raw_->SelectInstrument((Thermo::Device)type, controllerNumber); } CATCH_AND_FORWARD
     getRawByThread(0)->setCurrentController(type, controllerNumber);
 #endif
 }

--- a/pwiz_tools/MSConvertGUI/ProgressForm.cs
+++ b/pwiz_tools/MSConvertGUI/ProgressForm.cs
@@ -194,6 +194,7 @@ namespace MSConvertGUI
                     workItem = _unifiCredentialsByUrl[workItem].GetUrlWithAuthentication(workItem);
 
                 var config = runProgram.ParseCommandLine(_outputFolder, (workItem + "|" + _options).Trim('|'));
+                config.WriteConfig.continueOnError = true;
                 runProgram.QueueWork(config);
             }
 

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -362,6 +362,9 @@ Config parseCommandLine(int argc, char** argv)
         ("singleThreaded",
             po::value<boost::tribool>(&config.singleThreaded)->implicit_value(true)->default_value(boost::indeterminate),
             ": if true, reading and writing spectra will be done on a single thread")
+        ("continueOnError",
+            po::value<bool>(&config.writeConfig.continueOnError)->zero_tokens()->default_value(config.writeConfig.continueOnError),
+            ": if true, if an error is seen when enumerating a spectrum or chromatogram, it is skipped and enumeration will attempt to continue (but keep in mind a crash may follow, or the remaining data might be obviously or subtly incorrect)")
         ("help",
             po::value<bool>(&detailedHelp)->zero_tokens(),
             ": show this message, with extra detail on filter options")

--- a/pwiz_tools/examples/msbenchmark.cpp
+++ b/pwiz_tools/examples/msbenchmark.cpp
@@ -128,7 +128,7 @@ void enumerateSpectra(const string& filename, DetailLevel detailLevel, const vec
 
     start = boost::chrono::process_cpu_clock::now();
 
-    SpectrumWorkerThreads multithreadedSpectrumList(sl, useWorkerThreads);
+    SpectrumWorkerThreads multithreadedSpectrumList(sl, useWorkerThreads, false);
 
     IterationListenerRegistry ilr;
     IterationListenerPtr il(new UserFeedbackIterationListener);


### PR DESCRIPTION
Users have asked for this several times over the years and I was finally motivated to add it by a recent case where several esoteric features (e.g. PDA chromatogram) were corrupt in a RAW file but the rest could be converted ok. 