### PR TITLE
Change "_skylineTextBoxStreamWriterHelper" to be instance variable

### DIFF
--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -2867,7 +2867,7 @@ namespace pwiz.Skyline
                     if (_tool.OutputToImmediateWindow)
                     {
                         _parent.ShowImmediateWindow();
-                        _tool.RunTool(_parent.Document, _parent, _skylineTextBoxStreamWriterHelper, _parent, _parent);
+                        _tool.RunTool(_parent.Document, _parent, _parent._skylineTextBoxStreamWriterHelper, _parent, _parent);
                     }
                     else
                     {
@@ -2910,7 +2910,7 @@ namespace pwiz.Skyline
             }
         }
 
-        public static TextBoxStreamWriterHelper _skylineTextBoxStreamWriterHelper;
+        private TextBoxStreamWriterHelper _skylineTextBoxStreamWriterHelper;
 
         private ImmediateWindow CreateImmediateWindow()
         {


### PR DESCRIPTION
I noticed that when TestToolService fails, the contents of the Immediate Window includes all of the text from earlier tests that have run (everything since the last time ImmediateWindow.Clear was called by any of a couple of tests. I cannot think of any reason that we would want the immediate window to behave that way so I will change "_skylineTextBoxStreamWriterHelper" to be an instance variable instead of static.