### PR TITLE
Revert possible trigger for DiaUmpireTutorial failures

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -375,10 +375,9 @@ RawFileImpl::RawFileImpl(const string& filename)
 #endif
         }
 
+        instrumentModel_ = parseInstrumentModelType(modelString);
         if (instrumentModel_ == InstrumentModelType_Unknown)
-	        instrumentModel_ = parseInstrumentModelType(modelString);
-        if (instrumentModel_ == InstrumentModelType_Unknown)
-        	instrumentModel_ = parseInstrumentModelType(nameString);
+            instrumentModel_ = parseInstrumentModelType(nameString);
 
         detectors_ = getDetectorsForInstrumentModel(getInstrumentModel());
         massAnalyzers_ = getMassAnalyzersForInstrumentModel(getInstrumentModel());
@@ -1918,7 +1917,6 @@ void RawFileImpl::parseInstrumentMethod()
     sregex isolationMzOffsetRegex = sregex::compile("\\s*Isolation m/z Offset =\\s*(\\S+)\\s*");
     sregex reportedMassRegex = sregex::compile("\\s*Reported Mass =\\s*(\\S+) Mass\\s*");
     sregex scanDescriptionRegex = sregex::compile("\\s*Scan Description =\\s*(\\S+)\\s*");
-    sregex statusLogInstrumentModelRegex = sregex::compile("\\s*Instrument model\\s*-\\s*(.+)\\s*");
 
     smatch what;
     string line;
@@ -1931,12 +1929,6 @@ void RawFileImpl::parseInstrumentMethod()
         if (regex_match(line, what, scanSegmentRegex))
         {
             scanSegment = lexical_cast<int>(what[1]);
-            continue;
-        }
-
-        if (regex_match(line, what, statusLogInstrumentModelRegex))
-        {
-            instrumentModel_ = parseInstrumentModelType(what[1]);
             continue;
         }
 
@@ -2289,9 +2281,6 @@ vector<string> RawFileImpl::getInstrumentMethods() const
 #else
         for (int i = 0; i < raw_->InstrumentMethodsCount; ++i)
             result.emplace_back(ToStdString(raw_->GetInstrumentMethod(i)));
-        auto firstStatusLog = raw_->GetStatusLogForRetentionTime(0);
-        for (int i = 0; i < firstStatusLog->Length; ++i)
-	        result.emplace_back(ToStdString(firstStatusLog->Labels[i] + " " + firstStatusLog->Values[i]));
 #endif
         return result;
     }

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFile.cpp
@@ -375,7 +375,8 @@ RawFileImpl::RawFileImpl(const string& filename)
 #endif
         }
 
-        instrumentModel_ = parseInstrumentModelType(modelString);
+        if (instrumentModel_ == InstrumentModelType_Unknown)
+            instrumentModel_ = parseInstrumentModelType(modelString);
         if (instrumentModel_ == InstrumentModelType_Unknown)
             instrumentModel_ = parseInstrumentModelType(nameString);
 
@@ -1917,6 +1918,7 @@ void RawFileImpl::parseInstrumentMethod()
     sregex isolationMzOffsetRegex = sregex::compile("\\s*Isolation m/z Offset =\\s*(\\S+)\\s*");
     sregex reportedMassRegex = sregex::compile("\\s*Reported Mass =\\s*(\\S+) Mass\\s*");
     sregex scanDescriptionRegex = sregex::compile("\\s*Scan Description =\\s*(\\S+)\\s*");
+    sregex statusLogInstrumentModelRegex = sregex::compile("\\s*Instrument model\\s*-\\s*(.+)\\s*");
 
     smatch what;
     string line;
@@ -1929,6 +1931,12 @@ void RawFileImpl::parseInstrumentMethod()
         if (regex_match(line, what, scanSegmentRegex))
         {
             scanSegment = lexical_cast<int>(what[1]);
+            continue;
+        }
+
+        if (regex_match(line, what, statusLogInstrumentModelRegex))
+        {
+            instrumentModel_ = parseInstrumentModelType(what[1]);
             continue;
         }
 
