### PR TITLE
* fixed ConsoleInvalidValuesTest

### DIFF
--- a/pwiz_tools/Skyline/TestData/CommandLineRefineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineRefineTest.cs
@@ -22,8 +22,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Resources;
-using System.Security.Permissions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline;
 using pwiz.Skyline.Model;
@@ -525,30 +523,15 @@ namespace pwiz.SkylineTestData
             testedArguments.Add(arg);
         }
 
-        private static ResourceManager _ioResourceManager = new ResourceManager("mscorlib", typeof(FileIOPermission).Assembly);
         private void ValidateInvalidValuePath(CommandArgs.Argument arg, HashSet<CommandArgs.Argument> testedArguments)
         {
             const string BAD_VALUE = "Bad:\\Path\\Value";
             string argText = arg.GetArgumentTextWithValue(BAD_VALUE);
             var args = new[] { argText };
             if (arg != CommandArgs.ARG_IN)
-                args = new[] { "--in=" + DocumentPath }.Concat(args).ToArray();
+                args = args.Append("--in=" + DocumentPath).ToArray();
             string output = TextUtil.LineSeparate(args) + RunCommand(args);
-            string BadValueString(string errorFormat) => string.Format(errorFormat, BAD_VALUE);
-            var badPathStrings = new[]
-            {
-                BadValueString(Resources.CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_does_not_exist__Please_verify_the_file_location_and_try_again_),
-                BadValueString(Resources.SkylineWindow_ShareDocument_Failed_attempting_to_create_sharing_file__0__),
-                BadValueString(Resources.CommandArgs_ParseArgsInternal_Error__The_specified_working_directory__0__does_not_exist_),
-                BadValueString(Resources.CommandLine_Run_Error__Failed_to_open_log_file__0_),
-                string.Format(
-                    Resources.ValueInvalidPathException_ValueInvalidPathException_The_value___0___is_not_valid_for_the_argument__1__failed_attempting_to_convert_it_to_a_full_file_path_,
-                    BAD_VALUE, arg.ArgumentText),
-                _ioResourceManager.GetString("Argument_PathFormatNotSupported"),
-                "format is not supported" // apparently always in English for tools?
-            };
-            Assert.IsTrue(badPathStrings.Any(s => output.Contains(s)),
-                "{0} does not contain any of:\r\n{1}", output, TextUtil.LineSeparate(badPathStrings));
+            AssertEx.Contains(output, BAD_VALUE);
             testedArguments.Add(arg);
         }
 

--- a/pwiz_tools/Skyline/TestData/CommandLineRefineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineRefineTest.cs
@@ -22,6 +22,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Resources;
+using System.Security.Permissions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline;
 using pwiz.Skyline.Model;
@@ -444,7 +446,6 @@ namespace pwiz.SkylineTestData
 
             TestFilesDir = new TestFilesDir(TestContext, @"TestData\CommandLineRefine.zip");
             DocumentPath = InitRefineDocument("SRM_mini_single_replicate.sky");
-
             // Automatically test arguments that have Values
             foreach (var arg in allArgumentsSet)
             {
@@ -524,6 +525,7 @@ namespace pwiz.SkylineTestData
             testedArguments.Add(arg);
         }
 
+        private static ResourceManager _ioResourceManager = new ResourceManager("mscorlib", typeof(FileIOPermission).Assembly);
         private void ValidateInvalidValuePath(CommandArgs.Argument arg, HashSet<CommandArgs.Argument> testedArguments)
         {
             const string BAD_VALUE = "Bad:\\Path\\Value";
@@ -542,6 +544,7 @@ namespace pwiz.SkylineTestData
                 string.Format(
                     Resources.ValueInvalidPathException_ValueInvalidPathException_The_value___0___is_not_valid_for_the_argument__1__failed_attempting_to_convert_it_to_a_full_file_path_,
                     BAD_VALUE, arg.ArgumentText),
+                _ioResourceManager.GetString("Argument_PathFormatNotSupported"),
                 "format is not supported" // apparently always in English for tools?
             };
             Assert.IsTrue(badPathStrings.Any(s => output.Contains(s)),


### PR DESCRIPTION
@nickshulman Is there a better way to do this (get localized system error messages) that I missed?