### PR TITLE
Add an optional environment variable to override default parallel test worker connection timeout

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -792,7 +792,8 @@ namespace TestRunner
             int testsFailed = 0;
             int testsResultsReturned = 0;
             int workerCount = (int) commandLineArgs.ArgAsLong("workercount");
-            int workerTimeout = Convert.ToInt32(commandLineArgs.ArgAsStringOrDefault("workertimeout", "60"));
+            var dockerTimeoutSecondsOverride = Environment.GetEnvironmentVariable("SKYLINE_TESTRUNNER_DOCKER_TIMEOUT_SEC");
+            int workerTimeout = Convert.ToInt32(commandLineArgs.ArgAsStringOrDefault("workertimeout", dockerTimeoutSecondsOverride ?? "60"));
             int loop = (int) commandLineArgs.ArgAsLong("loop");
             var languages = GetLanguages(commandLineArgs);
 


### PR DESCRIPTION
Not sure why, but the default 60 timeout for TestRunner connecting to Docker workers often isn't enough on my Win10 machine. This change lets me set an environment variable "SKYLINE_TESTRUNNER_DOCKER_TIMEOUT_SEC" to extend that to whatever seems to work.

This value can already be set at the commandline, but I don't want to have to do that every time I start working in a new branch.