### PR TITLE
Refactoring for more extensive use of Nick's MoleculeMassOffset class in Skyline

### DIFF
--- a/pwiz_tools/Shared/Common/Chemistry/Formula.cs
+++ b/pwiz_tools/Shared/Common/Chemistry/Formula.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using pwiz.Common.Collections;
@@ -197,40 +198,109 @@ namespace pwiz.Common.Chemistry
     public class Formula<T> : AbstractFormula<T, int>
         where T : Formula<T>, new()
     {
-        public static T Parse(String formula)
+
+        public static bool IsNullOrEmpty(Formula<T> value)
         {
-            return new T {Dictionary = ImmutableSortedList.FromValues(ParseToDictionary(formula))};
+            return value == null || value.IsEmpty();
         }
 
-        public static Dictionary<string, int> ParseToDictionary(string formula)
+        public static T Parse(string formula)
         {
+            return Parse(formula, out _);
+        }
+
+        public static T Parse(string formula, out string regularizedFormula)
+        {
+            return new T { Dictionary = ImmutableSortedList.FromValues(ParseToDictionary(formula, out regularizedFormula)) };
+        }
+
+        /// <summary>
+        /// Parse a string like C12H5 into a dictionary.
+        /// Handles simple math like "C12H5-C3H2"
+        /// Returns a tidied-up version of the input that removes zero-count elements but preserves idiosyncratic things like "HOOON1"
+        /// </summary>
+        /// <param name="formula">original string describing the formula</param>
+        /// <param name="regularizedFormula">cleaned up formula string</param>
+        /// <returns></returns>
+        public static Dictionary<string, int> ParseToDictionary(string formula, out string regularizedFormula)
+        {
+            // Watch for trivial case
             var result = new Dictionary<string, int>();
+            if (string.IsNullOrEmpty(formula))
+            {
+                regularizedFormula = string.Empty;
+                return result;
+            }
+
             string currentElement = null;
             int? currentQuantity = null;
+            var currentPolarity = 1;
+            var polarityNext = 1;
+            var tidied = new StringBuilder(formula.Length);
+
+            void CloseOutCurrentElement()
+            {
+                if (currentElement != null)
+                {
+                    var currentAtomCount = currentPolarity * (currentQuantity ?? 1); // No count declared implies 1
+                    var hasAtom = result.TryGetValue(currentElement, out var previousAtomCount);
+                    var newAtomCount = previousAtomCount + currentAtomCount;
+                    if (hasAtom)
+                    {
+                        if (newAtomCount == 0)
+                        {
+                            result.Remove(currentElement);
+                        }
+                        else
+                        {
+                            result[currentElement] = newAtomCount;
+                        }
+                    }
+                    else if (newAtomCount != 0) // Beware explicitly declared 0 count e.g. "H0"
+                    {
+                        result.Add(currentElement, newAtomCount);
+                    }
+
+                    if ((currentQuantity ?? 1) > 0) // Omit any zero counts e.g. N0, but save any explicit counts e.g. "N1"
+                    {
+                        tidied.Append(currentElement);
+                        if (currentQuantity.HasValue) // Preserve the "1" in "N1" if that's how the user presented it
+                        {
+                            tidied.Append(currentQuantity.Value.ToString(CultureInfo.InvariantCulture));
+                        }
+                    }
+                }
+                else if ((currentQuantity ?? 0) != 0) // Input was something like "123" or "5C12H"
+                {
+                    throw new ArgumentException($@"""{formula}""");
+                }
+            }
+
             foreach (char ch in formula)
             {
                 if (Char.IsDigit(ch))
                 {
-                    currentQuantity = (currentQuantity??0) * 10 + (ch - '0');
+                    currentQuantity = (currentQuantity ?? 0) * 10 + (ch - '0');
                 }
                 else if (Char.IsUpper(ch))
                 {
                     // Close out current element, if any
-                    if (currentElement != null)
-                    {
-                        int previousAtomCount;
-                        var currentAtomCount = currentQuantity ?? 1; // No count declared implies 1
-                        if (result.TryGetValue(currentElement, out previousAtomCount))
-                        {
-                            result[currentElement] = previousAtomCount + currentAtomCount;
-                        }
-                        else if (currentAtomCount != 0) // Beware explicitly declared 0 count
-                        {
-                            result.Add(currentElement, previousAtomCount + currentAtomCount);
-                        }
-                    }
+                    CloseOutCurrentElement();
                     currentQuantity = null;
                     currentElement = string.Empty + ch;
+                    if (currentPolarity != polarityNext)
+                    {
+                        tidied.Append(@"-");
+                        currentPolarity = polarityNext;
+                    }
+                }
+                else if (Equals(ch, '-'))
+                {
+                    if (currentPolarity < 0)
+                    {
+                        throw new ArgumentException($@"Failed parsing ""{formula}"": molecular formula subtraction expressions are limited to a single operation");
+                    }
+                    polarityNext = -currentPolarity; // Flip +/- after we process the previous element
                 }
                 // Allow apostrophe for heavy isotopes (e.g. C' for 13C)
                 else if (!Char.IsWhiteSpace(ch))
@@ -238,82 +308,80 @@ namespace pwiz.Common.Chemistry
                     currentElement = currentElement + ch;
                 }
             }
-            if (currentElement != null)
-            {
-                int previousAtomCount;
-                var currentAtomCount = currentQuantity ?? 1; // No count declared implies 1
-                if (result.TryGetValue(currentElement, out previousAtomCount))
-                {
-                    result[currentElement] = previousAtomCount + currentAtomCount;
-                }
-                else if (currentAtomCount != 0) // Beware explicitly declared 0 count
-                {
-                    result.Add(currentElement, currentAtomCount);
-                }
-            }
+            CloseOutCurrentElement(); // Finish up the last element
+
+            regularizedFormula = tidied.ToString();
             return result;
         }
 
-        // Handle formulae which may contain subtractions, as is deprotonation description ie C12H8O2-H (=C12H7O2) or even C12H8O2-H2O (=C12H6O)
-        public static T ParseExpression(String formula)
-        {
-            return FromDict(ParseExpressionToDictionary(formula));
-        }
 
-        public static Dictionary<String, int> ParseExpressionToDictionary(string expression)
-        {
-            var parts = expression.Split('-');
-            if (parts.Length > 2)
-            {
-                throw new ArgumentException(@"Molecular formula subtraction expressions are limited a single operation");
-            }
-            var result = ParseToDictionary(parts[0]);
-            if (parts.Length > 1)
-            {
-                var subtractive = ParseToDictionary(parts[1]);
-                foreach (var element in subtractive)
-                {
-                    int previous;
-                    if (result.TryGetValue(element.Key, out previous))
-                    {
-                        int newCount = previous - element.Value;
-                        if (newCount == 0)
-                        {
-                            result.Remove(element.Key);
-                        }
-                        else
-                        {
-                            result[element.Key] = newCount;
-                        }
-                    }
-                    else
-                    {
-                        result.Add(element.Key, -element.Value);  // Seems weird, but possibly describing a proton lost from something other that H?
-                    }
-                }
-            }
-            return result;
-        }
 
         // Subtract other's atom counts from ours
         public T Difference(T other)
         {
-            var resultDict = new Dictionary<string, int>(this);
-            foreach (var kvp in other)
+            if (other == null || other.Count == 0)
             {
-                TryGetValue(kvp.Key, out int count);
-                count -= kvp.Value;
-                if (count == 0)
+                return (T)this;
+            }
+
+            var resultDict = new Dictionary<string, int>(this);
+            foreach (var kvpOther in other)
+            {
+                if (TryGetValue(kvpOther.Key, out var countCurrent))
                 {
-                    resultDict.Remove(kvp.Key);
+                    var newCount = countCurrent - kvpOther.Value;
+                    if (newCount == 0)
+                    {
+                        resultDict.Remove(kvpOther.Key);
+                    }
+                    else
+                    {
+                        resultDict[kvpOther.Key] = newCount;
+                    }
                 }
                 else
                 {
-                    resultDict[kvp.Key] = count;
+                    resultDict.Add(kvpOther.Key, -kvpOther.Value);
                 }
             }
 
             return FromDict(resultDict);
+        }
+
+        public T Plus(T other)
+        {
+            if (other == null || other.Count == 0)
+            {
+                return (T)this;
+            }
+
+            var resultDict = new Dictionary<string, int>(this);
+            foreach (var kvpOther in other)
+            {
+                if (TryGetValue(kvpOther.Key, out var count))
+                {
+                    var newCount = count + kvpOther.Value;
+                    if (newCount == 0)
+                    {
+                        resultDict.Remove(kvpOther.Key);
+                    }
+                    else
+                    {
+                        resultDict[kvpOther.Key] = newCount;
+                    }
+                }
+                else
+                {
+                    resultDict.Add(kvpOther.Key, kvpOther.Value);
+                }
+            }
+
+            return FromDict(resultDict);
+        }
+
+        public bool IsEmpty()
+        {
+            return Dictionary == null || Dictionary.Count == 0;
         }
 
         public static T FromDict(IDictionary<string, int> dict)
@@ -321,22 +389,39 @@ namespace pwiz.Common.Chemistry
             return new T {Dictionary = ImmutableSortedList.FromValues(dict.Where(entry=>entry.Value != 0))};
         }
 
+        public T AdjustElementCount(string element, int delta, bool allowNegative = false)
+        {
+            TryGetValue(element, out var existing);
+            var newCount = existing + delta;
+            if (allowNegative || newCount >= 0) // There are some to take away, or we're planning to add some
+            {
+                var dict = new Dictionary<string, int>(this);
+                if (newCount == 0)
+                {
+                    if (existing != 0)
+                    {
+                        dict.Remove(element);
+                        return FromDict(dict);
+                    }
+                    return this as T;
+                }
+                if (existing == 0)
+                {
+                    dict.Add(element, newCount);
+                }
+                else
+                {
+                    dict[element] = newCount;
+                }
+                return FromDict(dict);
+            }
+            return this as T;
+        }
+
         public static string AdjustElementCount(string formula, string element, int delta)
         {
-            var dict = Molecule.ParseToDictionary(formula);
-            int count;
-            if (!dict.TryGetValue(element, out count))
-                count = 0;
-            if ((count > 0) || (delta > 0)) // There are some to take away, or we're planning to add some
-            {
-                count += delta;
-                if (count >= 0)
-                {
-                    dict[element] = count;
-                    return Molecule.FromDict(dict).ToString();
-                }
-            }
-            return formula;
+            var dict = Parse(formula);
+            return dict.AdjustElementCount(element, delta).ToString();
         }
 
         public static bool AreEquivalentFormulas(string formulaLeft, string formulaRight)
@@ -346,8 +431,8 @@ namespace pwiz.Common.Chemistry
                 return true;
             }
             // Consider C2C'4H5 to be same as H5C'4C2, or "C10H30Si5O5H-CH4" same as "C9H26O5Si5", etc
-            var left = ParseExpression(formulaLeft);
-            var right = ParseExpression(formulaRight);
+            var left = Parse(formulaLeft);
+            var right = Parse(formulaRight);
             return left.Equals(right);
         }
 

--- a/pwiz_tools/Shared/Common/Chemistry/MoleculeMassOffset.cs
+++ b/pwiz_tools/Shared/Common/Chemistry/MoleculeMassOffset.cs
@@ -29,37 +29,167 @@ namespace pwiz.Common.Chemistry
     /// Holds a chemical formula as well as an extra offset for the monoisotopic mass and the average mass.
     /// This is used when a molecule is made up of some things that we know the chemical formula for,
     /// and other things where the user has only told us the mono and average masses.
+    ///
+    /// Examples of these formulas with mass offsets include crosslinking and Hardklor output.
+    ///
     /// </summary>
-    public class MoleculeMassOffset : Immutable, IFormattable
+    public class MoleculeMassOffset : Immutable, IFormattable, IEquatable<MoleculeMassOffset>, IComparable<MoleculeMassOffset>
     {
-        public static readonly MoleculeMassOffset EMPTY = new MoleculeMassOffset(Molecule.Empty, 0, 0);
-        public MoleculeMassOffset(Molecule molecule, double monoMassOffset, double averageMassOffset)
+        public static readonly MoleculeMassOffset EMPTY = new MoleculeMassOffset(Molecule.Empty, TypedMass.ZERO_MONO_MASSNEUTRAL, TypedMass.ZERO_AVERAGE_MASSNEUTRAL);
+
+        protected MoleculeMassOffset(Molecule molecule, TypedMass monoMassOffset, TypedMass averageMassOffset) // Use Create instead of constructor to avoid creating empty objects
         {
-            Molecule = molecule;
+            Molecule = molecule ?? Molecule.Empty;
             MonoMassOffset = monoMassOffset;
             AverageMassOffset = averageMassOffset;
         }
 
-        public MoleculeMassOffset(Molecule molecule) : this(molecule, 0, 0)
-        {
+        public Molecule Molecule { get; private set; }
+        public TypedMass MonoMassOffset { get; protected set; }
+        public TypedMass AverageMassOffset { get; protected set; }
 
+        public static string MASS_MOD_CUE_PLUS = @"[+";   // e.g. C12H5[+15.994915/16.1]
+        public static string MASS_MOD_CUE_MINUS = @"[-";  // e.g. C12H5[-15.994915/16.1]
+
+        public static bool ContainsMassOffsetCue(string str) => str.Contains(MASS_MOD_CUE_PLUS) || str.Contains(MASS_MOD_CUE_MINUS);
+
+        public bool IsEmpty =>
+            ReferenceEquals(this, MoleculeMassOffset.EMPTY) ||
+            (IsMassOnly && AverageMassOffset == 0 && MonoMassOffset == 0);
+
+        public static bool IsNullOrEmpty(MoleculeMassOffset moleculeMassOffset) =>
+            moleculeMassOffset == null || moleculeMassOffset.IsEmpty;
+
+        public TypedMass GetMassOffset(MassType massType) => massType.IsMonoisotopic() ? MonoMassOffset : AverageMassOffset;
+
+        public bool HasChemicalFormula => !Molecule.IsNullOrEmpty(Molecule);
+
+        public bool IsMassOnly => Molecule.IsNullOrEmpty(Molecule);
+
+        public bool HasMassModifications => MonoMassOffset != 0;
+
+        public MoleculeMassOffset SetElementCount(string element, int count)
+        {
+            var newMolecule = Molecule.SetElementCount(element, count);
+            return Change(newMolecule, MonoMassOffset, AverageMassOffset);
         }
 
-        public Molecule Molecule { get; private set; }
-        public double MonoMassOffset { get; private set; }
-        public double AverageMassOffset { get; private set; }
+        public bool HasElement(string element) => Molecule.ContainsKey(element);
+
+        public int GetElementCount(string element)
+        {
+            Molecule.TryGetValue(element, out var count);
+            return count;
+        }
+
+        public MoleculeMassOffset AdjustElementCount(string element, int delta)
+        {
+            var newMolecule = Molecule.AdjustElementCount(element, delta, true); // Deal with the formula
+            return Change(newMolecule, MonoMassOffset, AverageMassOffset);
+        }
 
         public MoleculeMassOffset Plus(MoleculeMassOffset moleculeMassOffset)
         {
-            var newMolecule = MoleculeFromEntries(Molecule.Concat(moleculeMassOffset.Molecule));
-            return new MoleculeMassOffset(newMolecule, MonoMassOffset + moleculeMassOffset.MonoMassOffset, AverageMassOffset + moleculeMassOffset.AverageMassOffset);
+            var newMolecule = Molecule.Plus(moleculeMassOffset.Molecule);
+            return Change(newMolecule, MonoMassOffset + moleculeMassOffset.MonoMassOffset, AverageMassOffset + moleculeMassOffset.AverageMassOffset);
         }
 
-        public MoleculeMassOffset Minus(MoleculeMassOffset moleculeMassOffset)
+        public MoleculeMassOffset Difference(MoleculeMassOffset moleculeMassOffset)
         {
-            var newMolecule = MoleculeFromEntries(Molecule.Concat(
-                moleculeMassOffset.Molecule.Select(entry => new KeyValuePair<string, int>(entry.Key, -entry.Value))));
-            return new MoleculeMassOffset(newMolecule, MonoMassOffset - moleculeMassOffset.MonoMassOffset, AverageMassOffset - moleculeMassOffset.AverageMassOffset);
+            var newMolecule = Molecule.Difference(moleculeMassOffset.Molecule);
+            return Change(newMolecule, MonoMassOffset - moleculeMassOffset.MonoMassOffset, AverageMassOffset - moleculeMassOffset.AverageMassOffset);
+        }
+
+        public MoleculeMassOffset ChangeIsMassH(bool isMassH)
+        {
+            return ChangeMassOffset(MonoMassOffset.ChangeIsMassH(isMassH), AverageMassOffset.ChangeIsMassH(isMassH));
+        }
+
+        public MoleculeMassOffset ChangeIsHeavy(bool isHeavy)
+        {
+            return ChangeMassOffset(MonoMassOffset.ChangeIsHeavy(isHeavy), AverageMassOffset.ChangeIsHeavy(isHeavy));
+        }
+
+        public bool IsHeavy => MonoMassOffset.IsHeavy();
+
+        public MoleculeMassOffset ChangeMassOffset(TypedMass mono, TypedMass avg)
+        {
+            return Change(Molecule, mono, avg);
+        }
+
+        public MoleculeMassOffset ChangeMassOffset(double mass)
+        {
+            return Change(Molecule, MonoMassOffset.ChangeMass(mass), AverageMassOffset.ChangeMass(mass));
+        }
+
+        public MoleculeMassOffset Change(Molecule molecule)
+        {
+            return Change(molecule, MonoMassOffset, AverageMassOffset);
+        }
+        
+        public virtual MoleculeMassOffset Change(Molecule molecule, TypedMass monoMassOffset, TypedMass averageMassOffset)
+        {
+            return Equals(molecule, Molecule) && monoMassOffset == MonoMassOffset && averageMassOffset == AverageMassOffset
+                ? this
+                : MoleculeMassOffset.Create(molecule, monoMassOffset, averageMassOffset);
+        }
+
+        public static MoleculeMassOffset Sum(IEnumerable<MoleculeMassOffset> parts)
+        {
+            var array = parts.ToArray();
+            var monoMassOffset = array.Sum(part => part.MonoMassOffset);
+            var averageMassOffset = array.Sum(part => part.AverageMassOffset);
+            return MoleculeMassOffset.Create(MoleculeFromEntries(array.SelectMany(part => part.Molecule)), 
+                TypedMass.Create(monoMassOffset, MassType.Monoisotopic), TypedMass.Create(averageMassOffset, MassType.Average));
+        }
+
+        public static MoleculeMassOffset Create(Molecule molecule, double? monoMassOffset, double? averageMassOffset)
+        {
+            return Create(molecule,
+                TypedMass.Create(monoMassOffset, MassType.Monoisotopic), TypedMass.Create(averageMassOffset, MassType.Average));
+        }
+
+        public static MoleculeMassOffset Create(Molecule molecule, TypedMass monoMassOffset, TypedMass averageMassOffset)
+        {
+            if (monoMassOffset == null)
+            {
+                monoMassOffset = TypedMass.ZERO_MONO_MASSNEUTRAL;
+            }
+            if (averageMassOffset == null)
+            {
+                averageMassOffset = TypedMass.ZERO_AVERAGE_MASSNEUTRAL;
+            }
+
+            return Molecule.IsNullOrEmpty(molecule) &&
+                   monoMassOffset== 0 && averageMassOffset == 0 ?
+                EMPTY :
+                new MoleculeMassOffset(molecule, monoMassOffset, averageMassOffset);
+        }
+
+        // N.B. The mass portion is always written with InvariantCulture.
+
+        public static string FormatMassModification(double massMod, int desiredDecimals)
+        {
+            if (massMod == 0)
+            {
+                return string.Empty;
+            }
+            var sign = massMod > 0 ? @"+" : string.Empty;
+            return string.Format($@"[{sign}{massMod.ToString($"F{desiredDecimals}", CultureInfo.InvariantCulture).TrimEnd('0')}]");
+        }
+
+        public static string FormatMassModification(double massModMono, double massModAverage, int desiredDecimals)
+        {
+            if (massModMono == 0 && massModAverage == 0)
+            {
+                return string.Empty;
+            }
+            if (Equals(massModMono, massModAverage))
+            {
+                return FormatMassModification(massModMono, desiredDecimals);
+            }
+            var sign = massModMono > 0 ? @"+" : string.Empty;
+            return string.Format($@"[{sign}{massModMono.ToString($"F{desiredDecimals}", CultureInfo.InvariantCulture).TrimEnd('0')}/{Math.Abs(massModAverage).ToString($"F{desiredDecimals}", CultureInfo.InvariantCulture).TrimEnd('0')}]");
         }
 
         public override string ToString()
@@ -67,35 +197,29 @@ namespace pwiz.Common.Chemistry
             return ToString(null, CultureInfo.CurrentCulture);
         }
 
+        // Satisfy IFormattable interface
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.Append(Molecule);
-            
-            if (MonoMassOffset != 0 || AverageMassOffset != 0)
-            {
-                if (Equals(MonoMassOffset, AverageMassOffset))
-                {
-                    stringBuilder.Append(ToSignedString(format, formatProvider, MonoMassOffset));
-                }
-                else
-                {
-                    stringBuilder.Append(@"(" + ToSignedString(format, formatProvider, MonoMassOffset) + "," +
-                                         ToSignedString(format, formatProvider, AverageMassOffset) + ")");
-                }
-            }
+            return ToString(6);
+        }
 
+        public virtual string ChemicalFormulaString() => Molecule.ToString();
+        
+        public string ToString(int desiredDigits)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.Append(ChemicalFormulaString());
+            stringBuilder.Append(FormatMassModification(MonoMassOffset, AverageMassOffset, desiredDigits)); // Use our standard notation e.g. [+1.23/1.24], [-1.2] etc
             return stringBuilder.ToString();
         }
 
-        private static string ToSignedString(string format, IFormatProvider formatProvider, double value)
+        public bool Equals(MoleculeMassOffset other)
         {
-            return (value >= 0 ? @"+" : string.Empty) + value.ToString(format, formatProvider);
-        }
-
-        protected bool Equals(MoleculeMassOffset other)
-        {
-            return Molecule.Equals(other.Molecule) && MonoMassOffset.Equals(other.MonoMassOffset) && AverageMassOffset.Equals(other.AverageMassOffset);
+            if (other == null)
+            {
+                return false;
+            }
+            return CompareTo(other) == 0;
         }
 
         public override bool Equals(object obj)
@@ -116,6 +240,76 @@ namespace pwiz.Common.Chemistry
                 return hashCode;
             }
         }
+
+        public int CompareTo(MoleculeMassOffset other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return 0;
+            }
+            if (ReferenceEquals(null, other))
+            {
+                return 1;
+            }
+
+            // Compare formulas
+            var d = Molecule.CompareTo(other.Molecule);
+            if (d != 0)
+            {
+                return d;
+            }
+
+            // Compare mass offsets
+            d = MonoMassOffset.CompareTo(other.MonoMassOffset);
+            if (d != 0)
+            {
+                return d;
+            }
+            d = AverageMassOffset.CompareTo(other.AverageMassOffset);
+            if (d != 0)
+            {
+                return d;
+            }
+
+            return 0;
+        }
+
+
+        public int CompareTolerant(MoleculeMassOffset other, double massTolerance)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return 0;
+            }
+
+            if (ReferenceEquals(null, other))
+            {
+                return 1;
+            }
+
+            // Compare formulas
+            var d = Molecule.CompareTo(other.Molecule);
+            if (d != 0)
+            {
+                return d;
+            }
+
+            // Compare mass offsets
+            d = MonoMassOffset.CompareTolerant(other.MonoMassOffset, massTolerance);
+            if (d != 0)
+            {
+                return d;
+            }
+            d = AverageMassOffset.CompareTolerant(other.AverageMassOffset, massTolerance);
+            if (d != 0)
+            {
+                return d;
+            }
+
+            return 0;
+        }
+
+
 
         private static Molecule MoleculeFromEntries(IEnumerable<KeyValuePair<string, int>> entries)
         {

--- a/pwiz_tools/Shared/Common/Chemistry/SignedMz.cs
+++ b/pwiz_tools/Shared/Common/Chemistry/SignedMz.cs
@@ -77,7 +77,7 @@ namespace pwiz.Common.Chemistry
 
         public static SignedMz operator +(SignedMz mz, double step)
         {
-            return new SignedMz(mz.Value + step, mz.IsNegative);
+            return step == 0 ? mz : new SignedMz(mz.Value + step, mz.IsNegative);
         }
 
         public static SignedMz operator +(SignedMz mz, SignedMz step)
@@ -85,7 +85,7 @@ namespace pwiz.Common.Chemistry
             // Extra care necessary to deal with zero correctly
             if (mz.IsNegative != step.IsNegative && mz.Value != 0 && step.Value != 0)
                 throw new InvalidOperationException(@"polarity mismatch");
-            return new SignedMz(mz.Value + step.Value, mz.IsNegative || step.IsNegative);
+            return step.Value == 0 ? mz : new SignedMz(mz.Value + step.Value, mz.IsNegative || step.IsNegative);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace pwiz.Common.Chemistry
         /// </summary>
         public static SignedMz operator -(SignedMz mz, double step)
         {
-            return new SignedMz(mz.Value - step, mz.IsNegative);
+            return step == 0 ? mz : new SignedMz(mz.Value - step, mz.IsNegative);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace pwiz.Common.Chemistry
             // Extra care necessary to deal with zero correctly
             if (mz.IsNegative != step.IsNegative && mz.Value != 0 && step.Value != 0)
                 throw new InvalidOperationException(@"polarity mismatch");
-            return new SignedMz(mz.Value - step.Value, mz.IsNegative || step.IsNegative);
+            return step.Value == 0 ? mz : new SignedMz(mz.Value - step.Value, mz.IsNegative || step.IsNegative);
         }
 
         public static bool operator <(SignedMz mzA, SignedMz mzB)

--- a/pwiz_tools/Shared/Common/Chemistry/TypedMass.cs
+++ b/pwiz_tools/Shared/Common/Chemistry/TypedMass.cs
@@ -1,0 +1,334 @@
+﻿/*
+ * Original author: Brian Pratt <bspratt .at. proteinms.net>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2023 University of Washington - Seattle, WA
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using pwiz.Common.SystemUtil;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Diagnostics.Contracts;
+
+
+namespace pwiz.Common.Chemistry
+{
+    /// <summary>
+    /// There are many places where we carry a mass or massH and also need to track how it was derived
+    /// </summary>
+    public class TypedMass :  IComparable<TypedMass>, IEquatable<TypedMass>, IFormattable
+    {
+        public static TypedMass ZERO_AVERAGE_MASSNEUTRAL = new TypedMass(0.0, MassType.Average);
+        public static TypedMass ZERO_MONO_MASSNEUTRAL = new TypedMass(0.0, MassType.Monoisotopic);
+
+        public static TypedMass ZERO_AVERAGE_MASSH = new TypedMass(0.0, MassType.AverageMassH);
+        public static TypedMass ZERO_MONO_MASSH = new TypedMass(0.0, MassType.MonoisotopicMassH);
+
+        public static TypedMass ZERO_AVERAGE_MASSNEUTRAL_HEAVY = new TypedMass(0.0, MassType.AverageHeavy);
+        public static TypedMass ZERO_MONO_MASSNEUTRAL_HEAVY = new TypedMass(0.0, MassType.MonoisotopicHeavy);
+
+        public static TypedMass ZERO_AVERAGE_MASSH_HEAVY = new TypedMass(0.0, MassType.AverageMassH | MassType.bHeavy);
+        public static TypedMass ZERO_MONO_MASSH_HEAVY = new TypedMass(0.0, MassType.MonoisotopicMassH | MassType.bHeavy);
+
+
+        private readonly double _value;
+        private readonly MassType _massType;
+
+        public double Value { get { return _value; } }
+        public MassType MassType { get { return _massType; } }
+        [Pure]
+        public bool IsMassH() { return _massType.IsMassH();  }
+        [Pure]
+        public bool IsMonoIsotopic() { return _massType.IsMonoisotopic(); }
+        [Pure]
+        public bool IsAverage() { return _massType.IsAverage(); }
+        [Pure]
+        public bool IsHeavy() { return _massType.IsHeavy(); }
+        [Pure]
+        public static bool IsNullOrEmpty(TypedMass t) => ReferenceEquals(t, null) || t._value == 0;
+
+        private TypedMass(double value, MassType t)
+        {
+            _value = value;
+            _massType = t;
+        }
+
+        // Use this instead of ctor to avoid lots of copies of ZERO_*_*
+        public static TypedMass Create(double? value, MassType t)
+        {
+            if ((value??0) == 0)
+            {
+                if (t.IsAverage())
+                {
+                    return t.IsHeavy() ?
+                        (t.IsMassH() ? ZERO_AVERAGE_MASSH_HEAVY : ZERO_AVERAGE_MASSNEUTRAL_HEAVY) :
+                        (t.IsMassH() ? ZERO_AVERAGE_MASSH : ZERO_AVERAGE_MASSNEUTRAL);
+                }
+
+                return t.IsHeavy() ?
+                    (t.IsMassH() ? ZERO_MONO_MASSH_HEAVY : ZERO_MONO_MASSNEUTRAL_HEAVY) : 
+                    (t.IsMassH() ? ZERO_MONO_MASSH : ZERO_MONO_MASSNEUTRAL);
+            }
+
+            return new TypedMass(value.Value, t);
+        }
+
+        public static double MassProton
+        {
+            get { return 1.007276; } // Must agree with Skyline's BioMassCalc.MassProton (Skyline has a test for that)
+        }
+
+        public static double MassElectron
+        {
+            get { return 0.00054857990946; } // Must agree with Skyline's BioMassCalc.MassElectron (Skyline has a test for that)
+        }
+
+        [Pure]
+        public bool Equivalent(TypedMass other)
+        {
+            if (IsMassH() != other.IsMassH())
+            {
+                var adjust = IsMassH() ? - MassProton : MassProton;
+                return Math.Abs(_value + adjust - other.Value) < MassElectron;
+            }
+            return Equals(other); // Can't lead with this, as it will throw if IsMassH doesn't agree
+        }
+
+        public TypedMass ChangeIsMassH(bool newIsMassH)
+        {
+            if (Equals(newIsMassH, IsMassH()))
+            {
+                return this;
+            }
+            return TypedMass.Create(_value, newIsMassH ? _massType | MassType.bMassH : _massType & ~MassType.bMassH);
+        }
+
+        public TypedMass ChangeMass(double mass)
+        {
+            return (_value != mass) ? TypedMass.Create(mass, _massType) : this;
+        }
+
+        public TypedMass ChangeIsHeavy(bool newIsHeavy)
+        {
+            if (Equals(newIsHeavy, IsHeavy()))
+            {
+                return this;
+            }
+            return TypedMass.Create(_value, newIsHeavy ? _massType | MassType.bHeavy : _massType & ~MassType.bHeavy);
+        }
+
+        public TypedMass ChangeIsMonoIsotopic(bool bIsMono)
+        {
+            return (bIsMono == IsMonoIsotopic()) ?
+                this :
+                TypedMass.Create(_value, (_massType & ~(MassType.Monoisotopic | MassType.Average)) | (bIsMono ? MassType.Monoisotopic : MassType.Average));
+        }
+
+        public TypedMass ChangeMassType(MassType massType)
+        {
+            return (massType == _massType) ?
+                this :
+                TypedMass.Create(_value, massType);
+        }
+
+        public static implicit operator double(TypedMass d)
+        {
+            return d.Value;
+        }
+
+        public static TypedMass operator +(TypedMass tm, double step)
+        {
+            return step == 0 ? tm : TypedMass.Create(tm.Value + step, tm._massType);
+        }
+
+        public static TypedMass operator -(TypedMass tm, double step)
+        {
+            return step == 0 ? tm : TypedMass.Create(tm.Value - step, tm._massType);
+        }
+
+        public static TypedMass operator+(TypedMass tm, TypedMass step)
+        {
+            return step.Value == 0 && tm._massType == step._massType ? // If step is zero, and the mass types are the same, return the original
+                tm : 
+                tm.Value == 0 && tm._massType == step._massType ? // If tm is zero, and the mass types are the same, return the step
+                step :
+                Create(tm.Value + step.Value, tm._massType | step._massType); // Make sure that the mass type includes bHeavy if either is heavy
+        }
+
+        public static TypedMass operator -(TypedMass tm, TypedMass step)
+        {
+            return step.Value == 0 && tm._massType == step._massType ? // If step is zero, and the mass types are the same, return the original
+                tm : 
+                Create(tm.Value - step.Value, tm._massType | step._massType); // Make sure that the mass type includes bHeavy if either is heavy
+        }
+
+        public static TypedMass operator *(TypedMass tm, double step)
+        {
+            return step == 1 ? tm : TypedMass.Create(tm.Value * step, tm._massType);
+        }
+
+        public int CompareTo(TypedMass other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return 1;
+            }
+            Debug.Assert(_massType.IsMonoisotopic() == other._massType.IsMonoisotopic());  // It's a mistake to compare mono and average
+            var d = Value.CompareTo(other.Value);
+            return d;
+        }
+
+        public int CompareTolerant(TypedMass other, double tolerance)
+        {
+            var d = CompareTo(other);
+            if (d != 0)
+            {
+                if (Math.Abs(Value - other.Value) <= tolerance)
+                {
+                    return 0;
+                }
+            }
+            return d;
+        }
+
+        public static bool operator <(TypedMass massA, TypedMass massB)
+        {
+            return massA.CompareTo(massB) < 0;
+        }
+
+        public static bool operator <=(TypedMass massA, TypedMass massB)
+        {
+            return massA.CompareTo(massB) <= 0;
+        }
+
+        public static bool operator >=(TypedMass massA, TypedMass massB)
+        {
+            return massA.CompareTo(massB) >= 0;
+        }
+
+        public static bool operator >(TypedMass massA, TypedMass massB)
+        {
+            return massA.CompareTo(massB) > 0;
+        }
+
+        public static bool operator ==(TypedMass massA, TypedMass massB)
+        {
+            return ReferenceEquals(massA, null) ? ReferenceEquals(massB, null) : massA.CompareTo(massB) == 0;
+        }
+
+        public static bool operator !=(TypedMass massA, TypedMass massB)
+        {
+            return !(massA == massB);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TypedMass)obj);
+        }
+
+        public bool Equals(TypedMass other)
+        {
+            return CompareTo(other) == 0;
+        }
+
+        public bool Equals(TypedMass other, double tolerance)
+        {
+            return CompareTo(other) == 0 || Math.Abs(Value - other.Value) <= tolerance;
+        }
+
+        public override int GetHashCode()
+        {
+            var result = Value.GetHashCode();
+            result = (result * 397) ^ _massType.GetHashCode();
+            return result;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString(CultureInfo.CurrentCulture);
+        }
+
+        public string ToString(CultureInfo ci)
+        {
+            return Value.ToString(ci);
+        }
+
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            return Value.ToString(format, formatProvider);
+        }
+
+    }
+
+    /// <summary>
+    /// Enum used to specify the use of monoisotopic or average
+    /// masses when calculating molecular masses.
+    /// </summary>
+    [Flags]
+    [IgnoreEnumValues(new object[] {
+        bMassH,
+        bHeavy,
+        MonoisotopicMassH,
+        AverageMassH,
+        MonoisotopicHeavy,
+        AverageHeavy})]
+    public enum MassType
+    {
+        // ReSharper disable InconsistentNaming
+        Monoisotopic = 0,
+        Average = 1,
+        bMassH = 2, // As with peptides, where masses are traditionally given as massH
+        bHeavy = 4, // As with small molecules described by mass only, which have already been processed by isotope-declaring adducts
+        MonoisotopicMassH = Monoisotopic | bMassH,
+        AverageMassH = Average | bMassH,
+        MonoisotopicHeavy = Monoisotopic | bHeavy,
+        AverageHeavy = Average | bHeavy
+        // ReSharper restore InconsistentNaming
+    }
+
+    public static class MassTypeExtension
+    {
+        [Pure]
+        public static bool IsMonoisotopic(this MassType val)
+        {
+            return !val.IsAverage();
+        }
+
+        [Pure]
+        public static bool IsAverage(this MassType val)
+        {
+            return (val & MassType.Average) != 0;
+        }
+
+        [Pure]
+        public static bool IsMassH(this MassType val)
+        {
+            return (val & MassType.bMassH) != 0;
+        }
+
+        // For small molecule use: distinguishes a mass calculated from an isotope-specifying adduct
+        [Pure]
+        public static bool IsHeavy(this MassType val)
+        {
+            return (val & MassType.bHeavy) != 0;
+        }
+    }
+
+
+}

--- a/pwiz_tools/Shared/Common/CommonUtil.csproj
+++ b/pwiz_tools/Shared/Common/CommonUtil.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Chemistry\MoleculeMassOffset.cs" />
     <Compile Include="Chemistry\MzTolerance.cs" />
     <Compile Include="Chemistry\SignedMz.cs" />
+    <Compile Include="Chemistry\TypedMass.cs" />
     <Compile Include="Collections\AbstractReadOnlyCollection.cs" />
     <Compile Include="Collections\AbstractReadOnlyDictionary.cs" />
     <Compile Include="Collections\AbstractReadOnlyList.cs" />

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
@@ -366,10 +366,12 @@ namespace pwiz.Skyline.Controls.Graphs
             {
                 var maxIntensity = 0.0;
 
-                if (DisplayedSpectrum != null)
+                var hasDisplayedSpectrumValues = DisplayedSpectrum != null && DisplayedSpectrum.Intensities.Any();
+                if (hasDisplayedSpectrumValues)
                     maxIntensity = DisplayedSpectrum.Intensities.Max();
 
-                if (DisplayedMirrorSpectrum != null)
+                var hasDisplayedMirrorSpectrumValues = DisplayedMirrorSpectrum != null && DisplayedMirrorSpectrum.Intensities.Any();
+                if (hasDisplayedMirrorSpectrumValues)
                     maxIntensity = Math.Max(maxIntensity, DisplayedMirrorSpectrum.Intensities.Max());
                 if (maxIntensity == 0)
                 {
@@ -378,8 +380,8 @@ namespace pwiz.Skyline.Controls.Graphs
                 }
                 maxIntensity *= YMAX_SCALE;
 
-                GraphPane.YAxis.Scale.Max = DisplayedSpectrum == null ? 0.0 : maxIntensity;
-                GraphPane.YAxis.Scale.Min = DisplayedMirrorSpectrum == null ? 0.0 : -maxIntensity;
+                GraphPane.YAxis.Scale.Max = !hasDisplayedSpectrumValues ? 0.0 : maxIntensity;
+                GraphPane.YAxis.Scale.Min = !hasDisplayedMirrorSpectrumValues ? 0.0 : -maxIntensity;
             }
 
             graphControl.Refresh();

--- a/pwiz_tools/Skyline/Controls/SeqNode/TransitionGroupTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/TransitionGroupTreeNode.cs
@@ -23,6 +23,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using pwiz.Common.Chemistry;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
@@ -401,8 +402,8 @@ namespace pwiz.Skyline.Controls.SeqNode
                             return true;
                         }
                         else if (tranGroup.IsCustomIon && nodeTree.IsSynchable() &&
-                                 string.IsNullOrEmpty(tranGroupThis.CustomMolecule.Formula) ==
-                                 string.IsNullOrEmpty(tranGroup.CustomMolecule.Formula))
+                                 tranGroupThis.CustomMolecule.MoleculeAndMassOffset.IsMassOnly ==
+                                 tranGroup.CustomMolecule.MoleculeAndMassOffset.IsMassOnly)
                         {
                             return true;
                         }

--- a/pwiz_tools/Skyline/Controls/SeqNode/TransitionTreeNode.cs
+++ b/pwiz_tools/Skyline/Controls/SeqNode/TransitionTreeNode.cs
@@ -181,10 +181,10 @@ namespace pwiz.Skyline.Controls.SeqNode
             {
                 if (!string.IsNullOrEmpty(tran.CustomIon.Name))
                     labelPrefix = tran.CustomIon.Name + labelPrefixSpacer;
-                else if (!string.IsNullOrEmpty(tran.CustomIon.Formula))
-                    labelPrefix = tran.CustomIon.Formula + labelPrefixSpacer;
+                else if (tran.CustomIon.HasChemicalFormula)
+                    labelPrefix = tran.CustomIon.Formula + labelPrefixSpacer; // Show formula (e.g. C12H5 or maybe C12H5[-1.2/1.21]
                 else
-                    labelPrefix = string.Empty;
+                    labelPrefix = string.Empty; // Just show the mass
             }
             else
             {
@@ -269,7 +269,7 @@ namespace pwiz.Skyline.Controls.SeqNode
                     table.AddDetailRow(Resources.TransitionTreeNode_RenderTip_Library_intensity, MathEx.RoundAboveZero(intensity,
                         (intensity < 10 ? 1 : 0), 4).ToString(LocalizationHelper.CurrentCulture), rt);
                 }
-                if (nodeTran.Transition.IsCustom() && !string.IsNullOrEmpty(nodeTran.Transition.CustomIon.Formula))
+                if (nodeTran.Transition.IsCustom() && nodeTran.Transition.CustomIon.MoleculeAndMassOffset.HasChemicalFormula)
                 {
                     table.AddDetailRow(Resources.TransitionTreeNode_RenderTip_Formula, nodeTran.Transition.CustomIon.Formula + nodeTran.Transition.Adduct.AdductFormula.ToString(LocalizationHelper.CurrentCulture), rt);
                 }

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using pwiz.BiblioSpec;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Controls;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Alerts;

--- a/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
@@ -22,6 +22,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model.Crosslinking;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Lib;

--- a/pwiz_tools/Skyline/Model/Crosslinking/ComplexFragmentIon.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/ComplexFragmentIon.cs
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 using System;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;

--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
@@ -111,7 +111,7 @@ namespace pwiz.Skyline.Model.Crosslinking
                     parts.Add(crosslink.Crosslinker.GetMoleculeMassOffset());
                 }
             }
-            return FragmentedMolecule.SumMoleculeMassOffsets(parts);
+            return MoleculeMassOffset.Sum(parts);
         }
 
         public TypedMass GetFragmentMass(NeutralFragmentIon complexFragmentIon)
@@ -126,11 +126,11 @@ namespace pwiz.Skyline.Model.Crosslinking
             MassType massType = settings.TransitionSettings.Prediction.FragmentMassType;
             if (massType.IsMonoisotopic())
             {
-                return new TypedMass(fragmentedMoleculeSettings.GetMonoMass(formula.Molecule) + formula.MonoMassOffset + BioMassCalc.MassProton, MassType.MonoisotopicMassH);
+                return TypedMass.Create(fragmentedMoleculeSettings.GetMonoMass(formula.Molecule) + formula.MonoMassOffset + BioMassCalc.MassProton, MassType.MonoisotopicMassH);
             }
             else
             {
-                return new TypedMass(fragmentedMoleculeSettings.GetAverageMass(formula.Molecule) + formula.AverageMassOffset + BioMassCalc.MassProton, MassType.AverageMassH);
+                return TypedMass.Create(fragmentedMoleculeSettings.GetAverageMass(formula.Molecule) + formula.AverageMassOffset + BioMassCalc.MassProton, MassType.AverageMassH);
             }
         }
 
@@ -155,7 +155,7 @@ namespace pwiz.Skyline.Model.Crosslinking
                 mass += BioMassCalc.MassProton;
             }
 
-            return new TypedMass(mass, massType);
+            return TypedMass.Create(mass, massType);
         }
 
         private MassDistribution _precursorMassDistribution;
@@ -183,7 +183,7 @@ namespace pwiz.Skyline.Model.Crosslinking
             {
                 parts.Add(crosslink.Crosslinker.GetMoleculeMassOffset());
             }
-            return FragmentedMolecule.SumMoleculeMassOffsets(parts);
+            return MoleculeMassOffset.Sum(parts);
         }
 
         public FragmentedMolecule.Settings GetFragmentedMoleculeSettings()

--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkStructure.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkStructure.cs
@@ -139,7 +139,7 @@ namespace pwiz.Skyline.Model.Crosslinking
             for (int i = 0; i < LinkedPeptides.Count; i++)
             {
                 IPrecursorMassCalc massCalc = settings.GetPrecursorCalc(labelType, LinkedExplicitMods[i]);
-                parts.Add(new MoleculeMassOffset(Molecule.Parse(massCalc.GetMolecularFormula(LinkedPeptides[i].Sequence))));
+                parts.Add(massCalc.GetMolecularFormula(LinkedPeptides[i].Sequence));
             }
 
             foreach (var crosslink in Crosslinks)
@@ -147,7 +147,7 @@ namespace pwiz.Skyline.Model.Crosslinking
                 parts.Add(crosslink.Crosslinker.GetMoleculeMassOffset());
             }
 
-            return FragmentedMolecule.SumMoleculeMassOffsets(parts);
+            return MoleculeMassOffset.Sum(parts);
         }
 
         public bool IsConnected()

--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkedSequence.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkedSequence.cs
@@ -19,9 +19,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Skyline.Model.DocSettings;
-using pwiz.Skyline.Util;
 
 namespace pwiz.Skyline.Model.Crosslinking
 {

--- a/pwiz_tools/Skyline/Model/CustomMolecule.cs
+++ b/pwiz_tools/Skyline/Model/CustomMolecule.cs
@@ -371,7 +371,7 @@ namespace pwiz.Skyline.Model
 
     public class CustomMolecule : IValidating, IComparable<CustomMolecule>
     {
-        private string _formula;
+        private MoleculeMassOffset _formulaAndOrMass;
         public const double MAX_MASS = 160000;
         public const double MIN_MASS = MeasuredIon.MIN_REPORTER_MASS;
 
@@ -383,50 +383,77 @@ namespace pwiz.Skyline.Model
         /// <param name="averageMass">The average mass of the molecule (can be calculated by the formula)</param>
         /// <param name="name">The arbitrary name given to this molecule</param>
         /// <param name="moleculeAccessionNumbers">Provides InChiKey, CAS number etc</param>
-        protected CustomMolecule(string formula, double? monoisotopicMass, double? averageMass, string name, MoleculeAccessionNumbers moleculeAccessionNumbers = null)
-            : this(formula, new TypedMass(monoisotopicMass ?? averageMass ?? 0, MassType.Monoisotopic),
-                            new TypedMass(averageMass ?? monoisotopicMass ?? 0, MassType.Average), name, moleculeAccessionNumbers)
+        public CustomMolecule(string formula, double? monoisotopicMass, double? averageMass, string name, MoleculeAccessionNumbers moleculeAccessionNumbers = null)
+            : this(formula, 
+                TypedMass.Create(monoisotopicMass ?? averageMass ?? 0, MassType.Monoisotopic),
+                TypedMass.Create(averageMass ?? monoisotopicMass ?? 0, MassType.Average), 
+                name, moleculeAccessionNumbers)
         {
         }
 
         public CustomMolecule(string formula, string name = null, MoleculeAccessionNumbers moleculeAccessionNumbers = null)
-            : this(formula, null, null, name, moleculeAccessionNumbers)
+            : this(formula, TypedMass.ZERO_MONO_MASSNEUTRAL, TypedMass.ZERO_AVERAGE_MASSNEUTRAL, name, moleculeAccessionNumbers)
         {
         }
-
+        
         public CustomMolecule(TypedMass monoisotopicMass, TypedMass averageMass, string name = null, MoleculeAccessionNumbers moleculeAccessionNumbers = null)
-            : this(null, monoisotopicMass, averageMass, name, moleculeAccessionNumbers)
+            : this(string.Empty, monoisotopicMass, averageMass, name, moleculeAccessionNumbers)
         {
         }
 
-        public static CustomMolecule FromSmallMoleculeLibraryAttributes(SmallMoleculeLibraryAttributes libraryAttributes)
+        public CustomMolecule(string formula, TypedMass monoisotopicMass, TypedMass averageMass, string name = null, MoleculeAccessionNumbers moleculeAccessionNumbers = null)
+            : this(ParsedMoleculeMassOffset.Create(formula, monoisotopicMass ?? TypedMass.ZERO_MONO_MASSNEUTRAL, averageMass ?? TypedMass.ZERO_AVERAGE_MASSNEUTRAL), name, moleculeAccessionNumbers)
         {
-            Assume.IsFalse(libraryAttributes.IsEmpty);
-            SmallMoleculeLibraryAttributes.ParseMolecularFormulaOrMassesString(libraryAttributes.ChemicalFormulaOrMassesString, out var formula, out var monoMass, out var averageMass);
-            return new CustomMolecule(formula, monoMass, averageMass, libraryAttributes.MoleculeName, libraryAttributes.CreateMoleculeID());
         }
 
-        public CustomMolecule(string formula, TypedMass monoisotopicMass, TypedMass averageMass, string name, MoleculeAccessionNumbers moleculeAccessionNumbers)
+        public CustomMolecule(MoleculeMassOffset mol, string name, MoleculeAccessionNumbers moleculeAccessionNumbers = null)
         {
-            Formula = formula;
-            MonoisotopicMass = monoisotopicMass;
-            AverageMass = averageMass;
+            SetFormula(mol);
             Name = name ?? string.Empty;
             AccessionNumbers = moleculeAccessionNumbers ?? MoleculeAccessionNumbers.EMPTY;
             Validate();
         }
 
+        public CustomMolecule(CustomMolecule other)
+        {
+            _formulaAndOrMass = other._formulaAndOrMass;
+            Name = other.Name;
+            MoleculeAndMassOffset = other.MoleculeAndMassOffset;
+            UnlabeledFormula = other.UnlabeledFormula;
+            AccessionNumbers = other.AccessionNumbers;
+        }
+
+        public static CustomMolecule FromSmallMoleculeLibraryAttributes(SmallMoleculeLibraryAttributes libraryAttributes)
+        {
+            Assume.IsFalse(libraryAttributes.IsEmpty);
+            var mol = libraryAttributes.ChemicalFormulaOrMasses;
+            return new CustomMolecule(mol, libraryAttributes.MoleculeName, libraryAttributes.CreateMoleculeID());
+        }
+
+        private void SetFormula(MoleculeMassOffset mol)
+        {
+            MoleculeAndMassOffset = mol;
+        }
+
         public static CustomMolecule EMPTY = new CustomMolecule
         {
-            Formula = string.Empty,
-            MonoisotopicMass =  TypedMass.ZERO_MONO_MASSH,
-            AverageMass = TypedMass.ZERO_AVERAGE_MASSNEUTRAL,
+            MoleculeAndMassOffset = ParsedMoleculeMassOffset.EMPTY,
+            AccessionNumbers = MoleculeAccessionNumbers.EMPTY,
             Name = string.Empty
         };
 
         public static bool IsNullOrEmpty(CustomMolecule mol)
         {
             return mol == null || mol.IsEmpty;
+        }
+
+        public bool HasChemicalFormula => _formulaAndOrMass!= null && _formulaAndOrMass.HasChemicalFormula;
+
+        public CustomMolecule AdjustElementCount(string element, int adjustCountBy)
+        {
+            return adjustCountBy == 0 ? 
+                this : 
+                new CustomMolecule(MoleculeAndMassOffset.AdjustElementCount(element, adjustCountBy), this.Name, this.AccessionNumbers);
         }
 
         /// <summary>
@@ -448,39 +475,46 @@ namespace pwiz.Skyline.Model
                        Name.Replace(TextUtil.SEPARATOR_TSV_STR, @" "); // Tab is a reserved char in our lib cache scheme
             }
         }
-        public string SecondaryEquivalenceKey { get { return UnlabeledFormula; } }
+        public string SecondaryEquivalenceKey { get { return UnlabeledFormula.IsMassOnly ? string.Empty : UnlabeledFormula.ToString(); } }
 
         [Track]
         public string Name { get; protected set; }
 
         [Track]
-        public string Formula // The molecular formula - may contain isotopes
+        public string Formula => _formulaAndOrMass?.ToString();
+
+        public MoleculeMassOffset MoleculeAndMassOffset // The molecular formula and/or unknown masses - may contain isotopes
         {
-            get { return _formula; }
+            get { return _formulaAndOrMass; }
             protected set
             {
-                _formula = BioMassCalc.MONOISOTOPIC.RegularizeFormula(value ?? string.Empty); // e.g. XeC12N1H0 => XeC12N1
-                var unlabeled = string.IsNullOrEmpty(_formula) ? _formula : BioMassCalc.MONOISOTOPIC.StripLabelsFromFormula(_formula);
-                UnlabeledFormula = Equals(_formula, unlabeled) ? _formula : unlabeled;
+                _formulaAndOrMass = value ?? MoleculeMassOffset.EMPTY;
+                UnlabeledFormula = BioMassCalc.StripLabelsFromFormula(_formulaAndOrMass);
             }
         } 
 
-        public string UnlabeledFormula { get; private set; } // Formula with any heavy isotopes translated to light
+        public MoleculeMassOffset UnlabeledFormula { get; private set; } // Formula with any heavy isotopes translated to light
 
         public MoleculeAccessionNumbers AccessionNumbers { get; private set; } // InChiKey, CAS, etc to match blib, (see pwiz_tools\BiblioSpec\src\SmallMolMetadata.h)
 
-        public TypedMass MonoisotopicMass { get; private set; }
-        public TypedMass AverageMass { get; private set; }
+        public TypedMass MonoisotopicMass  // Calculated mass of formula, or explicitly set mass (which clears any formula)
+        {
+            get => BioMassCalc.MONOISOTOPIC.CalculateMass(_formulaAndOrMass);
+        }
 
-        protected const int DEFAULT_ION_MASS_PRECISION = 6;
+        public TypedMass AverageMass // Calculated mass, or explicitly set mass (which clears any formula)
+        {
+            get => BioMassCalc.AVERAGE.CalculateMass(_formulaAndOrMass);
+        }
+
+        protected const int DEFAULT_ION_MASS_PRECISION = BioMassCalc.MassPrecision;
         protected static readonly string massFormat = @"{0} [{1:F0"+DEFAULT_ION_MASS_PRECISION+@"}/{2:F0"+DEFAULT_ION_MASS_PRECISION+@"}]";
         protected static readonly string massFormatSameMass = @"{0} [{1:F0" + DEFAULT_ION_MASS_PRECISION + @"}]";
         protected const string massFormatRegex = @"(?:[a-z][a-z]+)\s+\[([+-]?\d*\.\d+)(?![-+0-9\.])\/([+-]?\d*\.\d+)(?![-+0-9\.])\]";
 
         public SmallMoleculeLibraryAttributes GetSmallMoleculeLibraryAttributes()
         {
-            return SmallMoleculeLibraryAttributes.Create(Name, Formula,
-                MonoisotopicMass, AverageMass, // In case forumla is empty
+            return SmallMoleculeLibraryAttributes.Create(Name, MoleculeAndMassOffset,
                 AccessionNumbers.GetInChiKey(), AccessionNumbers.GetNonInChiKeys());
         }
 
@@ -505,9 +539,9 @@ namespace pwiz.Skyline.Model
 
         public List<string> AsFields()
         {
-            var massOrFormula = !string.IsNullOrEmpty(Formula) ?
-                Formula :
-                FormattedMasses(MonoisotopicMass, AverageMass);
+            var massOrFormula = MoleculeAndMassOffset.IsMassOnly ? 
+                FormattedMasses(MonoisotopicMass, AverageMass) : // e.g. "1.2345678/1.2345679"
+                MoleculeAndMassOffset.ToString(SERIALIZATION_DIGITS); // e.g. "C12H5[+1.2345678/1.2345679]"
             var parts = new[] { Name, massOrFormula, AccessionNumbers.ToString() };
             return (parts.All(string.IsNullOrEmpty) ? new[] { InvariantName } : parts).ToList();
         }
@@ -532,8 +566,8 @@ namespace pwiz.Skyline.Model
                 {
                     try
                     {
-                        var massMono = new TypedMass(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture), MassType.Monoisotopic);
-                        var massAvg =  new TypedMass(double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture), MassType.Average);
+                        var massMono = TypedMass.Create(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture), MassType.Monoisotopic);
+                        var massAvg =  TypedMass.Create(double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture), MassType.Average);
                         return new CustomMolecule(massMono, massAvg);
                     }
                     catch
@@ -542,15 +576,12 @@ namespace pwiz.Skyline.Model
                     }
                 }
             }
-            else if (formula != null && formula.Contains(MASS_SPLITTER))
+            else if (formula != null && (formula.Contains(MASS_SPLITTER) || MoleculeMassOffset.ContainsMassOffsetCue(formula)))
             {
-                // "formula" is actually mono and average masses
+                // "formula" is actually mono and average masses, e.g. "1.23/1.24", or possibly a formula and mass offset e.g. "C12H5[-1.2/1.21]"
                 try
                 {
-                    var values = formula.Split(MASS_SPLITTER);
-                    var massMono = new TypedMass(double.Parse(values[0], CultureInfo.InvariantCulture), MassType.Monoisotopic);
-                    var massAvg = new TypedMass(double.Parse(values[1], CultureInfo.InvariantCulture), MassType.Average);
-                    return new CustomMolecule(massMono, massAvg, name, new MoleculeAccessionNumbers(keysTSV));
+                    return new CustomMolecule(ParsedMoleculeMassOffset.Create(formula), name, new MoleculeAccessionNumbers(keysTSV));
                 }
                 catch
                 {
@@ -560,11 +591,11 @@ namespace pwiz.Skyline.Model
             return new CustomMolecule(formula, null, null, name, new MoleculeAccessionNumbers(keysTSV));
         }
 
-        public CustomMolecule ChangeFormula(string formula)
+        public CustomMolecule ChangeFormula(MoleculeMassOffset formula)
         {
-            if (Equals(Formula, formula))
+            if (Equals(MoleculeAndMassOffset, formula))
                 return this;
-            return new CustomMolecule(formula, null, null, Name, AccessionNumbers);
+            return new CustomMolecule(formula, Name, AccessionNumbers);
         }
 
         public string DisplayName
@@ -579,8 +610,8 @@ namespace pwiz.Skyline.Model
                 return Name;
             else if (!string.IsNullOrEmpty(key = PrimaryEquivalenceKey))
                 return key;
-            else if (!string.IsNullOrEmpty(Formula))
-                return Formula;
+            else if (!MoleculeAndMassOffset.IsMassOnly)
+                return MoleculeAndMassOffset.ToString();
             else if (tolerance != null)
             {
                 // Display mass at same precision as the tolerance value. Also do not repeat mass if mono and average are the same.
@@ -602,14 +633,16 @@ namespace pwiz.Skyline.Model
                 var key = PrimaryEquivalenceKey;
                 if (!string.IsNullOrEmpty(key))
                     return key;
-                else if (!string.IsNullOrEmpty(Formula))
-                    return Formula;
+                else if (!MoleculeAndMassOffset.IsMassOnly)
+                    return MoleculeAndMassOffset.ToString();
                 else
                     return String.Format(CultureInfo.InvariantCulture, massFormat, InvariantNameDetail, MonoisotopicMass, AverageMass);
             }
         }
 
         public const string INVARIANT_NAME_DETAIL = "Molecule";
+        private const int SERIALIZATION_DIGITS = 9; // Number of digits to use when serializing masses
+        private const double SERIALIZATION_TOLERANCE = 5E-10; // Tolerance for comparing serializing masses
         public virtual string InvariantNameDetail { get { return INVARIANT_NAME_DETAIL; } } 
         public virtual string DisplayNameDetail { get { return Resources.CustomMolecule_DisplayName_Molecule; } }
 
@@ -620,18 +653,6 @@ namespace pwiz.Skyline.Model
 
         public void Validate()
         {
-            if (!string.IsNullOrEmpty(Formula))
-            {
-                try
-                {
-                    MonoisotopicMass = SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, Formula);
-                    AverageMass = SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, Formula);
-                }
-                catch (ArgumentException x)
-                {
-                    throw new InvalidDataException(x.Message, x);  // Pass original as inner exception
-                }
-            }
             if (AverageMass == 0 || MonoisotopicMass == 0)
                 throw new InvalidDataException(Resources.CustomMolecule_Validate_Custom_molecules_must_specify_a_formula_or_valid_monoisotopic_and_average_masses_);
             if(AverageMass > MAX_MASS || MonoisotopicMass > MAX_MASS)
@@ -648,9 +669,7 @@ namespace pwiz.Skyline.Model
             {
                 return ReferenceEquals(this, EMPTY) ||
                        string.IsNullOrEmpty(Name) &&
-                       string.IsNullOrEmpty(Formula) &&
-                       MonoisotopicMass.Value == 0 &&
-                       AverageMass.Value == 0 &&
+                       MoleculeMassOffset.IsNullOrEmpty(MoleculeAndMassOffset) &&
                        AccessionNumbers.IsEmpty;
             }
         }
@@ -673,7 +692,7 @@ namespace pwiz.Skyline.Model
         {
             unchecked
             {
-                int hashCode = (Formula != null ? Formula.GetHashCode() : 0);
+                int hashCode = (MoleculeAndMassOffset != null ? MoleculeAndMassOffset.GetHashCode() : 0);
                 hashCode = (hashCode*397) ^ (Name != null ? Name.GetHashCode() : 0);
                 hashCode = (hashCode*397) ^ MonoisotopicMass.GetHashCode();
                 hashCode = (hashCode * 397) ^ AverageMass.GetHashCode();
@@ -729,9 +748,9 @@ namespace pwiz.Skyline.Model
             var mass = reader.GetNullableDoubleAttribute(ATTR.mass_average); // Pre-3.62 we wrote out massH for custom ions but not for reporter ions
             if (mass.HasValue)
             {
-                return new TypedMass(mass.Value, (this is SettingsCustomIon) ? MassType.Average : MassType.AverageMassH);
+                return TypedMass.Create(mass.Value, (this is SettingsCustomIon) ? MassType.Average : MassType.AverageMassH);
             }
-            return new TypedMass(reader.GetDoubleAttribute(ATTR.neutral_mass_average), MassType.Average); 
+            return TypedMass.Create(reader.GetDoubleAttribute(ATTR.neutral_mass_average), MassType.Average); 
         }
 
         public TypedMass ReadMonoisotopicMass(XmlReader reader)
@@ -739,9 +758,9 @@ namespace pwiz.Skyline.Model
             var mass = reader.GetNullableDoubleAttribute(ATTR.mass_monoisotopic); // Pre-3.62 we wrote out massH for custom ions but not for reporter ions
             if (mass.HasValue)
             {
-                return new TypedMass(mass.Value, (this is SettingsCustomIon) ? MassType.Monoisotopic : MassType.MonoisotopicMassH);
+                return TypedMass.Create(mass.Value, (this is SettingsCustomIon) ? MassType.Monoisotopic : MassType.MonoisotopicMassH);
             }
-            return new TypedMass(reader.GetDoubleAttribute(ATTR.neutral_mass_monoisotopic), MassType.Monoisotopic);
+            return TypedMass.Create(reader.GetDoubleAttribute(ATTR.neutral_mass_monoisotopic), MassType.Monoisotopic);
         }
 
         /// <summary>
@@ -759,35 +778,42 @@ namespace pwiz.Skyline.Model
         protected virtual void ReadAttributes(XmlReader reader, out Adduct embeddedAdduct)
         {
 
-            var formula = reader.GetAttribute(ATTR.formula);
-            if (!string.IsNullOrEmpty(formula))
+            var text = reader.GetAttribute(ATTR.formula);
+            text = text?.Trim(); // We've seen some trailing spaces in the wild
+            MoleculeMassOffset formula;
+            try
             {
-                formula = BioMassCalc.AddH(formula);  // Update this old style formula to current by adding the hydrogen we formerly left out due to assuming protonation
+                text = Adduct.FindInFormula(text, out embeddedAdduct);
+                formula = ParsedMoleculeMassOffset.Create(text);
+                if (!string.IsNullOrEmpty(text))
+                {
+                    formula = formula.AdjustElementCount(BioMassCalc.H, 1);  // Update this old style formula to current by adding the hydrogen we formerly left out due to assuming protonation
+                }
+                else
+                {
+                    text = reader.GetAttribute(ATTR.ion_formula) ?? reader.GetAttribute(ATTR.neutral_formula);
+                    text = Adduct.FindInFormula(text, out embeddedAdduct);
+                    formula = ParsedMoleculeMassOffset.Create(text);
+                }
             }
-            else
+            catch (Exception e)
             {
-                var text = reader.GetAttribute(ATTR.ion_formula) ?? reader.GetAttribute(ATTR.neutral_formula);
-                if (text != null)
-                    text = text.Trim(); // We've seen some trailing spaces in the wild
-                formula = text;
+                throw new InvalidDataException(e.Message, e);
             }
-            string neutralFormula;
-            Molecule mol;
-            // We commonly see the adduct inline with the neutral formula ("C12H5[M+Na]"), so be ready to preserve that
-            if (IonInfo.IsFormulaWithAdduct(formula, out mol, out embeddedAdduct, out neutralFormula))
+
+            var averageMass = ReadAverageMass(reader);
+            var monoisotopicMass = ReadMonoisotopicMass(reader);
+
+            if ((averageMass == 0) != (monoisotopicMass == 0))
             {
-                formula = neutralFormula;
+                // Expected both or neither to be zero
+                throw new InvalidDataException(Resources.CustomMolecule_Validate_Custom_molecules_must_specify_a_formula_or_valid_monoisotopic_and_average_masses_);
             }
-            else
-            {
-                embeddedAdduct = Adduct.EMPTY;
-            }
-            if (string.IsNullOrEmpty(formula))
-            {
-                AverageMass = ReadAverageMass(reader);
-                MonoisotopicMass = ReadMonoisotopicMass(reader);
-            }
-            Formula = formula;
+
+            SetFormula(MoleculeMassOffset.IsNullOrEmpty(formula) ? 
+                // ReSharper disable once PossibleNullReferenceException
+                formula.ChangeMassOffset(monoisotopicMass.ChangeIsMassH(false), averageMass.ChangeIsMassH(false)) : // Mass-only description
+                formula);
 
             Name = reader.GetAttribute(ATTR.custom_ion_name);
 
@@ -805,18 +831,18 @@ namespace pwiz.Skyline.Model
         {
             if (adduct.IsEmpty)
             {
-                writer.WriteAttributeIfString(ATTR.neutral_formula, Formula);
+                writer.WriteAttributeIfString(ATTR.neutral_formula,  MoleculeAndMassOffset.IsMassOnly ? string.Empty : MoleculeAndMassOffset.ToString()); // If it's mass only, let ATTR.neutral_mass_* show that
             }
             else
             {
-                writer.WriteAttributeIfString(ATTR.ion_formula, 
-                    (Formula ?? string.Empty) + 
-                    (adduct.IsProteomic ? string.Empty : adduct.ToString())); 
+                writer.WriteAttributeIfString(ATTR.ion_formula,
+                    (MoleculeAndMassOffset.IsMassOnly ? string.Empty : MoleculeAndMassOffset.ToString()) + // If it's mass only, let ATTR.neutral_mass_* show that
+                                                        (adduct.IsProteomic ? string.Empty : adduct.ToString())); 
             }
             Assume.IsFalse(AverageMass.IsMassH()); // We're going to read these as neutral masses
             Assume.IsFalse(MonoisotopicMass.IsMassH());
-            writer.WriteAttributeNullable(ATTR.neutral_mass_average, AverageMass);
-            writer.WriteAttributeNullable(ATTR.neutral_mass_monoisotopic, MonoisotopicMass);
+            writer.WriteAttributeNullable(ATTR.neutral_mass_average, MoleculeAndMassOffset.IsMassOnly ? AverageMass : Math.Round(AverageMass, BioMassCalc.MassPrecision));
+            writer.WriteAttributeNullable(ATTR.neutral_mass_monoisotopic, MoleculeAndMassOffset.IsMassOnly ? MonoisotopicMass : Math.Round(MonoisotopicMass, BioMassCalc.MassPrecision));
             if (!string.IsNullOrEmpty(Name))
                 writer.WriteAttribute(ATTR.custom_ion_name, Name);
             writer.WriteAttributeIfString(ATTR.id, AccessionNumbers.ToSerializableString());
@@ -829,15 +855,10 @@ namespace pwiz.Skyline.Model
             var result = string.CompareOrdinal(Name, other.Name);
             if (result == 0)
             {
-                result = string.CompareOrdinal(Formula, other.Formula);
+                result = MoleculeAndMassOffset.CompareTolerant(other.MoleculeAndMassOffset, SERIALIZATION_TOLERANCE);  // Allow for float vs double serialization effects
                 if (result == 0)
                 {
                     result = AccessionNumbers.CompareTo(other.AccessionNumbers);
-                    if (result == 0)
-                    {
-                        result = MonoisotopicMass.Equals(other.MonoisotopicMass, 5E-10) ? // Allow for float vs double serialization effects
-                            0 : MonoisotopicMass.CompareTo(other.MonoisotopicMass);
-                    }
                 }
             }
             return result;

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
@@ -137,11 +137,11 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         }
 
         // Helper function for PrecursorIonFormula and PrecursorNeutralFormula
-        private void GetPrecursorFormulaAndAdduct(out Adduct adduct, out string formula)
+        private void GetPrecursorFormulaAndAdduct(out Adduct adduct, out MoleculeMassOffset formula)
         {
             if (IsSmallMolecule())
             {
-                formula = (DocNode.CustomMolecule.Formula ?? string.Empty);
+                formula = DocNode.CustomMolecule.MoleculeAndMassOffset;
                 adduct = DocNode.PrecursorAdduct;
             }
             else
@@ -149,7 +149,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
                 var crosslinkBuilder = new CrosslinkBuilder(SrmDocument.Settings, DocNode.TransitionGroup.Peptide,
                     Peptide.DocNode.ExplicitMods, DocNode.LabelType);
                 adduct = Util.Adduct.FromChargeProtonated(Charge);
-                formula = crosslinkBuilder.GetPrecursorFormula().Molecule.ToString();
+                formula = crosslinkBuilder.GetPrecursorFormula();
             }
         }
 
@@ -159,10 +159,8 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             get
             {
                 // Given formula C12H8O3 and adduct M3H2+H, apply label 3H2 and ionization +H to return C12H'3H6
-                Adduct adduct;
-                string formula;
-                GetPrecursorFormulaAndAdduct(out adduct, out formula);
-                return string.IsNullOrEmpty(formula) ? string.Empty : adduct.ApplyToFormula(formula);
+                GetPrecursorFormulaAndAdduct(out var adduct, out var formula);
+                return MoleculeMassOffset.IsNullOrEmpty(formula) ? string.Empty : adduct.ApplyToMolecule(formula).ToString();
             }
         }
 
@@ -172,10 +170,9 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             get
             {
                 // Given formula C12H8O3 and adduct M3H2+H, apply label 3H2 but not ionization +H to return C12H'3H5
-                Adduct adduct;
-                string formula;
-                GetPrecursorFormulaAndAdduct(out adduct, out formula);
-                return string.IsNullOrEmpty(formula) ? string.Empty : adduct.ApplyIsotopeLabelsToFormula(formula);
+                // Given formula C12H8O3 and adduct M(-0.234)+H, apply mass-only label (-0.234) but not ionization +H to return C12H8O3[-0.234]
+                GetPrecursorFormulaAndAdduct(out var adduct, out var formula);
+                return MoleculeMassOffset.IsNullOrEmpty(formula) ? string.Empty : adduct.ApplyIsotopeLabelsToMolecule(formula).ToString();
             }
         }
 

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Transition.cs
@@ -127,11 +127,8 @@ namespace pwiz.Skyline.Model.Databinding.Entities
 
                 var neutralFormula = GetNeutralProductFormula();
                 var adduct = DocNode.Transition.Adduct;
-                var formulaWithAdductApplied = adduct.ApplyToMolecule(neutralFormula.Molecule);
-                var moleculeMassOffsetWithAdductApplied = new MoleculeMassOffset(
-                    Molecule.FromDict(formulaWithAdductApplied), neutralFormula.MonoMassOffset,
-                    neutralFormula.AverageMassOffset);
-                return moleculeMassOffsetWithAdductApplied.Molecule.ToString();
+                var formulaWithAdductApplied = adduct.ApplyToMolecule(neutralFormula);
+                return formulaWithAdductApplied.ToString();
             }
         }
         public string ProductNeutralFormula

--- a/pwiz_tools/Skyline/Model/DdaSearch/MsFraggerSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MsFraggerSearchEngine.cs
@@ -645,7 +645,7 @@ add_Nterm_protein = 0.000000
             foreach (var mod in fixedAndVariableModifs)
             {
                 // can't use mod with no formula or mass; CONSIDER throwing exception
-                if (mod.LabelAtoms == LabelAtoms.None && mod.Formula == null && mod.MonoisotopicMass == null ||
+                if (mod.LabelAtoms == LabelAtoms.None && mod.ParsedMoleculeMassOffset == null && mod.MonoisotopicMass == null ||
                     mod.LabelAtoms != LabelAtoms.None && mod.AAs.IsNullOrEmpty())
                     continue;
 
@@ -692,7 +692,7 @@ add_Nterm_protein = 0.000000
 
                 if (mod.LabelAtoms == LabelAtoms.None)
                 {
-                    double mass = mod.MonoisotopicMass ?? SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, mod.Formula, SequenceMassCalc.MassPrecision).Value;
+                    double mass = mod.MonoisotopicMass ?? SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, mod.ParsedMoleculeMassOffset, SequenceMassCalc.MassPrecision).Value;
 
                     string residues = string.Empty;
                     if (position.IsNullOrEmpty() || mod.AAs == null)

--- a/pwiz_tools/Skyline/Model/DdaSearch/MsgfPlusSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MsgfPlusSearchEngine.cs
@@ -238,7 +238,7 @@ namespace pwiz.Skyline.Model.DdaSearch
                         continue;
 
                     // can't use mod with no formula or mass; CONSIDER throwing exception
-                    if (mod.LabelAtoms == LabelAtoms.None && mod.Formula == null && mod.MonoisotopicMass == null ||
+                    if (mod.LabelAtoms == LabelAtoms.None && mod.ParsedMoleculeMassOffset == null && mod.MonoisotopicMass == null ||
                         mod.LabelAtoms != LabelAtoms.None && mod.AAs.IsNullOrEmpty())
                         continue;
 
@@ -273,7 +273,11 @@ namespace pwiz.Skyline.Model.DdaSearch
                         }
                     }
                     else
-                        addMod(mod.Formula ?? mod.MonoisotopicMass.ToString(), mod.AAs ?? @"*");
+                    {
+                        // ReSharper disable once PossibleNullReferenceException
+                        var modString = ParsedMoleculeMassOffset.IsNullOrEmpty(mod.ParsedMoleculeMassOffset) ? null : mod.ParsedMoleculeMassOffset.ToString();
+                        addMod(modString ?? mod.MonoisotopicMass.ToString(), mod.AAs ?? @"*");
+                    }
                 }
             }
         }

--- a/pwiz_tools/Skyline/Model/DocNode.cs
+++ b/pwiz_tools/Skyline/Model/DocNode.cs
@@ -1333,10 +1333,31 @@ namespace pwiz.Skyline.Model
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            var equal = base.Equals(obj) 
-                && ArrayUtil.EqualsDeep(obj.Children, Children)
-                && AutoManageChildren == obj.AutoManageChildren;
-            return equal; // For debugging convenience
+
+            if (!base.Equals(obj))
+            {
+                return false;
+            }
+
+            if (Children.Count != obj.Children.Count)
+            {
+                return false;
+            }
+
+            // This could be handled more compactly (though no more efficiently) by EqualsDeep, but that makes it difficult to set breakpoints
+            for (var i = 0; i < Children.Count; i++)
+            {
+                if (Children[i] == null && obj.Children[i] != null)
+                {
+                    return false;
+                }
+                if (!Children[i].Equals(obj.Children[i]))
+                {
+                    return false;
+                }
+            }
+
+            return AutoManageChildren == obj.AutoManageChildren;
         }
 
         public override bool Equals(object obj)

--- a/pwiz_tools/Skyline/Model/DocSettings/Loss.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Loss.cs
@@ -25,6 +25,7 @@ using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 using JetBrains.Annotations;
+using pwiz.Common.Chemistry;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.AuditLog;
 using pwiz.Skyline.Model.Serialization;
@@ -76,7 +77,7 @@ namespace pwiz.Skyline.Model.DocSettings
         public const double MIN_LOSS_MASS = 0.0001;
         public const double MAX_LOSS_MASS = 5000;
 
-        private string _formula;
+        private ParsedMoleculeMassOffset _formula;
 
         public FragmentLoss(string formula)
             : this(formula, null, null)
@@ -87,30 +88,32 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             MonoisotopicMass = monoisotopicMass ?? 0;
             AverageMass = averageMass ?? 0;
-            Formula = formula;
+            ParsedMoleculeMassOffset = ParsedMoleculeMassOffset.Create(formula);
             Inclusion = inclusion;
 
             Validate();
         }
 
         [Track]
-        public string Formula
+        public string Formula => ParsedMoleculeMassOffset.IsNullOrEmpty(ParsedMoleculeMassOffset) ? null : ParsedMoleculeMassOffset.ToString();
+
+        public ParsedMoleculeMassOffset ParsedMoleculeMassOffset
         {
             get { return _formula; }
             private set
             {
-                _formula = value;
-                if (_formula != null)
+                _formula = value ?? ParsedMoleculeMassOffset.EMPTY;
+                if (!ParsedMoleculeMassOffset.IsNullOrEmpty(_formula))
                 {
-                    MonoisotopicMass = SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, Formula, SequenceMassCalc.MassPrecision);
-                    AverageMass = SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, Formula, SequenceMassCalc.MassPrecision);
+                    MonoisotopicMass = SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, _formula, SequenceMassCalc.MassPrecision);
+                    AverageMass = SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, _formula, SequenceMassCalc.MassPrecision);
                 }
             }
         }
 
         public string FormulaNoNull
         {
-            get { return _formula ?? Resources.Loss_FormulaUnknown; }
+            get { return ParsedMoleculeMassOffset.IsNullOrEmpty(_formula) ? Resources.Loss_FormulaUnknown : _formula.ToString(); }
         }
 
         [Track]
@@ -147,7 +150,7 @@ namespace pwiz.Skyline.Model.DocSettings
             get
             {
                 StringBuilder stringBuilder = new StringBuilder();
-                stringBuilder.Append(StaticMod.FormatFormulaOrMass(Formula, -MonoisotopicMass, -AverageMass));
+                stringBuilder.Append(StaticMod.FormatFormulaOrMass(_formula, -MonoisotopicMass, -AverageMass));
                 if (Charge != 0)
                 {
                     stringBuilder.Append(Adduct.FromChargeProtonated(Charge));
@@ -232,7 +235,7 @@ namespace pwiz.Skyline.Model.DocSettings
             // Read tag attributes
             MonoisotopicMass = reader.GetNullableDoubleAttribute(ATTR.massdiff_monoisotopic) ?? 0;
             AverageMass = reader.GetNullableDoubleAttribute(ATTR.massdiff_average) ?? 0;
-            Formula = reader.GetAttribute(ATTR.formula);
+            ParsedMoleculeMassOffset = ParsedMoleculeMassOffset.Create(reader.GetAttribute(ATTR.formula));
             Inclusion = reader.GetEnumAttribute(ATTR.inclusion, LossInclusion.Library);
             Charge = reader.GetIntAttribute(ATTR.charge, 0);
 
@@ -272,7 +275,7 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Equals(other.Formula, Formula) &&
+            return Equals(other.ParsedMoleculeMassOffset, ParsedMoleculeMassOffset) &&
                    other.MonoisotopicMass.Equals(MonoisotopicMass) &&
                    other.AverageMass.Equals(AverageMass) &&
                    other.Inclusion.Equals(Inclusion) &&
@@ -291,7 +294,7 @@ namespace pwiz.Skyline.Model.DocSettings
         {
             unchecked
             {
-                int result = (Formula != null ? Formula.GetHashCode() : 0);
+                int result = (ParsedMoleculeMassOffset != null ? ParsedMoleculeMassOffset.GetHashCode() : 0);
                 result = (result * 397) ^ MonoisotopicMass.GetHashCode();
                 result = (result * 397) ^ AverageMass.GetHashCode();
                 result = (result * 397) ^ Inclusion.GetHashCode();

--- a/pwiz_tools/Skyline/Model/DocSettings/MeasuredIon.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/MeasuredIon.cs
@@ -264,9 +264,9 @@ namespace pwiz.Skyline.Model.DocSettings
                 if (charges.Any())  // Old style - fix it up a little for our revised ideas about custom ion ionization
                 {
                     adduct = Adduct.FromChargeNoMass(charges[0]);
-                    if (string.IsNullOrEmpty(parsedIon.NeutralFormula)) // Adjust the user-supplied masses
+                    if (parsedIon.MoleculeAndMassOffset.IsMassOnly) // Adjust the user-supplied masses
                     {
-                        SettingsCustomIon = new SettingsCustomIon(parsedIon.NeutralFormula, adduct,
+                        SettingsCustomIon = new SettingsCustomIon(string.Empty, adduct,
                             Math.Round(parsedIon.MonoisotopicMass + charges[0]*BioMassCalc.MONOISOTOPIC.GetMass(BioMassCalc.H), SequenceMassCalc.MassPrecision), // Assume user provided neutral mass.  Round new value easiest XML roundtripping.
                             Math.Round(parsedIon.AverageMass + charges[0]*BioMassCalc.AVERAGE.GetMass(BioMassCalc.H), SequenceMassCalc.MassPrecision), // Assume user provided neutral mass.  Round new value easiest XML roundtripping.
                             parsedIon.Name);
@@ -276,7 +276,7 @@ namespace pwiz.Skyline.Model.DocSettings
                         if (charges[0] > 1) // XML deserializer will have added an H already
                         {
                             var adductProtonated = Adduct.FromChargeProtonated(charges[0]-1);
-                            var formula = adductProtonated.ApplyToFormula(parsedIon.NeutralFormula);
+                            var formula = adductProtonated.ApplyToMolecule(parsedIon.MoleculeAndMassOffset).Molecule.ToString();
                             parsedIon = new CustomIon(formula, adduct, parsedIon.MonoisotopicMass, parsedIon.AverageMass, Name);
                         }
                     }
@@ -287,7 +287,7 @@ namespace pwiz.Skyline.Model.DocSettings
                 }
                 if (SettingsCustomIon == null)
                 {
-                    SettingsCustomIon = new SettingsCustomIon(parsedIon.NeutralFormula, adduct,
+                    SettingsCustomIon = new SettingsCustomIon(parsedIon.MoleculeAndMassOffset.ToString(), adduct,
                         parsedIon.MonoisotopicMass,
                         parsedIon.AverageMass,
                         parsedIon.Name);
@@ -313,7 +313,7 @@ namespace pwiz.Skyline.Model.DocSettings
             }
             else
             {
-                writer.WriteAttributeIfString(ATTR.ion_formula, SettingsCustomIon.NeutralFormula);
+                writer.WriteAttributeIfString(ATTR.ion_formula, SettingsCustomIon.MoleculeAndMassOffset.IsMassOnly ? null : SettingsCustomIon.MoleculeAndMassOffset.ToString());
                 // Masses are information only, if there is a formula, but Panorama may need these
                 writer.WriteAttribute(ATTR.mass_monoisotopic, SettingsCustomIon.MonoisotopicMass.Value);
                 writer.WriteAttribute(ATTR.mass_average, SettingsCustomIon.AverageMass.Value);

--- a/pwiz_tools/Skyline/Model/DocSettings/Modification.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Modification.cs
@@ -151,7 +151,7 @@ namespace pwiz.Skyline.Model.DocSettings
             AAs = aas;
             Terminus = term;
             IsVariable = IsExplicit = isVariable;   // All variable mods are explicit
-            Formula = formula;
+            ParsedMoleculeMassOffset = string.IsNullOrEmpty(formula) ? null : ParsedMoleculeMassOffset.Create(formula);
             LabelAtoms = labelAtoms;
             RelativeRT = relativeRT;
             MonoisotopicMass = monoMass;
@@ -176,7 +176,10 @@ namespace pwiz.Skyline.Model.DocSettings
         public bool IsVariable { get; private set; }
 
         [Track]
-        public string Formula { get; private set; }
+        public string Formula => ParsedMoleculeMassOffset?.ToString();
+
+        public ParsedMoleculeMassOffset ParsedMoleculeMassOffset { get; private set; } // Using ParsedMolecule because we want to retain serialized element order
+
         [Track]
         public double? MonoisotopicMass { get; private set; }
         [Track]
@@ -333,7 +336,7 @@ namespace pwiz.Skyline.Model.DocSettings
         /// </summary>
         public bool HasMod
         {
-            get { return (Formula != null || LabelAtoms != LabelAtoms.None || MonoisotopicMass.HasValue); }
+            get { return (ParsedMoleculeMassOffset != null || LabelAtoms != LabelAtoms.None || MonoisotopicMass.HasValue); }
         }
 
         public bool IsLoss(char aa, int indexAA, int len)
@@ -381,14 +384,14 @@ namespace pwiz.Skyline.Model.DocSettings
 
         public CrosslinkerSettings CrosslinkerSettings { get; private set; }
 
-        public MoleculeMassOffset GetMoleculeMassOffset()
+        public ParsedMoleculeMassOffset GetMoleculeMassOffset()
         {
-            if (string.IsNullOrEmpty(Formula))
+            if (ParsedMoleculeMassOffset.IsNullOrEmpty(ParsedMoleculeMassOffset))
             {
-                return new MoleculeMassOffset(Molecule.Empty, MonoisotopicMass ?? 0, AverageMass ?? 0);
+                return ParsedMoleculeMassOffset.Create(MonoisotopicMass??0, AverageMass??0);
             }
 
-            return new MoleculeMassOffset(Molecule.ParseExpression(Formula), 0, 0);
+            return ParsedMoleculeMassOffset;
         }
 
         public ItemDescription ItemDescription
@@ -468,7 +471,7 @@ namespace pwiz.Skyline.Model.DocSettings
                 {
                     if (HasMod || !HasLoss)
                     {
-                        lines.Add(summary = FormatFormulaOrMass(Formula, MonoisotopicMass, AverageMass));
+                        lines.Add(summary = FormatFormulaOrMass(ParsedMoleculeMassOffset, MonoisotopicMass, AverageMass));
                     }
                 }
 
@@ -525,11 +528,11 @@ namespace pwiz.Skyline.Model.DocSettings
         /// For example: H2O (-18)
         /// If the formula is blank then return <see cref="FormatMass"/>
         /// </summary>
-        public static string FormatFormulaOrMass(string formula, double? monoMass, double? averageMass)
+        public static string FormatFormulaOrMass(ParsedMoleculeMassOffset formula, double? monoMass, double? averageMass)
         {
-            if (!string.IsNullOrEmpty(formula))
+            if (!ParsedMoleculeMassOffset.IsNullOrEmpty(formula))
             {
-                var parts = new List<string> { formula };
+                var parts = new List<string> { formula.ToString() };
                 if (monoMass.HasValue)
                 {
                     var massString = monoMass.Value.ToString(@"0.#");
@@ -594,9 +597,9 @@ namespace pwiz.Skyline.Model.DocSettings
             return ChangeProp(ImClone(this), im => im.IsVariable = im.IsExplicit = prop);
         }
 
-        public StaticMod ChangeFormula(string prop)
+        public StaticMod ChangeFormula(ParsedMoleculeMassOffset prop)
         {
-            return ChangeProp(ImClone(this), im => im.Formula = prop);
+            return ChangeProp(ImClone(this), im => im.ParsedMoleculeMassOffset = prop);
         }
 
         public StaticMod ChangeLabelAtoms(LabelAtoms prop)
@@ -705,7 +708,7 @@ namespace pwiz.Skyline.Model.DocSettings
             {
                 throw new InvalidDataException(Resources.StaticMod_Validate_Terminal_modification_with_labeled_atoms_not_allowed);
             }
-            if (Formula == null && LabelAtoms == LabelAtoms.None)
+            if (ParsedMoleculeMassOffset == null && LabelAtoms == LabelAtoms.None)
             {
                 if (MonoisotopicMass == null || AverageMass == null)
                 {
@@ -722,16 +725,16 @@ namespace pwiz.Skyline.Model.DocSettings
                 // No explicit masses with formula or label atoms
                 if (MonoisotopicMass != null || AverageMass != null)
                     throw new InvalidDataException(Resources.StaticMod_Validate_Modification_with_a_formula_may_not_specify_modification_masses);
-                if (Formula != null)
+                if (ParsedMoleculeMassOffset != null)
                 {
-                    if (string.IsNullOrEmpty(Formula))
+                    if (ParsedMoleculeMassOffset.IsNullOrEmpty(ParsedMoleculeMassOffset))
                         throw new InvalidDataException(Resources.StaticMod_Validate_Modification_formula_may_not_be_empty);
                     if (LabelAtoms != LabelAtoms.None)
                         throw new InvalidDataException(Resources.StaticMod_Validate_Formula_not_allowed_with_labeled_atoms);
                     // Cache mass values to improve performance of variable modifications
                     // Throws an exception, if given an invalid formula.
-                    MonoisotopicMass = SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, Formula, SequenceMassCalc.MassPrecision);
-                    AverageMass = SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, Formula, SequenceMassCalc.MassPrecision);
+                    MonoisotopicMass = SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, ParsedMoleculeMassOffset, SequenceMassCalc.MassPrecision);
+                    AverageMass = SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, ParsedMoleculeMassOffset, SequenceMassCalc.MassPrecision);
                 }
             }
 
@@ -774,7 +777,8 @@ namespace pwiz.Skyline.Model.DocSettings
 
             Terminus = reader.GetAttribute(ATTR.terminus, ToModTerminus);
             IsVariable = IsExplicit = reader.GetBoolAttribute(ATTR.variable);
-            Formula = reader.GetAttribute(ATTR.formula);
+            var formula = reader.GetAttribute(ATTR.formula);
+            ParsedMoleculeMassOffset = string.IsNullOrEmpty(formula) ? null : ParsedMoleculeMassOffset.Create(formula);
             if (reader.GetBoolAttribute(ATTR.label_13C))
                 LabelAtoms |= LabelAtoms.C13;
             if (reader.GetBoolAttribute(ATTR.label_15N))
@@ -835,7 +839,7 @@ namespace pwiz.Skyline.Model.DocSettings
             writer.WriteAttributeIfString(ATTR.aminoacid, AAs);
             writer.WriteAttributeNullable(ATTR.terminus, Terminus);
             writer.WriteAttribute(ATTR.variable, IsVariable);
-            writer.WriteAttributeIfString(ATTR.formula, Formula);
+            writer.WriteAttributeIfString(ATTR.formula, ParsedMoleculeMassOffset.IsNullOrEmpty(ParsedMoleculeMassOffset) ? null : ParsedMoleculeMassOffset.ToString());
             writer.WriteAttribute(ATTR.label_13C, Label13C);
             writer.WriteAttribute(ATTR.label_15N, Label15N);
             writer.WriteAttribute(ATTR.label_18O, Label18O);
@@ -844,7 +848,7 @@ namespace pwiz.Skyline.Model.DocSettings
 //            writer.WriteAttribute(ATTR.label_37Cl, Label37Cl);
 //            writer.WriteAttribute(ATTR.label_81Br, Label81Br);
             writer.WriteAttribute(ATTR.relative_rt, RelativeRT, RelativeRT.Matching);
-            if (string.IsNullOrEmpty(Formula))
+            if (ParsedMoleculeMassOffset.IsNullOrEmpty(ParsedMoleculeMassOffset))
             {
                 writer.WriteAttributeNullable(ATTR.massdiff_monoisotopic, MonoisotopicMass);
                 writer.WriteAttributeNullable(ATTR.massdiff_average, AverageMass);
@@ -945,41 +949,19 @@ namespace pwiz.Skyline.Model.DocSettings
 
         private bool EquivalentFormulas(FragmentLoss loss1, FragmentLoss loss2)
         {
-            return ArrayUtil.EqualsDeep(GetFormulaCounts(loss1.Formula).ToArray(),
-                                        GetFormulaCounts(loss2.Formula).ToArray());
-        }
-
-        private IDictionary<string, int> GetFormulaCounts(string formula)
-        {
-            SortedDictionary<string, int> dictCounts = new SortedDictionary<string, int>();
-            BioMassCalc.MONOISOTOPIC.ParseCounts(ref formula, dictCounts, false);
-            return dictCounts;
+            return loss1.ParsedMoleculeMassOffset.Equals(loss2.ParsedMoleculeMassOffset);
         }
 
         private bool EquivalentFormulas(char aa, StaticMod obj)
         {
             SequenceMassCalc modCalc = new SequenceMassCalc(MassType.Monoisotopic);
 
-            double unexplainedMassThis, unexplainedMassObj;
+            var formulaThis = modCalc.GetModFormula(aa, this);
+            var formulaObj = modCalc.GetModFormula(aa, obj);
 
-            string formulaThis = modCalc.GetModFormula(aa, this, out unexplainedMassThis);
-            string formulaObj = modCalc.GetModFormula(aa, obj, out unexplainedMassObj);
-
-            // If either is null, both must be null.
-            if (formulaThis == null || formulaObj == null)
-                return formulaThis == null && formulaObj == null;
-
-            return unexplainedMassThis == unexplainedMassObj &&
-                   ArrayUtil.EqualsDeep(GetFormulaModCounts(formulaThis).ToArray(),
-                                        GetFormulaModCounts(formulaObj).ToArray());
+            return formulaThis.Equals(formulaObj);
         }
 
-        private IDictionary<string, int> GetFormulaModCounts(string formula)
-        {
-            SortedDictionary<string, int> dictCounts = new SortedDictionary<string, int>();
-            SequenceMassCalc.ParseModCounts(BioMassCalc.MONOISOTOPIC, formula, dictCounts);
-            return dictCounts;
-        }
 
         public bool Equals(StaticMod obj)
         {
@@ -1005,7 +987,7 @@ namespace pwiz.Skyline.Model.DocSettings
                 result = (result*397) ^ (Terminus.HasValue ? Terminus.Value.GetHashCode() : 0);
                 result = (result*397) ^ IsVariable.GetHashCode();
                 result = (result*397) ^ (AverageMass.HasValue ? AverageMass.Value.GetHashCode() : 0);
-                result = (result*397) ^ (Formula != null ? Formula.GetHashCode() : 0);
+                result = (result*397) ^ (ParsedMoleculeMassOffset != null ? ParsedMoleculeMassOffset.GetHashCode() : 0);
                 result = (result*397) ^ IsExplicit.GetHashCode();
                 result = (result*397) ^ LabelAtoms.GetHashCode();
                 result = (result*397) ^ RelativeRT.GetHashCode();

--- a/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
@@ -314,7 +314,7 @@ namespace pwiz.Skyline.Model.DocSettings
             return precursorCalc.GetPrecursorMass(seq);
         }
 
-        public TypedMass GetPrecursorMass(IsotopeLabelType labelType, CustomMolecule mol, TypedModifications mods, Adduct adductForIsotopeLabels, out string isotopicFormula)
+        public TypedMass GetPrecursorMass(IsotopeLabelType labelType, CustomMolecule mol, TypedModifications mods, Adduct adductForIsotopeLabels, out MoleculeMassOffset isotopicFormula)
         {
             return GetPrecursorCalc(labelType, ExplicitMods.EMPTY).GetPrecursorMass(mol, mods, adductForIsotopeLabels, out isotopicFormula);
         }
@@ -425,7 +425,7 @@ namespace pwiz.Skyline.Model.DocSettings
             return new Target(strModifiedSequence);
         }
 
-        public Adduct GetModifiedAdduct(Adduct adduct, string neutralFormula,
+        public Adduct GetModifiedAdduct(Adduct adduct, MoleculeMassOffset neutralFormula,
                                           IsotopeLabelType labelType,
                                           ExplicitMods mods)
         {
@@ -2284,18 +2284,18 @@ namespace pwiz.Skyline.Model.DocSettings
     {
         MassType MassType { get; }
         TypedMass GetPrecursorMass(Target seq);
-        TypedMass GetPrecursorMass(CustomMolecule custom, TypedModifications mods, Adduct adductForIsotopeLabels, out string isotopicFormula);
+        TypedMass GetPrecursorMass(CustomMolecule custom, TypedModifications mods, Adduct adductForIsotopeLabels, out MoleculeMassOffset isotopicFormula);
         bool IsModified(Target seq);
         Target GetModifiedSequence(Target seq, bool narrow);
         Target GetModifiedSequence(Target seq, SequenceModFormatType format, bool explicitModsOnly);
         Target GetModifiedSequenceDisplay(Target seq);
         double GetAAModMass(char aa, int seqIndex, int seqLength);
         MassDistribution GetMzDistribution(Target target, Adduct adduct, IsotopeAbundances abundances);
-        MassDistribution GetMZDistributionFromFormula(string formula, Adduct adduct, IsotopeAbundances abundances);
+        MassDistribution GetMZDistribution(MoleculeMassOffset formula, Adduct adduct, IsotopeAbundances abundances);
         MassDistribution GetMZDistributionSinglePoint(double mz);
-        string GetMolecularFormula(string peptideSequence);
+        MoleculeMassOffset GetMolecularFormula(string peptideSequence);
         bool HasLabels { get; }
-        Adduct GetModifiedAdduct(Adduct adduct, string neutralFormula);
+        Adduct GetModifiedAdduct(Adduct adduct, MoleculeMassOffset neutralFormula);
     }
 
     /// <summary>

--- a/pwiz_tools/Skyline/Model/DocSettings/TransitionSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/TransitionSettings.cs
@@ -742,7 +742,7 @@ namespace pwiz.Skyline.Model.DocSettings
 
         public static ImmutableList<Adduct> MakeChargeCollection(IList<Adduct> charges)
         {
-            var arrayCharges = charges.ToArrayStd();
+            var arrayCharges = charges.Select(adduct => adduct.Unlabeled).Distinct().ToArray(); // Ignore any isotope labeling in small mol adducts
             Array.Sort(arrayCharges);
             return MakeReadOnly(arrayCharges);
         }

--- a/pwiz_tools/Skyline/Model/DocSettings/UniMod.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/UniMod.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
 

--- a/pwiz_tools/Skyline/Model/Esp/EspFeatureCalc.cs
+++ b/pwiz_tools/Skyline/Model/Esp/EspFeatureCalc.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using pwiz.Skyline.Util;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Util.Extensions;
 
 namespace pwiz.Skyline.Model.Esp

--- a/pwiz_tools/Skyline/Model/IonMobility/DbPrecursorAndIonMobility.cs
+++ b/pwiz_tools/Skyline/Model/IonMobility/DbPrecursorAndIonMobility.cs
@@ -234,7 +234,7 @@ namespace pwiz.Skyline.Model.IonMobility
                 PeptideModifiedSequence = string.Empty;
                 var smallMoleculeLibraryAttributes = target.Molecule.GetSmallMoleculeLibraryAttributes();
                 MoleculeName = smallMoleculeLibraryAttributes.MoleculeName ?? string.Empty;
-                ChemicalFormula = smallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString ?? string.Empty;
+                ChemicalFormula = (smallMoleculeLibraryAttributes.ChemicalFormulaOrMasses ?? MoleculeMassOffset.EMPTY).ToString();
                 InChiKey = smallMoleculeLibraryAttributes.InChiKey ?? string.Empty;
                 OtherKeys = smallMoleculeLibraryAttributes.OtherKeys ?? string.Empty;
             }
@@ -254,10 +254,8 @@ namespace pwiz.Skyline.Model.IonMobility
         {
             get
             {
-                SmallMoleculeLibraryAttributes.ParseMolecularFormulaOrMassesString(ChemicalFormula,
-                    out var molecularFormula, out var massMono, out var massAverage);
                 return string.IsNullOrEmpty(PeptideModifiedSequence)
-                    ? SmallMoleculeLibraryAttributes.Create(MoleculeName, molecularFormula, massMono, massAverage, InChiKey, OtherKeys)
+                    ? SmallMoleculeLibraryAttributes.Create(MoleculeName, ChemicalFormula, InChiKey, OtherKeys)
                     : SmallMoleculeLibraryAttributes.EMPTY;
             }
         }

--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpec.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpec.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;

--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -797,7 +797,7 @@ namespace pwiz.Skyline.Model.Lib
                                 TypedMass monoMass = precursorAdduct.MassFromMz(precursorMz, MassType.Monoisotopic);
                                 TypedMass avgMass = precursorAdduct.MassFromMz(precursorMz, MassType.Average);
                                 smallMoleculeLibraryAttributes = SmallMoleculeLibraryAttributes.Create(moleculeName,
-                                    null, monoMass, avgMass, inChiKey, otherKeys);
+                                    ParsedMoleculeMassOffset.Create(null, monoMass, avgMass), inChiKey, otherKeys);
                             }
                             else
                             {
@@ -1305,6 +1305,10 @@ namespace pwiz.Skyline.Model.Lib
 
         protected override SpectrumPeaksInfo.MI[] ReadSpectrum(BiblioLiteSpectrumInfo info)
         {
+            if (info.NumPeaks == 0)
+            {
+                return Array.Empty<SpectrumPeaksInfo.MI>();
+            }
             return _sqliteConnection.ExecuteWithConnection(connection =>
             {
                 using (SQLiteCommand select = new SQLiteCommand(_sqliteConnection.Connection))
@@ -1425,6 +1429,10 @@ namespace pwiz.Skyline.Model.Lib
 
         private SpectrumPeaksInfo.MI[] ReadPeaks(SQLiteDataReader reader, int numPeaks, int refSpectraId, PooledSqliteConnection connection)
         {
+            if (numPeaks == 0)
+            {
+                return Array.Empty<SpectrumPeaksInfo.MI>();
+            }
             const int sizeMz = sizeof(double);
             const int sizeInten = sizeof(float);
 
@@ -1935,7 +1943,7 @@ namespace pwiz.Skyline.Model.Lib
                     {
                         string filePath = reader.GetString(iFilePath);
                         int redundantId = iRedundantId < 0 ? -1 : reader.GetInt32(iRedundantId);
-                        double retentionTime = reader.GetDouble(iRetentionTime);
+                        var retentionTime = UtilDB.GetNullableDouble(reader, iRetentionTime);
                         bool isBest = !hasRetentionTimesTable || reader.GetInt16(iBestSpectrum) != 0;
 
                         IonMobilityAndCCS ionMobilityInfo = IonMobilityAndCCS.EMPTY;

--- a/pwiz_tools/Skyline/Model/Lib/BlibData/DbRefSpectraPeakAnnotations.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BlibData/DbRefSpectraPeakAnnotations.cs
@@ -60,7 +60,7 @@ namespace pwiz.Skyline.Model.Lib.BlibData
                                 RefSpectra = refSpectra,
                                 PeakIndex = i,
                                 Name = annotation.Ion.Name,
-                                Formula = annotation.Ion.NeutralFormula,
+                                Formula = annotation.Ion.MoleculeAndMassOffset.ToString(),
                                 InchiKey = annotation.Ion.AccessionNumbers.GetInChiKey(),
                                 OtherKeys = annotation.Ion.AccessionNumbers.GetNonInChiKeys(),
                                 Adduct = annotation.Ion.Adduct.ToString(),

--- a/pwiz_tools/Skyline/Model/Lib/ChromLib/ChromatogramLibrary.cs
+++ b/pwiz_tools/Skyline/Model/Lib/ChromLib/ChromatogramLibrary.cs
@@ -490,8 +490,8 @@ namespace pwiz.Skyline.Model.Lib.ChromLib
                             var accessionNumbers = MoleculeAccessionNumbers.FromSerializableString(peptide13.MoleculeAccession);
 
                             var molecule = formula == null ? 
-                                new CustomMolecule(new TypedMass(peptide13.MassMonoisotopic, MassType.Monoisotopic), 
-                                    new TypedMass(peptide13.MassAverage, MassType.Average), name, accessionNumbers) : 
+                                new CustomMolecule(TypedMass.Create(peptide13.MassMonoisotopic, MassType.Monoisotopic), 
+                                    TypedMass.Create(peptide13.MassAverage, MassType.Average), name, accessionNumbers) : 
                                 new CustomMolecule(formula, name, accessionNumbers);
                             dictMolecules.Add(peptideId, molecule);
                             dictMoleculeLists.Add(peptideId, peptide13.Protein); // For small molecules "Protein" is really molecule list name

--- a/pwiz_tools/Skyline/Model/Lib/Library.cs
+++ b/pwiz_tools/Skyline/Model/Lib/Library.cs
@@ -1866,6 +1866,7 @@ namespace pwiz.Skyline.Model.Lib
 
     public sealed class SpectrumPeaksInfo
     {
+        public static SpectrumPeaksInfo EMPTY = new SpectrumPeaksInfo(Array.Empty<MI>());
         public SpectrumPeaksInfo(MI[] spectrum)
         {
             Peaks = spectrum;
@@ -2047,95 +2048,54 @@ namespace pwiz.Skyline.Model.Lib
         }
 
         // Helper for library caches
-        public static SmallMoleculeLibraryAttributes FromBytes(byte[] buf, int offset)
+        public static void ParseMolecularFormulaOrMassesString(string molecularFormulaOrMassesString, out ParsedMoleculeMassOffset mol)
         {
-            var itemLengths = new int[nItems];
-            var itemStarts = new int[nItems];
-            for (var i = 0; i < nItems; i++)
-            {
-                // read item length
-                itemLengths[i] = Library.GetInt32(buf, i, offset);
-                itemStarts[i] = i == 0 ? offset + nItems * sizeof(int) : itemStarts[i - 1] + itemLengths[i - 1];
-            }
-            return Create(
-                Encoding.UTF8.GetString(buf, itemStarts[0], itemLengths[0]),
-                Encoding.UTF8.GetString(buf, itemStarts[1], itemLengths[1]),
-                Encoding.UTF8.GetString(buf, itemStarts[2], itemLengths[2]),
-                Encoding.UTF8.GetString(buf, itemStarts[3], itemLengths[3]));
-        }
-
-        public static void ParseMolecularFormulaOrMassesString(string molecularFormulaOrMassesString,
-            out string molecularFormula, out TypedMass? massMono, out TypedMass? massAverage)
-        {
-            if (molecularFormulaOrMassesString != null && molecularFormulaOrMassesString.Contains(CustomMolecule.MASS_SPLITTER))
+            TypedMass massMono = null;
+            TypedMass massAverage = null;
+            string molecularFormula = null;
+            if (molecularFormulaOrMassesString != null && 
+                molecularFormulaOrMassesString.Contains(CustomMolecule.MASS_SPLITTER) && // e.g. "1.23/1.24", a mass-only record
+                !molecularFormulaOrMassesString.Contains(MoleculeMassOffset.MASS_MOD_CUE_PLUS) &&  // But not "[+1.23/1.24]" or  "[-1.23/1.24]" a mass offset record
+                !molecularFormulaOrMassesString.Contains(MoleculeMassOffset.MASS_MOD_CUE_MINUS))
             {
                 var parts = molecularFormulaOrMassesString.Split(CustomMolecule.MASS_SPLITTER); // We didn't have a formula so we saved masses
-                massMono = new TypedMass(double.Parse(parts[0], CultureInfo.InvariantCulture), MassType.Monoisotopic);
-                massAverage = new TypedMass(double.Parse(parts[1], CultureInfo.InvariantCulture), MassType.Average);
-                molecularFormula = null;
+                massMono = TypedMass.Create(double.Parse(parts[0], CultureInfo.InvariantCulture), MassType.Monoisotopic);
+                massAverage = TypedMass.Create(double.Parse(parts[1], CultureInfo.InvariantCulture), MassType.Average);
             }
             else
             {
-                massMono = null;
-                massAverage = null;
                 molecularFormula = molecularFormulaOrMassesString;
             }
+            mol = ParsedMoleculeMassOffset.Create(molecularFormula, massMono, massAverage);
         }
 
-        public static string FormatChemicalFormulaOrMassesString(string chemicalFormula, TypedMass? massMono, TypedMass? massAverage) // For serialization - represents formula or masses, depending on what's available
+        public string FormatChemicalFormulaOrMassesString() // For serialization - represents formula or masses, depending on what's available
         {
-            if (!string.IsNullOrEmpty(chemicalFormula))
+            if (MoleculeMassOffset.IsNullOrEmpty(ChemicalFormulaOrMasses))
             {
-                return chemicalFormula;
-
+                return string.Empty;
             }
-            if (massMono != null && massAverage != null)
+            if (!ChemicalFormulaOrMasses.IsMassOnly)
             {
-                Assume.IsTrue(massMono.Value.IsMonoIsotopic());
-                Assume.IsTrue(massAverage.Value.IsAverage());
-                return CustomMolecule.FormattedMasses(massMono.Value.Value, massAverage.Value.Value); // Format as dd.ddd/dd.ddd
+                // Return formula and mass offsets if any e.g. "C12H5[-1.23/1.24]"
+                return ChemicalFormulaOrMasses.ToString();
             }
-
-            return string.Empty;
+            else
+            {
+                // Return our traditional mass-only description y e.g. "1.23/1.24"
+                return CustomMolecule.FormattedMasses(ChemicalFormulaOrMasses.MonoMassOffset.Value, ChemicalFormulaOrMasses.AverageMassOffset.Value); // Format as dd.ddd/dd.ddd
+            }
         }
 
-        public static byte[] ToBytes(SmallMoleculeLibraryAttributes attributes)
-        {
-            attributes = attributes ?? EMPTY;
-            // Encode as <length><item><length><item>etc
-            var items = new List<byte[]>
-            {
-                Encoding.UTF8.GetBytes(attributes.MoleculeName ?? string.Empty),
-                Encoding.UTF8.GetBytes(attributes.ChemicalFormulaOrMassesString ?? string.Empty), // If no formula provided, encode monoMass and averageMass instead
-                Encoding.UTF8.GetBytes(attributes.InChiKey ?? string.Empty),
-                Encoding.UTF8.GetBytes(attributes.OtherKeys ?? string.Empty)
-            };
-            Assume.IsTrue(Equals(nItems,items.Count));
-            var results = new byte[items.Sum(item => item.Length + sizeof(int))];
-            var index = 0;
-            foreach (var item in items)
-            {
-                Array.Copy(BitConverter.GetBytes(item.Length), 0, results, index, sizeof(int));
-                index += sizeof(int);
-            }
-            foreach (var item in items)
-            {
-                Array.Copy(item, 0, results, index, item.Length);
-                index += item.Length;
-            }
-            return results;
-        }
-
-        public static SmallMoleculeLibraryAttributes Create(string moleculeName, string chemicalFormula, TypedMass? massMono, TypedMass? massAverage,
+        public static SmallMoleculeLibraryAttributes Create(string moleculeName, MoleculeMassOffset molecule,
             string inChiKey, string otherKeys)
         {
-            if (string.IsNullOrEmpty(moleculeName) && string.IsNullOrEmpty(chemicalFormula) &&
-                massMono == null && massAverage == null &&
+            if (string.IsNullOrEmpty(moleculeName) && MoleculeMassOffset.IsNullOrEmpty(molecule) &&
                 string.IsNullOrEmpty(inChiKey) && string.IsNullOrEmpty(otherKeys))
             {
                 return EMPTY;
             }
-            return new SmallMoleculeLibraryAttributes(moleculeName, chemicalFormula, massMono, massAverage, inChiKey, otherKeys);
+            return new SmallMoleculeLibraryAttributes(moleculeName, molecule, inChiKey, otherKeys);
         }
 
         public static SmallMoleculeLibraryAttributes Create(string moleculeName, string chemicalFormulaOrMassesString,
@@ -2147,29 +2107,49 @@ namespace pwiz.Skyline.Model.Lib
         public static SmallMoleculeLibraryAttributes Create(string moleculeName, string chemicalFormulaOrMassesString,
             string inChiKey, string otherKeys)
         {
-            ParseMolecularFormulaOrMassesString(chemicalFormulaOrMassesString,
-                out var chemicalFormula, out var massMono, out var massAverage);
-            if (string.IsNullOrEmpty(moleculeName) && string.IsNullOrEmpty(chemicalFormula) &&
-                massMono == null && massAverage == null &&
-                string.IsNullOrEmpty(inChiKey) && string.IsNullOrEmpty(otherKeys))
+            try
             {
-                return EMPTY;
+                var moleculeMassOffset = ParsedMoleculeMassOffset.Create(chemicalFormulaOrMassesString);
+                if (string.IsNullOrEmpty(moleculeName) && ParsedMoleculeMassOffset.IsNullOrEmpty(moleculeMassOffset) &&
+                    string.IsNullOrEmpty(inChiKey) && string.IsNullOrEmpty(otherKeys))
+                {
+                    return EMPTY;
+                }
+                return new SmallMoleculeLibraryAttributes(moleculeName, moleculeMassOffset, inChiKey, otherKeys);
             }
-            return new SmallMoleculeLibraryAttributes(moleculeName, chemicalFormula, massMono, massAverage, inChiKey, otherKeys);
+            catch (ArgumentException e)
+            {
+                throw new InvalidDataException(e.Message) ;
+            }
         }
 
-        private SmallMoleculeLibraryAttributes(string moleculeName, string chemicalFormula, TypedMass? massMono, TypedMass? massAverage, string inChiKey, string otherKeys)
+        private SmallMoleculeLibraryAttributes(string moleculeName, MoleculeMassOffset mol, string inChiKey, string otherKeys)
         {
             MoleculeName = moleculeName;
-            ChemicalFormulaOrMassesString = FormatChemicalFormulaOrMassesString(chemicalFormula, massMono, massAverage); // If no formula provided, encode monoMass and averageMass instead
+            ChemicalFormulaOrMasses = mol ?? MoleculeMassOffset.EMPTY; // If no formula provided, encodes monoMass and averageMass instead
             InChiKey = inChiKey;
             OtherKeys = otherKeys;
         }
 
+        private SmallMoleculeLibraryAttributes(string moleculeName, string chemicalFormula, TypedMass massMono, TypedMass massAverage, string inChiKey, string otherKeys)
+        {
+            try 
+            {
+                MoleculeName = moleculeName;
+                ChemicalFormulaOrMasses = ParsedMoleculeMassOffset.Create(chemicalFormula, massMono, massAverage); // If no formula provided, encode monoMass and averageMass instead
+                InChiKey = inChiKey;
+                OtherKeys = otherKeys;
+            }
+            catch (ArgumentException e)
+            {
+                throw new InvalidDataException(e.Message);
+            }
+        }
+
         public string MoleculeName { get; private set; }
-        public string ChemicalFormulaOrMassesString { get; private set; } // If no formula provided, encodes monoMass and averageMass instead as <mono>-slash-<average>
-        public string ChemicalFormula => ChemicalFormulaOrMassesString != null && !ChemicalFormulaOrMassesString.Contains(CustomMolecule.MASS_SPLITTER) // Returns null if ChemicalFormulaOrMassesString encodes masses instead of formula
-            ? ChemicalFormulaOrMassesString
+        public MoleculeMassOffset ChemicalFormulaOrMasses { get; private set; } // If no formula provided, encodes monoMass and averageMass instead as <mono>-slash-<average>
+        public string ChemicalFormula => ChemicalFormulaOrMasses.HasChemicalFormula // Return null if ChemicalFormulaOrMassesString encodes masses instead of formula
+            ? ChemicalFormulaOrMasses.ToString()
             : null;
 
         public string InChiKey { get; private set; }
@@ -2182,7 +2162,7 @@ namespace pwiz.Skyline.Model.Lib
 
         public string Validate()
         {
-            return string.IsNullOrEmpty(ChemicalFormulaOrMassesString) ||
+            return MoleculeMassOffset.IsNullOrEmpty(ChemicalFormulaOrMasses) ||
                     (string.IsNullOrEmpty(MoleculeName) && string.IsNullOrEmpty(InChiKey) && string.IsNullOrEmpty(OtherKeys))
                 ? Resources.SmallMoleculeLibraryAttributes_Validate_A_small_molecule_is_defined_by_a_chemical_formula_and_at_least_one_of_Name__InChiKey__or_other_keys__HMDB_etc_
                 : null;
@@ -2202,16 +2182,18 @@ namespace pwiz.Skyline.Model.Lib
                 {
                     smallMolLines.Add(new KeyValuePair<string, string> (Resources.SmallMoleculeLibraryAttributes_KeyValuePairs_Name, MoleculeName));
                 }
-                ParseMolecularFormulaOrMassesString(ChemicalFormulaOrMassesString, out var chemicalFormula, out var massMono, out var massAverage);
+                var chemicalFormula = ChemicalFormulaOrMasses.IsMassOnly ? null : ChemicalFormulaOrMasses.ToString();
                 if (!string.IsNullOrEmpty(chemicalFormula))
                 {
                     smallMolLines.Add(new KeyValuePair<string, string> (Resources.SmallMoleculeLibraryAttributes_KeyValuePairs_Formula, chemicalFormula));
                 }
-                if (massMono != null)
+                var massMono = BioMassCalc.MONOISOTOPIC.CalculateMass(ChemicalFormulaOrMasses);
+                if (massMono != 0)
                 {
                     smallMolLines.Add(new KeyValuePair<string, string>(Resources.SmallMoleculeLibraryAttributes_KeyValuePairs_Monoisotopic_mass, massMono.ToString()));
                 }
-                if (massAverage != null)
+                var massAverage = BioMassCalc.AVERAGE.CalculateMass(ChemicalFormulaOrMasses);
+                if (massAverage != 0)
                 {
                     smallMolLines.Add(new KeyValuePair<string, string>(Resources.SmallMoleculeLibraryAttributes_KeyValuePairs_Average_mass, chemicalFormula));
                 }
@@ -2241,7 +2223,7 @@ namespace pwiz.Skyline.Model.Lib
             if (other == null)
                 return false;
             return Equals(MoleculeName, other.MoleculeName) &&
-                   Equals(ChemicalFormulaOrMassesString, other.ChemicalFormulaOrMassesString) &&
+                   Equals(ChemicalFormulaOrMasses, other.ChemicalFormulaOrMasses) &&
                    Equals(InChiKey, other.InChiKey) &&
                    Equals(OtherKeys, other.OtherKeys);
         }
@@ -2250,7 +2232,7 @@ namespace pwiz.Skyline.Model.Lib
             unchecked
             {
                 var hashCode = (MoleculeName != null ? MoleculeName.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (ChemicalFormulaOrMassesString != null ? ChemicalFormulaOrMassesString.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (ChemicalFormulaOrMasses != null ? ChemicalFormulaOrMasses.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (InChiKey != null ? InChiKey.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (OtherKeys != null ? OtherKeys.GetHashCode() : 0);
                 return hashCode;
@@ -2280,7 +2262,7 @@ namespace pwiz.Skyline.Model.Lib
                 }
             }
 
-            if (!Equals(ChemicalFormulaOrMassesString, other.ChemicalFormulaOrMassesString))
+            if (!Equals(ChemicalFormulaOrMasses, other.ChemicalFormulaOrMasses))
             {
                 return null; // Conflict
             }
@@ -2298,7 +2280,7 @@ namespace pwiz.Skyline.Model.Lib
                 consensusOtherKeys = consensusAccession.GetNonInChiKeys();
             }
             
-            return Create(consensusName, ChemicalFormulaOrMassesString, consensusInChiKey,
+            return Create(consensusName, ChemicalFormulaOrMasses, consensusInChiKey,
                 consensusOtherKeys);
         }
 
@@ -2869,7 +2851,7 @@ namespace pwiz.Skyline.Model.Lib
             }
             else
             {
-                LibraryKey = new MoleculeLibraryKey(SmallMoleculeLibraryAttributes.Create(primaryKey, null, null, string.Empty), adduct);
+                LibraryKey = new MoleculeLibraryKey(SmallMoleculeLibraryAttributes.Create(primaryKey, string.Empty, null, string.Empty), adduct);
             }
         }
 

--- a/pwiz_tools/Skyline/Model/Lib/LibraryKey.cs
+++ b/pwiz_tools/Skyline/Model/Lib/LibraryKey.cs
@@ -351,7 +351,7 @@ namespace pwiz.Skyline.Model.Lib
                 KeyType = LibraryKeyProto.Types.KeyType.SmallMolecule,
                 Adduct = Adduct.AdductFormula ?? string.Empty,
                 MoleculeName = SmallMoleculeLibraryAttributes.MoleculeName ?? string.Empty,
-                ChemicalFormula = SmallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString ?? string.Empty,
+                ChemicalFormula = SmallMoleculeLibraryAttributes.ChemicalFormulaOrMasses.ToString(),
                 InChiKey = SmallMoleculeLibraryAttributes.InChiKey ?? string.Empty,
                 OtherKeys = SmallMoleculeLibraryAttributes.OtherKeys ?? string.Empty
             };
@@ -393,13 +393,13 @@ namespace pwiz.Skyline.Model.Lib
             }
 
             if (null == smallMoleculeLibraryAttributes.MoleculeName ||
-                null == smallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString ||
+                null == smallMoleculeLibraryAttributes.ChemicalFormulaOrMasses ||
                 null == smallMoleculeLibraryAttributes.InChiKey || 
                 null == smallMoleculeLibraryAttributes.OtherKeys)
             {
                 smallMoleculeLibraryAttributes = SmallMoleculeLibraryAttributes.Create(
                     smallMoleculeLibraryAttributes.MoleculeName ?? string.Empty,
-                    smallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString ?? string.Empty,
+                    smallMoleculeLibraryAttributes.ChemicalFormulaOrMasses ?? ParsedMoleculeMassOffset.EMPTY,
                     smallMoleculeLibraryAttributes.InChiKey ?? string.Empty,
                     smallMoleculeLibraryAttributes.OtherKeys ?? string.Empty);
             }
@@ -409,7 +409,7 @@ namespace pwiz.Skyline.Model.Lib
                 {
                     smallMoleculeLibraryAttributes = valueCache.CacheValue(SmallMoleculeLibraryAttributes.Create(
                         valueCache.CacheValue(smallMoleculeLibraryAttributes.MoleculeName),
-                        valueCache.CacheValue(smallMoleculeLibraryAttributes.ChemicalFormulaOrMassesString),
+                        valueCache.CacheValue(smallMoleculeLibraryAttributes.ChemicalFormulaOrMasses),
                         valueCache.CacheValue(smallMoleculeLibraryAttributes.InChiKey),
                         valueCache.CacheValue(smallMoleculeLibraryAttributes.OtherKeys)
                     ));

--- a/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
+++ b/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
@@ -26,6 +26,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Serialization;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
@@ -1107,7 +1108,7 @@ namespace pwiz.Skyline.Model.Lib
                     {
                         var formulaIn = formula;
                         charge = SmallMoleculeTransitionListReader.ValidateFormulaWithMzAndAdduct(mzMatchTolerance, true,
-                            ref formulaIn, ref adduct, new TypedMass(precursorMz.Value, MassType.Monoisotopic), null, isPositive, true, out _, out _, out _) ?? 0;
+                            ref formulaIn, ref adduct, TypedMass.Create(precursorMz.Value, MassType.Monoisotopic), null, isPositive, true, out _, out _, out _) ?? 0;
                         if (!Equals(formula, formulaIn))
                         {
                             // We would not expect to adjust the formula in a library import

--- a/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
+++ b/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
@@ -1246,16 +1246,27 @@ namespace pwiz.Skyline.Model.Lib
                         lenAnnotations = annotationsTSV.Length;
                         outStream.Write(annotationsTSV, 0, lenAnnotations);
                     }
-                    var key = isPeptide ? new LibKey(sequence, charge) : new LibKey(SmallMoleculeLibraryAttributes.Create(sequence, formula, inChiKey, otherKeys), adduct);
-                    var info = new NistSpectrumInfo(key, tfRatio ?? 1000, rt, irt, Convert.ToSingle(totalIntensity),
-                        (ushort) (copies ?? 1), (ushort) numNonZeroPeaks, lenCompressed, lenAnnotations, location);
-                    if (!isPeptide)
+
+                    NistSpectrumInfo info;
+                    try
                     {
-                        // Keep an eye out for ambiguous keys, probably due to library containing multiple machine types etc
-                        if (!knownKeys.Add(key))
+                        var key = isPeptide ? new LibKey(sequence, charge) : new LibKey(SmallMoleculeLibraryAttributes.Create(sequence, formula, inChiKey, otherKeys), adduct);
+                        info = new NistSpectrumInfo(key, tfRatio ?? 1000, rt, irt, Convert.ToSingle(totalIntensity),
+                            (ushort)(copies ?? 1), (ushort)numNonZeroPeaks, lenCompressed, lenAnnotations, location);
+                        if (!isPeptide)
                         {
-                            ambiguousKeys.Add(key); // Already in knownKeys, note ambiguity
+                            // Keep an eye out for ambiguous keys, probably due to library containing multiple machine types etc
+                            if (!knownKeys.Add(key))
+                            {
+                                ambiguousKeys.Add(key); // Already in knownKeys, note ambiguity
+                            }
                         }
+                    }
+                    catch (InvalidDataException)
+                    {
+                        // If the key is invalid, build a representation of the key that can be used to note failures
+                        var key = new LibKey(sequence ?? @"???", 0);
+                        info = new NistSpectrumInfo(key, 0, null, null, 0, 0, 0, 0, 0, location);
                     }
                     libraryEntries.Add(info);
                 }

--- a/pwiz_tools/Skyline/Model/Lib/SpectrumPeakAnnotation.cs
+++ b/pwiz_tools/Skyline/Model/Lib/SpectrumPeakAnnotation.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
 

--- a/pwiz_tools/Skyline/Model/Lib/SpectrumRanker.cs
+++ b/pwiz_tools/Skyline/Model/Lib/SpectrumRanker.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.Crosslinking;
@@ -106,7 +107,7 @@ namespace pwiz.Skyline.Model.Lib
             }
 
             var spectrumRanker = new SpectrumRanker(targetInfo, settings, fragmentFilter);
-            return spectrumRanker.RankSpectrum(info, minPeaks, score);
+            return spectrumRanker.RankSpectrum(info ?? SpectrumPeaksInfo.EMPTY, minPeaks, score);
         }
 
 
@@ -155,7 +156,6 @@ namespace pwiz.Skyline.Model.Lib
                 }
                 else if (!isProteomic && !Sequence.IsProteomic)
                 {
-                    string isotopicFormula;
                     var knownFragments = new List<MatchedFragmentIon>();
                     foreach (var tran in groupDocNode.Transitions)
                     {
@@ -178,7 +178,7 @@ namespace pwiz.Skyline.Model.Lib
                         new MoleculeMasses(
                             SequenceMassCalc.GetMZ(
                                 calcMatchPre.GetPrecursorMass(Sequence.Molecule, null, PrecursorAdduct,
-                                    out isotopicFormula), PrecursorAdduct), ionMasses);
+                                    out _), PrecursorAdduct), ionMasses);
                 }
                 else
                 {

--- a/pwiz_tools/Skyline/Model/Lib/ViewLibraryPepInfo.cs
+++ b/pwiz_tools/Skyline/Model/Lib/ViewLibraryPepInfo.cs
@@ -20,6 +20,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using pwiz.Common.Chemistry;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.Extensions;
@@ -239,7 +240,7 @@ namespace pwiz.Skyline.Model.Lib
                 massH = settings.GetPrecursorCalc(transitionGroup.TransitionGroup.LabelType, mods)
                     .GetPrecursorMass(Target);
             else
-                massH = new TypedMass(Key.PrecursorMz ?? 0, MassType.Monoisotopic);
+                massH = TypedMass.Create(Key.PrecursorMz ?? 0, MassType.Monoisotopic);
             return SequenceMassCalc.PersistentMZ(SequenceMassCalc.GetMZ(massH, transitionGroup.PrecursorAdduct));
         }
 
@@ -294,8 +295,8 @@ namespace pwiz.Skyline.Model.Lib
             {
                 // Create custom ion node for midas library
                 var precursor = Key.PrecursorMz.GetValueOrDefault();
-                var precursorMono = new TypedMass(precursor, MassType.Monoisotopic);
-                var precursorAverage = new TypedMass(precursor, MassType.Average);
+                var precursorMono = TypedMass.Create(precursor, MassType.Monoisotopic);
+                var precursorAverage = TypedMass.Create(precursor, MassType.Average);
                 var peptide = new Peptide(new CustomMolecule(precursorMono, precursorAverage, precursor.ToString(CultureInfo.CurrentCulture)));
                 transitionGroup = new TransitionGroupDocNode(new TransitionGroup(peptide, Adduct.EMPTY, IsotopeLabelType.light, true, null), null);
                 mods = new ExplicitMods(peptide, new ExplicitMod[0], new TypedExplicitModifications[0]);

--- a/pwiz_tools/Skyline/Model/Lib/XHunterSpec.cs
+++ b/pwiz_tools/Skyline/Model/Lib/XHunterSpec.cs
@@ -26,6 +26,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Serialization;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Properties;

--- a/pwiz_tools/Skyline/Model/ModifiedSequence.cs
+++ b/pwiz_tools/Skyline/Model/ModifiedSequence.cs
@@ -22,6 +22,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
@@ -300,9 +301,9 @@ namespace pwiz.Skyline.Model
             {
                 return mod.MonoisotopicMass.ToString(CultureInfo.CurrentCulture);
             }
-            if (!string.IsNullOrEmpty(mod.Formula))
+            if (!ParsedMoleculeMassOffset.IsNullOrEmpty(mod.Formula))
             {
-                return mod.Formula;
+                return mod.Formula.ToString();
             }
             return @"#UNKNOWNMODIFICATION#";
         }
@@ -357,7 +358,7 @@ namespace pwiz.Skyline.Model
 
             public string Name { get { return StaticMod.Name; } }
             public string ShortName { get { return StaticMod.ShortName; } }
-            public string Formula { get { return StaticMod.Formula; } }
+            public ParsedMoleculeMassOffset Formula { get { return StaticMod.ParsedMoleculeMassOffset; } }
             public int? UnimodId { get { return StaticMod.UnimodId; } }
             public double MonoisotopicMass { get; private set; }
             public double AverageMass { get; private set; }
@@ -438,7 +439,7 @@ namespace pwiz.Skyline.Model
                 char aa = unmodifiedSequence[i];
                 if ((staticMod.LabelAtoms & LabelAtoms.LabelsAA) != LabelAtoms.None && AminoAcid.IsAA(aa))
                 {
-                    string heavyFormula = SequenceMassCalc.GetHeavyFormula(aa, staticMod.LabelAtoms);
+                    var heavyFormula = SequenceMassCalc.GetHeavyFormula(aa, staticMod.LabelAtoms);
                     monoMass = SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, heavyFormula,
                         SequenceMassCalc.MassPrecision);
                     avgMass = SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, heavyFormula,

--- a/pwiz_tools/Skyline/Model/Peptide.cs
+++ b/pwiz_tools/Skyline/Model/Peptide.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using pwiz.Common.Chemistry;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Lib;

--- a/pwiz_tools/Skyline/Model/PeptideDocNode.cs
+++ b/pwiz_tools/Skyline/Model/PeptideDocNode.cs
@@ -101,13 +101,13 @@ namespace pwiz.Skyline.Model
             get
             {
                 var label = PeptideTreeNode.GetLabel(this, string.Empty);
-                return (CustomMolecule != null && !string.IsNullOrEmpty(CustomMolecule.Formula)) ? string.Format(@"{0} ({1})", label, CustomMolecule.Formula) : label;
+                return (CustomMolecule != null && !CustomMolecule.MoleculeAndMassOffset.IsMassOnly) ? string.Format(@"{0} ({1})", label, CustomMolecule.MoleculeAndMassOffset) : label;
             }
         }
 
         protected override IList<DocNode> OrderedChildren(IList<DocNode> children)
         {
-            if (Peptide.IsCustomMolecule && children.Any())
+            if (Peptide.IsCustomMolecule && children.Count > 1)
             {
                 // Enforce order for small molecules, except those that are fictions of the test system
                 return children.OrderBy(t => (TransitionGroupDocNode)t, new TransitionGroupDocNode.CustomIonPrecursorComparer()).ToArray();

--- a/pwiz_tools/Skyline/Model/Prosit/PrositMS2Spectra.cs
+++ b/pwiz_tools/Skyline/Model/Prosit/PrositMS2Spectra.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Prosit.Models;

--- a/pwiz_tools/Skyline/Model/Results/IsotopeDistInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/IsotopeDistInfo.cs
@@ -29,7 +29,7 @@ using pwiz.Skyline.Util;
 
 namespace pwiz.Skyline.Model.Results
 {
-    public sealed class IsotopeDistInfo : Immutable
+    public sealed class IsotopeDistInfo : Immutable, IEquatable<IsotopeDistInfo>
     {
         private readonly TypedMass _monoisotopicMass;
         private readonly Adduct _adduct;
@@ -214,7 +214,7 @@ namespace pwiz.Skyline.Model.Results
             double shift = SequenceMassCalc.GetPeptideInterval(decoyMassShift);    // Correct for shift applied to the distribution
             // ReSharper disable ImpureMethodCallOnReadonlyValueField
             return _monoisotopicMass.IsMassH() ? 
-                new TypedMass(SequenceMassCalc.GetMH(ExpectedPeaks[MassIndexToPeakIndex(massIndex)].Mz - shift, _adduct.AdductCharge), _monoisotopicMass.MassType) :
+                TypedMass.Create(SequenceMassCalc.GetMH(ExpectedPeaks[MassIndexToPeakIndex(massIndex)].Mz - shift, _adduct.AdductCharge), _monoisotopicMass.MassType) :
                 _adduct.MassFromMz(ExpectedPeaks[MassIndexToPeakIndex(massIndex)].Mz - shift, _monoisotopicMass.MassType);
             // ReSharper restore ImpureMethodCallOnReadonlyValueField
         }
@@ -269,7 +269,7 @@ namespace pwiz.Skyline.Model.Results
 
         #endregion
 
-        private struct MzRankProportion
+        private struct MzRankProportion : IEquatable<MzRankProportion>
         {
             public MzRankProportion(double mz, int rank, float proportion) : this()
             {
@@ -285,6 +285,13 @@ namespace pwiz.Skyline.Model.Results
             public override string ToString() // For ease in debugging
             {
                 return String.Format(@"mz {0} rank {1} proportion {2}", Mz, Rank, Proportion);
+            }
+
+            public bool Equals(MzRankProportion other)
+            {
+                return Mz == other.Mz && 
+                       Rank == other.Rank && 
+                       Proportion.Equals(other.Proportion);
             }
         }
     }

--- a/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
+++ b/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
@@ -310,6 +310,10 @@ namespace pwiz.Skyline.Model.Results
 
         public ChromSetFileMatch FindMatchingMSDataFile(MsDataFileUri filePathFind)
         {
+            if (filePathFind == null)
+            {
+                return null;
+            }
             // First look for an exact match
             var exactMatch = FindExactNameMatchingMSDataFile(filePathFind);
             if (exactMatch != null)
@@ -359,6 +363,10 @@ namespace pwiz.Skyline.Model.Results
         /// </summary>
         private ChromSetFileMatch FindExactNameMatchingMSDataFile(MsDataFileUri fileUri)
         {
+            if (fileUri == null)
+            {
+                return null;
+            }
             var filePathFind = fileUri.GetFilePath();
             string sampleName = fileUri.GetSampleName();
             int fileOrder = 0;

--- a/pwiz_tools/Skyline/Model/SequenceUtil.cs
+++ b/pwiz_tools/Skyline/Model/SequenceUtil.cs
@@ -131,8 +131,8 @@ namespace pwiz.Skyline.Model
     /// </summary>
     public class SequenceMassCalc : IPrecursorMassCalc, IFragmentMassCalc
     {
-        public static int MassPrecision { get { return 6; } }
-        public static double MassTolerance { get { return 1e-6; } }
+        public static int MassPrecision { get { return BioMassCalc.MassPrecision; } }
+        public static double MassTolerance { get { return BioMassCalc.MassTolerance; } }
 
 #pragma warning disable 1570 /// invalid character (&) in XML comment, and this URL doesn't work if we replace "&" with "&amp;"
         /// <summary>
@@ -172,7 +172,7 @@ namespace pwiz.Skyline.Model
         public static TypedMass PersistentNeutral(TypedMass mh)
         {
             Assume.IsTrue(mh.IsMassH());
-            return new TypedMass(Math.Round(mh - BioMassCalc.MassProton, MassPrecision), mh.MassType);
+            return TypedMass.Create(Math.Round(mh - BioMassCalc.MassProton, MassPrecision), mh.MassType);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace pwiz.Skyline.Model
                 MassType massType) // CONSIDER(bspratt) internally standardize on mass rather than massH?
         {
             Assume.IsTrue(adduct.IsProtonated, @"Expected a protonated adduct");
-            return new TypedMass(mz * adduct.AdductCharge - (adduct.AdductCharge - 1) * BioMassCalc.MassProton,
+            return TypedMass.Create(mz * adduct.AdductCharge - (adduct.AdductCharge - 1) * BioMassCalc.MassProton,
                 massType.IsMonoisotopic() ? MassType.MonoisotopicMassH : MassType.AverageMassH);
         }
 
@@ -223,54 +223,20 @@ namespace pwiz.Skyline.Model
 
         public static TypedMass FormulaMass(BioMassCalc calc, string desc, int? precision = null)
         {
-            string parse = desc;
-            double totalMass = calc.ParseMassExpression(ref parse);
-            if (totalMass == 0.0 || parse.Length > 0)
-                calc.ThrowArgumentException(desc);
-
-            return new TypedMass(precision.HasValue ? Math.Round(totalMass, precision.Value) : totalMass,
-                calc.MassType);
+            var mol = ParsedMoleculeMassOffset.Create(desc);
+            return FormulaMass(calc, mol, precision);
         }
 
-        public static string[] ParseModParts(BioMassCalc calc, string desc)
+        public static TypedMass FormulaMass(BioMassCalc calc, Molecule mol, int? precision = null)
         {
-            string parse = desc;
-            calc.ParseMass(ref parse);
-
-            string part1 = desc.Substring(0, desc.Length - parse.Length).Trim();
-            string part2 = string.Empty;
-
-            if (parse.Length > 0 && parse[0] == '-')
-            {
-                parse = parse.Substring(1);
-                part2 = parse.Trim();
-
-                calc.ParseMass(ref parse);
-            }
-
-            if ((part1.Length == 0 && part2.Length == 0) || parse.Length > 0)
-                calc.ThrowArgumentException(desc);
-
-            return new[] { part1, part2 };
+            var totalMass = calc.CalculateMass((IDictionary<string, int>)mol);
+            return (precision.HasValue ? totalMass.ChangeMass(Math.Round(totalMass, precision.Value)) : totalMass);
         }
 
-        public void ParseModCounts(string desc, IDictionary<string, int> dictAtomCounts)
+        public static TypedMass FormulaMass(BioMassCalc calc, MoleculeMassOffset mol, int? precision = null)
         {
-            ParseModCounts(_massCalc, desc, dictAtomCounts);
-        }
-
-        public static void ParseModCounts(BioMassCalc calc, string desc, IDictionary<string, int> dictAtomCounts)
-        {
-            string parse = desc;
-            calc.ParseCounts(ref parse, dictAtomCounts, false);
-            if (parse.Length > 0 && parse[0] == '-')
-            {
-                parse = parse.Substring(1);
-                calc.ParseCounts(ref parse, dictAtomCounts, true);
-            }
-
-            if (parse.Length > 0)
-                calc.ThrowArgumentException(desc);
+            var totalMass = calc.CalculateMass(mol);
+            return (precision.HasValue ? totalMass.ChangeMass( Math.Round(totalMass, precision.Value)) : totalMass);
         }
 
         public static string GetModDiffDescription(double massDiff)
@@ -353,74 +319,13 @@ namespace pwiz.Skyline.Model
             public readonly double[] _aminoCTermModMassesExtra = new double[128];
             public double _massModCleaveCExtra;
             public double _massModCleaveNExtra;
-            public readonly string[] _aminoModFormulas = new string[128];
-            public readonly string[] _aminoNTermModFormulas = new string[128];
-            public readonly string[] _aminoCTermModFormulas = new string[128];
-            public string _massModCleaveCFormula;
-            public string _massModCleaveNFormula;
+            public readonly Molecule[] _aminoModFormulas = new Molecule[128];
+            public readonly Molecule[] _aminoNTermModFormulas = new Molecule[128];
+            public readonly Molecule[] _aminoCTermModFormulas = new Molecule[128];
+            public Molecule _massModCleaveCFormula;
+            public Molecule _massModCleaveNFormula;
         }
-
-        // For internal use only - similar to Molecule class, but this is not immutable and not sorted (for speed)
-        private sealed class MoleculeUnsorted
-        {
-            public Dictionary<string, int> Elements { get; private set; }
-
-            public MoleculeUnsorted(Dictionary<string, int> elements)
-            {
-                Elements = elements;
-            }
-
-            public static MoleculeUnsorted Parse(string formula)
-            {
-                Molecule ion;
-                Adduct adduct;
-                string neutralFormula;
-                Assume.IsFalse(IonInfo.IsFormulaWithAdduct(formula, out ion, out adduct, out neutralFormula));
-                return new MoleculeUnsorted(Molecule.ParseExpressionToDictionary(formula));
-            }
-
-            public MoleculeUnsorted SetElementCount(string element, int count)
-            {
-                if (Elements.ContainsKey(element))
-                {
-                    Elements[element] = count;
-                }
-                else
-                {
-                    Elements.Add(element, count);
-                }
-                return this;
-            }
-
-            public int GetElementCount(string element)
-            {
-                int count;
-                if (Elements.TryGetValue(element, out count))
-                {
-                    return count;
-                }
-                return 0;
-            }
-
-            public override string ToString()
-            {
-                var result = new StringBuilder();
-                var sortedKeys = Elements.Keys.ToList();
-                sortedKeys.Sort();
-                foreach (var key in sortedKeys)
-                {
-                    result.Append(key);
-                    var value = Elements[key];
-                    if (value != 1)
-                    {
-                        result.Append(value);
-                    }
-                }
-                return result.ToString();
-            }
-
-        }
-
+        
         /// <summary>
         /// All summed modifications for this calculator
         /// </summary>
@@ -464,7 +369,7 @@ namespace pwiz.Skyline.Model
             // These values will be used to calculate masses that are later assumed to be massH
             type = type.IsMonoisotopic() ? MassType.MonoisotopicMassH : MassType.AverageMassH;
 
-            _massCalc = new BioMassCalc(type);
+            _massCalc = BioMassCalc.GetBioMassCalc(type);
 
             Labels = new HashSet<StaticMod>(); // Used by small molecules
 
@@ -476,7 +381,7 @@ namespace pwiz.Skyline.Model
             // _massAmmonia = _massCalc.CalculateMass("NH3");
 
             // ReSharper disable LocalizableElement
-            _massDiffB = new TypedMass(0.0, type);
+            _massDiffB = TypedMass.Create(0.0, type);
             _massDiffA = _massDiffB - _massCalc.CalculateMassFromFormula("CO");
             _massDiffC = _massCalc.CalculateMassFromFormula("NH3");
             _massDiffY = _massCalc.CalculateMassFromFormula("H2O");
@@ -498,11 +403,6 @@ namespace pwiz.Skyline.Model
             InitAminoAcidMasses();
         }
 
-        public double ParseModMass(string formula)
-        {
-            return FormulaMass(_massCalc, formula, MassPrecision);
-        }
-
         public double GetModMass(char aa, StaticMod mod)
         {
             if (_massCalc.MassType.IsMonoisotopic())
@@ -515,31 +415,20 @@ namespace pwiz.Skyline.Model
                 if (mod.AverageMass.HasValue)
                     return mod.AverageMass.Value;
             }
-            if (!string.IsNullOrEmpty(mod.Formula))
-                return FormulaMass(_massCalc, mod.Formula, MassPrecision);
+            if (!ParsedMoleculeMassOffset.IsNullOrEmpty(mod.ParsedMoleculeMassOffset))
+                return FormulaMass(_massCalc, mod.ParsedMoleculeMassOffset, MassPrecision);
             else if ((mod.LabelAtoms & LabelAtoms.LabelsAA) != LabelAtoms.None && AminoAcid.IsAA(aa))
                 return FormulaMass(_massCalc, GetHeavyFormula(aa, mod.LabelAtoms), MassPrecision);
             return 0;
         }
 
-        public string GetModFormula(char aa, StaticMod mod, out double unexplainedMass)
+        public ParsedMoleculeMassOffset GetModFormula(char aa, StaticMod mod)
         {
-            unexplainedMass = 0;
-            if (!string.IsNullOrEmpty(mod.Formula))
-                return mod.Formula;
+            if (!ParsedMoleculeMassOffset.IsNullOrEmpty(mod.ParsedMoleculeMassOffset))
+                return mod.GetMoleculeMassOffset(); // If it has a formula, use it
             else if ((mod.LabelAtoms & LabelAtoms.LabelsAA) != LabelAtoms.None)
-                return GetHeavyFormula(aa, mod.LabelAtoms);
-            if (_massCalc.MassType.IsMonoisotopic())
-            {
-                if (mod.MonoisotopicMass.HasValue)
-                    unexplainedMass = mod.MonoisotopicMass.Value;
-            }
-            else
-            {
-                if (mod.AverageMass.HasValue)
-                    unexplainedMass = mod.AverageMass.Value;
-            }
-            return null;
+                return GetHeavyFormula(aa, mod.LabelAtoms); // If it has a label, use the labeled version of the amino acid
+            return mod.GetMoleculeMassOffset(); // Return the mass offset information
         }
 
         public void AddStaticModifications(IEnumerable<StaticMod> mods)
@@ -566,19 +455,22 @@ namespace pwiz.Skyline.Model
                     if (mod.Terminus != null)
                     {
                         double mass = GetModMass('\0', mod);
-                        double unexplainedMass;
-                        string formula = GetModFormula('\0', mod, out unexplainedMass);
+                        var formulaAndMassOffset = GetModFormula('\0', mod);
+                        var formula = formulaAndMassOffset.Molecule;
+                        var unexplainedMass = formulaAndMassOffset.GetMassOffset(_massCalc.MassType);
                         if (mod.Terminus == ModTerminus.C)
                         {
                             modMasses._massModCleaveC += mass;
                             modMasses._massModCleaveCExtra += unexplainedMass;
-                            modMasses._massModCleaveCFormula = CombineFormulas(modMasses._massModCleaveCFormula, formula);
+                            modMasses._massModCleaveCFormula = 
+                                Molecule.IsNullOrEmpty(modMasses._massModCleaveCFormula) ? formula : modMasses._massModCleaveCFormula.Plus(formula);
                         }
                         else
                         {
                             modMasses._massModCleaveN += mass;
                             modMasses._massModCleaveNExtra += unexplainedMass;
-                            modMasses._massModCleaveNFormula = CombineFormulas(modMasses._massModCleaveNFormula, formula);
+                            modMasses._massModCleaveNFormula = 
+                                Molecule.IsNullOrEmpty(modMasses._massModCleaveNFormula) ? formula : modMasses._massModCleaveNFormula.Plus(formula);
                         }
                     }
                     else
@@ -613,32 +505,15 @@ namespace pwiz.Skyline.Model
             }
         }
 
-        private void AddMod(char aa, StaticMod mod, double[] modMasses, double[] modMassesExtra, string[] modFormulas)
+        private void AddMod(char aa, StaticMod mod, double[] modMasses, double[] modMassesExtra, Molecule[] modFormulas)
         {
             modMasses[aa] = modMasses[char.ToLowerInvariant(aa)] += GetModMass(aa, mod);
 
             // Deal with formulas and unexplained masses
-            double unexplainedMass;
-            string formula = GetModFormula(aa, mod, out unexplainedMass);
-            modFormulas[aa] = modFormulas[char.ToLowerInvariant(aa)] = CombineFormulas(modFormulas[aa], formula);
-            modMassesExtra[aa] = modMassesExtra[char.ToLowerInvariant(aa)] += unexplainedMass;
-        }
-
-        private string CombineFormulas(string formula1, string formula2)
-        {
-            if (formula1 == null)
-                return formula2;
-            if (formula2 == null)
-                return formula1;
-
-            var parts1 = ParseModParts(_massCalc, formula1);
-            var parts2 = ParseModParts(_massCalc, formula2);
-
-            var sb = new StringBuilder();
-            sb.Append(parts1[0]).Append(parts2[0]);
-            if (parts1[1].Length > 0 || parts2[1].Length > 0)
-                sb.Append('-').Append(parts1[1]).Append(parts2[1]);
-            return sb.ToString();
+            var formula = GetModFormula(aa, mod);
+            modFormulas[aa] = modFormulas[char.ToLowerInvariant(aa)] = 
+                Molecule.IsNullOrEmpty(modFormulas[aa]) ? formula.Molecule : modFormulas[aa].Plus(formula.Molecule);
+            modMassesExtra[aa] = modMassesExtra[char.ToLowerInvariant(aa)] += formula.GetMassOffset(_massCalc.MassType);
         }
 
         public bool IsModified(Target val)
@@ -707,17 +582,17 @@ namespace pwiz.Skyline.Model
             return GetModifiedSequence(seq, SequenceModFormatType.mass_diff_narrow, false);
         }
 
-        public Adduct GetModifiedAdduct(Adduct adduct, string neutralFormula)
+        public Adduct GetModifiedAdduct(Adduct adduct, MoleculeMassOffset neutralFormula)
         {
             return HasLabels ? GetModifiedAdduct(adduct, neutralFormula, Labels) : adduct;
         }
 
-        public static Adduct GetModifiedAdduct(Adduct adduct, string neutralFormula, IEnumerable<StaticMod> labels)
+        public static Adduct GetModifiedAdduct(Adduct adduct, MoleculeMassOffset neutralFormula, IEnumerable<StaticMod> labels)
         {
             // Pick out any label atoms
             var atoms = labels.Aggregate(LabelAtoms.None, (current, staticMod) => current | staticMod.LabelAtoms);
             var heavy = GetHeavyFormula(neutralFormula, atoms);
-            adduct = adduct.ChangeIsotopeLabels(BioMassCalc.MONOISOTOPIC.FindIsotopeLabelsInFormula(heavy));
+            adduct = adduct.ChangeIsotopeLabels(BioMassCalc.FindIsotopeLabelsInFormula(heavy.Molecule));
             return adduct;
         }
 
@@ -806,24 +681,29 @@ namespace pwiz.Skyline.Model
 
         public MassDistribution GetMzDistribution(Target target, Adduct adduct, IsotopeAbundances abundances, ExplicitSequenceMods mods = null)
         {
-            double unexplainedMass;
-            MoleculeUnsorted molecule;
+            MoleculeMassOffset molecule;
             if (target.IsProteomic)
             {
-                molecule = GetFormula(target.Sequence, mods, out unexplainedMass);
+                molecule = GetFormula(target.Sequence, mods);
             }
             else
             {
-                molecule = MoleculeUnsorted.Parse(target.Molecule.Formula);
-                unexplainedMass = 0;
+                molecule = target.Molecule.MoleculeAndMassOffset;
             }
-            return GetMzDistribution(molecule, adduct, abundances, unexplainedMass);
+            return GetMzDistribution(molecule, adduct, abundances);
         }
 
-        public MassDistribution GetMZDistributionFromFormula(string formula, Adduct adduct, IsotopeAbundances abundances)
+        public MassDistribution GetMZDistributionFromFormula(string formula, Adduct adduct,
+            IsotopeAbundances abundances)
         {
-            var molecule = MoleculeUnsorted.Parse(formula);
-            return GetMzDistribution(molecule, adduct, abundances, 0);
+            var molecule = ParsedMoleculeMassOffset.Create(formula);
+            return GetMzDistribution(molecule, adduct, abundances);
+        }
+
+        public MassDistribution GetMZDistribution(MoleculeMassOffset molecule, Adduct adduct,
+            IsotopeAbundances abundances)
+        {
+            return GetMzDistribution(molecule, adduct, abundances);
         }
 
         public MassDistribution GetMZDistributionSinglePoint(double mz)
@@ -831,25 +711,25 @@ namespace pwiz.Skyline.Model
             return MassDistribution.NewInstance(new SortedDictionary<double, double> {{mz, 1.0}}, _massResolution, _minimumAbundance);
         }
 
-        public string GetMolecularFormula(string peptideSequence)
+        public MoleculeMassOffset GetMolecularFormula(string peptideSequence)
         {
-           return GetNeutralFormula(peptideSequence, null);
+            return GetNeutralFormula(peptideSequence, null);
         }
 
         /// <summary>
         /// Convert a peptide to a small molecule formula (e.g. PEPTIDER => "C40H65N11O16")
         /// </summary>
-        public string GetNeutralFormula(string seq, ExplicitSequenceMods mods)
+        public MoleculeMassOffset GetNeutralFormula(string seq, ExplicitSequenceMods mods)
         {
-            double unexplainedMass;
-            var molecule = GetFormula(seq, mods, out unexplainedMass);
-            if (unexplainedMass != 0.0)
+            var molecule = GetFormula(seq, mods);
+            if (molecule.MonoMassOffset != 0.0 || molecule.Molecule.Values.Any(v => v < 0))
                 throw new ArgumentException(@"Unexplained mass when deriving molecular formula from sequence "+seq);
-            return molecule.ToString();
+            return molecule;
         }
 
-// ReSharper disable once ParameterTypeCanBeEnumerable.Local
-        private MassDistribution GetMzDistribution(MoleculeUnsorted molecule, Adduct adduct, IsotopeAbundances abundances, double unexplainedMass)
+        // ReSharper disable once ParameterTypeCanBeEnumerable.Local
+
+        private MassDistribution GetMzDistribution(MoleculeMassOffset molecule, Adduct adduct, IsotopeAbundances abundances)
         {
             // Low resolution to get back only peaks at Dalton (i.e. neutron) boundaries
             var md = new MassDistribution(_massResolution, _minimumAbundance);
@@ -857,17 +737,20 @@ namespace pwiz.Skyline.Model
             var charge = adduct.AdductCharge;
             // Note we use the traditional peptide-oriented calculation when adduct is protonated and not an n-mer, mostly for stability in tests
             var protonated = adduct.IsProtonated && (adduct.GetMassMultiplier() == 1);
-            var mol = protonated ? molecule.Elements : adduct.ApplyToMolecule(molecule.Elements);
-            foreach (var element in mol)
+            var mol = protonated ? molecule : adduct.ApplyToMolecule(molecule);
+            foreach (var element in mol.Molecule)
             {
                 result = result.Add(md.Add(abundances[element.Key]).Multiply(element.Value));
             }
+            var unexplainedMass = _massCalc.MassType.IsMonoisotopic()
+                ? molecule.MonoMassOffset
+                : molecule.AverageMassOffset;
             return result.OffsetAndDivide(unexplainedMass + charge * (protonated ? BioMassCalc.MassProton : -BioMassCalc.MassElectron), charge);
         }
 
-        private MoleculeUnsorted GetFormula(string seq, ExplicitSequenceMods mods, out double unexplainedMass)
+        private MoleculeMassOffset GetFormula(string seq, ExplicitSequenceMods mods)
         {
-            var formula = new FormulaBuilder(_massCalc);
+            var formula = new FormulaBuilder();
             var modMasses = GetModMasses(mods);
             formula.Append(modMasses._massModCleaveNFormula, modMasses._massModCleaveNExtra);
             formula.Append(modMasses._massModCleaveCFormula, modMasses._massModCleaveCExtra);
@@ -875,8 +758,8 @@ namespace pwiz.Skyline.Model
             {
                 char c = seq[i];
 
-                formula.Append(AMINO_FORMULAS[c])
-                       .Append(modMasses._aminoModFormulas[c], modMasses._aminoModMassesExtra[c]);
+                formula.Append(AMINO_FORMULAS[c]);
+                formula.Append(modMasses._aminoModFormulas[c], modMasses._aminoModMassesExtra[c]);
                 // Terminal modifications
                 if (i == 0)
                     formula.Append(modMasses._aminoNTermModFormulas[c], modMasses._aminoNTermModMassesExtra[c]);
@@ -887,90 +770,63 @@ namespace pwiz.Skyline.Model
             {
                 foreach (ExplicitMod mod in mods.AllMods)
                 {
-                    double modUnexplainedMass;
-                    string modFormula = GetModFormula(seq[mod.IndexAA], mod.Modification, out modUnexplainedMass);
-                    formula.Append(modFormula, modUnexplainedMass);
+                    var modFormula = GetModFormula(seq[mod.IndexAA], mod.Modification);
+                    formula.Append(modFormula);
                 }
             }
             formula.Append(H2O); // N-term = H, C-term = OH
-            unexplainedMass = formula.UnexplainedMass;
-            return new MoleculeUnsorted(formula.DictAtomCounts);
+            return formula.Sum();
         }
 
         private sealed class FormulaBuilder
         {
-            private readonly BioMassCalc _massCalc;
-            private readonly Dictionary<string, int> _dictAtomCounts;
-            private double _unexplainedMass;
+            private List<Molecule> _listAtomCounts;
+            private double _massOffsetMono;
+            private double _massOffsetAverage;
 
-            public FormulaBuilder(BioMassCalc massCalc)
+            public FormulaBuilder()
             {
-                _massCalc = massCalc;
-                _dictAtomCounts = new Dictionary<string, int>();
+                _listAtomCounts = new List<Molecule>();
             }
 
-            // ReSharper disable once UnusedMethodReturnValue.Local
-            public FormulaBuilder Append(string formula, double unexplainedMass = 0)
+            public void Append(MoleculeMassOffset formula)
             {
-                _unexplainedMass += unexplainedMass;
-                if (formula != null)
-                    ParseModCounts(_massCalc, formula, _dictAtomCounts);
-                return this;
-            }
-
-            public FormulaBuilder Append(IDictionary<string, int> formula, double unexplainedMass = 0)
-            {
-                _unexplainedMass += unexplainedMass;
-                if (formula != null)
+                if (!MoleculeMassOffset.IsNullOrEmpty(formula))
                 {
-                    foreach (var elementCount in formula)
-                    {
-                        int count;
-                        if (_dictAtomCounts.TryGetValue(elementCount.Key, out count))
-                        {
-                            _dictAtomCounts[elementCount.Key] = count + elementCount.Value;
-                        }
-                        else
-                        {
-                            _dictAtomCounts.Add(elementCount.Key, elementCount.Value);
-                        }
-                    }
-                }
-                return this;
-            }
-
-            /// <summary>
-            /// Returns any accumulated unexplained mass, plus the mass of any atoms with
-            /// negative counts.
-            /// </summary>
-            public double UnexplainedMass
-            {
-                get
-                {
-                    double unexplainedMass = _unexplainedMass;
-                    foreach (var atomCount in _dictAtomCounts.Where(p => p.Value < 0))
-                    {
-                        unexplainedMass += _massCalc.CalculateMassFromFormula(atomCount.Key + (-atomCount.Value));
-                    }
-                    return unexplainedMass;
+                    _listAtomCounts.Add(formula.Molecule);
+                    _massOffsetMono += formula.MonoMassOffset;
+                    _massOffsetAverage += formula.AverageMassOffset;
                 }
             }
 
-            public Dictionary<string, int> DictAtomCounts
+            public void Append(Molecule formula, double extraMass = 0)
             {
-                get { return _dictAtomCounts; }
+                if (!Molecule.IsNullOrEmpty(formula))
+                {
+                    _listAtomCounts.Add(formula);
+                }
+                _massOffsetMono += extraMass;
+                _massOffsetAverage += extraMass;
+            }
+
+            public MoleculeMassOffset Sum()
+            {
+                return MoleculeMassOffset.Create(Molecule.Sum(_listAtomCounts), _massOffsetMono, _massOffsetAverage);
             }
 
             public override string ToString()
             {
                 var formulaText = new StringBuilder();
-                foreach (var atomCount in _dictAtomCounts.OrderBy(p => p.Key).Where(p => p.Value > 0))
+                var mol = Sum();
+                foreach (var atomCount in mol.Molecule.OrderBy(p => p.Key).Where(p => p.Value > 0))
                 {
                     formulaText.Append(atomCount.Key);
                     if (atomCount.Value > 1)
                         formulaText.Append(atomCount.Value);
                 }
-                return formulaText.ToString();
+                var txt = formulaText.ToString();
+                txt += MoleculeMassOffset.FormatMassModification(mol.MonoMassOffset, mol.AverageMassOffset, 6);
+                return txt;
             }
         }
 
@@ -989,43 +845,27 @@ namespace pwiz.Skyline.Model
             get { return _massCalc.MassType; }
         }
 
-        public TypedMass GetPrecursorMass(CustomMolecule mol, Adduct adductForIsotopeLabels, out string isotopicFormula)
-        {
+        public TypedMass GetPrecursorMass(CustomMolecule mol, Adduct adductForIsotopeLabels, out MoleculeMassOffset isotopicFormula)       {
             return GetPrecursorMass(mol, null, adductForIsotopeLabels, out isotopicFormula);
         }
 
-        public TypedMass GetPrecursorMass(CustomMolecule mol, TypedModifications typedMods, Adduct adductForIsotopeLabels, out string isotopicFormula)
+        public TypedMass GetPrecursorMass(CustomMolecule mol, TypedModifications typedMods, Adduct adductForIsotopeLabels, out MoleculeMassOffset isotopicFormula)
         {
-            var mass = MassType.IsMonoisotopic() ? mol.MonoisotopicMass : mol.AverageMass;
-            var massCalc = MassType.IsMonoisotopic() ? BioMassCalc.MONOISOTOPIC : BioMassCalc.AVERAGE;
+            TypedMass mass;
 
-            // Isotope descriptions may be found in the typedMods, or in the adduct as when dealing with mass-only documents
+            // Isotope descriptions may be found in the typedMods, or in the adduct as when dealing with small molecules
             var isotopeDescriptionIsInAdduct = adductForIsotopeLabels.HasIsotopeLabels;
-            if (!string.IsNullOrEmpty(mol.Formula) && typedMods != null && !isotopeDescriptionIsInAdduct)
+            var formula = mol.MoleculeAndMassOffset;
+            if (typedMods != null && !isotopeDescriptionIsInAdduct)
             {
-                isotopicFormula = typedMods.LabelType.IsLight || !typedMods.Modifications.Any() ? mol.Formula : GetHeavyFormula(mol.Formula, typedMods.Modifications[0].LabelAtoms);
-                mass = massCalc.CalculateMassFromFormula(isotopicFormula);
+                isotopicFormula = typedMods.LabelType.IsLight || !typedMods.Modifications.Any() ? formula : GetHeavyFormula(formula, typedMods.Modifications[0].LabelAtoms);
             }
             else
             {
-                isotopicFormula = null;
-                if (isotopeDescriptionIsInAdduct)
-                {
-                    // Reduce an adduct like "[2M6Cl37+3H]" to "[M6Cl37]"
-                    var adduct = adductForIsotopeLabels.ChangeMassMultiplier(1).ChangeIonFormula(null);
-                    if (!string.IsNullOrEmpty(mol.Formula))
-                    {
-                        var ionInfo = new IonInfo(mol.Formula, adduct);
-                        isotopicFormula = ionInfo.FormulaWithAdductApplied;
-                        mass = massCalc.CalculateMassFromFormula(isotopicFormula);
-                    }
-                    else
-                    {
-                        // Assume that the isotope labeling can be fully applied: that is, if it's 6C13 then we can add 6*(massC13 - massC)
-                        mass =  adduct.ApplyToMass(mass);
-                    }
-                }
+                isotopicFormula = adductForIsotopeLabels.ApplyIsotopeLabelsToMolecule(formula);
             }
+            var massCalc = MassType.IsMonoisotopic() ? BioMassCalc.MONOISOTOPIC : BioMassCalc.AVERAGE;
+            mass = massCalc.CalculateMass(isotopicFormula);
             return mass;
         }
 
@@ -1033,8 +873,7 @@ namespace pwiz.Skyline.Model
         {
             if (target.IsProteomic)
                 return GetPrecursorMass(target.Sequence);
-            string ignored;
-            return GetPrecursorMass(target.Molecule, Adduct.EMPTY, out ignored);
+            return GetPrecursorMass(target.Molecule, Adduct.EMPTY, out _);
         }
 
         public TypedMass GetPrecursorMass(string seq)
@@ -1064,7 +903,7 @@ namespace pwiz.Skyline.Model
                     mass += mods.ModMasses[i];
             }
 
-            return new TypedMass(mass, MassType.IsMonoisotopic() ? MassType.MonoisotopicMassH : MassType.AverageMassH); // This is massH (due to +BioMassCalc.MassProton above)
+            return TypedMass.Create(mass, MassType.IsMonoisotopic() ? MassType.MonoisotopicMassH : MassType.AverageMassH); // This is massH (due to +BioMassCalc.MassProton above)
         }
 
         public IonTable<TypedMass> GetFragmentIonMasses(Target seq)
@@ -1168,19 +1007,20 @@ namespace pwiz.Skyline.Model
                     return isotopeDist.GetMassI(massIndex);
                 }
                 else if (transition.IsNonReporterCustomIon() && // Don't apply labels to reporter ions
-                    !string.IsNullOrEmpty(transition.CustomIon.NeutralFormula))
+                         !transition.CustomIon.MoleculeAndMassOffset.IsMassOnly)
                 {
                     if (Labels.Any())
                     {
-                        var formula = Labels.Aggregate(transition.CustomIon.NeutralFormula, (current, staticMod) => GetHeavyFormula(current, staticMod.LabelAtoms));
-                        return _massCalc.CalculateMassFromFormula(formula);
+                        var union = Labels.Aggregate(LabelAtoms.None, (current, staticMod) => current | staticMod.LabelAtoms);
+                        var formula = GetHeavyFormula(transition.CustomIon.MoleculeAndMassOffset, union);
+                        return _massCalc.CalculateMass(formula).ChangeIsMassH(false);
                     }
                     else if (Transition.IsPrecursor(type) && transition.Group.PrecursorAdduct.HasIsotopeLabels)
                     {
                         // Apply any labels found in the adduct description
                         var formula =
-                            transition.Group.PrecursorAdduct.ApplyIsotopeLabelsToFormula(transition.CustomIon.NeutralFormula);
-                        return _massCalc.CalculateMassFromFormula(formula);
+                            transition.Group.PrecursorAdduct.ApplyIsotopeLabelsToMolecule(transition.CustomIon.MoleculeAndMassOffset);
+                        return _massCalc.CalculateMass(formula).ChangeIsMassH(false);
                     }
                 }
                 return MassType.IsAverage() 
@@ -1199,8 +1039,7 @@ namespace pwiz.Skyline.Model
 
         public TypedMass GetPrecursorFragmentMass(CustomMolecule mol, Adduct adductForIsotopeLabels)
         {
-            string isotopicFormula;
-            return GetPrecursorMass(mol, adductForIsotopeLabels, out isotopicFormula);
+            return GetPrecursorMass(mol, adductForIsotopeLabels, out _);
         }
 
         public TypedMass GetPrecursorFragmentMass(Target target)
@@ -1263,7 +1102,7 @@ namespace pwiz.Skyline.Model
 
             mass += GetTermDeltaMass(type);    // Exactly match GetFragmentIonMasses()
 
-            return new TypedMass(mass, MassType.IsMonoisotopic() ? MassType.MonoisotopicMassH : MassType.AverageMassH); // This is massH ( + BioMassCalc.MassProton above)
+            return TypedMass.Create(mass, MassType.IsMonoisotopic() ? MassType.MonoisotopicMassH : MassType.AverageMassH); // This is massH ( + BioMassCalc.MassProton above)
         }
 
         private double GetTermMass(IonType type, ExplicitSequenceMods mods)
@@ -1315,7 +1154,7 @@ namespace pwiz.Skyline.Model
             {
                 var formula = AMINO_FORMULAS[i];
                 if (formula != null)
-                    _aminoMasses[i] = _massCalc.CalculateMassFromFormula(formula);
+                    _aminoMasses[i] = _massCalc.CalculateMass(formula);
             }
 
 
@@ -1333,8 +1172,8 @@ namespace pwiz.Skyline.Model
             // ReSharper restore CharImplicitlyConvertedToNumeric
         }
 
-        private static readonly Molecule[] AMINO_FORMULAS = new Molecule[128];
-        private static readonly Molecule H2O = Molecule.Parse(@"H2O");
+        private static readonly ParsedMoleculeMassOffset[] AMINO_FORMULAS = new ParsedMoleculeMassOffset[128];
+        private static readonly ParsedMoleculeMassOffset H2O = ParsedMoleculeMassOffset.Create(@"H2O");
         static SequenceMassCalc()
         {
 
@@ -1343,44 +1182,44 @@ namespace pwiz.Skyline.Model
             // ReSharper disable CharImplicitlyConvertedToNumeric
             // ReSharper disable LocalizableElement
             // CONSIDER(bspratt): what about B and Z? (see average values above for masses)
-            AMINO_FORMULAS['a'] = AMINO_FORMULAS['A'] = Molecule.Parse("C3H5ON");
-            AMINO_FORMULAS['c'] = AMINO_FORMULAS['C'] = Molecule.Parse("C3H5ONS");
-            AMINO_FORMULAS['d'] = AMINO_FORMULAS['D'] = Molecule.Parse("C4H5O3N");
-            AMINO_FORMULAS['e'] = AMINO_FORMULAS['E'] = Molecule.Parse("C5H7O3N");
-            AMINO_FORMULAS['f'] = AMINO_FORMULAS['F'] = Molecule.Parse("C9H9ON");
-            AMINO_FORMULAS['g'] = AMINO_FORMULAS['G'] = Molecule.Parse("C2H3ON");
-            AMINO_FORMULAS['h'] = AMINO_FORMULAS['H'] = Molecule.Parse("C6H7ON3");
-            AMINO_FORMULAS['i'] = AMINO_FORMULAS['I'] = Molecule.Parse("C6H11ON");
-            AMINO_FORMULAS['k'] = AMINO_FORMULAS['K'] = Molecule.Parse("C6H12ON2");
-            AMINO_FORMULAS['l'] = AMINO_FORMULAS['L'] = Molecule.Parse("C6H11ON");
-            AMINO_FORMULAS['m'] = AMINO_FORMULAS['M'] = Molecule.Parse("C5H9ONS");
-            AMINO_FORMULAS['n'] = AMINO_FORMULAS['N'] = Molecule.Parse("C4H6O2N2");
-            AMINO_FORMULAS['o'] = AMINO_FORMULAS['O'] = Molecule.Parse("C12H19N3O2");
-            AMINO_FORMULAS['p'] = AMINO_FORMULAS['P'] = Molecule.Parse("C5H7ON");
-            AMINO_FORMULAS['q'] = AMINO_FORMULAS['Q'] = Molecule.Parse("C5H8O2N2");
-            AMINO_FORMULAS['r'] = AMINO_FORMULAS['R'] = Molecule.Parse("C6H12ON4");
-            AMINO_FORMULAS['s'] = AMINO_FORMULAS['S'] = Molecule.Parse("C3H5O2N");
-            AMINO_FORMULAS['t'] = AMINO_FORMULAS['T'] = Molecule.Parse("C4H7O2N");
-            AMINO_FORMULAS['u'] = AMINO_FORMULAS['U'] = Molecule.Parse("C3H5NOSe");
-            AMINO_FORMULAS['v'] = AMINO_FORMULAS['V'] = Molecule.Parse("C5H9ON");
-            AMINO_FORMULAS['w'] = AMINO_FORMULAS['W'] = Molecule.Parse("C11H10ON2");
-            AMINO_FORMULAS['y'] = AMINO_FORMULAS['Y'] = Molecule.Parse("C9H9O2N");
+            AMINO_FORMULAS['a'] = AMINO_FORMULAS['A'] = ParsedMoleculeMassOffset.Create("C3H5ON");
+            AMINO_FORMULAS['c'] = AMINO_FORMULAS['C'] = ParsedMoleculeMassOffset.Create("C3H5ONS");
+            AMINO_FORMULAS['d'] = AMINO_FORMULAS['D'] = ParsedMoleculeMassOffset.Create("C4H5O3N");
+            AMINO_FORMULAS['e'] = AMINO_FORMULAS['E'] = ParsedMoleculeMassOffset.Create("C5H7O3N");
+            AMINO_FORMULAS['f'] = AMINO_FORMULAS['F'] = ParsedMoleculeMassOffset.Create("C9H9ON");
+            AMINO_FORMULAS['g'] = AMINO_FORMULAS['G'] = ParsedMoleculeMassOffset.Create("C2H3ON");
+            AMINO_FORMULAS['h'] = AMINO_FORMULAS['H'] = ParsedMoleculeMassOffset.Create("C6H7ON3");
+            AMINO_FORMULAS['i'] = AMINO_FORMULAS['I'] = ParsedMoleculeMassOffset.Create("C6H11ON");
+            AMINO_FORMULAS['k'] = AMINO_FORMULAS['K'] = ParsedMoleculeMassOffset.Create("C6H12ON2");
+            AMINO_FORMULAS['l'] = AMINO_FORMULAS['L'] = ParsedMoleculeMassOffset.Create("C6H11ON");
+            AMINO_FORMULAS['m'] = AMINO_FORMULAS['M'] = ParsedMoleculeMassOffset.Create("C5H9ONS");
+            AMINO_FORMULAS['n'] = AMINO_FORMULAS['N'] = ParsedMoleculeMassOffset.Create("C4H6O2N2");
+            AMINO_FORMULAS['o'] = AMINO_FORMULAS['O'] = ParsedMoleculeMassOffset.Create("C12H19N3O2");
+            AMINO_FORMULAS['p'] = AMINO_FORMULAS['P'] = ParsedMoleculeMassOffset.Create("C5H7ON");
+            AMINO_FORMULAS['q'] = AMINO_FORMULAS['Q'] = ParsedMoleculeMassOffset.Create("C5H8O2N2");
+            AMINO_FORMULAS['r'] = AMINO_FORMULAS['R'] = ParsedMoleculeMassOffset.Create("C6H12ON4");
+            AMINO_FORMULAS['s'] = AMINO_FORMULAS['S'] = ParsedMoleculeMassOffset.Create("C3H5O2N");
+            AMINO_FORMULAS['t'] = AMINO_FORMULAS['T'] = ParsedMoleculeMassOffset.Create("C4H7O2N");
+            AMINO_FORMULAS['u'] = AMINO_FORMULAS['U'] = ParsedMoleculeMassOffset.Create("C3H5NOSe");
+            AMINO_FORMULAS['v'] = AMINO_FORMULAS['V'] = ParsedMoleculeMassOffset.Create("C5H9ON");
+            AMINO_FORMULAS['w'] = AMINO_FORMULAS['W'] = ParsedMoleculeMassOffset.Create("C11H10ON2");
+            AMINO_FORMULAS['y'] = AMINO_FORMULAS['Y'] = ParsedMoleculeMassOffset.Create("C9H9O2N");
             // ReSharper restore LocalizableElement
             // ReSharper restore CharImplicitlyConvertedToNumeric
         }
 
-        public static Molecule GetAminoAcidFormula(char aa)
+        public static ParsedMoleculeMassOffset GetAminoAcidFormula(char aa)
         {
-            return Molecule.FromDict(AMINO_FORMULAS[aa]);
+            return AMINO_FORMULAS[aa];
         }
 
-        public static string GetHeavyFormula(char aa, LabelAtoms labelAtoms)
+        public static ParsedMoleculeMassOffset GetHeavyFormula(char aa, LabelAtoms labelAtoms)
         {
             var formulaAA = AMINO_FORMULAS[aa];
             if (formulaAA == null)
                 throw new ArgumentOutOfRangeException(string.Format(Resources.SequenceMassCalc_GetHeavyFormula_No_formula_found_for_the_amino_acid___0__, aa));
-            var formula = formulaAA.ToString();
-            return GetHeavyFormula(formula, labelAtoms) + @" - " + formula;
+
+            return formulaAA.ChangeMolecule(GetHeavyFormula(formulaAA, labelAtoms).Difference(formulaAA).Molecule);
         }
 
         private static readonly ImmutableList<Tuple<LabelAtoms, string, string>> 
@@ -1394,91 +1233,45 @@ namespace pwiz.Skyline.Model
             Tuple.Create(LabelAtoms.Br81, BioMassCalc.Br, BioMassCalc.Br81),
             Tuple.Create(LabelAtoms.P32, BioMassCalc.P, BioMassCalc.P32),
             Tuple.Create(LabelAtoms.S34, BioMassCalc.S, BioMassCalc.S34),
-
         });
-        public static string GetHeavyFormula(string formula, LabelAtoms labelAtoms)
+
+        public static MoleculeMassOffset GetHeavyFormula(string formulaString, LabelAtoms labelAtoms)
+        {
+            var formula = ParsedMoleculeMassOffset.Create(formulaString);
+            return GetHeavyFormula(formula, labelAtoms);
+        }
+
+        public static MoleculeMassOffset GetHeavyFormula(MoleculeMassOffset formula, LabelAtoms labelAtoms)
         {
             if (labelAtoms == LabelAtoms.None)
             {
                 return formula;
             }
-            var subsitutions = ALL_LABEL_SUBSTITUTIONS
+            var substitutions = ALL_LABEL_SUBSTITUTIONS
                 .Where(tuple => (tuple.Item1 & labelAtoms) != 0).ToArray();
-            StringBuilder result = new StringBuilder();
-            foreach (var symbol in TokenizeFormula(formula))
+            var result = new Dictionary<string, int>();
+            bool bHasSubstitutions = false;
+            foreach (var kvp in formula.Molecule)
             {
-                var subTuple = subsitutions.FirstOrDefault(tuple => tuple.Item2 == symbol);
-                if (subTuple == null)
+                var symbol = kvp.Key;
+                var subTuple = substitutions.FirstOrDefault(tuple => tuple.Item2 == symbol);
+                if (subTuple != null)
                 {
-                    result.Append(symbol);
+                    symbol = subTuple.Item3;
+                    bHasSubstitutions = true;
+                }
+
+                if (result.TryGetValue(symbol, out var count)) // In case two or more substitutions map to same original key
+                {
+                    result[symbol] = count + kvp.Value;
                 }
                 else
                 {
-                    result.Append(subTuple.Item3);
+                    result.Add(symbol, kvp.Value);
                 }
             }
-            return result.ToString();
-        }
 
-        /// <summary>
-        /// Split a formula up into its individual tokens.
-        /// A token is one of an element name, an integer, or the special characters space and minus sign.
-        /// </summary>
-        public static IEnumerable<string> TokenizeFormula(string formula)
-        {
-            int? ichElementStart = null;
-            int? ichCountStart = null;
-            for (int ich = 0; ich < formula.Length; ich++)
-            {
-                char ch = formula[ich];
-                bool isDigit = ch >= '0' && ch <= '9';
-                bool isElementNameStart = ch >= 'A' && ch <= 'Z';
-                bool isSpecial = ch == '-' || ch == ' ';
-                if (isDigit && ichCountStart.HasValue)
-                {
-                    continue;
-                }
-                if (!isDigit && !isSpecial && !isElementNameStart)
-                {
-                    // any other character is considered part of an element name, unless
-                    if (ichElementStart.HasValue)
-                    {
-                        continue;
-                    }
-                    // characters before the start of an element name are garbage, but we preserve them
-                    isSpecial = true;
-                }
-                if (ichElementStart.HasValue)
-                {
-                    yield return formula.Substring(ichElementStart.Value, ich - ichElementStart.Value);
-                    ichElementStart = null;
-                }
-                if (ichCountStart.HasValue)
-                {
-                    yield return formula.Substring(ichCountStart.Value, ich - ichCountStart.Value);
-                    ichCountStart = null;
-                }
-                if (isDigit)
-                {
-                    ichCountStart = ich;
-                }
-                if (isElementNameStart)
-                {
-                    ichElementStart = ich;
-                }
-                if (isSpecial)
-                {
-                    yield return new string(ch, 1);
-                }
-            }
-            if (ichElementStart.HasValue)
-            {
-                yield return formula.Substring(ichElementStart.Value);
-            }
-            if (ichCountStart.HasValue)
-            {
-                yield return formula.Substring(ichCountStart.Value);
-            }
+            return bHasSubstitutions ? formula.Change(Molecule.FromDict(result)).ChangeIsHeavy(true) : formula;
         }
     }
 
@@ -1516,7 +1309,7 @@ namespace pwiz.Skyline.Model
             get { return _massCalcBase.MassType; }
         }
 
-        public TypedMass GetPrecursorMass(CustomMolecule mol, TypedModifications mods, Adduct adductForIsotopeLabels, out string isotopicFormula)
+        public TypedMass GetPrecursorMass(CustomMolecule mol, TypedModifications mods, Adduct adductForIsotopeLabels, out MoleculeMassOffset isotopicFormula)
         {
             return _massCalcBase.GetPrecursorMass(mol, mods, adductForIsotopeLabels, out isotopicFormula);
         }
@@ -1530,8 +1323,7 @@ namespace pwiz.Skyline.Model
         {
             if (target.IsProteomic)
                 return GetPrecursorMass(target.Sequence);
-            string ignored;
-            return GetPrecursorMass(target.Molecule, null, Adduct.EMPTY, out ignored);
+            return GetPrecursorMass(target.Molecule, null, Adduct.EMPTY, out _);
         }
 
 
@@ -1561,7 +1353,7 @@ namespace pwiz.Skyline.Model
             return GetModifiedSequence(seq, SequenceModFormatType.mass_diff_narrow, false);
         }
 
-        public Adduct GetModifiedAdduct(Adduct adduct, string neutralFormula)
+        public Adduct GetModifiedAdduct(Adduct adduct,  MoleculeMassOffset neutralFormula)
         {
             return HasLabels ? 
                 SequenceMassCalc.GetModifiedAdduct(adduct, neutralFormula, _massCalcBase.Labels) : 
@@ -1573,7 +1365,7 @@ namespace pwiz.Skyline.Model
             return _massCalcBase.GetAAModMass(aa, seqIndex, seqLength, _mods);
         }
 
-        public string GetMolecularFormula(string seq)
+        public MoleculeMassOffset GetMolecularFormula(string seq)
         {
             return _massCalcBase.GetNeutralFormula(seq, _mods);
         }
@@ -1583,9 +1375,9 @@ namespace pwiz.Skyline.Model
             return _massCalcBase.GetMzDistribution(target, adduct, abundances, _mods);
         }
 
-        public MassDistribution GetMZDistributionFromFormula(string formula, Adduct adduct, IsotopeAbundances abundances)
+        public MassDistribution GetMZDistribution(MoleculeMassOffset molecule, Adduct adduct, IsotopeAbundances abundances)
         {
-            return _massCalcBase.GetMZDistributionFromFormula(formula, adduct, abundances);
+            return _massCalcBase.GetMZDistribution(molecule, adduct, abundances);
         }
 
         public MassDistribution GetMZDistributionSinglePoint(double mz)

--- a/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs
+++ b/pwiz_tools/Skyline/Model/Serialization/DocumentReader.cs
@@ -1011,10 +1011,10 @@ namespace pwiz.Skyline.Model.Serialization
             Results<PeptideChromInfo> results = null;
             TransitionGroupDocNode[] children = null;
             Adduct adduct = Adduct.EMPTY;
-            var customMolecule = isCustomMolecule ? CustomMolecule.Deserialize(reader, out adduct) : null; // This Deserialize only reads attribures, doesn't advance the reader
+            var customMolecule = isCustomMolecule ? CustomMolecule.Deserialize(reader, out adduct) : null; // This Deserialize only reads attributes, doesn't advance the reader
             if (customMolecule != null)
             {
-                if (DocumentMayContainMoleculesWithEmbeddedIons && string.IsNullOrEmpty(customMolecule.Formula) && customMolecule.MonoisotopicMass.IsMassH())
+                if (DocumentMayContainMoleculesWithEmbeddedIons && customMolecule.MoleculeAndMassOffset.IsMassOnly && customMolecule.MonoisotopicMass.IsMassH())
                 {
                     // Defined by mass only, assume it's not massH despite how it may have been written
                     customMolecule = new CustomMolecule(
@@ -1350,10 +1350,9 @@ namespace pwiz.Skyline.Model.Serialization
                 {
                     ionFormula = ionFormula.Trim(); // We've seen trailing spaces in the wild
                 }
-                Molecule mol;
                 string neutralFormula;
                 Adduct adduct;
-                var isFormulaWithAdduct = IonInfo.IsFormulaWithAdduct(ionFormula, out mol, out adduct, out neutralFormula);
+                var isFormulaWithAdduct = IonInfo.IsFormulaWithAdduct(ionFormula, out var _, out adduct, out neutralFormula);
                 if (isFormulaWithAdduct)
                 {
                     precursorAdduct = adduct;
@@ -1364,9 +1363,9 @@ namespace pwiz.Skyline.Model.Serialization
                 }
                 if (!string.IsNullOrEmpty(neutralFormula))
                 {
-                    var ionString = precursorAdduct.ApplyToFormula(neutralFormula);
-                    var moleculeWithAdduct = precursorAdduct.ApplyToFormula(peptide.CustomMolecule.Formula);
-                    Assume.IsTrue(Equals(ionString, moleculeWithAdduct), @"Expected precursor ion formula to match parent molecule with adduct applied");
+                    var ion = precursorAdduct.ApplyToFormula(neutralFormula);
+                    var moleculeWithAdduct = precursorAdduct.ApplyToMolecule(peptide.CustomMolecule.MoleculeAndMassOffset);
+                    Assume.IsTrue(ion.CompareTolerant(moleculeWithAdduct, BioMassCalc.MassTolerance) == 0, @"Expected precursor ion formula to match parent molecule with adduct applied");
                 }
             }
             var group = new TransitionGroup(peptide, precursorAdduct, typedMods.LabelType, false, decoyMassShift);
@@ -1572,7 +1571,7 @@ namespace pwiz.Skyline.Model.Serialization
                 else
                 {
                     customMolecule = CustomMolecule.Deserialize(reader, out adduct);
-                    if (DocumentMayContainMoleculesWithEmbeddedIons && string.IsNullOrEmpty(customMolecule.Formula) && customMolecule.MonoisotopicMass.IsMassH())
+                    if (DocumentMayContainMoleculesWithEmbeddedIons && customMolecule.MoleculeAndMassOffset.IsMassOnly && customMolecule.MonoisotopicMass.IsMassH())
                     {
                         // Defined by mass only, assume it's not massH despite how it may have been written
                         customMolecule = new CustomMolecule(customMolecule.MonoisotopicMass.ChangeIsMassH(false), customMolecule.AverageMass.ChangeIsMassH(false),
@@ -1596,16 +1595,16 @@ namespace pwiz.Skyline.Model.Serialization
                 if (!isPrecursor && isPre362NonReporterCustom &&
                     Math.Abs(declaredProductMz.Value - customMolecule.MonoisotopicMass / Math.Abs(adduct.AdductCharge)) < .001)
                 {
-                    string newFormula = null;
-                    if (!string.IsNullOrEmpty(customMolecule.Formula) &&
+                    CustomMolecule newFormula = null;
+                    if (!customMolecule.MoleculeAndMassOffset.IsMassOnly &&
                         Math.Abs(customMolecule.MonoisotopicMass - Math.Abs(adduct.AdductCharge) * declaredProductMz.Value) < .01)
                     {
                         // Adjust hydrogen count to get a molecular mass that makes sense for charge and mz
-                        newFormula = Molecule.AdjustElementCount(customMolecule.Formula, @"H", -adduct.AdductCharge);
+                        newFormula = customMolecule.AdjustElementCount(@"H", -adduct.AdductCharge);
                     }
-                    if (!string.IsNullOrEmpty(newFormula))
+                    if (!CustomMolecule.IsNullOrEmpty(newFormula))
                     {
-                        customMolecule = new CustomMolecule(newFormula, customMolecule.Name);
+                        customMolecule = newFormula;
                     }
                     else
                     {

--- a/pwiz_tools/Skyline/Model/Serialization/Pre372CustomIonTransitionGroupHandler.cs
+++ b/pwiz_tools/Skyline/Model/Serialization/Pre372CustomIonTransitionGroupHandler.cs
@@ -40,7 +40,7 @@ namespace pwiz.Skyline.Model.Serialization
         // Needed since we actually stored the precursor description rather than the molecule description in v3.71 and earlier
         private class PrecursorRawDetails
         {
-            public string _formulaUnlabeled;
+            public MoleculeMassOffset _formulaUnlabeled;
             public IDictionary<string,int> _labels;
             public Adduct _nominalAdduct;
             public Adduct _proposedAdduct;
@@ -79,7 +79,7 @@ namespace pwiz.Skyline.Model.Serialization
             {
                 var details = new PrecursorRawDetails
                 {
-                    _formulaUnlabeled = string.Empty,
+                    _formulaUnlabeled = MoleculeMassOffset.EMPTY,
                     _labels = null,
                     _nominalAdduct = Adduct.EMPTY,
                     _proposedAdduct = Adduct.EMPTY,
@@ -88,21 +88,18 @@ namespace pwiz.Skyline.Model.Serialization
                     _declaredHeavy = !IsotopeLabelType.LIGHT_NAME.Equals(reader.GetAttribute(DocumentSerializer.ATTR.isotope_label) ?? IsotopeLabelType.LIGHT_NAME)
                 };
                 var formula = reader.GetAttribute(DocumentSerializer.ATTR.ion_formula);
-                if (formula != null)
+                if (!string.IsNullOrEmpty(formula))
                 {
-                    details._formulaUnlabeled = formula.Trim(); // We've seen tailing spaces in the wild
-                    string precursorFormula;
-                    Adduct precursorAdduct;
-                    Molecule precursorMol;
-                    if (IonInfo.IsFormulaWithAdduct(formula, out precursorMol, out precursorAdduct, out precursorFormula))
+                    var isFormulaWithAdduct = IonInfo.IsFormulaWithAdduct(formula.Trim(), out var _, out var precursorAdduct, out var precursorFormula);
+                    details._formulaUnlabeled = ParsedMoleculeMassOffset.Create(precursorFormula);
+                    if (isFormulaWithAdduct)
                     {
-                        details._formulaUnlabeled = precursorFormula;
                         details._nominalAdduct = precursorAdduct;
                     }
                     else
                     {
-                        details._labels = BioMassCalc.MONOISOTOPIC.FindIsotopeLabelsInFormula(details._formulaUnlabeled);
-                        details._formulaUnlabeled = BioMassCalc.MONOISOTOPIC.StripLabelsFromFormula(details._formulaUnlabeled);
+                        details._labels = BioMassCalc.FindIsotopeLabelsInFormula(details._formulaUnlabeled.Molecule);
+                        details._formulaUnlabeled = BioMassCalc.StripLabelsFromFormula(details._formulaUnlabeled);
                     }
                 }
                 _precursorRawDetails.Add(details);
@@ -136,7 +133,7 @@ namespace pwiz.Skyline.Model.Serialization
             ProposeMoleculeWithCommonFormula(peptide);
 
             // Deal with mass-only declarations if no formulas were found
-            if (string.IsNullOrEmpty(ProposedMolecule.Formula))
+            if (ProposedMolecule.MoleculeAndMassOffset.IsMassOnly)
             {
                 return HandleMassOnlyDeclarations(ref peptide);
             } 
@@ -162,7 +159,7 @@ namespace pwiz.Skyline.Model.Serialization
 
         private XmlReader ConsiderMassShiftAdducts(ref Peptide peptide)
         {
-            var commonFormula = ProposedMolecule.Formula;
+            var commonFormula = ProposedMolecule.MoleculeAndMassOffset;
             var molMass = ProposedMolecule.MonoisotopicMass;
             foreach (var d in _precursorRawDetails.Where(d => Adduct.IsNullOrEmpty(d._proposedAdduct)))
             {
@@ -225,11 +222,11 @@ namespace pwiz.Skyline.Model.Serialization
                 // Start with the most common scenario, which is that the user meant (de)protonation
                 // See if we can arrive at a common formula ( by adding or removing H) that works with all charges as (de)protonations
                 // N.B. the parent molecule may well be completely unrelated to the children, as users were allowed to enter anything they wanted
-                var commonFormula = ProposedMolecule.Formula;
-                var precursorsWithFormulas = _precursorRawDetails.Where(d => !string.IsNullOrEmpty(d._formulaUnlabeled)).ToList();
+                var commonFormula = ProposedMolecule.MoleculeAndMassOffset;
+                var precursorsWithFormulas = _precursorRawDetails.Where(d => !d._formulaUnlabeled.IsMassOnly).ToList();
                 foreach (var detail in precursorsWithFormulas)
                 {
-                    var revisedCommonFormula = Molecule.AdjustElementCount(commonFormula, BioMassCalc.H, -detail._declaredCharge);
+                    var revisedCommonFormula = commonFormula.AdjustElementCount(BioMassCalc.H, -detail._declaredCharge);
                     var adjustedMolecule = new CustomMolecule(revisedCommonFormula, peptide.CustomMolecule.Name);
                     var mass = adjustedMolecule.MonoisotopicMass;
                     if (precursorsWithFormulas.TrueForAll(d =>
@@ -260,12 +257,12 @@ namespace pwiz.Skyline.Model.Serialization
         {
             // Examine any provided formulas (including parent molecule and/or precursor ions) and find common basis
             ProposedMolecule = peptide.CustomMolecule;
-            var precursorsWithFormulas = _precursorRawDetails.Where(d => !string.IsNullOrEmpty(d._formulaUnlabeled)).ToList();
+            var precursorsWithFormulas = _precursorRawDetails.Where(d => !d._formulaUnlabeled.IsMassOnly).ToList();
             var parentFormula = peptide.CustomMolecule.UnlabeledFormula;
-            var commonFormula = string.IsNullOrEmpty(parentFormula)
-                ? BioMassCalc.MONOISOTOPIC.FindFormulaIntersectionUnlabeled(
-                    precursorsWithFormulas.Select(p => p._formulaUnlabeled))
-                : parentFormula;
+            var commonFormula = parentFormula.IsMassOnly
+                ? BioMassCalc.FindFormulaIntersectionUnlabeled(
+                    precursorsWithFormulas.Select(p => p._formulaUnlabeled.Molecule))
+                : parentFormula.Molecule;
 
             // Check for consistent and correctly declared precursor formula+adduct
             var precursorsWithFormulasAndAdducts = precursorsWithFormulas.Where(d => !Adduct.IsNullOrEmpty(d._nominalAdduct)).ToList();
@@ -273,12 +270,12 @@ namespace pwiz.Skyline.Model.Serialization
                 precursorsWithFormulas.All(
                     d => d._formulaUnlabeled.Equals(precursorsWithFormulasAndAdducts[0]._formulaUnlabeled)))
             {
-                commonFormula = precursorsWithFormulasAndAdducts[0]._formulaUnlabeled;
+                commonFormula = precursorsWithFormulasAndAdducts[0]._formulaUnlabeled.Molecule;
             }
 
-            if (!string.IsNullOrEmpty(commonFormula))
+            if (!Molecule.IsNullOrEmpty(commonFormula))
             {
-                var parentComposition = Molecule.ParseExpression(commonFormula);
+                var parentComposition = commonFormula;
                 // Check for children proposing to label more atoms than parent provides, adjust parent as needed
                 foreach (var precursor in _precursorRawDetails.Where(d => d._labels != null))
                 {
@@ -291,14 +288,14 @@ namespace pwiz.Skyline.Model.Serialization
                         {
                             // Child proposes to label more of an atom than the parent possesses (seen in the wild) - update the parent
                             commonFormula =
-                                Molecule.AdjustElementCount(commonFormula, unlabeled, kvpIsotopeCount.Value - parentCount);
-                            parentComposition = Molecule.ParseExpression(commonFormula);
+                                commonFormula.AdjustElementCount(unlabeled, kvpIsotopeCount.Value - parentCount);
+                            parentComposition = commonFormula;
                         }
                     }
                 }
-                if (!Equals(peptide.CustomMolecule.Formula, commonFormula))
+                if (!Equals(peptide.CustomMolecule.MoleculeAndMassOffset.Molecule, commonFormula))
                 {
-                    ProposedMolecule = new CustomMolecule(commonFormula, peptide.CustomMolecule.Name);
+                    ProposedMolecule = new CustomMolecule(MoleculeMassOffset.Create(commonFormula, 0, 0), peptide.CustomMolecule.Name);
                 }
             }
         }
@@ -312,8 +309,8 @@ namespace pwiz.Skyline.Model.Serialization
                 foreach (var detail in _precursorRawDetails.OrderBy(d => d._declaredHeavy ? 1 : 0)) // Look at lights first
                 {
                     var parentMassAdjustment = adjustParentMass
-                        ? Adduct.NonProteomicProtonatedFromCharge(detail._declaredCharge).ApplyToMass(TypedMass.ZERO_MONO_MASSH)
-                        : TypedMass.ZERO_MONO_MASSH;
+                        ? Adduct.NonProteomicProtonatedFromCharge(detail._declaredCharge).ApplyToMass(TypedMass.ZERO_MONO_MASSNEUTRAL)
+                        : TypedMass.ZERO_MONO_MASSNEUTRAL;
                     var parentMonoisotopicMass = ProposedMolecule.MonoisotopicMass - parentMassAdjustment;
                     if (_precursorRawDetails.TrueForAll(d =>
                     {
@@ -357,7 +354,7 @@ namespace pwiz.Skyline.Model.Serialization
         private XmlReader UpdatePeptideAndInsertAdductsInXML(ref Peptide peptide, IEnumerable<Adduct> adducts)
         {
             var updatedPeptide = ReferenceEquals(ProposedMolecule, peptide.CustomMolecule) ? peptide : new Peptide(ProposedMolecule);
-            var ionFormulas = adducts.Select(a => updatedPeptide.CustomMolecule.Formula + a.ToString()).ToList();
+            var ionFormulas = adducts.Select(a => updatedPeptide.CustomMolecule.MoleculeAndMassOffset.ChemicalFormulaString() + a.ToString()).ToList();
             ReadAhead.ModifyAttributesInElement(DocumentSerializer.EL.precursor, DocumentSerializer.ATTR.ion_formula,
                 ionFormulas); // N.B. "ion_formula" consists of just the adduct for mass only molecules
             peptide = updatedPeptide;

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -357,12 +357,10 @@ namespace pwiz.Skyline.Model
                     adduct.MzFromNeutralMass(pep.CustomMolecule.AverageMass, MassType.Average);
                 var labelType = precursor.IsotopeLabelType ?? IsotopeLabelType.light;
                 // Match existing molecule if same formula or identical formula when stripped of labels
-                pepFound |= !string.IsNullOrEmpty(pep.CustomMolecule.Formula) &&
-                            (Equals(pep.CustomMolecule.Formula, precursor.NeutralFormula) ||
-                             Equals(pep.CustomMolecule.Formula, precursor.Formula) ||
-                             Equals(pep.CustomMolecule.UnlabeledFormula,
-                                 BioMassCalc.MONOISOTOPIC.StripLabelsFromFormula(precursor
-                                     .NeutralFormula)) ||
+                pepFound |= !pep.CustomMolecule.MoleculeAndMassOffset.IsMassOnly &&
+                            (Equals(pep.CustomMolecule.MoleculeAndMassOffset, precursor.NeutralFormula) ||
+                             Equals(pep.CustomMolecule.MoleculeAndMassOffset, precursor.Formula) ||
+                             Equals(pep.CustomMolecule.UnlabeledFormula, BioMassCalc.StripLabelsFromFormula(precursor.NeutralFormula)) ||
                              Equals(pep.CustomMolecule.UnlabeledFormula, precursor.UnlabeledFormula));
                 // Match existing molecule if similar m/z at the precursor charge
                 pepFound |= Math.Abs(ionMonoMz - precursorMonoMz) <= MzMatchTolerance &&
@@ -370,8 +368,8 @@ namespace pwiz.Skyline.Model
                             MzMatchTolerance && // (we don't just check mass since we don't have a tolerance value for that)
                             (adduct.AdductCharge < 0 == precursor.Adduct.AdductCharge < 0);
                 // Or no formula, and different isotope labels or matching label and mz
-                pepFound |= string.IsNullOrEmpty(pep.CustomMolecule.Formula) &&
-                            string.IsNullOrEmpty(precursor.Formula) &&
+                pepFound |= pep.CustomMolecule.MoleculeAndMassOffset.IsMassOnly &&
+                            precursor.Formula.IsMassOnly &&
                             (!pep.TransitionGroups.Any(t => Equals(t.TransitionGroup.LabelType,
                                  labelType)) || // First label of this kind
                              pep.TransitionGroups.Any(
@@ -702,9 +700,10 @@ namespace pwiz.Skyline.Model
             if (adductInferred.IsEmpty)
             {
                 // That formula and this mz don't yield a reasonable charge state - try adding an H
-                var ion2 = new CustomMolecule(BioMassCalc.AddH(ion.FormulaWithAdductApplied));
-                monoMass = ion2.GetMass(MassType.Monoisotopic);
-                averageMass = ion2.GetMass(MassType.Average);
+                var ion2 = ion.FormulaWithAdductApplied.SetElementCount(BioMassCalc.H,
+                    ion.FormulaWithAdductApplied.GetElementCount(BioMassCalc.H)+1);
+                monoMass = BioMassCalc.MONOISOTOPIC.CalculateMass(ion2);
+                averageMass = BioMassCalc.AVERAGE.CalculateMass(ion2);
                 mass = useMonoIsotopicMass
                     ? monoMass
                     : averageMass;
@@ -713,7 +712,7 @@ namespace pwiz.Skyline.Model
                     maxCharge, new int[0], TransitionCalc.MassShiftType.none, out _, out _);
                 if (!adductInferred.IsEmpty)
                 {
-                    moleculeFormula = ion2.Formula;
+                    moleculeFormula = ion2.ToString();
                 }
                 else
                 {
@@ -736,7 +735,7 @@ namespace pwiz.Skyline.Model
             var ion = new CustomMolecule(moleculeFormula);
             monoMass = ion.GetMass(MassType.Monoisotopic);
             averageMass = ion.GetMass(MassType.Average);
-            return new TypedMass(adduct.MzFromNeutralMass(massType.IsMonoisotopic() ? monoMass : averageMass, massType), massType); // m/z is not actually a mass, of course, but mono vs avg is interesting
+            return TypedMass.Create(adduct.MzFromNeutralMass(massType.IsMonoisotopic() ? monoMass : averageMass, massType), massType); // m/z is not actually a mass, of course, but mono vs avg is interesting
         }
 
         public static string NullForEmpty(string str)
@@ -789,6 +788,11 @@ namespace pwiz.Skyline.Model
                 ExplicitTransitionGroupValues = explicitTransitionGroupValues;
                 ExplicitTransitionValues = explicitTransitionValues;
                 Note = note;
+                if (Formula.IsMassOnly && !Formula.IsEmpty)
+                {
+                    // BioMassCalc parser will accept a mass-only formula, but we don't want to allow that here
+                    throw new ArgumentException(BioMassCalc.FormatArgumentExceptionMessage(formula));
+                }
             }
 
             public ParsedIonInfo ChangeNote(string note)
@@ -801,8 +805,9 @@ namespace pwiz.Skyline.Model
 
             public CustomMolecule ToCustomMolecule()
             {
-                return new CustomMolecule(Formula, MonoMass, AverageMass, MoleculeID.Name ?? string.Empty,
-                    MoleculeID.AccessionNumbers);
+                return Formula.IsMassOnly ?
+                    new CustomMolecule(MonoMass, AverageMass, MoleculeID.Name ?? string.Empty, MoleculeID.AccessionNumbers) :
+                    new CustomMolecule(Formula, MoleculeID.Name ?? string.Empty, MoleculeID.AccessionNumbers);
             }
         }
 
@@ -1043,7 +1048,7 @@ namespace pwiz.Skyline.Model
                 }
                 mzParsed = 0;
             }
-            var mz = new TypedMass(mzParsed, mzType); // mz is not actually a mass, of course, but we want to track mass type it was calculated from
+            var mz = TypedMass.Create(mzParsed, mzType); // mz is not actually a mass, of course, but we want to track mass type it was calculated from
             if ((mz < 0) || badMz)
             {
                 ShowTransitionError(new PasteError
@@ -1418,7 +1423,7 @@ namespace pwiz.Skyline.Model
                         if (getPrecursorColumns && isotopeLabelType == null) 
                         {
                             var ion = new IonInfo(formula, adduct);
-                            if (!IonInfo.EquivalentFormulas(ion.FormulaWithAdductApplied, ion.UnlabeledFormula)) // Formula+adduct contained some heavy isotopes
+                            if (!Equals(ion.FormulaWithAdductApplied, ion.UnlabeledFormula)) // Formula+adduct contained some heavy isotopes
                             {
                                 isotopeLabelType = IsotopeLabelType.heavy;
                                 if (INDEX_LABEL_TYPE >= 0)
@@ -1430,7 +1435,7 @@ namespace pwiz.Skyline.Model
                         // If formula contains isotope info, move it to the adduct
                         if (!adduct.IsEmpty)
                         {
-                            var labels = BioMassCalc.MONOISOTOPIC.FindIsotopeLabelsInFormula(formula);
+                            var labels = BioMassCalc.FindIsotopeLabelsInFormula(formula);
                             if (labels.Any())
                             {
                                 adduct = adduct.ChangeIsotopeLabels(labels);
@@ -1608,7 +1613,7 @@ namespace pwiz.Skyline.Model
                 // Parse molecule and neutral loss formulas to dictionaries, with syntax checking
                 // N.B. here we use pwiz.Skyline.Util.BioMassCalc rather than pwiz.Common.Chemistry.Molecule because it
                 // understands Skyline isotope symbols (e.g. H', C" etc) while pwiz.Common.Chemistry.Molecule does not
-                if (!BioMassCalc.TryParseFormula(precursorFormula, out var precursorMolecule, out var errMessage))
+                if (!BioMassCalc.MONOISOTOPIC.TryParseFormula(precursorFormula, out var precursorMolecule, out var errMessage))
                 {
                     ShowTransitionError(new PasteError
                     {
@@ -1618,7 +1623,20 @@ namespace pwiz.Skyline.Model
                     });
                     return false;
                 }
-                if (!BioMassCalc.TryParseFormula(neutralLoss, out var lossMolecule, out errMessage))
+
+                if (precursorMolecule.IsMassOnly)
+                {
+                    // There's no use for a loss formula if there's no precursor formula
+                    ShowTransitionError(new PasteError
+                    {
+                        Column = indexNeutralLoss,
+                        Line = row.Index,
+                        Message = Resources.SmallMoleculeTransitionListReader_ProcessNeutralLoss_Cannot_use_product_neutral_loss_chemical_formula_without_a_precursor_chemical_formula
+                    });
+                    return false;
+                }
+
+                if (!BioMassCalc.MONOISOTOPIC.TryParseFormula(neutralLoss, out var lossMolecule, out errMessage))
                 {
                     ShowTransitionError(new PasteError
                     {
@@ -1628,9 +1646,20 @@ namespace pwiz.Skyline.Model
                     });
                     return false;
                 }
+                else if (lossMolecule.IsMassOnly)
+                {
+                    // BioMassCalc parser will accept a mass-only formula, but we don't want to allow that here
+                    ShowTransitionError(new PasteError
+                    {
+                        Column = indexNeutralLoss,
+                        Line = row.Index,
+                        Message = BioMassCalc.FormatArgumentExceptionMessage(neutralLoss)
+                    });
+                    return false;
+                }
                 // Calculate the resulting fragment as precursor-loss, checking to see that we're not losing atoms that aren't there in the first place
                 var fragmentMolecule = precursorMolecule.Difference(lossMolecule);
-                if (fragmentMolecule.Values.Any(v => v < 0))
+                if (fragmentMolecule.Molecule.Values.Any(v => v < 0))
                 {
                     ShowTransitionError(new PasteError
                     {
@@ -1643,7 +1672,7 @@ namespace pwiz.Skyline.Model
                     return false;
                 }
 
-                formula = fragmentMolecule.ToDisplayString();
+                formula = fragmentMolecule.ToString();
             }
 
             return true; // Success
@@ -1677,7 +1706,7 @@ namespace pwiz.Skyline.Model
                 adduct = Adduct.FromStringAssumeChargeOnly(adductText);
                 IonInfo.ApplyAdductToFormula(formula ?? string.Empty, adduct); // Just to see if it throws
             }
-            catch (InvalidOperationException x)
+            catch (Exception x) when ((x is InvalidOperationException) || (x is ArgumentException))
             {
                 ShowTransitionError(new PasteError
                 {
@@ -1756,12 +1785,12 @@ namespace pwiz.Skyline.Model
             {
                 // Get mass from formula, then look at declared mz to decide if protonation is implied by charge
                 var adductH = Adduct.NonProteomicProtonatedFromCharge(charge); // [M-H] etc
-                var adductM = Adduct.FromChargeNoMass(charge); // [M-] etc
-                var ionH = new CustomMolecule(adductH.ApplyToFormula(formula));
-                var ionM = new CustomMolecule(adductM.ApplyToFormula(formula));
+                var adductM = Adduct.FromChargeNoMass(charge); // [M-] tc
+                var ionH = adductH.ApplyToFormula(formula);
+                var ionM = adductM.ApplyToFormula(formula);
                 var mass = mz * Math.Abs(charge);
-                adduct = Math.Abs(ionH.GetMass(MassType.Monoisotopic) - mass) <
-                         Math.Abs(ionM.GetMass(MassType.Monoisotopic) - mass)
+                adduct = Math.Abs(BioMassCalc.MONOISOTOPIC.CalculateMass(ionH) - mass) <
+                         Math.Abs(BioMassCalc.MONOISOTOPIC.CalculateMass(ionM) - mass)
                     ? adductH
                     : adductM;
             }
@@ -1795,13 +1824,13 @@ namespace pwiz.Skyline.Model
                 // Identify items with same formula and different adducts
                 var neutralFormula = parsedIonInfo.NeutralFormula;
                 var shortName = parsedIonInfo.MoleculeID.Name;
-                if (!string.IsNullOrEmpty(neutralFormula))
+                if (!MoleculeMassOffset.IsNullOrEmpty(neutralFormula))
                 {
                     molecule = new CustomMolecule(neutralFormula, shortName, parsedIonInfo.MoleculeID.AccessionNumbers);
                 }
                 else
                 {
-                    molecule = new CustomMolecule(parsedIonInfo.Formula, parsedIonInfo.MonoMass, parsedIonInfo.AverageMass, shortName, parsedIonInfo.MoleculeID.AccessionNumbers);
+                    molecule = new CustomMolecule(parsedIonInfo.MonoMass, parsedIonInfo.AverageMass, shortName, parsedIonInfo.MoleculeID.AccessionNumbers);
                 }
             }
             catch (ArgumentException e)
@@ -1863,16 +1892,12 @@ namespace pwiz.Skyline.Model
             if (!Equals(pep.CustomMolecule.MonoisotopicMass, customIon.MonoisotopicMass) && !adduct.HasIsotopeLabels)
             {
                 // Some kind of undescribed isotope labeling going on
-                if ((!string.IsNullOrEmpty(pep.CustomMolecule.Formula) && Equals(pep.CustomMolecule.Formula, customIon.Formula)) ||
-                    (string.IsNullOrEmpty(pep.CustomMolecule.Formula) && string.IsNullOrEmpty(customIon.Formula)))
+                // No formula for label, describe as mass
+                var labelMass = customIon.MonoisotopicMass - pep.CustomMolecule.MonoisotopicMass;
+                if (labelMass > 0)
                 {
-                    // No formula for label, describe as mass
-                    var labelMass = customIon.MonoisotopicMass - pep.CustomMolecule.MonoisotopicMass;
-                    if (labelMass > 0)
-                    {
-                        adduct = adduct.ChangeIsotopeLabels(labelMass); // Isostopes add weight
-                        isotopeLabelType = moleculeInfo.IsotopeLabelType ?? IsotopeLabelType.heavy;
-                    }
+                    adduct = adduct.ChangeIsotopeLabels(labelMass); // Isostopes add weight
+                    isotopeLabelType = moleculeInfo.IsotopeLabelType ?? IsotopeLabelType.heavy;
                 }
             }
             var group = new TransitionGroup(pep, adduct, isotopeLabelType);
@@ -1910,7 +1935,7 @@ namespace pwiz.Skyline.Model
                 return false;
             }
             // Formulas and/or masses must be non-empty, and match
-            return !((string.IsNullOrEmpty(precursor.Formula) || !Equals(precursor.Formula, fragment.Formula)) &&
+            return !((MoleculeMassOffset.IsNullOrEmpty(precursor.Formula) || !Equals(precursor.Formula, fragment.Formula)) &&
                      !Equals(precursor.MonoMass, fragment.MonoMass));
         }
 

--- a/pwiz_tools/Skyline/Model/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Transition.cs
@@ -860,7 +860,7 @@ namespace pwiz.Skyline.Model
                 var text = CustomIon.ToString();
                 // Was there enough information to generate a string more distinctive that just "Ion"?
                 if (String.IsNullOrEmpty(CustomIon.Name) && 
-                    String.IsNullOrEmpty(CustomIon.NeutralFormula))
+                    CustomIon.MoleculeAndMassOffset.IsMassOnly)
                 {
                     // No, add mz and charge to whatever generic text was used to describe it
                     var mz = Adduct.MzFromNeutralMass(CustomIon.MonoisotopicMass);

--- a/pwiz_tools/Skyline/Model/TransitionCalc.cs
+++ b/pwiz_tools/Skyline/Model/TransitionCalc.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Util;
 

--- a/pwiz_tools/Skyline/Model/TransitionGroup.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroup.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Results;
@@ -206,9 +207,8 @@ namespace pwiz.Skyline.Model
             {
                 // Get the normal precursor m/z for filtering, so that light and heavy ion picks will match.
                 var adduct = groupDocNode.TransitionGroup.PrecursorAdduct;
-                string isotopicFormula;
                 precursorMz = IsCustomIon ?
-                    adduct.MzFromNeutralMass(calcFilterPre.GetPrecursorMass(groupDocNode.CustomMolecule, null, Adduct.EMPTY, out isotopicFormula), 
+                    adduct.MzFromNeutralMass(calcFilterPre.GetPrecursorMass(groupDocNode.CustomMolecule, null, Adduct.EMPTY, out _), 
                         calcFilterPre.MassType.IsMonoisotopic() ? MassType.Monoisotopic : MassType.Average) : // Don't pass the isMassH bit
                     SequenceMassCalc.GetMZ(calcFilterPre.GetPrecursorMass(sequence), adduct);
             }

--- a/pwiz_tools/Skyline/Model/V01/Sequence.cs
+++ b/pwiz_tools/Skyline/Model/V01/Sequence.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
@@ -222,7 +223,7 @@ namespace pwiz.Skyline.Model.V01
                        double mh, double? rt)
             : this(fastaSequence, begin, end, missedCleavages)
         {
-            MassH = new TypedMass(mh, MassType.MonoisotopicMassH);
+            MassH = TypedMass.Create(mh, MassType.MonoisotopicMassH);
             PredictedRetentionTime = rt;
         }
 
@@ -447,7 +448,7 @@ namespace pwiz.Skyline.Model.V01
 
             IType = type;
             CleavageOffset = offset;
-            MassH = new TypedMass(mh, MassType.MonoisotopicMassH);
+            MassH = TypedMass.Create(mh, MassType.MonoisotopicMassH);
 
             // Derived values
             if (IsNTerminal())

--- a/pwiz_tools/Skyline/SettingsUI/EditCustomMoleculeDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditCustomMoleculeDlg.cs
@@ -197,7 +197,7 @@ namespace pwiz.Skyline.SettingsUI
             string labelMono = !defaultCharge.IsEmpty
                 ? Resources.EditCustomMoleculeDlg_EditCustomMoleculeDlg__Monoisotopic_m_z_
                 : Resources.EditCustomMoleculeDlg_EditCustomMoleculeDlg__Monoisotopic_mass_;
-            var defaultFormula = molecule == null ? string.Empty : molecule.Formula;
+            var defaultFormula = (molecule == null || molecule.MoleculeAndMassOffset.IsMassOnly) ? string.Empty : molecule.MoleculeAndMassOffset.ToString();
             var transition = initialId as Transition;
 
             FormulaBox.EditMode editMode;
@@ -682,8 +682,8 @@ namespace pwiz.Skyline.SettingsUI
                     return;
             }
 
-            var monoMass = new TypedMass(_formulaBox.MonoMass ?? 0, MassType.Monoisotopic);
-            var averageMass = new TypedMass(_formulaBox.AverageMass ?? 0, MassType.Average);
+            var monoMass = TypedMass.Create(_formulaBox.MonoMass ?? 0, MassType.Monoisotopic);
+            var averageMass = TypedMass.Create(_formulaBox.AverageMass ?? 0, MassType.Average);
             if (monoMass < CustomMolecule.MIN_MASS || averageMass < CustomMolecule.MIN_MASS)
             {
                 _formulaBox.ShowTextBoxErrorFormula(helper,
@@ -854,11 +854,11 @@ namespace pwiz.Skyline.SettingsUI
             else
             {
                 textName.Text = ResultCustomMolecule.Name ?? string.Empty;
-                var displayFormula = ResultCustomMolecule.Formula ?? string.Empty;
+                var displayFormula = ResultCustomMolecule.MoleculeAndMassOffset.IsMassOnly ? string.Empty : ResultCustomMolecule.MoleculeAndMassOffset.ToString();
                 _formulaBox.Formula = displayFormula + (ResultAdduct.IsEmpty || ResultAdduct.IsProteomic
                                           ? string.Empty
                                           : ResultAdduct.AdductFormula);
-                if (ResultCustomMolecule.Formula == null)
+                if (ResultCustomMolecule.MoleculeAndMassOffset == null)
                 {
                     _formulaBox.AverageMass = ResultCustomMolecule.AverageMass;
                     _formulaBox.MonoMass = ResultCustomMolecule.MonoisotopicMass;

--- a/pwiz_tools/Skyline/SettingsUI/EditMeasuredIonDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditMeasuredIonDlg.cs
@@ -100,9 +100,9 @@ namespace pwiz.Skyline.SettingsUI
                                       ? _measuredIon.MinFragmentLength.Value.ToString(LocalizationHelper.CurrentCulture)
                                       : string.Empty;
             }
-            else if (!string.IsNullOrEmpty(_measuredIon.SettingsCustomIon.NeutralFormula))
+            else if (!_measuredIon.SettingsCustomIon.MoleculeAndMassOffset.IsMassOnly)
             {
-                _formulaBox.Formula = _measuredIon.SettingsCustomIon.NeutralFormula;
+                _formulaBox.Formula = _measuredIon.SettingsCustomIon.MoleculeAndMassOffset.ToString();
                 textCharge.Text = _measuredIon.Charge.ToString(LocalizationHelper.CurrentCulture);
                 _formulaBox.Adduct = _measuredIon.Adduct;
             }

--- a/pwiz_tools/Skyline/SettingsUI/EditStaticModDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditStaticModDlg.cs
@@ -155,7 +155,7 @@ namespace pwiz.Skyline.SettingsUI
                     else
                         comboTerm.SelectedItem = modification.Terminus.Value.ToString();
                     cbVariableMod.Checked = modification.IsVariable;
-                    if (modification.Formula != null)
+                    if (modification.ParsedMoleculeMassOffset != null)
                     {
                         Formula = modification.Formula;
                         // Make sure the formula is showing
@@ -570,7 +570,7 @@ namespace pwiz.Skyline.SettingsUI
                 string aaString = comboAA.Text;
                 if (!string.IsNullOrEmpty(aaString) && aaString.Length == 1 &&
                         AminoAcid.IsAA(aaString[0])&& labelAtoms != LabelAtoms.None)
-                    formula = SequenceMassCalc.GetHeavyFormula(aaString[0], labelAtoms);
+                    formula = SequenceMassCalc.GetHeavyFormula(aaString[0], labelAtoms).ToString();
             }
 
             if (string.IsNullOrEmpty(formula))

--- a/pwiz_tools/Skyline/SettingsUI/FormulaBox.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FormulaBox.cs
@@ -45,8 +45,8 @@ namespace pwiz.Skyline.SettingsUI
         private readonly EditMode _editMode;
         private string _neutralFormula;
         private Dictionary<string, string> _isotopeLabelsForMassCalc;
-        private TypedMass _neutralMonoMass;
-        private TypedMass _neutralAverageMass;
+        private TypedMass _neutralMonoMass = TypedMass.ZERO_MONO_MASSNEUTRAL;
+        private TypedMass _neutralAverageMass = TypedMass.ZERO_AVERAGE_MASSNEUTRAL;
         private double? _averageMass; // Our internal value for mass, regardless of whether displaying mass or mz
         private double? _monoMass;    // Our internal value for mass, regardless of whether displaying mass or mz
 
@@ -131,7 +131,6 @@ namespace pwiz.Skyline.SettingsUI
                 {
                     return; // Do nothing - just initializing
                 }
-                Molecule ion;
                 Adduct newAdduct;
                 string newNeutralFormula;
                 string newTextFormulaText = null;
@@ -146,7 +145,7 @@ namespace pwiz.Skyline.SettingsUI
                     Adduct = newAdduct;
                     newTextFormulaText = value;
                 }
-                else if (IonInfo.IsFormulaWithAdduct(value, out ion, out newAdduct, out newNeutralFormula))
+                else if (IonInfo.IsFormulaWithAdduct(value, out var ion, out newAdduct, out newNeutralFormula))
                 {
                     // If we're allowing edit of adduct only, set aside the formula portion
                     var displayText = editAdductOnly ? newAdduct.AdductFormula : value;
@@ -205,8 +204,8 @@ namespace pwiz.Skyline.SettingsUI
                     // Update masses for this new formula value
                     try
                     {
-                        _neutralMonoMass = BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(value);
-                        _neutralAverageMass = BioMassCalc.AVERAGE.CalculateMassFromFormula(value);
+                        _neutralMonoMass = BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(value, out _);
+                        _neutralAverageMass = BioMassCalc.AVERAGE.CalculateMassFromFormula(value, out _);
                     }
                     catch
                     {
@@ -241,7 +240,7 @@ namespace pwiz.Skyline.SettingsUI
                     {
                         ChargeChange(this, EventArgs.Empty);
                     }
-                    if (!Equals(textFormula.Text, DisplayFormula))
+                    if (!Equals(textFormula.Text ?? string.Empty, DisplayFormula??string.Empty))
                     {
                         SetFormulaText(DisplayFormula);
                     }
@@ -646,9 +645,8 @@ namespace pwiz.Skyline.SettingsUI
                     formula = userinput;
                 }
                 string neutralFormula;
-                Molecule ion;
                 Adduct adduct;
-                if (!IonInfo.IsFormulaWithAdduct(formula, out ion, out adduct, out neutralFormula, true))
+                if (!IonInfo.IsFormulaWithAdduct(formula, out var ion, out adduct, out neutralFormula, true))
                 {
                     neutralFormula = formula;
                     if (!Adduct.TryParse(userinput, out adduct, Adduct.ADDUCT_TYPE.non_proteomic, true))

--- a/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.cs
@@ -34,6 +34,7 @@ using pwiz.Skyline.Model.Optimization;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.SettingsUI.IonMobility;
 using pwiz.Skyline.Util;
+using pwiz.Skyline.Util.Extensions;
 
 namespace pwiz.Skyline.SettingsUI
 {
@@ -359,9 +360,9 @@ namespace pwiz.Skyline.SettingsUI
 
             // Validate and store prediction settings
             string massType = comboPrecursorMass.SelectedItem.ToString();
-            MassType precursorMassType = MassTypeExtension.GetEnum(massType);
+            MassType precursorMassType = MassTypeLocalizationExtension.GetEnum(massType);
             massType = comboIonMass.SelectedItem.ToString();
-            MassType fragmentMassType = MassTypeExtension.GetEnum(massType);
+            MassType fragmentMassType = MassTypeLocalizationExtension.GetEnum(massType);
             string nameCE = comboCollisionEnergy.SelectedItem.ToString();
             CollisionEnergyRegression collisionEnergy =
                 Settings.Default.GetCollisionEnergyByName(nameCE);
@@ -773,7 +774,7 @@ namespace pwiz.Skyline.SettingsUI
         {
             get
             {
-                return MassTypeExtension.GetEnum(comboPrecursorMass.SelectedItem.ToString());
+                return MassTypeLocalizationExtension.GetEnum(comboPrecursorMass.SelectedItem.ToString());
             }
             set
             {
@@ -785,7 +786,7 @@ namespace pwiz.Skyline.SettingsUI
         {
             get
             {
-                return MassTypeExtension.GetEnum(comboIonMass.SelectedItem.ToString());
+                return MassTypeLocalizationExtension.GetEnum(comboIonMass.SelectedItem.ToString());
             }
             set
             {

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -820,7 +820,10 @@
       <DependentUpon>DDASearchControl.cs</DependentUpon>
     </Compile>
     <Compile Include="Util\DocumentCancellationToken.cs" />
+    <Compile Include="Util\Extensions\MassTypeLocalizationExtension.cs" />
     <Compile Include="Util\FormGroup.cs" />
+    <Compile Include="Util\HillSystemOrdering.cs" />
+    <Compile Include="Util\ParsedMoleculeMassOffset.cs" />
     <Compile Include="Util\PersistentString.cs" />
     <Compile Include="Util\UiModes.cs" />
     <Compile Include="ToolsUI\ColorGrid.cs">

--- a/pwiz_tools/Skyline/Skyline.sln.DotSettings
+++ b/pwiz_tools/Skyline/Skyline.sln.DotSettings
@@ -308,6 +308,8 @@ public $classname$ Change$PROP$($TYPE$ value) {&#xD;
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Proteome/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=proteomic/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=proteomics/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Protonated/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=protonation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=pwiz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Quant/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=quantitation/@EntryIndexedValue">True</s:Boolean>

--- a/pwiz_tools/Skyline/Test/AdductTest.cs
+++ b/pwiz_tools/Skyline/Test/AdductTest.cs
@@ -46,10 +46,10 @@ namespace pwiz.SkylineTest
             if (!Equals(expectedFormula, actualFormula))
             {
                 // ApplyAdductToFormula doesn't necessarily preserve element order, so check again as dictionary
-                var dictExpected = IonInfo.ApplyAdductToMoleculeAsDictionary(expectedFormula, Adduct.EMPTY);
-                var dictActual = IonInfo.ApplyAdductToMoleculeAsDictionary(PENTANE, adduct);
-                if (dictExpected.Count != dictActual.Count || 
-                    !dictExpected.All(kvp => dictActual.TryGetValue(kvp.Key, out var v) && v == kvp.Value))
+                var dictExpected = IonInfo.ApplyAdductToFormula(expectedFormula, Adduct.EMPTY);
+                var dictActual = IonInfo.ApplyAdductToFormula(PENTANE, adduct);
+                if (dictExpected.Molecule.Count != dictActual.Molecule.Count || 
+                    !dictExpected.Molecule.All(kvp => dictActual.Molecule.TryGetValue(kvp.Key, out var v) && v == kvp.Value))
                 {
                     Assert.AreEqual(expectedFormula, actualFormula, "unexpected formula for adduct " + adduct);
                 }
@@ -69,7 +69,9 @@ namespace pwiz.SkylineTest
             var mz = BioMassCalc.CalculateIonMz(calcMass, adduct);
             Assert.AreEqual(expectedMz, mz, .001);
             var massWithIsotopes = adduct.MassFromMz(mz, MassType.Monoisotopic);
-            Assert.AreEqual(massTaxol, massWithIsotopes - adduct.GetIsotopesIncrementalMonoisotopicMass() / adduct.GetMassMultiplier(), .0001);
+            var incrementalMassFromIsotopes = adduct.ApplyIsotopeLabelsToMass(TypedMass.ZERO_MONO_MASSNEUTRAL);
+            Assert.AreNotEqual(massWithIsotopes, incrementalMassFromIsotopes);
+            Assert.AreEqual(massTaxol, massWithIsotopes - incrementalMassFromIsotopes / adduct.GetMassMultiplier(), .0001);
             coverage.Add(adduct.AsFormula());
         }
 
@@ -82,20 +84,34 @@ namespace pwiz.SkylineTest
             });
         }
 
+        private string RoundtripFormulaString(string f)
+        {
+            BioMassCalc.MONOISOTOPIC.TryParseFormula(f, out var mol, out _);
+            return mol.ToString();
+        }
+
         private void TestAdductOperators()
         {
             // Test some underlying formula handling for fanciful user-supplied values
-            AssertEx.AreEqual("COOOHN", BioMassCalc.MONOISOTOPIC.RegularizeFormula("COOOHNS0"));
-            AssertEx.AreEqual("XeC12N1", BioMassCalc.MONOISOTOPIC.RegularizeFormula("XeC12N1H0"));
-            AssertEx.AreEqual("XeC12N1", BioMassCalc.MONOISOTOPIC.RegularizeFormula("XeC12N01H0"));
-            AssertEx.AreEqual("C'3C2H9NO2O\"2S1", BioMassCalc.MONOISOTOPIC.RegularizeFormula("C'3C2H9H'0NO2O\"2S001"));
+            AssertEx.AreEqual("COOOHN", RoundtripFormulaString("COOOHNS0"));
+            AssertEx.AreEqual("XeC12N1", RoundtripFormulaString("XeC12N1H0"));
+            AssertEx.AreEqual("XeC12N1", RoundtripFormulaString("XeC12N01H0"));
+            AssertEx.AreEqual("C'3C2H9NO2O\"2S1", RoundtripFormulaString("C'3C2H9H'0NO2O\"2S001"));
             var labels = new Dictionary<string, int>(){{"C'",3},{"O\"",2}}; // Find the C'3O"2 in  C'3C2H9H'0NO2O"2S (yes, H'0 - seen in the wild - but we drop zero counts)
-            AssertEx.AreEqual(labels, BioMassCalc.MONOISOTOPIC.FindIsotopeLabelsInFormula("C'3C2H9H'0NO2O\"2S"));
+            AssertEx.AreEqual(labels, BioMassCalc.FindIsotopeLabelsInFormula("C'3C2H9H'0NO2O\"2S"));
+            AssertEx.AreEqual(0, Adduct.SINGLY_PROTONATED.CompareTo(Adduct.FromStringAssumeProtonated("(M+H)+")));
             AssertEx.AreEqual(Adduct.SINGLY_PROTONATED, Adduct.FromStringAssumeProtonated("(M+H)+") );
+            AssertEx.IsTrue(ReferenceEquals(Adduct.SINGLY_PROTONATED, Adduct.FromStringAssumeProtonated("(M+H)+"))); // Check our cacheing
             AssertEx.IsTrue(Adduct.FromStringAssumeProtonatedNonProteomic("[M-H2O+H]+").SameEffect(Adduct.FromStringAssumeProtonatedNonProteomic("(M+H)+[-H2O]")));
             Assert.IsTrue(Molecule.AreEquivalentFormulas("C10H30Si5O5H-CH4", "C9H27O5Si5"));
-            Assert.AreEqual("C7H27O5Si4", BioMassCalc.MONOISOTOPIC.FindFormulaIntersection(new[] { "C8H30Si5O5H-CH4", "C9H27O5Si4", "C9H27O5Si5Na" }));
-            Assert.AreEqual("C7H27O5Si4", BioMassCalc.MONOISOTOPIC.FindFormulaIntersectionUnlabeled(new[] { "C7C'H30Si5O5H-CH4", "C9H27O5Si4", "C9H25H'2O5Si5Na" }));
+            AssertEx.AreEqual("C7H27O2Si4", BioMassCalc.FindFormulaIntersection(new[] { 
+                Molecule.Parse("C8H305O2Si5H-CH4"),
+                Molecule.Parse("C9H27O5Si4"),
+                Molecule.Parse("C9H27O5Si5Na")}).ToString());
+            AssertEx.AreEqual("C7H27O5Si4", BioMassCalc.FindFormulaIntersectionUnlabeled(new[] {
+                Molecule.Parse("C7C'H30Si5O5H-CH4"),
+                Molecule.Parse("C9H27O5Si4"),
+                Molecule.Parse("C9H25H'2O5Si5Na")}).ToString());
 
             // There is a difference between a proteomic adduct and non proteomic, primarily in how they display
             Assert.AreEqual(Adduct.FromStringAssumeChargeOnly("M+H"), Adduct.M_PLUS_H);
@@ -106,7 +122,12 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(Adduct.FromStringAssumeProtonated("M+H"), Adduct.SINGLY_PROTONATED);
             Assert.AreEqual(Adduct.FromStringAssumeChargeOnly("M+H").AsFormula(), Adduct.SINGLY_PROTONATED.AsFormula()); // But the underlying chemistry is the same
 
-            Assert.AreEqual(Adduct.FromStringAssumeProtonated("[M+S]+"), Adduct.FromStringAssumeProtonated("M+S").ChangeCharge(1));
+            var mPlusSPlus = Adduct.FromStringAssumeProtonated("[M+S]+");
+            AssertEx.AreEqual(1, mPlusSPlus.AdductCharge);
+            var mPlusS = Adduct.FromStringAssumeProtonated("M+S");
+            var mPlusSchangeCharge = mPlusS.ChangeCharge(1);
+            AssertEx.IsTrue(mPlusSPlus.SameEffect(mPlusSchangeCharge));
+            Assert.AreEqual(mPlusSPlus, mPlusSchangeCharge);
             Assert.AreEqual(Adduct.FromStringAssumeProtonated("M(-1.234)+2Na"), Adduct.FromStringAssumeProtonated("M(-1.234)+3Na").ChangeCharge(2));
             Assert.AreEqual(Adduct.FromStringAssumeProtonated("M1.234+2Na"), Adduct.FromStringAssumeProtonated("M1.234+3Na").ChangeCharge(2));
             Assert.AreEqual(Adduct.FromStringAssumeProtonated("M2Cl37-2Na"), Adduct.FromStringAssumeProtonated("M2Cl37+3Na").ChangeCharge(-2));
@@ -135,8 +156,8 @@ namespace pwiz.SkylineTest
             Assert.IsFalse(label.MassFromMz(300.0, MassType.Average).IsHeavy());
             Assert.IsTrue(label.MassFromMz(300.0, MassType.AverageHeavy).IsHeavy());
             Assert.IsTrue(label.MassFromMz(300.0, MassType.Average).IsAverage());
-            var massHeavy = label.ApplyToMass(new TypedMass(300, MassType.MonoisotopicHeavy)); // Will not have isotope effect added in mz calc, as it's already heavy
-            var massLight = label.ApplyToMass(new TypedMass(300, MassType.Monoisotopic)); // Will have isotope effect added in mz calc
+            var massHeavy = label.ApplyToMass(TypedMass.Create(300, MassType.MonoisotopicHeavy)); // Will not have isotope effect added in mz calc, as it's already heavy
+            var massLight = label.ApplyToMass(TypedMass.Create(300, MassType.Monoisotopic)); // Will have isotope effect added in mz calc
             Assert.AreNotEqual(massHeavy, massLight);
             Assert.AreNotEqual(label.MzFromNeutralMass(massHeavy), label.MzFromNeutralMass(massLight));
 
@@ -245,7 +266,7 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(
                 2 * (massNeutral + 3 * (BioMassCalc.MONOISOTOPIC.GetMass("C'") - BioMassCalc.MONOISOTOPIC.GetMass("C"))) -
                 BioMassCalc.MONOISOTOPIC.GetMass("Na"),
-                labeled.ApplyToMass(new TypedMass(massNeutral, MassType.Monoisotopic)));
+                labeled.ApplyToMass(TypedMass.Create(massNeutral, MassType.Monoisotopic)));
             Assert.AreEqual(unlabeled, labeled.ChangeIsotopeLabels(null));
             var labels = new Dictionary<string, int> {{label, 3}, {"H2", 4}};
             Assert.AreEqual(relabeled, labeled.ChangeIsotopeLabels(labels));
@@ -258,9 +279,9 @@ namespace pwiz.SkylineTest
             // Check Deuterium and Tritium handling
             Assert.AreEqual(BioMassCalc.MONOISOTOPIC.GetMass("Cl2Cl'3H5H'4N12"), BioMassCalc.MONOISOTOPIC.GetMass("Cl2Cl'3H5D4N12"));
             Assert.AreEqual(BioMassCalc.MONOISOTOPIC.GetMass("Cl2Cl'3H5H\"4N12"), BioMassCalc.MONOISOTOPIC.GetMass("Cl2Cl'3H5T4N12"));
-            Assert.AreEqual(Molecule.Parse("Cl2Cl'3H5H'4N12".Replace("Cl'", label).Replace("Cl", unlabel)),
-                Molecule.Parse(relabeled.ApplyIsotopeLabelsToFormula("Cl5H9N12".Replace("Cl", unlabel)))); // Replaces three of five Cl and four of nine H
-            var m100 = new TypedMass(100, MassType.Monoisotopic);
+            Assert.AreEqual(ParsedMoleculeMassOffset.Create("Cl2Cl'3H5H'4N12".Replace("Cl'", label).Replace("Cl", unlabel)),
+                relabeled.ApplyIsotopeLabelsToFormula("Cl5H9N12".Replace("Cl", unlabel))); // Replaces three of five Cl and four of nine H
+            var m100 = TypedMass.Create(100, MassType.Monoisotopic);
             var mdiff = 2 * (3 * (BioMassCalc.MONOISOTOPIC.GetMass(label) -
                                   BioMassCalc.MONOISOTOPIC.GetMass(unlabel)) +
                              4 * (BioMassCalc.MONOISOTOPIC.GetMass(BioMassCalc.H2) -
@@ -408,38 +429,38 @@ namespace pwiz.SkylineTest
             var Hectochlorin = "C27H34Cl2N2O9S2";
             var massHectochlorin = 664.108276; // http://www.chemspider.com/Chemical-Structure.552449.html?rid=3a7c08af-0886-4e82-9e4f-5211b8efb373
             var adduct = Adduct.FromStringAssumeProtonated("M+H");
-            var mol = IonInfo.ApplyAdductToFormula(Hectochlorin, adduct).ToString();
-            var mass = BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(mol);
+            var mol = IonInfo.ApplyAdductToFormula(Hectochlorin, adduct);
+            var mass = BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(mol.ToString(), out _);
             Assert.AreEqual(massHectochlorin + BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula("H"), mass, 0.00001);
-            var mz = BioMassCalc.CalculateIonMz(BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(Hectochlorin), adduct);
+            var mz = BioMassCalc.CalculateIonMz(BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(Hectochlorin, out _), adduct);
             Assert.AreEqual(665.11555415, mz, .000001);  // GNPS says 665.0 for Hectochlorin M+H
-            mol = IonInfo.ApplyAdductToFormula(Hectochlorin, Adduct.FromStringAssumeProtonated("MCl37+H")).ToString();
-            Assert.AreEqual("C27ClCl'H35N2O9S2", mol);
-            mass = BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(mol);
+            mol = IonInfo.ApplyAdductToFormula(Hectochlorin, Adduct.FromStringAssumeProtonated("MCl37+H"));
+            Assert.AreEqual("C27H35ClCl'N2O9S2", mol.ToString());
+            mass = BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(mol.ToString(), out _);
             Assert.AreEqual(667.11315, mass, .00001);
-            mol = IonInfo.ApplyAdductToFormula(Hectochlorin, Adduct.FromStringAssumeProtonated("M2Cl37+H")).ToString();
-            Assert.AreEqual("C27Cl'2H35N2O9S2", mol);
+            mol = IonInfo.ApplyAdductToFormula(Hectochlorin, Adduct.FromStringAssumeProtonated("M2Cl37+H"));
+            Assert.AreEqual("C27H35Cl'2N2O9S2", mol.ToString());
 
             // Test ability to describe isotope label by mass only
             var heavy = Adduct.FromStringAssumeProtonated("2M1.2345+H");
-            mz = BioMassCalc.CalculateIonMz(new TypedMass(massHectochlorin, MassType.Monoisotopic), heavy);
+            mz = BioMassCalc.CalculateIonMz(TypedMass.Create(massHectochlorin, MassType.Monoisotopic), heavy);
             heavy = Adduct.FromStringAssumeProtonated("2M1.2345");
-            mz = BioMassCalc.CalculateIonMass(new TypedMass(massHectochlorin, MassType.Monoisotopic), heavy);
+            mz = BioMassCalc.CalculateIonMass(TypedMass.Create(massHectochlorin, MassType.Monoisotopic), heavy);
             Assert.AreEqual(2 * (massHectochlorin + 1.23456), mz, .001);
             heavy = Adduct.FromStringAssumeProtonated("M1.2345");
-            mz = BioMassCalc.CalculateIonMass(new TypedMass(massHectochlorin, MassType.Monoisotopic), heavy);
+            mz = BioMassCalc.CalculateIonMass(TypedMass.Create(massHectochlorin, MassType.Monoisotopic), heavy);
             Assert.AreEqual(massHectochlorin + 1.23456, mz, .001);
             heavy = Adduct.FromStringAssumeProtonated("2M(-1.2345)+H");
-            mz = BioMassCalc.CalculateIonMz(new TypedMass(massHectochlorin, MassType.Monoisotopic), heavy);
+            mz = BioMassCalc.CalculateIonMz(TypedMass.Create(massHectochlorin, MassType.Monoisotopic), heavy);
             Assert.AreEqual((2 * (massHectochlorin - 1.23456) + BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula("H")), mz, .001);
             heavy = Adduct.FromStringAssumeProtonated("2M(-1.2345)");
-            mz = BioMassCalc.CalculateIonMass(new TypedMass(massHectochlorin, MassType.Monoisotopic), heavy);
+            mz = BioMassCalc.CalculateIonMass(TypedMass.Create(massHectochlorin, MassType.Monoisotopic), heavy);
             Assert.AreEqual(2 * (massHectochlorin - 1.23456), mz, .001);
             heavy = Adduct.FromStringAssumeProtonated("2M(1.2345)+H");
-            mz = BioMassCalc.CalculateIonMz(new TypedMass(massHectochlorin, MassType.Monoisotopic), heavy);
+            mz = BioMassCalc.CalculateIonMz(TypedMass.Create(massHectochlorin, MassType.Monoisotopic), heavy);
             Assert.AreEqual((2 * (massHectochlorin + 1.23456) + BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula("H")), mz, .001);
             heavy = Adduct.FromStringAssumeProtonated("2M(1.2345)");
-            mz = BioMassCalc.CalculateIonMass(new TypedMass(massHectochlorin, MassType.Monoisotopic), heavy);
+            mz = BioMassCalc.CalculateIonMass(TypedMass.Create(massHectochlorin, MassType.Monoisotopic), heavy);
             Assert.AreEqual(2 * (massHectochlorin + 1.23456), mz, .001);
 
             TestException(PENTANE, "zM+2H"); // That "z" doesn't make any sense as a mass multiplier (must be a positive integer)
@@ -453,10 +474,10 @@ namespace pwiz.SkylineTest
             TestException(PENTANE, "[M-2H]3-"); // Declared charge doesn't match described charge
 
             // Test label stripping
-            Assert.AreEqual("C5H9NO2S", (new IonInfo("C5H9H'3NO2S[M-3H]")).UnlabeledFormula);
+            Assert.AreEqual("C5H9NO2S", (new IonInfo("C5H9H'3NO2S[M-3H]")).UnlabeledFormula.ToString());
 
             // Peptide representations
-            Assert.AreEqual("C40H65N11O16", (new SequenceMassCalc(MassType.Average)).GetNeutralFormula("PEPTIDER", null));
+            Assert.AreEqual("C40H65N11O16", (new SequenceMassCalc(MassType.Average)).GetNeutralFormula("PEPTIDER", null).ToString());
 
             // Figuring out adducts from old style skyline doc ion molecules and ion precursors
             var adductDiff = Adduct.FromFormulaDiff("C6H27NO2Si2C'5", "C'5H11NO2", 3);

--- a/pwiz_tools/Skyline/Test/CustomMoleculeTest.cs
+++ b/pwiz_tools/Skyline/Test/CustomMoleculeTest.cs
@@ -18,6 +18,7 @@
  */
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Util;
@@ -52,7 +53,9 @@ namespace pwiz.SkylineTest
                 Assert.AreEqual(customMolecule, roundTrip.Molecule);
                 Assert.AreEqual(customMolecule.AccessionNumbers, roundTrip.Molecule.AccessionNumbers);
                 smallMoleculeLibraryAttributes = // Masses instead of formula
-                    SmallMoleculeLibraryAttributes.Create("MyMolecule", null, new TypedMass(123.4, MassType.Monoisotopic), new TypedMass(123.45, MassType.Average), "MyInChiKey", moleculeAccessionNumbers.GetNonInChiKeys());
+                    SmallMoleculeLibraryAttributes.Create("MyMolecule", 
+                        ParsedMoleculeMassOffset.Create(null,TypedMass.Create(123.4, MassType.Monoisotopic), TypedMass.Create(123.45, MassType.Average)), 
+                        "MyInChiKey", moleculeAccessionNumbers.GetNonInChiKeys());
             }
         }
     }

--- a/pwiz_tools/Skyline/Test/ExplicitModTest.cs
+++ b/pwiz_tools/Skyline/Test/ExplicitModTest.cs
@@ -50,7 +50,7 @@ namespace pwiz.SkylineTest
             var modifications = docStudy7.Settings.PeptideSettings.Modifications;
             Assert.AreEqual(0, modifications.StaticModifications.Count(mod => mod.IsExplicit));
             Assert.AreEqual(2, modifications.AllHeavyModifications.Count(mod => mod.IsExplicit));
-            Assert.AreEqual(4, modifications.AllHeavyModifications.Count(mod => mod.Formula != null));
+            Assert.AreEqual(4, modifications.AllHeavyModifications.Count(mod => mod.ParsedMoleculeMassOffset != null));
             Assert.AreEqual(3, docStudy7.Peptides.Count(peptide => peptide.HasExplicitMods));
             Assert.AreEqual(2, docStudy7.Peptides.Count(peptide => peptide.HasExplicitMods &&
                 peptide.ExplicitMods.StaticModifications.Count > 0 &&
@@ -133,7 +133,7 @@ namespace pwiz.SkylineTest
 
             modifications = docStudy7.Settings.PeptideSettings.Modifications;
             Assert.AreEqual(2, modifications.AllHeavyModifications.Count(mod => mod.IsExplicit && mod.Label13C));
-            Assert.AreEqual(2, modifications.AllHeavyModifications.Count(mod => mod.Formula != null));
+            Assert.AreEqual(2, modifications.AllHeavyModifications.Count(mod => mod.ParsedMoleculeMassOffset != null));
             Assert.AreEqual(3, docStudy7.Peptides.Count(peptide => peptide.HasExplicitMods));
             Assert.AreEqual(2, docStudy7.Peptides.Count(peptide => peptide.HasExplicitMods &&
                 peptide.ExplicitMods.StaticModifications.Count > 0 &&
@@ -258,7 +258,7 @@ namespace pwiz.SkylineTest
 
             var modSettings = docHeavyV.Settings.PeptideSettings.Modifications;
             Assert.AreEqual(5, modSettings.AllHeavyModifications.Count());
-            Assert.AreEqual(4, modSettings.AllHeavyModifications.Count(mod => mod.Formula != null));
+            Assert.AreEqual(4, modSettings.AllHeavyModifications.Count(mod => mod.ParsedMoleculeMassOffset != null));
             Assert.AreEqual(1, modSettings.AllHeavyModifications.Count(mod => mod.Label13C && mod.Label15N));
             Assert.AreEqual(3, docHeavyV.Peptides.Count(peptide => peptide.HasExplicitMods));
             Assert.AreEqual(1, docHeavyV.Peptides.Count(peptide => peptide.HasExplicitMods &&
@@ -279,7 +279,7 @@ namespace pwiz.SkylineTest
 
             modSettings = doc13V.Settings.PeptideSettings.Modifications;
             Assert.AreEqual(4, modSettings.AllHeavyModifications.Count());
-            Assert.AreEqual(3, modSettings.AllHeavyModifications.Count(mod => mod.Formula != null));
+            Assert.AreEqual(3, modSettings.AllHeavyModifications.Count(mod => mod.ParsedMoleculeMassOffset != null));
             Assert.AreEqual(1, modSettings.AllHeavyModifications.Count(mod => mod.Label13C));
             Assert.AreEqual(3, doc13V.Peptides.Count(peptide => peptide.HasExplicitMods));
             Assert.AreEqual(2, doc13V.Peptides.Count(peptide => peptide.HasExplicitMods &&
@@ -293,7 +293,7 @@ namespace pwiz.SkylineTest
 
             modSettings = doc13V.Settings.PeptideSettings.Modifications;
             Assert.AreEqual(4, modSettings.AllHeavyModifications.Count());
-            Assert.AreEqual(3, modSettings.AllHeavyModifications.Count(mod => mod.Formula != null));
+            Assert.AreEqual(3, modSettings.AllHeavyModifications.Count(mod => mod.ParsedMoleculeMassOffset != null));
             Assert.AreEqual(1, modSettings.AllHeavyModifications.Count(mod => mod.Label13C));
             Assert.AreEqual(3, doc13V.Peptides.Count(peptide => peptide.HasExplicitMods));
             Assert.AreEqual(2, doc13V.Peptides.Count(peptide => peptide.HasExplicitMods &&

--- a/pwiz_tools/Skyline/Test/FragmentedMoleculeTest.cs
+++ b/pwiz_tools/Skyline/Test/FragmentedMoleculeTest.cs
@@ -21,12 +21,12 @@ namespace pwiz.SkylineTest
             var modifiedSequence = new ModifiedSequence("PEPTIDE", new ModifiedSequence.Modification[0], MassType.Monoisotopic);
             var fragmentedMolecule = FragmentedMolecule.EMPTY.ChangeModifiedSequence(modifiedSequence);
             var precursorFormula = fragmentedMolecule.PrecursorFormula;
-            Assert.AreEqual(0, fragmentedMolecule.PrecursorFormula.MonoMassOffset);
-            Assert.AreEqual(0, fragmentedMolecule.PrecursorFormula.AverageMassOffset);
+            Assert.AreEqual(0.0, fragmentedMolecule.PrecursorFormula.MonoMassOffset);
+            Assert.AreEqual(0.0, fragmentedMolecule.PrecursorFormula.AverageMassOffset);
             var sequenceMassCalc = new SequenceMassCalc(MassType.Monoisotopic);
-            var expectedFormula = Molecule.Parse(sequenceMassCalc.GetMolecularFormula(modifiedSequence.GetUnmodifiedSequence()));
-            Assert.AreEqual(expectedFormula.Count, precursorFormula.Molecule.Count);
-            foreach (var entry in expectedFormula)
+            var expectedFormula = sequenceMassCalc.GetMolecularFormula(modifiedSequence.GetUnmodifiedSequence());
+            Assert.AreEqual(expectedFormula.Molecule.Count, precursorFormula.Molecule.Count);
+            foreach (var entry in expectedFormula.Molecule)
             {
                 Assert.AreEqual(entry.Value, precursorFormula.Molecule.GetElementCount(entry.Key));
             }
@@ -55,7 +55,7 @@ namespace pwiz.SkylineTest
                     var expectedMz = sequenceMassCalc.GetFragmentMass(transition, transitionGroupDocNode.IsotopeDist);
                     if (expectedMz.IsMassH())
                     {
-                        expectedMz = new TypedMass(expectedMz.Value - BioMassCalc.MassProton, expectedMz.MassType & ~MassType.bMassH);
+                        expectedMz = TypedMass.Create(expectedMz.Value - BioMassCalc.MassProton, expectedMz.MassType & ~MassType.bMassH);
                     }
                     var actualMz = actualMassDistribution.MostAbundanceMass;
                     if (Math.Abs(expectedMz - actualMz) > .001)

--- a/pwiz_tools/Skyline/Test/IonMobilityUnitTest.cs
+++ b/pwiz_tools/Skyline/Test/IonMobilityUnitTest.cs
@@ -114,7 +114,7 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(molser, CustomMolecule.FromSerializableString(text));
 
             // Test handling of SmallMoleculeLibraryAttributes for mass-only descriptions
-            var molserB = CustomMolecule.FromSmallMoleculeLibraryAttributes(SmallMoleculeLibraryAttributes.Create("caffeine$", null, new TypedMass(123.4, MassType.Monoisotopic), new TypedMass(123.45, MassType.Average), caffeineInChiKey, caffeineHMDB));
+            var molserB = CustomMolecule.FromSmallMoleculeLibraryAttributes(SmallMoleculeLibraryAttributes.Create("caffeine$", MoleculeMassOffset.Create(null, TypedMass.Create(123.4, MassType.Monoisotopic), TypedMass.Create(123.45, MassType.Average)), caffeineInChiKey, caffeineHMDB));
             var textB = molserB.ToSerializableString();
             Assert.AreEqual(molserB, CustomMolecule.FromSerializableString(textB));
 

--- a/pwiz_tools/Skyline/Test/LibraryLoadTest.cs
+++ b/pwiz_tools/Skyline/Test/LibraryLoadTest.cs
@@ -272,12 +272,17 @@ namespace pwiz.SkylineTest
                 {
                     for (var p = 0; p < peaksInfo.Peaks.Length; p++)
                     {
-                        List<SpectrumPeakAnnotation> annotations;
-                        if (!fragmentAnnotations.TryGetValue(p, out annotations))
+                        if (!fragmentAnnotations.TryGetValue(p, out var annotations))
                         {
-                            annotations = null;
+                            Assume.IsTrue(peaksInfo.Peaks[p].Annotations == null);
                         }
-                        Assume.IsTrue(CollectionUtil.EqualsDeep(annotations, peaksInfo.Peaks[p].Annotations), "did not find expected annotation in converted library");
+                        else
+                        {
+                            // Examine as strings to avoid issues with rounding in I/O
+                            Assume.IsTrue(CollectionUtil.EqualsDeep(
+                                annotations.Select(a => a.ToString()).ToList(),
+                                peaksInfo.Peaks[p].Annotations.Select(a => a.ToString()).ToList()), "did not find expected annotation in converted library");
+                        }
                     }
                 }
             }            

--- a/pwiz_tools/Skyline/Test/MQuestScoringTest.cs
+++ b/pwiz_tools/Skyline/Test/MQuestScoringTest.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Lib.ChromLib;

--- a/pwiz_tools/Skyline/Test/ModEquivalentTest.cs
+++ b/pwiz_tools/Skyline/Test/ModEquivalentTest.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Util;
@@ -84,16 +85,15 @@ namespace pwiz.SkylineTest
                 {
                     var original = unimodArray[i].Value;
                     modToMatch = (StaticMod)original.ChangeName("Test");
-                    var formula = original.Formula;
-                    if (formula != null)
+                    var formula = original.ParsedMoleculeMassOffset;
+                    if (!ParsedMoleculeMassOffset.IsNullOrEmpty(formula))
                     {
 
-                        var dictCounts = new Dictionary<string, int>();
-                        massCalc.ParseModCounts(formula, dictCounts);
+                        var dictCounts = new Dictionary<string, int>(formula.Molecule);
 
-                        string newFormula = GetFormula(formula, dictCounts);
+                        var newFormula = GetFormula(formula.ToString(), dictCounts);
 
-                        modToMatch = modToMatch.ChangeFormula(newFormula);
+                        modToMatch = modToMatch.ChangeFormula(ParsedMoleculeMassOffset.Create(newFormula));
                     }
 
                     count = CountEquivalent(unimodArray, modToMatch, compareDict, i);
@@ -112,26 +112,25 @@ namespace pwiz.SkylineTest
                 {
                     var original = unimodArray[i].Value;
 
-                    var formula = original.Formula;
+                    var formula = original.ParsedMoleculeMassOffset;
 
                     modToMatch = (StaticMod) original.ChangeName("Test");
                     if (formula != null)
                     {
 
-                        var dictCounts = new Dictionary<string, int>();
-                        massCalc.ParseModCounts(formula, dictCounts);
+                        var dictCounts = new Dictionary<string, int>(formula.Molecule);
 
                         if (dictCounts.TryGetValue("H", out count))
                             dictCounts["H"] = count + 5;
                         else
                             dictCounts["H"] = 5;
 
-                        string newFormula = GetFormula(formula, dictCounts);
+                        string newFormula = GetFormula(formula.ToString(), dictCounts);
                         if (newFormula.Contains("-"))
                             newFormula = newFormula + "H5";
                         else
                             newFormula = newFormula + " - H5";
-                        modToMatch = modToMatch.ChangeFormula(newFormula);
+                        modToMatch = modToMatch.ChangeFormula(ParsedMoleculeMassOffset.Create(newFormula));
                     }
                     
                     count = CountEquivalent(unimodArray, modToMatch, compareDict, i);
@@ -154,9 +153,8 @@ namespace pwiz.SkylineTest
                     modToMatch = (StaticMod)original.ChangeName("Test");
                     if (labelAtoms != LabelAtoms.None && original.AAs != null && original.AAs.Length == 1)
                     {
-                        double unexplainedMass;
-                        string newFormula = massCalc.GetModFormula(original.AAs[0], original, out unexplainedMass);
-                        Assert.AreEqual(0, unexplainedMass);
+                        var newFormula = massCalc.GetModFormula(original.AAs[0], original);
+                        Assert.AreEqual(0.0, newFormula.MonoMassOffset); // Should be no unexplained mass.
                         modToMatch = modToMatch.ChangeFormula(newFormula).ChangeLabelAtoms(LabelAtoms.None);
                     }
 
@@ -171,10 +169,10 @@ namespace pwiz.SkylineTest
                 foreach (StaticMod original in dict.Values)
                 {
                     modToMatch = (StaticMod)original.ChangeName("Test");
-                    if (original.Formula != null || original.Losses != null)
-                        modToMatch = modToMatch.ChangeFormula("H2OCl");
+                    if (original.ParsedMoleculeMassOffset != null || original.Losses != null)
+                        modToMatch = modToMatch.ChangeFormula(ParsedMoleculeMassOffset.Create("H2OCl"));
                     else if (original.LabelAtoms != LabelAtoms.None)
-                        modToMatch = modToMatch.ChangeFormula("H2OCl").ChangeLabelAtoms(LabelAtoms.None);
+                        modToMatch = modToMatch.ChangeFormula(ParsedMoleculeMassOffset.Create("H2OCl")).ChangeLabelAtoms(LabelAtoms.None);
 
                     count = CountEquivalent(unimodArray, modToMatch, compareDict, -1);
                     Assert.AreEqual(0, count);
@@ -183,7 +181,7 @@ namespace pwiz.SkylineTest
             }
         }
 
-        private static string GetFormula(string formula, Dictionary<string, int> dictCounts)
+        private static string GetFormula(string formula, IDictionary<string, int> dictCounts)
         {
             var sbNewFormula = new StringBuilder();
 
@@ -209,7 +207,14 @@ namespace pwiz.SkylineTest
             }
             if (firstMod.Value != 0)
             {
-               sbNewFormula.Append(firstMod.Key).Append(firstMod.Value);
+                if (firstMod.Value < 0)
+                {
+                    sbSubtractFormula.Append(firstMod.Key).Append(Math.Abs(firstMod.Value));
+                }
+                else
+                {
+                    sbNewFormula.Append(firstMod.Key).Append(firstMod.Value);
+                }
             }
             if (sbSubtractFormula.Length > 0)
                 sbNewFormula.Append("-").Append(sbSubtractFormula);

--- a/pwiz_tools/Skyline/Test/ModificationMatcherTest.cs
+++ b/pwiz_tools/Skyline/Test/ModificationMatcherTest.cs
@@ -266,9 +266,9 @@ namespace pwiz.SkylineTest
                 libkeyModMatcher.CreateMatches(modMatchDocContainer.Document.Settings,
                     docLibraries[yeastLibIndex].Keys, defSetSetLight, defSetHeavy);
                 Assert.IsTrue(libkeyModMatcher.MatcherPepMods.StaticModifications.Contains(mod =>
-                    mod.Formula.Equals(UniMod.GetModification(StaticModList.DEFAULT_NAME, true).Formula) && !mod.IsVariable));
+                    mod.ParsedMoleculeMassOffset.Equals(UniMod.GetModification(StaticModList.DEFAULT_NAME, true).ParsedMoleculeMassOffset) && !mod.IsVariable));
                 Assert.IsTrue(libkeyModMatcher.MatcherPepMods.StaticModifications.Contains(mod =>
-                    mod.Formula.Equals("O") && mod.IsVariable));
+                    mod.ParsedMoleculeMassOffset.ToString().Equals("O") && mod.IsVariable));
             }
         }
 

--- a/pwiz_tools/Skyline/Test/SrmDocumentTest.cs
+++ b/pwiz_tools/Skyline/Test/SrmDocumentTest.cs
@@ -100,26 +100,27 @@ namespace pwiz.SkylineTest
             AssertEx.ValidatesAgainstSchema(DOC_MOLECULES_31);
             var doc = AssertEx.Deserialize<SrmDocument>(DOC_MOLECULES_31);
             AssertEx.IsDocumentState(doc, null, 1, 1, 1, 1);
-            Assert.AreEqual("C12H99", doc.MoleculeTransitionGroups.First().CustomMolecule.Formula);
+            Assert.AreEqual("C12H99", doc.MoleculeTransitionGroups.First().CustomMolecule.MoleculeAndMassOffset.ToString());
             Assert.AreEqual(doc.Molecules.First().CustomMolecule , doc.MoleculeTransitionGroups.First().CustomMolecule);
         }
 
         [TestMethod]
         public void MoleculeParseTest()
         {
-            // Verify handling of simple formula arithmetic as used in ion forumlas
+            // Verify handling of simple formula arithmetic as used in ion formulas
             const string C12H8S2O6 = "C12H8S2O6";
             const string SO4 = "SO4";
             Assert.AreEqual(311.976229, BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(C12H8S2O6),.00001);
             var subtracted = C12H8S2O6+"-"+SO4;
-            AssertEx.ThrowsException<ArgumentException>(() => Molecule.ParseExpressionToDictionary(subtracted + subtracted));  // More than one subtraction operation not supported
-            Assert.AreEqual(BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(subtracted), BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(C12H8S2O6) - BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(SO4));
-            Assert.AreEqual(BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(C12H8S2O6+SO4), BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(C12H8S2O6) + BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(SO4));
+            AssertEx.ThrowsException<ArgumentException>(() => Molecule.ParseToDictionary(subtracted + subtracted, out _));  // More than one subtraction operation not supported
+            AssertEx.AreEqual(BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(subtracted), 
+                BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(C12H8S2O6) - BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(SO4), .1 * BioMassCalc.MassTolerance);
+            Assert.AreEqual(BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(C12H8S2O6+SO4), 
+                BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(C12H8S2O6) + BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(SO4), .1 * BioMassCalc.MassTolerance);
             var desc = subtracted;
-            var counts = new Dictionary<string, int>();
             var expected = new Dictionary<string,int> {{"C",12},{"H",8},{"S",1},{"O",2}};
-            BioMassCalc.MONOISOTOPIC.ParseCounts(ref desc, counts, false);
-            Assert.IsTrue(CollectionUtil.EqualsDeep(expected, counts));
+            BioMassCalc.MONOISOTOPIC.ParseFormulaMass(desc, out var counts);
+            Assert.IsTrue(CollectionUtil.EqualsDeep(expected, new Dictionary<string, int>(counts.Molecule)));
         }
 
         [TestMethod]
@@ -152,9 +153,9 @@ namespace pwiz.SkylineTest
             var neutralMassMolecule = precursorAdduct.MassFromMz(mzPrecursor, MassType.Monoisotopic);
             var fragmentAdduct = Adduct.M_PLUS;
             var neutralMassTransition = fragmentAdduct.MassFromMz(mzFragment, MassType.Monoisotopic);
-            var transition = new CustomIon(null, precursorAdduct, new TypedMass(neutralMassMolecule, MassType.Monoisotopic), new TypedMass(neutralMassMolecule, MassType.Average), "molecule");
-            var transition2 = new CustomIon(null, fragmentAdduct, new TypedMass(neutralMassTransition, MassType.Monoisotopic), new TypedMass(neutralMassTransition, MassType.Average), "molecule fragment");
-            var precursor = new CustomMolecule(new TypedMass(neutralMassMolecule, MassType.Monoisotopic), new TypedMass(neutralMassMolecule, MassType.Average), "molecule");
+            var transition = new CustomIon(null, precursorAdduct, TypedMass.Create(neutralMassMolecule, MassType.Monoisotopic), TypedMass.Create(neutralMassMolecule, MassType.Average), "molecule");
+            var transition2 = new CustomIon(null, fragmentAdduct, TypedMass.Create(neutralMassTransition, MassType.Monoisotopic), TypedMass.Create(neutralMassTransition, MassType.Average), "molecule fragment");
+            var precursor = new CustomMolecule(TypedMass.Create(neutralMassMolecule, MassType.Monoisotopic), TypedMass.Create(neutralMassMolecule, MassType.Average), "molecule");
             Assert.AreEqual(BioMassCalc.CalculateIonMz(precursor.GetMass(MassType.Monoisotopic), precursorAdduct), doc.MoleculeTransitionGroups.ElementAt(0).PrecursorMz, 1E-5);
             Assert.AreEqual(BioMassCalc.CalculateIonMz(transition.GetMass(MassType.Monoisotopic), precursorAdduct), doc.MoleculeTransitions.ElementAt(0).Mz, 1E-5);
             Assert.AreEqual(BioMassCalc.CalculateIonMz(transition2.GetMass(MassType.Monoisotopic), fragmentAdduct), doc.MoleculeTransitions.ElementAt(1).Mz, 1E-5);
@@ -175,6 +176,7 @@ namespace pwiz.SkylineTest
             if (doc.FormatVersion.CompareTo(DocumentFormat.VERSION_3_61) >= 0)
                 Assert.AreEqual(345.6, doc.MoleculeTransitionGroups.ElementAt(0).ExplicitValues.CollisionalCrossSectionSqA.Value, 1E-12);
             Assert.IsTrue(doc.MoleculeTransitions.ElementAt(0).Transition.IsCustom());
+            Assert.AreEqual(mzPrecursor, doc.MoleculeTransitionGroups.ElementAt(0).PrecursorMz, BioMassCalc.MassTolerance);
             Assert.AreEqual(transition.MonoisotopicMassMz, doc.MoleculeTransitions.ElementAt(0).Transition.CustomIon.MonoisotopicMassMz, mzToler);
             Assert.AreEqual(transition2.MonoisotopicMassMz, doc.MoleculeTransitions.ElementAt(1).Transition.CustomIon.MonoisotopicMassMz, mzToler);
             Assert.AreEqual(1, doc.MoleculeTransitionGroups.ElementAt(0).TransitionGroup.PrecursorAdduct.AdductCharge);

--- a/pwiz_tools/Skyline/Test/SrmSettingsChangeTest.cs
+++ b/pwiz_tools/Skyline/Test/SrmSettingsChangeTest.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.Extensions;

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -243,6 +243,7 @@
     <Compile Include="ToolDescriptionTest.cs" />
     <Compile Include="TransitionSettings07Test.cs" />
     <Compile Include="SubstringFinderTest.cs" />
+    <Compile Include="TypedMassTest.cs" />
     <Compile Include="TypeSafeEnumTest.cs" />
     <Compile Include="UndoManagerTest.cs" />
     <Compile Include="UniModTest.cs" />

--- a/pwiz_tools/Skyline/Test/TransitionSettings07Test.cs
+++ b/pwiz_tools/Skyline/Test/TransitionSettings07Test.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.Extensions;
@@ -95,8 +96,8 @@ namespace pwiz.SkylineTest
         public void ReporterIonTest()
         {
             // Test the code that updates old-style formulas
-            Assert.AreEqual("C5C'H13N2", BioMassCalc.AddH("C5C'H12N2"));
-            Assert.AreEqual("CO2H", BioMassCalc.AddH("CO2"));
+            Assert.AreEqual("C5C'H13N2", ParsedMoleculeMassOffset.Create("C5C'H12N2").AdjustElementCount("H",1).ToString());
+            Assert.AreEqual("CO2H", ParsedMoleculeMassOffset.Create("CO2").AdjustElementCount("H", 1).ToString());
 
             var docOriginal = new SrmDocument(SrmSettingsList.GetDefault().ChangeTransitionInstrument(instrument => instrument.ChangeMinMz(10)));  // H2O2 is not very heavy!
             IdentityPath path;

--- a/pwiz_tools/Skyline/Test/TypedMassTest.cs
+++ b/pwiz_tools/Skyline/Test/TypedMassTest.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * Original author: Brian Pratt <bspratt .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2023 University of Washington - Seattle, WA
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
+using pwiz.Skyline.Util;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTest
+{
+    /// <summary>
+    /// Tests to verify operation of the TypedMass class
+    /// </summary>
+    [TestClass]
+    public class TypedMassTest : AbstractUnitTest
+    {
+    
+        /// <summary>
+        /// Tests the TypedMass class.
+        /// </summary>
+        [TestMethod]
+        public void TypedMassUnitTest()
+        {
+            var a = TypedMass.Create(1, MassType.Average);
+            var b = TypedMass.Create(2, MassType.Average);
+            var c = TypedMass.Create(0, MassType.Average);
+            var d = TypedMass.Create(1, MassType.Average);
+            var e = TypedMass.Create(1, MassType.Monoisotopic);
+            var f = TypedMass.Create(1, MassType.MonoisotopicHeavy);
+            var g = TypedMass.Create(-1, MassType.MonoisotopicMassH);
+
+            AssertEx.AreEqual(BioMassCalc.MassProton, TypedMass.MassProton); // These should agree
+            AssertEx.AreEqual(BioMassCalc.MassElectron, TypedMass.MassElectron);
+
+            AssertEx.AreNotEqual(a, b, "these are not equal");
+            AssertEx.AreEqual(a, a);
+            AssertEx.AreEqual(a, d);
+            AssertEx.IsTrue(a == d);
+            AssertEx.IsFalse(a != d);
+            AssertEx.IsTrue(a < b);
+            AssertEx.IsTrue(b > a);
+            AssertEx.IsTrue(a <= b);
+            AssertEx.IsTrue(b >= a);
+            AssertEx.AreEqual(TypedMass.ZERO_AVERAGE_MASSNEUTRAL, c);
+            AssertEx.IsTrue(ReferenceEquals(TypedMass.ZERO_AVERAGE_MASSNEUTRAL, c));
+            AssertEx.AreEqual(e, f);
+            AssertEx.AreEqual(TypedMass.ZERO_AVERAGE_MASSNEUTRAL, d - a);
+            AssertEx.AreEqual(b, a + d);
+            AssertEx.AreEqual(b, a * 2);
+            AssertEx.AreEqual(g, d - b);
+            AssertEx.AreEqual(-1.0, g);
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Test/UniModHeavyList.xml
+++ b/pwiz_tools/Skyline/Test/UniModHeavyList.xml
@@ -1,16 +1,16 @@
 ﻿<HeavyModList>
-  <static_modification name="ICAT-C:13C(9) (C)" aminoacid="C" formula="C'9 - C9" unimod_id="106" short_name="C9I" />
-  <static_modification name="ICPL:13C(6)2H(4) (K)" aminoacid="K" formula="C'6H'4 - C6H4" unimod_id="866" />
-  <static_modification name="ICPL:13C(6)2H(4) (N-term)" terminus="N" formula="C'6H'4 - C6H4" unimod_id="866" />
-  <static_modification name="ICPL:2H(4) (K)" aminoacid="K" formula="H'4 - H4" unimod_id="687" short_name="IP4" />
-  <static_modification name="Label:18O(1) (C-term)" terminus="C" formula="O' - O" unimod_id="258" short_name="Ob1" />
-  <static_modification name="Label:18O(2) (C-term)" terminus="C" formula="O'2 - O2" unimod_id="193" short_name="Ob2" />
-  <static_modification name="mTRAQ:13C(3)15N(1) (K)" aminoacid="K" formula="C'3N' - C3N" unimod_id="889" short_name="M04" />
-  <static_modification name="mTRAQ:13C(3)15N(1) (N-term)" terminus="N" formula="C'3N' - C3N" unimod_id="889" short_name="M04" />
-  <static_modification name="mTRAQ:13C(3)15N(1) (Y)" aminoacid="Y" formula="C'3N' - C3N" unimod_id="889" short_name="M04" />
-  <static_modification name="mTRAQ:13C(6)15N(2) (K)" aminoacid="K" formula="C'6N'2 - C6N2" unimod_id="1302" short_name="M08" />
-  <static_modification name="mTRAQ:13C(6)15N(2) (N-term)" terminus="N" formula="C'6N'2 - C6N2" unimod_id="1302" short_name="M08" />
-  <static_modification name="mTRAQ:13C(6)15N(2) (Y)" aminoacid="Y" formula="C'6N'2 - C6N2" unimod_id="1302" short_name="M08" />
+  <static_modification name="ICAT-C:13C(9) (C)" aminoacid="C" formula="C'9-C9" unimod_id="106" short_name="C9I" />
+  <static_modification name="ICPL:13C(6)2H(4) (K)" aminoacid="K" formula="C'6H'4-C6H4" unimod_id="866" />
+  <static_modification name="ICPL:13C(6)2H(4) (N-term)" terminus="N" formula="C'6H'4-C6H4" unimod_id="866" />
+  <static_modification name="ICPL:2H(4) (K)" aminoacid="K" formula="H'4-H4" unimod_id="687" short_name="IP4" />
+  <static_modification name="Label:18O(1) (C-term)" terminus="C" formula="O'-O" unimod_id="258" short_name="Ob1" />
+  <static_modification name="Label:18O(2) (C-term)" terminus="C" formula="O'2-O2" unimod_id="193" short_name="Ob2" />
+  <static_modification name="mTRAQ:13C(3)15N(1) (K)" aminoacid="K" formula="C'3N'-C3N" unimod_id="889" short_name="M04" />
+  <static_modification name="mTRAQ:13C(3)15N(1) (N-term)" terminus="N" formula="C'3N'-C3N" unimod_id="889" short_name="M04" />
+  <static_modification name="mTRAQ:13C(3)15N(1) (Y)" aminoacid="Y" formula="C'3N'-C3N" unimod_id="889" short_name="M04" />
+  <static_modification name="mTRAQ:13C(6)15N(2) (K)" aminoacid="K" formula="C'6N'2-C6N2" unimod_id="1302" short_name="M08" />
+  <static_modification name="mTRAQ:13C(6)15N(2) (N-term)" terminus="N" formula="C'6N'2-C6N2" unimod_id="1302" short_name="M08" />
+  <static_modification name="mTRAQ:13C(6)15N(2) (Y)" aminoacid="Y" formula="C'6N'2-C6N2" unimod_id="1302" short_name="M08" />
   <static_modification name="Label:15N" label_15N="true" />
   <static_modification name="Label:13C" label_13C="true" />
   <static_modification name="Label:13C15N" label_13C="true" label_15N="true" />
@@ -18,42 +18,42 @@
   <static_modification name="Label:13C(6)15N(4) (C-term R)" aminoacid="R" terminus="C" label_13C="true" label_15N="true" />
   <static_modification name="Label:13C(6) (C-term K)" aminoacid="K" terminus="C" label_13C="true" />
   <static_modification name="Label:13C(6) (C-term R)" aminoacid="R" terminus="C" label_13C="true" />
-  <static_modification name="Acetyl:2H(3) (H)" aminoacid="H" formula="H'3 - H3" unimod_id="56" short_name="DAc" />
-  <static_modification name="Acetyl:2H(3) (K)" aminoacid="K" formula="H'3 - H3" unimod_id="56" short_name="DAc" />
-  <static_modification name="Acetyl:2H(3) (N-term)" terminus="N" formula="H'3 - H3" unimod_id="56" short_name="DAc" />
-  <static_modification name="Acetyl:2H(3) (S)" aminoacid="S" formula="H'3 - H3" unimod_id="56" short_name="DAc" />
-  <static_modification name="Acetyl:2H(3) (T)" aminoacid="T" formula="H'3 - H3" unimod_id="56" short_name="DAc" />
-  <static_modification name="Acetyl:2H(3) (Y)" aminoacid="Y" formula="H'3 - H3" unimod_id="56" short_name="DAc" />
-  <static_modification name="AEC-MAEC:2H(4) (S)" aminoacid="S" formula="H'4 - H4" unimod_id="792" />
-  <static_modification name="AEC-MAEC:2H(4) (T)" aminoacid="T" formula="H'4 - H4" unimod_id="792" />
-  <static_modification name="Carboxymethyl:13C(2) (C)" aminoacid="C" formula="C'2 - C2" unimod_id="775" />
-  <static_modification name="Dimethyl:2H(6) (K)" aminoacid="K" formula="H'6 - H6" unimod_id="1291" short_name="DM6" />
-  <static_modification name="Dimethyl:2H(6) (N-term)" terminus="N" formula="H'6 - H6" unimod_id="1291" short_name="DM6" />
-  <static_modification name="Dimethyl:2H(6)13C(2) (K)" aminoacid="K" formula="C'2H'6 - C2H6" unimod_id="330" short_name="DM8" />
-  <static_modification name="Dimethyl:2H(6)13C(2) (N-term)" terminus="N" formula="C'2H'6 - C2H6" unimod_id="330" short_name="DM8" />
-  <static_modification name="Dimethyl:2H(6)13C(2) (R)" aminoacid="R" formula="C'2H'6 - C2H6" unimod_id="330" short_name="DM8" />
-  <static_modification name="DTT_C:2H(6) (C)" aminoacid="C" formula="H'6 - H6" unimod_id="764" />
-  <static_modification name="DTT_ST:2H(6) (S)" aminoacid="S" formula="H'6 - H6" unimod_id="763" />
-  <static_modification name="DTT_ST:2H(6) (T)" aminoacid="T" formula="H'6 - H6" unimod_id="763" />
-  <static_modification name="EQAT:2H(5) (C)" aminoacid="C" formula="H'5 - H5" unimod_id="198" />
-  <static_modification name="ESP:2H(10) (K)" aminoacid="K" formula="H'10 - H10" unimod_id="91" />
-  <static_modification name="ESP:2H(10) (N-term)" terminus="N" formula="H'10 - H10" unimod_id="91" />
-  <static_modification name="GIST-Quat:2H(3) (K)" aminoacid="K" formula="H'3 - H3" unimod_id="61" />
-  <static_modification name="GIST-Quat:2H(3) (N-term)" terminus="N" formula="H'3 - H3" unimod_id="61" />
-  <static_modification name="GIST-Quat:2H(6) (K)" aminoacid="K" formula="H'6 - H6" unimod_id="62" />
-  <static_modification name="GIST-Quat:2H(6) (N-term)" terminus="N" formula="H'6 - H6" unimod_id="62" />
-  <static_modification name="GIST-Quat:2H(9) (K)" aminoacid="K" formula="H'9 - H9" unimod_id="63" />
-  <static_modification name="GIST-Quat:2H(9) (N-term)" terminus="N" formula="H'9 - H9" unimod_id="63" />
-  <static_modification name="ICAT-G:2H(8) (C)" aminoacid="C" formula="H'8 - H8" unimod_id="9" />
-  <static_modification name="ICAT-H:13C(6) (C)" aminoacid="C" formula="C'6 - C6" unimod_id="124" />
-  <static_modification name="ICDID:2H(6) (C)" aminoacid="C" formula="H'6 - H6" unimod_id="1019" />
-  <static_modification name="ICPL:2H(4) (N-term)" terminus="N" formula="H'4 - H4" unimod_id="687" short_name="IP4" />
-  <static_modification name="IGBP:13C(2) (C)" aminoacid="C" formula="C'2 - C2" unimod_id="499" />
-  <static_modification name="IMID:2H(4) (K)" aminoacid="K" formula="H'4 - H4" unimod_id="95" />
-  <static_modification name="Label:13C(1)2H(3) (M)" aminoacid="M" formula="H'3C' - H3C" unimod_id="862" />
+  <static_modification name="Acetyl:2H(3) (H)" aminoacid="H" formula="H'3-H3" unimod_id="56" short_name="DAc" />
+  <static_modification name="Acetyl:2H(3) (K)" aminoacid="K" formula="H'3-H3" unimod_id="56" short_name="DAc" />
+  <static_modification name="Acetyl:2H(3) (N-term)" terminus="N" formula="H'3-H3" unimod_id="56" short_name="DAc" />
+  <static_modification name="Acetyl:2H(3) (S)" aminoacid="S" formula="H'3-H3" unimod_id="56" short_name="DAc" />
+  <static_modification name="Acetyl:2H(3) (T)" aminoacid="T" formula="H'3-H3" unimod_id="56" short_name="DAc" />
+  <static_modification name="Acetyl:2H(3) (Y)" aminoacid="Y" formula="H'3-H3" unimod_id="56" short_name="DAc" />
+  <static_modification name="AEC-MAEC:2H(4) (S)" aminoacid="S" formula="H'4-H4" unimod_id="792" />
+  <static_modification name="AEC-MAEC:2H(4) (T)" aminoacid="T" formula="H'4-H4" unimod_id="792" />
+  <static_modification name="Carboxymethyl:13C(2) (C)" aminoacid="C" formula="C'2-C2" unimod_id="775" />
+  <static_modification name="Dimethyl:2H(6) (K)" aminoacid="K" formula="H'6-H6" unimod_id="1291" short_name="DM6" />
+  <static_modification name="Dimethyl:2H(6) (N-term)" terminus="N" formula="H'6-H6" unimod_id="1291" short_name="DM6" />
+  <static_modification name="Dimethyl:2H(6)13C(2) (K)" aminoacid="K" formula="C'2H'6-C2H6" unimod_id="330" short_name="DM8" />
+  <static_modification name="Dimethyl:2H(6)13C(2) (N-term)" terminus="N" formula="C'2H'6-C2H6" unimod_id="330" short_name="DM8" />
+  <static_modification name="Dimethyl:2H(6)13C(2) (R)" aminoacid="R" formula="C'2H'6-C2H6" unimod_id="330" short_name="DM8" />
+  <static_modification name="DTT_C:2H(6) (C)" aminoacid="C" formula="H'6-H6" unimod_id="764" />
+  <static_modification name="DTT_ST:2H(6) (S)" aminoacid="S" formula="H'6-H6" unimod_id="763" />
+  <static_modification name="DTT_ST:2H(6) (T)" aminoacid="T" formula="H'6-H6" unimod_id="763" />
+  <static_modification name="EQAT:2H(5) (C)" aminoacid="C" formula="H'5-H5" unimod_id="198" />
+  <static_modification name="ESP:2H(10) (K)" aminoacid="K" formula="H'10-H10" unimod_id="91" />
+  <static_modification name="ESP:2H(10) (N-term)" terminus="N" formula="H'10-H10" unimod_id="91" />
+  <static_modification name="GIST-Quat:2H(3) (K)" aminoacid="K" formula="H'3-H3" unimod_id="61" />
+  <static_modification name="GIST-Quat:2H(3) (N-term)" terminus="N" formula="H'3-H3" unimod_id="61" />
+  <static_modification name="GIST-Quat:2H(6) (K)" aminoacid="K" formula="H'6-H6" unimod_id="62" />
+  <static_modification name="GIST-Quat:2H(6) (N-term)" terminus="N" formula="H'6-H6" unimod_id="62" />
+  <static_modification name="GIST-Quat:2H(9) (K)" aminoacid="K" formula="H'9-H9" unimod_id="63" />
+  <static_modification name="GIST-Quat:2H(9) (N-term)" terminus="N" formula="H'9-H9" unimod_id="63" />
+  <static_modification name="ICAT-G:2H(8) (C)" aminoacid="C" formula="H'8-H8" unimod_id="9" />
+  <static_modification name="ICAT-H:13C(6) (C)" aminoacid="C" formula="C'6-C6" unimod_id="124" />
+  <static_modification name="ICDID:2H(6) (C)" aminoacid="C" formula="H'6-H6" unimod_id="1019" />
+  <static_modification name="ICPL:2H(4) (N-term)" terminus="N" formula="H'4-H4" unimod_id="687" short_name="IP4" />
+  <static_modification name="IGBP:13C(2) (C)" aminoacid="C" formula="C'2-C2" unimod_id="499" />
+  <static_modification name="IMID:2H(4) (K)" aminoacid="K" formula="H'4-H4" unimod_id="95" />
+  <static_modification name="Label:13C(1)2H(3) (M)" aminoacid="M" formula="H'3C'-H3C" unimod_id="862" />
   <static_modification name="Label:13C(3) (A)" aminoacid="A" label_13C="true" unimod_id="1296" short_name="+3a" />
   <static_modification name="Label:13C(3)15N(1) (A)" aminoacid="A" label_13C="true" label_15N="true" unimod_id="1297" short_name="+4a" />
-  <static_modification name="Label:13C(4) (M)" aminoacid="M" formula="C'4 - C4" unimod_id="1266" short_name="+4b" />
+  <static_modification name="Label:13C(4) (M)" aminoacid="M" formula="C'4-C4" unimod_id="1266" short_name="+4b" />
   <static_modification name="Label:13C(4)15N(1) (D)" aminoacid="D" label_13C="true" label_15N="true" unimod_id="1298" short_name="+05" />
   <static_modification name="Label:13C(5) (P)" aminoacid="P" label_13C="true" unimod_id="772" />
   <static_modification name="Label:13C(5)15N(1) (E)" aminoacid="E" label_13C="true" label_15N="true" unimod_id="268" short_name="+6a" />
@@ -89,42 +89,42 @@
   <static_modification name="Label:15N(2) (N)" aminoacid="N" label_15N="true" unimod_id="995" short_name="+02" />
   <static_modification name="Label:15N(2) (Q)" aminoacid="Q" label_15N="true" unimod_id="995" short_name="+02" />
   <static_modification name="Label:15N(2) (W)" aminoacid="W" label_15N="true" unimod_id="995" short_name="+02" />
-  <static_modification name="Label:15N(2)2H(9) (K)" aminoacid="K" formula="H'9N'2 - H9N2" unimod_id="944" />
+  <static_modification name="Label:15N(2)2H(9) (K)" aminoacid="K" formula="H'9N'2-H9N2" unimod_id="944" />
   <static_modification name="Label:15N(3) (H)" aminoacid="H" label_15N="true" unimod_id="996" short_name="+03" />
   <static_modification name="Label:15N(4) (R)" aminoacid="R" label_15N="true" unimod_id="897" short_name="+04" />
-  <static_modification name="Label:18O(1) (S)" aminoacid="S" formula="O' - O" unimod_id="258" short_name="Ob1" />
-  <static_modification name="Label:18O(1) (T)" aminoacid="T" formula="O' - O" unimod_id="258" short_name="Ob1" />
-  <static_modification name="Label:18O(1) (Y)" aminoacid="Y" formula="O' - O" unimod_id="258" short_name="Ob1" />
-  <static_modification name="Label:2H(10) (L)" aminoacid="L" formula="H'10 - H10" unimod_id="1299" short_name="D10" />
-  <static_modification name="Label:2H(3) (L)" aminoacid="L" formula="H'3 - H3" unimod_id="262" short_name="D03" />
-  <static_modification name="Label:2H(4) (F)" aminoacid="F" formula="H'4 - H4" unimod_id="481" short_name="D04" />
-  <static_modification name="Label:2H(4) (K)" aminoacid="K" formula="H'4 - H4" unimod_id="481" short_name="D04" />
-  <static_modification name="Label:2H(4) (Y)" aminoacid="Y" formula="H'4 - H4" unimod_id="481" short_name="D04" />
-  <static_modification name="Label:2H(4)13C(1) (R)" aminoacid="R" formula="H'4C' - H4C" unimod_id="1300" short_name="+5a" />
-  <static_modification name="Label:2H(9)13C(6)15N(2) (K)" aminoacid="K" formula="H'9C'6N'2 - H9C6N2" unimod_id="696" />
-  <static_modification name="Methyl:2H(3) (C-term)" terminus="C" formula="H'3 - H3" unimod_id="298" />
-  <static_modification name="Methyl:2H(3) (D)" aminoacid="D" formula="H'3 - H3" unimod_id="298" />
-  <static_modification name="Methyl:2H(3) (E)" aminoacid="E" formula="H'3 - H3" unimod_id="298" />
-  <static_modification name="Methyl:2H(3)13C(1) (R)" aminoacid="R" formula="C'H'3 - CH3" unimod_id="329" />
-  <static_modification name="mTRAQ:13C(3)15N(1) (H)" aminoacid="H" formula="C'3N' - C3N" unimod_id="889" short_name="M04" />
-  <static_modification name="mTRAQ:13C(3)15N(1) (S)" aminoacid="S" formula="C'3N' - C3N" unimod_id="889" short_name="M04" />
-  <static_modification name="mTRAQ:13C(3)15N(1) (T)" aminoacid="T" formula="C'3N' - C3N" unimod_id="889" short_name="M04" />
-  <static_modification name="mTRAQ:13C(6)15N(2) (H)" aminoacid="H" formula="C'6N'2 - C6N2" unimod_id="1302" short_name="M08" />
-  <static_modification name="mTRAQ:13C(6)15N(2) (S)" aminoacid="S" formula="C'6N'2 - C6N2" unimod_id="1302" short_name="M08" />
-  <static_modification name="mTRAQ:13C(6)15N(2) (T)" aminoacid="T" formula="C'6N'2 - C6N2" unimod_id="1302" short_name="M08" />
-  <static_modification name="Phenylisocyanate:2H(5) (N-term)" terminus="N" formula="H'5 - H5" unimod_id="412" />
-  <static_modification name="Propionamide:2H(3) (C)" aminoacid="C" formula="H'3 - H3" unimod_id="97" />
-  <static_modification name="Propionyl:13C(3) (K)" aminoacid="K" formula="C'3 - C3" unimod_id="59" />
-  <static_modification name="Propionyl:13C(3) (N-term)" terminus="N" formula="C'3 - C3" unimod_id="59" />
-  <static_modification name="QAT:2H(3) (C)" aminoacid="C" formula="H'3 - H3" unimod_id="196" />
-  <static_modification name="SecNEM:2H(5) (C)" aminoacid="C" formula="H'5 - H5" unimod_id="1034" />
-  <static_modification name="SPITC:13C(6) (K)" aminoacid="K" formula="C'6 - C6" unimod_id="464" />
-  <static_modification name="SPITC:13C(6) (N-term)" terminus="N" formula="C'6 - C6" unimod_id="464" />
-  <static_modification name="Succinyl:13C(4) (K)" aminoacid="K" formula="C'4 - C4" unimod_id="66" />
-  <static_modification name="Succinyl:13C(4) (N-term)" terminus="N" formula="C'4 - C4" unimod_id="66" />
-  <static_modification name="Succinyl:2H(4) (K)" aminoacid="K" formula="H'4 - H4" unimod_id="65" />
-  <static_modification name="Succinyl:2H(4) (N-term)" terminus="N" formula="H'4 - H4" unimod_id="65" />
-  <static_modification name="SulfanilicAcid:13C(6) (C-term)" terminus="C" formula="C'6 - C6" unimod_id="286" />
-  <static_modification name="SulfanilicAcid:13C(6) (D)" aminoacid="D" formula="C'6 - C6" unimod_id="286" />
-  <static_modification name="SulfanilicAcid:13C(6) (E)" aminoacid="E" formula="C'6 - C6" unimod_id="286" />
+  <static_modification name="Label:18O(1) (S)" aminoacid="S" formula="O'-O" unimod_id="258" short_name="Ob1" />
+  <static_modification name="Label:18O(1) (T)" aminoacid="T" formula="O'-O" unimod_id="258" short_name="Ob1" />
+  <static_modification name="Label:18O(1) (Y)" aminoacid="Y" formula="O'-O" unimod_id="258" short_name="Ob1" />
+  <static_modification name="Label:2H(10) (L)" aminoacid="L" formula="H'10-H10" unimod_id="1299" short_name="D10" />
+  <static_modification name="Label:2H(3) (L)" aminoacid="L" formula="H'3-H3" unimod_id="262" short_name="D03" />
+  <static_modification name="Label:2H(4) (F)" aminoacid="F" formula="H'4-H4" unimod_id="481" short_name="D04" />
+  <static_modification name="Label:2H(4) (K)" aminoacid="K" formula="H'4-H4" unimod_id="481" short_name="D04" />
+  <static_modification name="Label:2H(4) (Y)" aminoacid="Y" formula="H'4-H4" unimod_id="481" short_name="D04" />
+  <static_modification name="Label:2H(4)13C(1) (R)" aminoacid="R" formula="H'4C'-H4C" unimod_id="1300" short_name="+5a" />
+  <static_modification name="Label:2H(9)13C(6)15N(2) (K)" aminoacid="K" formula="H'9C'6N'2-H9C6N2" unimod_id="696" />
+  <static_modification name="Methyl:2H(3) (C-term)" terminus="C" formula="H'3-H3" unimod_id="298" />
+  <static_modification name="Methyl:2H(3) (D)" aminoacid="D" formula="H'3-H3" unimod_id="298" />
+  <static_modification name="Methyl:2H(3) (E)" aminoacid="E" formula="H'3-H3" unimod_id="298" />
+  <static_modification name="Methyl:2H(3)13C(1) (R)" aminoacid="R" formula="C'H'3-CH3" unimod_id="329" />
+  <static_modification name="mTRAQ:13C(3)15N(1) (H)" aminoacid="H" formula="C'3N'-C3N" unimod_id="889" short_name="M04" />
+  <static_modification name="mTRAQ:13C(3)15N(1) (S)" aminoacid="S" formula="C'3N'-C3N" unimod_id="889" short_name="M04" />
+  <static_modification name="mTRAQ:13C(3)15N(1) (T)" aminoacid="T" formula="C'3N'-C3N" unimod_id="889" short_name="M04" />
+  <static_modification name="mTRAQ:13C(6)15N(2) (H)" aminoacid="H" formula="C'6N'2-C6N2" unimod_id="1302" short_name="M08" />
+  <static_modification name="mTRAQ:13C(6)15N(2) (S)" aminoacid="S" formula="C'6N'2-C6N2" unimod_id="1302" short_name="M08" />
+  <static_modification name="mTRAQ:13C(6)15N(2) (T)" aminoacid="T" formula="C'6N'2-C6N2" unimod_id="1302" short_name="M08" />
+  <static_modification name="Phenylisocyanate:2H(5) (N-term)" terminus="N" formula="H'5-H5" unimod_id="412" />
+  <static_modification name="Propionamide:2H(3) (C)" aminoacid="C" formula="H'3-H3" unimod_id="97" />
+  <static_modification name="Propionyl:13C(3) (K)" aminoacid="K" formula="C'3-C3" unimod_id="59" />
+  <static_modification name="Propionyl:13C(3) (N-term)" terminus="N" formula="C'3-C3" unimod_id="59" />
+  <static_modification name="QAT:2H(3) (C)" aminoacid="C" formula="H'3-H3" unimod_id="196" />
+  <static_modification name="SecNEM:2H(5) (C)" aminoacid="C" formula="H'5-H5" unimod_id="1034" />
+  <static_modification name="SPITC:13C(6) (K)" aminoacid="K" formula="C'6-C6" unimod_id="464" />
+  <static_modification name="SPITC:13C(6) (N-term)" terminus="N" formula="C'6-C6" unimod_id="464" />
+  <static_modification name="Succinyl:13C(4) (K)" aminoacid="K" formula="C'4-C4" unimod_id="66" />
+  <static_modification name="Succinyl:13C(4) (N-term)" terminus="N" formula="C'4-C4" unimod_id="66" />
+  <static_modification name="Succinyl:2H(4) (K)" aminoacid="K" formula="H'4-H4" unimod_id="65" />
+  <static_modification name="Succinyl:2H(4) (N-term)" terminus="N" formula="H'4-H4" unimod_id="65" />
+  <static_modification name="SulfanilicAcid:13C(6) (C-term)" terminus="C" formula="C'6-C6" unimod_id="286" />
+  <static_modification name="SulfanilicAcid:13C(6) (D)" aminoacid="D" formula="C'6-C6" unimod_id="286" />
+  <static_modification name="SulfanilicAcid:13C(6) (E)" aminoacid="E" formula="C'6-C6" unimod_id="286" />
 </HeavyModList>

--- a/pwiz_tools/Skyline/Test/UniModStaticList.xml
+++ b/pwiz_tools/Skyline/Test/UniModStaticList.xml
@@ -1,7 +1,7 @@
 ﻿<StaticModList>
   <static_modification name="Acetyl (K)" aminoacid="K" formula="C2H2O" unimod_id="1" short_name="1Ac" />
   <static_modification name="Acetyl (N-term)" terminus="N" formula="C2H2O" unimod_id="1" short_name="1Ac" />
-  <static_modification name="Amidated (C-term)" terminus="C" formula="HN - O" unimod_id="2" short_name="Ami" />
+  <static_modification name="Amidated (C-term)" terminus="C" formula="HN-O" unimod_id="2" short_name="Ami" />
   <static_modification name="Ammonia-loss (N-term C)" aminoacid="C" terminus="N" formula="-H3N" unimod_id="385" short_name="dAm" />
   <static_modification name="Biotin (K)" aminoacid="K" formula="C10H14N2O2S" unimod_id="3" short_name="Btn" />
   <static_modification name="Biotin (N-term)" terminus="N" formula="C10H14N2O2S" unimod_id="3" short_name="Btn" />
@@ -9,10 +9,10 @@
   <static_modification name="Carbamyl (K)" aminoacid="K" formula="HCNO" unimod_id="5" short_name="CRM" />
   <static_modification name="Carbamyl (N-term)" terminus="N" formula="HCNO" unimod_id="5" short_name="CRM" />
   <static_modification name="Carboxymethyl (C)" aminoacid="C" formula="C2H2O2" unimod_id="6" short_name="Cmc" />
-  <static_modification name="Cation:Na (C-term)" terminus="C" formula="Na - H" unimod_id="30" short_name="NaX" />
-  <static_modification name="Cation:Na (DE)" aminoacid="D, E" formula="Na - H" unimod_id="30" short_name="NaX" />
+  <static_modification name="Cation:Na (C-term)" terminus="C" formula="Na-H" unimod_id="30" short_name="NaX" />
+  <static_modification name="Cation:Na (DE)" aminoacid="D, E" formula="Na-H" unimod_id="30" short_name="NaX" />
   <static_modification name="cysTMT6plex (C)" aminoacid="C" formula="H25C10C'4N2N'O2S" unimod_id="985" />
-  <static_modification name="Deamidated (NQ)" aminoacid="N, Q" formula="O - HN" unimod_id="7" short_name="Dea" />
+  <static_modification name="Deamidated (NQ)" aminoacid="N, Q" formula="O-HN" unimod_id="7" short_name="Dea" />
   <static_modification name="Dehydrated (N-term C)" aminoacid="C" terminus="N" formula="-H2O" unimod_id="23" short_name="Dhy" />
   <static_modification name="Dehydro (C)" aminoacid="C" formula="-H" unimod_id="374" short_name="-1H" />
   <static_modification name="DiLeu4plex (K)" aminoacid="K" formula="H13H'2C8NO'" unimod_id="1322" />
@@ -35,7 +35,7 @@
   <static_modification name="iTRAQ8plex (K)" aminoacid="K" formula="C'7N'C7H24N3O3" unimod_id="730" short_name="IT8" />
   <static_modification name="iTRAQ8plex (N-term)" terminus="N" formula="C'7N'C7H24N3O3" unimod_id="730" short_name="IT8" />
   <static_modification name="iTRAQ8plex (Y)" aminoacid="Y" formula="C'7N'C7H24N3O3" unimod_id="730" short_name="IT8" />
-  <static_modification name="Met-&gt;Hse (C-term M)" aminoacid="M" terminus="C" formula="O - H2CS" unimod_id="10" short_name="Hse" />
+  <static_modification name="Met-&gt;Hse (C-term M)" aminoacid="M" terminus="C" formula="O-H2CS" unimod_id="10" short_name="Hse" />
   <static_modification name="Met-&gt;Hsl (C-term M)" aminoacid="M" terminus="C" formula="-H4CS" unimod_id="11" short_name="Hsl" />
   <static_modification name="Methyl (C-term)" terminus="C" formula="CH2" unimod_id="34" short_name="1Me" />
   <static_modification name="Methyl (DE)" aminoacid="D, E" formula="CH2" unimod_id="34" short_name="1Me" />
@@ -103,10 +103,10 @@
   <static_modification name="AEBS (K)" aminoacid="K" formula="H9C8NO2S" unimod_id="276" />
   <static_modification name="AEBS (S)" aminoacid="S" formula="H9C8NO2S" unimod_id="276" />
   <static_modification name="AEBS (Y)" aminoacid="Y" formula="H9C8NO2S" unimod_id="276" />
-  <static_modification name="AEC-MAEC (S)" aminoacid="S" formula="C2H5NS - O" unimod_id="472" short_name="Aec" />
-  <static_modification name="AEC-MAEC (T)" aminoacid="T" formula="C2H5NS - O" unimod_id="472" short_name="Aec" />
-  <static_modification name="AHA-Alkyne (M)" aminoacid="M" formula="H5C4N5O - S" unimod_id="1000" />
-  <static_modification name="AHA-Alkyne-KDDDD (M)" aminoacid="M" formula="H37C26N11O14 - S" unimod_id="1001" />
+  <static_modification name="AEC-MAEC (S)" aminoacid="S" formula="C2H5NS-O" unimod_id="472" short_name="Aec" />
+  <static_modification name="AEC-MAEC (T)" aminoacid="T" formula="C2H5NS-O" unimod_id="472" short_name="Aec" />
+  <static_modification name="AHA-Alkyne (M)" aminoacid="M" formula="H5C4N5O-S" unimod_id="1000" />
+  <static_modification name="AHA-Alkyne-KDDDD (M)" aminoacid="M" formula="H37C26N11O14-S" unimod_id="1001" />
   <static_modification name="AHA-SS (M)" aminoacid="M" formula="H9C7N5O2" unimod_id="1249" />
   <static_modification name="AHA-SS_CAM (M)" aminoacid="M" formula="H12C9N6O3" unimod_id="1250" />
   <static_modification name="Ahx2+Hsl (C-term)" terminus="C" formula="H27C16N3O3" unimod_id="1015" />
@@ -124,8 +124,8 @@
   <static_modification name="AMTzHexNAc2 (T)" aminoacid="T" formula="H30C19N6O10" unimod_id="934" />
   <static_modification name="Archaeol (C)" aminoacid="C" formula="H86C43O2" unimod_id="410" short_name="Ach" />
   <static_modification name="Arg (N-term)" terminus="N" formula="H12C6N4O" unimod_id="1288" />
-  <static_modification name="Arg-&gt;GluSA (R)" aminoacid="R" formula="O - H5CN3" unimod_id="344" short_name="AGA" />
-  <static_modification name="Arg-&gt;Npo (R)" aminoacid="R" formula="C3NO2 - H" unimod_id="837" />
+  <static_modification name="Arg-&gt;GluSA (R)" aminoacid="R" formula="O-H5CN3" unimod_id="344" short_name="AGA" />
+  <static_modification name="Arg-&gt;Npo (R)" aminoacid="R" formula="C3NO2-H" unimod_id="837" />
   <static_modification name="Arg-&gt;Orn (R)" aminoacid="R" formula="-H2CN2" unimod_id="372" short_name="Orn" />
   <static_modification name="Arg-loss (C-term R)" aminoacid="R" terminus="C" formula="-H12C6N4O" unimod_id="1287" short_name="-1R" />
   <static_modification name="Arg2PG (R)" aminoacid="R" formula="H10C16O4" unimod_id="848" />
@@ -186,10 +186,10 @@
   <static_modification name="BMP-piperidinol (C)" aminoacid="C" formula="H17C18NO" unimod_id="1281" />
   <static_modification name="BMP-piperidinol (M)" aminoacid="M" formula="H17C18NO" unimod_id="1281" />
   <static_modification name="Bodipy (C)" aminoacid="C" formula="H21C20N4O3F2B" unimod_id="878" />
-  <static_modification name="Bromo (F)" aminoacid="F" formula="Br - H" unimod_id="340" short_name="1Br" />
-  <static_modification name="Bromo (H)" aminoacid="H" formula="Br - H" unimod_id="340" short_name="1Br" />
-  <static_modification name="Bromo (W)" aminoacid="W" formula="Br - H" unimod_id="340" short_name="1Br" />
-  <static_modification name="Bromo (Y)" aminoacid="Y" formula="Br - H" unimod_id="340" short_name="1Br" />
+  <static_modification name="Bromo (F)" aminoacid="F" formula="Br-H" unimod_id="340" short_name="1Br" />
+  <static_modification name="Bromo (H)" aminoacid="H" formula="Br-H" unimod_id="340" short_name="1Br" />
+  <static_modification name="Bromo (W)" aminoacid="W" formula="Br-H" unimod_id="340" short_name="1Br" />
+  <static_modification name="Bromo (Y)" aminoacid="Y" formula="Br-H" unimod_id="340" short_name="1Br" />
   <static_modification name="Bromobimane (C)" aminoacid="C" formula="H10C10N2O2" unimod_id="301" />
   <static_modification name="Butyryl (K)" aminoacid="K" formula="H6C4O" unimod_id="1289" short_name="Byr" />
   <static_modification name="C8-QAT (K)" aminoacid="K" formula="H29C14NO" unimod_id="513" />
@@ -220,7 +220,7 @@
   <static_modification name="Carboxy (K)" aminoacid="K" formula="CO2" unimod_id="299" short_name="Cox" />
   <static_modification name="Carboxy (Protein N-term M)" aminoacid="M" terminus="N" formula="CO2" unimod_id="299" short_name="Cox" />
   <static_modification name="Carboxy (W)" aminoacid="W" formula="CO2" unimod_id="299" short_name="Cox" />
-  <static_modification name="Carboxy-&gt;Thiocarboxy (Protein C-term G)" aminoacid="G" terminus="C" formula="S - O" unimod_id="420" short_name="Scx" />
+  <static_modification name="Carboxy-&gt;Thiocarboxy (Protein C-term G)" aminoacid="G" terminus="C" formula="S-O" unimod_id="420" short_name="Scx" />
   <static_modification name="Carboxyethyl (H)" aminoacid="H" formula="H4C3O2" unimod_id="378" short_name="CEt" />
   <static_modification name="Carboxyethyl (K)" aminoacid="K" formula="H4C3O2" unimod_id="378" short_name="CEt" />
   <static_modification name="Carboxymethyl (K)" aminoacid="K" formula="C2H2O2" unimod_id="6" short_name="Cmc" />
@@ -228,24 +228,24 @@
   <static_modification name="Carboxymethyl (W)" aminoacid="W" formula="C2H2O2" unimod_id="6" short_name="Cmc" />
   <static_modification name="CarboxymethylDMAP (N-term)" terminus="N" formula="H10C9N2O" unimod_id="1350" />
   <static_modification name="CarboxymethylDTT (C)" aminoacid="C" formula="H10C6O4S2" unimod_id="894" />
-  <static_modification name="Cation:Ag (C-term)" terminus="C" formula="Ag - H" unimod_id="955" />
-  <static_modification name="Cation:Ag (DE)" aminoacid="D, E" formula="Ag - H" unimod_id="955" />
-  <static_modification name="Cation:Ca[II] (C-term)" terminus="C" formula="Ca - H2" unimod_id="951" />
-  <static_modification name="Cation:Ca[II] (DE)" aminoacid="D, E" formula="Ca - H2" unimod_id="951" />
-  <static_modification name="Cation:Cu[I] (C-term)" terminus="C" formula="Cu - H" unimod_id="531" short_name="CuX" />
-  <static_modification name="Cation:Cu[I] (DE)" aminoacid="D, E" formula="Cu - H" unimod_id="531" short_name="CuX" />
-  <static_modification name="Cation:Fe[II] (C-term)" terminus="C" formula="Fe - H2" unimod_id="952" />
-  <static_modification name="Cation:Fe[II] (DE)" aminoacid="D, E" formula="Fe - H2" unimod_id="952" />
-  <static_modification name="Cation:K (C-term)" terminus="C" formula="K - H" unimod_id="530" short_name="KXX" />
-  <static_modification name="Cation:K (DE)" aminoacid="D, E" formula="K - H" unimod_id="530" short_name="KXX" />
-  <static_modification name="Cation:Li (C-term)" terminus="C" formula="Li - H" unimod_id="950" />
-  <static_modification name="Cation:Li (DE)" aminoacid="D, E" formula="Li - H" unimod_id="950" />
-  <static_modification name="Cation:Mg[II] (C-term)" terminus="C" formula="Mg - H2" unimod_id="956" />
-  <static_modification name="Cation:Mg[II] (DE)" aminoacid="D, E" formula="Mg - H2" unimod_id="956" />
-  <static_modification name="Cation:Ni[II] (C-term)" terminus="C" formula="Ni - H2" unimod_id="953" />
-  <static_modification name="Cation:Ni[II] (DE)" aminoacid="D, E" formula="Ni - H2" unimod_id="953" />
-  <static_modification name="Cation:Zn[II] (C-term)" terminus="C" formula="Zn - H2" unimod_id="954" />
-  <static_modification name="Cation:Zn[II] (DE)" aminoacid="D, E" formula="Zn - H2" unimod_id="954" />
+  <static_modification name="Cation:Ag (C-term)" terminus="C" formula="Ag-H" unimod_id="955" />
+  <static_modification name="Cation:Ag (DE)" aminoacid="D, E" formula="Ag-H" unimod_id="955" />
+  <static_modification name="Cation:Ca[II] (C-term)" terminus="C" formula="Ca-H2" unimod_id="951" />
+  <static_modification name="Cation:Ca[II] (DE)" aminoacid="D, E" formula="Ca-H2" unimod_id="951" />
+  <static_modification name="Cation:Cu[I] (C-term)" terminus="C" formula="Cu-H" unimod_id="531" short_name="CuX" />
+  <static_modification name="Cation:Cu[I] (DE)" aminoacid="D, E" formula="Cu-H" unimod_id="531" short_name="CuX" />
+  <static_modification name="Cation:Fe[II] (C-term)" terminus="C" formula="Fe-H2" unimod_id="952" />
+  <static_modification name="Cation:Fe[II] (DE)" aminoacid="D, E" formula="Fe-H2" unimod_id="952" />
+  <static_modification name="Cation:K (C-term)" terminus="C" formula="K-H" unimod_id="530" short_name="KXX" />
+  <static_modification name="Cation:K (DE)" aminoacid="D, E" formula="K-H" unimod_id="530" short_name="KXX" />
+  <static_modification name="Cation:Li (C-term)" terminus="C" formula="Li-H" unimod_id="950" />
+  <static_modification name="Cation:Li (DE)" aminoacid="D, E" formula="Li-H" unimod_id="950" />
+  <static_modification name="Cation:Mg[II] (C-term)" terminus="C" formula="Mg-H2" unimod_id="956" />
+  <static_modification name="Cation:Mg[II] (DE)" aminoacid="D, E" formula="Mg-H2" unimod_id="956" />
+  <static_modification name="Cation:Ni[II] (C-term)" terminus="C" formula="Ni-H2" unimod_id="953" />
+  <static_modification name="Cation:Ni[II] (DE)" aminoacid="D, E" formula="Ni-H2" unimod_id="953" />
+  <static_modification name="Cation:Zn[II] (C-term)" terminus="C" formula="Zn-H2" unimod_id="954" />
+  <static_modification name="Cation:Zn[II] (DE)" aminoacid="D, E" formula="Zn-H2" unimod_id="954" />
   <static_modification name="cGMP (C)" aminoacid="C" formula="H11C10N5O7P" unimod_id="849" />
   <static_modification name="cGMP (S)" aminoacid="S" formula="H11C10N5O7P" unimod_id="849" />
   <static_modification name="cGMP+RMP-loss (C)" aminoacid="C" formula="H4C5N5O" unimod_id="851" />
@@ -283,14 +283,14 @@
   <static_modification name="CuSMo (C)" aminoacid="C" formula="H24C19N8O15P2S3MoCu" unimod_id="444" short_name="CSM" />
   <static_modification name="Cy3-maleimide (C)" aminoacid="C" formula="H45C37N4O9S2" unimod_id="1348" />
   <static_modification name="Cy3b-maleimide (C)" aminoacid="C" formula="H38C37N4O7S" unimod_id="821" />
-  <static_modification name="Cyano (C)" aminoacid="C" formula="CN - H" unimod_id="438" short_name="1CN" />
+  <static_modification name="Cyano (C)" aminoacid="C" formula="CN-H" unimod_id="438" short_name="1CN" />
   <static_modification name="CyDye-Cy3 (C)" aminoacid="C" formula="H44C37N4O6S" unimod_id="494" />
   <static_modification name="CyDye-Cy5 (C)" aminoacid="C" formula="H44C38N4O6S" unimod_id="495" />
   <static_modification name="Cys-&gt;Dha (C)" aminoacid="C" formula="-H2S" unimod_id="368" short_name="DHA" />
-  <static_modification name="Cys-&gt;ethylaminoAla (C)" aminoacid="C" formula="H5C2N - S" unimod_id="940" />
-  <static_modification name="Cys-&gt;methylaminoAla (C)" aminoacid="C" formula="H3CN - S" unimod_id="939" />
-  <static_modification name="Cys-&gt;Oxoalanine (C)" aminoacid="C" formula="O - H2S" unimod_id="402" short_name="COa" />
-  <static_modification name="Cys-&gt;PyruvicAcid (Protein N-term C)" aminoacid="C" terminus="N" formula="O - H3NS" unimod_id="382" short_name="CPA" />
+  <static_modification name="Cys-&gt;ethylaminoAla (C)" aminoacid="C" formula="H5C2N-S" unimod_id="940" />
+  <static_modification name="Cys-&gt;methylaminoAla (C)" aminoacid="C" formula="H3CN-S" unimod_id="939" />
+  <static_modification name="Cys-&gt;Oxoalanine (C)" aminoacid="C" formula="O-H2S" unimod_id="402" short_name="COa" />
+  <static_modification name="Cys-&gt;PyruvicAcid (Protein N-term C)" aminoacid="C" terminus="N" formula="O-H3NS" unimod_id="382" short_name="CPA" />
   <static_modification name="Cysteinyl (C)" aminoacid="C" formula="H5C3NO2S" unimod_id="312" short_name="SCC" />
   <static_modification name="cysTMT (C)" aminoacid="C" formula="H25C14N3O2S" unimod_id="984" />
   <static_modification name="Cytopiloyne (C)" aminoacid="C" formula="H22C19O7" unimod_id="270" />
@@ -307,13 +307,13 @@
   <static_modification name="Cytopiloyne+water (S)" aminoacid="S" formula="H24C19O8" unimod_id="271" />
   <static_modification name="Cytopiloyne+water (T)" aminoacid="T" formula="H24C19O8" unimod_id="271" />
   <static_modification name="Cytopiloyne+water (Y)" aminoacid="Y" formula="H24C19O8" unimod_id="271" />
-  <static_modification name="DAET (S)" aminoacid="S" formula="H9C4NS - O" unimod_id="178" />
-  <static_modification name="DAET (T)" aminoacid="T" formula="H9C4NS - O" unimod_id="178" />
+  <static_modification name="DAET (S)" aminoacid="S" formula="H9C4NS-O" unimod_id="178" />
+  <static_modification name="DAET (T)" aminoacid="T" formula="H9C4NS-O" unimod_id="178" />
   <static_modification name="Dansyl (K)" aminoacid="K" formula="H11C12NO2S" unimod_id="139" />
   <static_modification name="Dansyl (N-term)" terminus="N" formula="H11C12NO2S" unimod_id="139" />
-  <static_modification name="Deamidated (Protein N-term F)" aminoacid="F" terminus="N" formula="O - HN" unimod_id="7" short_name="Dea" />
-  <static_modification name="Deamidated (R)" aminoacid="R" formula="O - HN" unimod_id="7" short_name="Dea" />
-  <static_modification name="Deamidated:18O(1) (NQ)" aminoacid="N, Q" formula="O' - HN" unimod_id="366" short_name="DeO" />
+  <static_modification name="Deamidated (Protein N-term F)" aminoacid="F" terminus="N" formula="O-HN" unimod_id="7" short_name="Dea" />
+  <static_modification name="Deamidated (R)" aminoacid="R" formula="O-HN" unimod_id="7" short_name="Dea" />
+  <static_modification name="Deamidated:18O(1) (NQ)" aminoacid="N, Q" formula="O'-HN" unimod_id="366" short_name="DeO" />
   <static_modification name="Decanoyl (S)" aminoacid="S" formula="H18C10O" unimod_id="449" short_name="Dec" />
   <static_modification name="Decanoyl (T)" aminoacid="T" formula="H18C10O" unimod_id="449" short_name="Dec" />
   <static_modification name="DEDGFLYMVYASQETFG (K)" aminoacid="K" formula="H122C89N18O31S" unimod_id="1010">
@@ -325,7 +325,7 @@
   <static_modification name="Dehydrated (S)" aminoacid="S" formula="-H2O" unimod_id="23" short_name="Dhy" />
   <static_modification name="Dehydrated (T)" aminoacid="T" formula="-H2O" unimod_id="23" short_name="Dhy" />
   <static_modification name="Dehydrated (Y)" aminoacid="Y" formula="-H2O" unimod_id="23" short_name="Dhy" />
-  <static_modification name="Delta:H(1)O(-1)18O(1) (N)" aminoacid="N" formula="O' - HN" unimod_id="170" short_name="DeW" />
+  <static_modification name="Delta:H(1)O(-1)18O(1) (N)" aminoacid="N" formula="O'-HN" unimod_id="170" short_name="DeW" />
   <static_modification name="Delta:H(2)C(2) (H)" aminoacid="H" formula="H2C2" unimod_id="254" short_name="AAS" />
   <static_modification name="Delta:H(2)C(2) (K)" aminoacid="K" formula="H2C2" unimod_id="254" short_name="AAS" />
   <static_modification name="Delta:H(2)C(2) (N-term)" terminus="N" formula="H2C2" unimod_id="254" short_name="AAS" />
@@ -336,7 +336,7 @@
   <static_modification name="Delta:H(4)C(2) (H)" aminoacid="H" formula="H4C2" unimod_id="255" short_name="AAR" />
   <static_modification name="Delta:H(4)C(2) (K)" aminoacid="K" formula="H4C2" unimod_id="255" short_name="AAR" />
   <static_modification name="Delta:H(4)C(2) (N-term)" terminus="N" formula="H4C2" unimod_id="255" short_name="AAR" />
-  <static_modification name="Delta:H(4)C(2)O(-1)S(1) (S)" aminoacid="S" formula="H4C2S - O" unimod_id="327" />
+  <static_modification name="Delta:H(4)C(2)O(-1)S(1) (S)" aminoacid="S" formula="H4C2S-O" unimod_id="327" />
   <static_modification name="Delta:H(4)C(3) (H)" aminoacid="H" formula="H4C3" unimod_id="256" />
   <static_modification name="Delta:H(4)C(3) (K)" aminoacid="K" formula="H4C3" unimod_id="256" />
   <static_modification name="Delta:H(4)C(3)O(1) (C)" aminoacid="C" formula="H4C3O" unimod_id="206" />
@@ -351,8 +351,8 @@
   <static_modification name="Delta:H(8)C(6)O(1) (L)" aminoacid="L" formula="H8C6O" unimod_id="1313" />
   <static_modification name="Delta:H(8)C(6)O(2) (K)" aminoacid="K" formula="H8C6O2" unimod_id="209" />
   <static_modification name="Delta:Hg(1) (C)" aminoacid="C" formula="Hg" unimod_id="291" />
-  <static_modification name="Delta:S(-1)Se(1) (C)" aminoacid="C" formula="Se - S" unimod_id="162" short_name="SSe" />
-  <static_modification name="Delta:S(-1)Se(1) (M)" aminoacid="M" formula="Se - S" unimod_id="162" short_name="SSe" />
+  <static_modification name="Delta:S(-1)Se(1) (C)" aminoacid="C" formula="Se-S" unimod_id="162" short_name="SSe" />
+  <static_modification name="Delta:S(-1)Se(1) (M)" aminoacid="M" formula="Se-S" unimod_id="162" short_name="SSe" />
   <static_modification name="Delta:Se(1) (C)" aminoacid="C" formula="Se" unimod_id="423" short_name="1Se" />
   <static_modification name="Deoxy (D)" aminoacid="D" formula="-O" unimod_id="447" short_name="dOx" />
   <static_modification name="Deoxy (S)" aminoacid="S" formula="-O" unimod_id="447" short_name="dOx" />
@@ -372,7 +372,7 @@
   <static_modification name="dHex(1)Hex(5)HexNAc(4) (N)" aminoacid="N" formula="H112C68N4O49" unimod_id="308" />
   <static_modification name="DHP (C)" aminoacid="C" formula="H8C8N" unimod_id="488" />
   <static_modification name="Diacylglycerol (C)" aminoacid="C" formula="H68C37O4" unimod_id="377" short_name="DiG" />
-  <static_modification name="Dibromo (Y)" aminoacid="Y" formula="Br2 - H2" unimod_id="534" short_name="2Br" />
+  <static_modification name="Dibromo (Y)" aminoacid="Y" formula="Br2-H2" unimod_id="534" short_name="2Br" />
   <static_modification name="Dicarbamidomethyl (D)" aminoacid="D" formula="H6C4N2O2" unimod_id="1290" short_name="2CM" />
   <static_modification name="dichlorination (C)" aminoacid="C" formula="Cl2" unimod_id="937" short_name="2Cl" />
   <static_modification name="dichlorination (Y)" aminoacid="Y" formula="Cl2" unimod_id="937" short_name="2Cl" />
@@ -392,9 +392,9 @@
   <static_modification name="Diethylphosphate (Y)" aminoacid="Y" formula="H9C4O3P" unimod_id="725" />
   <static_modification name="Difuran (Y)" aminoacid="Y" formula="H4C8O2" unimod_id="1279" />
   <static_modification name="Dihydroxyimidazolidine (R)" aminoacid="R" formula="H4C3O2" unimod_id="830" />
-  <static_modification name="Diiodo (H)" aminoacid="H" formula="I2 - H2" unimod_id="130" short_name="2Io" />
-  <static_modification name="Diiodo (Y)" aminoacid="Y" formula="I2 - H2" unimod_id="130" short_name="2Io" />
-  <static_modification name="Diironsubcluster (C)" aminoacid="C" formula="C5N2O5S2Fe2 - H" unimod_id="439" short_name="dFe" />
+  <static_modification name="Diiodo (H)" aminoacid="H" formula="I2-H2" unimod_id="130" short_name="2Io" />
+  <static_modification name="Diiodo (Y)" aminoacid="Y" formula="I2-H2" unimod_id="130" short_name="2Io" />
+  <static_modification name="Diironsubcluster (C)" aminoacid="C" formula="C5N2O5S2Fe2-H" unimod_id="439" short_name="dFe" />
   <static_modification name="Diisopropylphosphate (K)" aminoacid="K" formula="H13C6O3P" unimod_id="362" />
   <static_modification name="Diisopropylphosphate (N-term)" terminus="N" formula="H13C6O3P" unimod_id="362" />
   <static_modification name="Diisopropylphosphate (S)" aminoacid="S" formula="H13C6O3P" unimod_id="362" />
@@ -461,8 +461,8 @@
   <static_modification name="EQIGG (K)" aminoacid="K" formula="H32C20N6O8" unimod_id="846" />
   <static_modification name="ESP (K)" aminoacid="K" formula="C16H26N4O2S" unimod_id="90" />
   <static_modification name="ESP (N-term)" terminus="N" formula="C16H26N4O2S" unimod_id="90" />
-  <static_modification name="Ethanedithiol (S)" aminoacid="S" formula="H4C2S2 - O" unimod_id="200" />
-  <static_modification name="Ethanedithiol (T)" aminoacid="T" formula="H4C2S2 - O" unimod_id="200" />
+  <static_modification name="Ethanedithiol (S)" aminoacid="S" formula="H4C2S2-O" unimod_id="200" />
+  <static_modification name="Ethanedithiol (T)" aminoacid="T" formula="H4C2S2-O" unimod_id="200" />
   <static_modification name="Ethanolamine (C-term)" terminus="C" formula="H5C2N" unimod_id="734" />
   <static_modification name="Ethanolamine (D)" aminoacid="D" formula="H5C2N" unimod_id="734" />
   <static_modification name="Ethanolamine (E)" aminoacid="E" formula="H5C2N" unimod_id="734" />
@@ -474,10 +474,10 @@
   <static_modification name="Ethyl (E)" aminoacid="E" formula="H4C2" unimod_id="280" />
   <static_modification name="Ethyl (K)" aminoacid="K" formula="H4C2" unimod_id="280" />
   <static_modification name="Ethyl (N-term)" terminus="N" formula="H4C2" unimod_id="280" />
-  <static_modification name="Ethyl+Deamidated (N)" aminoacid="N" formula="H3C2O - N" unimod_id="931" />
-  <static_modification name="Ethyl+Deamidated (Q)" aminoacid="Q" formula="H3C2O - N" unimod_id="931" />
-  <static_modification name="ethylamino (S)" aminoacid="S" formula="H5C2N - O" unimod_id="926" />
-  <static_modification name="ethylamino (T)" aminoacid="T" formula="H5C2N - O" unimod_id="926" />
+  <static_modification name="Ethyl+Deamidated (N)" aminoacid="N" formula="H3C2O-N" unimod_id="931" />
+  <static_modification name="Ethyl+Deamidated (Q)" aminoacid="Q" formula="H3C2O-N" unimod_id="931" />
+  <static_modification name="ethylamino (S)" aminoacid="S" formula="H5C2N-O" unimod_id="926" />
+  <static_modification name="ethylamino (T)" aminoacid="T" formula="H5C2N-O" unimod_id="926" />
   <static_modification name="Ethylphosphate (K)" aminoacid="K" formula="H5C2O3P" unimod_id="726" />
   <static_modification name="Ethylphosphate (N-term)" terminus="N" formula="H5C2O3P" unimod_id="726" />
   <static_modification name="Ethylphosphate (S)" aminoacid="S" formula="H5C2O3P" unimod_id="726" />
@@ -488,9 +488,9 @@
   <static_modification name="FAD (Y)" aminoacid="Y" formula="H31C27N9O15P2" unimod_id="50" short_name="FAD" />
   <static_modification name="Farnesyl (C)" aminoacid="C" formula="H24C15" unimod_id="44" short_name="Far" />
   <static_modification name="Fluorescein (C)" aminoacid="C" formula="H14C22NO6" unimod_id="128" />
-  <static_modification name="Fluoro (F)" aminoacid="F" formula="F - H" unimod_id="127" />
-  <static_modification name="Fluoro (W)" aminoacid="W" formula="F - H" unimod_id="127" />
-  <static_modification name="Fluoro (Y)" aminoacid="Y" formula="F - H" unimod_id="127" />
+  <static_modification name="Fluoro (F)" aminoacid="F" formula="F-H" unimod_id="127" />
+  <static_modification name="Fluoro (W)" aminoacid="W" formula="F-H" unimod_id="127" />
+  <static_modification name="Fluoro (Y)" aminoacid="Y" formula="F-H" unimod_id="127" />
   <static_modification name="FMN (S)" aminoacid="S" formula="H19C17N4O8P" unimod_id="442" short_name="FMN" />
   <static_modification name="FMN (T)" aminoacid="T" formula="H19C17N4O8P" unimod_id="442" short_name="FMN" />
   <static_modification name="FMNC (C)" aminoacid="C" formula="H21C17N4O9P" unimod_id="443" short_name="FNC" />
@@ -646,8 +646,8 @@
   <static_modification name="IMID (K)" aminoacid="K" formula="C3H4N2" unimod_id="94" />
   <static_modification name="Iminobiotin (K)" aminoacid="K" formula="H15C10N3OS" unimod_id="89" />
   <static_modification name="Iminobiotin (N-term)" terminus="N" formula="H15C10N3OS" unimod_id="89" />
-  <static_modification name="Iodo (H)" aminoacid="H" formula="I - H" unimod_id="129" short_name="Iod" />
-  <static_modification name="Iodo (Y)" aminoacid="Y" formula="I - H" unimod_id="129" short_name="Iod" />
+  <static_modification name="Iodo (H)" aminoacid="H" formula="I-H" unimod_id="129" short_name="Iod" />
+  <static_modification name="Iodo (Y)" aminoacid="Y" formula="I-H" unimod_id="129" short_name="Iod" />
   <static_modification name="iodoTMT (C)" aminoacid="C" formula="H28C16N4O3" unimod_id="1341" />
   <static_modification name="iodoTMT (D)" aminoacid="D" formula="H28C16N4O3" unimod_id="1341" />
   <static_modification name="iodoTMT (E)" aminoacid="E" formula="H28C16N4O3" unimod_id="1341" />
@@ -680,41 +680,41 @@
   <static_modification name="iTRAQ8plex:13C(6)15N(2) (K)" aminoacid="K" formula="C'6N'2C8H24N2O3" unimod_id="731" />
   <static_modification name="iTRAQ8plex:13C(6)15N(2) (N-term)" terminus="N" formula="C'6N'2C8H24N2O3" unimod_id="731" />
   <static_modification name="iTRAQ8plex:13C(6)15N(2) (Y)" aminoacid="Y" formula="C'6N'2C8H24N2O3" unimod_id="731" />
-  <static_modification name="Label:13C(1)2H(3)+Oxidation (M)" aminoacid="M" formula="H'3C'O - H3C" unimod_id="885" />
-  <static_modification name="Label:13C(4)+Oxidation (M)" aminoacid="M" formula="C'4O - C4" unimod_id="1267" />
+  <static_modification name="Label:13C(1)2H(3)+Oxidation (M)" aminoacid="M" formula="H'3C'O-H3C" unimod_id="885" />
+  <static_modification name="Label:13C(4)+Oxidation (M)" aminoacid="M" formula="C'4O-C4" unimod_id="1267" />
   <static_modification name="Label:13C(4)15N(2)+GlyGly (K)" aminoacid="K" formula="H6C'4N'2O2" unimod_id="923" />
-  <static_modification name="Label:13C(6)+Acetyl (K)" aminoacid="K" formula="H2C'6O - C4" unimod_id="835" />
-  <static_modification name="Label:13C(6)+Dimethyl (K)" aminoacid="K" formula="H4C'6 - C4" unimod_id="986" />
-  <static_modification name="Label:13C(6)+GlyGly (K)" aminoacid="K" formula="H6C'6N2O2 - C2" unimod_id="799" />
-  <static_modification name="Label:13C(6)15N(2)+Acetyl (K)" aminoacid="K" formula="H2C'6N'2O - C4N2" unimod_id="836" />
-  <static_modification name="Label:13C(6)15N(2)+Dimethyl (K)" aminoacid="K" formula="H4C'6N'2 - C4N2" unimod_id="987" />
-  <static_modification name="Label:13C(6)15N(2)+GlyGly (K)" aminoacid="K" formula="H6C'6N'2O2 - C2" unimod_id="864" />
-  <static_modification name="Label:13C(6)15N(4)+Dimethyl (R)" aminoacid="R" formula="H4C'6N'4 - C4N4" unimod_id="1005" />
-  <static_modification name="Label:13C(6)15N(4)+Dimethyl:2H(6)13C(2) (R)" aminoacid="R" formula="H'6C'8N'4 - H2C6N4" unimod_id="1007" />
-  <static_modification name="Label:13C(6)15N(4)+Methyl (R)" aminoacid="R" formula="H2C'6N'4 - C5N4" unimod_id="1004" />
-  <static_modification name="Label:13C(6)15N(4)+Methyl:2H(3)13C(1) (R)" aminoacid="R" formula="H'3C'7N'4 - HC6N4" unimod_id="1006" />
-  <static_modification name="Label:13C(9)+Phospho (Y)" aminoacid="Y" formula="HC'9O3P - C9" unimod_id="185" />
-  <static_modification name="Label:2H(4)+Acetyl (K)" aminoacid="K" formula="H'4C2O - H2" unimod_id="834" />
+  <static_modification name="Label:13C(6)+Acetyl (K)" aminoacid="K" formula="H2C'6O-C4" unimod_id="835" />
+  <static_modification name="Label:13C(6)+Dimethyl (K)" aminoacid="K" formula="H4C'6-C4" unimod_id="986" />
+  <static_modification name="Label:13C(6)+GlyGly (K)" aminoacid="K" formula="H6C'6N2O2-C2" unimod_id="799" />
+  <static_modification name="Label:13C(6)15N(2)+Acetyl (K)" aminoacid="K" formula="H2C'6N'2O-C4N2" unimod_id="836" />
+  <static_modification name="Label:13C(6)15N(2)+Dimethyl (K)" aminoacid="K" formula="H4C'6N'2-C4N2" unimod_id="987" />
+  <static_modification name="Label:13C(6)15N(2)+GlyGly (K)" aminoacid="K" formula="H6C'6N'2O2-C2" unimod_id="864" />
+  <static_modification name="Label:13C(6)15N(4)+Dimethyl (R)" aminoacid="R" formula="H4C'6N'4-C4N4" unimod_id="1005" />
+  <static_modification name="Label:13C(6)15N(4)+Dimethyl:2H(6)13C(2) (R)" aminoacid="R" formula="H'6C'8N'4-H2C6N4" unimod_id="1007" />
+  <static_modification name="Label:13C(6)15N(4)+Methyl (R)" aminoacid="R" formula="H2C'6N'4-C5N4" unimod_id="1004" />
+  <static_modification name="Label:13C(6)15N(4)+Methyl:2H(3)13C(1) (R)" aminoacid="R" formula="H'3C'7N'4-HC6N4" unimod_id="1006" />
+  <static_modification name="Label:13C(9)+Phospho (Y)" aminoacid="Y" formula="HC'9O3P-C9" unimod_id="185" />
+  <static_modification name="Label:2H(4)+Acetyl (K)" aminoacid="K" formula="H'4C2O-H2" unimod_id="834" />
   <static_modification name="Label:2H(4)+GlyGly (K)" aminoacid="K" formula="H2H'4C4N2O2" unimod_id="853" />
   <static_modification name="lapachenole (C)" aminoacid="C" formula="H16C16O2" unimod_id="771" />
-  <static_modification name="Leu-&gt;MetOx (L)" aminoacid="L" formula="OS - H2C" unimod_id="905" />
+  <static_modification name="Leu-&gt;MetOx (L)" aminoacid="L" formula="OS-H2C" unimod_id="905" />
   <static_modification name="LeuArgGlyGly (K)" aminoacid="K" formula="H29C16N7O4" unimod_id="535" short_name="Umc" />
   <static_modification name="LG-anhydrolactam (K)" aminoacid="K" formula="H26C20O3" unimod_id="946" />
   <static_modification name="LG-anhydrolactam (N-term)" terminus="N" formula="H26C20O3" unimod_id="946" />
   <static_modification name="LG-anhyropyrrole (K)" aminoacid="K" formula="H26C20O2" unimod_id="948" />
   <static_modification name="LG-anhyropyrrole (N-term)" terminus="N" formula="H26C20O2" unimod_id="948" />
   <static_modification name="LG-Hlactam-K (K)" aminoacid="K" formula="H28C20O5" unimod_id="504" />
-  <static_modification name="LG-Hlactam-R (R)" aminoacid="R" formula="H26C19O5 - N2" unimod_id="506" />
+  <static_modification name="LG-Hlactam-R (R)" aminoacid="R" formula="H26C19O5-N2" unimod_id="506" />
   <static_modification name="LG-lactam-K (K)" aminoacid="K" formula="H28C20O4" unimod_id="503" />
-  <static_modification name="LG-lactam-R (R)" aminoacid="R" formula="H26C19O4 - N2" unimod_id="505" />
+  <static_modification name="LG-lactam-R (R)" aminoacid="R" formula="H26C19O4-N2" unimod_id="505" />
   <static_modification name="LG-pyrrole (K)" aminoacid="K" formula="H28C20O3" unimod_id="947" />
   <static_modification name="LG-pyrrole (N-term)" terminus="N" formula="H28C20O3" unimod_id="947" />
   <static_modification name="Lipoyl (K)" aminoacid="K" formula="H12C8OS2" unimod_id="42" short_name="Lip" />
   <static_modification name="Lys (N-term)" terminus="N" formula="H12C6N2O" unimod_id="1301" />
-  <static_modification name="Lys-&gt;Allysine (K)" aminoacid="K" formula="O - H3N" unimod_id="352" short_name="LAA" />
-  <static_modification name="Lys-&gt;AminoadipicAcid (K)" aminoacid="K" formula="O2 - H3N" unimod_id="381" short_name="AAA" />
-  <static_modification name="Lys-&gt;CamCys (K)" aminoacid="K" formula="OS - H4C" unimod_id="903" />
-  <static_modification name="Lys-&gt;MetOx (K)" aminoacid="K" formula="OS - H3CN" unimod_id="906" />
+  <static_modification name="Lys-&gt;Allysine (K)" aminoacid="K" formula="O-H3N" unimod_id="352" short_name="LAA" />
+  <static_modification name="Lys-&gt;AminoadipicAcid (K)" aminoacid="K" formula="O2-H3N" unimod_id="381" short_name="AAA" />
+  <static_modification name="Lys-&gt;CamCys (K)" aminoacid="K" formula="OS-H4C" unimod_id="903" />
+  <static_modification name="Lys-&gt;MetOx (K)" aminoacid="K" formula="OS-H3CN" unimod_id="906" />
   <static_modification name="Lys-loss (Protein C-term K)" aminoacid="K" terminus="C" formula="-H12C6N2O" unimod_id="313" short_name="-1K" />
   <static_modification name="Lysbiotinhydrazide (K)" aminoacid="K" formula="H15C10N3O2S" unimod_id="353" />
   <static_modification name="maleimide (C)" aminoacid="C" formula="H3C4NO2" unimod_id="773" />
@@ -733,8 +733,8 @@
   <static_modification name="Menadione-HQ (K)" aminoacid="K" formula="H8C11O2" unimod_id="767" />
   <static_modification name="MercaptoEthanol (S)" aminoacid="S" formula="H4C2S" unimod_id="928" />
   <static_modification name="MercaptoEthanol (T)" aminoacid="T" formula="H4C2S" unimod_id="928" />
-  <static_modification name="Met-&gt;Aha (M)" aminoacid="M" formula="N3 - H3CS" unimod_id="896" short_name="MAH" />
-  <static_modification name="Met-&gt;Hpg (M)" aminoacid="M" formula="C - H2S" unimod_id="899" />
+  <static_modification name="Met-&gt;Aha (M)" aminoacid="M" formula="N3-H3CS" unimod_id="896" short_name="MAH" />
+  <static_modification name="Met-&gt;Hpg (M)" aminoacid="M" formula="C-H2S" unimod_id="899" />
   <static_modification name="Met-loss (Protein N-term M)" aminoacid="M" terminus="N" formula="-H9C5NOS" unimod_id="765" />
   <static_modification name="Met-loss+Acetyl (Protein N-term M)" aminoacid="M" terminus="N" formula="-H7C3NS" unimod_id="766" />
   <static_modification name="Methyl (C)" aminoacid="C" formula="CH2" unimod_id="34" short_name="1Me" />
@@ -749,12 +749,12 @@
   <static_modification name="Methyl (S)" aminoacid="S" formula="CH2" unimod_id="34" short_name="1Me" />
   <static_modification name="Methyl (T)" aminoacid="T" formula="CH2" unimod_id="34" short_name="1Me" />
   <static_modification name="Methyl+Acetyl:2H(3) (K)" aminoacid="K" formula="HH'3C3O" unimod_id="768" />
-  <static_modification name="Methyl+Deamidated (N)" aminoacid="N" formula="HCO - N" unimod_id="528" short_name="MDe" />
-  <static_modification name="Methyl+Deamidated (Q)" aminoacid="Q" formula="HCO - N" unimod_id="528" short_name="MDe" />
+  <static_modification name="Methyl+Deamidated (N)" aminoacid="N" formula="HCO-N" unimod_id="528" short_name="MDe" />
+  <static_modification name="Methyl+Deamidated (Q)" aminoacid="Q" formula="HCO-N" unimod_id="528" short_name="MDe" />
   <static_modification name="Methyl-PEO12-Maleimide (C)" aminoacid="C" formula="H58C32N2O15" unimod_id="891" />
   <static_modification name="Methyl:2H(2) (K)" aminoacid="K" formula="H'2C" unimod_id="284" />
-  <static_modification name="Methylamine (S)" aminoacid="S" formula="H3CN - O" unimod_id="337" />
-  <static_modification name="Methylamine (T)" aminoacid="T" formula="H3CN - O" unimod_id="337" />
+  <static_modification name="Methylamine (S)" aminoacid="S" formula="H3CN-O" unimod_id="337" />
+  <static_modification name="Methylamine (T)" aminoacid="T" formula="H3CN-O" unimod_id="337" />
   <static_modification name="Methylmalonylation (S)" aminoacid="S" formula="H4C4O3" unimod_id="914" />
   <static_modification name="Methylphosphonate (S)" aminoacid="S" formula="H3CO2P" unimod_id="728" />
   <static_modification name="Methylphosphonate (T)" aminoacid="T" formula="H3CO2P" unimod_id="728" />
@@ -807,9 +807,9 @@
   <static_modification name="NHS-LC-Biotin (K)" aminoacid="K" formula="H25C16N3O3S" unimod_id="92" />
   <static_modification name="NHS-LC-Biotin (N-term)" terminus="N" formula="H25C16N3O3S" unimod_id="92" />
   <static_modification name="NIC (N-term)" terminus="N" formula="H3C6NO" unimod_id="697" />
-  <static_modification name="Nitro (W)" aminoacid="W" formula="NO2 - H" unimod_id="354" short_name="Ntr" />
-  <static_modification name="Nitro (Y)" aminoacid="Y" formula="NO2 - H" unimod_id="354" short_name="Ntr" />
-  <static_modification name="Nitrosyl (C)" aminoacid="C" formula="NO - H" unimod_id="275" />
+  <static_modification name="Nitro (W)" aminoacid="W" formula="NO2-H" unimod_id="354" short_name="Ntr" />
+  <static_modification name="Nitro (Y)" aminoacid="Y" formula="NO2-H" unimod_id="354" short_name="Ntr" />
+  <static_modification name="Nitrosyl (C)" aminoacid="C" formula="NO-H" unimod_id="275" />
   <static_modification name="Nmethylmaleimide (C)" aminoacid="C" formula="H5C5NO2" unimod_id="314" />
   <static_modification name="Nmethylmaleimide (K)" aminoacid="K" formula="H5C5NO2" unimod_id="314" />
   <static_modification name="Nmethylmaleimide+water (C)" aminoacid="C" formula="H7C5NO3" unimod_id="500" />
@@ -859,9 +859,9 @@
   <static_modification name="PEITC (N-term)" terminus="N" formula="H9C9NS" unimod_id="979" />
   <static_modification name="Pentylamine (Q)" aminoacid="Q" formula="H11C5N" unimod_id="801" />
   <static_modification name="PEO-Iodoacetyl-LC-Biotin (C)" aminoacid="C" formula="H30C18N4O5S" unimod_id="20" short_name="PEO" />
-  <static_modification name="PET (S)" aminoacid="S" formula="H7C7NS - O" unimod_id="264" />
-  <static_modification name="PET (T)" aminoacid="T" formula="H7C7NS - O" unimod_id="264" />
-  <static_modification name="Phe-&gt;CamCys (F)" aminoacid="F" formula="NOS - HC4" unimod_id="904" />
+  <static_modification name="PET (S)" aminoacid="S" formula="H7C7NS-O" unimod_id="264" />
+  <static_modification name="PET (T)" aminoacid="T" formula="H7C7NS-O" unimod_id="264" />
+  <static_modification name="Phe-&gt;CamCys (F)" aminoacid="F" formula="NOS-HC4" unimod_id="904" />
   <static_modification name="Phenylisocyanate (N-term)" terminus="N" formula="C7H5NO" unimod_id="411" />
   <static_modification name="Phospho (C)" aminoacid="C" formula="HO3P" unimod_id="21" short_name="Pho" />
   <static_modification name="Phospho (D)" aminoacid="D" formula="HO3P" unimod_id="21" short_name="Pho" />
@@ -894,13 +894,13 @@
   <static_modification name="Phytochromobilin (C)" aminoacid="C" formula="H36C33N4O6" unimod_id="389" short_name="pcm" />
   <static_modification name="Piperidine (K)" aminoacid="K" formula="H8C5" unimod_id="520" />
   <static_modification name="Piperidine (N-term)" terminus="N" formula="H8C5" unimod_id="520" />
-  <static_modification name="Pro-&gt;pyro-Glu (P)" aminoacid="P" formula="O - H2" unimod_id="359" short_name="PGP" />
+  <static_modification name="Pro-&gt;pyro-Glu (P)" aminoacid="P" formula="O-H2" unimod_id="359" short_name="PGP" />
   <static_modification name="Pro-&gt;Pyrrolidinone (P)" aminoacid="P" formula="-H2CO" unimod_id="360" short_name="PYD" />
   <static_modification name="Pro-&gt;Pyrrolidone (P)" aminoacid="P" formula="-CO" unimod_id="369" />
   <static_modification name="probiotinhydrazide (P)" aminoacid="P" formula="H18C10N4O2S" unimod_id="357" />
-  <static_modification name="Propargylamine (C-term)" terminus="C" formula="H3C3N - O" unimod_id="958" />
-  <static_modification name="Propargylamine (D)" aminoacid="D" formula="H3C3N - O" unimod_id="958" />
-  <static_modification name="Propargylamine (E)" aminoacid="E" formula="H3C3N - O" unimod_id="958" />
+  <static_modification name="Propargylamine (C-term)" terminus="C" formula="H3C3N-O" unimod_id="958" />
+  <static_modification name="Propargylamine (D)" aminoacid="D" formula="H3C3N-O" unimod_id="958" />
+  <static_modification name="Propargylamine (E)" aminoacid="E" formula="H3C3N-O" unimod_id="958" />
   <static_modification name="Propionamide (K)" aminoacid="K" formula="C3H5NO" unimod_id="24" short_name="PPa" />
   <static_modification name="Propionamide (N-term)" terminus="N" formula="C3H5NO" unimod_id="24" short_name="PPa" />
   <static_modification name="Propionyl (K)" aminoacid="K" formula="C3H4O" unimod_id="58" short_name="Poy" />
@@ -941,13 +941,13 @@
   <static_modification name="QEQTGG (K)" aminoacid="K" formula="H36C23N8O11" unimod_id="876" />
   <static_modification name="QQQTGG (K)" aminoacid="K" formula="H37C23N9O10" unimod_id="877" short_name="SU2" />
   <static_modification name="QTGG (K)" aminoacid="K" formula="H21C13N5O6" unimod_id="1293" short_name="SU1" />
-  <static_modification name="Quinone (W)" aminoacid="W" formula="O2 - H2" unimod_id="392" short_name="Qin" />
-  <static_modification name="Quinone (Y)" aminoacid="Y" formula="O2 - H2" unimod_id="392" short_name="Qin" />
+  <static_modification name="Quinone (W)" aminoacid="W" formula="O2-H2" unimod_id="392" short_name="Qin" />
+  <static_modification name="Quinone (Y)" aminoacid="Y" formula="O2-H2" unimod_id="392" short_name="Qin" />
   <static_modification name="Retinylidene (K)" aminoacid="K" formula="H26C20" unimod_id="380" short_name="Ret" />
   <static_modification name="Saligenin (H)" aminoacid="H" formula="H6C7O" unimod_id="1254" />
   <static_modification name="Saligenin (K)" aminoacid="K" formula="H6C7O" unimod_id="1254" />
-  <static_modification name="SecCarbamidomethyl (C)" aminoacid="C" formula="H3C2NOSe - S" unimod_id="1008" />
-  <static_modification name="SecNEM (C)" aminoacid="C" formula="C6H7NO2Se - S" unimod_id="1033" />
+  <static_modification name="SecCarbamidomethyl (C)" aminoacid="C" formula="H3C2NOSe-S" unimod_id="1008" />
+  <static_modification name="SecNEM (C)" aminoacid="C" formula="C6H7NO2Se-S" unimod_id="1033" />
   <static_modification name="Ser-&gt;LacticAcid (Protein N-term S)" aminoacid="S" terminus="N" formula="-HN" unimod_id="403" short_name="SLA" />
   <static_modification name="SMA (K)" aminoacid="K" formula="H9C6NO2" unimod_id="29" />
   <static_modification name="SMA (N-term)" terminus="N" formula="H9C6NO2" unimod_id="29" />
@@ -1016,8 +1016,8 @@
   <static_modification name="TMT6plex (T)" aminoacid="T" formula="H20C8C'4NN'O2" unimod_id="737" short_name="TM6" />
   <static_modification name="TNBS (K)" aminoacid="K" formula="HC6N3O6" unimod_id="751" />
   <static_modification name="TNBS (N-term)" terminus="N" formula="HC6N3O6" unimod_id="751" />
-  <static_modification name="trifluoro (L)" aminoacid="L" formula="F3 - H3" unimod_id="750" />
-  <static_modification name="Triiodo (Y)" aminoacid="Y" formula="I3 - H3" unimod_id="131" short_name="3Io" />
+  <static_modification name="trifluoro (L)" aminoacid="L" formula="F3-H3" unimod_id="750" />
+  <static_modification name="Triiodo (Y)" aminoacid="Y" formula="I3-H3" unimod_id="131" short_name="3Io" />
   <static_modification name="Triiodothyronine (Y)" aminoacid="Y" formula="HC6OI3" unimod_id="397" short_name="3IT" />
   <static_modification name="Trimethyl (K)" aminoacid="K" formula="H6C3" unimod_id="37" short_name="3Me">
     <potential_loss formula="H9C3N" massdiff_monoisotopic="59.073499" massdiff_average="59.11071" />
@@ -1028,9 +1028,9 @@
   <static_modification name="Trioxidation (W)" aminoacid="W" formula="O3" unimod_id="345" short_name="3Ox" />
   <static_modification name="Trioxidation (Y)" aminoacid="Y" formula="O3" unimod_id="345" short_name="3Ox" />
   <static_modification name="Tripalmitate (Protein N-term C)" aminoacid="C" terminus="N" formula="H96C51O5" unimod_id="51" short_name="3Pa" />
-  <static_modification name="Trp-&gt;Hydroxykynurenin (W)" aminoacid="W" formula="O2 - C" unimod_id="350" short_name="HKy" />
-  <static_modification name="Trp-&gt;Kynurenin (W)" aminoacid="W" formula="O - C" unimod_id="351" short_name="Kyn" />
-  <static_modification name="Trp-&gt;Oxolactone (W)" aminoacid="W" formula="O - H2" unimod_id="288" />
+  <static_modification name="Trp-&gt;Hydroxykynurenin (W)" aminoacid="W" formula="O2-C" unimod_id="350" short_name="HKy" />
+  <static_modification name="Trp-&gt;Kynurenin (W)" aminoacid="W" formula="O-C" unimod_id="351" short_name="Kyn" />
+  <static_modification name="Trp-&gt;Oxolactone (W)" aminoacid="W" formula="O-H2" unimod_id="288" />
   <static_modification name="Tyr-&gt;Dha (Y)" aminoacid="Y" formula="-H6C6O" unimod_id="400" short_name="YDA" />
   <static_modification name="Ub-amide (C)" aminoacid="C" formula="H14C9N3O2" unimod_id="1260" />
   <static_modification name="Ub-Br2 (C)" aminoacid="C" formula="H8C4N2O" unimod_id="1257" />

--- a/pwiz_tools/Skyline/Test/UniModTest.cs
+++ b/pwiz_tools/Skyline/Test/UniModTest.cs
@@ -52,7 +52,7 @@ namespace pwiz.SkylineTest
             foreach (StaticMod mod in UniMod.DictUniModIds.Values)
             {
                 // UniModCompiler should not set the masses.
-                if (mod.Formula == null)
+                if (mod.ParsedMoleculeMassOffset == null)
                 {
                     Assert.IsNull(mod.MonoisotopicMass);
                     Assert.IsNull(mod.AverageMass);
@@ -60,9 +60,9 @@ namespace pwiz.SkylineTest
                 else
                 {
                     Assert.AreEqual(mod.MonoisotopicMass,
-                                    SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, mod.Formula, SequenceMassCalc.MassPrecision));
+                                    SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, mod.ParsedMoleculeMassOffset, SequenceMassCalc.MassPrecision));
                     Assert.AreEqual(mod.AverageMass,
-                                    SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, mod.Formula, SequenceMassCalc.MassPrecision));
+                                    SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, mod.ParsedMoleculeMassOffset, SequenceMassCalc.MassPrecision));
                 }
                 // Everything amino acid/terminus that is part of the modification should be present in   
                 // the name of the modification.

--- a/pwiz_tools/Skyline/TestData/Results/MeasuredDriftValuesTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/MeasuredDriftValuesTest.cs
@@ -141,7 +141,7 @@ namespace pwiz.SkylineTestData.Results
                 revised.Add(new PrecursorIonMobilities(libKey, IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(expectedDT=4, eIonMobilityUnits.drift_time_msec), null, expectedOffset=0.234)));  // N.B. CCS handling would require actual raw data in this test, it's covered in a perf test
                 var pepSequence = "DEADEELS";
                 var libKey2 = asSmallMolecules ?
-                    new LibKey(SmallMoleculeLibraryAttributes.Create(pepSequence, "C12H5", null, null, null, null), Adduct.M_PLUS_2H) : 
+                    new LibKey(SmallMoleculeLibraryAttributes.Create(pepSequence, "C12H5", null, string.Empty), Adduct.M_PLUS_2H) : 
                     new LibKey(pepSequence, Adduct.DOUBLY_PROTONATED);
                 revised.Add(new PrecursorIonMobilities(libKey2, IonMobilityAndCCS.GetIonMobilityAndCCS(IonMobilityValue.GetIonMobilityValue(5, eIonMobilityUnits.drift_time_msec), null, 0.123)));
                 var libraryName = "test";

--- a/pwiz_tools/Skyline/TestFunctional/AuditLogSavingTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AuditLogSavingTest.cs
@@ -67,18 +67,21 @@ namespace pwiz.SkylineTestFunctional
             // Make sure that there's an entry describing 1) number of nodes and 2) settings changes from default settings
             Assert.AreEqual(1, SkylineWindow.Document.AuditLog.AuditLogEntries.Count);
 
-            if(!RecordNewestEntry())
+            if (!RecordNewestEntry())
                 RunUI(() => { LOG_ENTRY_MESSAGES[0].AssertEquals(SkylineWindow.Document.AuditLog.AuditLogEntries); });
 
             // Modify and save the document so that the audit log gets saved
-            ChangeSettings(settings => settings.ChangePeptideFilter(filter => filter.ChangeExcludeNTermAAs(3))); // Change from 2 to 3
+            ChangeSettings(settings =>
+                settings.ChangePeptideFilter(filter => filter.ChangeExcludeNTermAAs(3))); // Change from 2 to 3
 
             RunUI(() => SkylineWindow.SaveDocument());
 
             RecordNewestEntry();
 
-            Assert.IsTrue(File.Exists(SrmDocument.GetAuditLogPath(SkylineWindow.DocumentFilePath)), "Audit log does not exist after saving document");
-            AssertEx.ValidateAuditLogAgainstSchema(File.ReadAllText(SrmDocument.GetAuditLogPath(SkylineWindow.DocumentFilePath)));
+            Assert.IsTrue(File.Exists(SrmDocument.GetAuditLogPath(SkylineWindow.DocumentFilePath)),
+                "Audit log does not exist after saving document");
+            AssertEx.ValidateAuditLogAgainstSchema(
+                File.ReadAllText(SrmDocument.GetAuditLogPath(SkylineWindow.DocumentFilePath)));
 
             // Also validate an old document
             AssertEx.ValidateAuditLogAgainstSchema(File.ReadAllText(TestFilesDir.GetTestPath("old_rat_plasma.skyl")));
@@ -114,7 +117,9 @@ namespace pwiz.SkylineTestFunctional
             // Wait until document gets switched, otherwise WaitForDocumentLoaded will think that the document is already loaded
             // since we're not waiting for the document to open (OpenDocumentNoWait)
             WaitForCondition(() => !ReferenceEquals(oldRef, SkylineWindow.Document));
-            Assert.AreNotEqual(expectedHash, SkylineWindow.Document.DocumentHash); // If this wasn't the case the dialogs would never show up, but check anyways
+            Assert.AreNotEqual(expectedHash,
+                SkylineWindow.Document
+                    .DocumentHash); // If this wasn't the case the dialogs would never show up, but check anyways
             WaitForDocumentLoaded();
             RunUI(() => SkylineWindow.SaveDocument()); // Save so that hash in audit log matches document now
 
@@ -126,7 +131,10 @@ namespace pwiz.SkylineTestFunctional
 
             // Check that this entry got saved and read correctly, we don't record here
             if (!IsRecordMode)
-                RunUI(() => { LOG_ENTRY_MESSAGES[1].AssertEquals(SkylineWindow.Document.AuditLog.AuditLogEntries.Parent); });
+                RunUI(() =>
+                {
+                    LOG_ENTRY_MESSAGES[1].AssertEquals(SkylineWindow.Document.AuditLog.AuditLogEntries.Parent);
+                });
 
             if (!RecordNewestEntry())
                 RunUI(() => { LOG_ENTRY_MESSAGES[2].AssertEquals(SkylineWindow.Document.AuditLog.AuditLogEntries); });
@@ -134,7 +142,7 @@ namespace pwiz.SkylineTestFunctional
             var fasta = FastaImporter.ToFasta(PROTEINLIST_CLIPBOARD_TEXT, TextUtil.SEPARATOR_TSV);
             RunDlg<EmptyProteinsDlg>(() => SkylineWindow.Paste(fasta), dlg => dlg.KeepEmptyProteins());
 
-            if(!RecordNewestEntry())
+            if (!RecordNewestEntry())
                 RunUI(() => { LOG_ENTRY_MESSAGES[3].AssertEquals(SkylineWindow.Document.AuditLog.AuditLogEntries); });
 
             RunUI(SkylineWindow.ShowAuditLog);
@@ -210,7 +218,6 @@ namespace pwiz.SkylineTestFunctional
         private static void ChangeSettings(Func<SrmSettings, SrmSettings> changeSettings)
         {
             RunUI(() => { SkylineWindow.ChangeSettings(changeSettings(SkylineWindow.DocumentUI.Settings), true); });
-            
         }
 
         private static string GetDocumentHash()
@@ -227,151 +234,197 @@ IPI:IPI00187593.1|SWISS-PROT:P23977|ENSEMBL:ENSRNOP00000024015;ENSRNOP0000004727
 IPI:IPI00187596.1|SWISS-PROT:P23978|ENSEMBL:ENSRNOP00000009705|REFSEQ:NP_077347	MATDNSKVADGQISTEVSEAPVASDKPKTLVVKVQKKAGDLPDRDTWKGRFDFLMSCVGYAIGLGNVWRFPYLCGKNGGGAFLIPYFLTLIFAGVPLFLLECSLGQYTSIGGLGVWKLAPMFKGVGLAAAVLSFWLNIYYIVIISWAIYYLYNSFTTTLPWKQCDNPWNTDRCFSNYSLVNTTNMTSAVVEFWERNMHQMTDGLDKPGQIRWPLAITLAIAWVLVYFCIWKGVGWTGKVVYFSATYPYIMLIILFFRGVTLPGAKEGILFYITPNFRKLSDSEVWLDAATQIFFSYGLGLGSLIALGSYNSFHNNVYRDSIIVCCINSCTSMFAGFVIFSIVGFMAHVTKRSIADVAASGPGLAFLAYPEAVTQLPISPLWAILFFSMLLMLGIDSQFCTVEGFITALVDEYPRLLRNRRELFIAAVCIVSYLIGLSNITQGGIYVFKLFDYYSASGMSLLFLVFFECVSISWFYGVNRFYDNIQEMVGSRPCIWWKLCWSFFTPIIVAGVFLFSAVQMTPLTMGSYVFPKWGQGVGWLMALSSMVLIPGYMAYMFLTLKGSLKQRLQVMIQPSEDIVRPENGPEQPQAGSSASKEAYI";
 
 
-        private static LogEntryMessages[] LOG_ENTRY_MESSAGES = {
+        private static LogEntryMessages[] LOG_ENTRY_MESSAGES =
+        {
             new LogEntryMessages(
-                new LogMessage(LogLevel.undo_redo, MessageType.start_log_existing_doc, SrmDocument.DOCUMENT_TYPE.proteomic, false),
-                new LogMessage(LogLevel.summary, MessageType.start_log_existing_doc, SrmDocument.DOCUMENT_TYPE.proteomic, false),
+                new LogMessage(LogLevel.undo_redo, MessageType.start_log_existing_doc,
+                    SrmDocument.DOCUMENT_TYPE.proteomic, false),
+                new LogMessage(LogLevel.summary, MessageType.start_log_existing_doc,
+                    SrmDocument.DOCUMENT_TYPE.proteomic, false),
                 new[]
                 {
-                    new DetailLogMessage(LogLevel.undo_redo, MessageType.start_log_existing_doc, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.undo_redo, MessageType.start_log_existing_doc,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false),
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:DocumentNodeCounts}{2:PropertySeparator}{0:DocumentNodeCounts_MoleculeGroupCount}",
                         "{3:1}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:DocumentNodeCounts}{2:PropertySeparator}{0:DocumentNodeCounts_MoleculeCount}",
                         "{3:1}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:DocumentNodeCounts}{2:PropertySeparator}{0:DocumentNodeCounts_PrecursorCount}",
                         "{3:1}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:DocumentNodeCounts}{2:PropertySeparator}{0:DocumentNodeCounts_TransitionCount}",
                         "{3:6}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Prediction}{2:PropertySeparator}{0:PeptidePrediction_MeasuredRTWindow}",
                         "{3:2}",
                         "{3:5}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Filter}{2:PropertySeparator}{0:PeptideFilter_ExcludeNTermAAs}",
                         "{3:25}",
                         "{3:2}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Filter}{2:PropertySeparator}{0:PeptideFilter_MinPeptideLength}",
                         "{3:8}",
                         "{3:6}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Filter}{2:PropertySeparator}{0:PeptideFilter_MaxPeptideLength}",
                         "{3:25}",
                         "{3:30}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Filter}{2:PropertySeparator}{0:PeptideFilter_AutoSelect}",
                         "{3:True}",
                         "{3:False}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.removed_from, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.removed_from,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Modifications}{2:PropertySeparator}{0:PeptideModifications_StaticModifications}",
                         "\"Carbamidomethyl (C)\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Modifications}{2:PropertySeparator}{0:PeptideModifications_StaticModifications}",
                         "\"Carbamidomethyl Cysteine\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Modifications}{2:PropertySeparator}{0:PeptideModifications_StaticModifications}{2:PropertySeparator}\"Carbamidomethyl Cysteine\"{2:PropertySeparator}{0:StaticMod_AAs}",
                         "\"C\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Modifications}{2:PropertySeparator}{0:PeptideModifications_StaticModifications}{2:PropertySeparator}\"Carbamidomethyl Cysteine\"{2:PropertySeparator}{0:StaticMod_Formula}",
                         "\"C2H3ON\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Modifications}{2:PropertySeparator}{0:PeptideModifications_StaticModifications}{2:PropertySeparator}\"Carbamidomethyl Cysteine\"{2:PropertySeparator}{0:StaticMod_MonoisotopicMass}",
                         "{3:57.021464}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Modifications}{2:PropertySeparator}{0:PeptideModifications_StaticModifications}{2:PropertySeparator}\"Carbamidomethyl Cysteine\"{2:PropertySeparator}{0:StaticMod_AverageMass}",
                         "{3:57.05162}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Prediction}{2:PropertySeparator}{0:TransitionPrediction_NonNullCollisionEnergy}",
                         "\"{2:None}\"",
                         "\"Thermo\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.contains, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.contains, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Prediction}{2:PropertySeparator}{0:TransitionPrediction_NonNullCollisionEnergy}{2:PropertySeparator}{0:CollisionEnergyRegression_Conversions}",
                         "{ {0:ChargeRegressionLine_Charge} = {3:2}, {0:ChargeRegressionLine_Slope} = {3:0.034}, {0:ChargeRegressionLine_Intercept} = {3:3.314} }"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.contains, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.contains, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Prediction}{2:PropertySeparator}{0:TransitionPrediction_NonNullCollisionEnergy}{2:PropertySeparator}{0:CollisionEnergyRegression_Conversions}",
                         "{ {0:ChargeRegressionLine_Charge} = {3:3}, {0:ChargeRegressionLine_Slope} = {3:0.044}, {0:ChargeRegressionLine_Intercept} = {3:3.314} }"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Filter}{2:PropertySeparator}{0:TransitionFilter_SmallMoleculePrecursorAdductsString}",
                         "\"[M+H]\"",
                         "\"[M-3H], [M-2H], [M-H], [M-], [M+H], [M+], [M+2H], [M+3H]\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Filter}{2:PropertySeparator}{0:TransitionFilter_SmallMoleculeFragmentAdductsString}",
                         "\"[M+]\"",
                         "\"[M-3], [M-2], [M-], [M+], [M+2], [M+3]\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Filter}{2:PropertySeparator}{0:TransitionFilter_StartFragmentFinderLabel}",
                         "\"{6:MzFragmentFinder_m_z__gt__precursor}\"",
                         "\"{6:OrdinalFragmentFinder_ion_3}\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Filter}{2:PropertySeparator}{0:TransitionFilter_EndFragmentFinderLabel}",
                         "\"{6:DeltaFragmentFinder_3_ions}\"",
                         "\"{6:LastFragmentFinder_last_ion__minus__1}\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.removed_all, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.removed_all,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Filter}{2:PropertySeparator}{0:TransitionFilter_MeasuredIons}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Filter}{2:PropertySeparator}{0:TransitionFilter_AutoSelect}",
                         "{3:True}",
                         "{3:False}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Libraries}{2:PropertySeparator}{0:TransitionLibraries_IonCount}",
                         "{3:3}",
                         "{3:4}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Libraries}{2:PropertySeparator}{0:TransitionLibraries_Pick}",
                         "\"{6:TransitionLibraryPick_all}\"",
                         "\"{6:TransitionLibraryPick_none}\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Libraries}{2:PropertySeparator}{0:TransitionLibraries_PickMostIntenseIons}",
                         "{3:True}",
                         "{3:False}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_TransitionSettings}{2:TabSeparator}{0:TransitionSettings_Integration}{2:PropertySeparator}{0:TransitionIntegration_IsIntegrateAll}",
                         "{3:False}",
                         "{3:True}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}",
                         "\"SubjectId\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"SubjectId\"{2:PropertySeparator}{0:AnnotationDef_AnnotationTargets}",
                         "\"replicate\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"SubjectId\"{2:PropertySeparator}{0:AnnotationDef_Type}",
                         "\"{6:AnnotationType_text}\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}",
                         "\"BioReplicate\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"BioReplicate\"{2:PropertySeparator}{0:AnnotationDef_AnnotationTargets}",
                         "\"replicate\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"BioReplicate\"{2:PropertySeparator}{0:AnnotationDef_Type}",
                         "\"{6:AnnotationType_text}\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}",
                         "\"Condition\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"Condition\"{2:PropertySeparator}{0:AnnotationDef_AnnotationTargets}",
                         "\"replicate\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"Condition\"{2:PropertySeparator}{0:AnnotationDef_Type}",
                         "\"{6:AnnotationType_value_list}\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.contains, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.contains, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"Condition\"{2:PropertySeparator}{0:AnnotationDef_Items}",
                         "\"Healthy\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.contains, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.contains, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"Condition\"{2:PropertySeparator}{0:AnnotationDef_Items}",
                         "\"Diseased\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.added_to, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}",
                         "\"MissingData\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"MissingData\"{2:PropertySeparator}{0:AnnotationDef_AnnotationTargets}",
                         "\"peptide\""),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, true,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.is_, SrmDocument.DOCUMENT_TYPE.proteomic,
+                        string.Empty, true,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_DataSettings}{2:TabSeparator}{0:DataSettings_AnnotationDefs}{2:PropertySeparator}\"MissingData\"{2:PropertySeparator}{0:AnnotationDef_Type}",
                         "\"{6:AnnotationType_true_false}\""),
                 }, @"{0:DocumentNodeCounts_MoleculeGroupCount} = {3:1},
@@ -387,31 +440,40 @@ IPI:IPI00187596.1|SWISS-PROT:P23978|ENSEMBL:ENSRNOP00000009705|REFSEQ:NP_077347	
                     "{3:3}"),
                 new[]
                 {
-                    new DetailLogMessage(LogLevel.undo_redo, MessageType.changed_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.undo_redo, MessageType.changed_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Filter}{2:PropertySeparator}{0:PeptideFilter_ExcludeNTermAAs}",
                         "{3:3}"),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.all_info, MessageType.changed_from_to,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "{0:Settings}{2:PropertySeparator}{0:SrmSettings_PeptideSettings}{2:TabSeparator}{0:PeptideSettings_Filter}{2:PropertySeparator}{0:PeptideFilter_ExcludeNTermAAs}",
                         "{3:2}",
                         "{3:3}"),
                 }),
             new LogEntryMessages(
-                new LogMessage(LogLevel.undo_redo, MessageType.modified_outside_of_skyline, SrmDocument.DOCUMENT_TYPE.none, false,
+                new LogMessage(LogLevel.undo_redo, MessageType.modified_outside_of_skyline,
+                    SrmDocument.DOCUMENT_TYPE.none, false,
                     "Changed Exlude N-Terminal AA's from 3 to 4 manually"),
-                new LogMessage(LogLevel.summary, MessageType.modified_outside_of_skyline, SrmDocument.DOCUMENT_TYPE.none, false,
+                new LogMessage(LogLevel.summary, MessageType.modified_outside_of_skyline,
+                    SrmDocument.DOCUMENT_TYPE.none, false,
                     "Changed Exlude N-Terminal AA's from 3 to 4 manually"),
                 new[]
                 {
-                    new DetailLogMessage(LogLevel.undo_redo, MessageType.modified_outside_of_skyline, SrmDocument.DOCUMENT_TYPE.none, string.Empty, false,
+                    new DetailLogMessage(LogLevel.undo_redo, MessageType.modified_outside_of_skyline,
+                        SrmDocument.DOCUMENT_TYPE.none, string.Empty, false,
                         "Changed Exlude N-Terminal AA's from 3 to 4 manually"),
                 }),
             new LogEntryMessages(
-                new LogMessage(LogLevel.undo_redo, MessageType.imported_fasta_paste, SrmDocument.DOCUMENT_TYPE.none, false),
-                new LogMessage(LogLevel.summary, MessageType.imported_fasta_paste, SrmDocument.DOCUMENT_TYPE.none, false),
+                new LogMessage(LogLevel.undo_redo, MessageType.imported_fasta_paste, SrmDocument.DOCUMENT_TYPE.none,
+                    false),
+                new LogMessage(LogLevel.summary, MessageType.imported_fasta_paste, SrmDocument.DOCUMENT_TYPE.none,
+                    false),
                 new[]
                 {
-                    new DetailLogMessage(LogLevel.undo_redo, MessageType.imported_fasta_paste, SrmDocument.DOCUMENT_TYPE.none, string.Empty, false),
-                    new DetailLogMessage(LogLevel.all_info, MessageType.kept_empty_proteins, SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
+                    new DetailLogMessage(LogLevel.undo_redo, MessageType.imported_fasta_paste,
+                        SrmDocument.DOCUMENT_TYPE.none, string.Empty, false),
+                    new DetailLogMessage(LogLevel.all_info, MessageType.kept_empty_proteins,
+                        SrmDocument.DOCUMENT_TYPE.proteomic, string.Empty, false,
                         "3"),
                 }, @">IPI:IPI00187591.3|SWISS-PROT:Q4V8C5-1|ENSEMBL:ENSRNOP00000023455
 MDALEEESFALSFSSASDAEFDAVVGCLEDIIMDAEFQLLQRSFMDKYYQEFEDTEENKLTYTPIFNEYISLVEKYIEEQLLERIPGFNMAAFTTTLQHHKDEVAGDIFDMLLTFTDFLAFKEMFLDYRAEKEGRGLDLSSGLVVTSLCKSSSTPASQNNLRH
@@ -420,8 +482,6 @@ MSKSKCSVGPMSSVVAPAKESNAVGPREVELILVKEQNGVQLTNSTLINPPQTPVEAQERETWSKKIDFLLSVIGFAVDL
 >IPI:IPI00187596.1|SWISS-PROT:P23978|ENSEMBL:ENSRNOP00000009705|REFSEQ:NP_077347
 MATDNSKVADGQISTEVSEAPVASDKPKTLVVKVQKKAGDLPDRDTWKGRFDFLMSCVGYAIGLGNVWRFPYLCGKNGGGAFLIPYFLTLIFAGVPLFLLECSLGQYTSIGGLGVWKLAPMFKGVGLAAAVLSFWLNIYYIVIISWAIYYLYNSFTTTLPWKQCDNPWNTDRCFSNYSLVNTTNMTSAVVEFWERNMHQMTDGLDKPGQIRWPLAITLAIAWVLVYFCIWKGVGWTGKVVYFSATYPYIMLIILFFRGVTLPGAKEGILFYITPNFRKLSDSEVWLDAATQIFFSYGLGLGSLIALGSYNSFHNNVYRDSIIVCCINSCTSMFAGFVIFSIVGFMAHVTKRSIADVAASGPGLAFLAYPEAVTQLPISPLWAILFFSMLLMLGIDSQFCTVEGFITALVDEYPRLLRNRRELFIAAVCIVSYLIGLSNITQGGIYVFKLFDYYSASGMSLLFLVFFECVSISWFYGVNRFYDNIQEMVGSRPCIWWKLCWSFFTPIIVAGVFLFSAVQMTPLTMGSYVFPKWGQGVGWLMALSSMVLIPGYMAYMFLTLKGSLKQRLQVMIQPSEDIVRPENGPEQPQAGSSASKEAYI
 "),
-
-
         };
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/AuditLogTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AuditLogTest.cs
@@ -23,6 +23,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.DataBinding;
 using pwiz.Common.SystemUtil;

--- a/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
@@ -424,7 +424,7 @@ namespace pwiz.SkylineTestFunctional
             var editMoleculeDlg =
                 ShowDialog<EditCustomMoleculeDlg>(
                     () => SkylineWindow.ModifyTransition((TransitionTreeNode) SkylineWindow.SequenceTree.SelectedNode));
-            var monoMass = new TypedMass(805, MassType.Monoisotopic);
+            var monoMass = TypedMass.Create(805, MassType.Monoisotopic);
             RunUI(() =>
             {
                 // Check neutral mass calculation
@@ -533,7 +533,7 @@ namespace pwiz.SkylineTestFunctional
             var editMoleculeDlg =
                 ShowDialog<EditCustomMoleculeDlg>(
                     () => SkylineWindow.ModifyTransition((TransitionTreeNode)SkylineWindow.SequenceTree.SelectedNode));
-            var monoMass = new TypedMass(805, MassType.Monoisotopic);
+            var monoMass = TypedMass.Create(805, MassType.Monoisotopic);
             RunUI(() =>
             {
                 Assert.AreEqual(BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(C12H12),
@@ -788,7 +788,7 @@ namespace pwiz.SkylineTestFunctional
             });
             OkDialog(editMoleculeDlg, editMoleculeDlg.OkDialog);
             var newDoc = WaitForDocumentChange(doc);
-            var compareIon = new CustomMolecule(new TypedMass(monoMass, MassType.Monoisotopic), new TypedMass(averageMass, MassType.Average), formula);
+            var compareIon = new CustomMolecule(TypedMass.Create(monoMass, MassType.Monoisotopic), TypedMass.Create(averageMass, MassType.Average), formula);
             Assert.AreEqual(compareIon, newDoc.Molecules.ElementAt(0).CustomMolecule);
             Assert.AreEqual(compareIon, newDoc.MoleculeTransitionGroups.ElementAt(0).CustomMolecule);
             Assert.AreEqual(adduct.AdductCharge, newDoc.MoleculeTransitionGroups.ElementAt(0).PrecursorCharge);

--- a/pwiz_tools/Skyline/TestFunctional/ExportSmallMolSpectralLibraryTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExportSmallMolSpectralLibraryTest.cs
@@ -157,12 +157,12 @@ namespace pwiz.SkylineTestFunctional
             {
                 AssertEx.IsTrue(docAfter.MoleculeTransitions.Contains(m =>
                     m.Transition.Group.Peptide.CustomMolecule.Name.Equals("PE(18:0_18:1)") &&
-                    string.IsNullOrEmpty(m.Transition.Group.Peptide.CustomMolecule.Formula) &&
+                    m.Transition.Group.Peptide.CustomMolecule.MoleculeAndMassOffset.IsMassOnly &&
                     Equals(m.Transition.FragmentIonName, fragmentName)));
             }
             AssertEx.IsTrue(docAfter.MoleculeTransitions.Contains(m =>
                 m.Transition.Group.Peptide.CustomMolecule.Name.Equals("PE(12:0_14:0)") &&
-                Equals(m.Transition.Group.Peptide.CustomMolecule.Formula, "C31H62NO8P")));
+                Equals(m.Transition.Group.Peptide.CustomMolecule.MoleculeAndMassOffset.ToString(), "C31H62NO8P")));
         }
 
         private void CheckRefSpectra(IList<DbRefSpectra> spectra, string name, string formula, string precursorAdduct, 

--- a/pwiz_tools/Skyline/TestFunctional/InvalidPeptidesInLibraryTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/InvalidPeptidesInLibraryTest.cs
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -81,11 +80,14 @@ namespace pwiz.SkylineTestFunctional
             });
 
             var messageDlg = ShowDialog<AlertDlg>(peptideSettingsUI.OkDialog);
-            var expectedMessage = string.Format(Resources.CachedLibrary_WarnInvalidEntries_, libName, expectedInvalidCount,
-                expectedTotalCount, string.Empty);
-            // TODO: This assertion currently only works in English
-            if (Thread.CurrentThread.CurrentCulture.Equals(new CultureInfo("en")))
+
+            // N.B. This assertion does not work in Japanese because it places text after the list of invalid peptides so StartsWith fails.
+            if (!Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName.Equals(@"ja"))
+            {
+                var expectedMessage = string.Format(Resources.CachedLibrary_WarnInvalidEntries_, libName, expectedInvalidCount,
+                    expectedTotalCount, string.Empty);
                 StringAssert.StartsWith(messageDlg.Message, expectedMessage);
+            }
             OkDialog(messageDlg, messageDlg.OkDialog);
             WaitForClosedForm(peptideSettingsUI);
         }

--- a/pwiz_tools/Skyline/TestFunctional/NeutralLossTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NeutralLossTest.cs
@@ -20,12 +20,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Controls;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.SettingsUI;
-using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
 using pwiz.SkylineTestUtil;
 

--- a/pwiz_tools/Skyline/TestFunctional/OptimizeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/OptimizeTest.cs
@@ -22,6 +22,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Common.SystemUtil;
 using pwiz.ProteowizardWrapper;
 using pwiz.Skyline.Alerts;

--- a/pwiz_tools/Skyline/TestFunctional/SmallMoleculesDocumentGridTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SmallMoleculesDocumentGridTest.cs
@@ -54,7 +54,7 @@ namespace pwiz.SkylineTestFunctional
             EnsureMixedTransitionListReport();
             CheckDocumentGridAndColumns(mixedSky,
                 MIXED_TRANSITION_LIST_REPORT_NAME,
-                49, 32, SrmDocument.DOCUMENT_TYPE.mixed, "C19H34[M-H]", "custom", "C12H19", "C12H19", "C12H18");
+                49, 32, SrmDocument.DOCUMENT_TYPE.mixed, "C19H34[M-H]", "custom", "C12H19", "C12H19[+1.006727]", "C12H18[+1.006727]");
 
             CheckDocumentGridAndColumns(mixedSky,
                 Resources.SkylineViewContext_GetDocumentGridRowSources_Precursors,

--- a/pwiz_tools/Skyline/TestPerf/DriftTimePredictorTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DriftTimePredictorTutorialTest.cs
@@ -52,7 +52,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't take about 10
 
         private const string EXT_ZIP = ".zip";
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void TestDriftTimePredictorTutorial()
         {
 //            IsPauseForScreenShots = true;

--- a/pwiz_tools/Skyline/TestPerf/HiResMetabolomicsTutorial.cs
+++ b/pwiz_tools/Skyline/TestPerf/HiResMetabolomicsTutorial.cs
@@ -40,6 +40,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using pwiz.Common.Chemistry;
 
 namespace TestPerf // This would be in TestTutorials if it didn't involve a 2GB download
 {

--- a/pwiz_tools/Skyline/TestPerf/OrbiPrmTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/OrbiPrmTutorialTest.cs
@@ -69,7 +69,7 @@ namespace TestPerf
         private static string SAMPLES_DIR = Path.Combine(DATA_DIR, "Samples");
         private static string STANDARDS_DIR = Path.Combine(DATA_DIR, "Standards");
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void TestOrbiPrmTutorial()
         {
 //            IsPauseForScreenShots = true;

--- a/pwiz_tools/Skyline/TestPerf/PerfAssociateProteinsTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfAssociateProteinsTest.cs
@@ -21,6 +21,7 @@ using System.Drawing;
 using System.Globalization;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Alerts;
 using pwiz.Skyline.FileUI;
 using pwiz.Skyline.Model.DocSettings;
@@ -28,7 +29,6 @@ using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Proteome;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.SettingsUI;
-using pwiz.Skyline.Util;
 using pwiz.SkylineTestUtil;
 
 namespace TestPerf

--- a/pwiz_tools/Skyline/TestPerf/PerfElectronIonizationAllIonsTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfElectronIonizationAllIonsTest.cs
@@ -34,7 +34,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
     public class ElectronIonizationAllIonsTest : AbstractFunctionalTestEx
     {
 
-        [TestMethod] 
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)] 
         public void ElectronIonizationAllIonsPerfTest()
         {
             TestFilesZip = GetPerfTestDataURL(@"PerfElectronIonizationAllIonsTest.zip");

--- a/pwiz_tools/Skyline/TestPerf/PerfImportResultsNativeVsMz5Test.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportResultsNativeVsMz5Test.cs
@@ -138,7 +138,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                 true); // Also run the raw data as centroided data
         }
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void zzzNativeVsMz5_BrukerFullScanMS1filteringPerformanceTest()
         {
             NativeVsMz5ChromatogramPerformanceTest(

--- a/pwiz_tools/Skyline/TestPerf/PerfThermoNegativeFAIMSTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfThermoNegativeFAIMSTest.cs
@@ -47,7 +47,7 @@ namespace TestPerf // Tests in this namespace are skipped unless the RunPerfTest
     [TestClass]
     public class PerfThermoNegativeFAIMSTest : AbstractFunctionalTestEx
     {
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void TestThermoNegativeFAIMS()
         {
             TestFilesZip = GetPerfTestDataURL(@"PerfThermoNegativeFAIMS.zip");

--- a/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
@@ -77,7 +77,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             }
         }
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void UniquePeptides0PerfTest()
         {
             // Scenarios to test:
@@ -85,35 +85,35 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             scenario(PeptideFilter.PeptideUniquenessConstraint.none, "human_and_yeast.protdb");
         }
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void UniquePeptides1PerfTest()
         {
             // 1)  No current background proteome
             scenario(PeptideFilter.PeptideUniquenessConstraint.gene, null, "human_and_yeast_no_metadata.protdb", true);
         }
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void UniquePeptides2PerfTest()
         {
             // 2)  Current background proteome same as in new settings, needs digest and protein metadata search
             scenario(PeptideFilter.PeptideUniquenessConstraint.protein, "human_and_yeast_no_digest.protdb");
         }
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void UniquePeptides3PerfTest()
         {
             // 3)  Current background proteome same as in new settings, needs protein metadata search
             scenario(PeptideFilter.PeptideUniquenessConstraint.gene, "human_and_yeast_no_metadata_too.protdb");
         }
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void UniquePeptides4PerfTest()
         {
             // 4)  Current background proteome not same as in new settings
             scenario(PeptideFilter.PeptideUniquenessConstraint.species, "human_and_yeast.protdb", "human_and_yeast_no_metadata.protdb");
         }
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
         public void UniquePeptides5PerfTest()
         {
             // Just verify that we've fixed a problem with opening files with uniqueness mode already turned on

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -770,7 +770,7 @@ namespace TestRunner
             int testsFailed = 0;
             int testsResultsReturned = 0;
             int workerCount = (int) commandLineArgs.ArgAsLong("workercount");
-            int workerTimeout = Convert.ToInt32(commandLineArgs.ArgAsStringOrDefault("workertimeout", "30"));
+            int workerTimeout = Convert.ToInt32(commandLineArgs.ArgAsStringOrDefault("workertimeout", "60"));
             int loop = (int) commandLineArgs.ArgAsLong("loop");
             var languages = commandLineArgs.ArgAsString("language").Split(',');
 

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -578,7 +578,10 @@ namespace TestRunnerLib
             var msAmandaTmpDir = Path.Combine(Path.GetTempPath(), @"~SK_MSAmanda" /* must match MSAmandaSearchWrapper.MS_AMANDA_TMP */);
             try
             {
-                Directory.Delete(msAmandaTmpDir, true);
+                if (Directory.Exists(msAmandaTmpDir))
+                {
+                    Directory.Delete(msAmandaTmpDir, true);
+                }
             }
             catch
             {
@@ -1118,7 +1121,7 @@ namespace TestRunnerLib
 
             p?.WaitForExit();
             if (p == null || p.ExitCode != 0)
-                throw new InvalidOperationException($"{message}\r\n\r\nDetails:\r\n'{command} {args}' returned an error ({output.ToString().Trim()});");
+                throw new InvalidOperationException($"{message}\r\n\r\nDetails:\r\n'\"{command}\" {args}' returned an error ({output.ToString().Trim()});");
              
             return output.ToString();
         }

--- a/pwiz_tools/Skyline/TestTutorial/AbsoluteQuantTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AbsoluteQuantTutorialTest.cs
@@ -22,6 +22,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Common.DataBinding;
 using pwiz.Skyline.Controls;
 using pwiz.Skyline.Controls.Databinding;

--- a/pwiz_tools/Skyline/TestTutorial/SRMTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/SRMTutorialTest.cs
@@ -23,6 +23,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Alerts;
 using pwiz.Skyline.Controls.Graphs;
 using pwiz.Skyline.EditUI;
@@ -33,7 +34,6 @@ using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.SettingsUI;
-using pwiz.Skyline.Util;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTestTutorial

--- a/pwiz_tools/Skyline/TestTutorial/SmallMoleculesQuantificationTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/SmallMoleculesQuantificationTutorial.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.Chemistry;
 using pwiz.Common.DataBinding;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline;

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -24,7 +24,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using pwiz.Common.Chemistry;
-using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Properties;
@@ -75,11 +74,9 @@ namespace pwiz.Skyline.Util
 
     public class Adduct : Immutable, IComparable, IEquatable<Adduct>, IAuditLogObject
     {
-        // CONSIDER(bspratt): Nick suggests we change this ImmutableDictionary to Molecule once that is performant, and supports negative counts
-        private ImmutableDictionary<string, int> Composition { get; set; } // The chemical makeup of the adduct
+        private Molecule Composition { get; set; } // The chemical makeup of the adduct - the "2H" part in 4M3Cl37+2H
         private string Description { get; set; } // The text description (will be empty for protonation, we just use charge)
-        private ImmutableDictionary<string, KeyValuePair<string, int>> IsotopeLabels { get; set; } // Key is unlabeled atom, value is <LabeledAtom, count>
-        private double? IsotopeLabelMass { get; set; } // Sometimes we are only given an incremental mass for label purposes (if we have isotope formula this is null)
+        private MoleculeMassOffset IsotopeLabels { get; set; } // Isotope information - the "3Cl37" in  4M3Cl37+2H or "1.23" in 2M(1.23)+Na
         private TypedMass AverageMassAdduct { get; set; } // Average mass of the adduct itself - the "2H" in 4M3Cl37+2H
         private TypedMass MonoMassAdduct { get; set; } // Monoisotopic mass of the adduct itself - the "2H" in 4M3Cl37+2H
         private int MassMultiplier { get; set; } // Returns, for example, the 2 in "[2M+Na]", which means the ion is two molecules + the adduct mass. 
@@ -290,11 +287,39 @@ namespace pwiz.Skyline.Util
             return result;
         }
 
+        /// <summary>
+        /// Examine a string to see if it contains an adduct description at the end
+        /// </summary>
+        /// <param name="formulaWithAdduct">possibly a string ending with an adduct description</param>
+        /// <param name="result">resulting adduct object, if any</param>
+        /// <returns>input string trimmed of adduct string</returns>
+        public static string FindInFormula(string formulaWithAdduct, out Adduct result)
+        {
+            if (!string.IsNullOrEmpty(formulaWithAdduct))
+            {
+                var possibleAdductStart = formulaWithAdduct.LastIndexOf('[');
+                if (possibleAdductStart >= 0) // Has '['
+                {
+                    var possible = formulaWithAdduct.Substring(possibleAdductStart);
+                    if (possible.Count(c => c == ']') == 1 && // Has closing ']'
+                        possible[1] != '+' && possible[1] != '-') // Isn't a mass modification
+                    {
+                        if (Adduct.TryParse(possible, out result))
+                        {
+                            return formulaWithAdduct.Substring(0,possibleAdductStart).Trim();
+                        }
+                    }
+                }
+            }
+            result = EMPTY;
+            return formulaWithAdduct; // Not found
+        }
+
         private void ParseDescription(string input)
         {
             int? declaredCharge = null;
             int? calculatedCharge = null;
-            IsotopeLabels = null;
+            IsotopeLabels = MoleculeMassOffset.EMPTY;
             var match = ADDUCT_OUTER_REGEX.Match(input.Trim());
             var success = match.Success && (match.Groups.Count == 6);
 
@@ -336,11 +361,13 @@ namespace pwiz.Skyline.Util
                 var hasIsotopeLabels = !string.IsNullOrEmpty(label);
                 if (hasIsotopeLabels)
                 {
-                    double labelMass;
-                    if (double.TryParse(label, NumberStyles.Float, CultureInfo.InvariantCulture, out labelMass))
+                    var isotopeLabels = new Dictionary<string, int>();
+                    double labelMass = 0;
+
+                    if (double.TryParse(label, NumberStyles.Float, CultureInfo.InvariantCulture, out var tryLabelMass))
                     {
                         // Sometimes all we're given is a mass offset eg M1.002+2H
-                        IsotopeLabelMass = labelMass;
+                        labelMass = tryLabelMass;
                     }
                     else
                     {
@@ -358,7 +385,6 @@ namespace pwiz.Skyline.Util
                         label = DICT_ADDUCT_ISOTOPE_NICKNAMES.Aggregate(label, (current, nickname) => current.Replace(nickname.Key, nickname.Value)); // eg Cl37 -> Cl'
                         // Problem: normal chemical formula for "6C132N15H" -> "6C'2NH'" would be "C'6N'15H"
                         var ionMatches = ADDUCT_ION_REGEX.Matches(label);
-                        var isotopeLabels = new Dictionary<string, KeyValuePair<string, int>>();
                         foreach (Match m in ionMatches)
                         {
                             if (m.Groups.Count < 1)
@@ -374,12 +400,11 @@ namespace pwiz.Skyline.Util
                             }
 
                             var isotope = m.Groups[@"ion"].Value;
-                            var unlabel = BioMassCalc.DICT_HEAVYSYMBOL_TO_MONOSYMBOL.Aggregate(isotope, (current, kvp) => current.Replace(kvp.Key, kvp.Value));
-
-                            isotopeLabels.Add(unlabel, new KeyValuePair<string, int>(isotope, multiplierM));
+ 
+                            isotopeLabels.Add(isotope, multiplierM);
                         }
-                        IsotopeLabels = new ImmutableDictionary<string, KeyValuePair<string, int>>(isotopeLabels);
                     }
+                    IsotopeLabels = MoleculeMassOffset.Create(Molecule.FromDict(isotopeLabels), labelMass, labelMass);
                 }
 
                 var declaredChargeCountStr = match.Groups[@"declaredChargeCount"].Value;
@@ -458,35 +483,52 @@ namespace pwiz.Skyline.Util
                         {
                             ion = realname;
                         }
-                        var ionMolecule = Molecule.Parse(ion);
-                        if (ionMolecule.Count == 0)
+
+                        try
                         {
-                            success = multiplierM == 1 && remaining != 0; // Allow pointless + in "M+-H2O+H" but not trailing +in "M-H2O+H+"
+                            var ionMolecule = ParsedMoleculeMassOffset.Create(ion);
+                            if (ionMolecule.IsEmpty)
+                            {
+                                success = multiplierM == 1 && remaining != 0; // Allow pointless + in "M+-H2O+H" but not trailing +in "M-H2O+H+"
+                            }
+                            foreach (var pair in ionMolecule)
+                            {
+                                int count;
+                                if (composition.TryGetValue(pair.Key, out count))
+                                {
+                                    count += pair.Value * multiplierM;
+                                    if (count == 0)
+                                    {
+                                        composition.Remove(pair.Key);
+                                    }
+                                    else
+                                    {
+                                        composition[pair.Key] = count;
+                                    }
+                                }
+                                else if (pair.Value != 0)
+                                {
+                                    composition.Add(pair.Key, pair.Value * multiplierM);
+                                }
+                            }
                         }
-                        foreach (var pair in ionMolecule)
+                        catch (ArgumentException)
                         {
-                            int count;
-                            if (composition.TryGetValue(pair.Key, out count))
-                            {
-                                composition[pair.Key] = count + pair.Value * multiplierM;
-                            }
-                            else
-                            {
-                                composition.Add(pair.Key, pair.Value * multiplierM);
-                            }
+                            throw new InvalidOperationException(
+                                string.Format(Resources.BioMassCalc_ApplyAdductToFormula_Unknown_symbol___0___in_adduct_description___1__,
+                                    ion, input));
                         }
                     }
                 }
             }
             AdductCharge = calculatedCharge ?? declaredCharge ?? 0;
-            Composition = new ImmutableDictionary<string, int>(composition);
-            var resultMol = Molecule.FromDict(composition);
-            if (!resultMol.Keys.All(k => BioMassCalc.MONOISOTOPIC.IsKnownSymbol(k)))
+            if (!composition.Keys.All(k => BioMassCalc.MONOISOTOPIC.IsKnownSymbol(k)))
             {
                 throw new InvalidOperationException(
                     string.Format(Resources.BioMassCalc_ApplyAdductToFormula_Unknown_symbol___0___in_adduct_description___1__,
-                        resultMol.Keys.First(k => !BioMassCalc.MONOISOTOPIC.IsKnownSymbol(k)), input));
+                        composition.Keys.First(k => !BioMassCalc.MONOISOTOPIC.IsKnownSymbol(k)), input));
             }
+            Composition = Molecule.FromDict(composition);
             if (!success)
             {
                 // Allow charge free neutral like [M] or nmer like [3M]
@@ -560,7 +602,7 @@ namespace pwiz.Skyline.Util
         {
             return adduct == null || adduct.IsEmpty;
         }
-        public bool HasIsotopeLabels { get { return (IsotopeLabelMass ?? 0) != 0 || (IsotopeLabels != null && IsotopeLabels.Count > 0); } } // Does the adduct description include isotopes, like "6Cl37" in "M6Cl37+2H"
+        public bool HasIsotopeLabels => IsotopeLabels.HasMassModifications || IsotopeLabels.HasChemicalFormula; // Does the adduct description include isotopes, like "6Cl37" in "M6Cl37+2H"
 
 
         // Helper function for UI - does this string look like it's on its way to being an adduct?
@@ -618,11 +660,11 @@ namespace pwiz.Skyline.Util
                 return knownAdduct;
             }
 
-            int z;
-            if (int.TryParse(value, out z))
+            if (int.TryParse(value, out var z))
             {
                 var result = FromCharge(z, parserMode);
                 dict[value] = result; // Cache this on the likely chance that we'll see this representation again
+                return result;
             }
 
             // Reuse the more common non-proteomic adducts
@@ -722,9 +764,14 @@ namespace pwiz.Skyline.Util
         public static Adduct FromFormulaDiff(string left, string right, int charge)
         {
             // Take adduct as the difference between two chemical formulas
-            var l = Molecule.Parse(left.Trim());
-            var r = Molecule.Parse(right.Trim());
-            var adductFormula = l.Difference(r).ToString();
+            var l = ParsedMoleculeMassOffset.Create(left.Trim());
+            var r = ParsedMoleculeMassOffset.Create(right.Trim());
+            return FromFormulaDiff(l, r, charge);
+        }
+
+        public static Adduct FromFormulaDiff(MoleculeMassOffset left, MoleculeMassOffset right, int charge)
+        {
+            var adductFormula = left.Difference(right).ToString();
             if (string.IsNullOrEmpty(adductFormula))
             {
                 return FromChargeNoMass(charge);
@@ -738,9 +785,15 @@ namespace pwiz.Skyline.Util
         public static Adduct ProtonatedFromFormulaDiff(string left, string right, int charge)
         {
             // Take adduct as the difference between two chemical formulas, assuming that H is for protonation
-            var l = Molecule.Parse(left.Trim());
-            var r = Molecule.Parse(right.Trim());
-            var d = l.Difference(r);
+            var l = ParsedMoleculeMassOffset.Create(left.Trim());
+            var r =ParsedMoleculeMassOffset.Create(right.Trim());
+            return ProtonatedFromFormulaDiff(l, r, charge);
+        }
+
+        public static Adduct ProtonatedFromFormulaDiff(MoleculeMassOffset left, MoleculeMassOffset right, int charge)
+        {
+            // Take adduct as the difference between two chemical formulas, assuming that H is for protonation
+            var d = left.Difference(right).Molecule;
             if (d.Values.Any(count => count < 0) || d.Values.All(count => count == 0))
             {
                 return NonProteomicProtonatedFromCharge(charge); // No difference in formulas, try straight protonation
@@ -771,14 +824,15 @@ namespace pwiz.Skyline.Util
         /// <summary>
         /// Splits a string which might be a formula and adduct (e.g. C12H5[M+H] returns "C12H5" and sets adduct to Adduct.M_PLUS_H)
         /// </summary>
-        public static string SplitFormulaAndTrailingAdduct(string formulaAndAdductText, ADDUCT_TYPE adductType, out Adduct adduct)
+        public static string SplitFormulaAndTrailingAdduct(string input, ADDUCT_TYPE adductType, out Adduct adduct)
         {
+            var formulaAndAdductText = (input??string.Empty).Trim();
             if (string.IsNullOrEmpty(formulaAndAdductText))
             {
                 adduct = EMPTY;
                 return string.Empty;
             }
-            var parts = formulaAndAdductText.Split('[');
+            var parts = Regex.Split(formulaAndAdductText, @"\[(?![+-])");  // Split on [ but not on [+ or [-
             if (!Adduct.TryParse(formulaAndAdductText.Substring(parts[0].Length), out adduct, adductType))
             {
                 adduct = EMPTY;
@@ -1057,9 +1111,7 @@ namespace pwiz.Skyline.Util
         /// Some internals made public for test purposes
         /// </summary>
         public int GetMassMultiplier() { return MassMultiplier; }
-        public ImmutableDictionary<string, int> GetComposition() { return Composition; }
-        public TypedMass GetIsotopesIncrementalAverageMass() { return IsotopesIncrementalAverageMass; }
-        public TypedMass GetIsotopesIncrementalMonoisotopicMass() { return IsotopesIncrementalMonoMass; }
+        public Molecule GetComposition() { return Composition; }
 
         // Common terms for small molecule adducts per http://fiehnlab.ucdavis.edu/staff/kind/Metabolomics/MS-Adduct-Calculator/ESI-MS-adducts.xls
         // See also (An interesting list of pseudoelements is at http://winter.group.shef.ac.uk/chemputer/pseudo-elements.html for a longer list we may wish to implement later
@@ -1290,158 +1342,166 @@ namespace pwiz.Skyline.Util
             return charges;
         }
 
-        public Dictionary<string, int> ApplyToMolecule(IDictionary<string, int> molecule)
+        public MoleculeMassOffset ApplyToMolecule(Molecule molecule)
         {
-            var resultDict = new Dictionary<string, int>();
-            ApplyToMolecule(molecule, resultDict);
-            return resultDict;
+            return ApplyToMolecule(MoleculeMassOffset.Create(molecule, 0, 0));
         }
 
         /// <summary>
         /// Handle the "2" and "4Cl37" in "[2M4Cl37+H]", and add the H
         /// </summary>
-        public void ApplyToMolecule(IDictionary<string, int> molecule, IDictionary<string, int> resultDict)
+        public MoleculeMassOffset ApplyToMolecule(MoleculeMassOffset molecule)
         {
-            if (IsotopeLabels != null && IsotopeLabels.Count != 0 && molecule.Keys.Any(BioMassCalc.ContainsIsotopicElement))
+            if (HasIsotopeLabels && (molecule.IsHeavy || BioMassCalc.ContainsIsotopicElement(molecule.Molecule)))
             {
-                // Don't apply labels twice
-                Unlabeled.ApplyToMolecule(molecule, resultDict);
-                return;
+                // Molecule is already labeled, use the unlabeled version of this adduct 
+                return Unlabeled.ApplyToMolecule(molecule);
             }
-            // Deal with any mass multipler (the 2 in "[2M+Na]")
-            foreach (var pair in molecule)
+
+            var resultDict = new Dictionary<string, int>(molecule.Molecule);
+
+            // Deal with any mass multiplier (the 2 in "[2M+Na]")
+            if (MassMultiplier != 1)
             {
-                resultDict.Add(pair.Key, MassMultiplier * pair.Value);
+                foreach (var element in resultDict.Keys.ToArray())
+                {
+                    resultDict[element] *= MassMultiplier;
+                }
             }
 
             // Add in the "Na" of [M+Na] (or remove the 4H in [M-4H])
             foreach (var pair in Composition)
             {
-                int count;
-                if (resultDict.TryGetValue(pair.Key, out count))
+                if (resultDict.TryGetValue(pair.Key, out var count))
                 {
-                    resultDict[pair.Key] = count + pair.Value;
+                    count += pair.Value;
+                    if (count == 0)
+                    {
+                        resultDict.Remove(pair.Key);
+                    }
+                    else
+                    {
+                        resultDict[pair.Key] = count;
+                    }
                 }
-                else
+                else if (pair.Value != 0)
                 {
-                    resultDict.Add(pair);
+                    resultDict.Add(pair.Key, pair.Value);
+                    count = pair.Value;
                 }
-                if (resultDict[pair.Key] < 0 && !Equals(pair.Key, BioMassCalc.H)) // Treat H loss as a general proton loss
+                if (count < 0 && !Equals(pair.Key, BioMassCalc.H)) // Treat H loss as a general proton loss
                 {
                     throw new InvalidOperationException(
                         string.Format(Resources.Adduct_ApplyToMolecule_Adduct___0___calls_for_removing_more__1__atoms_than_are_found_in_the_molecule__2_,
-                            this, pair.Key, Molecule.FromDict(molecule)));
+                            this, pair.Key, molecule.ToString()));
                 }
             }
 
-            // Deal with labeling (the "4Cl37" in "[M4Cl37+2H]")
-            // N.B. in "[2M4Cl37+2H]" we'd replace 8 Cl rather than 4
-            if (IsotopeLabels != null && IsotopeLabels.Count > 0)
-            {
-                var unlabeled = resultDict.ToArray();
-                foreach (var unlabeledSymbolAndCount in unlabeled)
-                {
-                    KeyValuePair<string, int> isotopeSymbolAndCount;
-                    var unlabeledSymbol = unlabeledSymbolAndCount.Key;
-                    if (IsotopeLabels.TryGetValue(unlabeledSymbol, out isotopeSymbolAndCount))
-                    {
-                        // If label is "2Cl37" and molecule is CH4Cl5 then result is CH4Cl3Cl'2
-                        var isotopeSymbol = isotopeSymbolAndCount.Key;
-                        var isotopeCount = MassMultiplier * isotopeSymbolAndCount.Value;
-                        var unlabeledCount = unlabeledSymbolAndCount.Value - isotopeCount;
-                        if (unlabeledCount >= 0)
-                        {
-                            resultDict[unlabeledSymbol] = unlabeledCount; // Number of remaining non-label atoms
-                        }
-                        else // Can't remove that which is not there
-                        {
-                            throw new InvalidOperationException(
-                                string.Format(Resources.Adduct_ApplyToMolecule_Adduct___0___calls_for_labeling_more__1__atoms_than_are_found_in_the_molecule__2_,
-                                    this, unlabeledSymbol, Molecule.FromDict(molecule)));
-                        }
-                        int exist;
-                        if (resultDict.TryGetValue(isotopeSymbol, out exist))
-                        {
-                            resultDict[isotopeSymbol] = exist + isotopeCount;
-                        }
-                        else
-                        {
-                            resultDict.Add(isotopeSymbol, isotopeCount);
-                        }
-                    }
-                }
-            }
+            return ApplyIsotopeValues(molecule, MassMultiplier, resultDict);
         }
 
-        public string ApplyToFormula(string formula)
-        {
-            var resultMol = Molecule.FromDict(ApplyToMolecule(Molecule.ParseExpressionToDictionary(formula)));
-            return resultMol.ToString();
-        }
-
-        public string ApplyIsotopeLabelsToFormula(string formula)
+        private MoleculeMassOffset ApplyIsotopeValues(MoleculeMassOffset molecule, int massMultiplier, IDictionary<string, int> resultDict)
         {
             if (!HasIsotopeLabels)
             {
-                return formula;
+                return molecule.Change(Molecule.FromDict(resultDict)); // Nothing to do, but previous caller may have manipulated the formula as represented in resultDict
             }
-            var molecule = Molecule.ParseExpressionToDictionary(formula);
-            var resultDict = new Dictionary<string, int>();
-            foreach (var pair in molecule)
+
+            TypedMass massModMono;
+            TypedMass massModAvg;
+            if (molecule.IsMassOnly)
             {
-                KeyValuePair<string, int> isotope;
-                if (IsotopeLabels != null && IsotopeLabels.TryGetValue(pair.Key, out isotope))
+                // Just add the incremental mass of of the declared isotopes
+                massModMono = molecule.MonoMassOffset + IsotopesIncrementalMonoMass;
+                massModAvg = molecule.AverageMassOffset + IsotopesIncrementalAverageMass;
+            }
+            else
+            {
+                // Deal with mass-only labeling (the "(-1.23)" in [2M(-1.23)+Na]")
+                // N.B. in "[2M2.45+2H]" we'd add 4.90 rather than 2.45, that is, "[+2.45]" with a count of 2
+                // Same idea as handling "4Cl37" in the example below
+                massModMono =
+                    (molecule.MonoMassOffset + IsotopeLabels.MonoMassOffset) * massMultiplier;
+                massModAvg =
+                    (molecule.AverageMassOffset + IsotopeLabels.AverageMassOffset) * massMultiplier;
+                massModMono = massModMono.ChangeIsHeavy(true);
+                massModAvg = massModAvg.ChangeIsHeavy(true);
+
+                // Deal with labeling (the "4Cl37" in "[M4Cl37+2H]")
+                // N.B. in "[2M4Cl37+2H]" we'd replace 8 Cl rather than 4
+                foreach (var isotopeSymbolAndCount in IsotopeLabels.Molecule)
                 {
+                    var unlabeledSymbol = BioMassCalc.DICT_HEAVYSYMBOL_TO_MONOSYMBOL[isotopeSymbolAndCount.Key];
+                    resultDict.TryGetValue(unlabeledSymbol, out var unlabeledCount);
                     // If label is "2Cl37" and molecule is CH4Cl5 then result is CH4Cl3Cl'2
-                    var unlabelCount = pair.Value - isotope.Value;
-                    if (unlabelCount > 0)
+                    var isotopeCount = massMultiplier * isotopeSymbolAndCount.Value;
+                    unlabeledCount -= isotopeCount;
+                    if (unlabeledCount > 0)
                     {
-                        int existResult;
-                        if (resultDict.TryGetValue(pair.Key, out existResult))
+                        resultDict[unlabeledSymbol] = unlabeledCount; // Number of remaining non-label atoms
+                    }
+                    else if (unlabeledCount == 0)
+                    {
+                        resultDict.Remove(unlabeledSymbol); // Number of remaining non-label atoms)
+                    }
+                    else // Can't remove that which is not there
+                    {
+                        throw new InvalidOperationException(
+                            string.Format(
+                                Resources
+                                    .Adduct_ApplyToMolecule_Adduct___0___calls_for_labeling_more__1__atoms_than_are_found_in_the_molecule__2_,
+                                this, unlabeledSymbol, molecule.ToString()));
+                    }
+
+                    var isotopeSymbol = isotopeSymbolAndCount.Key;
+                    if (resultDict.TryGetValue(isotopeSymbol, out var exist))
+                    {
+                        exist += isotopeCount;
+                        if (exist == 0)
                         {
-                            resultDict[pair.Key] = existResult + unlabelCount;
+                            resultDict.Remove(isotopeSymbol);
                         }
                         else
                         {
-                            resultDict.Add(pair.Key, unlabelCount);
+                            resultDict[isotopeSymbol] = exist;
                         }
                     }
-                    else if (unlabelCount < 0)
+                    else if (isotopeCount != 0)
                     {
-                        throw new InvalidOperationException(
-                            string.Format(Resources.Adduct_ApplyToMolecule_Adduct___0___calls_for_labeling_more__1__atoms_than_are_found_in_the_molecule__2_,
-                                this, pair.Key, Molecule.FromDict(molecule)));
-                    }
-                    int exist;
-                    if (resultDict.TryGetValue(isotope.Key, out exist))
-                    {
-                        resultDict[isotope.Key] = exist + isotope.Value;
-                    }
-                    else
-                    {
-                        resultDict.Add(isotope.Key, isotope.Value);
-                    }
-                }
-                else
-                {
-                    int exist;
-                    if (resultDict.TryGetValue(pair.Key, out exist))
-                    {
-                        resultDict[pair.Key] = exist + pair.Value;
-                    }
-                    else
-                    {
-                        resultDict.Add(pair.Key, pair.Value);
+                        resultDict.Add(isotopeSymbol, isotopeCount);
                     }
                 }
             }
-            var resultMol = Molecule.FromDict(resultDict);
-            return resultMol.ToString();
+
+            return molecule.Change(Molecule.FromDict(resultDict), massModMono, massModAvg);
+        }
+
+        public MoleculeMassOffset ApplyToFormula(string formula)
+        {
+            return ApplyToMolecule(ParsedMoleculeMassOffset.Create(formula));
+        }
+
+        public MoleculeMassOffset ApplyIsotopeLabelsToFormula(string formula)
+        {
+            var molecule = ParsedMoleculeMassOffset.Create(formula);
+            return ApplyIsotopeLabelsToMolecule(molecule);
+        }
+
+        // Apply just the isotope effect, e.g "2Cl37" in 2MCl37+Na
+        public MoleculeMassOffset ApplyIsotopeLabelsToMolecule(MoleculeMassOffset molecule)
+        {
+            if (!HasIsotopeLabels)
+            {
+                return molecule;
+            }
+            var resultDict = new Dictionary<string, int>(molecule.Molecule);
+
+            return ApplyIsotopeValues(molecule, 1, resultDict);
         }
 
         public double ApplyIsotopeLabelsToMass(TypedMass mass)
         {
-            // Account for the added mass of any labels delared in the adduct, e.g. for [2M4Cl37+H] add 2x4x the difference in mass between CL37 and Cl
+            // Account for the added mass of any labels declared in the adduct, e.g. for [2M4Cl37+H] add 2x4x the difference in mass between CL37 and Cl
             if (mass.IsHeavy())
             {
                 return mass; // Mass already has isotope masses factored in
@@ -1455,7 +1515,7 @@ namespace pwiz.Skyline.Util
 
         /// <summary>
         /// Returns the effect of the adduct on the input mass,
-        /// including the mass multipler and any isotope labels if the mass isn't marked heavy (ie already has labels accounted for)
+        /// including the mass multiplier and any isotope labels if the mass isn't marked heavy (ie already has labels accounted for)
         /// </summary>
         public TypedMass ApplyToMass(TypedMass neutralMass)
         {
@@ -1487,7 +1547,9 @@ namespace pwiz.Skyline.Util
             if (neutralMass != 0 && t.IsMassH())
             {
                 Assume.IsTrue(IsProtonated); // Expect massH to be a peptide thing only
-                var iMass = t.IsAverage() ? IsotopesIncrementalAverageMass : IsotopesIncrementalMonoMass; // For example, mass of the 2*3*(cl37-Cl)in 2M3Cl37+2H
+                var iMass = t.IsHeavy() ? 
+                    0.0 :  // Don't reapply isotope label mass
+                    (t.IsAverage() ? IsotopesIncrementalAverageMass : IsotopesIncrementalMonoMass); // For example, mass of the 2*3*(cl37-Cl)in 2M3Cl37+2H
                 return (iMass + neutralMass * MassMultiplier + (AdductCharge-1) * BioMassCalc.MassProton) / Math.Abs(AdductCharge);
             }
             // Treat protonation as a special case, so the numbers agree with how we traditionally deal with peptide charges
@@ -1498,7 +1560,7 @@ namespace pwiz.Skyline.Util
                     t.IsAverage() ? IsotopesIncrementalAverageMass : IsotopesIncrementalMonoMass; // For example, mass of the 2*3*(cl37-Cl)in 2M3Cl37+2H
                 return (isotopeIncrementalMass + neutralMass * MassMultiplier + AdductCharge * BioMassCalc.MassProton) / Math.Abs(AdductCharge);
             }
-            var adductMass = t.IsHeavy() ? // Don't reapply isotope label mass
+            double adductMass = t.IsHeavy() ? // Don't reapply isotope label mass
                 (t.IsAverage() ? AverageMassAdduct : MonoMassAdduct) : // For example, mass of the 2H in 2M3Cl37+2H
                 (t.IsAverage() ? AverageMassAdduct + IsotopesIncrementalAverageMass : MonoMassAdduct + IsotopesIncrementalMonoMass); // For example, mass of the 2H and 2*3*(cl37-Cl)in 2M3Cl37+2H
             return (neutralMass * MassMultiplier + adductMass - AdductCharge * BioMassCalc.MassElectron) / Math.Abs(AdductCharge);  
@@ -1516,58 +1578,52 @@ namespace pwiz.Skyline.Util
             if (IsProtonated)
             {
                 // Treat this as a special case, so the numbers agree with how we deal with peptide charges
-                return new TypedMass((mz * Math.Abs(AdductCharge) - AdductCharge * BioMassCalc.MassProton) / MassMultiplier, t);
+                return TypedMass.Create((mz * Math.Abs(AdductCharge) - AdductCharge * BioMassCalc.MassProton) / MassMultiplier, t);
             }
             var adductMass = t.IsAverage() ? AverageMassAdduct : MonoMassAdduct;
-            return new TypedMass((mz * Math.Abs(AdductCharge) + AdductCharge * BioMassCalc.MassElectron - adductMass) / MassMultiplier, t);
+            return TypedMass.Create((mz * Math.Abs(AdductCharge) + AdductCharge * BioMassCalc.MassElectron - adductMass) / MassMultiplier, t);
         }
 
         private void InitializeAsCharge(int charge, ADDUCT_TYPE mode)
         {
             Description = null;
             AdductCharge = charge;
-            var composition = new Dictionary<string, int>();
             MassMultiplier = 1;
             if ((mode != ADDUCT_TYPE.charge_only) && (AdductCharge != 0))
             {
-                composition.Add(@"H", AdductCharge);
+                var absCharge = Math.Abs(AdductCharge);
+                Composition = Molecule.Parse($@"{((AdductCharge < 0) ? @"-" : string.Empty)}H{((absCharge==0)?string.Empty:absCharge.ToString(CultureInfo.InvariantCulture))}");
             }
-            Composition = new ImmutableDictionary<string, int>(composition);
+            else
+            {
+                Composition = Molecule.Empty;
+            }
+            IsotopeLabels = MoleculeMassOffset.EMPTY;
             InitializeMasses();
         }
 
         private void InitializeMasses()
         {
-            AverageMassAdduct = BioMassCalc.AVERAGE.CalculateMassFromFormula(Composition); // The average mass of the +2Na in [2M4Cl37+2Na]
-            MonoMassAdduct = BioMassCalc.MONOISOTOPIC.CalculateMassFromFormula(Composition); // The mono mass of the +2Na in [2M4Cl37+2Na]
-            if (IsotopeLabelMass.HasValue)
+            AverageMassAdduct = BioMassCalc.AVERAGE.CalculateMass(Composition); // The average mass of the +2Na in [2M4Cl37+2Na]
+            MonoMassAdduct = BioMassCalc.MONOISOTOPIC.CalculateMass(Composition); // The mono mass of the +2Na in [2M4Cl37+2Na]
+            double isotopeLabelsAverageMassOffset =  IsotopeLabels.AverageMassOffset;
+            double isotopeLabelsMonoMassOffset = IsotopeLabels.MonoMassOffset;
+            foreach (var isotope in IsotopeLabels.Molecule)
             {
-                IsotopesIncrementalAverageMass = new TypedMass(MassMultiplier * IsotopeLabelMass.Value, MassType.AverageHeavy);
-                IsotopesIncrementalMonoMass= new TypedMass(MassMultiplier * IsotopeLabelMass.Value, MassType.MonoisotopicHeavy);
+                // Account for the added mass of any labels declared in the adduct, e.g. for [2M4Cl37+H] add 2x4x the difference in mass between CL37 and Cl
+                var unlabled = BioMassCalc.GetMonoisotopicSymbol(isotope.Key);
+                var label = isotope.Key;
+                var labelCount = isotope.Value;
+                isotopeLabelsAverageMassOffset += labelCount*(BioMassCalc.AVERAGE.GetMass(label) - BioMassCalc.AVERAGE.GetMass(unlabled));
+                isotopeLabelsMonoMassOffset += labelCount*(BioMassCalc.MONOISOTOPIC.GetMass(label) - BioMassCalc.MONOISOTOPIC.GetMass(unlabled));
             }
-            else if (IsotopeLabels != null)
-            {
-                double avg = 0;
-                double mono = 0;
-                foreach (var isotope in IsotopeLabels)
-                {
-                    // Account for the added mass of any labels delared in the adduct, e.g. for [2M4Cl37+H] add 2x4x the difference in mass between CL37 and Cl
-                    var unlabel = isotope.Key;
-                    var label = isotope.Value.Key;
-                    var labelCount = isotope.Value.Value;
-                    avg += labelCount*(BioMassCalc.AVERAGE.GetMass(label) - BioMassCalc.AVERAGE.GetMass(unlabel));
-                    mono += labelCount*(BioMassCalc.MONOISOTOPIC.GetMass(label) - BioMassCalc.MONOISOTOPIC.GetMass(unlabel));
-                }
-                IsotopesIncrementalAverageMass = new TypedMass(MassMultiplier * avg, MassType.AverageHeavy);
-                IsotopesIncrementalMonoMass = new TypedMass(MassMultiplier * mono, MassType.MonoisotopicHeavy);
-            }
-            else
-            {
-                IsotopesIncrementalAverageMass = TypedMass.ZERO_AVERAGE_MASSNEUTRAL;
-                IsotopesIncrementalMonoMass = TypedMass.ZERO_MONO_MASSNEUTRAL;
-            }
+            IsotopesIncrementalAverageMass = TypedMass.Create(MassMultiplier * isotopeLabelsAverageMassOffset,
+                isotopeLabelsAverageMassOffset == 0 ? MassType.Average : MassType.AverageHeavy);
+            IsotopesIncrementalMonoMass = TypedMass.Create(MassMultiplier * isotopeLabelsMonoMassOffset,
+                isotopeLabelsMonoMassOffset == 0 ? MassType.Monoisotopic : MassType.MonoisotopicHeavy);
             Unlabeled = ChangeIsotopeLabels(string.Empty); // Useful for dealing with labels and mass-only small molecule declarations
-            IsProtonated = Composition.Any() && Composition.All(pair => pair.Key == BioMassCalc.H || pair.Key == BioMassCalc.H2 || pair.Key == BioMassCalc.H3);
+            IsProtonated = Composition.Any() && Composition.All(pair => // All H, H', H", D or T
+                BioMassCalc.GetMonoisotopicSymbol(pair.Key) == BioMassCalc.H);
             IsProteomic = IsProtonated && string.IsNullOrEmpty(Description); 
         }
 
@@ -1576,34 +1632,13 @@ namespace pwiz.Skyline.Util
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (Equals(this, obj)) return true;
+            if (this.Equals(obj)) return true;
 
             if (!Equals(obj.AdductCharge, AdductCharge) || 
-                !Equals(obj.Composition.Count, Composition.Count) || 
+                !Equals(obj.Composition, Composition) || 
                 !Equals(obj.MassMultiplier, MassMultiplier) ||
-                !Equals(obj.IsotopeLabelMass, IsotopeLabelMass) ||
-                !Equals(IsotopeLabels == null, obj.IsotopeLabels == null) ||
-                (IsotopeLabels != null && obj.IsotopeLabels != null && !Equals(obj.IsotopeLabels.Count, IsotopeLabels.Count)))
+                !Equals(obj.IsotopeLabels, IsotopeLabels))
                 return false;
-            foreach (var atom in Composition)
-            {
-                int otherCount;
-                if (!obj.Composition.TryGetValue(atom.Key, out otherCount))
-                    return false;
-                if (!Equals(atom.Value, otherCount))
-                    return false;
-            }
-            if (IsotopeLabels != null)
-            {
-                foreach (var label in IsotopeLabels)
-                {
-                    KeyValuePair<string, int> otherLabelCount;
-                    if (obj.IsotopeLabels == null || !obj.IsotopeLabels.TryGetValue(label.Key, out otherLabelCount))
-                        return false;
-                    if (!Equals(label.Value.Value, otherLabelCount.Value))
-                        return false;
-                }
-            }
             return true;
         }
 
@@ -1612,11 +1647,8 @@ namespace pwiz.Skyline.Util
         {
             _hashCode = (Description != null ? Description.GetHashCode() : 0);
             _hashCode = (_hashCode * 397) ^ AdductCharge.GetHashCode();
-            foreach (var pair in Composition)
-            {
-                _hashCode = (_hashCode * 397) ^ pair.Key.GetHashCode();
-                _hashCode = (_hashCode * 397) ^ pair.Value.GetHashCode();
-            }
+            _hashCode = (_hashCode * 397) ^ IsotopeLabels.GetHashCode();
+            _hashCode = (_hashCode * 397) ^ Composition.GetHashCode();
         }
 
 
@@ -1687,9 +1719,19 @@ namespace pwiz.Skyline.Util
 
         public int CompareTo(object obj)
         {
-            if (ReferenceEquals(null, obj)) return 1;
-            if (ReferenceEquals(this, obj)) return 0;
-            var that = (Adduct)obj;
+            return ReferenceEquals(null, obj) ? 1 : CompareTo(obj as Adduct);
+        }
+
+        public int CompareTo(Adduct that)
+        {
+            if (ReferenceEquals(null, that))
+            {
+                return 1;
+            }
+            if (ReferenceEquals(this, that))
+            {
+                return 0;
+            }
             var comp = AdductCharge.CompareTo(that.AdductCharge);
             if (comp != 0)
             {
@@ -1700,26 +1742,15 @@ namespace pwiz.Skyline.Util
             {
                 return comp;
             }
-            comp =  Composition.Count.CompareTo(that.Composition.Count);
+            comp =  Composition.CompareTo(that.Composition);
             if (comp != 0)
             {
                 return comp;
             }
-            foreach (var atomCount in Composition)
+            comp = IsotopeLabels.CompareTo(that.IsotopeLabels);
+            if (comp != 0)
             {
-                int otherVal;
-                if (Composition.TryGetValue(atomCount.Key, out otherVal))
-                {
-                    comp = atomCount.Value.CompareTo(otherVal);
-                    if (comp != 0)
-                    {
-                        return comp;
-                    }
-                }
-                else
-                {
-                    return 1;
-                }
+                return comp;
             }
             return 0;
         }
@@ -1799,5 +1830,6 @@ namespace pwiz.Skyline.Util
 
             return Math.Abs(AdductCharge) <= Math.Abs(precursorCharge);
         }
+
     }
 }

--- a/pwiz_tools/Skyline/Util/BioMassCalc.cs
+++ b/pwiz_tools/Skyline/Util/BioMassCalc.cs
@@ -18,199 +18,15 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using pwiz.Common.Chemistry;
-using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Properties;
 
 namespace pwiz.Skyline.Util
 {
-    /// <summary>
-    /// Enum used to specify the use of monoisotopic or average
-    /// masses when calculating molecular masses.
-    /// </summary>
-    [Flags]
-    [IgnoreEnumValues(new object [] {
-        bMassH,
-        bHeavy,
-        MonoisotopicMassH,
-        AverageMassH,
-        MonoisotopicHeavy,
-        AverageHeavy})]
-    public enum MassType
-    {
-// ReSharper disable InconsistentNaming
-        Monoisotopic = 0, 
-        Average = 1,
-        bMassH = 2, // As with peptides, where masses are traditionally given as massH
-        bHeavy = 4, // As with small molecules described by mass only, which have already been processed by isotope-declaring adducts
-        MonoisotopicMassH = Monoisotopic | bMassH, 
-        AverageMassH = Average | bMassH,
-        MonoisotopicHeavy = Monoisotopic | bHeavy, 
-        AverageHeavy = Average | bHeavy
-// ReSharper restore InconsistentNaming
-    }
-    public static class MassTypeExtension
-    {
-        private static string[] LOCALIZED_VALUES
-        {
-            get
-            {
-                return new[]
-                {
-                    Resources.ExportStrategyExtension_LOCALIZED_VALUES_Monoisotopic,
-                    Resources.ExportStrategyExtension_LOCALIZED_VALUES_Average
-                };
-            }
-        }
-        public static string GetLocalizedString(this MassType val)
-        {
-            return LOCALIZED_VALUES[(int)val & (int)MassType.Average]; // Strip off bMassH, bHeavy
-        }
-
-        public static MassType GetEnum(string enumValue)
-        {
-            return Helpers.EnumFromLocalizedString<MassType>(enumValue, LOCALIZED_VALUES);
-        }
-
-        public static MassType GetEnum(string enumValue, MassType defaultValue)
-        {
-            return Helpers.EnumFromLocalizedString(enumValue, LOCALIZED_VALUES, defaultValue);
-        }
-        [Pure]
-        public static bool IsMonoisotopic(this MassType val)
-        {
-            return !val.IsAverage();
-        }
-
-        [Pure]
-        public static bool IsAverage(this MassType val)
-        {
-            return (val & MassType.Average) != 0;
-        }
-
-        [Pure]
-        public static bool IsMassH(this MassType val)
-        {
-            return (val & MassType.bMassH) != 0;
-        }
-        
-        // For small molecule use: distinguishes a mass calculated from an isotope-specifying adduct
-        [Pure]
-        public static bool IsHeavy(this MassType val)
-        {
-            return (val & MassType.bHeavy) != 0;  
-        }
-    }
-
-    /// <summary>
-    /// There are many places where we carry a mass or massH and also need to track how it was derived
-    /// </summary>
-    public struct TypedMass :  IComparable<TypedMass>, IEquatable<TypedMass>, IFormattable
-    {
-        public static TypedMass ZERO_AVERAGE_MASSNEUTRAL = new TypedMass(0.0, MassType.Average);
-        public static TypedMass ZERO_MONO_MASSNEUTRAL = new TypedMass(0.0, MassType.Monoisotopic);
-
-        public static TypedMass ZERO_AVERAGE_MASSH = new TypedMass(0.0, MassType.AverageMassH);
-        public static TypedMass ZERO_MONO_MASSH = new TypedMass(0.0, MassType.MonoisotopicMassH);
-
-        private readonly double _value;
-        private readonly MassType _massType;
-
-        public double Value { get { return _value; } }
-        public MassType MassType { get { return _massType; } }
-        [Pure]
-        public bool IsMassH() { return _massType.IsMassH();  }
-        [Pure]
-        public bool IsMonoIsotopic() { return _massType.IsMonoisotopic(); }
-        [Pure]
-        public bool IsAverage() { return _massType.IsAverage(); }
-        [Pure]
-        public bool IsHeavy() { return _massType.IsHeavy(); }
-
-        public TypedMass(double value, MassType t)
-        {
-            _value = value;
-            _massType = t;
-        }
-
-        [Pure]
-        public bool Equivalent(TypedMass other)
-        {
-            if (IsMassH() != other.IsMassH())
-            {
-                var adjust = IsMassH() ? -BioMassCalc.MassProton : BioMassCalc.MassProton;
-                return Math.Abs(_value + adjust - other.Value) < BioMassCalc.MassElectron;
-            }
-            return Equals(other); // Can't lead with this, as it will throw if IsMassH doesn't agree
-        }
-
-        public TypedMass ChangeIsMassH(bool newIsMassH)
-        {
-            if (Equals(newIsMassH, IsMassH()))
-            {
-                return this;
-            }
-            return new TypedMass(_value, newIsMassH ? _massType | MassType.bMassH : _massType & ~MassType.bMassH);
-        }
-
-        public static implicit operator double(TypedMass d)
-        {
-            return d.Value;
-        }
-
-        public static TypedMass operator +(TypedMass tm, double step)
-        {
-            return new TypedMass(tm.Value + step, tm._massType);
-        }
-
-        public static TypedMass operator -(TypedMass tm, double step)
-        {
-            return new TypedMass(tm.Value - step, tm._massType);
-        }
-
-        public int CompareTo(TypedMass other)
-        {
-            Assume.IsTrue(_massType == other._massType);  // It's a mistake to mix these types
-            return Value.CompareTo(other.Value);
-        }
-
-        public bool Equals(TypedMass other)
-        {
-            return CompareTo(other) == 0;
-        }
-
-        public bool Equals(TypedMass other, double tolerance)
-        {
-            return CompareTo(other) == 0 || Math.Abs(Value - other.Value) <= tolerance;
-        }
-
-        public override int GetHashCode()
-        {
-            var result = Value.GetHashCode();
-            result = (result * 397) ^ _massType.GetHashCode();
-            return result;
-        }
-
-        public override string ToString()
-        {
-            return Value.ToString(CultureInfo.CurrentCulture);
-        }
-
-        public string ToString(CultureInfo ci)
-        {
-            return Value.ToString(ci);
-        }
-
-        public string ToString(string format, IFormatProvider formatProvider)
-        {
-            return Value.ToString(format, formatProvider);
-        }
-    }
-
     /// <summary>
     /// Calculates molecular masses based on atomic masses.
     /// Atomic masses come from http://www.unimod.org/unimod_help.html.
@@ -227,13 +43,23 @@ namespace pwiz.Skyline.Util
     ///  </summary>
     public class BioMassCalc
     {
+        // Reasonable values for comparison and serialization of masses
+        public const int MassPrecision = 6;
+        public const double MassTolerance = 1e-6;
+        public const string MASS_FORMAT = @"0.######";
+
+
         public static readonly BioMassCalc MONOISOTOPIC = new BioMassCalc(MassType.Monoisotopic);
         public static readonly BioMassCalc AVERAGE = new BioMassCalc(MassType.Average);
+        public static readonly BioMassCalc MONOISOTOPIC_MASSH = new BioMassCalc(MassType.MonoisotopicMassH);
+        public static readonly BioMassCalc AVERAGE_MASSH = new BioMassCalc(MassType.AverageMassH);
 
         public static readonly IsotopeAbundances DEFAULT_ABUNDANCES = IsotopeAbundances.Default;
 
-        
-// ReSharper disable LocalizableElement
+        public const string SKYLINE_ISOTOPE_HINT1 = @"'"; // Denotes most abundant isotope
+        public const string SKYLINE_ISOTOPE_HINT2 = @""""; // Denotes second most abundant isotope
+
+        // ReSharper disable LocalizableElement
         public const string H = "H";    // Hydrogen
         public const string H2 = "H'";  // Deuterium
         public const string H3 = "H\""; // Tritium
@@ -309,9 +135,13 @@ namespace pwiz.Skyline.Util
                     { Cu65, new KeyValuePair<double, double>(64.92778970, 0.99) },  // N.B. No idea if this is a realistic value 
                 };
 
-        public static bool IsSkylineHeavySymbol(string symbol)
+        public static bool IsHeavySymbol(string symbol)  // True if matches D, T, or ends with ' or "
         {
-            return DICT_HEAVYSYMBOL_TO_MASS.ContainsKey(symbol);
+            return MONOISOTOPIC._atomicMasses.TryGetValue(symbol, out var massInfo) && massInfo._bHeavy;
+        }
+        public static bool IsSkylineHeavySymbol(string symbol)  // True if ends with ' or ", but not synonyms like D or T
+        {
+            return symbol != null && (symbol.EndsWith(@"'") || symbol.EndsWith(@""""));
         }
 
         /// <summary>
@@ -319,30 +149,46 @@ namespace pwiz.Skyline.Util
         /// CONSIDER(bspratt) would be trivial to add support for pwiz-style _2H -> H' _37Cl-> CL' etc
         /// NB if you do so, make sure to update BiblioSpec BuildParser.cpp which explicitly rejects '_' in formulas
         /// </summary>
-        private static Dictionary<string, string> DICT_HEAVYSYMBOL_NICKNAMES => new Dictionary<string, string>
-                {
-                    {D, H2}, // IUPAC Deuterium
-                    {T, H3} // IUPAC Tritium
-                };
+        public static ReadOnlyDictionary<string, string> DICT_HEAVYSYMBOL_NICKNAMES => new ReadOnlyDictionary<string, string>(
+            new Dictionary<string, string>(){
+                {D, H2}, // IUPAC Deuterium
+                {T, H3} // IUPAC Tritium
+            });
 
         /// <summary>
         /// A dictionary mapping heavy isotope symbols to their corresponding monoisotopic element.
         /// This dictionary contains entries for Skyline-style isotope symbols (e.g. H' for Deuterium -> H)
         /// as well as common synonyms (e.g. D for Deuterium -> H)
         /// </summary>
-        public static readonly Dictionary<string, string> DICT_HEAVYSYMBOL_TO_MONOSYMBOL = // Map Cl' to Cl, D to H etc
+        public static readonly ReadOnlyDictionary<string, string> DICT_HEAVYSYMBOL_TO_MONOSYMBOL = // Map Cl' to Cl, D to H etc
+            new ReadOnlyDictionary<string, string>(
              DICT_HEAVYSYMBOL_TO_MASS.ToDictionary(kvp => kvp.Key, kvp => kvp.Key)
                 .ToArray().Concat(DICT_HEAVYSYMBOL_NICKNAMES.ToDictionary(kvp => kvp.Key, kvp => kvp.Value).ToArray())
                     .ToDictionary(kvp => kvp.Key,
-                        kvp => kvp.Value.Replace(@"'", string.Empty).Replace(@"""", string.Empty));
+                        kvp => kvp.Value.Replace(SKYLINE_ISOTOPE_HINT1, string.Empty).Replace(SKYLINE_ISOTOPE_HINT2, string.Empty)));
 
-        private static readonly char[] HEAVYSYMBOL_HINTS = new char[] {'\'', '"', 'D', 'T'}; // If a formula does not contain any of these, it's not heavy labeled
 
         /// <summary>
         /// A list of Skyline-style isotope symbols (e.g. H')
         /// DOES NOT include synonyms such as D for Deuterium
         /// </summary>
-        public static IEnumerable<string> HeavySymbols { get { return DICT_HEAVYSYMBOL_TO_MASS.Keys; } }
+        public static readonly string[] HeavySymbols = DICT_HEAVYSYMBOL_TO_MASS.Keys.ToArray();
+
+        /// <summary>
+        /// Determine whether a string describes and isotope of an element
+        /// </summary>
+        /// <param name="xElement">string describing an element, possibly an isotope, e.g. "Cl" or "Cl'" or "D" </param>
+        /// <param name="yElement">string describing another element that might be the light version of xElement</param>
+        /// <returns>true if, for example, xElement is "N'" and yElement is "N"</returns>
+        public static bool ElementIsIsotopeOf(string xElement, string yElement)
+        {
+            if (BioMassCalc.DICT_HEAVYSYMBOL_TO_MONOSYMBOL.TryGetValue(xElement, out var light) &&
+                Equals(yElement, light))
+            {
+                return true;
+            }
+            return false;
+        }
 
         /// <summary>
         /// Returns the index of an atomic symbol the mass distribution
@@ -413,15 +259,39 @@ namespace pwiz.Skyline.Util
             return expression;
         }
 
-        private readonly Dictionary<string, double> _atomicMasses =
-            new Dictionary<string, double>();
+        private struct MassInfo
+        {
+            public double _mass;
+            public bool _bHeavy;
+        }
+
+        private readonly Dictionary<string, MassInfo> _atomicMasses =
+            new Dictionary<string, MassInfo>();
+
+
 
         /// <summary>
         /// Create a simple mass calculator for use in calculating
-        /// protein, peptide and fragment masses.
+        /// molecule masses.
         /// </summary>
         /// <param name="type">Monoisotopic or average mass calculations</param>
-        public BioMassCalc(MassType type)
+        public static BioMassCalc GetBioMassCalc(MassType type)
+        {
+            switch (type)
+            {
+                case MassType.Average:
+                    return AVERAGE;
+                case MassType.AverageMassH:
+                    return AVERAGE_MASSH;
+                case MassType.Monoisotopic:
+                    return MONOISOTOPIC;
+                case MassType.MonoisotopicMassH:
+                    return MONOISOTOPIC_MASSH;
+            }
+            return new BioMassCalc(type);
+        }
+
+        private BioMassCalc(MassType type)   
         {
             MassType = type;
             AddMass(H, 1.00794); //Unimod
@@ -509,49 +379,40 @@ namespace pwiz.Skyline.Util
 
         public MassType MassType { get; private set; }
 
-        public string FormatArgumentExceptionMessage(string desc)
+        public static string FormatArgumentExceptionMessage(string desc)
         {
             string errmsg =
                 string.Format(
                     Resources.BioMassCalc_CalculateMass_The_expression__0__is_not_a_valid_chemical_formula, desc) +
                 Resources.BioMassCalc_FormatArgumentException__Supported_chemical_symbols_include__;
-            foreach (var key in _atomicMasses.Keys)
+            foreach (var key in MONOISOTOPIC._atomicMasses.Keys)
                 errmsg += key + @" "; 
             return errmsg;
         }
 
-        public void ThrowArgumentException(string desc)
+        public static void ThrowArgumentException(string desc)
         {
             throw new ArgumentException(FormatArgumentExceptionMessage(desc));
         }
 
-        public static bool ContainsIsotopicElement(string desc)
+        public static bool ContainsIsotopicElement(IEnumerable<KeyValuePair<string, int>> desc)
         {
-            return DICT_HEAVYSYMBOL_TO_MONOSYMBOL.Keys.Any(desc.Contains); // Look for Cl', O", D, T etc
+            return desc.Any(kvp => MONOISOTOPIC._atomicMasses.TryGetValue(kvp.Key, out var massInfo) && massInfo._bHeavy); // Look for Cl', O", D, T etc
         }
 
-        public static bool TryParseFormula(string formula, out Molecule resultMolecule, out string errMessage)
+        public bool TryParseFormula(string formula, out MoleculeMassOffset resultMolecule, out string errorMessage)
         {
             try
             {
-                var unprocessed = formula;
-                var resultDict = new Dictionary<string, int>();
-                // ParseMass checks for unknown symbols, so it's useful to us as a syntax checking parser even if we don't care about mass
-                // N.B. Monoisotopic vs Average doesn't actually matter here as we're just interested in the atom counts in resultDict
-                MONOISOTOPIC.ParseMass(ref unprocessed, resultDict); 
-                if (unprocessed.Length > 0)
-                {
-                    MONOISOTOPIC.ThrowArgumentException(formula); // Did not parse completely
-                }
-
-                resultMolecule = Molecule.FromDict(resultDict);
-                errMessage = string.Empty;
+                // ParseFormulaMass checks for unknown symbols, so it's useful to us as a syntax checking parser even if we don't care about mass
+                ParseFormulaMass(formula, out resultMolecule);
+                errorMessage = string.Empty;
                 return true;
             }
             catch (ArgumentException e)
             {
-                resultMolecule = Molecule.Empty;
-                errMessage = e.Message;
+                resultMolecule = MoleculeMassOffset.EMPTY;
+                errorMessage = e.Message;
                 return false;
             }
         }
@@ -562,31 +423,53 @@ namespace pwiz.Skyline.Util
         /// atoms are chemical symbols like H, or C, or C' etc.
         /// </summary>
         /// <param name="desc">The molecule description string</param>
+        /// <param name="mol">The resulting molecule object</param>
         /// <returns>The mass of the specified molecule</returns>
-        public TypedMass CalculateMassFromFormula(string desc)
+        public TypedMass CalculateMassFromFormula(string desc, out MoleculeMassOffset mol)
         {
-            string parse = desc;
-            double totalMass = ParseMassExpression(ref parse);
-
-            if (totalMass == 0.0 || parse.Length > 0)
+            var totalMass = ParseFormulaMass(desc, out mol);
+            if (totalMass == 0.0)
                 ThrowArgumentException(desc);
-            var massType = ContainsIsotopicElement(desc) ?
-                MassType.IsAverage() ? MassType.AverageHeavy : MassType.MonoisotopicHeavy : // Formula contained isotope declaration
-                MassType.IsAverage() ? MassType.Average : MassType.Monoisotopic;
-
-            return new TypedMass(totalMass, massType);
+            return totalMass;
         }
 
-        public TypedMass CalculateMassFromFormula(IDictionary<string, int> desc)
+        public TypedMass CalculateMassFromFormula(string desc)
         {
-            double totalMass = ParseMass(desc);
+            return CalculateMassFromFormula(desc, out _);
+        }
 
-            if (desc.Count > 0 && totalMass == 0.0) // Non-empty description should produce a mass
+        public bool TryCalculateMassFromFormula(string desc, out TypedMass mass)
+        {
+            try
             {
-                ThrowArgumentException(desc.ToString());
+                mass = CalculateMassFromFormula(desc, out _);
+                return true;
             }
+            catch
+            {
+                mass = TypedMass.Create(0, MassType);
+            }
+            return true;
+        }
 
-            return new TypedMass(totalMass, MassType);
+        public TypedMass CalculateMass(MoleculeMassOffset mol)
+        {
+            if (MoleculeMassOffset.IsNullOrEmpty(mol))
+            {
+                return TypedMass.Create(0, this.MassType);
+            }
+            return CalculateMass((IDictionary<string, int>)mol.Molecule) + (MassType.IsMonoisotopic()
+                ? mol.MonoMassOffset
+                : mol.AverageMassOffset);
+        }
+
+        public TypedMass CalculateMass(Molecule mol)
+        {
+            if (Molecule.IsNullOrEmpty(mol))
+            {
+                return TypedMass.Create(0, this.MassType);
+            }
+            return CalculateMass((IDictionary<string, int>)mol);
         }
 
         /// <summary>
@@ -596,7 +479,7 @@ namespace pwiz.Skyline.Util
         /// </summary>
         /// <param name="desc">the formula</param>
         /// <returns>the tidied up formula</returns>
-        public string RegularizeFormula(string desc)
+        public static string RegularizeFormula(string desc)
         {
             if (string.IsNullOrEmpty(desc))
             {
@@ -625,7 +508,7 @@ namespace pwiz.Skyline.Util
 
                 if (atomCount != 0) // Drop "H0"
                 {
-                    atomCounts.Add(new KeyValuePair<string, string> (atom, atomCountString));
+                    atomCounts.Add(new KeyValuePair<string, string>(atom, atomCountString));
                 }
 
                 desc = desc.Substring(nDigits).TrimStart();
@@ -643,76 +526,74 @@ namespace pwiz.Skyline.Util
         {
             if (string.IsNullOrEmpty(desc))
                 return null;
-            if (desc.IndexOfAny(HEAVYSYMBOL_HINTS) == -1)
-            {
-                return desc; // Nothing there that looks like a heavy label
-            }
-            var parse = desc;
-            var dictAtomCounts = new Dictionary<string, int>();
-            var atomOrder = new List<string>(); // Returned as the original order of elements - e.g. C3C'4H2O7 => C,C',H,O
-            ParseCounts(ref parse, dictAtomCounts, false, atomOrder);
-            if (!string.IsNullOrEmpty(parse))
+
+            if (!TryParseFormula(desc, out var mol, out _))
             {
                 return desc; // That wasn't understood as a formula
             }
 
             // Look for any heavy isotopes in the formula and replace them with unlabeled versions
-            foreach (var kvp in dictAtomCounts.ToArray())
+            var dictUnlabeled = StripLabelsFromFormula(mol.Molecule);
+
+            return !dictUnlabeled.Any() ? null : mol.Change(dictUnlabeled).ToString();
+        }
+
+        public static MoleculeMassOffset StripLabelsFromFormula(MoleculeMassOffset atomCounts)
+        {
+            return atomCounts.Change(StripLabelsFromFormula(atomCounts.Molecule));
+        }
+
+        public static Molecule StripLabelsFromFormula(Molecule molecule)
+        {
+            if (!ContainsIsotopicElement(molecule))
+            {
+                return molecule;
+            }
+            var result = new Dictionary<string, int>(molecule);
+            // Look for any heavy isotopes in the formula and replace them with unlabeled versions
+            foreach (var kvp in molecule)
             {
                 // For each heavy isotope in the formula
                 if (DICT_HEAVYSYMBOL_TO_MONOSYMBOL.TryGetValue(kvp.Key, out var unlabeled))
                 {
-                    dictAtomCounts.TryGetValue(unlabeled, out var count); // Get current count of unlabeled version, if any
-                    dictAtomCounts[unlabeled] = count + kvp.Value; // Add the heavy version's count to the unlabeled version's count
-                    dictAtomCounts.Remove(kvp.Key); // And remove heavy isotope from the formula
-                    // Preserve order - e.g. C3C'4H2O3 comes out as C7H2O3 and not something dependent on dictionary implementation like H2O3C7 etc
-                    var index = atomOrder.IndexOf(kvp.Key);
-                    if (index >= 0)
+                    if (result.TryGetValue(unlabeled, out var count)) // Get current count of unlabeled version, if any
                     {
-                        if (atomOrder.Contains(unlabeled))
-                        {
-                            atomOrder.RemoveAt(index); // Formula was mixed heavy and light - e.g. C and C'
-                        }
-                        else
-                        {
-                            atomOrder[index] = unlabeled; // Formula was all heavy - e.g. C' but no C
-                        }
+                        result[unlabeled] = count + kvp.Value; // Add the heavy version's count to the unlabeled version's count
                     }
+                    else
+                    {
+                        result.Add(unlabeled, kvp.Value);
+                    }
+                    result.Remove(kvp.Key); // And remove heavy isotope from the formula
                 }
             }
 
-            if (!atomOrder.Any())
-            {
-                return null;
-            }
-            return string.Concat(atomOrder.Select(atom =>
-            {
-                return dictAtomCounts.TryGetValue(atom, out var atomCount) && atomCount != 0 ? // We have seen things like C30H46N2O1XeH'0 in the wild - H' won't be in dictAtomCounts
-                    (atomCount > 1 ? $@"{atom}{atomCount.ToString(CultureInfo.InvariantCulture)}" : atom) :
-                    string.Empty;
-            })); 
+            return Molecule.FromDict(result);
         }
 
         /// <summary>
         /// Find the C'3O"2 in  C'3C2H9H'0NO2O"2S (yes, H'0 - seen in the wild - but drop zero counts)
         /// </summary>
-        public IDictionary<string, int> FindIsotopeLabelsInFormula(string desc)
+        public static IDictionary<string, int> FindIsotopeLabelsInFormula(string desc)
         {
             if (string.IsNullOrEmpty(desc))
                 return null;
-            var parse = desc;
-            var dictAtomCounts = new Dictionary<string, int>();
-            ParseCounts(ref parse, dictAtomCounts, false);
-            return dictAtomCounts.Where(pair => DICT_HEAVYSYMBOL_TO_MONOSYMBOL.ContainsKey(pair.Key)).ToDictionary(p => p.Key, p => p.Value); 
+            var mol = Molecule.Parse(desc);
+            return FindIsotopeLabelsInFormula(mol);
+        }
+
+        public static IDictionary<string, int> FindIsotopeLabelsInFormula(IEnumerable<KeyValuePair<string, int>> desc)
+        {
+            return desc?.Where(pair => DICT_HEAVYSYMBOL_TO_MONOSYMBOL.ContainsKey(pair.Key)).ToDictionary(p => p.Key, p => p.Value);
         }
 
         /// <summary>
         /// Find the intersection of a list of formulas, ignoring labels
         /// e.g. for C12H3H'2S2, C10H5, and C10H4Nz, return C10H4
         /// </summary>
-        public string FindFormulaIntersectionUnlabeled(IEnumerable<string> formulas)
+        public static Molecule FindFormulaIntersectionUnlabeled(IEnumerable<Molecule> formulas)
         {
-            var unlabeled = formulas.Select(f => MONOISOTOPIC.StripLabelsFromFormula(f)).ToList();
+            var unlabeled = formulas.Select(StripLabelsFromFormula).ToList();
             return FindFormulaIntersection(unlabeled);
         }
 
@@ -720,18 +601,18 @@ namespace pwiz.Skyline.Util
         /// Find the intersection of a list of formulas
         /// e.g. for C12H5S2, C10H5, and C10H4Nz, return C10H4
         /// </summary>
-        public string FindFormulaIntersection(IList<string> formulas)
+        public static Molecule FindFormulaIntersection(IList<Molecule> formulas)
         {
             if (formulas.Count == 0)
-                return string.Empty;
+                return Molecule.Empty;
             if (formulas.Count == 1)
                 return formulas[0];
-            if (formulas.Count == 2 && string.Equals(formulas[0], formulas[1]))
+            if (formulas.Count == 2 && formulas[0].Equals(formulas[1]))
                 return formulas[0];
-            var common = Molecule.ParseExpressionToDictionary(formulas[0]);
+            var common = new Dictionary<string, int>(formulas[0]);
             for (var i = 1; i < formulas.Count; i++)
             {
-                var next = Molecule.ParseExpression(formulas[i]);
+                var next = formulas[i];
                 foreach (var kvp in next)
                 {
                     int count;
@@ -740,15 +621,15 @@ namespace pwiz.Skyline.Util
                         common[kvp.Key] = Math.Min(count, kvp.Value);
                     }
                 }
-                foreach (var kvp in common)
+                foreach (var key in common.Keys.ToArray())
                 {
-                    if (!next.ContainsKey(kvp.Key) || next[kvp.Key] == 0)
+                    if (!next.ContainsKey(key) || next[key] == 0)
                     {
-                        common[kvp.Key] = 0;
+                        common[key] = 0;
                     }
                 }
             }
-            return Molecule.FromDict(common).ToString();
+            return Molecule.FromDict(common);
         }
 
         /// <summary>
@@ -777,249 +658,39 @@ namespace pwiz.Skyline.Util
         }
 
         /// <summary>
-        /// For fixing up old custom ion formulas in which we artificially
-        /// reduced the hydrogen count by one, in anticipation of our
-        /// calculations adding it back in because they thought that was
-        /// the only kind of ionization.  Now we assume that the formula is that
-        /// of the ion, and don't perform protonation by adding a hydrogen mass
-        /// </summary>
-        /// <param name="formula">the formula that needs an H added</param>
-        /// <returns></returns>
-        public static string AddH(string formula)
-        {
-            bool foundH = false;
-            string result = string.Empty;
-            string desc = formula;
-            desc = desc.Trim();
-            while (desc.Length > 0)
-            {
-                string sym = NextSymbol(desc);
-                double massAtom = AVERAGE.GetMass(sym);
-
-                // Stop if unrecognized atom found.
-                if (massAtom == 0)
-                {
-                    // CONSIDER: Throw with a useful message?
-                    break;
-                }
-                result += sym;
-                desc = desc.Substring(sym.Length);
-                int endCount = 0;
-                while (endCount < desc.Length && Char.IsDigit(desc[endCount]))
-                    endCount++;
-
-                if (sym == H)
-                {
-                    foundH = true;
-                    int count = 1;
-                    if (endCount > 0)
-                        count = int.Parse(desc.Substring(0, endCount), CultureInfo.InvariantCulture);
-                    result += (count + 1).ToString(CultureInfo.InvariantCulture);
-                }
-                else
-                {
-                    result += desc.Substring(0, endCount);
-                }
-                desc = desc.Substring(endCount).TrimStart();
-            }
-            if (!foundH)  // CONSIDER: bspratt is this really what we want?  CO2 -> CO2H?
-                result +=  H; 
-            return result;
-        }
-
-        /// <summary>
         /// Parses a chemical formula expressed as "[{atom}[count][spaces]]*",
         /// e.g. "C6H11ON", where supported atoms are H, O, N, C, S or P, etc.
         /// returning the total mass for the formula.
+        ///
+        /// Simple formula math like "C12H5-C3H2" is supported.
         /// 
-        /// The parser removes atoms and counts until it encounters a character
-        /// it does not understand as being part of the chemical formula.
-        /// The remainder is returned in the desc parameter.
-        /// 
-        /// This parser will stop at the first minus sign. If you need to parse
-        /// an expression that might contain a minus sign, use <see cref="ParseMassExpression"/>.
         /// </summary>
-        /// <param name="desc">Input description, and remaining string after parsing</param>
-        /// <param name="molReturn">Optional dictionary for returning the atoms and counts</param>
+        /// <param name="formula">Input description, and remaining string after parsing</param>
+        /// <param name="molReturn">Returns the atoms and counts</param>
         /// <returns>Total mass of formula parsed</returns>
-        public double ParseMass(ref string desc, Dictionary<string, int> molReturn = null)
+        public TypedMass ParseFormulaMass(string formula, out MoleculeMassOffset molReturn)
         {
-            double totalMass = 0.0;
-            desc = desc.Trim();
-            Molecule mol;
-            Adduct adduct;
-            string neutralFormula;
-            Dictionary<string, int> dict = null;
-            if (IonInfo.IsFormulaWithAdduct(desc, out mol, out adduct, out neutralFormula))
-            {
-                totalMass += mol.Sum(p => p.Value*GetMass(p.Key));
-                desc = string.Empty; // Signal that we parsed the whole thing
-                if (molReturn != null)
-                {
-                    dict = mol.Dictionary.ToDictionary(kvp=>kvp.Key, kvp=>kvp.Value);
-                }
-            }
-            else
-            {
-                if (molReturn != null)
-                {
-                    dict = new Dictionary<string, int>();
-                }
-                while (desc.Length > 0)
-                {
-                    string sym = NextSymbol(desc);
-                    double massAtom = GetMass(sym);
-
-                    // Stop if unrecognized atom found.
-                    if (massAtom == 0)
-                    {
-                        // CONSIDER: Throw with a useful message?
-                        break;
-                    }
-
-                    desc = desc.Substring(sym.Length);
-                    int endCount = 0;
-                    while (endCount < desc.Length && Char.IsDigit(desc[endCount]))
-                        endCount++;
-
-                    var count = 1;
-                    if (endCount > 0)
-                    {
-                        if (!int.TryParse(desc.Substring(0, endCount), out count))
-                            count = int.MaxValue; // We know at this point that it should parse, so it's probably just too big
-                    }
-                    totalMass += massAtom * count;
-                    if (dict != null)
-                    {
-                        if (dict.TryGetValue(sym, out var oldCount))
-                        {
-                            dict[sym] = count + oldCount;
-                        }
-                        else
-                        {
-                            dict.Add(sym, count);
-                        }
-                    }
-                    desc = desc.Substring(endCount).TrimStart();
-                }
-            }
-
-            if (molReturn != null)
-            {
-                foreach (var kvp in dict)
-                {
-                    var sym = kvp.Key;
-                    var count = kvp.Value;
-                    if (molReturn.TryGetValue(sym, out var oldCount))
-                    {
-                        molReturn[sym] = count + oldCount;
-                    }
-                    else
-                    {
-                        molReturn.Add(sym, count);
-                    }
-                }
-            }
-            return totalMass;            
+            molReturn = ParsedMoleculeMassOffset.Create(formula);
+            return CalculateMass(molReturn.Molecule) + molReturn.GetMassOffset(MassType);
         }
 
-        /// <summary>
-        /// Parse a formula which may contain both positive and negative parts (e.g. "C'4-C4").
-        /// </summary>
-        public double ParseMassExpression(ref string desc)
-        {
-            double totalMass = ParseMass(ref desc);
-            if (desc.StartsWith(@"-"))
-            {
-                // As is deprotonation description ie C12H8O2-H (=C12H7O2) or even C12H8O2-H2O (=C12H6O)
-                desc = desc.Substring(1);
-                totalMass -= ParseMass(ref desc);
-            }
-            return totalMass;
-        }
-
-        public double ParseMass(IDictionary<string, int> desc)
+        public TypedMass CalculateMass(IDictionary<string, int> desc)
         {
             double totalMass = 0;
+            var isHeavy = false;
             foreach (var elementCount in desc)
             {
-                double massAtom = GetMass(elementCount.Key);
-
                 // Stop if unrecognized atom found.
-                if (massAtom == 0)
+                if (!_atomicMasses.TryGetValue(elementCount.Key, out var massInfo))
                 {
-                    // CONSIDER: Throw with a useful message?
-                    break;
+                    ThrowArgumentException(elementCount.Key); // Did not parse completely
                 }
-                totalMass += massAtom * elementCount.Value;
+                totalMass += massInfo._mass * elementCount.Value;
+                isHeavy |= massInfo._bHeavy;
             }
-            return totalMass;
-        }
 
-        /// <summary>
-        /// Add or subtract the atom counts from a molecular formula to a <see cref="IDictionary{TKey,TValue}"/>
-        /// of atomic symbols and counts.
-        /// </summary>
-        /// <param name="desc">Molecular formula</param>
-        /// <param name="dictAtomCounts">Dictionary of atomic symbols and counts (may already contain counts from other formulas)</param>
-        /// <param name="negative">True if counts should be subtracted</param>
-        /// <param name="atomOrder">If non-null, used to note order of appearance of atomic symbols in formula</param>
-        public void ParseCounts(ref string desc, IDictionary<string, int> dictAtomCounts, bool negative, IList<string> atomOrder=null)
-        {
-            if (string.IsNullOrEmpty(desc))
-            {
-                return;
-            }
-            desc = desc.Trim();
-            while (desc.Length > 0)
-            {
-                if (desc.StartsWith(@"-"))
-                {
-                    // As is deprotonation description ie C12H8O2-H (=C12H7O2) or even C12H8O2-H2O (=C12H6O)
-                    desc = desc.Substring(1);
-                    ParseCounts(ref desc, dictAtomCounts, !negative, atomOrder);
-                    break;
-                }
-                string sym = NextSymbol(desc);
-                double massAtom = GetMass(sym);
-
-                // Stop if unrecognized atom found.
-                if (massAtom == 0)
-                {
-                    // CONSIDER: Throw with a useful message?
-                    break;
-                }
-
-                desc = desc.Substring(sym.Length);
-                int endCount = 0;
-                while (endCount < desc.Length && Char.IsDigit(desc[endCount]))
-                    endCount++;
-
-                int count = 1;
-                if (endCount > 0)
-                    count = int.Parse(desc.Substring(0, endCount), CultureInfo.InvariantCulture);
-
-                if (negative)
-                    count = -count;
-
-                if (dictAtomCounts.ContainsKey(sym))
-                {
-                    dictAtomCounts[sym] += count;
-                }
-                else
-                {
-                    dictAtomCounts.Add(sym, count);
-                    if (atomOrder != null)
-                    {
-                        atomOrder.Add(sym);
-                    }
-                }
-
-                if (dictAtomCounts[sym] == 0)
-                    dictAtomCounts.Remove(sym);
-
-                desc = desc.Substring(endCount).TrimStart();
-            }
+            var massType = isHeavy ? (MassType | MassType.bHeavy) : MassType;
+            return TypedMass.Create(totalMass, massType);
         }
 
         /// <summary>
@@ -1029,9 +700,8 @@ namespace pwiz.Skyline.Util
         /// <returns>The mass of the single atom</returns>
         public double GetMass(string sym)
         {
-            double mass;
-            if (_atomicMasses.TryGetValue(sym, out mass))
-                return mass;
+            if (_atomicMasses.TryGetValue(sym, out var massInfo))
+                return massInfo._mass;
             return 0;
         }
 
@@ -1044,6 +714,8 @@ namespace pwiz.Skyline.Util
         /// <param name="ave">Average mass</param>
         private void AddMass(string sym, double ave)
         {
+            var bHeavy = IsSkylineHeavySymbol(sym) || DICT_HEAVYSYMBOL_NICKNAMES.Keys.Any(sym.Equals); // Matches D, T, anything with ' or "
+
             if (MassType.IsMonoisotopic())
             {
                 double monoMass;
@@ -1056,11 +728,12 @@ namespace pwiz.Skyline.Util
                     // It's a special element such as H" which is just a single isotope: the mono mass is the average mass
                     monoMass = ave;
                 }
-                _atomicMasses[sym] = monoMass;
+
+                _atomicMasses[sym] = new MassInfo() { _mass = monoMass, _bHeavy = bHeavy };
             }
             else
             {
-                _atomicMasses[sym] = ave;
+                _atomicMasses[sym] = new MassInfo() { _mass = ave, _bHeavy = bHeavy };
             }
         }
 

--- a/pwiz_tools/Skyline/Util/Extensions/MassTypeLocalizationExtension.cs
+++ b/pwiz_tools/Skyline/Util/Extensions/MassTypeLocalizationExtension.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * Original author: Brian Pratt <bspratt .at. proteinms.net>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2023 University of Washington - Seattle, WA
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using pwiz.Common.Chemistry;
+using pwiz.Skyline.Properties;
+
+namespace pwiz.Skyline.Util.Extensions
+{
+    public static class MassTypeLocalizationExtension
+    {
+        private static string[] LOCALIZED_VALUES
+        {
+            get
+            {
+                return new[]
+                {
+                    Resources.ExportStrategyExtension_LOCALIZED_VALUES_Monoisotopic,
+                    Resources.ExportStrategyExtension_LOCALIZED_VALUES_Average
+                };
+            }
+        }
+        public static string GetLocalizedString(this MassType val)
+        {
+            return LOCALIZED_VALUES[(int)val & (int)MassType.Average]; // Strip off bMassH, bHeavy
+        }
+
+        public static MassType GetEnum(string enumValue)
+        {
+            return Helpers.EnumFromLocalizedString<MassType>(enumValue, LOCALIZED_VALUES);
+        }
+
+        public static MassType GetEnum(string enumValue, MassType defaultValue)
+        {
+            return Helpers.EnumFromLocalizedString(enumValue, LOCALIZED_VALUES, defaultValue);
+        }
+
+    }
+}

--- a/pwiz_tools/Skyline/Util/HillSystemOrdering.cs
+++ b/pwiz_tools/Skyline/Util/HillSystemOrdering.cs
@@ -1,0 +1,194 @@
+﻿/*
+ * Original author: Brian Pratt <bspratt .at. proteinms.net>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2023 University of Washington - Seattle, WA
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using pwiz.Common.Chemistry;
+
+namespace pwiz.Skyline.Util
+{
+    /// <summary>
+    /// Implements ToOrderedString(Molecule molecule, string orderOverride) which performs
+    /// ToString on a molecule, but enforcing Hill System order (C, H, then alphabetically)
+    /// or a custom order based on an order override string like "Cl3N2D" (so Cl, N, H, D, then alphabetically -
+    /// note that it understands the isotope notation "D" and includes H in the sort order)
+    /// </summary>
+    public class HillSystemOrdering : IComparer<string>
+    {
+        internal static HillSystemOrdering DEFAULT_ORDER = new HillSystemOrdering(null)
+        {
+            _elementOrder = new Dictionary<string, int>()
+                {
+                    { @"C", 0 }, { @"C'", 1 }, { @"C\", 2 },
+                    { @"H", 3 }, { @"H'", 4 }, { @"D", 5 }, { @"H\", 6 }, { @"T", 7 }
+                },
+            _checkIsotopes = false
+        };
+
+        private HillSystemOrdering(string orderOverride)
+        {
+            if (!string.IsNullOrEmpty(orderOverride))
+            {
+                var elements = Regex.Matches(orderOverride, @"([A-Z][a-z]?)");
+                _elementOrder = new Dictionary<string, int>();
+                foreach (Match m in elements)
+                {
+                    if (!_elementOrder.ContainsKey(m.Value))
+                    {
+                        _elementOrder[m.Value] = _elementOrder.Count;
+                    }
+                    _hasIsotopesInOrderHint |= BioMassCalc.DICT_HEAVYSYMBOL_TO_MONOSYMBOL.ContainsKey(m.Value);
+                }
+                _checkIsotopes = true;
+            }
+        }
+
+        private Dictionary<string, int> _elementOrder;
+        private bool _checkIsotopes;
+        private bool _hasIsotopesInOrderHint;
+
+        // Try to find element's place in the original order, treating elements and their isotopes as interchangeable for position purposes
+        private int IndexOfElementOrRelatedIsotope(string element)
+        {
+            if (_elementOrder.TryGetValue(element, out var order))
+            {
+                return order;
+            }
+
+            if (!_checkIsotopes)
+            {
+                return -1;
+            }
+
+            // Maybe it was an isotope that got changed to light e.g. original string was C'2 but now dictionary holds C2
+            if (BioMassCalc.DICT_HEAVYSYMBOL_TO_MONOSYMBOL.TryGetValue(element, out var light))
+            {
+                if (_elementOrder.TryGetValue(light, out order))
+                {
+                    return order;
+                }
+            }
+
+            if (_hasIsotopesInOrderHint)
+            {
+                // Maybe it was a light that got changed to an isotope  e.g. original string was C2 but now dictionary holds C"2
+                foreach (var kvp in
+                         BioMassCalc.DICT_HEAVYSYMBOL_TO_MONOSYMBOL.Where(kvp => Equals(kvp.Value, element)))
+                {
+                    if (_elementOrder.TryGetValue(kvp.Key, out order))
+                    {
+                        return order;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        int IComparer<string>.Compare(string xElement, string yElement)
+        {
+            var xOrder = IndexOfElementOrRelatedIsotope(xElement);
+            var yOrder = IndexOfElementOrRelatedIsotope(yElement);
+
+            if (xOrder == yOrder)
+            {
+                // Either they're isotopes of each other (e.g. H and H'), or two elements that weren't in the ordered list at all
+                if (BioMassCalc.ElementIsIsotopeOf(xElement, yElement))
+                {
+                    return 1; // X is an isotope of Y, so X should appear after Y in output string
+                }
+                if (BioMassCalc.ElementIsIsotopeOf(yElement, xElement))
+                {
+                    return -1; // Y is an isotope of X, so Y should appear after X in output string
+                }
+                return string.Compare(xElement, yElement, StringComparison.Ordinal);
+            }
+
+            return xOrder == -1 ?
+                1 : // Only yElement is in the known order, xElement should appear after yElement in output string
+                yOrder == -1 ? -1 : // Only xElement is in the known order, yElement should appear after xElement in output string
+                    xOrder.CompareTo(yOrder); // Both in known order, sort on that basis
+        }
+
+        /// <summary>
+        /// Perform ToString on a molecule, but enforcing Hill System order (C, H, then alphabetically)
+        /// or a custom order based on a string like "Cl3N2D"
+        /// </summary>
+        public static string ToOrderedString(Molecule mol, string orderOverride)
+        {
+            if (Molecule.IsNullOrEmpty(mol))
+            {
+                return string.Empty;
+            }
+
+            var result = new StringBuilder();
+            var anyNegative = false;
+
+            var elementOrderComparer = string.IsNullOrEmpty(orderOverride) ?
+                HillSystemOrdering.DEFAULT_ORDER :
+                new HillSystemOrdering(orderOverride);
+
+            // Write out the formula in the desired order
+            var orderedKeys = mol.Keys.OrderBy(k => k, elementOrderComparer).ToArray();
+            foreach (var key in orderedKeys)
+            {
+                var count = mol[key];
+                if (count > 0)
+                {
+                    result.Append(key);
+                    if (count != 1) // "H" is same as "H1"
+                    {
+                        result.Append(count);
+                    }
+                }
+                else if (count < 0)
+                {
+                    anyNegative = true;
+                }
+            }
+
+            if (anyNegative)
+            {
+                result.Append(@"-");
+                foreach (var key in orderedKeys)
+                {
+                    var count = mol[key];
+                    if (count < 0)
+                    {
+                        {
+                            result.Append(key);
+                            if (count != -1)
+                            {
+                                result.Append(-count);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return result.ToString();
+        }
+    }
+
+
+
+}

--- a/pwiz_tools/Skyline/Util/IonInfo.cs
+++ b/pwiz_tools/Skyline/Util/IonInfo.cs
@@ -16,12 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using System;
-using System.Collections.Generic;
-using System.Linq;
+
 using pwiz.Common.Chemistry;
 using pwiz.Common.SystemUtil;
-using pwiz.Skyline.Properties;
 
 namespace pwiz.Skyline.Util
 {
@@ -32,22 +29,29 @@ namespace pwiz.Skyline.Util
     ///  </summary>
     public class IonInfo : Immutable
     {
-
-        private string _formula;  // Chemical formula, possibly followed by adduct description - something like "C12H3[M+H]" or "[2M+K]" or "M+H" or "[M+H]+" or "[M+Br]-" 
-        private string _unlabledFormula;   // Chemical formula after adduct application and stripping of labels
-
+        private MoleculeMassOffset _neutralFormula; // Chemical formula and/or unexplained masses, no adduct applied
+        private Adduct _adduct;
+        private MoleculeMassOffset _ionFormula;  // Chemical formula and/or unexplained masses after adduct application
+        private MoleculeMassOffset _unlabledFormula;   // Chemical formula after adduct application and stripping of labels
 
         /// <summary>
         /// Constructs an IonInfo, which holds a neutral formula and adduct, or possibly just a chemical formula if no adduct is included in the description
         /// </summary>
         public IonInfo(string formulaWithOptionalAdduct, Adduct adduct)
         {
-            Formula = formulaWithOptionalAdduct + adduct.AdductFormula;
+            var ionString = Adduct.SplitFormulaAndTrailingAdduct(formulaWithOptionalAdduct, Adduct.ADDUCT_TYPE.charge_only, out var parsedAdduct);
+            _adduct = Adduct.IsNullOrEmpty(adduct) ? parsedAdduct : adduct;
+            Formula = ParsedMoleculeMassOffset.Create(ionString);
         }
 
-        public IonInfo(string formulaWithOptionalAdduct)
+        public IonInfo(MoleculeMassOffset formula, Adduct adduct)
         {
-            Formula = formulaWithOptionalAdduct;
+            _adduct = Adduct.IsNullOrEmpty(adduct) ? Adduct.EMPTY : adduct;
+            Formula = formula;
+        }
+
+        public IonInfo(string formulaWithOptionalAdduct) : this(formulaWithOptionalAdduct, Adduct.EMPTY)
+        {
         }
 
         /// <summary>
@@ -60,30 +64,25 @@ namespace pwiz.Skyline.Util
         /// <summary>
         /// Formula description as originally provided to constructor.
         /// </summary>
-        public string Formula
+        public MoleculeMassOffset Formula
         {
-            get { return _formula; }
+            get { return _ionFormula; }
             protected set
             {
-                _formula = value;
-                _unlabledFormula = BioMassCalc.MONOISOTOPIC.StripLabelsFromFormula(FormulaWithAdductApplied);
-                Helpers.AssignIfEquals(ref _unlabledFormula, _formula); // Save some string space if actually unlableled
+                _neutralFormula = value;
+                _ionFormula = _adduct.IsEmpty ?  _neutralFormula : _adduct.ApplyToMolecule(_neutralFormula);
+                _unlabledFormula = BioMassCalc.StripLabelsFromFormula(_ionFormula);
             }
         }
 
         /// <summary>
         /// Internal formula description with adduct description stripped off, or null if there is no adduct description
         /// </summary>
-        public string NeutralFormula
+        public MoleculeMassOffset NeutralFormula
         {
             get
             {
-                var adductStart = AdductStartIndex;
-                if (adductStart == 0)
-                {
-                    return null; // There is no formula, just an adduct
-                }
-                return adductStart < 0 ? _formula : _formula.Substring(0, adductStart);
+                return _neutralFormula;
             }
         }
 
@@ -94,23 +93,14 @@ namespace pwiz.Skyline.Util
         {
             get
             {
-                int adductStart = AdductStartIndex;
-                return adductStart < 0 ? null : _formula.Substring(adductStart);
-            }
-        }
-
-        private int AdductStartIndex
-        {
-            get
-            {
-                return _formula != null ? _formula.IndexOf('[') : -1;
+                return _adduct.AdductFormula;
             }
         }
 
         /// <summary>
         /// Returns chemical formula with adduct applied then labels stripped
         /// </summary>
-        public string UnlabeledFormula
+        public MoleculeMassOffset UnlabeledFormula
         {
             get { return _unlabledFormula; }
         }
@@ -118,98 +108,30 @@ namespace pwiz.Skyline.Util
         /// <summary>
         /// Chemical formula after adduct description, if any, is applied
         /// </summary>
-        public string FormulaWithAdductApplied
+        public MoleculeMassOffset FormulaWithAdductApplied
         {
             get
             {
-                if (string.IsNullOrEmpty(AdductText))
-                {
-                    return _formula;
-                }
-                int charge;
-                var mol = ApplyAdductInFormula(_formula, out charge);
-                return mol.ToString();
+                return _ionFormula;
             }
-        }
-
-        public static bool EquivalentFormulas(string fL, string fR)
-        {
-            if (fL == null)
-            {
-                return fR == null;
-            }
-            if (fR == null)
-            {
-                return false;
-            }
-            if (Equals(fL, fR))
-            {
-                return true;
-            }
-            var moleculeL = Molecule.Parse(fL.Trim());
-            var moleculeR = Molecule.Parse(fR.Trim());
-            return moleculeL.Equals(moleculeR);
         }
 
         /// <summary>
-        /// Check to see if an adduct is only a charge declaration, as in "[M+]".
+        /// Take a chemical formula (possibly with mass modifier) and apply the described adduct to it.
         /// </summary>
-        /// <param name="formula">A string like "C12H3[M+H]"</param>
-        /// <returns>True if the adduct description contributes nothing to the ion formula other than charge information, such as "[M+]"</returns>
-        public static bool AdductIsChargeOnly(string formula)
-        {
-            int charge;
-            return Equals(ApplyAdductInFormula(formula, out charge), ApplyAdductInFormula(formula.Split('[')[0], out charge));
-        }
-
-        /// <summary>
-        /// Take a molecular formula with adduct in it and return a Molecule.
-        /// </summary>
-        /// <param name="formula">A string like "C12H3[M+H]"</param>
-        /// <param name="charge">Charge derived from adduct description by counting H, K etc as found in DICT_ADDUCT_ION_CHARGES</param>
-        /// <returns></returns>
-        public static Molecule ApplyAdductInFormula(string formula, out int charge)
-        {
-            var withoutAdduct = (formula ?? string.Empty).Split('[')[0];
-            var adduct = Adduct.FromStringAssumeProtonated((formula ?? string.Empty).Substring(withoutAdduct.Length));
-            charge = adduct.AdductCharge;
-            return ApplyAdductToFormula(withoutAdduct, adduct);
-        }
-
-        /// <summary>
-        /// Take a molecular formula and apply the described adduct to it.
-        /// </summary>
-        /// <param name="formula">A string like "C12H3"</param>
-        /// <param name="adduct">An adduct derived from a string like "[M+H]" or "[2M+K]" or "M+H" or "[M+H]+" or "[M+Br]- or "M2C13+Na" </param>
-        /// <returns>A Molecule whose formula is the combination of the input formula and adduct</returns>
-        public static Molecule ApplyAdductToFormula(string formula, Adduct adduct)
-        {
-            var resultDict = ApplyAdductToMoleculeAsDictionary(formula, adduct);
-            var resultMol = Molecule.FromDict(resultDict);
-            if (!resultMol.Keys.All(k => BioMassCalc.MONOISOTOPIC.IsKnownSymbol(k)))
-            {
-                throw new InvalidOperationException(string.Format(Resources.BioMassCalc_ApplyAdductToFormula_Unknown_symbol___0___in_adduct_description___1__, resultMol.Keys.First(k => !BioMassCalc.MONOISOTOPIC.IsKnownSymbol(k)), formula + adduct));
-            }
-            return resultMol;
-        }
-
-        /// <summary>
-        /// Take a molecular formula and apply the described adduct to it.
-        /// </summary>
-        /// <param name="formula">A string like "C12H3"</param>
+        /// <param name="formula">A string like "C12H3" or C11N3H5[+2.34]</param>
         /// <param name="adduct">An adduct derived from a string like "[M+H]" or "[2M+K]" or "M+H" or "[M+H]+" or "[M+Br]- or "M2C13+Na" </param>
         /// <returns>A dictionary of atomic elements and counts, resulting from the combination of the input formula and adduct</returns>
-        public static Dictionary<string, int> ApplyAdductToMoleculeAsDictionary(string formula, Adduct adduct)
+        public static MoleculeMassOffset ApplyAdductToFormula(string formula, Adduct adduct)
         {
-            var molecule = Molecule.Parse(formula.Trim());
-            var resultDict = new Dictionary<string, int>();
-            adduct.ApplyToMolecule(molecule, resultDict);
-            return resultDict;
+            var trimmed = formula.Trim();
+            var molecule = ParsedMoleculeMassOffset.Create(trimmed);
+            return adduct.ApplyToMolecule(molecule);
         }
 
-        public static bool IsFormulaWithAdduct(string formula, out Molecule molecule, out Adduct adduct, out string neutralFormula, bool strict = false)
+        public static bool IsFormulaWithAdduct(string formula, out MoleculeMassOffset molecule, out Adduct adduct, out string neutralFormula, bool strict = false)
         {
-            molecule = null;
+            molecule = MoleculeMassOffset.EMPTY;
             adduct = Adduct.EMPTY;
             neutralFormula = null;
             if (string.IsNullOrEmpty(formula))
@@ -217,23 +139,19 @@ namespace pwiz.Skyline.Util
                 return false;
             }
             // Does formula contain an adduct description?  If so, pull charge from that.
-            var parts = formula.Split('[');
-            if (parts.Length == 2 && parts[1].Count(c => c==']') == 1)
+            // Watch out for mass modifications, e.g. C12H5[+1.23][M+3H] 
+            neutralFormula = Adduct.SplitFormulaAndTrailingAdduct(formula, Adduct.ADDUCT_TYPE.non_proteomic, out adduct);
+            if (!adduct.IsEmpty)
             {
-                neutralFormula = parts[0];
-                var adductString = formula.Substring(neutralFormula.Length);
-                if (Adduct.TryParse(adductString, out adduct, Adduct.ADDUCT_TYPE.non_proteomic, strict))
-                {
-                    molecule = neutralFormula.Length > 0 ? ApplyAdductToFormula(neutralFormula, adduct) : Molecule.Empty;
-                    return true;
-                }
+                molecule = ApplyAdductToFormula(neutralFormula, adduct);
+                return true;
             }
             return false;
         }
 
         public override string ToString()
         {
-            return _formula ?? string.Empty;
+            return _ionFormula?.ToString() ?? string.Empty;
         }
     }
 }

--- a/pwiz_tools/Skyline/Util/ParsedMoleculeMassOffset.cs
+++ b/pwiz_tools/Skyline/Util/ParsedMoleculeMassOffset.cs
@@ -1,0 +1,245 @@
+﻿/*
+ * Original author: Brian Pratt <bspratt .at. protein.ms>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2023 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using pwiz.Common.Chemistry;
+
+namespace pwiz.Skyline.Util
+{
+
+    /// <summary>
+    ///
+    /// A molecule with optional mass offsets that can express the chemical formula it came from in its original form.
+    /// 
+    /// </summary>
+    public class ParsedMoleculeMassOffset : MoleculeMassOffset
+    {
+
+        private string _orderHintString;
+        private int _originalMoleculeHashCode;
+        public new static ParsedMoleculeMassOffset EMPTY = new ParsedMoleculeMassOffset(Molecule.Empty, TypedMass.ZERO_MONO_MASSNEUTRAL, TypedMass.ZERO_AVERAGE_MASSNEUTRAL, string.Empty, 0);
+
+        public new bool IsEmpty => ReferenceEquals(this, ParsedMoleculeMassOffset.EMPTY) || base.IsEmpty;
+
+        public static bool IsNullOrEmpty(ParsedMoleculeMassOffset parsedMoleculeMassOffset) => parsedMoleculeMassOffset == null || parsedMoleculeMassOffset.IsEmpty;
+
+        public static ParsedMoleculeMassOffset Create(double monoMassOffset, double averageMassOffset)
+        {
+            return Create(null,
+                monoMassOffset == 0 ? TypedMass.ZERO_MONO_MASSNEUTRAL : TypedMass.Create(monoMassOffset, MassType.Monoisotopic),
+                averageMassOffset == 0 ? TypedMass.ZERO_AVERAGE_MASSNEUTRAL : TypedMass.Create(averageMassOffset, MassType.Average));
+        }
+
+        public static ParsedMoleculeMassOffset Create(string formula, double monoMassOffset = 0, double averageMassOffset = 0)
+        {
+            return Create(formula, 
+                monoMassOffset == 0 ? TypedMass.ZERO_MONO_MASSNEUTRAL : TypedMass.Create(monoMassOffset, MassType.Monoisotopic),
+                averageMassOffset == 0 ? TypedMass.ZERO_AVERAGE_MASSNEUTRAL : TypedMass.Create(averageMassOffset, MassType.Average));
+        }
+
+        public static ParsedMoleculeMassOffset Create(MoleculeMassOffset formula)
+        {
+            return IsNullOrEmpty(formula) ?
+                EMPTY :
+                new ParsedMoleculeMassOffset(formula.Molecule, formula.MonoMassOffset, formula.AverageMassOffset, String.Empty, 0) ;
+        }
+
+        public static ParsedMoleculeMassOffset Create(string formulaAndMasses, TypedMass monoMassOffset, TypedMass averageMassOffset)
+        {
+            // Watch out for mass offsets appearing in the string representation
+            SplitFormulaAndMasses(formulaAndMasses, out var formula, out var monoDeclared, out var averageDeclared);
+            if (TypedMass.IsNullOrEmpty(monoMassOffset))
+            {
+                monoMassOffset = monoDeclared;
+                averageMassOffset = averageDeclared;
+            }
+
+            if (string.IsNullOrEmpty(formula) && TypedMass.IsNullOrEmpty(monoMassOffset) && TypedMass.IsNullOrEmpty(averageMassOffset))
+            {
+                return EMPTY;
+            }
+
+            try
+            {
+                var molecule = Molecule.Parse(formula, out var regularizedFormula);
+                monoMassOffset = TypedMass.IsNullOrEmpty(monoMassOffset) ? TypedMass.ZERO_MONO_MASSNEUTRAL : monoMassOffset;
+                averageMassOffset = TypedMass.IsNullOrEmpty(averageMassOffset) ? TypedMass.ZERO_AVERAGE_MASSNEUTRAL : averageMassOffset;
+                var result = new ParsedMoleculeMassOffset(molecule, monoMassOffset, averageMassOffset, regularizedFormula, molecule.GetHashCode());
+                return result;
+            }
+            catch (ArgumentException)
+            {
+                throw new ArgumentException(BioMassCalc.FormatArgumentExceptionMessage(formula));
+            }
+            
+        }
+
+        private ParsedMoleculeMassOffset(Molecule molecule, TypedMass monoMassOffset, TypedMass averageMassOffset, string formula, int originalMoleculeHashCode) :
+            base(molecule, monoMassOffset, averageMassOffset)
+        {
+            _orderHintString = formula;
+            _originalMoleculeHashCode = originalMoleculeHashCode;
+            var mass = BioMassCalc.MONOISOTOPIC.CalculateMass(molecule); // Syntax check, as well as noting any isotopes in formula
+            if (mass.IsHeavy())
+            {
+                MonoMassOffset = MonoMassOffset.ChangeIsHeavy(true);
+                AverageMassOffset = AverageMassOffset.ChangeIsHeavy(true);
+            }
+        }
+
+        public bool HasIsotopes() => MonoMassOffset.IsHeavy() || BioMassCalc.ContainsIsotopicElement(Molecule);
+
+        public override MoleculeMassOffset Change(Molecule newMolecule, TypedMass monoMassOffset, TypedMass averageMassOffset)
+        {
+            if (Molecule.IsNullOrEmpty(newMolecule) && monoMassOffset == 0 && averageMassOffset == 0)
+            {
+                return EMPTY;
+            }
+
+            if (Molecule.Equals(newMolecule) && MonoMassOffset.Equals(monoMassOffset) && AverageMassOffset.Equals(averageMassOffset))
+            {
+                return this;
+            }
+
+            return new ParsedMoleculeMassOffset(newMolecule, monoMassOffset, averageMassOffset, _orderHintString, _originalMoleculeHashCode);
+        }
+
+        public ParsedMoleculeMassOffset ChangeMolecule(Molecule newMolecule)
+        {
+            if (Molecule.Equals(newMolecule))
+            {
+                return this;
+            }
+            return new ParsedMoleculeMassOffset(newMolecule, MonoMassOffset, AverageMassOffset, _orderHintString, _originalMoleculeHashCode);
+        }
+        
+        public static bool TryParse(string formulaAndMasses, out ParsedMoleculeMassOffset result, out string errorMessage)
+        {
+            try
+            {
+                errorMessage = string.Empty;
+                result = Create(formulaAndMasses);
+                return true;
+            }
+            catch (ArgumentException e)
+            {
+                errorMessage = e.Message;
+                result = EMPTY;
+                return false;
+            }
+        }
+
+        public static bool StringContainsMassOffsetCue(string formula) =>
+            formula.Contains(MASS_MOD_CUE_PLUS) || formula.Contains(MASS_MOD_CUE_MINUS);
+
+        /// <summary>
+        ///  Separate the formula and mass offset declarations in a string
+        /// </summary>
+        /// <param name="formulaAndMasses">input string  e.g. "C12H5", "C12H5[-1.2/1.21]", "[+1.3/1.31]", "1.3/1.31", "C12H5[-1.2/1.21]-C2H[-1.1]"</param>
+        /// <param name="formula">string with any mass modifiers stripped out e.g.  "C12H5[-1.2/1.21]-C2H[-1.1]" ->  "C12H5-C2H" </param>
+        /// <param name="mono">effect of any mono mass modifiers e.g. "C12H5[-1.2/1.21]-C2H[-1.1]" => 0.1 </param>
+        /// <param name="average">effect of any avg mass modifiers e.g. "C12H5[-1.2/1.21]-C2H[-1.1]" => 0.11</param>
+        private static void SplitFormulaAndMasses(string formulaAndMasses, out string formula, out TypedMass mono, out TypedMass average)
+        {
+            mono = TypedMass.ZERO_MONO_MASSNEUTRAL;
+            average = TypedMass.ZERO_AVERAGE_MASSNEUTRAL;
+            formula = formulaAndMasses?.Trim();
+            if (string.IsNullOrEmpty(formula))
+            {
+                return;
+            }
+            // A few different possibilities here, e.g. "C12H5", "C12H5[-1.2/1.21]", "[+1.3/1.31]", "1.3/1.31"
+            // Also possibly  "C12H5[-1.2/1.21]-C2H[-1.1]"
+            double modMassMono = 0;
+            double modMassAvg = 0;
+            var position = 0;
+            while (StringContainsMassOffsetCue(formula))
+            {
+                var cuePlus = formula.IndexOf(MASS_MOD_CUE_PLUS, position, StringComparison.InvariantCulture);
+                var cueMinus = formula.IndexOf(MASS_MOD_CUE_MINUS, position, StringComparison.InvariantCulture);
+                if (cuePlus < 0)
+                {
+                    cuePlus = int.MaxValue;
+                }
+                if (cueMinus < 0)
+                {
+                    cueMinus = int.MaxValue;
+                }
+                // e.g. "C12H5[-1.2/1.21]", "{+1.3/1.31]",  "{-1.3]"
+                position = Math.Min(cuePlus, cueMinus);
+                var close = formula.IndexOf(']', position);
+                var parts = formula.Substring(position, close-position).Split('/');
+                double negate = Equals(cueMinus, position) ? -1 : 1;
+                if (formula.Substring(0, position).Contains('-'))
+                {
+                    negate *= -1;
+                }
+                var monoMass = negate * double.Parse(parts[0].Substring(2).Trim(), CultureInfo.InvariantCulture);
+                modMassMono += monoMass;
+                modMassAvg += (parts.Length > 1 ? negate * double.Parse(parts[1].Trim(), CultureInfo.InvariantCulture) : monoMass);
+                formula = formula.Substring(0, position) + formula.Substring(close+1);
+            }
+            if (formula.Contains(@"/"))
+            {
+                // e.g.  "1.3/1.31"
+                var parts = formula.Split(new[] { '/' });
+                modMassMono = double.Parse(parts[0], CultureInfo.InvariantCulture);
+                modMassAvg = double.Parse(parts[1], CultureInfo.InvariantCulture);
+                formula = string.Empty;
+            }
+
+            mono = TypedMass.Create(modMassMono, MassType.Monoisotopic); 
+            average = TypedMass.Create(modMassAvg, MassType.Average);
+        }
+
+        /// <summary>
+        /// Return a string representation as close as possible to the one that gave rise to this object
+        /// </summary>
+        public override string ChemicalFormulaString()
+        {
+            // Nicely format the part of the object that's described as a chemical formula.
+            if (IsMassOnly)
+            {
+                return string.Empty;
+            }
+
+            // It's likely that _orderHintString is the very string that this was built from, if so just return that
+            if (!string.IsNullOrEmpty(_orderHintString) && Molecule.GetHashCode() == _originalMoleculeHashCode)
+            {
+                return _orderHintString;
+            }
+
+            // Otherwise, we need to rebuild the string from the molecule, using the order hint if available, ir Hill System order if not
+            return HillSystemOrdering.ToOrderedString(Molecule, _orderHintString);
+        }
+
+        public IEnumerator<KeyValuePair<string, int>> GetEnumerator()
+        {
+            return Molecule.GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            return ToString(BioMassCalc.MassPrecision);
+        }
+        
+    }
+}

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -1507,7 +1507,7 @@ namespace pwiz.Skyline.Util
 
         public static TEnum EnumFromLocalizedString<TEnum>(string value, string[] localizedStrings, TEnum defaultValue)
         {
-            int i = localizedStrings.IndexOf(v => Equals(v, value));
+            int i = localizedStrings.IndexOf(v => Equals(v, value??string.Empty));
             return (i == -1 ? defaultValue : (TEnum) (object) i);
         }
 

--- a/pwiz_tools/Skyline/Util/Xml.cs
+++ b/pwiz_tools/Skyline/Util/Xml.cs
@@ -27,6 +27,7 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using pwiz.Common.Chemistry;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.Hibernate;
 using pwiz.Skyline.Properties;
@@ -275,6 +276,12 @@ namespace pwiz.Skyline.Util
         {
             if (value.HasValue)
                 writer.WriteAttribute(name, value.Value);
+        }
+
+        public static void WriteAttributeNullable(this XmlWriter writer, Enum name, double? value, int precision)
+        {
+            if (value.HasValue)
+                writer.WriteAttribute(name, value.Value, precision);
         }
 
         public static void WriteAttributeIfString(this XmlWriter writer, Enum name, string value)
@@ -959,6 +966,18 @@ namespace pwiz.Skyline.Util
                 sb.Append(str[i]);
             }
             return sb.ToString();
+        }
+
+        // Inspect a file path for characters that must be escaped for use in XML (currently just "&")
+        // Return a suitably escaped version of the string
+        public static string EscapePath(string path)
+        {
+            if (path.Contains(@"&")) // Valid windows filename character, may need escaping
+            {
+                // But it may also be in use as an escape character - don't mess with &quot; etc
+                path = Regex.Replace(path, @"&(?!(?:apos|quot|[gl]t|amp);|#)", @"&amp;");
+            }
+            return path;
         }
 
         public static string GetInvalidDataMessage(string path, Exception x)


### PR DESCRIPTION
  - More use of MoleculeMassOffset instead of strings for internal representation of molecules. Increasingly we need to track mass offset in addition to chemical formula (e.g. crosslinking, feature finding) this tides that up
  - Centralized molecule string parsing code including handling of formula math (e.g. "C12H5NO-H2O"). Now it's all done in BioMassCalc (formerly there were a few other places doing string manipulation)
  - Moved TypedMass to pwiz_tools/Shared/Common/Chemistry for use with MoleculeMassOffset  mass offset values
  - Skyline/Util/ParsedMoleculeMassOffset extends MoleculeMassOffset for molecules whose formulas need to be represented to users in their original form (wasn't a problem when we just carried strings around, but just showing the elements in alpha sort order is confusing in many cases (e.g. user input N1C12S3H but we show "C12HNS3" instead of "N1C12S3H" - funky order but presumably it means something to them for downstream tools table lookups or whatever)
  - TypedMass and MoleculeMassOffset ctors are now private - using Create() and Change() methods instead prevents duplication of objects - especially empty ones
  - BioMassCalc ctor is now private, with a GetBioMassCalc() function that provides already-constructed objects for reuse
  - Tweaks to BioMassCalc to make it cheaper to ask about presence of isotopes in formulas

This is in support of the feature detection work where formula+offset is important, though that's not included here for clarity of purpose.