@@ -2281,6 +2289,9 @@ vector<string> RawFileImpl::getInstrumentMethods() const
 #else
         for (int i = 0; i < raw_->InstrumentMethodsCount; ++i)
             result.emplace_back(ToStdString(raw_->GetInstrumentMethod(i)));
+        auto firstStatusLog = raw_->GetStatusLogForRetentionTime(0);
+        for (int i = 0; i < firstStatusLog->Length; ++i)
+            result.emplace_back(ToStdString(firstStatusLog->Labels[i] + " " + firstStatusLog->Values[i]));
 #endif
         return result;
     }

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFileTypes.h
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFileTypes.h
@@ -160,11 +160,11 @@ struct InstrumentNameToModelMapping
 
 const InstrumentNameToModelMapping nameToModelMapping[] =
 {
-    {"MAT253", InstrumentModelType_MAT253, Exact},
-    {"MAT900XP", InstrumentModelType_MAT900XP, Exact},
-    {"MAT900XP TRAP", InstrumentModelType_MAT900XP_Trap, Exact},
-    {"MAT95XP", InstrumentModelType_MAT95XP, Exact},
-    {"MAT95XP TRAP", InstrumentModelType_MAT95XP_Trap, Exact},
+    {"MAT253", InstrumentModelType_MAT253, ExactNoSpaces},
+    {"MAT900XP", InstrumentModelType_MAT900XP, ExactNoSpaces},
+    {"MAT900XPTRAP", InstrumentModelType_MAT900XP_Trap, ExactNoSpaces},
+    {"MAT95XP", InstrumentModelType_MAT95XP, ExactNoSpaces},
+    {"MAT95XPTRAP", InstrumentModelType_MAT95XP_Trap, ExactNoSpaces},
     {"SSQ7000", InstrumentModelType_SSQ_7000, ExactNoSpaces},
     {"TSQ7000", InstrumentModelType_TSQ_7000, ExactNoSpaces},
     {"TSQ8000EVO", InstrumentModelType_TSQ_8000_Evo, ExactNoSpaces},

--- a/pwiz_aux/msrc/utility/vendor_api/thermo/RawFileTypes.h
+++ b/pwiz_aux/msrc/utility/vendor_api/thermo/RawFileTypes.h
@@ -160,11 +160,11 @@ struct InstrumentNameToModelMapping
 
 const InstrumentNameToModelMapping nameToModelMapping[] =
 {
-    {"MAT253", InstrumentModelType_MAT253, ExactNoSpaces},
-    {"MAT900XP", InstrumentModelType_MAT900XP, ExactNoSpaces},
-    {"MAT900XPTRAP", InstrumentModelType_MAT900XP_Trap, ExactNoSpaces},
-    {"MAT95XP", InstrumentModelType_MAT95XP, ExactNoSpaces},
-    {"MAT95XPTRAP", InstrumentModelType_MAT95XP_Trap, ExactNoSpaces},
+    {"MAT253", InstrumentModelType_MAT253, Exact},
+    {"MAT900XP", InstrumentModelType_MAT900XP, Exact},
+    {"MAT900XP TRAP", InstrumentModelType_MAT900XP_Trap, Exact},
+    {"MAT95XP", InstrumentModelType_MAT95XP, Exact},
+    {"MAT95XP TRAP", InstrumentModelType_MAT95XP_Trap, Exact},
     {"SSQ7000", InstrumentModelType_SSQ_7000, ExactNoSpaces},
     {"TSQ7000", InstrumentModelType_TSQ_7000, ExactNoSpaces},
     {"TSQ8000EVO", InstrumentModelType_TSQ_8000_Evo, ExactNoSpaces},


### PR DESCRIPTION
Revert "- fixed reading instrument model for very old Thermo RAW files which may store instrument model only in status log - added commandline parameters for msconvert to output file"

This reverts commit a2350d7526d1c321fc658420b3a1b089ac64cdd1.