### PR TITLE
Skyline: clean-up and fix leak in new panorama client code

### DIFF
--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.cs
@@ -49,13 +49,28 @@ namespace pwiz.PanoramaClient
             {
                 FolderBrowser = new LKContainerBrowser(servers, state, false, selectedPath);
             }
-            FolderBrowser.Dock = DockStyle.Fill;
-            FolderBrowser.NodeClick += DirectoryPicker_MouseClick;
-            folderPanel.Controls.Add(FolderBrowser);
-            up.Enabled = false;
             SelectedPath = selectedPath;
-            back.Enabled = false;
-            forward.Enabled = false;
+
+            InitializeDialog();
+        }
+
+        private void InitializeDialog()
+        {
+            FolderBrowser.Dock = DockStyle.Fill;
+            folderPanel.Controls.Add(FolderBrowser);
+            FolderBrowser.NodeClick += DirectoryPicker_MouseClick;
+            if (string.IsNullOrEmpty(_treeState))
+            {
+                up.Enabled = false;
+                back.Enabled = false;
+                forward.Enabled = false;
+            }
+            else
+            {
+                up.Enabled = FolderBrowser.UpEnabled;
+                back.Enabled = FolderBrowser.BackEnabled;
+                forward.Enabled = FolderBrowser.ForwardEnabled;
+            }
         }
 
         private void Open_Click(object sender, EventArgs e)
@@ -141,31 +156,16 @@ namespace pwiz.PanoramaClient
 
 
         #region Test Support
-        public PanoramaDirectoryPicker()
+
+        public PanoramaDirectoryPicker(Uri serverUri, string user, string pass, JToken folderJson)
         {
             InitializeComponent();
-            IsLoaded = false;
-        }
 
-        public void InitializeTestDialog(Uri serverUri, string user, string pass, JToken folderJson)
-        {
             var server = new PanoramaServer(serverUri, user, pass);
             FolderBrowser = new TestPanoramaFolderBrowser(server, folderJson);
-            FolderBrowser.Dock = DockStyle.Fill;
-            folderPanel.Controls.Add(FolderBrowser);
-            FolderBrowser.NodeClick += DirectoryPicker_MouseClick;
-            if (string.IsNullOrEmpty(_treeState))
-            {
-                up.Enabled = false;
-                back.Enabled = false;
-                forward.Enabled = false;
-            }
-            else
-            {
-                up.Enabled = FolderBrowser.UpEnabled;
-                back.Enabled = FolderBrowser.BackEnabled;
-                forward.Enabled = FolderBrowser.ForwardEnabled;
-            }
+
+            InitializeDialog();
+
             IsLoaded = true;
         }
 

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
@@ -90,7 +90,7 @@ namespace pwiz.PanoramaClient
             else
             {
                 ActiveServer = ServerList.FirstOrDefault();
-                tree.TopNode.Expand();
+                tree.TopNode?.Expand();
             }
 
             if (string.IsNullOrEmpty(InitialPath) || GetType() == typeof(WebDavBrowser))
