### PR TITLE
TestPrositOutputToEncyclopediaLibraries was failing on parallel clients due to very small numerical differences in resulting TSV files…

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
+++ b/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
@@ -1086,11 +1086,11 @@ namespace pwiz.Skyline.Model.Lib
                             string mzField = linePeak.Substring(0, iSeperator1++);
                             string intensityField = linePeak.Substring(iSeperator1, iSeperator2 - iSeperator1);
 
-                            if (!TryParseFloatUncertainCulture(mzField, out var mz))
+                            if (!TextUtil.TryParseFloatUncertainCulture(mzField, out var mz))
                             {
                                 ThrowIoExceptionInvalidPeakFormat(lineCount, i, sequence);
                             }
-                            if (!TryParseFloatUncertainCulture(intensityField, out var intensity))
+                            if (!TextUtil.TryParseFloatUncertainCulture(intensityField, out var intensity))
                             {
                                 ThrowIoExceptionInvalidPeakFormat(lineCount, i, sequence);
                             }
@@ -1460,7 +1460,7 @@ namespace pwiz.Skyline.Model.Lib
                 match = REGEX_MOLWEIGHT.Match(line);
                 if (match.Success)
                 {
-                    if (!TryParseDoubleUncertainCulture(match.Groups[1].Value, out var mw))
+                    if (!TextUtil.TryParseDoubleUncertainCulture(match.Groups[1].Value, out var mw))
                     {
                         ThrowIOException(lineCount,
                             string.Format(Resources.NistLibraryBase_CreateCache_Could_not_read_the_precursor_m_z_value___0__,
@@ -1663,31 +1663,9 @@ namespace pwiz.Skyline.Model.Lib
         {
             double rt;
             var valString = rtString.Split(MINOR_SEP).First();
-            if (!TryParseDoubleUncertainCulture(valString, out rt))
+            if (!TextUtil.TryParseDoubleUncertainCulture(valString, out rt))
                 return null;
             return isMinutes ? rt : rt / 60;
-        }
-
-        private static bool TryParseDoubleUncertainCulture(string valString, out double dval)
-        {
-            // .MSP from Golm GMD may have European decimals
-            if (!double.TryParse(valString, NumberStyles.Float, CultureInfo.InvariantCulture, out dval) &&
-                !double.TryParse(valString.Replace(',', '.'), NumberStyles.Float, CultureInfo.InvariantCulture, out dval))
-            {
-                return false;
-            }
-            return true;
-        }
-
-        private static bool TryParseFloatUncertainCulture(string valString, out float fval)
-        {
-            // .MSP from Golm GMD may have European decimals
-            if (!float.TryParse(valString, NumberStyles.Float, CultureInfo.InvariantCulture, out fval) &&
-                !float.TryParse(valString.Replace(',', '.'), NumberStyles.Float, CultureInfo.InvariantCulture, out fval))
-            {
-                return false;
-            }
-            return true;
         }
 
         protected override void SetLibraryEntries(IEnumerable<NistSpectrumInfo> entries)

--- a/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
+++ b/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
@@ -69,7 +69,7 @@ namespace pwiz.SkylineTest
             string fastaFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705.fasta");
             string dlibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.dlib");
             string elibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.elib");
-            var columnTolerances = new Dictionary<int, double>() { { 0, 0.0000000001 }, { 5, .000000001 } };  // Allow some numerical wiggle in columns 0 and 5
+            var columnTolerances = new Dictionary<int, double>() { { -1, 0.0000000001 } };  // Allow some numerical wiggle in any column numerical column ("-1" means all columns)
             IProgressStatus status = new ProgressStatus();
 
             // test prosit output to dlib

--- a/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
+++ b/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using pwiz.Common.Database;
@@ -68,6 +69,7 @@ namespace pwiz.SkylineTest
             string fastaFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705.fasta");
             string dlibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.dlib");
             string elibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.elib");
+            var columnTolerances = new Dictionary<int, double>() { { 0, 0.0001 }, { 5, .001 } };  // Allow some numerical wiggle in columns 0 and 5
             IProgressStatus status = new ProgressStatus();
 
             // test prosit output to dlib
@@ -80,7 +82,7 @@ namespace pwiz.SkylineTest
                 var actual = SqliteOperations.DumpTable(dlibFilepath, "entries");
                 //string dlibActualTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-dlib-actual.tsv");
                 //File.WriteAllLines(dlibActualTsvFilepath, actual);
-                AssertEx.NoDiff(File.ReadAllText(dlibExpectedTsvFilepath), string.Join("\n", actual));
+                AssertEx.NoDiff(File.ReadAllText(dlibExpectedTsvFilepath), string.Join("\n", actual), null, columnTolerances);
             }
 
             // test generate chromatogram library
@@ -103,7 +105,7 @@ namespace pwiz.SkylineTest
                     .Concat(SqliteOperations.DumpTable(elibFilepath, "peptidescores", sortColumns: new[] { "PeptideModSeq", "PrecursorCharge" }));
                 //string elibActualTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-elib-actual.tsv");
                 //File.WriteAllLines(elibActualTsvFilepath, actual);
-                AssertEx.NoDiff(File.ReadAllText(elibExpectedTsvFilepath), string.Join("\n", actual));
+                AssertEx.NoDiff(File.ReadAllText(elibExpectedTsvFilepath), string.Join("\n", actual), null, columnTolerances);
             }
 
             // test generate quant library
@@ -131,7 +133,7 @@ namespace pwiz.SkylineTest
                     .Concat(SqliteOperations.DumpTable(elibQuantFilepath, "retentiontimes", sortColumns: new[] { "SourceFile", "Library" }));
                 //string elibActualTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-quant-elib-actual.tsv");
                 //File.WriteAllLines(elibActualTsvFilepath, actual);
-                AssertEx.NoDiff(File.ReadAllText(elibExpectedTsvFilepath), string.Join("\n", actual));
+                AssertEx.NoDiff(File.ReadAllText(elibExpectedTsvFilepath), string.Join("\n", actual), null, columnTolerances);
             }
 
             TestFilesDir.Cleanup();

--- a/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
+++ b/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
@@ -69,7 +69,7 @@ namespace pwiz.SkylineTest
             string fastaFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705.fasta");
             string dlibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.dlib");
             string elibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.elib");
-            var columnTolerances = new Dictionary<int, double>() { { 0, 0.0001 }, { 5, .001 } };  // Allow some numerical wiggle in columns 0 and 5
+            var columnTolerances = new Dictionary<int, double>() { { 0, 0.0000000001 }, { 5, .000000001 } };  // Allow some numerical wiggle in columns 0 and 5
             IProgressStatus status = new ProgressStatus();
 
             // test prosit output to dlib

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -679,7 +679,7 @@ namespace TestRunner
                 var dockerBaseImage = Environment.OSVersion.Version.Build >= 22000
                     ? string.Empty
                     : "--build-arg BASE_WINDOWS_IMAGE=mcr.microsoft.com/windows:1809-amd64";
-                RunTests.RunCommand("docker", $"build {buildPath} -t {RunTests.DOCKER_IMAGE_NAME} {dockerBaseImage}", RunTests.IS_DOCKER_RUNNING_MESSAGE, true);
+                RunTests.RunCommand("docker", $"build \"{buildPath}\" -t \"{RunTests.DOCKER_IMAGE_NAME}\" {dockerBaseImage}", RunTests.IS_DOCKER_RUNNING_MESSAGE, true);
             }
         }
 

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -918,10 +918,9 @@ namespace pwiz.SkylineTestUtil
                     {
                         if (colsActual[c] != colsExpected[c])
                         {
-                            double valActual, valExpected;
-                            if (!columnTolerances.ContainsKey(c) || // No tolerance given
-                                !(double.TryParse(colsActual[c], out valActual) &&
-                                  double.TryParse(colsExpected[c], out valExpected)) || // One or both don't parse as doubles
+                            if (!columnTolerances.ContainsKey(c) || // No tolerance given for this column
+                                !(TextUtil.TryParseDoubleUncertainCulture(colsActual[c], out var valActual) &&
+                                  TextUtil.TryParseDoubleUncertainCulture(colsExpected[c], out var valExpected)) || // One or both don't parse as doubles
                                 (Math.Abs(valActual - valExpected) >
                                  columnTolerances[c] + columnTolerances[c] / 1000)) // Allow for rounding cruft
                             {

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -833,7 +833,8 @@ namespace pwiz.SkylineTestUtil
             return sb.ToString();
         }
 
-        public static void NoDiff(string target, string actual, string helpMsg=null, Dictionary<int, double> columnTolerances = null)
+        public static void NoDiff(string target, string actual, string helpMsg=null, 
+            Dictionary<int, double> columnTolerances = null) // Per-column numerical tolerances if strings can be read as TSV, "-1" means any column
         {
             if (helpMsg == null)
                 helpMsg = String.Empty;
@@ -873,7 +874,7 @@ namespace pwiz.SkylineTestUtil
         }
 
         private static bool LinesEquivalentIgnoringTimeStampsAndGUIDs(string lineExpected, string lineActual,
-            Dictionary<int, double> columnTolerances = null)
+            Dictionary<int, double> columnTolerances = null) // Per-column numerical tolerances if strings can be read as TSV, "-1" means any column
         {
             if (string.Equals(lineExpected, lineActual))
             {
@@ -918,11 +919,11 @@ namespace pwiz.SkylineTestUtil
                     {
                         if (colsActual[c] != colsExpected[c])
                         {
-                            if (!columnTolerances.ContainsKey(c) || // No tolerance given for this column
+                            // See if there's a tolerance for this column, or a default tolerance (column "-1" in the dictionary)
+                            if ((!columnTolerances.TryGetValue(c, out var tolerance) && !columnTolerances.TryGetValue(-1, out tolerance)) || // No tolerance given for this column
                                 !(TextUtil.TryParseDoubleUncertainCulture(colsActual[c], out var valActual) &&
                                   TextUtil.TryParseDoubleUncertainCulture(colsExpected[c], out var valExpected)) || // One or both don't parse as doubles
-                                (Math.Abs(valActual - valExpected) >
-                                 columnTolerances[c] + columnTolerances[c] / 1000)) // Allow for rounding cruft
+                                (Math.Abs(valActual - valExpected) > tolerance + tolerance / 1000)) // Allow for rounding cruft
                             {
                                 return false; // Can't account for difference
                             }

--- a/pwiz_tools/Skyline/Util/Extensions/Text.cs
+++ b/pwiz_tools/Skyline/Util/Extensions/Text.cs
@@ -732,6 +732,28 @@ namespace pwiz.Skyline.Util.Extensions
                 return false;
             }
         }
+
+        // Try to read a string as a double in InvariantCulture, failing that try to read it as a double using "," as the decimal separator
+        public static bool TryParseDoubleUncertainCulture(string valString, out double dval)
+        {
+            if (!double.TryParse(valString, NumberStyles.Float, CultureInfo.InvariantCulture, out dval) &&
+                !double.TryParse(valString.Replace(',', '.'), NumberStyles.Float, CultureInfo.InvariantCulture, out dval))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        // Try to read a string as a float in InvariantCulture, failing that try to read it as a float using "," as the decimal separator
+        public static bool TryParseFloatUncertainCulture(string valString, out float fval)
+        {
+            if (!float.TryParse(valString, NumberStyles.Float, CultureInfo.InvariantCulture, out fval) &&
+                !float.TryParse(valString.Replace(',', '.'), NumberStyles.Float, CultureInfo.InvariantCulture, out fval))
+            {
+                return false;
+            }
+            return true;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
…. Added some tolerances, and made the tolerance check able to handle doubles with "." or "," decimal separators.

Also added some quotes to TestRunner's Docker invocations.