### PR TITLE
Fix "clean.bat" to not delete checked in file

### DIFF
--- a/clean.bat
+++ b/clean.bat
@@ -49,7 +49,7 @@ rmdir /s /q pwiz_aux\msrc\utility\vendor_api\ABI\vc9 > nul 2>&1
 del /f /q pwiz_aux\msrc\utility\vendor_api\Agilent\*.dll > nul 2>&1
 rmdir /s /q pwiz_aux\msrc\utility\vendor_api\Agilent\x86 > nul 2>&1
 rmdir /s /q pwiz_aux\msrc\utility\vendor_api\Agilent\x64 > nul 2>&1
-del /f /q pwiz_aux\msrc\utility\vendor_api\Agilent\EULA.* > nul 2>&1
+del /f /q pwiz_aux\msrc\utility\vendor_api\Agilent\EULA.MHDAC > nul 2>&1
 rmdir /s /q pwiz_aux\msrc\utility\vendor_api\Agilent\Documents > nul 2>&1
 del /f /q pwiz_aux\msrc\utility\vendor_api\Bruker\*.manifest > nul 2>&1
 del /f /q pwiz_aux\msrc\utility\vendor_api\Bruker\baf2sql_c.h > nul 2>&1


### PR DESCRIPTION
Change "clean.bat" so that it deletes "EULA.MHDAC" from "Agilent.7z" but preserves "EULA.Agilent.txt" which is actually checked in. With this fix, when you do a clean build you will not end up a spurious local change.