### PR TITLE
Fix problem where parallel testing wouldn't work unless you passed in…

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -840,7 +840,6 @@ namespace TestRunner
                 if (commandLineArgs.HasArg("workerport"))
                 {
                     workerPort = (int)commandLineArgs.ArgAsLong("workerport");
-                    receiver.Bind($"tcp://*:{workerPort}");
                 }
                 else
                 {
@@ -848,6 +847,7 @@ namespace TestRunner
                     // // The Windows server "macs2.gs.washington.edu" is configured to be able to use any port between 9810 and 9820
                     workerPort = UnusedPortFinder.FindUnusedPort(9810, 65535);
                 }
+                receiver.Bind($"tcp://*:{workerPort}");
                 string workerNames = null;
 
                 // try to kill docker workers if process is terminated externally (e.g. SkylineTester)


### PR DESCRIPTION
… a workerport.

The code path where it chose the first unused port was missing the line that binds the port.