### PR TITLE
Perform centroiding for Water none-DDA/IMS data spectrum by spectrum

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
@@ -48,6 +48,7 @@
 #include "MassLynxLockMassProcessor.hpp"
 #include "MassLynxRawProcessor.hpp"
 #include "MassLynxParameters.hpp"
+#include "MassLynxScanProcessor.hpp"
 //#include "cdtdefs.h"
 //#include "compresseddatacluster.h"
 #pragma warning (pop)
@@ -428,9 +429,11 @@ struct PWIZ_API_DECL RawData
         }
     }
 
-    void EnableDDAProcessing()
+    void EnableProcessing(bool bEnableDDAProcessing)
     {
-        DDAProcessor.SetRawReader(Reader);
+        ScanProcessor.SetRawData(Reader);
+        if (bEnableDDAProcessing)
+            DDAProcessor.SetRawData(Reader);      
     }
 
     unsigned int GetDDAScanCount()
@@ -475,9 +478,30 @@ struct PWIZ_API_DECL RawData
         return true;
     }
 
+    bool ReadScan(int function, int scan, bool doCentroid, vector<float>& masses, vector<float>& intensities)
+    {
+        try
+        {
+            MassLynxParameters parameters;
+            ScanProcessor.Load(function, scan);
+
+            if (doCentroid)
+                ScanProcessor.Centroid();
+
+            ScanProcessor.GetScan(masses, intensities);
+        }
+        catch (MassLynxRawException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     private:
     MassLynxLockMassProcessor LockMass;
     MassLynxDDAProcessor DDAProcessor;
+    MassLynxScanProcessor ScanProcessor;
     mutable MassLynxRawProcessorWithProgress PeakPicker;
     mutable boost::shared_ptr<RawData> centroidRaw_;
     mutable int workingDriftTimeFunctionIndex_;


### PR DESCRIPTION
Will be used for none-IMS/SONAR data and when the --ddaProcessing option is not used 
This will result in the exported spectra being lockmass corrected if the lockmasRefiner filter is used

Not addressed: base peak values will be inaccurate as they are read from the profile data
There will be some changes to the ATEHLSTLSEK_profile-centroid test results