### PR TITLE
Parallel mode error handling and connection check

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -242,7 +242,7 @@ namespace TestRunner
             "?;/?;-?;help;skylinetester;debug;results;" +
             "test;skip;filter;form;" +
             "loop=0;repeat=1;pause=0;startingpage=1;random=off;offscreen=on;multi=1;wait=off;internet=off;originalurls=off;" +
-            "parallelmode=off;workercount=0;waitforworkers=off;keepworkerlogs=off;workername;queuehost;workerport;alwaysupcltpassword;" +
+            "parallelmode=off;workercount=0;waitforworkers=off;keepworkerlogs=off;workername;queuehost;workerport;workertimeout;alwaysupcltpassword;" +
             "maxsecondspertest=-1;" +
             "demo=off;showformnames=off;showpages=off;status=off;buildcheck=0;screenshotlist;" +
             "quality=off;pass0=off;pass1=off;pass2=on;" +
@@ -770,6 +770,7 @@ namespace TestRunner
             int testsFailed = 0;
             int testsResultsReturned = 0;
             int workerCount = (int) commandLineArgs.ArgAsLong("workercount");
+            int workerTimeout = Convert.ToInt32(commandLineArgs.ArgAsStringOrDefault("workertimeout", "15"));
             int loop = (int) commandLineArgs.ArgAsLong("loop");
             var languages = commandLineArgs.ArgAsString("language").Split(',');
 
@@ -972,10 +973,9 @@ namespace TestRunner
                     // listen for workerName/IP/tasksPort/resultsPort/heartbeatPort string from a worker
                     if (!receiver.TryReceiveFrameString(TimeSpan.FromSeconds(1), out var workerId))
                     {
-                        const int MAX_SECONDS_TO_WAIT_FOR_WORKER_CONNECTION = 15;
-                        if (waitingForWorkers.Elapsed.TotalSeconds > MAX_SECONDS_TO_WAIT_FOR_WORKER_CONNECTION)
+                        if (waitingForWorkers.Elapsed.TotalSeconds > workerTimeout)
                         {
-                            Console.Error.WriteLine($"No workers connected to the server in {MAX_SECONDS_TO_WAIT_FOR_WORKER_CONNECTION} seconds.");
+                            Console.Error.WriteLine($"No workers connected to the server in {workerTimeout} seconds.");
                             Console.Error.WriteLine("Be sure to check BOTH public and private options if prompted to \"Allow TestRunner to communicate on these networks\".");
                             Console.Error.WriteLine("See https://skyline.ms/wiki/home/development/page.view?name=Troubleshooting_parallel_mode for troubleshooting tips.\r\n");
                             Environment.Exit(1);

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -1132,7 +1132,7 @@ namespace TestRunner
         {
             string skylinePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var skylineDirectory = skylinePath != null ? new DirectoryInfo(skylinePath) : null;
-            while (skylineDirectory != null && skylineDirectory.Name != "Skyline")
+            while (skylineDirectory != null && skylineDirectory.Name.ToLowerInvariant() != "skyline")
                 skylineDirectory = skylineDirectory.Parent;
             return skylineDirectory;
         }

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -1260,6 +1260,7 @@ namespace TestRunner
                 results, log, verbose, clientMode);
 
             var timer = new Stopwatch();
+            timer.Start();
             using (new DebuggerListener(runTests))
             {
                 if (asNightly && !string.IsNullOrEmpty(dmpDir) && Directory.Exists(dmpDir))

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -1132,9 +1132,21 @@ namespace TestRunner
         {
             string skylinePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var skylineDirectory = skylinePath != null ? new DirectoryInfo(skylinePath) : null;
-            while (skylineDirectory != null && skylineDirectory.Name.ToLowerInvariant() != "skyline")
+            while (skylineDirectory != null)
+            {
                 skylineDirectory = skylineDirectory.Parent;
-            return skylineDirectory;
+                if (skylineDirectory == null)
+                    break;
+
+                if (skylineDirectory.Name.ToLowerInvariant() == "skyline")
+                    return skylineDirectory;
+                else
+                    foreach (var subdir in skylineDirectory.GetDirectories())
+                        if (Directory.Exists(Path.Combine(subdir.FullName, "pwiz_tools", "Skyline")))
+                            return new DirectoryInfo(Path.Combine(subdir.FullName, "pwiz_tools", "Skyline"));
+            }
+
+            return null;
         }
 
         private static void TeamCitySettings(CommandLineArgs commandLineArgs, out bool teamcityTestDecoration, out string testSpecification)
@@ -1247,6 +1259,7 @@ namespace TestRunner
                 pauseDialogs, pauseSeconds, pauseStartingPage, useVendorReaders, timeoutMultiplier, 
                 results, log, verbose, clientMode);
 
+            var timer = new Stopwatch();
             using (new DebuggerListener(runTests))
             {
                 if (asNightly && !string.IsNullOrEmpty(dmpDir) && Directory.Exists(dmpDir))
@@ -1583,6 +1596,7 @@ namespace TestRunner
                 }
             }
 
+            Console.WriteLine($"Tests finished in {timer.Elapsed} ({timer.Elapsed.TotalSeconds}s)");
             return runTests.FailureCount == 0;
         }
 

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -1142,6 +1142,7 @@ namespace TestRunnerLib
             workerNames ??= string.Join(" ", GetDockerWorkerNames());
 
             Console.WriteLine(@"Sending docker kill command to all workers.");
+            Console.WriteLine(@$"docker kill {workerNames}");
             var psi = new ProcessStartInfo("docker", $@"kill {workerNames}");
             psi.CreateNoWindow = true;
             psi.UseShellExecute = false;

--- a/pwiz_tools/Skyline/TestUtil/ExtensionTestContext.cs
+++ b/pwiz_tools/Skyline/TestUtil/ExtensionTestContext.cs
@@ -100,13 +100,15 @@ namespace pwiz.SkylineTestUtil
                     return directory;
             }
 
-            // As last resort, hunt around the current working directory to find the pwiz repository root (e.g. when running TestRunner in Docker container)
+            // As last resort, hunt around the current working directory and its subdirectories to find the pwiz repository root
+            // (e.g. when running TestRunner in Docker container or from SkylineTester.zip)
             var up = string.Empty;
             var relPath = @".";
             for (var depth = 0; depth < 10; depth++)
             {
-                if (File.Exists(Path.Combine(relPath, "pwiz_tools", "Skyline", "Skyline.sln")))
-                    return Path.GetFullPath(Path.Combine(relPath, "pwiz_tools", "Skyline"));
+                foreach(var subdir in Directory.GetDirectories(relPath).Append(relPath))
+                    if (File.Exists(Path.Combine(subdir, "pwiz_tools", "Skyline", "Skyline.sln")))
+                        return Path.GetFullPath(Path.Combine(subdir, "pwiz_tools", "Skyline"));
                 up = Path.Combine(up, @"..");
                 relPath = Path.Combine(Directory.GetCurrentDirectory(), up);
             }


### PR DESCRIPTION
* added try/catch around async operations for parallel mode (to reduce whitespace changes and prepare for future refactoring I moved most of the code of these operations to local functions)
* added parallel mode check that at least one worker has connected within 15 seconds and moved the "check BOTH private and public" note to the error when no worker connects)