### PR TITLE
- added mass resolving power to Thermo scans

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/BSA-FT-ETD-centroid.mzML
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/BSA-FT-ETD-centroid.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="BSA-FT-ETD" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.117" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -9,7 +9,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="RAW1" name="BSA-FT-ETD.raw" location="file:///C:\pwiz.git\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
+      <sourceFile id="RAW1" name="BSA-FT-ETD.raw" location="file:///C:\dev\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
         <cvParam cvRef="MS" accession="MS:1000768" name="Thermo nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="a778e19dee487f78697e5445b9a601286f7e63ab"/>
@@ -25,7 +25,7 @@
     <software id="Xcalibur" version="">
       <cvParam cvRef="MS" accession="MS:1000532" name="Xcalibur" value=""/>
     </software>
-    <software id="pwiz" version="3.0.20071">
+    <software id="pwiz" version="3.0.23188">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -74,6 +74,7 @@
           <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
           <scan>
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="16.061954736267" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+            <cvParam cvRef="MS" accession="MS:1000800" name="mass resolving power" value="15000"/>
             <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value="FTMS + p NSI d Full ms2 722.32@etd111.39 [120.00-1455.00]"/>
             <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="55.047115325928" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <userParam name="[Thermo Trailer Extra]Monoisotopic M/Z:" value="722.32421875" type="xsd:float"/>

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/BSA-FT-ETD.mzML
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/BSA-FT-ETD.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="BSA-FT-ETD" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.117" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -9,7 +9,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="RAW1" name="BSA-FT-ETD.raw" location="file:///C:\pwiz.git\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
+      <sourceFile id="RAW1" name="BSA-FT-ETD.raw" location="file:///C:\dev\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
         <cvParam cvRef="MS" accession="MS:1000768" name="Thermo nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="a778e19dee487f78697e5445b9a601286f7e63ab"/>
@@ -25,7 +25,7 @@
     <software id="Xcalibur" version="">
       <cvParam cvRef="MS" accession="MS:1000532" name="Xcalibur" value=""/>
     </software>
-    <software id="pwiz" version="3.0.20071">
+    <software id="pwiz" version="3.0.23188">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -70,6 +70,7 @@
           <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
           <scan>
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="16.061954736267" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+            <cvParam cvRef="MS" accession="MS:1000800" name="mass resolving power" value="15000"/>
             <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value="FTMS + p NSI d Full ms2 722.32@etd111.39 [120.00-1455.00]"/>
             <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="55.047115325928" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <userParam name="[Thermo Trailer Extra]Monoisotopic M/Z:" value="722.32421875" type="xsd:float"/>

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/BSA-FT-HCD-centroid.mzML
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/BSA-FT-HCD-centroid.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="BSA-FT-HCD" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.117" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -9,7 +9,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="RAW1" name="BSA-FT-HCD.raw" location="file:///C:\pwiz.git\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
+      <sourceFile id="RAW1" name="BSA-FT-HCD.raw" location="file:///C:\dev\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
         <cvParam cvRef="MS" accession="MS:1000768" name="Thermo nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="32881a1435dbc82dbd039bd3ca5403b9b30fbac0"/>
@@ -25,7 +25,7 @@
     <software id="Xcalibur" version="">
       <cvParam cvRef="MS" accession="MS:1000532" name="Xcalibur" value=""/>
     </software>
