### PR TITLE
Fix intermittent failure in TestAuditLogTutorial.

### DIFF
--- a/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
@@ -537,6 +537,7 @@ namespace pwiz.SkylineTestTutorial
             // ShowDialog causes problems debugging
             RunUI(SkylineWindow.ShowAuditLog);
             var auditLogForm = WaitForOpenForm<AuditLogForm>();
+            WaitForCondition(() => auditLogForm.IsComplete);
             if (Program.SkylineOffscreen)
                 return;
 


### PR DESCRIPTION
Fix intermittent failure in TestAuditLogTutorial (failure would never happen on Nightly because failure required Skyline onscreen)