### PR TITLE
* updated cherrypick action branch to 23.1

### DIFF
--- a/.github/workflows/cherrypick-pr-to-release.yml
+++ b/.github/workflows/cherrypick-pr-to-release.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Cherry pick PR to release
       uses: chambm/gh-backport-action@master
       with:
-        pr_branch: 'Skyline/skyline_22_2'
+        pr_branch: 'Skyline/skyline_23_1'
         pr_title: 'Automatic cherry pick of #{pr_number} from {base_branch} to {pr_branch}'
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This doesn't actually need to be updated on release branch because the action will always be run based on master or a PR based on master, but it's a simple test that can't affect the release.