### PR TITLE
MSFragger DDA PASEF search and better BiblioSpec errors

### DIFF
--- a/pwiz/data/msdata/MSData.cpp
+++ b/pwiz/data/msdata/MSData.cpp
@@ -24,7 +24,8 @@
 
 #include "MSData.hpp"
 #include "pwiz/utility/misc/Std.hpp"
-#include <boost/lexical_cast.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include "pwiz/utility/misc/optimized_lexical_cast.hpp"
 #include "Diff.hpp"
 
 namespace pwiz {
@@ -1140,6 +1141,24 @@ PWIZ_API_DECL IndexList SpectrumList::findSpotID(const string& spotID) const
     return result;
 }
 
+/// returns true iff the id formats match
+PWIZ_API_DECL bool SpectrumList::checkNativeIdMatch(const string& firstIdInFile, const string& searchedId) const
+{
+    auto actualId = pwiz::msdata::id::parse(firstIdInFile);
+    auto actualIdKeys = actualId | boost::adaptors::map_keys;
+    auto actualIdKeySet = std::set<std::string>(actualIdKeys.begin(), actualIdKeys.end());
+
+    auto expectedId = pwiz::msdata::id::parse(searchedId);
+    auto expectedIdKeys = expectedId | boost::adaptors::map_keys;
+    auto expectedIdKeySet = std::set<std::string>(expectedIdKeys.begin(), expectedIdKeys.end());
+
+    std::vector<std::string> missingIdKeys;
+    std::set_symmetric_difference(expectedIdKeySet.begin(), expectedIdKeySet.end(),
+        actualIdKeySet.begin(), actualIdKeySet.end(),
+        std::back_inserter(missingIdKeys));
+
+    return missingIdKeys.empty();
+}
 
 PWIZ_API_DECL const shared_ptr<const DataProcessing> SpectrumList::dataProcessingPtr() const
 {

--- a/pwiz/data/msdata/MSData.hpp
+++ b/pwiz/data/msdata/MSData.hpp
@@ -708,6 +708,9 @@ class PWIZ_API_DECL SpectrumList
     /// find all spectrum indexes with spotID (returns empty vector on failure)
     virtual IndexList findSpotID(const std::string& spotID) const;
 
+    /// if find() fails to find a spectrum id, can use this to check whether the id fields of the input id and the spectrum list are matching
+    virtual bool checkNativeIdMatch(const std::string& firstIdInList, const std::string& searchedId) const;
+
     /// retrieve a spectrum by index
     /// - binary data arrays will be provided if (getBinaryData == true);
     /// - client may assume the underlying Spectrum* is valid 

--- a/pwiz/data/msdata/SpectrumListBase.cpp
+++ b/pwiz/data/msdata/SpectrumListBase.cpp
@@ -27,6 +27,7 @@
 #include "pwiz/utility/misc/Stream.hpp"
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/functional/hash.hpp>
 
 
 namespace {
@@ -70,20 +71,7 @@ PWIZ_API_DECL size_t pwiz::msdata::SpectrumListBase::checkNativeIdFindResult(siz
                 return size();
         }
 
-        auto actualId = pwiz::msdata::id::parse(firstId);
-        auto actualIdKeys = actualId | boost::adaptors::map_keys;
-        auto actualIdKeySet = std::set<std::string>(actualIdKeys.begin(), actualIdKeys.end());
-
-        auto expectedId = pwiz::msdata::id::parse(id);
-        auto expectedIdKeys = expectedId | boost::adaptors::map_keys;
-        auto expectedIdKeySet = std::set<std::string>(expectedIdKeys.begin(), expectedIdKeys.end());
-
-        std::vector<std::string> missingIdKeys;
-        std::set_symmetric_difference(expectedIdKeySet.begin(), expectedIdKeySet.end(),
-            actualIdKeySet.begin(), actualIdKeySet.end(),
-            std::back_inserter(missingIdKeys));
-
-        if (!missingIdKeys.empty())
+        if (!checkNativeIdMatch(firstId, id))
             warn_once(("[SpectrumList::find] mismatch between spectrum id format of the file (" + firstId + ") and the looked-up id (" + id + ")").c_str());
         return size();
     }

--- a/pwiz/data/msdata/SpectrumListBase.hpp
+++ b/pwiz/data/msdata/SpectrumListBase.hpp
@@ -27,8 +27,6 @@
 
 #include "pwiz/data/msdata/MSData.hpp"
 #include "pwiz/utility/misc/IntegerSet.hpp"
-#include <boost/functional/hash.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/make_shared.hpp>
 #include <stdexcept>
 #include <iostream>
@@ -58,7 +56,7 @@ class PWIZ_API_DECL ListBase
 class PWIZ_API_DECL SpectrumListBase : public SpectrumList
 {
     public:
-    SpectrumListBase() : MSLevelsNone(), spectrum_id_mismatch_hash_(impl_.hash("spectrum id mismatch")) {};
+    SpectrumListBase() : spectrum_id_mismatch_hash_(impl_.hash("spectrum id mismatch")) {}
 
     /// issues a warning once per list instance (based on string hash)
     void warn_once(const char* msg) const { impl_.warn_once(msg); }
@@ -80,8 +78,8 @@ class PWIZ_API_DECL SpectrumListBase : public SpectrumList
     DataProcessingPtr dp_;
 
     private:
-    size_t spectrum_id_mismatch_hash_;
     ListBase impl_;
+    size_t spectrum_id_mismatch_hash_;
 };
 
 

--- a/pwiz_tools/BiblioSpec/src/BlibBuild.cpp
+++ b/pwiz_tools/BiblioSpec/src/BlibBuild.cpp
@@ -269,7 +269,7 @@ int main(int argc, char* argv[])
             if (builder.is_empty()) {
                 builder.abort_current_library();
                 if (success) {
-                    Verbosity::error("No spectra were found for the new library. Check detailed output to troubleshoot.");
+                    Verbosity::error("No spectra were found for the new library.");
                 }
             } else {
                 builder.collapseSources();

--- a/pwiz_tools/BiblioSpec/src/BlibBuild.cpp
+++ b/pwiz_tools/BiblioSpec/src/BlibBuild.cpp
@@ -269,7 +269,7 @@ int main(int argc, char* argv[])
             if (builder.is_empty()) {
                 builder.abort_current_library();
                 if (success) {
-                    Verbosity::error("No spectra were found for the new library.");
+                    Verbosity::error("No spectra were found for the new library. Check detailed output to troubleshoot.");
                 }
             } else {
                 builder.collapseSources();

--- a/pwiz_tools/BiblioSpec/src/BuildParser.cpp
+++ b/pwiz_tools/BiblioSpec/src/BuildParser.cpp
@@ -32,6 +32,7 @@ BuildParser::BuildParser(BlibBuilder& maker,
 : fullFilename_(filename),
   blibMaker_(maker),
   fileProgressIncrement_(0),
+  filteredOutPsmCount_(0),
   lookUpBy_(SCAN_NUM_ID)
 {
     // initialize amino acid masses
@@ -329,7 +330,7 @@ sqlite3_int64 BuildParser::insertProtein(const Protein* protein) {
 void BuildParser::buildTables(PSM_SCORE_TYPE scoreType, string specFilename, bool showSpecProgress) {
     // return if no psms for this file
     if( psms_.size() == 0 ) {
-        Verbosity::status("No matches found in %s.", curSpecFileName_.c_str() );
+        Verbosity::warn("No matches passed score filter in %s. %d matches did not pass filter.", curSpecFileName_.c_str(), filteredOutPsmCount_ );
         curSpecFileName_.clear();
         if( fileProgress_ ) { 
             if( fileProgressIncrement_ == 0 ){
@@ -340,6 +341,8 @@ void BuildParser::buildTables(PSM_SCORE_TYPE scoreType, string specFilename, boo
         }
         return;
     }
+
+    Verbosity::status("Read %d matches that passed the score filter (%d matches did not pass).", psms_.size(), filteredOutPsmCount_);
 
     // make sure sequences are uppercase; generate modified sequences if necessary
     verifySequences();

--- a/pwiz_tools/BiblioSpec/src/BuildParser.h
+++ b/pwiz_tools/BiblioSpec/src/BuildParser.h
@@ -96,6 +96,7 @@ class BuildParser : protected SAXHandler{
   ProgressIndicator* readAddProgress_;  ///< 2 steps: read file, add spec
   PSM* curPSM_;           ///< temp holding space for psm being parsed
   vector<PSM*> psms_;     ///< collected list of psms parsed from file
+  int filteredOutPsmCount_; ///< number of psms that did not pass threshold
   SpecFileReader* specReader_; ///< for getting peak lists
   SPEC_ID_TYPE lookUpBy_; ///< default is by scan number
   bool preferEmbeddedSpectra_; ///< default is true except for MaxQuant

--- a/pwiz_tools/BiblioSpec/src/MascotResultsReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MascotResultsReader.cpp
@@ -211,10 +211,6 @@ bool MascotResultsReader::parseFile(){
         double expectationValue = 
             ms_results_->getPeptideExpectationValue(ionScore, specId);
 
-        if( expectationValue > scoreThreshold_ ) {
-            continue;
-        }
-
         // look for the filename in the title
         ms_inputquery spec(*ms_file_, specId);
         string file = getFilename(spec);
@@ -225,6 +221,11 @@ bool MascotResultsReader::parseFile(){
             vector<PSM*> tmpPsms;
             fileMap_[file] = tmpPsms;
             mapAccess = fileMap_.find(file);
+        }
+
+        if (expectationValue > scoreThreshold_) {
+            ++filteredOutPsmCount_;
+            continue;
         }
 
         // add all PSMs that are rank 1, remove duplicates later

--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
@@ -728,6 +728,7 @@ void MaxQuantReader::storeLine(MaxQuantLine& entry)
     {
         Verbosity::comment(V_DETAIL, "Not saving PSM %d with PEP %f (line %d)",
                            entry.scanNumber, entry.pep, lineNum_);
+        ++filteredOutPsmCount_;
         return;
     }
     else if (entry.masses.empty() || entry.intensities.empty())

--- a/pwiz_tools/BiblioSpec/src/PepXMLreader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PepXMLreader.cpp
@@ -619,6 +619,7 @@ bool PepXMLreader::scorePasses(double score){
     default:
         throw std::runtime_error("analysis type " + lexical_cast<string>(analysisType_) + " is not handled by PepXMLreader::scorePasses (bug)");
     }
+    ++filteredOutPsmCount_;
     return false;
 }
 

--- a/pwiz_tools/BiblioSpec/src/PercolatorXmlReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PercolatorXmlReader.cpp
@@ -387,9 +387,9 @@ void PercolatorXmlReader::addCurPSM(){
     if(curPSM_ == NULL)
         throw BlibException(false, "No PSM was read for this 'psm' tag.");
 
+    string filename = curPSM_->specName;
     if(curPSM_->score < qvalueThreshold_){ // add the psm to the map
         // retrieve and remove the filename from the psm
-        string filename = curPSM_->specName;
         curPSM_->specName.clear();
 
         Verbosity::comment(V_DETAIL, "For file %s adding PSM: "
@@ -406,6 +406,11 @@ void PercolatorXmlReader::addCurPSM(){
             (mapAccess->second).push_back(curPSM_);
         }
         curPSM_ = NULL;
+    }
+    else
+    {
+        ++filteredOutPsmCount_;
+        fileMap_.insert(make_pair(filename, vector<PSM*>()));
     }
 }
 

--- a/pwiz_tools/BiblioSpec/src/PrideXmlReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/PrideXmlReader.cpp
@@ -450,6 +450,8 @@ void PrideXmlReader::endPeptideItem()
     {
         psms_.push_back(curPSM_);
     }
+    else
+        ++filteredOutPsmCount_;
 
     lastState();
 }

--- a/pwiz_tools/BiblioSpec/src/ProteinPilotReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/ProteinPilotReader.cpp
@@ -249,17 +249,19 @@ void ProteinPilotReader::parseMatchElement(const XML_Char** attr)
                             "Cannot find spectrum associated with match %s, "
                             "sequence %s.", getAttrValue("xml:id", attr),
                             getAttrValue("seq", attr));
-    } 
+    }
+    // find out what spectrum file this came from
+    string searchID = getRequiredAttrValue("searches", attr);
 
     // get confidence and skip if doesn't pass cutoff 
     // or if it is ranked higher than first
     double score = getDoubleRequiredAttrValue("confidence", attr);
     if( score < probCutOff_ || score < curPSM_->score ) {
         skipMods_ = true;
+        ++filteredOutPsmCount_;
+        searchIdPsmMap_.insert(make_pair(searchID, vector<PSM*>()));
         return;
     } 
-    // find out what spectrum file this came from
-    string searchID = getRequiredAttrValue("searches", attr);
     // create a vector of PSMs for this search/file if not present
     map<string, vector<PSM*> >::iterator mapAccess 
         = searchIdPsmMap_.find(searchID);

--- a/pwiz_tools/BiblioSpec/src/ProxlXmlReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/ProxlXmlReader.cpp
@@ -407,6 +407,8 @@ void ProxlXmlReader::calcPsms() {
                             break;
                     }
                 }
+                else
+                    ++filteredOutPsmCount_;
                 delete proxlPsm;
             }
         }

--- a/pwiz_tools/BiblioSpec/src/PwizReader.h
+++ b/pwiz_tools/BiblioSpec/src/PwizReader.h
@@ -115,6 +115,7 @@ class PwizReader : public BiblioSpec::SpecFileReader {
     size_t curPositionInIndexMzPairs_;
     vector< pair<int,double> > indexMzPairs_; // scan/pre-mz pairs, may besorted byeither
     BiblioSpec::SPEC_ID_TYPE idType_;
+    BiblioSpec::V_LEVEL idNotFoundWarnLevel_;
 
 
     /**

--- a/pwiz_tools/BiblioSpec/src/SQTreader.cpp
+++ b/pwiz_tools/BiblioSpec/src/SQTreader.cpp
@@ -279,6 +279,7 @@ void SQTreader::extractPSMs()
         if( curPSM_->score > scoreThreshold ) {// good matches score 0 to threshold
             delete curPSM_;
             curPSM_ = NULL;
+            ++filteredOutPsmCount_;
             continue;
         }
         // get the unmodified seq and mods from the file's version of seq

--- a/pwiz_tools/BiblioSpec/src/TSVReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/TSVReader.cpp
@@ -135,6 +135,8 @@ namespace {
             }
             else if (line.score > scoreThreshold_) {
                 Verbosity::comment(V_DETAIL, "Not saving PSM with score %f (line %d)", line.score, lineNum_);
+                ++filteredOutPsmCount_;
+                fileMap_.insert(make_pair(line.filename, vector<TSVPSM*>()));
                 return;
             }
 

--- a/pwiz_tools/BiblioSpec/src/WatersMseReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/WatersMseReader.cpp
@@ -595,6 +595,7 @@ void WatersMseReader::insertCurPSM(){
         } else if( curMsePSM_->score <= scoreThreshold_ ){
             Verbosity::comment(V_DETAIL, "Not inserting psm %d with score %f",
                                curMsePSM_->specKey, curMsePSM_->score);
+            ++filteredOutPsmCount_;
         }
         curMsePSM_->clear();
     }

--- a/pwiz_tools/BiblioSpec/src/mzTabReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/mzTabReader.cpp
@@ -202,12 +202,18 @@ void mzTabReader::parseLine(const string& line) {
         vector< pair<string, string> > spectra;
         parseSpectrum(fields, spectra);        
         double score;
-        if (!parseScore(fields, score)) {
-            return;
-        }
+        bool passedThreshold = parseScore(fields, score);
+        if (!passedThreshold)
+            ++filteredOutPsmCount_;
+
         const string scanPrefix = "scan=";
         const string indexPrefix = "index=";
         for (vector< pair<string, string> >::const_iterator i = spectra.begin(); i != spectra.end(); i++) {
+            if (!passedThreshold)
+            {
+                fileMap_.insert(make_pair(i->first, vector<PSM*>()));
+                continue;
+            }
             curPSM_ = new PSM();
             curPSM_->charge = charge;
             curPSM_->unmodSeq = seq;

--- a/pwiz_tools/BiblioSpec/tests/inputs/mismatched-nativeid-format.mzid
+++ b/pwiz_tools/BiblioSpec/tests/inputs/mismatched-nativeid-format.mzid
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MzIdentML id="PeptideShaker v1.16.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" version="1.1.0" creationDate="2019-02-08T18:10:34">
+	<cvList>
+		<cv id="PSI-MS" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" fullName="PSI-MS"/>
+		<cv id="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" fullName="UNIMOD"/>
+		<cv id="UO" uri="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo" fullName="UNIT-ONTOLOGY"/>
+		<cv id="PRIDE" uri="https://github.com/PRIDE-Utilities/pride-ontology/blob/master/pride_cv.obo" fullName="PRIDE"/>
+	</cvList>
+	<AnalysisSoftwareList>
+		<AnalysisSoftware name="PeptideShaker" version="1.16.4" id="ID_software" uri="http://compomics.github.io/projects/peptide-shaker.html">
+			<ContactRole contact_ref="PS_DEV">
+				<Role>
+					<cvParam cvRef="PSI-MS" accession="MS:1001267" name="software vendor"/>
+				</Role>
+			</ContactRole>
+			<SoftwareName>
+				<cvParam cvRef="PSI-MS" accession="MS:1002458" name="PeptideShaker"/>
+			</SoftwareName>
+			<Customizations>No customisations</Customizations>
+		</AnalysisSoftware>
+	</AnalysisSoftwareList>
+	<Provider id="PROVIDER">
+		<ContactRole contact_ref="PROVIDER">
+			<Role>
+				<cvParam cvRef="PSI-MS" accession="MS:1001271" name="researcher"/>
+			</Role>
+		</ContactRole>
+	</Provider>
+	<AuditCollection>
+		<Person firstName="Proteomics" lastName="Galaxy" id="PROVIDER">
+			<cvParam cvRef="PSI-MS" accession="MS:1000587" name="contact address" value="galaxyp@umn.edu"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1000589" name="contact email" value="galaxyp@umn.edu"/>
+			<Affiliation organization_ref="ORG_DOC_OWNER"/>
+		</Person>
+		<Organization name="University of Minnesota" id="ORG_DOC_OWNER">
+			<cvParam cvRef="PSI-MS" accession="MS:1000586" name="contact name" value="University of Minnesota"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1000587" name="contact address" value="Minneapolis, MN 55455, Vereinigte Staaten"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1000589" name="contact email" value="galaxyp@umn.edu"/>
+		</Organization>
+		<Organization name="PeptideShaker developers" id="PS_DEV">
+			<cvParam cvRef="PSI-MS" accession="MS:1000586" name="contact name" value="PeptideShaker developers"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1000587" name="contact address" value="Proteomics Unit, Building for Basic Biology, University of Bergen, Jonas Liesvei 91, N-5009 Bergen, Norway"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1000588" name="contact URL" value="http://compomics.github.io/projects/peptide-shaker.html"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1000589" name="contact email" value="peptide-shaker@googlegroups.com"/>
+		</Organization>
+	</AuditCollection>
+	<SequenceCollection>
+		<DBSequence id="Q80Y81" accession="Q80Y81" searchDatabase_ref="SearchDB_1" >
+			<cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description" value="RNZ2_MOUSE Zinc phosphodiesterase ELAC protein 2 OS=Mus musculus GN=Elac2 PE=1 SV=1"/>
+		</DBSequence>
+		<DBSequence id="Q80UW0" accession="Q80UW0" searchDatabase_ref="SearchDB_1" >
+			<cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description" value="H6ST2_MOUSE Heparan-sulfate 6-O-sulfotransferase 2 OS=Mus musculus GN=Hs6st2 PE=2 SV=3"/>
+		</DBSequence>
+		<DBSequence id="Q80X81" accession="Q80X81" searchDatabase_ref="SearchDB_1" >
+			<cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description" value="Q80X81_MOUSE Acetyl-Coenzyme A acetyltransferase 3 OS=Mus musculus GN=Acat3 PE=1 SV=1"/>
+		</DBSequence>
+		<DBSequence id="Q8CAY6" accession="Q8CAY6" searchDatabase_ref="SearchDB_1" >
+			<cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description" value="THIC_MOUSE Acetyl-CoA acetyltransferase, cytosolic OS=Mus musculus GN=Acat2 PE=1 SV=2"/>
+		</DBSequence>
+		<DBSequence id="Q61699" accession="Q61699" searchDatabase_ref="SearchDB_1" >
+			<cvParam cvRef="PSI-MS" accession="MS:1001088" name="protein description" value="HS105_MOUSE Heat shock protein 105 kDa OS=Mus musculus GN=Hsph1 PE=1 SV=2"/>
+		</DBSequence>
+		<Peptide id="RGPFEIEAFYSDPQGVPYPEAK">
+			<PeptideSequence>RGPFELEAFYSDPQGVPYPEAK</PeptideSequence>
+			<Modification monoisotopicMassDelta="144.102062" residues="K" location="22" >
+				<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+			</Modification>
+			<Modification monoisotopicMassDelta="144.102062" residues="R" location="0" >
+				<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+			</Modification>
+		</Peptide>
+		<Peptide id="EIVPVIVSSRK">
+			<PeptideSequence>EIVPVLVSSRK</PeptideSequence>
+			<Modification monoisotopicMassDelta="144.102062" residues="K" location="11" >
+				<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+			</Modification>
+			<Modification monoisotopicMassDelta="144.102062" residues="E" location="0" >
+				<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+			</Modification>
+		</Peptide>
+		<Peptide id="DIFIQRYQFMR">
+			<PeptideSequence>DLFLQRYQFMR</PeptideSequence>
+			<Modification monoisotopicMassDelta="144.102062" residues="D" location="0" >
+				<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+			</Modification>
+		</Peptide>
+		<Peptide id="RSQYPEIVFIGTGSAIPMK_15.99491461956-ATAA-18">
+			<PeptideSequence>RSQYPEIVFLGTGSAIPMK</PeptideSequence>
+			<Modification monoisotopicMassDelta="144.102062" residues="K" location="19" >
+				<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+			</Modification>
+			<Modification monoisotopicMassDelta="144.102062" residues="R" location="0" >
+				<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+			</Modification>
+			<Modification monoisotopicMassDelta="15.994915" residues="M" location="18" >
+				<cvParam cvRef="UNIMOD" accession="UNIMOD:35" name="Oxidation"/>
+			</Modification>
+		</Peptide>
+		<PeptideEvidence isDecoy="false" pre="K" post="I" start="473" end="491" peptide_ref="RSQYPEIVFIGTGSAIPMK_15.99491461956-ATAA-18" dBSequence_ref="Q80Y81" id="PepEv_5147" />
+		<PeptideEvidence isDecoy="false" pre="K" post="Q" start="493" end="503" peptide_ref="DIFIQRYQFMR" dBSequence_ref="Q80UW0" id="PepEv_5510" />
+		<PeptideEvidence isDecoy="false" pre="K" post="G" start="201" end="211" peptide_ref="EIVPVIVSSRK" dBSequence_ref="Q80X81" id="PepEv_4410" />
+		<PeptideEvidence isDecoy="false" pre="K" post="G" start="201" end="211" peptide_ref="EIVPVIVSSRK" dBSequence_ref="Q8CAY6" id="PepEv_4411" />
+		<PeptideEvidence isDecoy="false" pre="R" post="I" start="437" end="458" peptide_ref="RGPFEIEAFYSDPQGVPYPEAK" dBSequence_ref="Q61699" id="PepEv_5258" />
+	</SequenceCollection>
+	<AnalysisCollection>
+		<SpectrumIdentification spectrumIdentificationList_ref="SIL_1" spectrumIdentificationProtocol_ref="SearchProtocol_1" id="SpecIdent_1">
+			<InputSpectra spectraData_ref="Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.mgf"/>
+			<SearchDatabaseRef searchDatabase_ref="SearchDB_1"/>
+		</SpectrumIdentification>
+		<ProteinDetection proteinDetectionProtocol_ref="PeptideShaker_1" proteinDetectionList_ref="Protein_groups" id="PD_1">
+			<InputSpectrumIdentifications spectrumIdentificationList_ref="SIL_1"/>
+		</ProteinDetection>
+	</AnalysisCollection>
+	<AnalysisProtocolCollection>
+		<SpectrumIdentificationProtocol analysisSoftware_ref="ID_software" id="SearchProtocol_1">
+			<SearchType>
+				<cvParam cvRef="PSI-MS" accession="MS:1001083" name="ms-ms search"/>
+			</SearchType>
+			<AdditionalSearchParams>
+				<cvParam cvRef="PSI-MS" accession="MS:1001211" name="parent mass type mono"/>
+				<cvParam cvRef="PSI-MS" accession="MS:1001256" name="fragment mass type mono"/>
+			</AdditionalSearchParams>
+			<ModificationParams>
+				<SearchModification residues="C" massDelta="57.021464" fixedMod= "true" >
+					<cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+				</SearchModification>
+				<SearchModification residues="K" massDelta="144.102062" fixedMod= "true" >
+					<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+				</SearchModification>
+				<SearchModification residues="." massDelta="144.102062" fixedMod= "true" >
+					<SpecificityRules>
+						<cvParam cvRef="PSI-MS" accession="MS:1001189" name="modification specificity peptide N-term"/>
+					</SpecificityRules>
+					<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+				</SearchModification>
+				<SearchModification residues="M" massDelta="15.994915" fixedMod= "false" >
+					<cvParam cvRef="UNIMOD" accession="UNIMOD:35" name="Oxidation"/>
+				</SearchModification>
+				<SearchModification residues="Y" massDelta="144.102062" fixedMod= "false" >
+					<cvParam cvRef="UNIMOD" accession="UNIMOD:214" name="iTRAQ4plex"/>
+				</SearchModification>
+			</ModificationParams>
+			<Enzymes independent="false">
+			<Enzyme missedCleavages="2" semiSpecific="false" id="Enz1" name="Trypsin">
+				<EnzymeName>
+					<cvParam cvRef="PSI-MS" accession="MS:1001251" name="Trypsin"/>
+				</EnzymeName>
+			</Enzyme>
+		</Enzymes>
+		<FragmentTolerance>
+			<cvParam accession="MS:1001412" cvRef="PSI-MS" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" value="0.05" name="search tolerance plus value" />
+			<cvParam accession="MS:1001413" cvRef="PSI-MS" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" value="0.05" name="search tolerance minus value" />
+		</FragmentTolerance>
+		<ParentTolerance>
+			<cvParam accession="MS:1001412" cvRef="PSI-MS" unitCvRef="UO" unitName="parts per million" unitAccession="UO:0000169" value="10.0" name="search tolerance plus value" />
+			<cvParam accession="MS:1001413" cvRef="PSI-MS" unitCvRef="UO" unitName="parts per million" unitAccession="UO:0000169" value="10.0" name="search tolerance minus value" />
+		</ParentTolerance>
+		<Threshold>
+			<cvParam cvRef="PSI-MS" accession="MS:1001364" name="peptide sequence-level global FDR" value="1.0"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1002350" name="PSM-level global FDR" value="1.0"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1002567" name="phosphoRS score threshold" value="95.0"/>
+			<cvParam cvRef="PSI-MS" accession="MS:1002557" name="D-Score threshold" value="95.0"/>
+		</Threshold>
+	</SpectrumIdentificationProtocol>
+	<ProteinDetectionProtocol analysisSoftware_ref="ID_software" id="PeptideShaker_1">
+		<Threshold>
+			<cvParam cvRef="PSI-MS" accession="MS:1002369" name="protein group-level global FDR" value="0.01"/>
+		</Threshold>
+	</ProteinDetectionProtocol>
+</AnalysisProtocolCollection>
+<DataCollection>
+	<Inputs>
+		<SourceFile location="file:/export/galaxy-central/database/job_working_directory/016/16155/working/PeptideShakerCLI/.PeptideShaker_unzip_temp/searchgui_input_PeptideShaker_temp/Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.t.xml" id="SourceFile_3">
+			<FileFormat>
+				<cvParam cvRef="PSI-MS" accession="MS:1001401" name="X!Tandem xml format"/>
+			</FileFormat>
+		</SourceFile>
+		<SearchDatabase numDatabaseSequences="10592" location="file:/export/galaxy-central/database/job_working_directory/016/16155/working/PeptideShakerCLI/.PeptideShaker_unzip_temp/peptideshaker_output_PeptideShaker_temp/data/input_database.fasta" id="SearchDB_1">
+			<FileFormat>
+				<cvParam cvRef="PSI-MS" accession="MS:1001348" name="FASTA format"/>
+			</FileFormat>
+			<DatabaseName>
+				<userParam name="input_database.fasta"/>
+			</DatabaseName>
+			<cvParam cvRef="PSI-MS" accession="MS:1001073" name="database type amino acid"/>
+		</SearchDatabase>
+		<SpectraData location="file:/export/galaxy-central/database/job_working_directory/016/16155/working/PeptideShakerCLI/.PeptideShaker_unzip_temp/peptideshaker_output_PeptideShaker_temp/data/Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.mgf" id="Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.mgf" name="Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.mgf">
+			<FileFormat>
+				<cvParam cvRef="PSI-MS" accession="MS:1001062" name="Mascot MGF format"/>
+			</FileFormat>
+			<SpectrumIDFormat>
+				<cvParam cvRef="PSI-MS" accession="MS:1000774" name="multiple peak list nativeID format"/>
+			</SpectrumIDFormat>
+		</SpectraData>
+	</Inputs>
+	<AnalysisData>
+		<SpectrumIdentificationList id="SIL_1">
+			<FragmentationTable>
+				<Measure id="Measure_MZ">
+					<cvParam cvRef="PSI-MS" accession="MS:1001225" name="product ion m/z" unitCvRef="PSI-MS" unitAccession="MS:1000040" unitName="m/z" />
+				</Measure>
+				<Measure id="Measure_Int">
+					<cvParam cvRef="PSI-MS" accession="MS:1001226" name="product ion intensity" unitCvRef="PSI-MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+				</Measure>
+				<Measure id="Measure_Error">
+					<cvParam cvRef="PSI-MS" accession="MS:1001227" name="product ion m/z error" unitCvRef="PSI-MS" unitAccession="MS:1000040" unitName="m/z"/>
+				</Measure>
+			</FragmentationTable>
+			<SpectrumIdentificationResult spectraData_ref="Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.mgf" spectrumID="scanId=422034" id="SIR_1">
+				<SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="RGPFEIEAFYSDPQGVPYPEAK" calculatedMassToCharge="929.1406981159289" experimentalMassToCharge="929.47998" chargeState="3" id="SII_1_1">
+					<PeptideEvidenceRef peptideEvidence_ref="PepEv_5258"/>
+					<Fragmentation>
+						<IonType charge="1" index="10 18">
+							<FragmentArray measure_ref="Measure_MZ" values="136.0755"/>
+							<FragmentArray measure_ref="Measure_Int" values="637.194458"/>
+							<FragmentArray measure_ref="Measure_Error" values="-1.9037980200664606E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001239" name="frag: immonium ion"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="114.110405"/>
+							<FragmentArray measure_ref="Measure_Int" values="742.38855"/>
+							<FragmentArray measure_ref="Measure_Error" values="-2.746990520279269E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="114"/>
+						</IonType>
+						<IonType charge="1" index="5 7 8 9 10 11 12">
+							<FragmentArray measure_ref="Measure_MZ" values="731.398132 973.522278 1044.555176 1191.62915 1354.709839 1441.750244 1556.744995"/>
+							<FragmentArray measure_ref="Measure_Int" values="280.966644 442.955017 564.234253 458.13092 343.378754 171.501633 1682.521362"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.0024475184078482926 -6.354669221764198E-5 -0.004279331402358366 0.001280755607467654 0.018641223057557 0.02701781878749898 -0.005174205042521862"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001224" name="frag: b ion"/>
+						</IonType>
+						<IonType charge="2" index="5 6 7 8 9 12">
+							<FragmentArray measure_ref="Measure_MZ" values="366.200531 422.742279 487.263611 522.783264 596.317627 778.876282"/>
+							<FragmentArray measure_ref="Measure_Int" values="291.98941 179.131683 644.625671 1056.302612 472.560638 740.333252"/>
+							<FragmentArray measure_ref="Measure_Error" values="-9.494742020592639E-4 -0.0012334627670611553 -0.001198006752076708 -1.0189910722147033E-4 5.4144397722666326E-5 -0.0024408359273593305"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001224" name="frag: b ion"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="115.107422"/>
+							<FragmentArray measure_ref="Measure_Int" values="610.01178"/>
+							<FragmentArray measure_ref="Measure_Error" values="-2.9259245202695183E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="115"/>
+						</IonType>
+						<IonType charge="1" index="1 2 3 4 5 6">
+							<FragmentArray measure_ref="Measure_MZ" values="291.216187 362.250519 491.296204 588.346313 751.413574 848.461975"/>
+							<FragmentArray measure_ref="Measure_Int" values="278.894043 961.270691 274.524872 3054.900146 372.012421 2139.986084"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.001320414687882021 -0.0014613700221275394 0.0016305420078310817 -0.0010243068420550117 0.00290816060794441 -0.0014546882420063412"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001220" name="frag: y ion"/>
+						</IonType>
+						<IonType charge="2" index="4">
+							<FragmentArray measure_ref="Measure_MZ" values="294.677185"/>
+							<FragmentArray measure_ref="Measure_Int" values="255.900696"/>
+							<FragmentArray measure_ref="Measure_Error" values="-1.2188682700298159E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001220" name="frag: y ion"/>
+						</IonType>
+						<IonType charge="1" index="4 9">
+							<FragmentArray measure_ref="Measure_MZ" values="120.080429"/>
+							<FragmentArray measure_ref="Measure_Int" values="411.441986"/>
+							<FragmentArray measure_ref="Measure_Error" values="-3.4676024202440203E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001239" name="frag: immonium ion"/>
+						</IonType>
+					</Fragmentation>
+					<cvParam cvRef="PSI-MS" accession="MS:1002466" name="PeptideShaker PSM score" value="86.7778"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1002467" name="PeptideShaker PSM confidence" value="100.0"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1001330" name="X!Tandem:expect" value="2.1E-9"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1001117" name="theoretical mass" value="2784.4002649473505" unitCvRef="UO" unitAccession="UO:0000221" unitName="dalton"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Confident"/>
+				</SpectrumIdentificationItem>
+				<cvParam cvRef="PSI-MS" accession="MS:1000796" name="spectrum title" value="Mo_Tai_iTRAQ_f8.16371.16371.3"/>
+				<cvParam cvRef="PSI-MS" accession="MS:1000894" name="retention time" value="-1.0" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+			</SpectrumIdentificationResult>
+			<SpectrumIdentificationResult spectraData_ref="Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.mgf" spectrumID="scanId=421863" id="SIR_2">
+				<SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="RSQYPEIVFIGTGSAIPMK_15.99491461956-ATAA-18" calculatedMassToCharge="800.106271859852" experimentalMassToCharge="800.107422" chargeState="3" id="SII_2_1">
+					<PeptideEvidenceRef peptideEvidence_ref="PepEv_5147"/>
+					<Fragmentation>
+						<IonType charge="1" index="4">
+							<FragmentArray measure_ref="Measure_MZ" values="136.075546"/>
+							<FragmentArray measure_ref="Measure_Int" values="430.226837"/>
+							<FragmentArray measure_ref="Measure_Error" values="-1.4437980200909806E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001239" name="frag: immonium ion"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="114.110344"/>
+							<FragmentArray measure_ref="Measure_Int" values="4034.994873"/>
+							<FragmentArray measure_ref="Measure_Error" values="-3.356990520302361E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="114"/>
+						</IonType>
+						<IonType charge="1" index="4 6 7 8 9 10">
+							<FragmentArray measure_ref="Measure_MZ" values="679.365479 905.458069 1018.543274 1117.611816 1264.680298 1377.792969"/>
+							<FragmentArray measure_ref="Measure_Int" values="735.988892 2689.670898 2179.756104 1845.75769 1088.513916 293.75412"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.0010946466878749561 -0.0016722901322054895 -5.312672622039827E-4 -4.031802523059014E-4 -3.350932424837083E-4 0.028271929627635473"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001224" name="frag: b ion"/>
+						</IonType>
+						<IonType charge="2" index="4 5 6 7 8 9">
+							<FragmentArray measure_ref="Measure_MZ" values="340.185303 388.713257 453.2323 509.774872 559.309082 632.845764"/>
+							<FragmentArray measure_ref="Measure_Int" values="707.284363 349.639923 3589.40625 3673.583984 1509.701538 610.201843"/>
+							<FragmentArray measure_ref="Measure_Error" values="-5.274100620908939E-4 0.001044665512949905 -0.001208878472084507 -6.688670370635919E-4 -6.658235322447581E-4 0.001809219972756182"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001224" name="frag: b ion"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="115.107445"/>
+							<FragmentArray measure_ref="Measure_Int" values="5113.102539"/>
+							<FragmentArray measure_ref="Measure_Error" values="-2.6959245202817783E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="115"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="116.110947"/>
+							<FragmentArray measure_ref="Measure_Int" values="257.288208"/>
+							<FragmentArray measure_ref="Measure_Error" values="-1.22430252034178E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="116"/>
+						</IonType>
+						<IonType charge="1" index="1 2 3 6 7 9">
+							<FragmentArray measure_ref="Measure_MZ" values="291.215607 438.253052 535.303101 806.461853 863.484375 1021.55603"/>
+							<FragmentArray measure_ref="Measure_Int" values="1271.78772 266.972809 4940.25293 353.738464 359.964966 279.992706"/>
+							<FragmentArray measure_ref="Measure_Error" values="7.404146878684514E-4 0.0027858821379140863 7.103328789526131E-5 0.0056168671778777934 0.006675146607904026 0.009187957627887045"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001220" name="frag: y ion"/>
+						</IonType>
+						<IonType charge="2" index="3 8">
+							<FragmentArray measure_ref="Measure_MZ" values="268.156281 482.775055"/>
+							<FragmentArray measure_ref="Measure_Int" values="420.967865 270.700256"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.0011277832379619213 0.008727605692968154"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001220" name="frag: y ion"/>
+						</IonType>
+						<IonType charge="1" index="9">
+							<FragmentArray measure_ref="Measure_MZ" values="120.080544"/>
+							<FragmentArray measure_ref="Measure_Int" values="2393.269775"/>
+							<FragmentArray measure_ref="Measure_Error" values="-2.3176024201632117E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001239" name="frag: immonium ion"/>
+						</IonType>
+					</Fragmentation>
+					<cvParam cvRef="PSI-MS" accession="MS:1002466" name="PeptideShaker PSM score" value="78.5387"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1002467" name="PeptideShaker PSM confidence" value="100.0"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1001330" name="X!Tandem:expect" value="1.4E-8"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1001117" name="theoretical mass" value="2397.29698617912" unitCvRef="UO" unitAccession="UO:0000221" unitName="dalton"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Confident"/>
+				</SpectrumIdentificationItem>
+				<cvParam cvRef="PSI-MS" accession="MS:1000796" name="spectrum title" value="Mo_Tai_iTRAQ_f8.15275.15275.3"/>
+				<cvParam cvRef="PSI-MS" accession="MS:1000894" name="retention time" value="-1.0" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+			</SpectrumIdentificationResult>
+			<SpectrumIdentificationResult spectraData_ref="Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.mgf" spectrumID="scanId=421822" id="SIR_3">
+				<SpectrumIdentificationItem passThreshold="false" rank="1" peptide_ref="DIFIQRYQFMR" calculatedMassToCharge="554.2965152707687" experimentalMassToCharge="554.299011" chargeState="3" id="SII_3_1">
+					<PeptideEvidenceRef peptideEvidence_ref="PepEv_5510"/>
+					<Fragmentation>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="114.110458"/>
+							<FragmentArray measure_ref="Measure_Int" values="98483.664063"/>
+							<FragmentArray measure_ref="Measure_Error" values="-2.2169905203384133E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="114"/>
+						</IonType>
+						<IonType charge="1" index="1 2 5">
+							<FragmentArray measure_ref="Measure_MZ" values="260.140198 373.223297 761.41272"/>
+							<FragmentArray measure_ref="Measure_Int" values="13365.770508 7781.437988 4043.625977"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.003916088557900821 0.002951111427876185 -0.018681283972114215"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001224" name="frag: b ion"/>
+						</IonType>
+						<IonType charge="2" index="4">
+							<FragmentArray measure_ref="Measure_MZ" values="317.228546"/>
+							<FragmentArray measure_ref="Measure_Int" values="1201.167969"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.03849587724795356"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001224" name="frag: b ion"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="115.107498"/>
+							<FragmentArray measure_ref="Measure_Int" values="36369.804688"/>
+							<FragmentArray measure_ref="Measure_Error" values="-2.1659245201988142E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="115"/>
+						</IonType>
+						<IonType charge="1" index="1">
+							<FragmentArray measure_ref="Measure_MZ" values="175.118744"/>
+							<FragmentArray measure_ref="Measure_Int" values="5137.306641"/>
+							<FragmentArray measure_ref="Measure_Error" values="-2.0817411203211122E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001220" name="frag: y ion"/>
+						</IonType>
+						<IonType charge="2" index="6 8 9 10">
+							<FragmentArray measure_ref="Measure_MZ" values="450.719299 571.306641 644.842285 701.398987"/>
+							<FragmentArray measure_ref="Measure_Int" values="14351.481445 7561.960449 1767.469849 2438.133789"/>
+							<FragmentArray measure_ref="Measure_Error" values="-0.009773264166994977 0.006247994627983644 0.007685038132876798 0.022355049567977403"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001220" name="frag: y ion"/>
+						</IonType>
+					</Fragmentation>
+					<cvParam cvRef="PSI-MS" accession="MS:1002466" name="PeptideShaker PSM score" value="-10.0"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1002467" name="PeptideShaker PSM confidence" value="0.0"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1001330" name="X!Tandem:expect" value="10.0"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1001117" name="theoretical mass" value="1659.8677164118703" unitCvRef="UO" unitAccession="UO:0000221" unitName="dalton"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Not Validated"/>
+				</SpectrumIdentificationItem>
+				<cvParam cvRef="PSI-MS" accession="MS:1000796" name="spectrum title" value="Mo_Tai_iTRAQ_f8.14943.14943.3"/>
+				<cvParam cvRef="PSI-MS" accession="MS:1000894" name="retention time" value="-1.0" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+			</SpectrumIdentificationResult>
+			<SpectrumIdentificationResult spectraData_ref="Mo_Tai_Trimmed_mgfs__Mo_Tai_iTRAQ_f8.mgf" spectrumID="scanId=421095" id="SIR_4">
+				<SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="EIVPVIVSSRK" calculatedMassToCharge="505.65512546730884" experimentalMassToCharge="505.656708" chargeState="3" id="SII_4_1">
+					<PeptideEvidenceRef peptideEvidence_ref="PepEv_4410"/>
+					<PeptideEvidenceRef peptideEvidence_ref="PepEv_4411"/>
+					<Fragmentation>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="114.110313"/>
+							<FragmentArray measure_ref="Measure_Int" values="196847.609375"/>
+							<FragmentArray measure_ref="Measure_Error" values="-3.666990520230229E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="114"/>
+						</IonType>
+						<IonType charge="1" index="1 2 3 4 5 6">
+							<FragmentArray measure_ref="Measure_MZ" values="274.154022 387.237396 486.305023 583.357727 682.425781 795.514404"/>
+							<FragmentArray measure_ref="Measure_Int" values="34930.847656 41586.246094 72494.085938 4871.934082 25056.433594 5421.28418"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.0020900244178960747 0.0014000472878592518 6.131342978505927E-4 5.532854478360605E-4 1.933724579430418E-4 0.004752395327955128"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001224" name="frag: b ion"/>
+						</IonType>
+						<IonType charge="2" index="4">
+							<FragmentArray measure_ref="Measure_MZ" values="292.181305"/>
+							<FragmentArray measure_ref="Measure_Int" values="7002.522949"/>
+							<FragmentArray measure_ref="Measure_Error" values="-9.20090682029695E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001224" name="frag: b ion"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="115.107338"/>
+							<FragmentArray measure_ref="Measure_Int" values="124226.945313"/>
+							<FragmentArray measure_ref="Measure_Error" values="-3.7659245202803504E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="115"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="116.110916"/>
+							<FragmentArray measure_ref="Measure_Int" values="5221.551758"/>
+							<FragmentArray measure_ref="Measure_Error" values="-1.534302520269648E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="116"/>
+						</IonType>
+						<IonType charge="1" index="0">
+							<FragmentArray measure_ref="Measure_MZ" values="117.159462"/>
+							<FragmentArray measure_ref="Measure_Int" values="1580.335449"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.04503773194797134"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1002668" name="frag: iTRAQ 4plex reporter ion" value="117"/>
+						</IonType>
+						<IonType charge="1" index="1 3 4 5 6 7 8 9">
+							<FragmentArray measure_ref="Measure_MZ" values="291.214905 534.348755 621.378052 720.448303 833.532104 932.599182 1029.652588 1128.721436"/>
+							<FragmentArray measure_ref="Measure_Int" values="15176.336914 4236.182129 29728.085938 27772.375 47949.128906 19686.976563 70640.109375 7453.367188"/>
+							<FragmentArray measure_ref="Measure_Error" values="3.841468787868507E-5 7.489868178254255E-4 -0.00198241745215455 -1.453304422511792E-4 -4.083075722292051E-4 -0.001744220562272858 -0.0011020694123544672 -6.679824023194669E-4"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001220" name="frag: y ion"/>
+						</IonType>
+						<IonType charge="2" index="3 4 5 6 7 8 9 10">
+							<FragmentArray measure_ref="Measure_MZ" values="267.67865 311.216034 360.727234 417.269257 466.805481 515.329834 564.863464 621.378052"/>
+							<FragmentArray measure_ref="Measure_Int" values="3835.696289 2879.681641 2920.091797 17420.564453 7575.007324 130462.46875 20754.271484 29728.085938"/>
+							<FragmentArray measure_ref="Measure_Error" values="0.0010087600029464738 0.022378557867909876 -6.283986271000686E-4 -6.373871921141472E-4 0.00137965631284942 -6.492681121699206E-4 -0.0012262246071941263 -0.028670213172176773"/>
+							<cvParam cvRef="PSI-MS" accession="MS:1001220" name="frag: y ion"/>
+						</IonType>
+					</Fragmentation>
+					<cvParam cvRef="PSI-MS" accession="MS:1002466" name="PeptideShaker PSM score" value="62.0761"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1002467" name="PeptideShaker PSM confidence" value="100.0"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1001330" name="X!Tandem:expect" value="6.2E-7"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1001117" name="theoretical mass" value="1513.9435470014905" unitCvRef="UO" unitAccession="UO:0000221" unitName="dalton"/>
+					<cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Confident"/>
+				</SpectrumIdentificationItem>
+				<cvParam cvRef="PSI-MS" accession="MS:1000796" name="spectrum title" value="Mo_Tai_iTRAQ_f8.10292.10292.3"/>
+				<cvParam cvRef="PSI-MS" accession="MS:1000894" name="retention time" value="-1.0" unitCvRef="UO" unitAccession="UO:0000010" unitName="second"/>
+			</SpectrumIdentificationResult>
+		</SpectrumIdentificationList>
+	</AnalysisData>
+</DataCollection>
+</MzIdentML>

--- a/pwiz_tools/BiblioSpec/tests/inputs/mismatched-scan-numbers.pepXML
+++ b/pwiz_tools/BiblioSpec/tests/inputs/mismatched-scan-numbers.pepXML
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="pepXML_std.xsl"?>
+<msms_pipeline_analysis date="2019-11-21T15:49:59" xmlns="http://regis-web.systemsbiology.net/pepXML" summary_xml="d:\test\bruker\tims\Hela%2QC_PASEF_Slot1-5_01_57_cutout_2min.pepXML" xsi:schemaLocation="http://sashimi.sourceforge.net/schema_revision/pepXML/pepXML_v118.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<msms_run_summary base_name="Hela%20QC_PASEF_Slot1-5_01_57_cutout_2min" raw_data_type="raw" raw_data="mzBIN">
+<sample_enzyme name="trypsin">
+<specificity cut="KR" no_cut="P" sense="C"/>
+</sample_enzyme>
+<search_summary base_name="Hela%2QC_PASEF_Slot1-5_01_57_cutout_2min" precursor_mass_type="monoisotopic" search_engine="X! Tandem" search_engine_version="MSFragger-2.2" fragment_mass_type="monoisotopic" search_id="1">
+<search_database local_path="D:\oldD\fasta\20150928-RefSeq-human.protein.revCat.fasta" type="AA"/>
+<enzymatic_search_constraint enzyme="default" min_number_termini="2" max_num_internal_cleavages="1"/>
+<aminoacid_modification aminoacid="C" massdiff="57.0215" mass="160.0307" variable="N"/>
+<aminoacid_modification aminoacid="M" massdiff="15.9949" mass="147.0354" variable="Y"/>
+<terminal_modification massdiff="42.0106" protein_terminus="Y" mass="43.0184" terminus="N" variable="Y"/>
+<parameter name="# MSFragger.build" value="MSFragger-2.2"/>
+<parameter name="database_name" value="D:\oldD\fasta\20150928-RefSeq-human.protein.revCat.fasta"/>
+<parameter name="decoy_prefix" value="XXX_"/>
+<parameter name="num_threads" value="15"/>
+<parameter name="precursor_mass_lower" value="-50.0"/>
+<parameter name="precursor_mass_upper" value="50.0"/>
+<parameter name="precursor_mass_units" value="1"/>
+<parameter name="precursor_true_tolerance" value="20.0"/>
+<parameter name="precursor_true_units" value="1"/>
+<parameter name="fragment_mass_tolerance" value="20.0"/>
+<parameter name="fragment_mass_units" value="1"/>
+<parameter name="calibrate_mass" value="2"/>
+<parameter name="write_calibrated_mgf" value="1"/>
+<parameter name="isotope_error" value="0/1/2"/>
+<parameter name="mass_offsets" value="0"/>
+<parameter name="precursor_mass_mode" value="SELECTED"/>
+<parameter name="localize_delta_mass" value="0"/>
+<parameter name="intensity_transform" value="0"/>
+<parameter name="remove_precursor_peak" value="1"/>
+<parameter name="remove_precursor_range" value="-1.50,1.50"/>
+<parameter name="delta_mass_exclude_ranges" value="(-1.5,3.5)"/>
+<parameter name="fragment_ion_series" value="b,y"/>
+<parameter name="search_enzyme_name" value="trypsin"/>
+<parameter name="search_enzyme_cutafter" value="KR"/>
+<parameter name="search_enzyme_butnotafter" value="P"/>
+<parameter name="num_enzyme_termini" value="2"/>
+<parameter name="allowed_missed_cleavage" value="1"/>
+<parameter name="clip_nTerm_M" value="1"/>
+<parameter name="allow_multiple_variable_mods_on_residue" value="0"/>
+<parameter name="max_variable_mods_per_mod" value="3"/>
+<parameter name="max_variable_mods_combinations" value="5000"/>
+<parameter name="output_file_extension" value="pepXML"/>
+<parameter name="output_format" value="pepXML"/>
+<parameter name="output_report_topN" value="1"/>
+<parameter name="output_max_expect" value="50.0"/>
+<parameter name="report_alternative_proteins" value="0"/>
+<parameter name="override_charge" value="0"/>
+<parameter name="precursor_charge" value="1 4"/>
+<parameter name="digest_min_length" value="7"/>
+<parameter name="digest_max_length" value="50"/>
+<parameter name="digest_mass_range" value="500.0 5000.0"/>
+<parameter name="max_fragment_charge" value="2"/>
+<parameter name="track_zero_topN" value="0"/>
+<parameter name="zero_bin_accept_expect" value="0.0"/>
+<parameter name="zero_bin_mult_expect" value="1.0"/>
+<parameter name="add_topN_complementary" value="0"/>
+<parameter name="minimum_peaks" value="15"/>
+<parameter name="use_topN_peaks" value="200"/>
+<parameter name="min_fragments_modelling" value="2"/>
+<parameter name="min_matched_fragments" value="4"/>
+<parameter name="minimum_ratio" value="0.0"/>
+<parameter name="clear_mz_range" value="0.0 0.0"/>
+<parameter name="excluded_scan_list_file" value=""/>
+<parameter name="variable_mod_01" value="15.99490 M"/>
+<parameter name="variable_mod_02" value="42.01060 [^"/>
+<parameter name="add_A_alanine" value="0.000000"/>
+<parameter name="add_B_user_amino_acid" value="0.000000"/>
+<parameter name="add_C_cysteine" value="57.021464"/>
+<parameter name="add_Cterm_peptide" value="0.0"/>
+<parameter name="add_Cterm_protein" value="0.0"/>
+<parameter name="add_D_aspartic_acid" value="0.000000"/>
+<parameter name="add_E_glutamic_acid" value="0.000000"/>
+<parameter name="add_F_phenylalanine" value="0.000000"/>
+<parameter name="add_G_glycine" value="0.000000"/>
+<parameter name="add_H_histidine" value="0.000000"/>
+<parameter name="add_I_isoleucine" value="0.000000"/>
+<parameter name="add_J_user_amino_acid" value="0.000000"/>
+<parameter name="add_K_lysine" value="0.000000"/>
+<parameter name="add_L_leucine" value="0.000000"/>
+<parameter name="add_M_methionine" value="0.000000"/>
+<parameter name="add_N_asparagine" value="0.000000"/>
+<parameter name="add_Nterm_peptide" value="0.0"/>
+<parameter name="add_Nterm_protein" value="0.0"/>
+<parameter name="add_O_user_amino_acid" value="0.000000"/>
+<parameter name="add_P_proline" value="0.000000"/>
+<parameter name="add_Q_glutamine" value="0.000000"/>
+<parameter name="add_R_arginine" value="0.000000"/>
+<parameter name="add_S_serine" value="0.000000"/>
+<parameter name="add_T_threonine" value="0.000000"/>
+<parameter name="add_U_user_amino_acid" value="0.000000"/>
+<parameter name="add_V_valine" value="0.000000"/>
+<parameter name="add_W_tryptophan" value="0.000000"/>
+<parameter name="add_X_user_amino_acid" value="0.000000"/>
+<parameter name="add_Y_tyrosine" value="0.000000"/>
+<parameter name="add_Z_user_amino_acid" value="0.000000"/>
+</search_summary>
+<spectrum_query start_scan="421" ion_mobility="1.2009081" assumed_charge="2" spectrum="Hela_QC_PASEF_Slot1-5_01_57_cutout_2min.421.421.2" end_scan="421" index="1" precursor_neutral_mass="2317.9421" retention_time_sec="3600.674">
+<search_result>
+<search_hit peptide="NTAAMVCSLENRDECLMCGS" massdiff="1.0156" calc_neutral_pep_mass="2316.9265" peptide_next_aa="-" num_missed_cleavages="1" num_tol_term="2" num_tot_proteins="1" tot_num_ions="38" hit_rank="1" num_matched_ions="12" protein="NP_001024.1" peptide_prev_aa="R" is_rejected="0">
+<modification_info>
+<mod_aminoacid_mass mass="160.0307" position="7"/>
+<mod_aminoacid_mass mass="160.0307" position="15"/>
+<mod_aminoacid_mass mass="160.0307" position="18"/>
+</modification_info>
+<search_score name="hyperscore" value="23.270"/>
+<search_score name="nextscore" value="8.785"/>
+<search_score name="expect" value="3.610e-04"/>
+</search_hit>
+</search_result>
+</spectrum_query>
+<spectrum_query start_scan="422" ion_mobility="1.0267171" assumed_charge="2" spectrum="Hela_QC_PASEF_Slot1-5_01_57_cutout_2min.422.422.2" end_scan="422" index="2" precursor_neutral_mass="1533.6818" retention_time_sec="3600.674">
+<search_result>
+<search_hit peptide="EYTACELMNIYK" massdiff="-0.0026" calc_neutral_pep_mass="1533.6843" peptide_next_aa="T" num_missed_cleavages="0" num_tol_term="2" num_tot_proteins="1" tot_num_ions="22" hit_rank="1" num_matched_ions="8" protein="XP_006712233.1" peptide_prev_aa="K" is_rejected="0">
+<modification_info>
+<mod_aminoacid_mass mass="160.0307" position="5"/>
+</modification_info>
+<search_score name="hyperscore" value="16.791"/>
+<search_score name="nextscore" value="8.503"/>
+<search_score name="expect" value="1.690e-03"/>
+</search_hit>
+</search_result>
+</spectrum_query>
+<spectrum_query start_scan="423" ion_mobility="0.85685045" assumed_charge="3" spectrum="Hela_QC_PASEF_Slot1-5_01_57_cutout_2min.423.423.3" end_scan="423" index="3" precursor_neutral_mass="1776.8328" retention_time_sec="3600.674">
+<search_result>
+<search_hit peptide="MLHFLTAVVGSTCDVK" massdiff="-0.0575" calc_neutral_pep_mass="1776.8903" peptide_next_aa="V" num_missed_cleavages="0" num_tol_term="2" num_tot_proteins="1" tot_num_ions="60" hit_rank="1" num_matched_ions="9" protein="NP_663760.1" peptide_prev_aa="R" is_rejected="0">
+<modification_info>
+<mod_aminoacid_mass mass="160.0307" position="13"/>
+</modification_info>
+<search_score name="hyperscore" value="18.616"/>
+<search_score name="nextscore" value="18.616"/>
+<search_score name="expect" value="9.354e-03"/>
+</search_hit>
+</search_result>
+</spectrum_query>>
+</msms_run_summary>
+</msms_pipeline_analysis>

--- a/pwiz_tools/Shared/BiblioSpec/BlibBuild.cs
+++ b/pwiz_tools/Shared/BiblioSpec/BlibBuild.cs
@@ -452,8 +452,11 @@ namespace pwiz.BiblioSpec
                 {
                     // If something happened (error or cancel) to end processing, then
                     // get rid of the possibly partial library.
-                    File.Delete(OutputPath);
-                    File.Delete(OutputPath + EXT_SQLITE_JOURNAL);
+                    if (OutputPath != null)
+                    {
+                        File.Delete(OutputPath);
+                        File.Delete(OutputPath + EXT_SQLITE_JOURNAL);
+                    }
                 }
                 else
                 {

--- a/pwiz_tools/Shared/BiblioSpec/BlibBuild.cs
+++ b/pwiz_tools/Shared/BiblioSpec/BlibBuild.cs
@@ -344,11 +344,14 @@ namespace pwiz.BiblioSpec
             // Arguments for BlibBuild
             // ReSharper disable LocalizableElement
             List<string> argv = new List<string> { "-s", "-A", "-H" };  // Read from stdin, get ambiguous match messages, high precision modifications
+
+            argv.Add("-v");
+            // Verbose for debugging
             if (DebugMode)
-            {
-                argv.Add("-v"); // Verbose for debugging
                 argv.Add("debug");
-            }
+            else
+                argv.Add("warn");
+
             if (libraryBuildAction == LibraryBuildAction.Create)
                 argv.Add("-o");
             if (CutOffScore.HasValue)
@@ -381,7 +384,7 @@ namespace pwiz.BiblioSpec
             }
             string dirCommon = PathEx.GetCommonRoot(InputFiles);
 
-            string stdinFilename = Path.GetTempFileName();
+            string stdinFilename = Path.Combine(Path.GetDirectoryName(OutputPath) ?? string.Empty, Path.GetFileNameWithoutExtension(OutputPath) + $"{DateTime.Now.ToString("yyyyMMddhhmm")}.stdin.txt");
             argv.Add($"-S \"{stdinFilename}\"");
             using (var stdinFile = new StreamWriter(stdinFilename, false, new UTF8Encoding(false)))
             {
@@ -445,13 +448,17 @@ namespace pwiz.BiblioSpec
                 // Keep a copy of what got sent to BlibBuild for debugging purposes
                 commandArgs = psiBlibBuilder.Arguments + Environment.NewLine + string.Join(Environment.NewLine, File.ReadAllLines(stdinFilename));
 
-                File.Delete(stdinFilename);
                 if (!isComplete)
                 {
                     // If something happened (error or cancel) to end processing, then
                     // get rid of the possibly partial library.
                     File.Delete(OutputPath);
                     File.Delete(OutputPath + EXT_SQLITE_JOURNAL);
+                }
+                else
+                {
+                    // keep the stdin file if an error occurred
+                    File.Delete(stdinFilename);
                 }
             }
             return isComplete;

--- a/pwiz_tools/Shared/Common/SystemUtil/ProcessRunner.cs
+++ b/pwiz_tools/Shared/Common/SystemUtil/ProcessRunner.cs
@@ -134,7 +134,8 @@ namespace pwiz.Common.SystemUtil
                     if (writer != null && (HideLinePrefix == null || !line.StartsWith(HideLinePrefix)))
                         writer.WriteLine(line);
 
-                    if (progress == null || line.ToLowerInvariant().StartsWith(@"error"))
+                    string lineLower = line.ToLowerInvariant();
+                    if (progress == null || lineLower.StartsWith(@"error") || lineLower.StartsWith(@"warning"))
                     {
                         sbError.AppendLine(line);
                     }

--- a/pwiz_tools/Skyline/Model/DdaSearch/MsFraggerSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MsFraggerSearchEngine.cs
@@ -788,11 +788,11 @@ add_Nterm_protein = 0.000000
             return false;
         }
 
-        public bool IsCanceled => _cancelToken.IsCancellationRequested;
+        public bool IsCanceled => _cancelToken?.IsCancellationRequested ?? false;
         public UpdateProgressResponse UpdateProgress(IProgressStatus status)
         {
             SearchProgressChanged?.Invoke(this, status);
-            return _cancelToken.IsCancellationRequested ? UpdateProgressResponse.cancel : UpdateProgressResponse.normal;
+            return IsCanceled ? UpdateProgressResponse.cancel : UpdateProgressResponse.normal;
         }
 
         public bool HasUI => false;

--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -144,6 +144,8 @@ namespace pwiz.SkylineTestFunctional
             BuildLibraryError("truncated.pep.XML", null);
             BuildLibraryError("missing_mzxml.pep.XML", null, null, "could not find matches for the following");
             BuildLibraryError("..\\mascot\\F027319.dat", null, 1e-12, "No matches passed score filter");
+            BuildLibraryError(TestFilesDir.GetVendorTestData(TestFilesDir.VendorDir.BiblioSpec, "mismatched-scan-numbers.pepXML"), null, null, "WARNING: Could not find native id");
+            BuildLibraryError(TestFilesDir.GetVendorTestData(TestFilesDir.VendorDir.BiblioSpec, "mismatched-nativeid-format.mzid"), null, null, "WARNING: Mismatch between spectrum");
 
             // Test trying to build using an existing library (e.g. msp/sptxt)
             EnsurePeptideSettings();

--- a/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
@@ -180,7 +180,8 @@ namespace pwiz.SkylineTestUtil
             UIMF,
             UNIFI,
             Waters,
-            DiaUmpire
+            DiaUmpire,
+            BiblioSpec
         }
 
         /// <summary>
@@ -201,6 +202,10 @@ namespace pwiz.SkylineTestUtil
                 {
                     return Path.Combine(projectDir, @"..\..\pwiz\analysis\spectrum_processing\SpectrumList_DiaUmpireTest.data");
                 }
+                else if (vendorDir == VendorDir.BiblioSpec)
+                {
+                    return Path.Combine(projectDir, @"..\..\pwiz_tools\BiblioSpec\tests\inputs");
+                }
                 else
                 {
                     vendorReaderPath = Path.Combine(projectDir, @"..\..\pwiz\data\vendor_readers");
@@ -212,6 +217,8 @@ namespace pwiz.SkylineTestUtil
                 vendorReaderPath = Path.Combine(projectDir, @".."); // one up from TestZipFiles, and no vendorStr intermediate directory
                 if (vendorDir == VendorDir.DiaUmpire)
                     return Path.Combine(vendorReaderPath, "SpectrumList_DiaUmpireTest.data");
+                else if (vendorDir == VendorDir.BiblioSpec)
+                    return Path.Combine(vendorReaderPath, "BiblioSpecTestData");
                 else
                     return Path.Combine(vendorReaderPath, $"Reader_{vendorStr}_Test.data");
             }

--- a/pwiz_tools/Skyline/Util/DataSourceUtil.cs
+++ b/pwiz_tools/Skyline/Util/DataSourceUtil.cs
@@ -76,6 +76,15 @@ namespace pwiz.Skyline.Util
             return !Equals(GetSourceType(dirInfo), FOLDER_TYPE);
         }
 
+        public static string GetSourceType(string path)
+        {
+            if (File.Exists(path))
+                return GetSourceType(new FileInfo(path));
+            if (Directory.Exists(path))
+                return GetSourceType(new DirectoryInfo(path));
+            return UNKNOWN_TYPE;
+        }
+
         public static string GetSourceType(DirectoryInfo dirInfo)
         {
             try


### PR DESCRIPTION
- fixed MSFragger DDA search to handle DDA PASEF data correctly
- added log output of the count of BiblioSpec PSMs that do not pass score filter and improved error message when score filter is the cause of no PSMs being added
* moved Skyline BlibBuild stdin file to input file directory and set it to only be deleted if library build succeeds (so the file will still be available to rerun the BlibBuild command if the library build fails)
* added ProcessRunner lines starting with "warning" to error log