### PR TITLE
Attempt to fix "TestAssayLibraryImport"

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
@@ -58,7 +58,9 @@ namespace pwiz.SkylineTestFunctional
             TestModificationMatcher();
             TestBlankDocScenario();
             TestEmbeddedIrts();
-
+            // It's conceivable that calling GC.Collect here prevents a file locking issue in TestAssayImport2
+            GC.Collect();
+            GC.Collect();
             TestAssayImport2();
             TestPaser();
         }

--- a/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
@@ -250,6 +250,10 @@ namespace pwiz.SkylineTestUtil
 
         public static void CheckForFileLocks(string path, bool useDeletion = false)
         {
+            // It's conceivable that calling GC.Collect prevents a file locking issue by causing some stream's
+            // finalizer to run
+            GC.Collect();
+            GC.Collect();
             string GetProcessNamesLockingFile(string lockedDirectory, Exception exceptionShowingLockedFileName)
             {
                 var output = string.Empty;


### PR DESCRIPTION
Add a few calls to "GC.Collect".
If the problem is that a stream is not being closed, then garbage collecting might prevent the test failure.