### PR TITLE
Fix exception doing Save As on document with very large .skyd file.

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -282,7 +282,7 @@ namespace pwiz.Skyline.Model.Results
                 im.ReadStream.CloseStream();
                 im.ReadStream = manager.CreatePooledStream(prop,false);
             });
-        }        
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
Fixed error doing "Save As" on document with very large .skyd file after removing a replicate.

If "ChromatogramCache.OptimizeToPath" takes a long time to run, and there is a settings change going on in the background, then two threads were trying to use the same ReadStream at the same time and that resulted in an error about how "FileStream" is not thread safe.