### PR TITLE
Fix BiblioSpec combine ion mobility

### DIFF
--- a/pwiz_tools/BiblioSpec/src/PwizReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PwizReader.cpp
@@ -58,12 +58,13 @@ void PwizReader::openFile(const char* filename, bool mzSort){
     try {
         fileName_ = filename;
         delete fileReader_;
+        fileReader_ = new MSData();
+        Reader::Config readerConfig;
+        readerConfig.combineIonMobilitySpectra = true;
+        readers_.read(fileName_, *fileReader_, 0, readerConfig);
         #ifdef VENDOR_READERS
-        fileReader_ = new MSDataFile(fileName_, &allReaders_);
         if (SpectrumList_PeakPicker::supportsVendorPeakPicking(fileName_))
             SpectrumListFactory::wrap(*fileReader_, "peakPicking true 1-");
-        #else
-        fileReader_ = new MSDataFile(fileName_);
         #endif
         allSpectra_ = fileReader_->run.spectrumListPtr;
 

--- a/pwiz_tools/BiblioSpec/src/PwizReader.h
+++ b/pwiz_tools/BiblioSpec/src/PwizReader.h
@@ -40,6 +40,8 @@ using std::unique_ptr;
 //        if it is of benefit.  It did not benefit BlibBuild, and so was made conditional.
 #ifdef VENDOR_READERS
 #include "pwiz_tools/common/FullReaderList.hpp"
+#else
+#include "pwiz/data/msdata/DefaultReaderList.hpp"
 #endif
 using namespace pwiz::msdata;
 
@@ -103,9 +105,11 @@ class PwizReader : public BiblioSpec::SpecFileReader {
  private:
     string fileName_;
 #ifdef VENDOR_READERS
-    FullReaderList allReaders_;
+    FullReaderList readers_;
+#else
+    DefaultReaderList readers_;
 #endif
-    MSDataFile* fileReader_;
+    MSData* fileReader_;
     CVID nativeIdFormat_;
     SpectrumListPtr allSpectra_;
     size_t curPositionInIndexMzPairs_;


### PR DESCRIPTION
- fixed BiblioSpec to read ion mobility vendor files in combined spectra form (addresses BiblioSpec taking forever to try to read MSAmanda searches direct from ddaPASEF .d)