### PR TITLE
Cherry pick 2654 to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,8 +381,13 @@ Version.cpp
 /pwiz_tools/Bumbershoot/idpicker/Resources/Resources.*
 /pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/Properties/AssemblyInfo.cs
 
+# Vendor reader test data extracted from tarballs (newer data should be committed directly to git)
+/pwiz/data/vendor_readers/*/Reader*Test.data/**/1SRef
+/pwiz/data/vendor_readers/*/Reader*Test.data/**.raw
+/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data
+/pwiz/data/vendor_readers/UIMF/Reader_UIMF_Test.data
+
 # Files that get extracted from vendor reader distros
-Reader*Test.data
 /pwiz_aux/msrc/utility/vendor_api/**/*.dll
 /pwiz_aux/msrc/utility/vendor_api/*/EULA.*
 /pwiz_aux/msrc/utility/vendor_api/ABI/LicenseKey.h

--- a/pwiz/analysis/spectrum_processing/SpectrumList_PeakPicker.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_PeakPicker.cpp
@@ -138,19 +138,8 @@ SpectrumList_PeakPicker::SpectrumList_PeakPicker(
         method.userParams.emplace_back("ms levels", msLevelsToPeakPickStr);
 
     if (algorithm_)
-        noVendorCentroidingWarningMessage_ = string("[SpectrumList_PeakPicker]: vendor centroiding requested but not available for this data; falling back to ") + algorithm_->name();
+        noVendorCentroidingWarningMessage_ = string("[SpectrumList_PeakPicker]: vendor centroiding requested but not available for non-vendor formats (and UNIFI); falling back to ") + algorithm_->name();
 
-    if (preferVendorPeakPicking && !mode_ && (algorithm_ != NULL)) // VendorOnlyPeakPicker sets algorithm null, we deal with this at get binary data time
-    {
-        cerr << "Warning: vendor peakPicking was requested, but is unavailable";
-#ifdef WIN32
-        cerr << " for this input data. ";
-#else
-        cerr << " as it depends on Windows DLLs.  ";
-#endif
-        cerr << "Using ProteoWizard centroiding algorithm instead." << endl;
-		cerr << "High-quality peak-picking can be enabled using the cwt flag." << endl;
-    }
     dp_->processingMethods.push_back(method);
 }
 

--- a/pwiz/data/vendor_readers/.gitattributes
+++ b/pwiz/data/vendor_readers/.gitattributes
@@ -1,0 +1,5 @@
+# Don't change line endings on vendor data
+**/Reader*Test.data/** binary
+
+# Do show diffs on reference mzMLs
+*.mzML diff

--- a/pwiz/data/vendor_readers/ABI/Reader_ABI_Test.data/.gitattributes
+++ b/pwiz/data/vendor_readers/ABI/Reader_ABI_Test.data/.gitattributes
@@ -1,2 +1,0 @@
-# Don't change line endings on vendor data
-* binary

--- a/pwiz/data/vendor_readers/Agilent/Reader_Agilent_Test.data/.gitattributes
+++ b/pwiz/data/vendor_readers/Agilent/Reader_Agilent_Test.data/.gitattributes
@@ -1,2 +1,0 @@
-# Don't change line endings on vendor data
-* binary

--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/.gitattributes
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker_Test.data/.gitattributes
@@ -1,2 +1,0 @@
-# Don't change line endings on vendor data
-* binary

--- a/pwiz/data/vendor_readers/Mobilion/Reader_Mobilion_Test.data/.gitattributes
+++ b/pwiz/data/vendor_readers/Mobilion/Reader_Mobilion_Test.data/.gitattributes
@@ -1,2 +1,0 @@
-# Don't change line endings on vendor data
-* binary

--- a/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/.gitattributes
+++ b/pwiz/data/vendor_readers/Shimadzu/Reader_Shimadzu_Test.data/.gitattributes
@@ -1,2 +1,0 @@
-# Don't change line endings on vendor data
-* binary

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/.gitattributes
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Test.data/.gitattributes
@@ -1,2 +1,0 @@
-# Don't change line endings on vendor data
-* binary

--- a/pwiz/data/vendor_readers/UIMF/Reader_UIMF_Test.data/.gitattributes
+++ b/pwiz/data/vendor_readers/UIMF/Reader_UIMF_Test.data/.gitattributes
@@ -1,2 +1,0 @@
-# Don't change line endings on vendor data
-* binary

--- a/pwiz/data/vendor_readers/Waters/Reader_Waters_Test.data/.gitattributes
+++ b/pwiz/data/vendor_readers/Waters/Reader_Waters_Test.data/.gitattributes
@@ -1,2 +1,0 @@
-# Don't change line endings on vendor data
-* binary


### PR DESCRIPTION
- removed "Warning: vendor peakPicking was requested, but is unavailable" message that showed even when no spectra in the file need centroiding
* consolidated .gitattributes files from most vendor test data directories and set mzML files to be diffable in the consolidated file
* made more specific .gitignore rules so new mzML files in vendor test data directories won't be ignored