### PR TITLE
- fixed buffer overrun with long CV param values in mz5

### DIFF
--- a/pwiz/data/msdata/mz5/Datastructures_mz5.cpp
+++ b/pwiz/data/msdata/mz5/Datastructures_mz5.cpp
@@ -446,7 +446,7 @@ void CVParamMZ5::init(const char* value, const unsigned long& cvrefid,
 {
     if (value)
     {
-        strcpy(this->value, value);
+        strncpy(this->value, value, CVL);
     } else {
         this->value[0] = '\0';
     }

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -951,8 +951,8 @@ void processFile(const string& filename, const Config& config, const ReaderList&
 
             *os_ << "calculating source file checksums" << endl;
             calculateSHA1Checksums(msd);
-            //if (!msd.dataProcessingPtrs.empty() && !msd.dataProcessingPtrs[0]->processingMethods.empty())
-            //    msd.dataProcessingPtrs[0]->processingMethods[0].set(MS_command_line_parameters, args);
+            if (!msd.dataProcessingPtrs.empty() && !msd.dataProcessingPtrs[0]->processingMethods.empty())
+                msd.dataProcessingPtrs[0]->processingMethods[0].set(MS_command_line_parameters, args);
 
             // if config.singleThreaded is not explicitly set, determine whether to use worker threads by querying SpectrumListWrappers
             Config configCopy(config);


### PR DESCRIPTION
- fixed buffer overrun with long CV param values in mz5
- uncommented command-line processingMethod CV param in msconvert