-    <software id="pwiz" version="3.0.20071">
+    <software id="pwiz" version="3.0.23188">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -74,6 +74,7 @@
           <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
           <scan>
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="16.0606255656" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+            <cvParam cvRef="MS" accession="MS:1000800" name="mass resolving power" value="15000"/>
             <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value="FTMS + p NSI d Full ms2 722.32@hcd30.00 [120.00-1455.00]"/>
             <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="55.047115325928" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <userParam name="[Thermo Trailer Extra]Monoisotopic M/Z:" value="722.32421875" type="xsd:float"/>

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/BSA-FT-HCD.mzML
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/BSA-FT-HCD.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="BSA-FT-HCD" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.117" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -9,7 +9,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="RAW1" name="BSA-FT-HCD.raw" location="file:///C:\pwiz.git\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
+      <sourceFile id="RAW1" name="BSA-FT-HCD.raw" location="file:///C:\dev\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
         <cvParam cvRef="MS" accession="MS:1000768" name="Thermo nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="32881a1435dbc82dbd039bd3ca5403b9b30fbac0"/>
@@ -25,7 +25,7 @@
     <software id="Xcalibur" version="">
       <cvParam cvRef="MS" accession="MS:1000532" name="Xcalibur" value=""/>
     </software>
-    <software id="pwiz" version="3.0.20071">
+    <software id="pwiz" version="3.0.23188">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -70,6 +70,7 @@
           <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
           <scan>
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="16.0606255656" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+            <cvParam cvRef="MS" accession="MS:1000800" name="mass resolving power" value="15000"/>
             <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value="FTMS + p NSI d Full ms2 722.32@hcd30.00 [120.00-1455.00]"/>
             <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="55.047115325928" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
             <userParam name="[Thermo Trailer Extra]Monoisotopic M/Z:" value="722.32421875" type="xsd:float"/>

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/FT-HCD-MSX-centroid.mzML
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/FT-HCD-MSX-centroid.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="FT-HCD-MSX" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.117" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -9,7 +9,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="RAW1" name="FT-HCD-MSX.raw" location="file:///C:\pwiz.git\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
+      <sourceFile id="RAW1" name="FT-HCD-MSX.raw" location="file:///C:\dev\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
         <cvParam cvRef="MS" accession="MS:1000768" name="Thermo nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="dcd88877d6ee5625921f67b535ffe0159084f881"/>
@@ -25,7 +25,7 @@
     <software id="Xcalibur" version="">
       <cvParam cvRef="MS" accession="MS:1000532" name="Xcalibur" value=""/>
     </software>
-    <software id="pwiz" version="3.0.20071">
+    <software id="pwiz" version="3.0.23188">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -74,6 +74,7 @@
           <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
           <scan>
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="26.688152" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+            <cvParam cvRef="MS" accession="MS:1000800" name="mass resolving power" value="35000"/>
             <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value="FTMS + c NSI Full msx ms2 522.99@hcd27.00 698.07@hcd27.00 502.98@hcd27.00 768.10@hcd27.00 [70.00-1590.00]"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="59.999998658895" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/FT-HCD-MSX.mzML
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/FT-HCD-MSX.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="FT-HCD-MSX" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.117" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -9,7 +9,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="RAW1" name="FT-HCD-MSX.raw" location="file:///C:\pwiz.git\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
+      <sourceFile id="RAW1" name="FT-HCD-MSX.raw" location="file:///C:\dev\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
         <cvParam cvRef="MS" accession="MS:1000768" name="Thermo nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="dcd88877d6ee5625921f67b535ffe0159084f881"/>
@@ -25,7 +25,7 @@
     <software id="Xcalibur" version="">
       <cvParam cvRef="MS" accession="MS:1000532" name="Xcalibur" value=""/>
     </software>
-    <software id="pwiz" version="3.0.20071">
+    <software id="pwiz" version="3.0.23188">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -70,6 +70,7 @@
           <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
           <scan>
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="26.688152" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+            <cvParam cvRef="MS" accession="MS:1000800" name="mass resolving power" value="35000"/>
             <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value="FTMS + c NSI Full msx ms2 522.99@hcd27.00 698.07@hcd27.00 502.98@hcd27.00 768.10@hcd27.00 [70.00-1590.00]"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
             <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="59.999998658895" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/IsolationMzOffset-ReportedMassOffset-centroid.mzML
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/IsolationMzOffset-ReportedMassOffset-centroid.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="IsolationMzOffset-ReportedMassOffset" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.117" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -9,7 +9,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="RAW1" name="IsolationMzOffset-ReportedMassOffset.raw" location="file:///C:\pwiz.git\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
+      <sourceFile id="RAW1" name="IsolationMzOffset-ReportedMassOffset.raw" location="file:///C:\dev\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
         <cvParam cvRef="MS" accession="MS:1000768" name="Thermo nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="7d2b7f94d82b3df7ad4a49868be18aad08a7c89d"/>
