### PR TITLE
Attempt to fix TestAssayLibraryImport

### DIFF
--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -1886,11 +1886,13 @@ namespace pwiz.Skyline
             {
                 return;
             }
-            else
-            {
-                FileEx.SafeDelete(AssayLibraryFileName);
-                FileEx.SafeDelete(Path.ChangeExtension(AssayLibraryFileName, BiblioSpecLiteSpec.EXT_REDUNDANT));
-            }
+            // Do a garbage collection in case any finalizer is supposed to release a file handle
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            FileEx.SafeDelete(AssayLibraryFileName);
+            FileEx.SafeDelete(Path.ChangeExtension(AssayLibraryFileName, BiblioSpecLiteSpec.EXT_REDUNDANT));
             ImportMassList(inputs, description, true);
         }
 

--- a/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
@@ -250,6 +250,10 @@ namespace pwiz.SkylineTestUtil
 
         public static void CheckForFileLocks(string path, bool useDeletion = false)
         {
+            // Do a garbage collection in case any finalizer is supposed to release a file handle
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
             string GetProcessNamesLockingFile(string lockedDirectory, Exception exceptionShowingLockedFileName)
             {
                 var output = string.Empty;


### PR DESCRIPTION
This fix does two things:
1. Get rid of "_sessionFactory" in "IrtDb" class, and instead open and dispose the session factory whenever it is needed.
2. Add calls to GC.Collect and GC.WaitForPendingFinalizers before trying to delete files.

This seems to make the test failure less likely to happen, but it is hard to tell for sure.
I am still running tests on my computer.