### PR TITLE
Skyline: Delete TestRunner.exe user.config files before SkylineTester runs it

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -241,6 +241,7 @@ namespace SkylineTester
             TestsRun = 0;
             if (Directory.Exists(_resultsDir))
                 Try.Multi<Exception>(() => Directory.Delete(_resultsDir, true), 4, false);
+            DeleteTestRunnerConfigFiles();
 
             var testRunner = Path.Combine(GetSelectedBuildDir(), "TestRunner.exe");
             _testRunnerIndex = new List<int>();
@@ -280,6 +281,20 @@ namespace SkylineTester
                     _resultsDir.Quote(),
                     AccessInternet.Checked ? "internet=on " : "",
                     args));
+            }
+        }
+
+        /// <summary>
+        /// Deletes all TestRunner.exe config folders to avoid user.config corruption
+        /// that can cause tests to fail indefinitely until it is cleaned up.
+        /// </summary>
+        private void DeleteTestRunnerConfigFiles()
+        {
+            var configsRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "AppData/Local/University_of_Washington");
+            foreach (var configDir in Directory.EnumerateDirectories(configsRoot, "TestRunner.exe*"))
+            {
+                Try.Multi<Exception>(() => Directory.Delete(configDir, true), 4, false);
             }
         }
 


### PR DESCRIPTION
- avoids file corruption that can cause SkylineNightly to fail indefinitely