@@ -565,7 +565,7 @@ public class WebDavBrowser : PanoramaFolderBrowser
             try
             {
                 query = new Uri(string.Concat(folderInfo.Server.URI, PanoramaUtil.WEBDAV, folderInfo.FolderPath, "?method=json"));
-                var webClient = new WebClientWithCredentials(query, folderInfo.Server.Username, folderInfo.Server.Password);
+                using var webClient = new WebClientWithCredentials(query, folderInfo.Server.Username, folderInfo.Server.Password);
                 JToken json = webClient.Get(query);
                 if ((int)json[@"fileCount"] != 0)
                 {

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteFileControl.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteFileControl.cs
@@ -259,7 +259,6 @@ namespace SkylineBatch
                     using (PanoramaFilePicker dlg = new PanoramaFilePicker(panoramaServers, state, showWebdav, selectedPath))
                     {
                         dlg.OkButtonText = "Select";
-                        dlg.InitializeDialog();
                         if (dlg.ShowDialog() != DialogResult.Cancel)
                         {
                             Settings.Default.PanoramaTreeState = dlg.FolderBrowser.TreeState;

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteSourceForm.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteSourceForm.cs
@@ -139,8 +139,7 @@ namespace SkylineBatch
 
         public void OpenFromPanorama(string server, string user, string pass, JToken folderJson)
         {
-            using var dlg = new PanoramaDirectoryPicker();
-            dlg.InitializeTestDialog(new Uri(server), user, pass, folderJson);
+            using var dlg = new PanoramaDirectoryPicker(new Uri(server), user, pass, folderJson);
             if (dlg.ShowDialog() != DialogResult.Cancel)
             {
 

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -901,40 +901,24 @@ namespace pwiz.Skyline
             OpenFromPanorama();
         }
 
-        /// <summary>
-        /// Method used for testing <see cref="PanoramaFilePicker"/>
-        /// </summary>
-        public void ShowPanoramaFilePicker(string server, string user, string pass, JToken folderJson, JToken fileJson = null, JToken sizeJson = null)
-        {
-            using var dlg = new PanoramaFilePicker();
-            dlg.InitializeTestDialog(new Uri(server), user, pass, folderJson, fileJson, sizeJson);
-            dlg.ShowDialog(this);
-        }
-
         public void OpenFromPanorama(string downloadFilePath = null)
         {
             var servers = Settings.Default.ServerList;
             if (servers.Count == 0)
             {
-                DialogResult buttonPress = MultiButtonMsgDlg.Show(
-                    this,
-                    TextUtil.LineSeparate(
-                        Resources.SkylineWindow_OpenFromPanorama_No_Panorama_servers_were_found_,
-                        Resources.SkylineWindow_OpenFromPanorama_Press__Add__to_add_a_new_server_),
-                    Resources.SkylineWindow_OpenFromPanorama_Add);
-                if (buttonPress == DialogResult.Cancel)
+                if (MultiButtonMsgDlg.Show(this,
+                        TextUtil.LineSeparate(
+                            Resources.SkylineWindow_OpenFromPanorama_No_Panorama_servers_were_found_,
+                            Resources.SkylineWindow_OpenFromPanorama_Press__Add__to_add_a_new_server_),
+                        Resources.SkylineWindow_OpenFromPanorama_Add) == DialogResult.Cancel)
                     return;
 
-                if (buttonPress == DialogResult.OK)
-                {
-                    var serverPanoramaWeb = new Server(PanoramaUtil.PANORAMA_WEB, string.Empty, string.Empty);
-                    var newServer = servers.EditItem(this, serverPanoramaWeb, null, null);
-                    if (newServer == null)
-                        return;
+                var serverPanoramaWeb = new Server(PanoramaUtil.PANORAMA_WEB, string.Empty, string.Empty);
+                var newServer = servers.EditItem(this, serverPanoramaWeb, null, null);
+                if (newServer == null)
+                    return;
 
-                    servers.Add(newServer);
-                }
-
+                servers.Add(newServer);
             }
 
             var panoramaServers = servers.Cast<PanoramaServer>().ToList();
@@ -948,16 +932,6 @@ namespace pwiz.Skyline
             try
             {
                 using var dlg = new PanoramaFilePicker(panoramaServers, state);
-                using (var longWaitDlg = new LongWaitDlg
-                       {
-                           Text = Resources.SkylineWindow_OpenFromPanorama_Loading_remote_server_folders,
-                       })
-                {
-                    longWaitDlg.PerformWork(this, 0,
-                        () => dlg.InitializeDialog());
-                    if (longWaitDlg.IsCanceled)
-                        return;
-                }
                 if (dlg.ShowDialog(this) != DialogResult.Cancel)
                 {
                     Settings.Default.PanoramaTreeState = dlg.FolderBrowser.TreeState;
@@ -1020,7 +994,6 @@ namespace pwiz.Skyline
             {
                 MessageDlg.ShowException(this, e);
             }
-            Settings.Default.Save();
         }
 
         public bool DownloadPanoramaFile(string downloadPath, string fileName, string fileUrl, PanoramaServer curServer, long size, IPanoramaClient panoramaClient = null)

--- a/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
@@ -279,7 +279,6 @@ namespace pwiz.SkylineTestConnected
         private void ShowPanoramaFilePicker(List<PanoramaServer> serverList, string selectedPath)
         {
             using var remoteDlg = new PanoramaFilePicker(serverList, string.Empty, true, selectedPath);
-            remoteDlg.InitializeDialog();   // TODO: Get rid of this test initialization method
             remoteDlg.ShowDialog();
         }
 

--- a/pwiz_tools/Skyline/TestFunctional/TestPanoramaClient.cs
+++ b/pwiz_tools/Skyline/TestFunctional/TestPanoramaClient.cs
@@ -87,7 +87,7 @@ namespace pwiz.SkylineTestFunctional
             var folderJson = testClient.GetInfoForFolders(new PanoramaServer(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD),
                 TARGETED);
             var remoteDlg = ShowDialog<PanoramaFilePicker>(() => 
-                SkylineWindow.ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, fileJson, sizeJson));
+                ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, fileJson, sizeJson));
 
             WaitForCondition(9000, () => remoteDlg.IsLoaded);
 
@@ -121,7 +121,7 @@ namespace pwiz.SkylineTestFunctional
             var folderJson = testClient.GetInfoForFolders(new PanoramaServer(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD),
                 TARGETED);
             var remoteDlg = ShowDialog<PanoramaFilePicker>(() =>
-                SkylineWindow.ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, fileJson, sizeJson));
+                ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, fileJson, sizeJson));
 
             WaitForCondition(9000, () => remoteDlg.IsLoaded);
 
@@ -157,7 +157,7 @@ namespace pwiz.SkylineTestFunctional
             var folderJson = testClient.GetInfoForFolders(new PanoramaServer(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD),
                 TARGETED);
             var remoteDlg = ShowDialog<PanoramaFilePicker>(() =>
-                SkylineWindow.ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, fileJson, sizeJson));
+                ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, fileJson, sizeJson));
 
             WaitForCondition(9000, () => remoteDlg.IsLoaded);
 
