### PR TITLE
Fix some issues revealed by PR#2405 ("AssertSerializable")

### DIFF
--- a/pwiz_tools/Skyline/Model/PeptideDocNode.cs
+++ b/pwiz_tools/Skyline/Model/PeptideDocNode.cs
@@ -873,7 +873,7 @@ namespace pwiz.Skyline.Model
                             explicitMods.GetHeavyModifications().ToArray(),
                             ExplicitMods.GetHeavyModifications().ToArray()) ||
                         !ReferenceEquals(explicitMods.StaticModifications, ExplicitMods.StaticModifications)
-                       )
+                        || !Equals(explicitMods.CrosslinkStructure, ExplicitMods.CrosslinkStructure))
                     {
                         diff = new SrmSettingsDiff(diff, SrmSettingsDiff.ALL);
                     }

--- a/pwiz_tools/Skyline/Model/TransitionDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionDocNode.cs
@@ -845,7 +845,8 @@ namespace pwiz.Skyline.Model
                             {
                                 StdDev = peakShapeValues.Value.StdDev,
                                 Skewness = peakShapeValues.Value.Skewness,
-                                Kurtosis = peakShapeValues.Value.Kurtosis
+                                Kurtosis = peakShapeValues.Value.Kurtosis,
+                                ShapeCorrelation = peakShapeValues.Value.ShapeCorrelation
                             };
                     }
                     yield return transitionPeak;

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -21093,29 +21093,11 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Attempted modification of a read-only collection..
-        /// </summary>
-        public static string OneOrManyList_Add_Attempted_modification_of_a_read_only_collection {
-            get {
-                return ResourceManager.GetString("OneOrManyList_Add_Attempted_modification_of_a_read_only_collection", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The index {0} must be 0 for a single entry list..
         /// </summary>
         public static string OneOrManyList_ValidateIndex_The_index__0__must_be_0_for_a_single_entry_list {
             get {
                 return ResourceManager.GetString("OneOrManyList_ValidateIndex_The_index__0__must_be_0_for_a_single_entry_list", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The index {0} must be between 0 and {1}..
-        /// </summary>
-        public static string OneOrManyList_ValidateIndex_The_index__0__must_be_between_0_and__1__ {
-            get {
-                return ResourceManager.GetString("OneOrManyList_ValidateIndex_The_index__0__must_be_between_0_and__1__", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -6860,14 +6860,8 @@ Skylineにインポートする前に必要に応じてライブラリをフィ�
   <data name="OK" xml:space="preserve">
     <value>OK</value>
   </data>
-  <data name="OneOrManyList_Add_Attempted_modification_of_a_read_only_collection" xml:space="preserve">
-    <value>読み取り専用コレクションの修飾を試みました。</value>
-  </data>
   <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_0_for_a_single_entry_list" xml:space="preserve">
     <value>単一入力エントリリストに対するインデックス{0}は0でなければなりません。</value>
-  </data>
-  <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_between_0_and__1__" xml:space="preserve">
-    <value>インデックス{0}は0と{1}の間でなければなりません。</value>
   </data>
   <data name="Open" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\open.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -1341,9 +1341,6 @@
   <data name="FindNodeDlg_AdvancedVisible_Hide_Advanced" xml:space="preserve">
     <value>&lt;&lt; Hide Ad&amp;vanced</value>
   </data>
-  <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_between_0_and__1__" xml:space="preserve">
-    <value>The index {0} must be between 0 and {1}.</value>
-  </data>
   <data name="OptimizationDb_GetOptimizationDb_The_file__0__could_not_be_opened___1_" xml:space="preserve">
     <value>The file {0} could not be opened. {1}</value>
   </data>
@@ -3434,9 +3431,6 @@ Are you sure you want to continue?</value>
   </data>
   <data name="DefineAnnotationDlg_OkDialog_Choose_at_least_one_type_for_this_annotation_to_apply_to" xml:space="preserve">
     <value>Choose at least one type for this annotation to apply to.</value>
-  </data>
-  <data name="OneOrManyList_Add_Attempted_modification_of_a_read_only_collection" xml:space="preserve">
-    <value>Attempted modification of a read-only collection.</value>
   </data>
   <data name="PeptideGridViewDriver_ValidateRow_Missing_value_on_line__0_" xml:space="preserve">
     <value>Missing value on line {0}</value>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -6867,14 +6867,8 @@ Example: Looplink: T [4]
   <data name="OK" xml:space="preserve">
     <value>确定</value>
   </data>
-  <data name="OneOrManyList_Add_Attempted_modification_of_a_read_only_collection" xml:space="preserve">
-    <value>尝试修饰一个只读采集。</value>
-  </data>
   <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_0_for_a_single_entry_list" xml:space="preserve">
     <value>指数 {0} 针对单一条目列表必须是 0。</value>
-  </data>
-  <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_between_0_and__1__" xml:space="preserve">
-    <value>指数 {0} 必须在 0 和 {1} 之间。</value>
   </data>
   <data name="Open" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\open.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -1482,7 +1482,9 @@
     <Compile Include="Model\MultiProgressStatus.cs" />
     <Compile Include="Model\OptimizationStep.cs" />
     <Compile Include="Model\DocSettings\IsotopeEnrichments.cs" />
-    <Compile Include="Model\DocSettings\Loss.cs" />
+    <Compile Include="..\..\..\sky_assertserializable\pwiz_tools\Skyline\Model\DocSettings\Loss.cs">
+      <Link>Model\DocSettings\Loss.cs</Link>
+    </Compile>
     <Compile Include="Model\DocSettings\MeasuredIon.cs" />
     <Compile Include="Model\DocSettings\UniMod.cs" />
     <Compile Include="Model\DocSettings\UniModData.cs" />

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -1482,9 +1482,7 @@
     <Compile Include="Model\MultiProgressStatus.cs" />
     <Compile Include="Model\OptimizationStep.cs" />
     <Compile Include="Model\DocSettings\IsotopeEnrichments.cs" />
-    <Compile Include="..\..\..\sky_assertserializable\pwiz_tools\Skyline\Model\DocSettings\Loss.cs">
-      <Link>Model\DocSettings\Loss.cs</Link>
-    </Compile>
+    <Compile Include="Model\DocSettings\Loss.cs" />
     <Compile Include="Model\DocSettings\MeasuredIon.cs" />
     <Compile Include="Model\DocSettings\UniMod.cs" />
     <Compile Include="Model\DocSettings\UniModData.cs" />

--- a/pwiz_tools/Skyline/TestFunctional/EditNeutralLossesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditNeutralLossesTest.cs
@@ -1,0 +1,109 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2023 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.Properties;
+using pwiz.Skyline.SettingsUI;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTestFunctional
+{
+    /// <summary>
+    /// Tests that adding a loss on a modification which already has some losses
+    /// correctly updates transitions whose loss indexes got shifted.
+    /// </summary>
+    [TestClass]
+    public class EditNeutralLossesTest : AbstractFunctionalTest
+    {
+        [TestMethod]
+        public void TestEditNeutralLosses()
+        {
+            RunFunctionalTest();
+        }
+
+        protected override void DoTest()
+        {
+            const string modificationName = "MyModification";
+            // Define a modification with one loss
+            RunLongDlg<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI, peptideSettingsUi =>
+                {
+                    RunUI(()=>peptideSettingsUi.SelectedTab = PeptideSettingsUI.TABS.Modifications);
+                    RunLongDlg<EditListDlg<SettingsListBase<StaticMod>, StaticMod>>(peptideSettingsUi.EditStaticMods,
+                        editStaticMods =>
+                        {
+                            RunLongDlg< EditStaticModDlg>(editStaticMods.AddItem, editStaticMod =>
+                            {
+                                RunUI(() =>
+                                {
+                                    editStaticMod.Modification =
+                                        new StaticMod(modificationName, null, null, "H10O6");
+                                });
+                                RunDlg<EditFragmentLossDlg>(editStaticMod.AddLoss, editFragmentLossDlg =>
+                                {
+                                    editFragmentLossDlg.Loss = new FragmentLoss("H4O2", null, null, LossInclusion.Always);
+                                    editFragmentLossDlg.OkDialog();
+                                });
+                            }, editStaticMod=>editStaticMod.OkDialog());
+                        }, editStaticMods=>editStaticMods.OkDialog());
+                }, peptideSettingsUi => peptideSettingsUi.OkDialog()
+            );
+            // Insert a peptide with that modification
+            RunUI(() =>
+            {
+                SkylineWindow.Paste("PEPTIDE[106.05]");
+            });
+            var transition = SkylineWindow.Document.MoleculeTransitions.FirstOrDefault(t=>null != t.Losses);
+            Assert.IsNotNull(transition);
+            Assert.AreEqual(0, transition.Losses.Losses[0].LossIndex);
+            Assert.AreEqual(1, transition.Losses.Losses[0].PrecursorMod.Losses.Count);
+            AssertEx.Serializable(SkylineWindow.Document);
+
+            // Edit the modification definition and add a loss with a smaller mass, causing the existing loss to be moved down the list
+            RunLongDlg<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI, peptideSettingsUi =>
+                {
+                    RunLongDlg<EditListDlg<SettingsListBase<StaticMod>, StaticMod>>(peptideSettingsUi.EditStaticMods,
+                        editStaticMods =>
+                        {
+                            RunUI(()=>editStaticMods.SelectItem(modificationName));
+                            RunLongDlg<EditStaticModDlg>(editStaticMods.EditItem, editStaticMod =>
+                            {
+                                RunDlg<EditFragmentLossDlg>(editStaticMod.AddLoss, editFragmentLossDlg =>
+                                {
+                                    editFragmentLossDlg.Loss = new FragmentLoss("H2O", null, null, LossInclusion.Never);
+                                    editFragmentLossDlg.OkDialog();
+                                });
+                            }, editStaticMod => editStaticMod.OkDialog());
+                        }, editStaticMods => editStaticMods.OkDialog());
+                }, 
+                peptideSettingsUi =>
+                {
+                    peptideSettingsUi.OkDialog();
+                });
+            
+            // Make sure that the LossIndex in the transition is the new correct value
+            transition = SkylineWindow.Document.MoleculeTransitions.First(t => null != t.Losses);
+            Assert.AreEqual(1, transition.Losses.Losses[0].LossIndex);
+            Assert.AreEqual(2, transition.Losses.Losses[0].PrecursorMod.Losses.Count);
+
+            // Make sure that the document can round-trip to XML
+            AssertEx.Serializable(SkylineWindow.Document);
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -180,6 +180,7 @@
     <Compile Include="DdaScoringTest.cs" />
     <Compile Include="DocumentGridExportTest.cs" />
     <Compile Include="DocumentGridUndoTest.cs" />
+    <Compile Include="EditNeutralLossesTest.cs" />
     <Compile Include="EncyclopeDiaLibraryMatchTest.cs" />
     <Compile Include="EncyclopeDiaPeptidesWithNoSignalTest.cs" />
     <Compile Include="ExplicitMissingPeakBoundsTest.cs" />

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -30,7 +30,6 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
-using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.FileUI;
 using pwiz.Skyline.Properties;
@@ -407,69 +406,6 @@ namespace pwiz.Skyline.Util
                 map.Add(keySelector(value), value);
             return map;
         }
-    }
-
-    /// <summary>
-    /// A read-only list class for the case when a list most commonly contains a
-    /// single entry, but must also support multiple entries.  This list may not
-    /// be empty, thought it may contain a single null element.
-    /// </summary>
-    /// <typeparam name="TItem">Type of the elements in the list</typeparam>
-    public class OneOrManyList<TItem> : AbstractReadOnlyList<TItem>
-    {
-        private ImmutableList<TItem> _list;
-
-        public OneOrManyList(params TItem[] elements)
-        {
-            _list = ImmutableList.ValueOf(elements);
-        }
-
-        public OneOrManyList(IList<TItem> elements)
-        {
-            _list = ImmutableList.ValueOf(elements);
-        }
-
-        public override int Count
-        {
-            get { return _list.Count; }
-        }
-
-        public override TItem this[int index]
-        {
-            get
-            {
-                return _list[index];
-            }
-        }
-
-        public OneOrManyList<TItem> ChangeAt(int index, TItem item)
-        {
-            return new OneOrManyList<TItem>(_list.ReplaceAt(index, item));
-        }
-
-        #region object overrides
-
-        public bool Equals(OneOrManyList<TItem> obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            return _list.Equals(obj._list);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((OneOrManyList<TItem>) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return _list.GetHashCode();
-        }
-
-        #endregion
     }
 
     /// <summary>


### PR DESCRIPTION
Fixed bug where adding a new neutral loss to a static modification could result in a document that could not be reopened after it was saved. Fixed bug where "ShapeCorrelation" would not round-trip when saving large document.