@@ -25,7 +25,7 @@
     <software id="Xcalibur" version="">
       <cvParam cvRef="MS" accession="MS:1000532" name="Xcalibur" value=""/>
     </software>
-    <software id="pwiz" version="3.0.20150">
+    <software id="pwiz" version="3.0.23188">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -74,6 +74,7 @@
           <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
           <scan>
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="6.800121878211" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+            <cvParam cvRef="MS" accession="MS:1000800" name="mass resolving power" value="60000"/>
             <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value="FTMS + p NSI d Full ms2 379.71@hcd27.00 [150.00-1700.00]"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="3"/>
             <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="14.715546742082" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/IsolationMzOffset-ReportedMassOffset.mzML
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/IsolationMzOffset-ReportedMassOffset.mzML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="IsolationMzOffset-ReportedMassOffset" version="1.1.0">
   <cvList count="2">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.30" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.117" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
     <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
   </cvList>
   <fileDescription>
@@ -9,7 +9,7 @@
       <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
     </fileContent>
     <sourceFileList count="1">
-      <sourceFile id="RAW1" name="IsolationMzOffset-ReportedMassOffset.raw" location="file:///C:\pwiz.git\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
+      <sourceFile id="RAW1" name="IsolationMzOffset-ReportedMassOffset.raw" location="file:///C:\dev\pwiz\pwiz\data\vendor_readers\Thermo\Reader_Thermo_Test.data">
         <cvParam cvRef="MS" accession="MS:1000768" name="Thermo nativeID format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format" value=""/>
         <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="7d2b7f94d82b3df7ad4a49868be18aad08a7c89d"/>
@@ -25,7 +25,7 @@
     <software id="Xcalibur" version="">
       <cvParam cvRef="MS" accession="MS:1000532" name="Xcalibur" value=""/>
     </software>
-    <software id="pwiz" version="3.0.20150">
+    <software id="pwiz" version="3.0.23188">
       <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
     </software>
   </softwareList>
@@ -70,6 +70,7 @@
           <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
           <scan>
             <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="6.800121878211" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+            <cvParam cvRef="MS" accession="MS:1000800" name="mass resolving power" value="60000"/>
             <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value="FTMS + p NSI d Full ms2 379.71@hcd27.00 [150.00-1700.00]"/>
             <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="3"/>
             <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="14.715546742082" unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>

--- a/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/SpectrumList_Thermo.cpp
@@ -325,6 +325,12 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Thermo::spectrum(size_t index, DetailLeve
             result->spotID += "x" + scanInfo->trailerExtraValue("Absolute Y Position:");
         }
 
+        long resolvingPower = scanInfo->trailerExtraValueLong("Orbitrap Resolution:");
+        if (resolvingPower <= 0)
+            resolvingPower = scanInfo->trailerExtraValueLong("FT Resolution:");
+        if (resolvingPower > 0)
+            scan.set(MS_mass_resolving_power, resolvingPower);
+
         MassAnalyzerType analyzerType = scanInfo->massAnalyzerType();
         if (ie.controllerType == Controller_MS)
             scan.instrumentConfigurationPtr = findInstrumentConfiguration(msd_, translate(analyzerType));


### PR DESCRIPTION
- added mass resolving power to scans when "FT Resolution" or "Orbitrap Resolution" item is available in Thermo RAW scan trailer

Requested on psidev mailing list.