### PR TITLE
fix: quameter TIC: avoid summing of double and integer values

### DIFF
--- a/pwiz_tools/Bumbershoot/quameter/quameter.cpp
+++ b/pwiz_tools/Bumbershoot/quameter/quameter.cpp
@@ -903,7 +903,7 @@ namespace quameter
                             info.chromatogram.MS1RT.push_back(curRT);
                         } // done with unidentified MS2 scans
                         
-                        double TIC = accumulate(intensV.begin(), intensV.end(), 0);
+                        double TIC = accumulate(intensV.begin(), intensV.end(), 0.0);
                         ms1TICs.push_back(TIC);
                         totalTIC += TIC;
                     }


### PR DESCRIPTION
- Use a `double` as initial value for the `accumulate` call to calculate the TIC in `quameter`. Closes #2684 .