### PR TITLE
Fix spectrum filters for small molecule documents

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -382,10 +382,6 @@ namespace pwiz.Skyline.Model.Results
                 }
             }
 
-            if (!spectrumClassFilter.IsEmpty)
-            {
-                yield break;
-            }
             // Look for matching chromatograms which do not have a text id.
             int i = FindEntry(precursorMz, tolerance);
             if (i < 0)
@@ -408,15 +404,19 @@ namespace pwiz.Skyline.Model.Results
                     continue;
                 }
 
-                if (nodePep != null && !TextIdEqual(entry, nodePep))
+                if (nodePep != null && !TextIdEqual(entry, nodePep, spectrumClassFilter))
                     continue;
                 yield return i;
             }
         }
 
-        private bool TextIdEqual(ChromGroupHeaderInfo entry, PeptideDocNode nodePep)
+        private bool TextIdEqual(ChromGroupHeaderInfo entry, PeptideDocNode nodePep, SpectrumClassFilter spectrumClassFilter)
         {
             var chromatogramGroupId = GetChromatogramGroupId(entry);
+            if (!Equals(spectrumClassFilter, chromatogramGroupId?.SpectrumClassFilter ?? default(SpectrumClassFilter)))
+            {
+                return false;
+            }
             if (chromatogramGroupId == null)
             {
                 return true;

--- a/pwiz_tools/Skyline/TestFunctional/EditSpectrumFilterTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditSpectrumFilterTest.cs
@@ -31,11 +31,22 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class EditSpectrumFilterTest : AbstractFunctionalTest
+    public class EditSpectrumFilterTest : AbstractFunctionalTestEx
     {
+        private RefinementSettings.ConvertToSmallMoleculesMode SmallMoleculeTestMode { get; set; }
+
         [TestMethod]
         public void TestEditSpectrumFilter()
         {
+            SmallMoleculeTestMode = RefinementSettings.ConvertToSmallMoleculesMode.none;
+            TestFilesZip = @"TestFunctional\EditSpectrumFilterTest.zip";
+            RunFunctionalTest();
+        }
+
+        [TestMethod]
+        public void TestEditSpectrumFilterAsSmallMolecules()
+        {
+            SmallMoleculeTestMode = RefinementSettings.ConvertToSmallMoleculesMode.formulas;
             TestFilesZip = @"TestFunctional\EditSpectrumFilterTest.zip";
             RunFunctionalTest();
         }
@@ -45,6 +56,10 @@ namespace pwiz.SkylineTestFunctional
             RunUI(()=>
             {
                 SkylineWindow.OpenFile(TestFilesDir.GetTestPath("SpectrumClassFilterTestDocument.sky"));
+                if (SmallMoleculeTestMode != RefinementSettings.ConvertToSmallMoleculesMode.none)
+                {
+                    ConvertDocumentToSmallMolecules(SmallMoleculeTestMode);
+                }
                 Assert.AreEqual(1, SkylineWindow.Document.MoleculeCount);
                 Assert.AreEqual(1, SkylineWindow.Document.MoleculeTransitionGroupCount);
                 SkylineWindow.SelectedPath =


### PR DESCRIPTION
Fixed bug where Spectrum Filters in small molecule documents result in "Chromatogram Information Unavailable" (reported by Tara)