@@ -194,7 +194,7 @@ namespace pwiz.SkylineTestFunctional
             var folderJson = testClient.GetInfoForFolders(new PanoramaServer(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD),
                 TARGETED);
             var remoteDlg = ShowDialog<PanoramaFilePicker>(() =>
-                SkylineWindow.ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, filesJson, sizesJson));
+                ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, filesJson, sizesJson));
 
             WaitForCondition(9000, () => remoteDlg.IsLoaded);
 
@@ -240,7 +240,7 @@ namespace pwiz.SkylineTestFunctional
             var folderJson = testClient.GetInfoForFolders(new PanoramaServer(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD),
                 TARGETED);
             var remoteDlg = ShowDialog<PanoramaFilePicker>(() =>
-                SkylineWindow.ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, filesJson, sizesJson));
+                ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, filesJson, sizesJson));
 
             WaitForCondition(9000, () => remoteDlg.IsLoaded);
             var sizeObj = new FileSizeFormatProvider();
@@ -295,7 +295,7 @@ namespace pwiz.SkylineTestFunctional
             var folderJson = testClient.GetInfoForFolders(new PanoramaServer(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD),
                 TARGETED);
             var remoteDlg = ShowDialog<PanoramaFilePicker>(() =>
-                SkylineWindow.ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, fileJson, sizeJson));
+                ShowPanoramaFilePicker(VALID_SERVER, string.Empty, string.Empty, folderJson, fileJson, sizeJson));
 
             WaitForCondition(9000, () => remoteDlg.IsLoaded);
 
@@ -346,10 +346,21 @@ namespace pwiz.SkylineTestFunctional
             OkDialog(remoteDlg, remoteDlg.OkDialog);
         }
 
+        /// <summary>
+        /// Method used for testing <see cref="PanoramaFilePicker"/>
+        /// </summary>
+        public void ShowPanoramaFilePicker(string server, string user, string pass, JToken folderJson, JToken fileJson = null, JToken sizeJson = null)
+        {
+            using var dlg = new PanoramaFilePicker(new Uri(server), user, pass, folderJson, fileJson, sizeJson);
+            dlg.ShowDialog(SkylineWindow);
+        }
+
+        /// <summary>
+        /// Method used for testing <see cref="PanoramaDirectoryPicker"/>
+        /// </summary>
         private void ShowPanoramaDirectoryPicker(JToken folderJson)
         {
-            using var remoteDlg = new PanoramaDirectoryPicker();
-            remoteDlg.InitializeTestDialog(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD, folderJson);
+            using var remoteDlg = new PanoramaDirectoryPicker(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD, folderJson);
             remoteDlg.ShowDialog(SkylineWindow);
         }
 


### PR DESCRIPTION
Use for LongWaitDlg was causing a Thread handle leak because was creating a control on a background thread and adding event handlers to that control. I don't think the LongWaitDlg was serving its intended purpose. So, I just removed it. I am left wondering how this code should actually be querying the web server for its JSON information in a way that involves a LongWaitDlg that can actually be canceled. But, I left that for another time. The existing code didn't do that, and it wasn't doing anything inside LongWaitDlg.PerformWork() that would ever be slow enough to require the progress form to show, and it had not support for canceling.

I did a bit of code clean up and simplification along the way also.