### PR TITLE
* fixed SendGa4AnalyticsHitTest to accept 200 response

### DIFF
--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -388,7 +388,17 @@ namespace pwiz.Skyline
             // ReSharper restore LocalizableElement
         }
 
-        internal static int SendGa4AnalyticsHit(bool useDebugUrl = false)
+        /// <summary>
+        /// Sends a page_view to the Skyline Google Analytics 4 property.
+        /// </summary>
+        /// <param name="responseStr">The body of the HTTP response, usually expected to be empty.</param>
+        /// <param name="useDebugUrl">If true, sets _dbg=true, which sends the hit to the debug view instead of the real one.</param>
+        /// <returns>The HTTP status code of the response to the analytics hit.</returns>
+        /// <remarks>
+        /// The browser-style collect endpoint is used because GA4's Measurement Protocol does not support automatic resolution of the geographic location of the client.
+        /// The parameters are mostly gleaned from observing a browser's HTTP request to GA4 when browsing a Skyline website page.
+        /// </remarks>
+        internal static int SendGa4AnalyticsHit(out string responseStr, bool useDebugUrl = false)
         {
             // ReSharper disable LocalizableElement
             var clientId = Settings.Default.InstallationId;
@@ -424,11 +434,19 @@ namespace pwiz.Skyline
             var responseStream = response.GetResponseStream();
             if (null != responseStream)
             {
-                new StreamReader(responseStream).ReadToEnd();
+                var responseReader = new StreamReader(responseStream);
+                responseStr = responseReader.ReadToEnd();
             }
+            else
+                responseStr = string.Empty;
 
             return (int) response.StatusCode;
             // ReSharper restore LocalizableElement
+        }
+
+        internal static int SendGa4AnalyticsHit(bool useDebugUrl = false)
+        {
+            return SendGa4AnalyticsHit(out _, useDebugUrl);
         }
 
         public static void StartToolService()

--- a/pwiz_tools/Skyline/Test/AnalyticsTest.cs
+++ b/pwiz_tools/Skyline/Test/AnalyticsTest.cs
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline;
 using pwiz.SkylineTestUtil;
@@ -28,7 +29,10 @@ namespace pwiz.SkylineTest
         [TestMethod]
         public void SendGa4AnalyticsHitTest()
         {
-            Assert.AreEqual(204, Program.SendGa4AnalyticsHit(true));
+            int httpStatus = Program.SendGa4AnalyticsHit(out var responseStr, true);
+            if (httpStatus == 200)
+                Console.WriteLine(@"Unexpected response body from SendGa4AnalyticsHit: " + responseStr);
+            CollectionAssert.Contains(new [] {200, 204}, httpStatus, "SendGa4AnalyticsHit expected 200 or 204, responded with {0}", httpStatus);
         }
     }
 }

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -647,7 +647,7 @@ namespace TestRunner
                 var pwizRoot = Path.GetDirectoryName(Path.GetDirectoryName(GetSkylineDirectory().FullName));
                 string workerName = $"docker_check{GetTestRunTimeStamp()}";
                 string testRunnerExe = GetTestRunnerExe();
-                string dockerArgs = $"run --name {workerName} -it --rm -v \"{pwizRoot}\":c:\\pwiz {RunTests.DOCKER_IMAGE_NAME} \"{testRunnerExe} help\"";
+                string dockerArgs = $"run --name {workerName} -it --rm -v \"{pwizRoot}\":c:\\pwiz --entrypoint cmd {RunTests.DOCKER_IMAGE_NAME} \"/c {testRunnerExe} help\"";
                 string checkOutput = RunTests.RunCommand("docker", dockerArgs, "Error checking whether always_up_runner can start");
                 if (checkOutput.Contains("StartService FAILED"))
                 {
@@ -794,7 +794,7 @@ namespace TestRunner
             int workerCount = (int) commandLineArgs.ArgAsLong("workercount");
             int workerTimeout = Convert.ToInt32(commandLineArgs.ArgAsStringOrDefault("workertimeout", "60"));
             int loop = (int) commandLineArgs.ArgAsLong("loop");
-            var languages = commandLineArgs.ArgAsString("language").Split(',');
+            var languages = GetLanguages(commandLineArgs);
 
             if (commandLineArgs.ArgAsBool("buildcheck"))
             {
@@ -843,8 +843,8 @@ namespace TestRunner
                 }
                 else
                 {
-                    // // Select the first unused port above 9810 to communicate with the worker.
-                    // // The Windows server "macs2.gs.washington.edu" is configured to be able to use any port between 9810 and 9820
+                    // Select the first unused port above 9810 to communicate with the worker.
+                    // The Windows server "macs2.gs.washington.edu" is configured to be able to use any port between 9810 and 9820
                     workerPort = UnusedPortFinder.FindUnusedPort(9810, 65535);
                 }
                 receiver.Bind($"tcp://*:{workerPort}");
@@ -1154,6 +1154,14 @@ namespace TestRunner
             return testsFailed == 0;
         }
 
+        private static string[] GetLanguages(CommandLineArgs args)
+        {
+            string value = args.ArgAsString("language");
+            if (value == "all")
+                return allLanguages;
+            return value.Split(',');
+        }
+
         private static DirectoryInfo GetSkylineDirectory()
         {
             string skylinePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
@@ -1347,7 +1355,7 @@ namespace TestRunner
                 // Get list of languages
                 var languages = buildMode
                     ? new[] { "en" }
-                    : commandLineArgs.ArgAsString("language").Split(',');
+                    : GetLanguages(commandLineArgs);
 
                 if (showFormNames)
                     runTests.Skyline.Set("ShowFormNames", true);


### PR DESCRIPTION
* fixed SendGa4AnalyticsHitTest to accept 200 response, but print response body as debug output
* improved performance of stale Docker image check
* added "all" option for languages in TestRunner

If I go ahead and add 200 as an accepted value for the test, it'll be a problem to figure out which computers returned 200 instead of 204 in order to check the new response output. :(