### PR TITLE
Fix IndexOutOfRangeException if crosslinked peptide if modification has labeled atoms instead of a formula.

### DIFF
--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkBuilder.cs
@@ -164,8 +164,9 @@ namespace pwiz.Skyline.Model.Crosslinking
             if (_precursorMassDistribution == null)
             {
                 var fragmentedMoleculeSettings = FragmentedMolecule.Settings.FromSrmSettings(Settings);
+                var moleculeMassOffset = GetPrecursorFormula();
                 _precursorMassDistribution = fragmentedMoleculeSettings
-                    .GetMassDistribution(GetPrecursorFormula().Molecule, 0, 0);
+                    .GetMassDistribution(moleculeMassOffset.Molecule, moleculeMassOffset.MonoMassOffset, 0);
             }
 
             return _precursorMassDistribution;

--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkedSequence.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkedSequence.cs
@@ -131,6 +131,7 @@ namespace pwiz.Skyline.Model.Crosslinking
                 stringBuilder.Append(@"[");
                 var staticMod = crosslink.Crosslinker;
                 var modification = new ModifiedSequence.Modification(new ExplicitMod(-1, staticMod),
+                    staticMod.ParsedMolecule,
                     staticMod.MonoisotopicMass ?? 0, staticMod.AverageMass ?? 0);
                 stringBuilder.Append(modificationFormatter(modification));
                 stringBuilder.Append(@"@");

--- a/pwiz_tools/Skyline/Model/ModifiedSequence.cs
+++ b/pwiz_tools/Skyline/Model/ModifiedSequence.cs
@@ -334,11 +334,12 @@ namespace pwiz.Skyline.Model
 
         public class Modification : Immutable
         {
-            public Modification(ExplicitMod explicitMod, double monoMass, double avgMass)
+            public Modification(ExplicitMod explicitMod, ParsedMolecule formula, double monoMass, double avgMass)
             {
                 ExplicitMod = explicitMod;
                 MonoisotopicMass = monoMass;
                 AverageMass = avgMass;
+                Formula = formula;
             }
 
             public ExplicitMod ExplicitMod { get; private set; }
@@ -357,7 +358,7 @@ namespace pwiz.Skyline.Model
 
             public string Name { get { return StaticMod.Name; } }
             public string ShortName { get { return StaticMod.ShortName; } }
-            public ParsedMolecule Formula { get { return StaticMod.ParsedMolecule; } }
+            public ParsedMolecule Formula { get; private set; }
             public int? UnimodId { get { return StaticMod.UnimodId; } }
             public double MonoisotopicMass { get; private set; }
             public double AverageMass { get; private set; }
@@ -433,19 +434,20 @@ namespace pwiz.Skyline.Model
             var avgMass = staticMod.AverageMass ??
                           SrmSettings.AverageMassCalc.GetAAModMass(unmodifiedSequence[i], i,
                               unmodifiedSequence.Length);
+            var formula = explicitMod.Modification.ParsedMolecule;
             if (monoMass == 0 && avgMass == 0)
             {
                 char aa = unmodifiedSequence[i];
                 if ((staticMod.LabelAtoms & LabelAtoms.LabelsAA) != LabelAtoms.None && AminoAcid.IsAA(aa))
                 {
-                    var heavyFormula = SequenceMassCalc.GetHeavyFormula(aa, staticMod.LabelAtoms);
-                    monoMass = SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, heavyFormula,
+                    formula = SequenceMassCalc.GetHeavyFormula(aa, staticMod.LabelAtoms);
+                    monoMass = SequenceMassCalc.FormulaMass(BioMassCalc.MONOISOTOPIC, formula,
                         SequenceMassCalc.MassPrecision);
-                    avgMass = SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, heavyFormula,
+                    avgMass = SequenceMassCalc.FormulaMass(BioMassCalc.AVERAGE, formula,
                         SequenceMassCalc.MassPrecision);
                 }
             }
-            return new Modification(explicitMod, monoMass, avgMass);
+            return new Modification(explicitMod, formula, monoMass, avgMass);
         }
 
         public static Modification ResolveModification(SrmSettings settings, IsotopeLabelType labelType, string unmodifiedSequence,

--- a/pwiz_tools/Skyline/Test/CrosslinkModTest.cs
+++ b/pwiz_tools/Skyline/Test/CrosslinkModTest.cs
@@ -552,9 +552,11 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(3, precursorTransitions.Count);
             var monoPrecursorTransition = precursorTransitions[0];
             Assert.AreEqual(0, monoPrecursorTransition.Transition.MassIndex);
+
+            // Make a different transition with a mass-only modification which is exactly 3 Daltons
             var explicitModsWith4DaMod = explicitMods.ChangeHeavyModifications(new[]
             {
-                new ExplicitMod(7, new StaticMod("MassOnly", "K", null, null, LabelAtoms.None, 4, 4.5))
+                new ExplicitMod(7, new StaticMod("MassOnly", "K", null, null, LabelAtoms.None, 3, 3.5))
             });
             var transitionGroupDocNodeWith4DaMod = new TransitionGroupDocNode(transitionGroup, Annotations.EMPTY,
                 settings, explicitModsWith4DaMod,
@@ -566,7 +568,10 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(3, precursorTransitionsWith4DaMod.Count);
             var monoTransitionWith4DaMod = precursorTransitionsWith4DaMod[0];
             Assert.AreEqual(0, monoTransitionWith4DaMod.Transition.MassIndex);
-            Assert.AreEqual(monoPrecursorTransition.Mz + (4 - heavyMod.MonoisotopicMass) / 2, monoTransitionWith4DaMod.Mz);
+
+            Assert.AreEqual(2, monoPrecursorTransition.Transition.Charge);
+            // The 3 Dalton modification is 5 Daltons less than the heavy modification, so the charge 2 m/z should be 2.5 less
+            Assert.AreEqual(monoPrecursorTransition.Mz - 2.5, monoTransitionWith4DaMod.Mz, .01);
         }
     }
 }


### PR DESCRIPTION
Fixed error when crosslinked peptides has heavy atoms (reported by Alessio)
