### PR TITLE
"failed" is a useful log search term for dealing with build/test issues, but "doctest" uses the word even when it succeeds ("0 failed").…

### DIFF
--- a/libraries/doctest.h
+++ b/libraries/doctest.h
@@ -6198,7 +6198,7 @@ namespace {
                                                                           Color::Green)
               << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
               << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-              << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
+              << std::setw(failwidth) << p.numTestCasesFailed << " failures" << Color::None << " |";
             if(opt.no_skipped_summary == false) {
                 const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
                 s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
@@ -6210,7 +6210,7 @@ namespace {
               << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
               << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
               << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
-              << p.numAssertsFailed << " failed" << Color::None << " |\n";
+              << p.numAssertsFailed << " failures" << Color::None << " |\n";
             s << Color::Cyan << "[doctest] " << Color::None
               << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
               << ((p.numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;


### PR DESCRIPTION
I've changed it to report "0 failures". (This has been bugging me for years)

This change will be lost next time we update the file from its parent GitHub repo but that doesn't happen very often.