### PR TITLE
Switch dependency ordering between SkylineCmd and Skyline projects

### DIFF
--- a/pwiz_tools/Skyline/Jamfile.jam
+++ b/pwiz_tools/Skyline/Jamfile.jam
@@ -342,23 +342,7 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
         This is a fake file so Skyline can point at both msparser.dll and msparserD.dll unconditionally.
         ) > "$(<)"
     }
-    
-    
-    rule make_fake_SkylineCmd ( targets + : sources * : properties * )
-    {
-        return [ build-properties $(targets) : $(sources) : $(properties) ] ;
-    }
 
-    actions make_fake_SkylineCmd
-    {
-        @($(STDOUT):E=
-        This is a fake SkylineCmd so Skyline can point at it without a circular dependency.
-        ) > "$(<)"
-    }
-
-    make SkylineCmd.exe : : @make_fake_SkylineCmd : <conditional>@build-location ;
-    explicit SkylineCmd.exe ;
-    
     if --official in [ modules.peek : ARGV ]
     {
         constant SKYLINE_PROSIT_CONFIG : "$(SKYLINE_PATH)/Model/Prosit/Config/PrositConfig_production.xml" ;
@@ -426,7 +410,6 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
             <conditional>@build-location
             <conditional>@install-vendor-api-dependencies
             <dependency>NugetRestore
-            <dependency>SkylineCmd.exe
             <dependency>../../pwiz/utility/bindings/CLI//pwiz_data_cli/<location>$(PWIZ_WRAPPER_PATH)/obj/$(PLATFORM)
             <dependency>../../pwiz/utility/bindings/CLI//pwiz_data_cli.xml/<location>$(PWIZ_WRAPPER_PATH)/obj/$(PLATFORM)
             <dependency>../../pwiz/utility/bindings/CLI/timstof_prm_scheduler//PrmPasefScheduler/<location>$(PWIZ_WRAPPER_PATH)/obj/$(PLATFORM)

--- a/pwiz_tools/Skyline/Skyline.sln
+++ b/pwiz_tools/Skyline/Skyline.sln
@@ -10,6 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skyline", "Skyline.csproj", "{DDA2EA4C-B632-4FDF-94BA-F71E4C152056}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FA16A0EF-EDF7-4515-BD93-44BADD7AB98A} = {FA16A0EF-EDF7-4515-BD93-44BADD7AB98A}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", "{E0FA262A-744E-4D98-A43F-4723A4D95827}"
 EndProject
@@ -66,9 +69,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestConnected", "TestConnected\TestConnected.csproj", "{5D4E9180-FD66-4C11-8C16-11921865EDBD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkylineCmd", "SkylineCmd\SkylineCmd.csproj", "{FA16A0EF-EDF7-4515-BD93-44BADD7AB98A}"
-	ProjectSection(ProjectDependencies) = postProject
-		{DDA2EA4C-B632-4FDF-94BA-F71E4C152056} = {DDA2EA4C-B632-4FDF-94BA-F71E4C152056}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkylineNightlyShim", "SkylineNightlyShim\SkylineNightlyShim.csproj", "{3C7F5209-6507-42C5-80CE-472AE6A51CD1}"
 EndProject


### PR DESCRIPTION
Make it so that Skyline project depends on SkylineCmd project instead of the other way around.
As far as I can tell this fixes the problem where doing a build immediately after having done a clean build fails.