### PR TITLE
The latest ReSharper (2023.2.20230731.174521) gives hundreds of new warnings…

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/AbstractViewContext.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/AbstractViewContext.cs
@@ -236,13 +236,11 @@ namespace pwiz.Common.DataBinding
             {
                 var dataFormats = ListAvailableExportFormats().ToArray();
                 string fileFilter = string.Join(@"|", dataFormats.Select(format => format.FileFilter).ToArray());
-                using (var saveFileDialog = new SaveFileDialog
+                using (var saveFileDialog = new SaveFileDialog())
                 {
-                    Filter = fileFilter,
-                    InitialDirectory = GetExportDirectory(),
-                    FileName = GetDefaultExportFilename(bindingListSource.ViewInfo),
-                })
-                {
+                    saveFileDialog.Filter = fileFilter;
+                    saveFileDialog.InitialDirectory = GetExportDirectory();
+                    saveFileDialog.FileName = GetDefaultExportFilename(bindingListSource.ViewInfo);
                     if (saveFileDialog.ShowDialog(FormUtil.FindTopLevelOwner(owner)) == DialogResult.Cancel)
                     {
                         return;

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/BoundDataGridView.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/BoundDataGridView.cs
@@ -291,8 +291,7 @@ namespace pwiz.Common.DataBinding.Controls
             base.OnRowValidating(e);
             if (!e.Cancel)
             {
-                bool cancelRowEdit;
-                if (_bindingListSource != null && !_bindingListSource.ValidateRow(e.RowIndex, out cancelRowEdit))
+                if (_bindingListSource != null && !_bindingListSource.ValidateRow(e.RowIndex, out _))
                 {
                     e.Cancel = true;
                 }

--- a/pwiz_tools/Shared/CommonUtil/Chemistry/IsotopeAbundances.cs
+++ b/pwiz_tools/Shared/CommonUtil/Chemistry/IsotopeAbundances.cs
@@ -193,8 +193,8 @@ namespace pwiz.Common.Chemistry
             foreach (var entry in defaults)
             {
                 var isotopes = new Dictionary<double, double>();
-                var list = traditional_Skyline_CHONPS.ContainsKey(entry.Key)
-                    ? traditional_Skyline_CHONPS[entry.Key]
+                var list = traditional_Skyline_CHONPS.TryGetValue(entry.Key, out var value)
+                    ? value
                     : entry.Value;
                 for (int i = 0; i < list.Length; i += 2)
                 {

--- a/pwiz_tools/Shared/CommonUtil/Collections/AbstractReadOnlyDictionary.cs
+++ b/pwiz_tools/Shared/CommonUtil/Collections/AbstractReadOnlyDictionary.cs
@@ -83,8 +83,7 @@ namespace pwiz.Common.Collections
 
         public bool ContainsKey(TKey key)
         {
-            TValue value;
-            return TryGetValue(key, out value);
+            return TryGetValue(key, out _);
         }
 
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)

--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/ProducerConsumerWorker.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/ProducerConsumerWorker.cs
@@ -224,8 +224,7 @@ namespace pwiz.Common.SystemUtil
         public void Clear()
         {
             // Clear work queue.
-            TItem item;
-            while (_queue.TryTake(out item))
+            while (_queue.TryTake(out _))
             {
             }
 

--- a/pwiz_tools/Shared/MSGraph/MSGraphPane.cs
+++ b/pwiz_tools/Shared/MSGraph/MSGraphPane.cs
@@ -115,9 +115,9 @@ namespace pwiz.MSGraph
             out CurveItem closestCurve, out PointF closestPoint)
         {
             // Determine boundaries of point search in graph coordinates.
-            double xLo, xHi, y;
-            ReverseTransform(new PointF(pt.X - maxDistance, 0), out xLo, out y);
-            ReverseTransform(new PointF(pt.X + maxDistance, 0), out xHi, out y);
+            double xLo, xHi;
+            ReverseTransform(new PointF(pt.X - maxDistance, 0), out xLo, out _);
+            ReverseTransform(new PointF(pt.X + maxDistance, 0), out xHi, out _);
 
             closestCurve = null;
             closestPoint = new PointF();

--- a/pwiz_tools/Shared/ProteomeDb/API/ProteomeDb.cs
+++ b/pwiz_tools/Shared/ProteomeDb/API/ProteomeDb.cs
@@ -263,8 +263,7 @@ namespace pwiz.ProteomeDatabase.API
 
         public void AddFastaFile(StreamReader reader, IProgressMonitor progressMonitor, ref IProgressStatus status, bool delayAnalyzeDb)
         {
-            int duplicateSequenceCount;
-            AddFastaFile(reader, progressMonitor, ref status, delayAnalyzeDb, out duplicateSequenceCount);
+            AddFastaFile(reader, progressMonitor, ref status, delayAnalyzeDb, out _);
         }
 
         public void AddFastaFile(StreamReader reader, IProgressMonitor progressMonitor, ref IProgressStatus status,

--- a/pwiz_tools/Shared/ProteomeDb/Fasta/WebEnabledFastaImporter.cs
+++ b/pwiz_tools/Shared/ProteomeDb/Fasta/WebEnabledFastaImporter.cs
@@ -730,8 +730,7 @@ namespace pwiz.ProteomeDatabase.Fasta
                 else if (prot.GetProteinMetadata().GetSearchType() == UNIPROTKB_TAG)
                 {
                     // Check for homegrown numbering schemes
-                    long dummy;
-                    if (Int64.TryParse(search, out dummy))
+                    if (Int64.TryParse(search, out _))
                     {
                         prot.SetWebSearchCompleted();  // All numbers, not a Uniprot ID
                     }

--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -26,7 +26,6 @@ using pwiz.CLI.cv;
 using pwiz.CLI.data;
 using pwiz.CLI.msdata;
 using pwiz.CLI.analysis;
-using pwiz.CLI.util;
 using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.Spectra;
@@ -988,14 +987,14 @@ namespace pwiz.ProteowizardWrapper
 
         private double[] GetIonMobilityArray(Spectrum s)
         {
-            BinaryDataDouble data = null;
+            double[] data = null;
             // Remember where the ion mobility value came from and continue getting it from the
             // same place throughout the file. Trying to get an ion mobility value from a CVID
             // where there is none can be slow.
             if (_cvidIonMobility.HasValue)
             {
                 if (_cvidIonMobility.Value != CVID.CVID_Unknown)
-                    data = s.getArrayByCVID(_cvidIonMobility.Value)?.data;
+                    data = s.getArrayByCVID(_cvidIonMobility.Value)?.data?.Storage();
             }
             else
             {
@@ -1031,16 +1030,16 @@ namespace pwiz.ProteowizardWrapper
                     _cvidIonMobility = CVID.CVID_Unknown;
             }
 
-            return data?.Storage();
+            return data;
         }
 
-        private BinaryDataDouble TryGetIonMobilityData(Spectrum s, CVID cvid, ref CVID? cvidIonMobility)
+        private double[] TryGetIonMobilityData(Spectrum s, CVID cvid, ref CVID? cvidIonMobility)
         {
-            var data = s.getArrayByCVID(cvid)?.data;
+            using var data = s.getArrayByCVID(cvid)?.data;
             if (data != null)
                 cvidIonMobility = cvid;
 
-            return data;
+            return data?.Storage();
         }
 
         private MsDataSpectrum GetSpectrum(Spectrum spectrum, int spectrumIndex)

--- a/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/MsDataFileImpl.cs
@@ -1036,7 +1036,7 @@ namespace pwiz.ProteowizardWrapper
 
         private BinaryDataDouble TryGetIonMobilityData(Spectrum s, CVID cvid, ref CVID? cvidIonMobility)
         {
-            using var data = s.getArrayByCVID(cvid)?.data;
+            var data = s.getArrayByCVID(cvid)?.data;
             if (data != null)
                 cvidIonMobility = cvid;
 
@@ -1217,8 +1217,7 @@ namespace pwiz.ProteowizardWrapper
                 
                 for (var i = 0; i < len; i++)
                 {
-                    int index;
-                    var id = GetChromatogramId(i, out index);
+                    var id = GetChromatogramId(i, out _);
 
                     if (IsSingleIonCurrentId(id))
                         return true;

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/Axis.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/Axis.cs
@@ -839,7 +839,7 @@ namespace ZedGraph
 			this.MinSpace = 0;
 			// Calculate the space required for the current graph assuming scalefactor = 1.0
 			// and apply the bufferFraction
-            float space = this.CalcSpace( g, pane, 1.0F, out _ ) * bufferFraction;
+			float space = this.CalcSpace( g, pane, 1.0F, out _ ) * bufferFraction;
 			// isGrowOnly indicates the minSpace can grow but not shrink
 			if ( isGrowOnly )
 				space = Math.Max( oldSpace, space );

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/Axis.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/Axis.cs
@@ -799,8 +799,8 @@ namespace ZedGraph
 				SetTransformMatrix( g, pane, scaleFactor );
 
 				double baseVal = _scale.CalcBaseTic();
-				float topPix, rightPix;
-				_scale.GetTopRightPix( pane, out topPix, out rightPix );
+				float topPix;
+				_scale.GetTopRightPix( pane, out topPix, out _ );
 
 				shiftPos = CalcTotalShift( pane, scaleFactor, shiftPos );
 
@@ -839,8 +839,7 @@ namespace ZedGraph
 			this.MinSpace = 0;
 			// Calculate the space required for the current graph assuming scalefactor = 1.0
 			// and apply the bufferFraction
-			float fixedSpace;
-			float space = this.CalcSpace( g, pane, 1.0F, out fixedSpace ) * bufferFraction;
+            float space = this.CalcSpace( g, pane, 1.0F, out _ ) * bufferFraction;
 			// isGrowOnly indicates the minSpace can grow but not shrink
 			if ( isGrowOnly )
 				space = Math.Max( oldSpace, space );

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/DateScale.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/DateScale.cs
@@ -341,13 +341,12 @@ namespace ZedGraph
 		{
 			int nTics = 1;
 
-			int year1, year2, month1, month2, day1, day2, hour1, hour2, minute1, minute2;
-			int second1, second2, millisecond1, millisecond2;
+			int year1, year2, month1, month2;
 
-			XDate.XLDateToCalendarDate( _min, out year1, out month1, out day1,
-										out hour1, out minute1, out second1, out millisecond1 );
-			XDate.XLDateToCalendarDate( _max, out year2, out month2, out day2,
-										out hour2, out minute2, out second2, out millisecond2 );
+            XDate.XLDateToCalendarDate( _min, out year1, out month1, out _,
+										out _, out _, out _, out _ );
+			XDate.XLDateToCalendarDate( _max, out year2, out month2, out _,
+										out _, out _, out _, out _ );
 
 			switch ( _majorUnit )
 			{

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/DateScale.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/DateScale.cs
@@ -343,7 +343,7 @@ namespace ZedGraph
 
 			int year1, year2, month1, month2;
 
-            XDate.XLDateToCalendarDate( _min, out year1, out month1, out _,
+			XDate.XLDateToCalendarDate( _min, out year1, out month1, out _,
 										out _, out _, out _, out _ );
 			XDate.XLDateToCalendarDate( _max, out year2, out month2, out _,
 										out _, out _, out _, out _ );

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/GraphPane.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/GraphPane.cs
@@ -2130,8 +2130,8 @@ namespace ZedGraph
 									curve is HiLowBarItem || curve is OHLCBarItem ||
 									curve is JapaneseCandleStickItem )
 								{
-									double baseVal, lowVal, hiVal;
-									valueHandler.GetValues( curve, iPt, out baseVal,
+									double lowVal, hiVal;
+									valueHandler.GetValues( curve, iPt, out _,
 											out lowVal, out hiVal );
 
 									if ( lowVal > hiVal )
@@ -2172,8 +2172,7 @@ namespace ZedGraph
 								{
 									if ( curve is LineItem && _lineType == LineType.Stack )
 									{
-										double zVal;
-										valueHandler.GetValues( curve, iPt, out xVal, out zVal, out yVal );
+                                        valueHandler.GetValues( curve, iPt, out xVal, out _, out yVal );
 									}
 
 									distX = ( xVal - xAct ) * xPixPerUnit;
@@ -2267,9 +2266,7 @@ namespace ZedGraph
 
 				if ( link.IsActive )
 				{
-					CurveItem nearestCurve;
-
-					if ( FindNearestPoint( mousePt, curve, out nearestCurve, out index ) )
+                    if ( FindNearestPoint( mousePt, curve, out _, out index ) )
 					{
 						source = curve;
 						return true;

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/GraphPane.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/GraphPane.cs
@@ -2172,7 +2172,7 @@ namespace ZedGraph
 								{
 									if ( curve is LineItem && _lineType == LineType.Stack )
 									{
-                                        valueHandler.GetValues( curve, iPt, out xVal, out _, out yVal );
+										valueHandler.GetValues( curve, iPt, out xVal, out _, out yVal );
 									}
 
 									distX = ( xVal - xAct ) * xPixPerUnit;
@@ -2266,7 +2266,7 @@ namespace ZedGraph
 
 				if ( link.IsActive )
 				{
-                    if ( FindNearestPoint( mousePt, curve, out _, out index ) )
+					if ( FindNearestPoint( mousePt, curve, out _, out index ) )
 					{
 						source = curve;
 						return true;

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/Line.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/Line.cs
@@ -650,7 +650,7 @@ namespace ZedGraph
 					lastX = int.MaxValue,
 					lastY = int.MaxValue;
 
-			double curX, curY, lowVal;
+			double curX, curY;
 			PointPair curPt, lastPt = new PointPair();
 
 			bool lastBad = true;
@@ -689,7 +689,7 @@ namespace ZedGraph
 						curPt = points[i];
 						if ( pane.LineType == LineType.Stack )
 						{
-							if ( !valueHandler.GetValues( curve, i, out curX, out lowVal, out curY ) )
+							if ( !valueHandler.GetValues( curve, i, out curX, out _, out curY ) )
 							{
 								curX = PointPair.Missing;
 								curY = PointPair.Missing;
@@ -863,7 +863,7 @@ namespace ZedGraph
 			float tmpX, tmpY,
 					lastX = float.MaxValue,
 					lastY = float.MaxValue;
-			double curX, curY, lowVal;
+			double curX, curY;
 			PointPair curPt, lastPt = new PointPair();
 
 			bool lastBad = true;
@@ -893,7 +893,7 @@ namespace ZedGraph
 						curPt = points[i];
 						if ( pane.LineType == LineType.Stack )
 						{
-							if ( !valueHandler.GetValues( curve, i, out curX, out lowVal, out curY ) )
+							if ( !valueHandler.GetValues( curve, i, out curX, out _, out curY ) )
 							{
 								curX = PointPair.Missing;
 								curY = PointPair.Missing;
@@ -1181,7 +1181,7 @@ namespace ZedGraph
 				float curX, curY,
 							lastX = 0,
 							lastY = 0;
-				double x, y, lowVal;
+				double x, y;
 				ValueHandler valueHandler = new ValueHandler( pane, false );
 
 				// Step type plots get twice as many points.  Always add three points so there is
@@ -1199,7 +1199,7 @@ namespace ZedGraph
 						// use the valueHandler only for stacked types
 						if ( pane.LineType == LineType.Stack )
 						{
-							valueHandler.GetValues( curve, i, out x, out lowVal, out y );
+							valueHandler.GetValues( curve, i, out x, out _, out y );
 						}
 						// otherwise, just access the values directly.  Avoiding the valueHandler for
 						// non-stacked types is an optimization to minimize overhead in case there are
@@ -1303,7 +1303,7 @@ namespace ZedGraph
 				float curX, curY,
 						lastX = 0,
 						lastY = 0;
-				double x, y, hiVal;
+				double x, y;
 				ValueHandler valueHandler = new ValueHandler( pane, false );
 
 				// Step type plots get twice as many points.  Always add three points so there is
@@ -1321,7 +1321,7 @@ namespace ZedGraph
 					if ( !points[i].IsInvalid )
 					{
 						// Get the user scale values for the current point
-						valueHandler.GetValues( curve, i, out x, out y, out hiVal );
+						valueHandler.GetValues( curve, i, out x, out y, out _ );
 
 						if ( x == PointPair.Missing || y == PointPair.Missing )
 							continue;

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/LineItem.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/LineItem.cs
@@ -367,9 +367,9 @@ namespace ZedGraph
 			if ( pt.IsInvalid )
 				return false;
 
-			double x, y, z;
+			double x, y;
 			ValueHandler valueHandler = new ValueHandler( pane, false );
-			valueHandler.GetValues( this, i, out x, out z, out y );
+			valueHandler.GetValues( this, i, out x, out _, out y );
 
 			Axis yAxis = GetYAxis( pane );
 			Axis xAxis = GetXAxis( pane );

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/Symbol.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/Symbol.cs
@@ -584,7 +584,7 @@ namespace ZedGraph
 			// (Dale-a-b) we'll set an element to true when it has been drawn	
 			bool[,] isPixelDrawn = new bool[maxX + 1, maxY + 1];
 
-			double curX, curY, lowVal;
+			double curX, curY;
 			IPointList points = curve.Points;
 
 			if ( points != null && ( _border.IsVisible || _fill.IsVisible ) )
@@ -623,7 +623,7 @@ namespace ZedGraph
 						    object tag = null; 
 							if ( pane.LineType == LineType.Stack )
 							{
-								valueHandler.GetValues( curve, i, out curX, out lowVal, out curY );
+								valueHandler.GetValues( curve, i, out curX, out _, out curY );
 							}
 							// otherwise, just access the values directly.  Avoiding the valueHandler for
 							// non-stacked types is an optimization to minimize overhead in case there are

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/XDate.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/XDate.cs
@@ -361,9 +361,7 @@ namespace ZedGraph
 		/// 8 for August.</param>
 		public void GetDate( out int year, out int month, out int day )
 		{
-			int hour, minute, second;
-			
-			XLDateToCalendarDate( _xlDate, out year, out month, out day, out hour, out minute, out second );
+            XLDateToCalendarDate( _xlDate, out year, out month, out day, out _, out _, out int _ );
 		}
 		
 		/// <summary>
@@ -1109,9 +1107,9 @@ namespace ZedGraph
 		/// floating point format</returns>
 		public static double XLDateToDayOfYear( double xlDate )
 		{
-			int year, month, day, hour, minute, second;
-			XLDateToCalendarDate( xlDate, out year, out month, out day,
-									out hour, out minute, out second );
+			int year;
+			XLDateToCalendarDate( xlDate, out year, out _, out _,
+									out _, out _, out int _ );
 			return XLDateToJulianDay( xlDate ) - CalendarDateToJulianDay( year, 1, 1, 0, 0, 0 ) + 1.0;
 		}
 		

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/XDate.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/XDate.cs
@@ -361,7 +361,7 @@ namespace ZedGraph
 		/// 8 for August.</param>
 		public void GetDate( out int year, out int month, out int day )
 		{
-            XLDateToCalendarDate( _xlDate, out year, out month, out day, out _, out _, out int _ );
+			XLDateToCalendarDate( _xlDate, out year, out month, out day, out _, out _, out int _ );
 		}
 		
 		/// <summary>

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.ContextMenu.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.ContextMenu.cs
@@ -67,7 +67,7 @@ namespace ZedGraph
 			// Determine object state
 			Point mousePt = this.PointToClient( Control.MousePosition );
 			int iPt;
-            object nearestObj;
+			object nearestObj;
 
 			using ( Graphics g = this.CreateGraphics() )
 			{

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.ContextMenu.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.ContextMenu.cs
@@ -67,12 +67,11 @@ namespace ZedGraph
 			// Determine object state
 			Point mousePt = this.PointToClient( Control.MousePosition );
 			int iPt;
-			GraphPane pane;
-			object nearestObj;
+            object nearestObj;
 
 			using ( Graphics g = this.CreateGraphics() )
 			{
-				if ( this.MasterPane.FindNearestPaneObject( mousePt, g, out pane,
+				if ( this.MasterPane.FindNearestPaneObject( mousePt, g, out _,
 						out nearestObj, out iPt ) )
 				{
 					CurveItem item = nearestObj as CurveItem;

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.Events.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.Events.cs
@@ -760,13 +760,13 @@ namespace ZedGraph
 									label = (string)pt.Tag;
 								else
 								{
-									double xVal, yVal, lowVal;
+									double xVal, yVal;
 									ValueHandler valueHandler = new ValueHandler( pane, false );
 									if ( ( curve is BarItem || curve is ErrorBarItem || curve is HiLowBarItem )
 											&& pane.BarSettings.Base != BarBase.X )
-										valueHandler.GetValues( curve, iPt, out yVal, out lowVal, out xVal );
+										valueHandler.GetValues( curve, iPt, out yVal, out _, out xVal );
 									else
-										valueHandler.GetValues( curve, iPt, out xVal, out lowVal, out yVal );
+										valueHandler.GetValues( curve, iPt, out xVal, out _, out yVal );
 
 									string xStr = MakeValueLabel( curve.GetXAxis( pane ), xVal, iPt,
 										curve.IsOverrideOrdinal );
@@ -821,8 +821,8 @@ namespace ZedGraph
 				}
 				else
 				{
-					double x, x2, y, y2;
-					pane.ReverseTransform( mousePt, out x, out x2, out y, out y2 );
+					double x, y, y2;
+					pane.ReverseTransform( mousePt, out x, out _, out y, out y2 );
 					string xStr = MakeValueLabel( pane.XAxis, x, -1, true );
 					string yStr = MakeValueLabel( pane.YAxis, y, -1, true );
 					string y2Str = MakeValueLabel( pane.Y2Axis, y2, -1, true );
@@ -1413,12 +1413,12 @@ namespace ZedGraph
 
 				#region New Code to Select on Rubber Band
 
-				double x1, x2, xx1, xx2;
+				double x1, x2;
 				double[] y1, y2, yy1, yy2;
 				PointF startPoint = ( (Control)sender ).PointToClient( new Point( Convert.ToInt32( this._dragPane.Rect.X ), Convert.ToInt32( this._dragPane.Rect.Y ) ) );
 
-				_dragPane.ReverseTransform( _dragStartPt, out x1, out xx1, out y1, out yy1 );
-				_dragPane.ReverseTransform( mousePtF, out x2, out xx2, out y2, out yy2 );
+				_dragPane.ReverseTransform( _dragStartPt, out x1, out _, out y1, out yy1 );
+				_dragPane.ReverseTransform( mousePtF, out x2, out _, out y2, out yy2 );
 
 				CurveList objects = new CurveList();
 
@@ -1468,12 +1468,11 @@ namespace ZedGraph
 				//Point mousePt = new Point( e.X, e.Y );
 
 				int iPt;
-				GraphPane pane;
-				object nearestObj;
+                object nearestObj;
 
 				using ( Graphics g = this.CreateGraphics() )
 				{
-					if ( this.MasterPane.FindNearestPaneObject( mousePt, g, out pane,
+					if ( this.MasterPane.FindNearestPaneObject( mousePt, g, out _,
 								out nearestObj, out iPt ) )
 					{
 						if ( nearestObj is CurveItem && iPt >= 0 )

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.Events.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphControl.Events.cs
@@ -1468,7 +1468,7 @@ namespace ZedGraph
 				//Point mousePt = new Point( e.X, e.Y );
 
 				int iPt;
-                object nearestObj;
+				object nearestObj;
 
 				using ( Graphics g = this.CreateGraphics() )
 				{

--- a/pwiz_tools/Skyline/Alerts/KeyValueGridDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/KeyValueGridDlg.cs
@@ -146,14 +146,12 @@ namespace pwiz.Skyline.Alerts
             var activeScreen = parent == null ? Screen.PrimaryScreen : Screen.FromHandle(parent.Handle); 
             int defaultHeight = Math.Min(3 * activeScreen.Bounds.Height / 4, layout.GetRowHeights().Sum() + 50);
 
-            using (var dlg = new MultiButtonMsgDlg(layout, Resources.OK)
+            using (var dlg = new MultiButtonMsgDlg(layout, Resources.OK))
             {
-                Text = title,
-                ClientSize = new Size(400, defaultHeight),
-                StartPosition = FormStartPosition.CenterParent,
-                ShowInTaskbar = false
-            })
-            {
+                dlg.Text = title;
+                dlg.ClientSize = new Size(400, defaultHeight);
+                dlg.StartPosition = FormStartPosition.CenterParent;
+                dlg.ShowInTaskbar = false;
                 dlg.MinimumSize = dlg.Size;
                 layout.Size = dlg.ClientSize;
                 layout.Height -= 35;

--- a/pwiz_tools/Skyline/Alerts/LocateFileDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/LocateFileDlg.cs
@@ -88,11 +88,9 @@ namespace pwiz.Skyline.Alerts
 
         private void FindPath()
         {
-            using (var openFileDialog = new OpenFileDialog
+            using (var openFileDialog = new OpenFileDialog())
             {
-                Multiselect = false
-            })
-            {
+                openFileDialog.Multiselect = false;
                 if (openFileDialog.ShowDialog(this) == DialogResult.OK)
                 {
                     textPath.Text = openFileDialog.FileName;                    
@@ -117,12 +115,7 @@ namespace pwiz.Skyline.Alerts
 
                 else
                 {
-                    if (!filePaths.ContainsKey(_pathContainer))
-                        filePaths.Add(_pathContainer, textPath.Text);
-                    else
-                    {
-                        filePaths[_pathContainer] = textPath.Text;
-                    }
+                    filePaths[_pathContainer] = textPath.Text;
                 }
 
                 Settings.Default.ToolFilePaths = CopyFilePaths(filePaths);

--- a/pwiz_tools/Skyline/Alerts/MissingFileDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/MissingFileDlg.cs
@@ -90,15 +90,13 @@ namespace pwiz.Skyline.Alerts
 
         private void btnBrowse_Click(object sender, System.EventArgs e)
         {
-            using (var openFileDialog = new OpenFileDialog
-                {
-                    Filter = Filter,
-                    InitialDirectory = FileDlgInitialPath,
-                    Title = Title,
-                    CheckFileExists = true,
-                    FileName = FileHint
-                })
+            using (var openFileDialog = new OpenFileDialog())
             {
+                openFileDialog.Filter = Filter;
+                openFileDialog.InitialDirectory = FileDlgInitialPath;
+                openFileDialog.Title = Title;
+                openFileDialog.CheckFileExists = true;
+                openFileDialog.FileName = FileHint;
                 if (openFileDialog.ShowDialog(this) == DialogResult.Cancel)
                     return;
 

--- a/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.cs
@@ -103,8 +103,9 @@ namespace pwiz.Skyline.Alerts
 
         public void Download()
         {
-            using (var downloadProgressDlg = new LongWaitDlg { Message = string.Format(Resources.MsFraggerDownloadDlg_Download_Downloading_MSFragger__0_, MsFraggerSearchEngine.MSFRAGGER_VERSION) })
+            using (var downloadProgressDlg = new LongWaitDlg())
             {
+                downloadProgressDlg.Message = string.Format(Resources.MsFraggerDownloadDlg_Download_Downloading_MSFragger__0_, MsFraggerSearchEngine.MSFRAGGER_VERSION);
                 if (Program.FunctionalTest && !Program.UseOriginalURLs)
                 {
                     var msFraggerDownloadInfo = MsFraggerSearchEngine.MsFraggerDownloadInfo;

--- a/pwiz_tools/Skyline/Alerts/PathChooserDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/PathChooserDlg.cs
@@ -49,11 +49,9 @@ namespace pwiz.Skyline.Alerts
         public String SkylineFileLocation { get; set; }
         private void btnBrowse_Click(object sender, EventArgs e)
         {
-            using (var choseDirectoryDialog = new FolderBrowserDialog
+            using (var choseDirectoryDialog = new FolderBrowserDialog())
             {
-                SelectedPath = ExtractionPath
-            })
-            {
+                choseDirectoryDialog.SelectedPath = ExtractionPath;
                 if (choseDirectoryDialog.ShowDialog() == DialogResult.OK)
                 {
                     ExtractionPath = choseDirectoryDialog.SelectedPath;

--- a/pwiz_tools/Skyline/Alerts/ShareResultsFilesDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/ShareResultsFilesDlg.cs
@@ -231,10 +231,8 @@ namespace pwiz.Skyline.Alerts
             if (string.IsNullOrEmpty(initialDir))
                 initialDir = null;
 
-            using var openDataSource = new OpenDataSourceDialog(Settings.Default.RemoteAccountList, missingFiles)
-            {
-                InitialDirectory = new MsDataFilePath(initialDir)
-            };
+            using var openDataSource = new OpenDataSourceDialog(Settings.Default.RemoteAccountList, missingFiles);
+            openDataSource.InitialDirectory = new MsDataFilePath(initialDir);
 
             if (openDataSource.ShowDialog(this) == DialogResult.OK)
             {
@@ -283,12 +281,10 @@ namespace pwiz.Skyline.Alerts
                 initialDir = null;
 
             // Ask the user for the directory to search
-            using var searchFolderDialog = new FolderBrowserDialog
-            {
-                ShowNewFolderButton = false,
-                SelectedPath = initialDir,
-                Description = Resources.ShareResultsFilesDlg_LocateMissingFilesFromFolder_Please_select_the_folder_containing_the_missing_files_
-            };
+            using var searchFolderDialog = new FolderBrowserDialog();
+            searchFolderDialog.ShowNewFolderButton = false;
+            searchFolderDialog.SelectedPath = initialDir;
+            searchFolderDialog.Description = Resources.ShareResultsFilesDlg_LocateMissingFilesFromFolder_Please_select_the_folder_containing_the_missing_files_;
 
             if (searchFolderDialog.ShowDialog() == DialogResult.OK)
             {
@@ -303,11 +299,9 @@ namespace pwiz.Skyline.Alerts
         public void SearchDirectoryForMissingFiles(string folderPath)
         {
             var matchedFiles = new List<string>();
-            using (var longWaitDlg = new LongWaitDlg
-                   {
-                       Text = Resources.ImportResultsControl_FindResultsFiles_Searching_for_Results_Files
-                   })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = Resources.ImportResultsControl_FindResultsFiles_Searching_for_Results_Files;
                 try
                 {
                     var missingNames = new HashSet<string>(listboxMissingFiles.Items.OfType<string>());

--- a/pwiz_tools/Skyline/Alerts/SimpleFileDownloaderDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/SimpleFileDownloaderDlg.cs
@@ -103,14 +103,12 @@ namespace pwiz.Skyline.Alerts
                 label.Width += 10;
             }
 
-            using (var dlg = new MultiButtonMsgDlg(layout, Resources.AlertDlg_GetDefaultButtonText__Yes, Resources.AlertDlg_GetDefaultButtonText__No, false)
+            using (var dlg = new MultiButtonMsgDlg(layout, Resources.AlertDlg_GetDefaultButtonText__Yes, Resources.AlertDlg_GetDefaultButtonText__No, false))
             {
-                Text = title,
-                ClientSize = new Size(defaultWidth, defaultHeight),
-                StartPosition = FormStartPosition.CenterParent,
-                ShowInTaskbar = false
-            })
-            {
+                dlg.Text = title;
+                dlg.ClientSize = new Size(defaultWidth, defaultHeight);
+                dlg.StartPosition = FormStartPosition.CenterParent;
+                dlg.ShowInTaskbar = false;
                 dlg.MinimumSize = dlg.Size;
                 layout.Size = dlg.ClientSize;
                 layout.Height -= 35;
@@ -120,8 +118,10 @@ namespace pwiz.Skyline.Alerts
                     return result;
             }
 
-            using (var dlg = new LongWaitDlg { Message = Resources.SimpleFileDownloaderDlg_Show_Downloading_required_files___, ProgressValue = 0 })
+            using (var dlg = new LongWaitDlg())
             {
+                dlg.Message = Resources.SimpleFileDownloaderDlg_Show_Downloading_required_files___;
+                dlg.ProgressValue = 0;
                 dlg.PerformWork(parent, 50, pm => SimpleFileDownloader.DownloadRequiredFiles(requiredFilesList, pm));
             }
             return DialogResult.Yes;

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -1930,10 +1930,9 @@ namespace pwiz.Skyline
                 if (!checkAllReplicates)
                 {
                     // check if the document already has a replicate with this name
-                    int indexChrom;
                     ChromatogramSet chromatogram;
                     if (!_doc.Settings.MeasuredResults.TryGetChromatogramSet(replicateName,
-                        out chromatogram, out indexChrom))
+                        out chromatogram, out _))
                     {
                         listNewNamedPaths.Add(namedPaths);
                         continue;
@@ -2003,8 +2002,7 @@ namespace pwiz.Skyline
                         // If we are appending to an existing replicate in the document
                         // make sure this file is not already in the replicate.
                         ChromatogramSet chromatogram;
-                        int index;
-                        _doc.Settings.MeasuredResults.TryGetChromatogramSet(replicateName, out chromatogram, out index);
+                        _doc.Settings.MeasuredResults.TryGetChromatogramSet(replicateName, out chromatogram, out _);
 
                         string replicateFileString = replicateFile.ToString();
                         if (chromatogram.MSDataFilePaths.Any(filePath => StringComparer.OrdinalIgnoreCase.Equals(filePath.ToString(), replicateFileString)))
@@ -2352,9 +2350,8 @@ namespace pwiz.Skyline
                 List<PeptideGroupDocNode> peptideGroupsNew;
                 try
                 {
-                    IdentityPath firstAdded, nextAdd;
                     doc = ImportPeptideSearch.ImportFasta(doc, commandArgs.FastaPath, import.IrtStandard, progressMonitor, null,
-                        out firstAdded, out nextAdd, out peptideGroupsNew);
+                        out _, out _, out peptideGroupsNew);
                 }
                 catch (Exception x)
                 {
@@ -2384,7 +2381,6 @@ namespace pwiz.Skyline
 
                 using (var reader = new StreamReader(filePath))
                 {
-                    IdentityPath firstAddedForFile, nextAdd;
                     _doc = _doc.ImportDocumentXml(reader,
                                                 filePath,
                                                 commandArgs.DocImportResultsMerge.Value,
@@ -2393,8 +2389,8 @@ namespace pwiz.Skyline
                                                 Settings.Default.StaticModList,
                                                 Settings.Default.HeavyModList,
                                                 null,   // Always add to the end
-                                                out firstAddedForFile,
-                                                out nextAdd,
+                                                out _,
+                                                out _,
                                                 false);
                 }
             }
@@ -2670,10 +2666,8 @@ namespace pwiz.Skyline
             using (var readerFasta = new StreamReader(PathEx.SafePath(path)))
             {
                 var progressMonitor = new CommandProgressMonitor(_out, new ProgressStatus(string.Empty));
-                IdentityPath selectPath;
                 long lines = Helpers.CountLinesInFile(path);
-                int emptiesIgnored;
-                ModifyDocument(d => d.ImportFasta(readerFasta, progressMonitor, lines, false, null, out selectPath, out emptiesIgnored));
+                ModifyDocument(d => d.ImportFasta(readerFasta, progressMonitor, lines, false, null, out _, out _));
             }
             
             // Remove all empty proteins unless otherwise specified
@@ -2686,11 +2680,9 @@ namespace pwiz.Skyline
         {
             _out.WriteLine(Resources.CommandLine_ImportTransitionList_Importing_transiton_list__0____, Path.GetFileName(commandArgs.TransitionListPath));
 
-            IdentityPath selectPath;
             List<MeasuredRetentionTime> irtPeptides;
             List<SpectrumMzInfo> librarySpectra;
             List<TransitionImportErrorInfo> errorList;
-            List<PeptideGroupDocNode> peptideGroups;
             var retentionTimeRegression = _doc.Settings.PeptideSettings.Prediction.RetentionTime;
             RCalcIrt calcIrt = retentionTimeRegression != null ? (retentionTimeRegression.Calculator as RCalcIrt) : null;
 
@@ -2698,7 +2690,7 @@ namespace pwiz.Skyline
             var inputs = new MassListInputs(commandArgs.TransitionListPath);
             var importer = _doc.PreImportMassList(inputs, progressMonitor, false, SrmDocument.DOCUMENT_TYPE.none, false, Document.DocumentType);
             var docNew = _doc.ImportMassList(inputs, importer, progressMonitor, null,
-                out selectPath, out irtPeptides, out librarySpectra, out errorList, out peptideGroups);
+                out _, out irtPeptides, out librarySpectra, out errorList, out _);
 
             // If nothing was imported (e.g. operation was canceled or zero error-free transitions) and also no errors, just return
             if (ReferenceEquals(docNew, _doc) && !errorList.Any())
@@ -2768,7 +2760,7 @@ namespace pwiz.Skyline
                         try
                         {
                             List<SpectrumMzInfo> irtLibrarySpectra;
-                            docNew = docNew.ImportMassList(irtInputs, null, out selectPath, out irtPeptides, out irtLibrarySpectra, out errorList);
+                            docNew = docNew.ImportMassList(irtInputs, null, out _, out irtPeptides, out irtLibrarySpectra, out errorList);
                             if (errorList.Any())
                             {
                                 throw new InvalidDataException(errorList[0].ErrorMessage);

--- a/pwiz_tools/Skyline/Controls/Databinding/DataboundGridControl.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/DataboundGridControl.cs
@@ -265,10 +265,7 @@ namespace pwiz.Skyline.Controls.Databinding
 
         public bool IsEnableFillDown()
         {
-            PropertyDescriptor[] propertyDescriptors;
-            int firstRowIndex;
-            int lastRowIndex;
-            return GetRectangularSelection(out propertyDescriptors, out firstRowIndex, out lastRowIndex);
+            return GetRectangularSelection(out _, out _, out _);
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/Controls/Databinding/SkylineViewContext.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/SkylineViewContext.cs
@@ -255,15 +255,13 @@ namespace pwiz.Skyline.Controls.Databinding
 
         public bool Export(Control owner, ViewInfo viewInfo)
         {
-            using (var saveFileDialog = new SaveFileDialog
+            using (var saveFileDialog = new SaveFileDialog())
             {
-                InitialDirectory = GetExportDirectory(),
-                OverwritePrompt = true,
-                DefaultExt = TextUtil.EXT_CSV,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FILTER_CSV, TextUtil.FILTER_TSV),
-                FileName = GetDefaultExportFilename(viewInfo),
-            })
-            {
+                saveFileDialog.InitialDirectory = GetExportDirectory();
+                saveFileDialog.OverwritePrompt = true;
+                saveFileDialog.DefaultExt = TextUtil.EXT_CSV;
+                saveFileDialog.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FILTER_CSV, TextUtil.FILTER_TSV);
+                saveFileDialog.FileName = GetDefaultExportFilename(viewInfo);
                 // TODO: If document has been saved, initial directory should be document directory
                 if (saveFileDialog.ShowDialog(FormUtil.FindTopLevelOwner(owner)) == DialogResult.Cancel)
                 {
@@ -305,12 +303,9 @@ namespace pwiz.Skyline.Controls.Databinding
                 return SafeWriteToFile(owner, fileName, stream =>
                 {
                     bool success = false;
-                    using (
-                        var longWait = new LongWaitDlg
-                        {
-                            Text = Resources.ExportReportDlg_ExportReport_Generating_Report
-                        })
+                    using (var longWait = new LongWaitDlg())
                     {
+                        longWait.Text = Resources.ExportReportDlg_ExportReport_Generating_Report;
                         var action = new Action<IProgressMonitor>(progressMonitor =>
                         {
                             IProgressStatus status = new ProgressStatus(Resources.ExportReportDlg_ExportReport_Building_report);
@@ -639,13 +634,11 @@ namespace pwiz.Skyline.Controls.Databinding
 
         public override void ExportViews(Control owner, ViewSpecList viewSpecList)
         {
-            using (var saveFileDialog = new SaveFileDialog
+            using (var saveFileDialog = new SaveFileDialog())
             {
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                CheckPathExists = true,
-                Filter = TextUtil.FileDialogFilterAll(Resources.ExportReportDlg_ShowShare_Skyline_Reports, ReportSpecList.EXT_REPORTS)
-            })
-            {
+                saveFileDialog.InitialDirectory = Settings.Default.ActiveDirectory;
+                saveFileDialog.CheckPathExists = true;
+                saveFileDialog.Filter = TextUtil.FileDialogFilterAll(Resources.ExportReportDlg_ShowShare_Skyline_Reports, ReportSpecList.EXT_REPORTS);
                 saveFileDialog.ShowDialog(FormUtil.FindTopLevelOwner(owner));
                 if (!string.IsNullOrEmpty(saveFileDialog.FileName))
                 {
@@ -666,14 +659,12 @@ namespace pwiz.Skyline.Controls.Databinding
 
         public override void ImportViews(Control owner, ViewGroup group)
         {
-            using (var importDialog = new OpenFileDialog
+            using (var importDialog = new OpenFileDialog())
             {
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                CheckPathExists = true,
-                Filter = TextUtil.FileDialogFilterAll(Resources.ExportReportDlg_ShowShare_Skyline_Reports,
-                    ReportSpecList.EXT_REPORTS)
-            })
-            {
+                importDialog.InitialDirectory = Settings.Default.ActiveDirectory;
+                importDialog.CheckPathExists = true;
+                importDialog.Filter = TextUtil.FileDialogFilterAll(Resources.ExportReportDlg_ShowShare_Skyline_Reports,
+                    ReportSpecList.EXT_REPORTS);
                 importDialog.ShowDialog(FormUtil.FindTopLevelOwner(owner));
 
                 if (string.IsNullOrEmpty(importDialog.FileName))

--- a/pwiz_tools/Skyline/Controls/Databinding/SkylineWindowDataSchema.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/SkylineWindowDataSchema.cs
@@ -60,11 +60,9 @@ namespace pwiz.Skyline.Controls.Databinding
         protected override SrmDocument EndDeferSettingsChanges(SrmDocument document, SrmDocument originalDocument)
         {
             string message = Resources.DataGridViewPasteHandler_EndDeferSettingsChangesOnDocument_Updating_settings;
-            using (var longWaitDlg = new LongWaitDlg
-                   {
-                       Message = message
-                   })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Message = message;
                 SrmDocument newDocument = document;
                 longWaitDlg.PerformWork(SkylineWindow, 1000, progressMonitor =>
                 {

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.cs
@@ -592,13 +592,11 @@ namespace pwiz.Skyline.Controls.Graphs
 
         private void ModifyDocument(string message, Action<SrmSettingsChangeMonitor> modifyAction)
         {
-            using (var longWaitDlg = new LongWaitDlg(Program.MainWindow)
+            using (var longWaitDlg = new LongWaitDlg(Program.MainWindow))
             {
-                Text = Text, // Same as dialog box
-                Message = message,
-                ProgressValue = 0
-            })
-            {
+                longWaitDlg.Text = Text; // Same as dialog box
+                longWaitDlg.Message = message;
+                longWaitDlg.ProgressValue = 0;
                 try
                 {
                     longWaitDlg.PerformWork(this, 800, progressMonitor =>

--- a/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AsyncChromatogramsGraph2.cs
@@ -341,7 +341,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
         private GraphInfo GetInfo(string key)
         {
-            return key != null && _graphs.ContainsKey(key) ? _graphs[key] : null;
+            return key != null && _graphs.TryGetValue(key, out var graph) ? graph : null;
         }
 
         private void AddUnfinishedLine(GraphPane graphPane, float? currentTime)

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -1645,7 +1645,6 @@ namespace pwiz.Skyline.Controls.Graphs
             }
             float end = tranPeakInfo.EndRetentionTime;
             float start = tranPeakInfo.StartRetentionTime;
-            chromatogramInfo.AsArrays(out _, out _);
 
             var peakTimeIntensities = chromatogramInfo.TimeIntensities.InterpolateTime(start).InterpolateTime(end)
                 .Truncate(start, end);

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -602,11 +602,9 @@ namespace pwiz.Skyline.Controls.Graphs
             if (settingsOld != null && settingsOld.HasResults && settingsNew.HasResults)
             {
                 ChromatogramSet chromatogramSetOld;
-                int resultsIndexOld;
                 ChromatogramSet chromatogramSetNew;
-                int resultsIndexNew;
-                if (settingsOld.MeasuredResults.TryGetChromatogramSet(_nameChromatogramSet, out chromatogramSetOld, out resultsIndexOld)
-                    != settingsNew.MeasuredResults.TryGetChromatogramSet(_nameChromatogramSet, out chromatogramSetNew, out resultsIndexNew))
+                if (settingsOld.MeasuredResults.TryGetChromatogramSet(_nameChromatogramSet, out chromatogramSetOld, out _)
+                    != settingsNew.MeasuredResults.TryGetChromatogramSet(_nameChromatogramSet, out chromatogramSetNew, out _))
                 {
                     return false;
                 }
@@ -910,17 +908,14 @@ namespace pwiz.Skyline.Controls.Graphs
                 // Make sure all the chromatogram info for the relevant transition groups is present.
                 float mzMatchTolerance = (float) settings.TransitionSettings.Instrument.MzMatchTolerance;
                 var displayType = GetDisplayType(DocumentUI);
-                bool changedGroupIds;
-                if (displayToExtractor.ContainsKey(displayType))
+                if (displayToExtractor.TryGetValue(displayType, out var extractor))
                 {
-                    var extractor = displayToExtractor[displayType];
                     if (EnsureChromInfo(results,
-                                        chromatograms,
-                                        nodeGroups,
-                                        groupPaths,
-                                        extractor,
-                                        out changedGroups,
-                                        out changedGroupIds))
+                            chromatograms,
+                            nodeGroups,
+                            groupPaths,
+                            extractor,
+                            out changedGroups))
                     {
                         // Update the file choice toolbar, if the set of groups has changed
                         // Overkill for summary graphs, but the files still might change with any
@@ -954,8 +949,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                         nodeGroups,
                                         groupPaths,
                                         mzMatchTolerance,
-                                        out changedGroups,
-                                        out changedGroupIds))
+                                        out changedGroups))
                     {
                         // Update the file choice toolbar, if the set of groups has changed
                         if (changedGroups)
@@ -980,8 +974,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                                                nodeGroups,
                                                                groupPaths,
                                                                mzMatchTolerance,
-                                                               out changedGroups,
-                                                               out changedGroupIds))
+                                                               out changedGroups))
                 {
                     // Update the file choice toolbar, if the set of groups has changed
                     if (changedGroups)
@@ -1652,9 +1645,7 @@ namespace pwiz.Skyline.Controls.Graphs
             }
             float end = tranPeakInfo.EndRetentionTime;
             float start = tranPeakInfo.StartRetentionTime;
-            double[] allTimes;
-            double[] allIntensities;
-            chromatogramInfo.AsArrays(out allTimes, out allIntensities);
+            chromatogramInfo.AsArrays(out _, out _);
 
             var peakTimeIntensities = chromatogramInfo.TimeIntensities.InterpolateTime(start).InterpolateTime(end)
                 .Truncate(start, end);
@@ -2344,10 +2335,9 @@ namespace pwiz.Skyline.Controls.Graphs
                     var listTimes = new List<double>();
                     foreach (var group in transitionGroups)
                     {
-                        IsotopeLabelType labelType;
                         double[] retentionTimes;
                         if (settings.TryGetRetentionTimes(lookupSequence, group.PrecursorAdduct,
-                                                          lookupMods, FilePath, out labelType, out retentionTimes))
+                                                          lookupMods, FilePath, out _, out retentionTimes))
                         {
                             listTimes.AddRange(retentionTimes);
                         }
@@ -2522,13 +2512,12 @@ namespace pwiz.Skyline.Controls.Graphs
                                      TransitionGroupDocNode[] nodeGroups,
                                      IdentityPath[] groupPaths,
                                      ChromExtractor extractor,
-                                     out bool changedGroups,
-                                     out bool changedGroupIds)
+                                     out bool changedGroups)
         {
             bool qcTraceNameMatches = extractor != ChromExtractor.qc ||
                                       _arrayChromInfo?[0]?[0].TextId == Settings.Default.ShowQcTraceName;
 
-            if (UpdateGroups(nodeGroups, groupPaths, out changedGroups, out changedGroupIds) &&
+            if (UpdateGroups(nodeGroups, groupPaths, out changedGroups) &&
                 _extractor == extractor &&
                 qcTraceNameMatches &&
                 ReferenceEquals(results, _measuredResults))
@@ -2602,10 +2591,9 @@ namespace pwiz.Skyline.Controls.Graphs
                                      TransitionGroupDocNode[] nodeGroups,
                                      IdentityPath[] groupPaths,
                                      float mzMatchTolerance,
-                                     out bool changedGroups,
-                                     out bool changedGroupIds)
+                                     out bool changedGroups)
         {
-            if (UpdateGroups(nodeGroups, groupPaths, out changedGroups, out changedGroupIds) 
+            if (UpdateGroups(nodeGroups, groupPaths, out changedGroups) 
                 && !_extractor.HasValue 
                 && ReferenceEquals(results, _measuredResults))
                 return true;
@@ -2725,27 +2713,13 @@ namespace pwiz.Skyline.Controls.Graphs
         /// </summary>
         /// <returns>True if groups are already up to date, False if they were changed</returns>
         private bool UpdateGroups(TransitionGroupDocNode[] nodeGroups, IdentityPath[] groupPaths,
-                                  out bool changedGroups, out bool changedGroupIds)
+                                  out bool changedGroups)
         {
             changedGroups = false;
-            changedGroupIds = false;
             if (ArrayUtil.ReferencesEqual(nodeGroups, _nodeGroups) && _arrayChromInfo != null)
                 return true;
 
             changedGroups = true;
-            int lenNew = nodeGroups.SafeLength();
-            int lenOld = _nodeGroups.SafeLength();
-            if (lenNew != lenOld)
-                changedGroupIds = true;
-            else
-            {
-                for (int i = 0; i < lenNew; i++)
-                {
-                    if (!ReferenceEquals(nodeGroups[i].Id, _nodeGroups[i].Id))
-                        changedGroupIds = true;
-                }
-            }
-
             _nodeGroups = nodeGroups;
             _groupPaths = groupPaths;
             return false;
@@ -2924,8 +2898,8 @@ namespace pwiz.Skyline.Controls.Graphs
             graphItem = FindBestPeakItem(curve);
             if (graphItem != null)
             {
-                double displayTime, yTemp;
-                graphPane.ReverseTransform(pt, out displayTime, out yTemp);
+                double displayTime;
+                graphPane.ReverseTransform(pt, out displayTime, out _);
                 return graphItem.GetValidPeakBoundaryTime(displayTime);
             }
 
@@ -2941,8 +2915,8 @@ namespace pwiz.Skyline.Controls.Graphs
             graphPane = GraphPaneFromPoint(pt);
             if (null != graphPane)
             {
-                double time, yTemp;
-                graphPane.ReverseTransform(pt, out time, out yTemp);
+                double time;
+                graphPane.ReverseTransform(pt, out time, out _);
 
                 foreach (var graphItemNext in GetGraphItems(graphPane))
                 {
@@ -3085,18 +3059,15 @@ namespace pwiz.Skyline.Controls.Graphs
             using (Graphics g = CreateGraphics())
             {
                 object nearest;
-                int index;
                 GraphPane nearestGraphPane;
-                if (FindNearestObject(pt, g, out nearestGraphPane, out nearest, out index))
+                if (FindNearestObject(pt, g, out nearestGraphPane, out nearest))
                 {
                     var label = nearest as TextObj;
                     if (label != null)
                     {
                         doFullScanTracking = false;
-                        TransitionGroupDocNode nodeGroup;
-                        TransitionDocNode nodeTran;
                         if (_showPeptideTotals ||
-                            (!_extractor.HasValue && !FindAnnotatedPeakRetentionTime(label, out nodeGroup, out nodeTran).IsZero) ||
+                            (!_extractor.HasValue && !FindAnnotatedPeakRetentionTime(label, out _, out _).IsZero) ||
                             !FindAnnotatedSpectrumRetentionTime(label).IsZero)
                         {
                             graphControl.Cursor = Cursors.Hand;
@@ -3110,14 +3081,13 @@ namespace pwiz.Skyline.Controls.Graphs
                     var line = nearest as LineObj;
                     if (line != null)
                     {
-                        ChromGraphItem graphItem;
                         if (!FindAnnotatedSpectrumRetentionTime(line).IsZero)
                         {
                             graphControl.Cursor = Cursors.Hand;
                             return true;
                         }
                         GraphPane graphPane;
-                        if (!_extractor.HasValue && (!FindBestPeakBoundary(pt, out graphPane, out graphItem).IsZero || graphPane != nearestGraphPane))
+                        if (!_extractor.HasValue && (!FindBestPeakBoundary(pt, out graphPane, out _).IsZero || graphPane != nearestGraphPane))
                         {
                             graphControl.Cursor = Cursors.VSplit;
                             return true;
@@ -3236,9 +3206,8 @@ namespace pwiz.Skyline.Controls.Graphs
                 {
                     GraphPane nearestGraphPane;
                     object nearest;
-                    int index;
 
-                    if (FindNearestObject(pt, g, out nearestGraphPane, out nearest, out index))
+                    if (FindNearestObject(pt, g, out nearestGraphPane, out nearest))
                     {
                         var label = nearest as TextObj;
                         if (label != null)
@@ -3437,8 +3406,8 @@ namespace pwiz.Skyline.Controls.Graphs
         public bool DoDrag(GraphPane graphPane, PointF pt)
         {
             // Calculate new location of boundary from mouse position
-            double time, yTemp;
-            graphPane.ReverseTransform(pt, out time, out yTemp);
+            double time;
+            graphPane.ReverseTransform(pt, out time, out _);
 
             bool changed = false;
             foreach (var dragInfo in _peakBoundDragInfos)
@@ -3469,14 +3438,14 @@ namespace pwiz.Skyline.Controls.Graphs
             Refresh();
         }
 
-        private bool FindNearestObject(PointF pt, Graphics g, out GraphPane nearestGraphPane, out object nearestCurve, out int index)
+        private bool FindNearestObject(PointF pt, Graphics g, out GraphPane nearestGraphPane, out object nearestCurve)
         {
             try
             {
                 var graphPane = GraphPaneFromPoint(pt);
                 if (null != graphPane)
                 {
-                    if (graphPane.FindNearestObject(pt, g, out nearestCurve, out index))
+                    if (graphPane.FindNearestObject(pt, g, out nearestCurve, out _))
                     {
                         nearestGraphPane = graphPane;
                         return true;
@@ -3492,7 +3461,6 @@ namespace pwiz.Skyline.Controls.Graphs
             }
             nearestGraphPane = null;
             nearestCurve = null;
-            index = -1;
             return false;
         }
 

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -1444,8 +1444,7 @@ namespace pwiz.Skyline.Controls.Graphs
             using (Graphics g = CreateGraphics())
             {
                 object nearestObject;
-                int index;
-                if (GraphPane.FindNearestObject(mousePoint, g, out nearestObject, out index))
+                if (GraphPane.FindNearestObject(mousePoint, g, out nearestObject, out _))
                 {
                     var textObj = nearestObject as TextObj;
                     if (textObj != null)

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphHelper.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphHelper.cs
@@ -631,8 +631,8 @@ namespace pwiz.Skyline.Controls.Graphs
                     }
                 }
 
-                double tMinX, tMinY, tMaxX, tMaxY;
-                curveList.GetCurveRange(g, curve, out tMinX, out tMaxX, out tMinY, out tMaxY);
+                double tMaxY;
+                curveList.GetCurveRange(g, curve, out _, out _, out _, out tMaxY);
 
                 maxY = Math.Max(maxY, tMaxY);
             }

--- a/pwiz_tools/Skyline/Controls/Graphs/MeanErrorBarItem.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/MeanErrorBarItem.cs
@@ -96,9 +96,9 @@ namespace pwiz.Skyline.Controls.Graphs
                 return;
             }
 
-            double curBase, curLowVal, curHiVal;
+            double curBase, curHiVal;
             ValueHandler valueHandler = new ValueHandler(pane, false);
-            valueHandler.GetValues(curve, index, out curBase, out curLowVal, out curHiVal);
+            valueHandler.GetValues(curve, index, out curBase, out _, out curHiVal);
 
             float pixBase = baseAxis.Scale.Transform(curve.IsOverrideOrdinal, index, curBase);
             double lowError = curHiVal - errorTag.Error;

--- a/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
@@ -845,7 +845,6 @@ namespace pwiz.Skyline.Controls.Graphs
                         // Initialize the one calculator
                         calc = Settings.Default.RTScoreCalculatorList.Initialize(null, calc);
 
-                        double unused;
                         _regressionAll = RetentionTimeRegression.CalcSingleRegression(XmlNamedElement.NAME_INTERNAL,
                             calc,
                             _targetTimes,
@@ -853,7 +852,7 @@ namespace pwiz.Skyline.Controls.Graphs
                             true,
                             _regressionMethod,
                             out _statisticsAll,
-                            out unused,
+                            out _,
                             token);
 
                         token.ThrowIfCancellationRequested();

--- a/pwiz_tools/Skyline/Controls/Graphs/RTReplicateGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTReplicateGraphPane.cs
@@ -364,8 +364,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 }
                 Assume.IsNotNull(chromInfoData, @"chromInfoData");
                 Assume.IsNotNull(chromInfoData.ChromFileInfo, @"chromInfoData.ChromFileInfo");
-                RegressionLine regressionFunction;
-                return !RetentionTimeTransform.RtTransformOp.TryGetRegressionFunction(chromInfoData.ChromFileInfo.FileId, out regressionFunction);
+                return !RetentionTimeTransform.RtTransformOp.TryGetRegressionFunction(chromInfoData.ChromFileInfo.FileId, out _);
             }
 
             protected override bool IsMissingValue(TransitionChromInfoData chromInfoData)

--- a/pwiz_tools/Skyline/Controls/Graphs/SummaryBarGraphPaneBase.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SummaryBarGraphPaneBase.cs
@@ -336,8 +336,7 @@ namespace pwiz.Skyline.Controls.Graphs
             using (Graphics g = sender.CreateGraphics())
             {
                 object nearestObject;
-                int index;
-                if (FindNearestObject(new PointF(mouseEventArgs.X, mouseEventArgs.Y), g, out nearestObject, out index))
+                if (FindNearestObject(new PointF(mouseEventArgs.X, mouseEventArgs.Y), g, out nearestObject, out _))
                 {
                     var axis = nearestObject as XAxis;
                     if (axis != null)

--- a/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/EditGroupComparisonDlg.cs
@@ -297,8 +297,8 @@ namespace pwiz.Skyline.Controls.GroupComparison
                 helper.ShowTextBoxError(tbxName, GroupComparisonStrings.EditGroupComparisonDlg_btnOK_Click_There_is_already_a_group_comparison_named__0__, name);
                 return;
             }
-            double confidenceLevel;
-            if (!helper.ValidateDecimalTextBox(tbxConfidenceLevel, 0, 100, out confidenceLevel))
+
+            if (!helper.ValidateDecimalTextBox(tbxConfidenceLevel, 0, 100, out _))
             {
                 return;
             }

--- a/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeBarGraph.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeBarGraph.cs
@@ -286,9 +286,9 @@ namespace pwiz.Skyline.Controls.GroupComparison
             {
                 return null;
             }
-            CurveItem nearestCurve;
+
             int iNearest;
-            if (!zedGraphControl.GraphPane.FindNearestPoint(pt, _barGraph, out nearestCurve, out iNearest))
+            if (!zedGraphControl.GraphPane.FindNearestPoint(pt, _barGraph, out _, out iNearest))
             {
                 return null;
             }

--- a/pwiz_tools/Skyline/Controls/Lists/ListViewContext.cs
+++ b/pwiz_tools/Skyline/Controls/Lists/ListViewContext.cs
@@ -128,9 +128,8 @@ namespace pwiz.Skyline.Controls.Lists
 
             try
             {
-                ListItemId listItemId;
                 var listData = SkylineDataSchema.Document.Settings.DataSettings.FindList(ListName);
-                listData.AddRow(values, out listItemId);
+                listData.AddRow(values, out _);
                 return true;
             }
             catch (Exception exception)

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.cs
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.cs
@@ -726,11 +726,9 @@ namespace pwiz.Skyline.Controls.Spectra
             var filters = new List<FilterClause>();
             var transitionGroupIdentityPathLists = new List<ICollection<IdentityPath>>();
             var activeClassColumns = GetActiveClassColumns().ToList();
-            using (var longWaitDlg = new LongWaitDlg
-                   {
-                       Message = Resources.SpectraGridForm_AddSpectrumFilters_Examining_filters
-                   })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Message = Resources.SpectraGridForm_AddSpectrumFilters_Examining_filters;
                 var document = SkylineWindow.DocumentUI;
                 longWaitDlg.PerformWork(this, 1000, broker =>
                 {

--- a/pwiz_tools/Skyline/Controls/Startup/ActionTutorial.cs
+++ b/pwiz_tools/Skyline/Controls/Startup/ActionTutorial.cs
@@ -79,30 +79,24 @@ namespace pwiz.Skyline.Controls.Startup
             skylineWindow.ResetDefaultSettings();
             try
             {
-                using (var longWaitDlg = new LongWaitDlg
+                using (var longWaitDlg = new LongWaitDlg())
                 {
-                    Text = Resources.ActionTutorial_LongWaitDlgAction_Downloading_Tutorial_Zip_File,
-                    Message =
-                        String.Format(
-                            Resources
-                                .ActionTutorial_LongWaitDlgAction_Downloading_to___0__1_Tutorial_will_open_in_browser_when_download_is_complete_,
-                            getTempPath(), Environment.NewLine),
-                    ProgressValue = 0
-                })
-                {
+                    longWaitDlg.Text = Resources.ActionTutorial_LongWaitDlgAction_Downloading_Tutorial_Zip_File;
+                    longWaitDlg.Message = String.Format(
+                        Resources
+                            .ActionTutorial_LongWaitDlgAction_Downloading_to___0__1_Tutorial_will_open_in_browser_when_download_is_complete_,
+                        getTempPath(), Environment.NewLine);
+                    longWaitDlg.ProgressValue = 0;
                     longWaitDlg.PerformWork(skylineWindow, 1000, DownloadTutorials);
                     if (longWaitDlg.IsCanceled)
                     {
                         return;
                     }
                 }
-                using (var longWaitDlg = new LongWaitDlg
+                using (var longWaitDlg = new LongWaitDlg())
                 {
-                    Text =
-                        Resources.ActionTutorial_LongWaitDlgAction_Extracting_Tutorial_Zip_File_in_the_same_directory_,
-                    ProgressValue = 0
-                })
-                {
+                    longWaitDlg.Text = Resources.ActionTutorial_LongWaitDlgAction_Extracting_Tutorial_Zip_File_in_the_same_directory_;
+                    longWaitDlg.ProgressValue = 0;
                     longWaitDlg.PerformWork(skylineWindow, 1000, ExtractTutorial);
                 }
             }

--- a/pwiz_tools/Skyline/Controls/Startup/StartPage.cs
+++ b/pwiz_tools/Skyline/Controls/Startup/StartPage.cs
@@ -653,12 +653,10 @@ namespace pwiz.Skyline.Controls.Startup
 
         private string OpenFileDlg()
         {
-            using (var openNewFileDlg = new OpenFileDialog
+            using (var openNewFileDlg = new OpenFileDialog())
             {
-                Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC_AND_SKY_ZIP, SrmDocumentSharing.FILTER_SHARING, SkypFile.FILTER_SKYP),
-                FilterIndex = 1
-            })
-            {
+                openNewFileDlg.Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC_AND_SKY_ZIP, SrmDocumentSharing.FILTER_SHARING, SkypFile.FILTER_SKYP);
+                openNewFileDlg.FilterIndex = 1;
                 if (openNewFileDlg.ShowDialog() != DialogResult.OK)
                     return null;
 

--- a/pwiz_tools/Skyline/EditUI/AddPeakCompareDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/AddPeakCompareDlg.cs
@@ -151,11 +151,9 @@ namespace pwiz.Skyline.EditUI
                 MessageDlg.Show(this, message);
                 return;
             }
-            using (var longWaitDlg = new LongWaitDlg
+            using (var longWaitDlg = new LongWaitDlg())
             {
-                Text = isModel ? Resources.AddPeakCompareDlg_OkDialog_Comparing_Models : Resources.AddPeakCompareDlg_OkDialog_Comparing_Imported_Files
-            })
-            {
+                longWaitDlg.Text = isModel ? Resources.AddPeakCompareDlg_OkDialog_Comparing_Models : Resources.AddPeakCompareDlg_OkDialog_Comparing_Imported_Files;
                 try
                 {
                     longWaitDlg.PerformWork(this, 1000, pm => BoundaryComparer.GenerateComparison(Document, pm));
@@ -207,15 +205,13 @@ namespace pwiz.Skyline.EditUI
 
         public void Browse()
         {
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.CreateIrtCalculatorDlg_ImportTextFile_Import_Transition_List__iRT_standards_,
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                DefaultExt = TextUtil.EXT_CSV,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
-                    Resources.SkylineWindow_importMassListMenuItem_Click_Transition_List, TextUtil.EXT_CSV, TextUtil.EXT_TSV))
-            })
-            {
+                dlg.Title = Resources.CreateIrtCalculatorDlg_ImportTextFile_Import_Transition_List__iRT_standards_;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.DefaultExt = TextUtil.EXT_CSV;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
+                    Resources.SkylineWindow_importMassListMenuItem_Click_Transition_List, TextUtil.EXT_CSV, TextUtil.EXT_TSV));
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
@@ -392,14 +392,12 @@ namespace pwiz.Skyline.EditUI
         // prompts user to select a fasta file to use for matching proteins
         public void ImportFasta()
         {
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.SkylineWindow_ImportFastaFile_Import_FASTA,
-                InitialDirectory = Settings.Default.FastaDirectory,
-                CheckPathExists = true,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(Resources.OpenFileDialog_FASTA_files, DataSourceUtil.EXT_FASTA))
-            })
-            {
+                dlg.Title = Resources.SkylineWindow_ImportFastaFile_Import_FASTA;
+                dlg.InitialDirectory = Settings.Default.FastaDirectory;
+                dlg.CheckPathExists = true;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(Resources.OpenFileDialog_FASTA_files, DataSourceUtil.EXT_FASTA));
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.FastaDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -688,8 +686,7 @@ namespace pwiz.Skyline.EditUI
 
         public void NewTargetsFinalSync(out int proteins, out int peptides, out int precursors, out int transitions)
         {
-            int? emptyProteins;
-            NewTargetsFinalSync(out proteins, out peptides, out precursors, out transitions, out emptyProteins);
+            NewTargetsFinalSync(out proteins, out peptides, out precursors, out transitions, out _);
         }
 
         public void NewTargetsFinalSync(out int proteins, out int peptides, out int precursors, out int transitions, out int? emptyProteins)

--- a/pwiz_tools/Skyline/EditUI/PasteDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.cs
@@ -209,8 +209,7 @@ namespace pwiz.Skyline.EditUI
 
         private SrmDocument GetNewDocument(SrmDocument document, bool validating, ref IdentityPath selectedPath)
         {
-            List<PeptideGroupDocNode> newPeptideGroups;
-            return GetNewDocument(document, validating, ref selectedPath, out newPeptideGroups);
+            return GetNewDocument(document, validating, ref selectedPath, out _);
         }
 
         private SrmDocument GetNewDocument(SrmDocument document, bool validating, ref IdentityPath selectedPath, out List<PeptideGroupDocNode> newPeptideGroups)
@@ -761,8 +760,7 @@ namespace pwiz.Skyline.EditUI
                 return;
             }
             var proteinName = Convert.ToString(row.Cells[colPeptideProtein.Index].Value);
-            ProteinMetadata metadata;
-            FastaSequence fastaSequence = GetFastaSequence(row, proteinName, out metadata);
+            FastaSequence fastaSequence = GetFastaSequence(row, proteinName, out _);
             row.Cells[colPeptideProteinDescription.Index].Value = fastaSequence == null ? null : fastaSequence.Description;
         }
 
@@ -1262,11 +1260,9 @@ namespace pwiz.Skyline.EditUI
 
         static IEnumerable<IList<string>> ParseColumnarData(String text)
         {
-            IFormatProvider formatProvider;
             char separator;
-            Type[] types;
 
-            if (!MassListImporter.IsColumnar(text, out formatProvider, out separator, out types))
+            if (!MassListImporter.IsColumnar(text, out _, out separator, out _))
             {
                 string line;
                 var reader = new StringReader(text);
@@ -1532,9 +1528,9 @@ namespace pwiz.Skyline.EditUI
             {
                 var reader = new StringReader(TbxFasta.Text);
                 IdentityPath to = selectedPath;
-                IdentityPath firstAdded, nextAdd;
+                IdentityPath firstAdded;
                 newPeptideGroups = importer.Import(reader, monitor, -1).ToList();
-                document = document.AddPeptideGroups(newPeptideGroups, false, to, out firstAdded, out nextAdd);
+                document = document.AddPeptideGroups(newPeptideGroups, false, to, out firstAdded, out _);
                 selectedPath = firstAdded;
             }
             catch (Exception exception)

--- a/pwiz_tools/Skyline/EditUI/PermuteIsotopeModificationsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PermuteIsotopeModificationsDlg.cs
@@ -98,11 +98,9 @@ namespace pwiz.Skyline.EditUI
                 var globalIsotopeMods = Settings.Default.HeavyModList.ToList();
                 var newDocument = deferSettingsChangeDoc;
                 var simplePermutation = SimplePermutation;
-                using (var longWaitDlg = new LongWaitDlg()
+                using (var longWaitDlg = new LongWaitDlg())
                 {
-                    Text = Resources.PermuteIsotopeModificationsDlg_OkDialog_Permuting_Isotope_Modifications
-                })
-                {
+                    longWaitDlg.Text = Resources.PermuteIsotopeModificationsDlg_OkDialog_Permuting_Isotope_Modifications;
                     longWaitDlg.PerformWork(this, 1000, progressMonitor =>
                     {
                         var isotopePermuter = new IsotopeModificationPermuter(isotopeModification,

--- a/pwiz_tools/Skyline/EditUI/ReintegrateDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/ReintegrateDlg.cs
@@ -98,11 +98,9 @@ namespace pwiz.Skyline.EditUI
                     return;
             }
 
-            using (var longWaitDlg = new LongWaitDlg
-                {
-                    Text = Resources.ReintegrateDlg_OkDialog_Reintegrating,
-                })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = Resources.ReintegrateDlg_OkDialog_Reintegrating;
                 try
                 {
                     var scoringModel = _driverPeakScoringModel.SelectedItem;

--- a/pwiz_tools/Skyline/EditUI/RenameProteinsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/RenameProteinsDlg.cs
@@ -155,14 +155,11 @@ namespace pwiz.Skyline.EditUI
 
         private void btnFASTA_Click(object sender, EventArgs e)
         {
-            using (OpenFileDialog dlg = new OpenFileDialog
-                                            {
-                                                Title = Resources.RenameProteinsDlg_btnFASTA_Click_Add_FASTA_File,
-                                                InitialDirectory = Settings.Default.FastaDirectory,
-                                                CheckPathExists = true
-                                                // FASTA files often have no extension as well as .fasta and others
-                                            })
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
+                dlg.Title = Resources.RenameProteinsDlg_btnFASTA_Click_Add_FASTA_File;
+                dlg.InitialDirectory = Settings.Default.FastaDirectory;
+                dlg.CheckPathExists = true; // FASTA files often have no extension as well as .fasta and others
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.FastaDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -300,8 +297,7 @@ namespace pwiz.Skyline.EditUI
             var dictNodeToNewName = new Dictionary<string, string>();
             foreach (var nodePepGroup in _document.MoleculeGroups)
             {
-                string newname;
-                if (!dictNodeToNewName.TryGetValue(nodePepGroup.Name, out newname))
+                if (!dictNodeToNewName.TryGetValue(nodePepGroup.Name, out _))
                 {
                     string text = null;
                     switch (mode)

--- a/pwiz_tools/Skyline/EditUI/SchedulingGraphPropertyDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/SchedulingGraphPropertyDlg.cs
@@ -120,13 +120,10 @@ namespace pwiz.Skyline.EditUI
 
         private void btnBrukerTemplateBrowse_Click(object sender, EventArgs e)
         {
-            using (var openFileDialog = new OpenFileDialog
+            using (var openFileDialog = new OpenFileDialog())
             {
-                Title = Resources.ExportMethodDlg_btnBrowseTemplate_Click_Method_Template,
-                // Extension based on currently selected type
-                CheckPathExists = true
-            })
-            {
+                openFileDialog.Title = Resources.ExportMethodDlg_btnBrowseTemplate_Click_Method_Template; // Extension based on currently selected type
+                openFileDialog.CheckPathExists = true;
                 var templateName = textBrukerTemplate.Text;
                 if (!string.IsNullOrEmpty(templateName))
                 {

--- a/pwiz_tools/Skyline/EditUI/UniquePeptidesDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/UniquePeptidesDlg.cs
@@ -197,12 +197,10 @@ namespace pwiz.Skyline.EditUI
 
         private void LaunchPeptideProteinsQuery()
         {
-            using (var longWaitDlg = new LongWaitDlg
-                {
-                    Text = Resources.UniquePeptidesDlg_LaunchPeptideProteinsQuery_Querying_Background_Proteome_Database,
-                    Message = Resources.UniquePeptidesDlg_LaunchPeptideProteinsQuery_Looking_for_proteins_with_matching_peptide_sequences
-                })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = Resources.UniquePeptidesDlg_LaunchPeptideProteinsQuery_Querying_Background_Proteome_Database;
+                longWaitDlg.Message = Resources.UniquePeptidesDlg_LaunchPeptideProteinsQuery_Looking_for_proteins_with_matching_peptide_sequences;
                 try
                 {
                     longWaitDlg.PerformWork(this, 1000, QueryPeptideProteins);

--- a/pwiz_tools/Skyline/FileUI/ChooseIrtStandardPeptidesDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ChooseIrtStandardPeptidesDlg.cs
@@ -261,14 +261,12 @@ namespace pwiz.Skyline.FileUI
 
         private void ImportTextFile()
         {
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                Title = Resources.ChooseIrtStandardPeptides_ImportTextFile_Import_Transition_List__iRT_standards_,
-                InitialDirectory = Path.GetDirectoryName(_documentFilePath),
-                DefaultExt = TextUtil.EXT_CSV,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(Resources.ChooseIrtStandardPeptides_ImportTextFile_Transition_List, TextUtil.EXT_CSV, TextUtil.EXT_TSV))
-            })
-            {
+                dlg.Title = Resources.ChooseIrtStandardPeptides_ImportTextFile_Import_Transition_List__iRT_standards_;
+                dlg.InitialDirectory = Path.GetDirectoryName(_documentFilePath);
+                dlg.DefaultExt = TextUtil.EXT_CSV;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(Resources.ChooseIrtStandardPeptides_ImportTextFile_Transition_List, TextUtil.EXT_CSV, TextUtil.EXT_TSV));
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);

--- a/pwiz_tools/Skyline/FileUI/CreateIrtCalculatorDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/CreateIrtCalculatorDlg.cs
@@ -182,11 +182,11 @@ namespace pwiz.Skyline.FileUI
                         MessageDlg.Show(this, Resources.CreateIrtCalculatorDlg_OkDialog_Transition_list_field_must_contain_a_path_to_a_valid_file_);
                         return;
                     }
-                    IdentityPath selectPath;
+
                     List<MeasuredRetentionTime> irtPeptides;
                     List<TransitionImportErrorInfo> errorList;
                     var inputs = new MassListInputs(textImportText.Text);
-                    docNew = docNew.ImportMassList(inputs, null, out selectPath, out irtPeptides, out _librarySpectra, out errorList);
+                    docNew = docNew.ImportMassList(inputs, null, out _, out irtPeptides, out _librarySpectra, out errorList);
                     if (errorList.Any())
                     {
                         throw new InvalidDataException(errorList[0].ErrorMessage);
@@ -240,14 +240,12 @@ namespace pwiz.Skyline.FileUI
 
         public void BrowseDb()
         {
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.EditIrtCalcDlg_btnBrowseDb_Click_Open_iRT_Database,
-                InitialDirectory = Path.GetDirectoryName(DocumentFilePath),
-                DefaultExt = IrtDb.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB)
-            })
-            {
+                dlg.Title = Resources.EditIrtCalcDlg_btnBrowseDb_Click_Open_iRT_Database;
+                dlg.InitialDirectory = Path.GetDirectoryName(DocumentFilePath);
+                dlg.DefaultExt = IrtDb.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -269,15 +267,13 @@ namespace pwiz.Skyline.FileUI
 
         public void CreateDb(TextBox textBox)
         {
-            using (var dlg = new SaveFileDialog
+            using (var dlg = new SaveFileDialog())
             {
-                Title = Resources.EditIrtCalcDlg_btnCreateDb_Click_Create_iRT_Database,
-                InitialDirectory = Path.GetDirectoryName(DocumentFilePath),
-                OverwritePrompt = true,
-                DefaultExt = IrtDb.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB)
-            })
-            {
+                dlg.Title = Resources.EditIrtCalcDlg_btnCreateDb_Click_Create_iRT_Database;
+                dlg.InitialDirectory = Path.GetDirectoryName(DocumentFilePath);
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = IrtDb.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -296,15 +292,13 @@ namespace pwiz.Skyline.FileUI
 
         public void ImportTextFile()
         {
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.CreateIrtCalculatorDlg_ImportTextFile_Import_Transition_List__iRT_standards_,
-                InitialDirectory = Path.GetDirectoryName(DocumentFilePath),
-                DefaultExt = TextUtil.EXT_CSV,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
-                    Resources.SkylineWindow_importMassListMenuItem_Click_Transition_List, TextUtil.EXT_CSV, TextUtil.EXT_TSV))
-            })
-            {
+                dlg.Title = Resources.CreateIrtCalculatorDlg_ImportTextFile_Import_Transition_List__iRT_standards_;
+                dlg.InitialDirectory = Path.GetDirectoryName(DocumentFilePath);
+                dlg.DefaultExt = TextUtil.EXT_CSV;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
+                    Resources.SkylineWindow_importMassListMenuItem_Click_Transition_List, TextUtil.EXT_CSV, TextUtil.EXT_TSV));
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);

--- a/pwiz_tools/Skyline/FileUI/ExportAnnotationsDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ExportAnnotationsDlg.cs
@@ -228,15 +228,13 @@ namespace pwiz.Skyline.FileUI
             }
             strSaveFileName += @"Annotations.csv";
             bool success;
-            using (var dlg = new SaveFileDialog
+            using (var dlg = new SaveFileDialog())
             {
-                FileName = strSaveFileName,
-                DefaultExt = TextUtil.EXT_CSV,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FILTER_CSV),
-                InitialDirectory = Settings.Default.ExportDirectory,
-                OverwritePrompt = true,
-            })
-            {
+                dlg.FileName = strSaveFileName;
+                dlg.DefaultExt = TextUtil.EXT_CSV;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FILTER_CSV);
+                dlg.InitialDirectory = Settings.Default.ExportDirectory;
+                dlg.OverwritePrompt = true;
                 if (dlg.ShowDialog(this) != DialogResult.OK)
                 {
                     return;

--- a/pwiz_tools/Skyline/FileUI/ExportChromatogramDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ExportChromatogramDlg.cs
@@ -71,14 +71,12 @@ namespace pwiz.Skyline.FileUI
                 MessageDlg.Show(this, Resources.ExportChromatogramDlg_OkDialog_At_least_one_file_must_be_selected);
                 return;
             }
-            using (var dlg = new SaveFileDialog
-                {
-                    Title = Resources.ExportChromatogramDlg_OkDialog_Export_Chromatogram,
-                    OverwritePrompt = true,
-                    DefaultExt = EXT,
-                    Filter = TextUtil.FileDialogFilterAll(Resources.ExportChromatogramDlg_OkDialog_Chromatogram_Export_Files, EXT),
-                })
+            using (var dlg = new SaveFileDialog())
             {
+                dlg.Title = Resources.ExportChromatogramDlg_OkDialog_Export_Chromatogram;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = EXT;
+                dlg.Filter = TextUtil.FileDialogFilterAll(Resources.ExportChromatogramDlg_OkDialog_Chromatogram_Export_Files, EXT);
                 if (!string.IsNullOrEmpty(DocumentFilePath))
                 {
                     dlg.InitialDirectory = Path.GetDirectoryName(DocumentFilePath);
@@ -96,11 +94,9 @@ namespace pwiz.Skyline.FileUI
         {
             var fileNames = (from object fileName in checkedListVars.CheckedItems select fileName.ToString()).ToList();
 
-            using (var longWaitDlg = new LongWaitDlg
+            using (var longWaitDlg = new LongWaitDlg())
             {
-                Text = Resources.ExportChromatogramDlg_OkDialog_Exporting_Chromatograms,
-            })
-            {
+                longWaitDlg.Text = Resources.ExportChromatogramDlg_OkDialog_Exporting_Chromatograms;
                 try
                 {
                     longWaitDlg.PerformWork(this, 1000,

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.cs
@@ -1093,15 +1093,13 @@ namespace pwiz.Skyline.FileUI
                         break;
                 }
 
-                using (var dlg = new SaveFileDialog
-                    {
-                        Title = title,
-                        InitialDirectory = Settings.Default.ExportDirectory,
-                        OverwritePrompt = true,
-                        DefaultExt = ext,
-                        Filter = TextUtil.FileDialogFilterAll(filter, ext)
-                    })
+                using (var dlg = new SaveFileDialog())
                 {
+                    dlg.Title = title;
+                    dlg.InitialDirectory = Settings.Default.ExportDirectory;
+                    dlg.OverwritePrompt = true;
+                    dlg.DefaultExt = ext;
+                    dlg.Filter = TextUtil.FileDialogFilterAll(filter, ext);
                     if (dlg.ShowDialog(this) == DialogResult.Cancel)
                     {
                         return;
@@ -1977,11 +1975,9 @@ namespace pwiz.Skyline.FileUI
             if (Equals(InstrumentType, ExportInstrumentType.AGILENT6400) ||
                 Equals(InstrumentType, ExportInstrumentType.BRUKER_TOF))
             {
-                using (var chooseDirDialog = new FolderBrowserDialog
-                    {
-                        Description = Resources.ExportMethodDlg_btnBrowseTemplate_Click_Method_Template,
-                    })
+                using (var chooseDirDialog = new FolderBrowserDialog())
                 {
+                    chooseDirDialog.Description = Resources.ExportMethodDlg_btnBrowseTemplate_Click_Method_Template;
                     if (!string.IsNullOrEmpty(templateName))
                     {
                         chooseDirDialog.SelectedPath = templateName;
@@ -2009,13 +2005,10 @@ namespace pwiz.Skyline.FileUI
                 return;
             }
 
-            using (var openFileDialog = new OpenFileDialog
-                {
-                    Title = Resources.ExportMethodDlg_btnBrowseTemplate_Click_Method_Template,
-                    // Extension based on currently selected type
-                    CheckPathExists = true
-                })
+            using (var openFileDialog = new OpenFileDialog())
             {
+                openFileDialog.Title = Resources.ExportMethodDlg_btnBrowseTemplate_Click_Method_Template; // Extension based on currently selected type
+                openFileDialog.CheckPathExists = true;
                 if (!string.IsNullOrEmpty(templateName))
                 {
                     try
@@ -2303,11 +2296,9 @@ namespace pwiz.Skyline.FileUI
                 return;
             }
 
-            using (var longWait = new LongWaitDlg
-                    {
-                        Text = Resources.ExportDlgProperties_PerformLongExport_Exporting_Methods
-                    })
+            using (var longWait = new LongWaitDlg())
             {
+                longWait.Text = Resources.ExportDlgProperties_PerformLongExport_Exporting_Methods;
                 try
                 {
                     var status = longWait.PerformWork(_dialog, 800, performExport);

--- a/pwiz_tools/Skyline/FileUI/ImportResultsDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportResultsDlg.cs
@@ -332,11 +332,9 @@ namespace pwiz.Skyline.FileUI
 
         public static MsDataFileUri[] GetDataSourcePaths(Control parent, string documentSavedPath)
         {
-            using (var dlgOpen = new OpenDataSourceDialog(Settings.Default.RemoteAccountList)
-                {
-                    Text = Resources.ImportResultsDlg_GetDataSourcePathsFile_Import_Results_Files
-                })
+            using (var dlgOpen = new OpenDataSourceDialog(Settings.Default.RemoteAccountList))
             {
+                dlgOpen.Text = Resources.ImportResultsDlg_GetDataSourcePathsFile_Import_Results_Files;
                 // The dialog expects null to mean no directory was supplied, so don't assign
                 // an empty string.
                 string initialDir = Path.GetDirectoryName(documentSavedPath) ?? Settings.Default.SrmResultsDirectory;
@@ -422,13 +420,11 @@ namespace pwiz.Skyline.FileUI
 
         private MsDataFilePath[] GetWiffSubPaths(string filePath)
         {
-            using (var longWaitDlg = new LongWaitDlg
-                {
-                    Text = Resources.ImportResultsDlg_GetWiffSubPaths_Sample_Names,
-                    Message = string.Format(Resources.ImportResultsDlg_GetWiffSubPaths_Reading_sample_names_from__0__, 
-                                            Path.GetFileName(filePath))
-                })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = Resources.ImportResultsDlg_GetWiffSubPaths_Sample_Names;
+                longWaitDlg.Message = string.Format(Resources.ImportResultsDlg_GetWiffSubPaths_Reading_sample_names_from__0__, 
+                    Path.GetFileName(filePath));
                 string[] dataIds = null;
                 try
                 {
@@ -460,13 +456,11 @@ namespace pwiz.Skyline.FileUI
         public KeyValuePair<string, MsDataFileUri[]>[] GetDataSourcePathsDir()
         {
             string initialDir = Path.GetDirectoryName(_documentSavedPath);
-            using (FolderBrowserDialog dlg = new FolderBrowserDialog
-                {
-                    Description = Resources.ImportResultsDlg_GetDataSourcePathsDir_Results_Directory,
-                    ShowNewFolderButton = false,
-                    SelectedPath = initialDir
-                })
+            using (FolderBrowserDialog dlg = new FolderBrowserDialog())
             {
+                dlg.Description = Resources.ImportResultsDlg_GetDataSourcePathsDir_Results_Directory;
+                dlg.ShowNewFolderButton = false;
+                dlg.SelectedPath = initialDir;
                 if (dlg.ShowDialog(this) != DialogResult.OK)
                     return null;
 

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -277,8 +277,9 @@ namespace pwiz.Skyline.FileUI
             var peptides = new List<string>(count);
             var stripped = new Dictionary<string, string>(); // Map peptide -> stripped peptide
 
-            using (var longWaitDlg = new LongWaitDlg() { Message = checkBoxAssociateProteins.Text })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Message = checkBoxAssociateProteins.Text;
                 longWaitDlg.PerformWork(this, 1000, progressMonitor =>
                 {
                     // If there are headers, add one describing the protein name column we will add - if we haven't already
@@ -1304,8 +1305,8 @@ namespace pwiz.Skyline.FileUI
                     errorList?.Clear(); // Looking for a new set of errors
                     var readerType = GetRadioType();
 
-                    using var longWaitDlg = new LongWaitDlg
-                        {Text = Resources.ImportTransitionListColumnSelectDlg_CheckForErrors_Checking_for_errors___};
+                    using var longWaitDlg = new LongWaitDlg();
+                    longWaitDlg.Text = Resources.ImportTransitionListColumnSelectDlg_CheckForErrors_Checking_for_errors___;
                     longWaitDlg.PerformWork(this, 1000, progressMonitor =>
                     {
 

--- a/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.cs
@@ -72,14 +72,12 @@ namespace pwiz.Skyline.FileUI
 
         public void OkDialog()
         {
-            using (var dlg = new SaveFileDialog
+            using (var dlg = new SaveFileDialog())
             {
-                Title = Resources.MProphetFeaturesDlg_OkDialog_Export_mProphet_Features,
-                OverwritePrompt = true,
-                DefaultExt = EXT,
-                Filter = TextUtil.FileDialogFilterAll(Resources.MProphetFeaturesDlg_OkDialog_mProphet_Feature_Files, EXT),
-            })
-            {
+                dlg.Title = Resources.MProphetFeaturesDlg_OkDialog_Export_mProphet_Features;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = EXT;
+                dlg.Filter = TextUtil.FileDialogFilterAll(Resources.MProphetFeaturesDlg_OkDialog_mProphet_Feature_Files, EXT);
                 if (!string.IsNullOrEmpty(DocumentFilePath))
                 {
                     dlg.InitialDirectory = Path.GetDirectoryName(DocumentFilePath);
@@ -100,11 +98,9 @@ namespace pwiz.Skyline.FileUI
 //                }
                 var resultsHandler = new MProphetResultsHandler(Document, mProphetScoringModel);
 
-                using (var longWaitDlg = new LongWaitDlg
+                using (var longWaitDlg = new LongWaitDlg())
                 {
-                    Text = Resources.SkylineWindow_OpenSharedFile_Extracting_Files,
-                })
-                {
+                    longWaitDlg.Text = Resources.SkylineWindow_OpenSharedFile_Extracting_Files;
                     try
                     {
                         longWaitDlg.PerformWork(this, 1000, b =>

--- a/pwiz_tools/Skyline/FileUI/MinimizeResultsDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/MinimizeResultsDlg.cs
@@ -220,15 +220,13 @@ namespace pwiz.Skyline.FileUI
             if (asNewFile || string.IsNullOrEmpty(targetFile))
             {
                 using (var saveFileDialog =
-                    new SaveFileDialog
-                    {
-                        InitialDirectory = Properties.Settings.Default.ActiveDirectory,
-                        OverwritePrompt = true,
-                        DefaultExt = SrmDocument.EXT,
-                        Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC),
-                        FileName = Path.GetFileName(targetFile),
-                    })
+                    new SaveFileDialog())
                 {
+                    saveFileDialog.InitialDirectory = Properties.Settings.Default.ActiveDirectory;
+                    saveFileDialog.OverwritePrompt = true;
+                    saveFileDialog.DefaultExt = SrmDocument.EXT;
+                    saveFileDialog.Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC);
+                    saveFileDialog.FileName = Path.GetFileName(targetFile);
                     if (saveFileDialog.ShowDialog(this) != DialogResult.OK)
                     {
                         return;

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.cs
@@ -243,12 +243,10 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             if (PerformDDASearch)
             {
                 MsDataFileUri[] dataSources;
-                using (var dlg = new OpenDataSourceDialog(Settings.Default.RemoteAccountList)
-                       {
-                           Text = Resources.ImportResultsControl_browseToResultsFileButton_Click_Import_Peptide_Search,
-                           InitialDirectory = new MsDataFilePath(Path.GetDirectoryName(DocumentContainer.DocumentFilePath)),
-                       })
+                using (var dlg = new OpenDataSourceDialog(Settings.Default.RemoteAccountList))
                 {
+                    dlg.Text = Resources.ImportResultsControl_browseToResultsFileButton_Click_Import_Peptide_Search;
+                    dlg.InitialDirectory = new MsDataFilePath(Path.GetDirectoryName(DocumentContainer.DocumentFilePath));
                     // Use saved source type, if there is one.
                     //string sourceType = Settings.Default.SrmResultsSourceType;
                     //if (!string.IsNullOrEmpty(sourceType))
@@ -336,12 +334,10 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             bool retry = false;
             do
             {
-                using (var longWaitDlg = new LongWaitDlg
-                       {
-                           Text = Resources.BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_Peptide_Search_Library,
-                           Message = Resources.BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_document_library_for_peptide_search_,
-                       })
+                using (var longWaitDlg = new LongWaitDlg())
                 {
+                    longWaitDlg.Text = Resources.BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_Peptide_Search_Library;
+                    longWaitDlg.Message = Resources.BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_document_library_for_peptide_search_;
                     // Disable the wizard, because the LongWaitDlg does not
                     try
                     {
@@ -511,8 +507,9 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             if (docLibSpec == null)
                 return false;
 
-            using (var longWait = new LongWaitDlg {Text = Resources.BuildPeptideSearchLibraryControl_LoadPeptideSearchLibrary_Loading_Library})
+            using (var longWait = new LongWaitDlg())
             {
+                longWait.Text = Resources.BuildPeptideSearchLibraryControl_LoadPeptideSearchLibrary_Loading_Library;
                 try
                 {
                     var status = longWait.PerformWork(WizardForm, 800, monitor => ImportPeptideSearch.LoadPeptideSearchLibrary(LibraryManager, docLibSpec, monitor));

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.cs
@@ -370,8 +370,9 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
             var libraries = new List<Library>();
             var librarySpecs = new List<LibrarySpec>();
-            using (var longWait = new LongWaitDlg { Text = Resources.ViewLibraryDlg_LoadLibrary_Loading_Library })
+            using (var longWait = new LongWaitDlg())
             {
+                longWait.Text = Resources.ViewLibraryDlg_LoadLibrary_Loading_Library;
                 string libraryName = string.Empty;
 
                 try

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.cs
@@ -262,14 +262,12 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             {
                 initialDir = Path.GetDirectoryName(DocumentContainer.DocumentFilePath);
             }
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.ImportFastaControl_browseFastaBtn_Click_Open_FASTA,
-                InitialDirectory = initialDir,
-                CheckPathExists = true,
-                Filter = @"FASTA files|*.fasta;*.fa;*.faa|All files|*.*"
-            })
-            {
+                dlg.Title = Resources.ImportFastaControl_browseFastaBtn_Click_Open_FASTA;
+                dlg.InitialDirectory = initialDir;
+                dlg.CheckPathExists = true;
+                dlg.Filter = @"FASTA files|*.fasta;*.fa;*.faa|All files|*.*";
                 if (dlg.ShowDialog(WizardForm) == DialogResult.OK)
                 {
                     fastaFilepath = dlg.FileName;
@@ -444,8 +442,9 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
                         PasteError error = null;
                         // Import FASTA as content
-                        using (var longWaitDlg = new LongWaitDlg(DocumentContainer) { Text = Resources.ImportFastaControl_ImportFasta_Insert_FASTA })
+                        using (var longWaitDlg = new LongWaitDlg(DocumentContainer))
                         {
+                            longWaitDlg.Text = Resources.ImportFastaControl_ImportFasta_Insert_FASTA;
                             var docImportFasta = docNew;
                             longWaitDlg.PerformWork(WizardForm, 1000, longWaitBroker =>
                             {
@@ -467,8 +466,9 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                         var fastaPath = string.IsNullOrEmpty(FastaImportTargetsFile) ? tbxFasta.Text : FastaImportTargetsFile;
                         try
                         {
-                            using (var longWaitDlg = new LongWaitDlg(DocumentContainer) { Text = Resources.ImportFastaControl_ImportFasta_Insert_FASTA })
+                            using (var longWaitDlg = new LongWaitDlg(DocumentContainer))
                             {
+                                longWaitDlg.Text = Resources.ImportFastaControl_ImportFasta_Insert_FASTA;
                                 IdentityPath to = selectedPath;
                                 var docImportFasta = docNew;
                                 longWaitDlg.PerformWork(WizardForm, 1000, longWaitBroker =>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportResultsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportResultsControl.cs
@@ -103,12 +103,10 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         private void browseToResultsFileButton_Click(object sender, EventArgs e)
         {
             MsDataFileUri[] dataSources;
-            using (var dlg = new OpenDataSourceDialog(Settings.Default.RemoteAccountList)
+            using (var dlg = new OpenDataSourceDialog(Settings.Default.RemoteAccountList))
             {
-                Text = Resources.ImportResultsControl_browseToResultsFileButton_Click_Import_Peptide_Search,
-                InitialDirectory = new MsDataFilePath(DocumentDirectory)
-            })
-            {
+                dlg.Text = Resources.ImportResultsControl_browseToResultsFileButton_Click_Import_Peptide_Search;
+                dlg.InitialDirectory = new MsDataFilePath(DocumentDirectory);
                 // Use saved source type, if there is one.
                 string sourceType = Settings.Default.SrmResultsSourceType;
                 if (!string.IsNullOrEmpty(sourceType))
@@ -133,13 +131,11 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         private void findResultsFilesButton_Click(object sender, EventArgs e)
         {
             // Ask the user for the directory to search
-            using (var dlg = new FolderBrowserDialog
+            using (var dlg = new FolderBrowserDialog())
             {
-                Description = Resources.ImportResultsControl_findResultsFilesButton_Click_Results_Directory,
-                ShowNewFolderButton = false,
-                SelectedPath = Path.GetDirectoryName(DocumentDirectory)
-            })
-            {
+                dlg.Description = Resources.ImportResultsControl_findResultsFilesButton_Click_Results_Directory;
+                dlg.ShowNewFolderButton = false;
+                dlg.SelectedPath = Path.GetDirectoryName(DocumentDirectory);
                 if (dlg.ShowDialog(WizardForm) != DialogResult.OK)
                     return;
 
@@ -155,11 +151,9 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         public bool UpdateResultsFiles(IEnumerable<string> dirPaths, bool overwrite)
         {
-            using (var longWaitDlg = new LongWaitDlg
-                {
-                    Text = Resources.ImportResultsControl_FindResultsFiles_Searching_for_Results_Files
-                })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = Resources.ImportResultsControl_FindResultsFiles_Searching_for_Results_Files;
                 try
                 {
                     longWaitDlg.PerformWork(WizardForm, 1000, longWaitBroker =>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportResultsDIAControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportResultsDIAControl.cs
@@ -94,11 +94,9 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         public void Browse(string path = null)
         {
-            using (var dlgOpen = new OpenDataSourceDialog(Settings.Default.RemoteAccountList)
+            using (var dlgOpen = new OpenDataSourceDialog(Settings.Default.RemoteAccountList))
             {
-                Text = BrowseResultsDialogText
-            })
-            {
+                dlgOpen.Text = BrowseResultsDialogText;
                 // The dialog expects null to mean no directory was supplied, so don't assign an empty string.
                 string initialDir = path ?? Path.GetDirectoryName(DocumentContainer.DocumentFilePath);
                 dlgOpen.InitialDirectory = new MsDataFilePath(initialDir);

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
@@ -311,8 +311,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         private bool ValidateEntries()
         {
             var helper = new MessageBoxHelper(this.ParentForm);
-            double ms1Tol;
-            if (!helper.ValidateDecimalTextBox(txtMS1Tolerance, 0, 100, out ms1Tol))
+            if (!helper.ValidateDecimalTextBox(txtMS1Tolerance, 0, 100, out _))
             {
                 helper.ShowTextBoxError(txtMS1Tolerance, 
                     Resources.DdaSearch_SearchSettingsControl_MS1_Tolerance_incorrect);
@@ -320,8 +319,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             }
             ImportPeptideSearch.SearchEngine.SetPrecursorMassTolerance(PrecursorTolerance);
 
-            double ms2Tol;
-            if (!helper.ValidateDecimalTextBox(txtMS2Tolerance, 0, 100, out ms2Tol))
+            if (!helper.ValidateDecimalTextBox(txtMS2Tolerance, 0, 100, out _))
             {
                 helper.ShowTextBoxError(txtMS2Tolerance, 
                     Resources.DdaSearch_SearchSettingsControl_MS2_Tolerance_incorrect);

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
@@ -85,11 +85,9 @@ namespace pwiz.Skyline.FileUI
 
             try
             {
-                using (var waitDlg = new LongWaitDlg
-                    {
-                        Text = Resources.PublishDocumentDlg_PublishDocumentDlg_Load_Retrieving_information_on_servers
-                    })
+                using (var waitDlg = new LongWaitDlg())
                 {
+                    waitDlg.Text = Resources.PublishDocumentDlg_PublishDocumentDlg_Load_Retrieving_information_on_servers;
                     waitDlg.PerformWork(this, 800, () => PublishDocumentDlgLoad(listServerFolders));
                 }
             }
@@ -303,19 +301,16 @@ namespace pwiz.Skyline.FileUI
 
         private void btnBrowse_Click(object sender, EventArgs e)
         {
-            using (var dlg = new SaveFileDialog
-                                 {
-                                     InitialDirectory = Settings.Default.LibraryDirectory,
-                                     SupportMultiDottedExtensions = true,
-                                     DefaultExt = SrmDocumentSharing.EXT_SKY_ZIP,
-                                     Filter =
-                                         TextUtil.FileDialogFiltersAll(
-                                             Resources.PublishDocumentDlg_btnBrowse_Click_Skyline_Shared_Documents,
-                                             SrmDocumentSharing.EXT),
-                                     FileName = tbFilePath.Text,
-                                     Title = Resources.PublishDocumentDlg_btnBrowse_Click_Upload_Document
-                                 })
+            using (var dlg = new SaveFileDialog())
             {
+                dlg.InitialDirectory = Settings.Default.LibraryDirectory;
+                dlg.SupportMultiDottedExtensions = true;
+                dlg.DefaultExt = SrmDocumentSharing.EXT_SKY_ZIP;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(
+                    Resources.PublishDocumentDlg_btnBrowse_Click_Skyline_Shared_Documents,
+                    SrmDocumentSharing.EXT);
+                dlg.FileName = tbFilePath.Text;
+                dlg.Title = Resources.PublishDocumentDlg_btnBrowse_Click_Upload_Document;
                 if (dlg.ShowDialog(Parent) == DialogResult.OK)
                 {
                     tbFilePath.Text = dlg.FileName;

--- a/pwiz_tools/Skyline/FileUI/RescoreResultsDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/RescoreResultsDlg.cs
@@ -69,15 +69,13 @@ namespace pwiz.Skyline.FileUI
             if (asNewFile || string.IsNullOrEmpty(targetFile))
             {
                 using (var saveFileDialog =
-                    new SaveFileDialog
-                    {
-                        InitialDirectory = Settings.Default.ActiveDirectory,
-                        OverwritePrompt = true,
-                        DefaultExt = SrmDocument.EXT,
-                        Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC),
-                        FileName = Path.GetFileName(targetFile),
-                    })
+                    new SaveFileDialog())
                 {
+                    saveFileDialog.InitialDirectory = Settings.Default.ActiveDirectory;
+                    saveFileDialog.OverwritePrompt = true;
+                    saveFileDialog.DefaultExt = SrmDocument.EXT;
+                    saveFileDialog.Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC);
+                    saveFileDialog.FileName = Path.GetFileName(targetFile);
                     if (saveFileDialog.ShowDialog(this) != DialogResult.OK)
                     {
                         return;

--- a/pwiz_tools/Skyline/FileUI/ShareListDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ShareListDlg.cs
@@ -105,13 +105,11 @@ namespace pwiz.Skyline.FileUI
 
         private void btnOk_Click(object sender, EventArgs e)
         {
-            using (var saveFileDialog = new SaveFileDialog
-                {
-                    InitialDirectory = Settings.Default.ActiveDirectory,
-                    CheckPathExists = true,
-                    Filter = Filter
-                })
+            using (var saveFileDialog = new SaveFileDialog())
             {
+                saveFileDialog.InitialDirectory = Settings.Default.ActiveDirectory;
+                saveFileDialog.CheckPathExists = true;
+                saveFileDialog.Filter = Filter;
                 saveFileDialog.ShowDialog(this);
                 if (!string.IsNullOrEmpty(saveFileDialog.FileName))
                     OkDialog(saveFileDialog.FileName);
@@ -193,13 +191,11 @@ namespace pwiz.Skyline.FileUI
 
         public static string GetImportFileName(Form parent, string filter)
         {
-            using (var dialog = new OpenFileDialog
-                {
-                    InitialDirectory = Settings.Default.ActiveDirectory,
-                    CheckPathExists = true,
-                    Filter = filter
-                })
+            using (var dialog = new OpenFileDialog())
             {
+                dialog.InitialDirectory = Settings.Default.ActiveDirectory;
+                dialog.CheckPathExists = true;
+                dialog.Filter = filter;
                 if (dialog.ShowDialog(parent) == DialogResult.Cancel)
                     return null;
                 return dialog.FileName;

--- a/pwiz_tools/Skyline/FileUI/SkypSupport.cs
+++ b/pwiz_tools/Skyline/FileUI/SkypSupport.cs
@@ -46,11 +46,9 @@ namespace pwiz.Skyline.FileUI
 
             try
             {
-                using (var longWaitDlg = new LongWaitDlg
+                using (var longWaitDlg = new LongWaitDlg())
                 {
-                    Text = Resources.SkypSupport_Open_Downloading_Skyline_Document_Archive,
-                })
-                {
+                    longWaitDlg.Text = Resources.SkypSupport_Open_Downloading_Skyline_Document_Archive;
                     var progressStaus = longWaitDlg.PerformWork(parentWindow ?? _skyline, 1000, progressMonitor => Download(skyp, progressMonitor));
                     if (longWaitDlg.IsCanceled)
                         return false;

--- a/pwiz_tools/Skyline/Menus/EditMenu.cs
+++ b/pwiz_tools/Skyline/Menus/EditMenu.cs
@@ -140,8 +140,9 @@ namespace pwiz.Skyline.Menus
             var docCopy = DocumentUI.RemoveAllBut(SequenceTree.SelectedDocNodes);
             docCopy = docCopy.ChangeMeasuredResults(null);
             var stringWriter = new XmlStringWriter();
-            using (var writer = new XmlTextWriter(stringWriter) { Formatting = Formatting.Indented })
+            using (var writer = new XmlTextWriter(stringWriter))
             {
+                writer.Formatting = Formatting.Indented;
                 XmlSerializer ser = new XmlSerializer(typeof(SrmDocument));
                 ser.Serialize(writer, docCopy);
             }
@@ -300,7 +301,6 @@ namespace pwiz.Skyline.Menus
 
                 try
                 {
-                    IdentityPath nextAdd;
                     ModifyDocument(string.Format(Resources.SkylineWindow_Paste_Paste__0__, (pasteToPeptideList ? Resources.SkylineWindow_Paste_peptides : Resources.SkylineWindow_Paste_proteins)), doc =>
                         doc.ImportDocumentXml(new StringReader(dataObjectSkyline.Substring(dataObjectSkyline.IndexOf('<'))),
                             null,
@@ -311,7 +311,7 @@ namespace pwiz.Skyline.Menus
                             Settings.Default.HeavyModList,
                             nodePaste != null ? nodePaste.Path : null,
                             out selectPath,
-                            out nextAdd,
+                            out _,
                             pasteToPeptideList), docPair => AuditLogEntry.DiffDocNodes(MessageType.pasted_targets, docPair));
                 }
                 catch (Exception)
@@ -579,8 +579,9 @@ namespace pwiz.Skyline.Menus
             // If filtered peptides, ask the user whether to filter or keep.
             if (listFilterPeptides.Count > 0)
             {
-                using (var dlg = new PasteFilteredPeptidesDlg { Peptides = listFilterPeptides })
+                using (var dlg = new PasteFilteredPeptidesDlg())
                 {
+                    dlg.Peptides = listFilterPeptides;
                     switch (dlg.ShowDialog(SkylineWindow))
                     {
                         case DialogResult.Cancel:
@@ -681,14 +682,12 @@ namespace pwiz.Skyline.Menus
             if (selectedSrmTreeNode == null)
                 return;
 
-            using (EditNoteDlg dlg = new EditNoteDlg
+            using (EditNoteDlg dlg = new EditNoteDlg())
             {
-                Text = selPaths.Count > 1
+                dlg.Text = selPaths.Count > 1
                     ? Resources.SkylineWindow_EditNote_Edit_Note
                     : TextUtil.SpaceSeparate(Resources.SkylineWindow_EditNote_Edit_Note, selectedSrmTreeNode.Heading,
-                        SequenceTree.SelectedNode.Text)
-            })
-            {
+                        SequenceTree.SelectedNode.Text);
                 dlg.Init(selectedSrmTreeNode.Document, selPaths);
                 if (dlg.ShowDialog(SkylineWindow) == DialogResult.OK)
                 {
@@ -819,8 +818,9 @@ namespace pwiz.Skyline.Menus
                 return;
             }
 
-            using (var longWait = new LongWaitDlg(SkylineWindow) { Text = Resources.SkylineWindow_ApplyPeak_Applying_Peak })
+            using (var longWait = new LongWaitDlg(SkylineWindow))
             {
+                longWait.Text = Resources.SkylineWindow_ApplyPeak_Applying_Peak;
                 SrmDocument doc = null;
                 try
                 {
@@ -1097,12 +1097,10 @@ namespace pwiz.Skyline.Menus
 
         public void ShowPasteFastaDlg()  // Expose for test access
         {
-            using (var pasteDlg = new PasteDlg(SkylineWindow)
+            using (var pasteDlg = new PasteDlg(SkylineWindow))
             {
-                SelectedPath = SelectedPath,
-                PasteFormat = PasteFormat.fasta
-            })
-            {
+                pasteDlg.SelectedPath = SelectedPath;
+                pasteDlg.PasteFormat = PasteFormat.fasta;
                 if (pasteDlg.ShowDialog(SkylineWindow) == DialogResult.OK)
                     SelectedPath = pasteDlg.SelectedPath;
             }
@@ -1115,12 +1113,10 @@ namespace pwiz.Skyline.Menus
 
         public void ShowPastePeptidesDlg()
         {
-            using (var pasteDlg = new PasteDlg(SkylineWindow)
+            using (var pasteDlg = new PasteDlg(SkylineWindow))
             {
-                SelectedPath = SelectedPath,
-                PasteFormat = PasteFormat.peptide_list
-            })
-            {
+                pasteDlg.SelectedPath = SelectedPath;
+                pasteDlg.PasteFormat = PasteFormat.peptide_list;
                 if (pasteDlg.ShowDialog(SkylineWindow) == DialogResult.OK)
                     SelectedPath = pasteDlg.SelectedPath;
             }
@@ -1133,12 +1129,10 @@ namespace pwiz.Skyline.Menus
 
         public void ShowPasteProteinsDlg()
         {
-            using (var pasteDlg = new PasteDlg(SkylineWindow)
+            using (var pasteDlg = new PasteDlg(SkylineWindow))
             {
-                SelectedPath = SelectedPath,
-                PasteFormat = PasteFormat.protein_list
-            })
-            {
+                pasteDlg.SelectedPath = SelectedPath;
+                pasteDlg.PasteFormat = PasteFormat.protein_list;
                 if (pasteDlg.ShowDialog(SkylineWindow) == DialogResult.OK)
                     SelectedPath = pasteDlg.SelectedPath;
             }
@@ -1158,10 +1152,9 @@ namespace pwiz.Skyline.Menus
 
                 IFormatProvider formatProvider;
                 char separator;
-                Type[] columnTypes;
                 var text = transitionDlg.TransitionListText;
                 // As long as it has columns we want to parse the input as a transition list
-                if (MassListImporter.IsColumnar(text, out formatProvider, out separator, out columnTypes))
+                if (MassListImporter.IsColumnar(text, out formatProvider, out separator, out _))
                 {
                     try
                     {
@@ -1723,10 +1716,8 @@ namespace pwiz.Skyline.Menus
             var skylineDataSchema = new SkylineDataSchema(SkylineWindow, SkylineDataSchema.GetLocalizedSchemaLocalizer());
             var rootColumn = ColumnDescriptor.RootColumn(skylineDataSchema, typeof(SpectrumClass));
             using var autoComplete = new SpectrumFilterAutoComplete(SkylineWindow);
-            using var dlg = new EditSpectrumFilterDlg(rootColumn, filterPages)
-            {
-                AutoComplete = autoComplete
-            };
+            using var dlg = new EditSpectrumFilterDlg(rootColumn, filterPages);
+            dlg.AutoComplete = autoComplete;
             if (filterPagesSet.Count != 1)
             {
                 dlg.CreateCopy = true;

--- a/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
@@ -112,8 +112,8 @@ namespace pwiz.Skyline.Model
 
         protected virtual AAModMatch? GetMatch(AAModKey key)
         {
-            return Matches.ContainsKey(key)
-                ? Matches[key]
+            return Matches.TryGetValue(key, out var match)
+                ? match
                 : (AAModMatch?)null;
         }
 
@@ -1061,8 +1061,7 @@ namespace pwiz.Skyline.Model
 
         public PeptideDocNode CreateDocNodeFromMatches(PeptideDocNode nodePep, IEnumerable<AAModInfo> infos)
         {
-            bool hasHeavy;
-            return CreateDocNodeFromMatches(nodePep, infos, true, out hasHeavy);
+            return CreateDocNodeFromMatches(nodePep, infos, true, out _);
         }
 
         public PeptideDocNode CreateDocNodeFromMatches(PeptideDocNode nodePep, IEnumerable<AAModInfo> infos, bool stringPaste, out bool hasHeavy)
@@ -1087,9 +1086,9 @@ namespace pwiz.Skyline.Model
                 var heavyMod = modMatch.HeavyMod;
                 if (heavyMod != null)
                 {
-                    var type = UserDefinedTypedMods.ContainsKey(modMatch.HeavyMod)
-                                   ? UserDefinedTypedMods[modMatch.HeavyMod]
-                                   : DocDefHeavyLabelType;
+                    var type = UserDefinedTypedMods.TryGetValue(modMatch.HeavyMod, out var mod)
+                        ? mod
+                        : DocDefHeavyLabelType;
                     List<ExplicitMod> listHeavyMods;
                     if (!dictHeavyMods.TryGetValue(type, out listHeavyMods))
                     {

--- a/pwiz_tools/Skyline/Model/Annotations.cs
+++ b/pwiz_tools/Skyline/Model/Annotations.cs
@@ -197,10 +197,7 @@ namespace pwiz.Skyline.Model
             var newAnnotations = (_annotations != null ?
                 new Dictionary<string, string>(_annotations) :
                 new Dictionary<string, string>());
-            if (newAnnotations.ContainsKey(name))
-                newAnnotations[name] = value;
-            else
-                newAnnotations.Add(name, value);      
+            newAnnotations[name] = value;      
             return new Annotations(Note, newAnnotations, ColorIndex);
         }
 
@@ -236,11 +233,7 @@ namespace pwiz.Skyline.Model
             {
                 foreach (KeyValuePair<string, string> annotation in newAnnotations)
                 {
-                    string value;
-                    if (dictNodeAnnotations.TryGetValue(annotation.Key, out value))
-                        dictNodeAnnotations[annotation.Key] = annotation.Value;
-                    else
-                        dictNodeAnnotations.Add(annotation.Key, annotation.Value);
+                    dictNodeAnnotations[annotation.Key] = annotation.Value;
                 }
             }
             newColorIndex = newColorIndex != -1 ? newColorIndex : ColorIndex;
@@ -279,9 +272,9 @@ namespace pwiz.Skyline.Model
                 annotationsNew = new Dictionary<string, string>(annotationsNew);
                 foreach (var annotation in annotations._annotations)
                 {
-                    if (annotationsNew.ContainsKey(annotation.Key))
+                    if (annotationsNew.TryGetValue(annotation.Key, out var value))
                     {
-                        if (Equals(annotation.Value, annotationsNew[annotation.Key]))
+                        if (Equals(annotation.Value, value))
                             continue;
                         throw new InvalidDataException(string.Format(Resources.Annotations_Merge_Annotation_conflict_for__0__found_attempting_to_merge_annotations,
                                                                      annotation.Key));

--- a/pwiz_tools/Skyline/Model/AuditLog/AuditLogEntry.cs
+++ b/pwiz_tools/Skyline/Model/AuditLog/AuditLogEntry.cs
@@ -256,8 +256,9 @@ namespace pwiz.Skyline.Model.AuditLog
         {
             using (var fileSaver = new FileSaver(fileName))
             {
-                using (var writer = new XmlTextWriter(fileSaver.SafeName, Encoding.UTF8) { Formatting = Formatting.Indented })
+                using (var writer = new XmlTextWriter(fileSaver.SafeName, Encoding.UTF8))
                 {
+                    writer.Formatting = Formatting.Indented;
                     WriteToXmlWriter(writer, documentHash);
                 }
 

--- a/pwiz_tools/Skyline/Model/ComparePeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ComparePeakBoundaries.cs
@@ -127,10 +127,9 @@ namespace pwiz.Skyline.Model
                 {
                     var line = reader.ReadLine();
                     var fieldNames = PeakBoundaryImporter.FIELD_NAMES.ToList();
-                    int fieldsTotal;
                     int[] fieldIndices;
                     var separator = PeakBoundaryImporter.DetermineCorrectSeparator(line, fieldNames,
-                        PeakBoundaryImporter.REQUIRED_NO_CHROM, out fieldIndices, out fieldsTotal);
+                        PeakBoundaryImporter.REQUIRED_NO_CHROM, out fieldIndices, out _);
                     ApexPresent = separator != null && fieldIndices[(int) PeakBoundaryImporter.Field.apex_time] != -1;
                 }
                 _docCompare = Importer.Import(FilePath, progressMonitor, lineCount, true, !ApexPresent);

--- a/pwiz_tools/Skyline/Model/CustomMolecule.cs
+++ b/pwiz_tools/Skyline/Model/CustomMolecule.cs
@@ -107,8 +107,8 @@ namespace pwiz.Skyline.Model
             var keys = FormatAccessionNumbers(keysTSV, inChiKey);
             if (!string.IsNullOrEmpty(inChiKey))
             {
-                if (keys.ContainsKey(TagInChiKey))
-                    Assume.AreEqual(inChiKey, keys[TagInChiKey]);
+                if (keys.TryGetValue(TagInChiKey, out var key))
+                    Assume.AreEqual(inChiKey, key);
                 else
                     keys.Add(TagInChiKey, inChiKey);
             }

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
@@ -128,8 +128,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
                 else
                 {
                     var parent = DataSchema.Document.FindNode(IdentityPath.Parent) as PeptideDocNode;
-                    Adduct adduct;
-                    var molecule = RefinementSettings.ConvertToSmallMolecule(RefinementSettings.ConvertToSmallMoleculesMode.formulas, SrmDocument, parent, out adduct, DocNode.TransitionGroup.PrecursorAdduct.AdductCharge, DocNode.TransitionGroup.LabelType);
+                    var molecule = RefinementSettings.ConvertToSmallMolecule(RefinementSettings.ConvertToSmallMoleculesMode.formulas, SrmDocument, parent, out _, DocNode.TransitionGroup.PrecursorAdduct.AdductCharge, DocNode.TransitionGroup.LabelType);
                     return molecule.InvariantName ?? string.Empty;
                 }
             }

--- a/pwiz_tools/Skyline/Model/Databinding/SkylineDataSchema.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/SkylineDataSchema.cs
@@ -450,8 +450,7 @@ namespace pwiz.Skyline.Model.Databinding
                 return string.Empty;
 
             // TODO: only allow reflection for all info? Okay to use null for decimal places?
-            bool unused;
-            return DiffNode.ObjectToString(true, value, null, out unused);
+            return DiffNode.ObjectToString(true, value, null, out _);
         }
 
         public void ModifyDocument(EditDescription editDescription, Func<SrmDocument, SrmDocument> action, Func<SrmDocumentPair, AuditLogEntry> logFunc = null)

--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -177,9 +177,9 @@ namespace pwiz.Skyline.Model.DdaSearch
 
         public override void SetFragmentIons(string ions)
         {
-            if (Settings.ChemicalData.Instruments.ContainsKey(ions))
+            if (Settings.ChemicalData.Instruments.TryGetValue(ions, out var instrument))
             {
-                Settings.ChemicalData.CurrentInstrumentSetting = Settings.ChemicalData.Instruments[ions];
+                Settings.ChemicalData.CurrentInstrumentSetting = instrument;
             }
         }
 

--- a/pwiz_tools/Skyline/Model/DdaSearch/MsFraggerSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MsFraggerSearchEngine.cs
@@ -739,8 +739,8 @@ add_Nterm_protein = 0.000000
                 modParamLines.Add(@"add_C_cysteine = 0"); // disable default cysteine static mod
 
             foreach (var kvp in staticModsByAA)
-                if (AminoAcidFormulas.FullNames.ContainsKey(kvp.Key))
-                    modParamLines.Add($@"add_{kvp.Key}_{AminoAcidFormulas.FullNames[kvp.Key].ToLowerInvariant().Replace(' ', '_')} = {kvp.Value.ToString(CultureInfo.InvariantCulture)}");
+                if (AminoAcidFormulas.FullNames.TryGetValue(kvp.Key, out var fullName))
+                    modParamLines.Add($@"add_{kvp.Key}_{fullName.ToLowerInvariant().Replace(' ', '_')} = {kvp.Value.ToString(CultureInfo.InvariantCulture)}");
 
             modParamLines.Sort();
             _modParams = string.Join(Environment.NewLine, modParamLines);

--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -675,10 +675,9 @@ namespace pwiz.Skyline.Model.DocSettings
             try
             {
                 listRTs = new List<double>();
-                int minCount;
                 calcPeptides = allPeptides
                     ? listPeptides
-                    : calculator.ChooseRegressionPeptides(listPeptides, out minCount).ToList();
+                    : calculator.ChooseRegressionPeptides(listPeptides, out _).ToList();
                 peptideScores = RetentionTimeScoreCache.CalcScores(calculator, calcPeptides, scoreCache, token);
             }
             catch (Exception)

--- a/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
@@ -1534,8 +1534,7 @@ namespace pwiz.Skyline.Model.DocSettings
         /// </summary>
         public bool Accept(SrmSettings settings, Peptide peptide, ExplicitMods mods, Adduct charge)
         {
-            bool allowVariableMods;
-            return Accept(settings, peptide, mods, new[] { charge }, PeptideFilterType.library, out allowVariableMods);
+            return Accept(settings, peptide, mods, new[] { charge }, PeptideFilterType.library, out _);
         }
 
         private enum PeptideFilterType

--- a/pwiz_tools/Skyline/Model/Export.cs
+++ b/pwiz_tools/Skyline/Model/Export.cs
@@ -1637,9 +1637,9 @@ namespace pwiz.Skyline.Model
             writer.Write(FieldSeparator);
             // Retention Index
             double retentionIndexKey = rt.GetValueOrDefault();
-            if (_retentionIndices.ContainsKey(retentionIndexKey))
+            if (_retentionIndices.TryGetValue(retentionIndexKey, out var retentionIndex))
             {
-                writer.Write(_retentionIndices[retentionIndexKey]);
+                writer.Write(retentionIndex);
             }
             else
             {
@@ -3845,7 +3845,7 @@ namespace pwiz.Skyline.Model
                 }
             }
 
-            public PointPairList Get(SchedulingMetrics metricType) { return _metrics.ContainsKey(metricType) ? _metrics[metricType] : new PointPairList(); }
+            public PointPairList Get(SchedulingMetrics metricType) { return _metrics.TryGetValue(metricType, out var metric) ? metric : new PointPairList(); }
         }
     }
 
@@ -4644,8 +4644,7 @@ namespace pwiz.Skyline.Model
 
             try
             {
-                uint type;
-                if (RegQueryValueEx(hKeyQuery, valueName, 0, out type, sb, ref size) != 0)
+                if (RegQueryValueEx(hKeyQuery, valueName, 0, out _, sb, ref size) != 0)
                     return null;
             }
             finally

--- a/pwiz_tools/Skyline/Model/GlobalizedObject.cs
+++ b/pwiz_tools/Skyline/Model/GlobalizedObject.cs
@@ -235,9 +235,8 @@ namespace pwiz.Skyline.Model
                             actualPropType = propDict[val.Key].PropertyType.GetGenericArguments()[0];
                             converterKey = GetConverterKey(val.Value.GetType(), actualPropType);
                         }
-                        if (TypeConverterDictionary.ContainsKey(converterKey))
+                        if (TypeConverterDictionary.TryGetValue(converterKey, out var parseMethod))
                         {
-                            var parseMethod = TypeConverterDictionary[converterKey];
                             var value = parseMethod.Invoke(this, new[] { val.Value });
                             propDict[val.Key].SetValue(this, value);
                         }

--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -1401,8 +1401,7 @@ namespace pwiz.Skyline.Model
                             continue;
 
                         int massShift;
-                        int nearestCharge;
-                        var charge = CalcPrecursorCharge(precursorMassH, null, precursorMz, tolerance, !nodePep.IsProteomic, isDecoy, out massShift, out nearestCharge);
+                        var charge = CalcPrecursorCharge(precursorMassH, null, precursorMz, tolerance, !nodePep.IsProteomic, isDecoy, out massShift, out _);
                         if (!charge.IsEmpty)
                         {
                             indexPrec = i;
@@ -1438,10 +1437,6 @@ namespace pwiz.Skyline.Model
                         if (productMz == 0)
                             continue;
 
-                        IonType? ionType;
-                        int? ordinal;
-                        TransitionLosses losses;
-                        int massShift;
                         var charge = TransitionCalc.CalcProductCharge(productPrecursorMass,
                                                                       null, // CONSIDER: Use product charge field?
                                                                       transitionExp.Precursor.PrecursorAdduct,
@@ -1452,10 +1447,10 @@ namespace pwiz.Skyline.Model
                                                                       tolerance,
                                                                       calc.MassType,
                                                                       transitionExp.ProductShiftType,
-                                                                      out ionType,
-                                                                      out ordinal,
-                                                                      out losses,
-                                                                      out massShift);
+                                                                      out _,
+                                                                      out _,
+                                                                      out _,
+                                                                      out _);
 
                         // Look for the maximum product m/z, or this function may settle for a
                         // collision energy or retention time that matches a single amino acid
@@ -1789,8 +1784,7 @@ namespace pwiz.Skyline.Model
                         continue;
 
                     string fieldValue = fields[i];
-                    double tempDouble;
-                    if (!double.TryParse(fieldValue, NumberStyles.Number, provider, out tempDouble))
+                    if (!double.TryParse(fieldValue, NumberStyles.Number, provider, out _))
                     {
                         if (fieldValue.Length > 2 && !EXCLUDE_PROTEIN_VALUES.Contains(fieldValue.ToLowerInvariant()))
                             listDescriptive.Add(i);
@@ -1819,8 +1813,7 @@ namespace pwiz.Skyline.Model
                     for (int i = valueCounts.Length - 1; i >= 0; i--)
                     {
                         // Discard any column with empty cells or which is less repetitive
-                        int count;
-                        if (valueCounts[i].TryGetValue(string.Empty, out count) || valueCounts[i].Count > sequenceCounts.Count)
+                        if (valueCounts[i].TryGetValue(string.Empty, out _) || valueCounts[i].Count > sequenceCounts.Count)
                             listDescriptive.RemoveAt(i);
                     }
                     // If more than one possible value, and there are headers, look for
@@ -1994,8 +1987,7 @@ namespace pwiz.Skyline.Model
 
             private static void AddCount(string key, IDictionary<string, int> dict)
             {
-                int count;
-                if (dict.TryGetValue(key, out count))
+                if (dict.TryGetValue(key, out _))
                     dict[key]++;
                 else
                     dict.Add(key, 1);
@@ -2288,8 +2280,7 @@ namespace pwiz.Skyline.Model
 
         private static Type GetColumnType(string value, IFormatProvider provider)
         {
-            double result;
-            if (double.TryParse(value, NumberStyles.Number, provider, out result))
+            if (double.TryParse(value, NumberStyles.Number, provider, out _))
                 return typeof(double);
             else if (FastaSequence.IsExSequence(value))
                 return typeof(FastaSequence);

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -244,8 +244,7 @@ namespace pwiz.Skyline.Model
             var peakTimes = new List<double>();
             string line = reader.ReadLine();
             int[] fieldIndices;
-            int fieldsTotal;
-            char correctSeparator = ReadFirstLine(line, FIELD_NAMES, REQUIRED_FIELDS, out fieldIndices, out fieldsTotal);
+            char correctSeparator = ReadFirstLine(line, FIELD_NAMES, REQUIRED_FIELDS, out fieldIndices, out _);
             // Find the first 50 peak times that are not #N/A, if any is larger than the maxRT, then times are in seconds
             while (peakTimes.Count < 50)
             {

--- a/pwiz_tools/Skyline/Model/IonMobility/IonMobilityLibrary.cs
+++ b/pwiz_tools/Skyline/Model/IonMobility/IonMobilityLibrary.cs
@@ -321,8 +321,9 @@ namespace pwiz.Skyline.Model.IonMobility
             // N.B. assumes we are not attempting to find multiple conformers
             // (so, returns Dictionary<LibKey, IonMobilityAndCCS> instead of Dictionary<LibKey, IList<IonMobilityAndCCS>>)
             Dictionary<LibKey, IonMobilityAndCCS> measured;
-            using (var finder = new IonMobilityFinder(document, documentFilePath, progressMonitor) { UseHighEnergyOffset = useHighEnergyOffset })
+            using (var finder = new IonMobilityFinder(document, documentFilePath, progressMonitor))
             {
+                finder.UseHighEnergyOffset = useHighEnergyOffset;
                 measured = finder.FindIonMobilityPeaks(); // Returns null on cancel
             }
             return measured;

--- a/pwiz_tools/Skyline/Model/Irt/DbIrtPeptide.cs
+++ b/pwiz_tools/Skyline/Model/Irt/DbIrtPeptide.cs
@@ -128,8 +128,7 @@ namespace pwiz.Skyline.Model.Irt
             var uniqueIrtPeptidesDict = new Dictionary<Target, DbIrtPeptide>();
             foreach (var irtPeptide in irtPeptides)
             {
-                DbIrtPeptide duplicateIrtPeptide;
-                if (irtPeptide.Standard || !uniqueIrtPeptidesDict.TryGetValue(irtPeptide.ModifiedTarget, out duplicateIrtPeptide))
+                if (irtPeptide.Standard || !uniqueIrtPeptidesDict.TryGetValue(irtPeptide.ModifiedTarget, out _))
                 {
                     uniqueIrtPeptidesDict[irtPeptide.ModifiedTarget] = irtPeptide;
                 }

--- a/pwiz_tools/Skyline/Model/Lib/AlignedRetentionTimes.cs
+++ b/pwiz_tools/Skyline/Model/Lib/AlignedRetentionTimes.cs
@@ -162,8 +162,7 @@ namespace pwiz.Skyline.Model.Lib
 
         public override IEnumerable<Target> GetStandardPeptides(IEnumerable<Target> peptides)
         {
-            int minCount;
-            return ChooseRegressionPeptides(peptides, out minCount);
+            return ChooseRegressionPeptides(peptides, out _);
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/Lib/Midas/MidasLibrary.cs
+++ b/pwiz_tools/Skyline/Model/Lib/Midas/MidasLibrary.cs
@@ -195,8 +195,7 @@ namespace pwiz.Skyline.Model.Lib.Midas
                 double? precursor = null;
                 try
                 {
-                    int tmp;
-                    var chromKey = ChromKey.FromId(msd.GetChromatogramId(i, out tmp), false);
+                    var chromKey = ChromKey.FromId(msd.GetChromatogramId(i, out _), false);
                     precursor = chromKey.Precursor;
                 }
                 catch

--- a/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
+++ b/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
@@ -414,7 +414,6 @@ namespace pwiz.Skyline.Model.Lib
 
                 // http://sashimi.svn.sourceforge.net/viewvc/sashimi/trunk/trans_proteomic_pipeline/src/Search/SpectraST/Peptide.cpp?revision=5277&view=markup
                 // line 1196
-// ReSharper disable LocalizableElement
                 {"ICAT_light", SequenceMassCalc.GetModDiffDescription(227.126991)}, 
                 {"ICAT-C", SequenceMassCalc.GetModDiffDescription(227.126991)}, // PSI new name
                 {"ICAT_heavy", SequenceMassCalc.GetModDiffDescription(236.157185)},
@@ -466,7 +465,6 @@ namespace pwiz.Skyline.Model.Lib
                 {"Ub_LysC", SequenceMassCalc.GetModDiffDescription(1431.831075)}, // Ubiquitin LysC tail
                 {"GlyGly", SequenceMassCalc.GetModDiffDescription(114.042927)}, // Ubiquitin/NEDD8 Tryptic tail (2 glycines)
             };
-        // ReSharper restore LocalizableElement
 
 #pragma warning disable 169
         private static readonly Dictionary<string, string> MODIFICATION_MASSES_AVG = new Dictionary<string, string>

--- a/pwiz_tools/Skyline/Model/ModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/ModificationMatcher.cs
@@ -73,10 +73,9 @@ namespace pwiz.Skyline.Model
             if(!MoveNextSingleSequence())
                 return false;
             // Skip sequences that can be created from the current settings.
-            TransitionGroupDocNode nodeGroup;
             // Check first if the sequence has any modifications, because creating doc nodes is expensive
             while (!HasMods(_sequences.Current) ||
-                   CreateDocNodeFromSettings(new Target(_sequences.Current), null, DIFF_GROUPS, out nodeGroup) != null)
+                   CreateDocNodeFromSettings(new Target(_sequences.Current), null, DIFF_GROUPS, out _) != null)
             {
                 if (!MoveNextSingleSequence())
                     return false;
@@ -437,9 +436,8 @@ namespace pwiz.Skyline.Model
               : new Peptide(null, seqUnmod, null, null,
                             Settings.PeptideSettings.Enzyme.CountCleavagePoints(seqUnmod));
             // First, try to create the peptide using the current settings.
-            TransitionGroupDocNode nodeGroup;
             PeptideDocNode nodePep = 
-                CreateDocNodeFromSettings(new Target(seq), peptide, SrmSettingsDiff.ALL, out nodeGroup);
+                CreateDocNodeFromSettings(new Target(seq), peptide, SrmSettingsDiff.ALL, out _);
             if (nodePep != null)
                 return nodePep;
             // Create the peptideDocNode.

--- a/pwiz_tools/Skyline/Model/PeakMatcher.cs
+++ b/pwiz_tools/Skyline/Model/PeakMatcher.cs
@@ -538,8 +538,8 @@ namespace pwiz.Skyline.Model
                 var abundancesOther = new List<double>();
                 foreach (var fragment in _abundances.Keys.Union(other._abundances.Keys))
                 {
-                    abundancesThis.Add(_abundances.ContainsKey(fragment) ? _abundances[fragment] : 0);
-                    abundancesOther.Add(other._abundances.ContainsKey(fragment) ? other._abundances[fragment] : 0);
+                    abundancesThis.Add(_abundances.TryGetValue(fragment, out var abundance) ? abundance : 0);
+                    abundancesOther.Add(other._abundances.TryGetValue(fragment, out var otherAbundance) ? otherAbundance : 0);
                 }
                 var statisticsThis = new Statistics(abundancesThis);
                 var statisticsOther = new Statistics(abundancesOther);

--- a/pwiz_tools/Skyline/Model/Proteome/BackgroundProteome.cs
+++ b/pwiz_tools/Skyline/Model/Proteome/BackgroundProteome.cs
@@ -123,14 +123,7 @@ namespace pwiz.Skyline.Model.Proteome
                 }
                 foreach (var pair in newDict)
                 {
-                    if (!_peptideUniquenessDict.ContainsKey(pair.Key))
-                    {
-                        _peptideUniquenessDict.Add(pair.Key, pair.Value);
-                    }
-                    else
-                    {
-                        _peptideUniquenessDict[pair.Key] = pair.Value;
-                    }
+                    _peptideUniquenessDict[pair.Key] = pair.Value;
                 }
                 _enzymeNameForPeptideUniquenessDictDigest = enzyme.Name;
                 if (!_parent.UpdateProgressAndCheckForCancellation(progressMonitor, 100))

--- a/pwiz_tools/Skyline/Model/Proteome/BackgroundProteomeSpec.cs
+++ b/pwiz_tools/Skyline/Model/Proteome/BackgroundProteomeSpec.cs
@@ -107,8 +107,7 @@ namespace pwiz.Skyline.Model.Proteome
 
         public FastaSequence GetFastaSequence(String proteinName)
         {
-            ProteinMetadata metadata;
-            return GetFastaSequence(proteinName, out metadata);
+            return GetFastaSequence(proteinName, out _);
         }
 
         public FastaSequence GetFastaSequence(String proteinName, out ProteinMetadata foundMetadata)

--- a/pwiz_tools/Skyline/Model/RefinementSettings.cs
+++ b/pwiz_tools/Skyline/Model/RefinementSettings.cs
@@ -885,8 +885,7 @@ namespace pwiz.Skyline.Model
             SrmDocument document, PeptideDocNode nodePep,
             Dictionary<LibKey, LibKey> smallMoleculeConversionPrecursorMap = null)
         {
-            Adduct adduct;
-            return ConvertToSmallMolecule(mode, document, nodePep, out adduct, 0, null, smallMoleculeConversionPrecursorMap);
+            return ConvertToSmallMolecule(mode, document, nodePep, out _, 0, null, smallMoleculeConversionPrecursorMap);
         }
 
         public static CustomMolecule ConvertToSmallMolecule(ConvertToSmallMoleculesMode mode, 

--- a/pwiz_tools/Skyline/Model/Results/ChromData.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromData.cs
@@ -731,8 +731,8 @@ namespace pwiz.Skyline.Model.Results
 
         private int ExtendBoundary(ChromDataPeak peakPrimary, bool useRaw, int indexBoundary, int increment, int toleranceLen)
         {
-            float maxIntensity, deltaIntensity;
-            GetIntensityMetrics(indexBoundary, useRaw, out maxIntensity, out deltaIntensity);
+            float maxIntensity;
+            GetIntensityMetrics(indexBoundary, useRaw, out maxIntensity);
 
             int lenIntensities = peakPrimary.Data.Intensities.Count;
             // Look for a descent proportional to the height of the peak.  Because, SRM data is
@@ -748,8 +748,8 @@ namespace pwiz.Skyline.Model.Results
                  i >= 0 && i < lenIntensities && Math.Abs(indexBoundary - i) < toleranceLen;
                  i += increment)
             {
-                float maxIntensityCurrent, deltaIntensityCurrent;
-                GetIntensityMetrics(i, useRaw, out maxIntensityCurrent, out deltaIntensityCurrent);
+                float maxIntensityCurrent;
+                GetIntensityMetrics(i, useRaw, out maxIntensityCurrent);
 
                 // If intensity goes above the maximum, stop looking
                 if (maxIntensityCurrent > maxHeight)
@@ -762,7 +762,7 @@ namespace pwiz.Skyline.Model.Results
                     if (indexBoundary == i)
                         maxIntensity = maxIntensityCurrent;
                     else
-                        GetIntensityMetrics(indexBoundary, useRaw, out maxIntensity, out deltaIntensity);
+                        GetIntensityMetrics(indexBoundary, useRaw, out maxIntensity);
                 }
             }
 
@@ -771,8 +771,8 @@ namespace pwiz.Skyline.Model.Results
 
         private int RetractBoundary(ChromDataPeak peakPrimary, bool useRaw, int indexBoundary, int increment)
         {
-            float maxIntensity, deltaIntensity;
-            GetIntensityMetrics(indexBoundary, useRaw, out maxIntensity, out deltaIntensity);
+            float maxIntensity;
+            GetIntensityMetrics(indexBoundary, useRaw, out maxIntensity);
 
             int lenIntensities = peakPrimary.Data.Intensities.Count;
             // Look for a descent proportional to the height of the peak.  Because, SRM data is
@@ -786,8 +786,8 @@ namespace pwiz.Skyline.Model.Results
             // Extend the index in the direction of the increment
             for (int i = indexBoundary + increment; i > 0 && i < lenIntensities - 1; i += increment)
             {
-                float maxIntensityCurrent, deltaIntensityCurrent;
-                GetIntensityMetrics(i, useRaw, out maxIntensityCurrent, out deltaIntensityCurrent);
+                float maxIntensityCurrent;
+                GetIntensityMetrics(i, useRaw, out maxIntensityCurrent);
 
                 // If intensity goes above the maximum, stop looking
                 if (maxIntensityCurrent > maxHeight || maxIntensityCurrent - maxIntensity > maxAscent)
@@ -800,7 +800,7 @@ namespace pwiz.Skyline.Model.Results
             return indexBoundary;
         }
 
-        private void GetIntensityMetrics(int i, bool useRaw, out float maxIntensity, out float deltaIntensity)
+        private void GetIntensityMetrics(int i, bool useRaw, out float maxIntensity)
         {
             var peakData = this[0];
             var intensities = (useRaw ? peakData.Data.Intensities
@@ -820,7 +820,6 @@ namespace pwiz.Skyline.Model.Results
                 else if (currentIntensity < minIntensity)
                     minIntensity = currentIntensity;
             }
-            deltaIntensity = maxIntensity - minIntensity;
         }
 
         private void AddPeak(ChromDataPeak dataPeak)

--- a/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
+++ b/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
@@ -630,8 +630,8 @@ namespace pwiz.Skyline.Model.Results
             {
                 return msDataFileUri;
             }
-            string dataFilePathPartIgnore;
-            return GetExistingDataFilePath(cachePath, msDataFilePath, out dataFilePathPartIgnore);
+
+            return GetExistingDataFilePath(cachePath, msDataFilePath, out _);
         }
         
         /// <summary>
@@ -1309,8 +1309,7 @@ namespace pwiz.Skyline.Model.Results
             path = GetLocationPart(path); // Just in case the url args contain '|'
             string[] parts = path.Split('|');
 
-            int sampleIndex;
-            return parts.Length == 3 && int.TryParse(parts[2], out sampleIndex);
+            return parts.Length == 3 && int.TryParse(parts[2], out _);
         }
 
         public static string GetPathSampleNamePart(string path)

--- a/pwiz_tools/Skyline/Model/Results/IonMobilityFinder.cs
+++ b/pwiz_tools/Skyline/Model/Results/IonMobilityFinder.cs
@@ -153,10 +153,7 @@ namespace pwiz.Skyline.Model.Results
                         highEnergyIonMobilityValueOffset = Math.Round(ms2IonMobility.IonMobility.Mobility.Value - ms1IonMobility.IonMobility.Mobility.Value, 6); // Excessive precision is just distracting noise TODO(bspratt) ask vendors what "excessive" means here
                     }
                     var value =  IonMobilityAndCCS.GetIonMobilityAndCCS(ms1IonMobility.IonMobility, ms1IonMobility.CollisionalCrossSectionSqA, highEnergyIonMobilityValueOffset);
-                    if (!measured.ContainsKey(dt.Key))
-                        measured.Add(dt.Key, value);
-                    else
-                        measured[dt.Key] = value;
+                    measured[dt.Key] = value;
                 }
                 // Check for data for which we have only MS2 to go on
                 foreach (var im in _ms2IonMobilities)
@@ -178,10 +175,7 @@ namespace pwiz.Skyline.Model.Results
                             }
                         }
 
-                        if (!measured.ContainsKey(im.Key))
-                            measured.Add(im.Key, value);
-                        else
-                            measured[im.Key] = value;
+                        measured[im.Key] = value;
                     }
                 }
             }
@@ -364,10 +358,10 @@ namespace pwiz.Skyline.Model.Results
             double maxIntensity = 0;
 
             // Avoid picking MS2 ion mobility values wildly different from MS1 values
-            if ((msLevel == 2) && _ms1IonMobilities.ContainsKey(libKey))
+            if ((msLevel == 2) && _ms1IonMobilities.TryGetValue(libKey, out var mobility))
             {
                 _ms1IonMobilityBest =
-                    _ms1IonMobilities[libKey].OrderByDescending(p => p.Intensity)
+                    mobility.OrderByDescending(p => p.Intensity)
                         .FirstOrDefault()
                         .IonMobility.IonMobility;
                 var imMS1 = _ms1IonMobilityBest.Mobility ?? 0;

--- a/pwiz_tools/Skyline/Model/Results/OverlapDemultiplexer.cs
+++ b/pwiz_tools/Skyline/Model/Results/OverlapDemultiplexer.cs
@@ -82,8 +82,7 @@ namespace pwiz.Skyline.Model.Results
             {
                 long widthRegion = isoBoundaries[i + 1] - isoBoundaries[i];
                 long centerRegion = (isoBoundaries[i + 1] + isoBoundaries[i]) / 2;
-                int windowIndex;
-                if (widthRegion >= minDeconvHash && TryGetWindowFromMz(IsoWindowHasher.UnHash(centerRegion), out windowIndex))
+                if (widthRegion >= minDeconvHash && TryGetWindowFromMz(IsoWindowHasher.UnHash(centerRegion), out _))
                 {
                     _deconvRegions.Add(new DeconvolutionRegion(isoBoundaries[i], isoBoundaries[i + 1], _deconvRegions.Count));
                 }

--- a/pwiz_tools/Skyline/Model/Results/RemoteApi/RemoteSession.cs
+++ b/pwiz_tools/Skyline/Model/Results/RemoteApi/RemoteSession.cs
@@ -102,8 +102,7 @@ namespace pwiz.Skyline.Model.Results.RemoteApi
                     return;
                 }
                 _responses.Remove(key);
-                RemoteServerException exceptionIgnore;
-                AsyncFetch(requestUri, fetcher, out exceptionIgnore);
+                AsyncFetch(requestUri, fetcher, out _);
             }
 
         }

--- a/pwiz_tools/Skyline/Model/Results/SpectraChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectraChromDataProvider.cs
@@ -849,8 +849,7 @@ namespace pwiz.Skyline.Model.Results
                 if (_runningAsync)
                 {
                     // Just in case the Read thread is waiting to add a spectrum to a full pending list
-                    SpectrumInfo info;
-                    _pendingInfoList.TryTake(out info);
+                    _pendingInfoList.TryTake(out _);
                 }
                 return dataFile;
             }

--- a/pwiz_tools/Skyline/Model/SequenceUtil.cs
+++ b/pwiz_tools/Skyline/Model/SequenceUtil.cs
@@ -277,8 +277,7 @@ namespace pwiz.Skyline.Model
                     var shortName = mod.ShortName;
                     if (string.IsNullOrEmpty(shortName))
                     {
-                        bool isStructural;
-                        var foundMod = UniMod.GetModification(mod.Name, out isStructural);
+                        var foundMod = UniMod.GetModification(mod.Name, out _);
                         if (foundMod != null)
                             shortName = foundMod.ShortName;
                     }

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -171,8 +171,7 @@ namespace pwiz.Skyline.Model
                         continue; // This won't succeed, but keep gathering errors
                     }
                     IdentityPath first;
-                    IdentityPath next;
-                    document = document.AddPeptideGroups(new[] {node}, false, to, out first, out next);
+                    document = document.AddPeptideGroups(new[] {node}, false, to, out first, out _);
                     if (string.IsNullOrEmpty(defaultPepGroupName))
                     {
                         defaultPepGroupName = node.Name;

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -1397,18 +1397,16 @@ namespace pwiz.Skyline.Model
         public SrmDocument ImportFasta(TextReader reader, bool peptideList,
                 IdentityPath to, out IdentityPath firstAdded)
         {
-            int emptiesIgnored;
-            return ImportFasta(reader, null, -1, peptideList, to, out firstAdded, out emptiesIgnored);
+            return ImportFasta(reader, null, -1, peptideList, to, out firstAdded, out _);
         }
 
         public SrmDocument ImportFasta(TextReader reader, IProgressMonitor progressMonitor, long lines, bool peptideList,
                 IdentityPath to, out IdentityPath firstAdded, out int emptyPeptideGroups)
         {
             FastaImporter importer = new FastaImporter(this, peptideList);
-            IdentityPath nextAdd;
             IEnumerable<PeptideGroupDocNode> imported = importer.Import(reader, progressMonitor, lines);
             emptyPeptideGroups = importer.EmptyPeptideGroupCount;
-            return AddPeptideGroups(imported, peptideList, to, out firstAdded, out nextAdd);
+            return AddPeptideGroups(imported, peptideList, to, out firstAdded, out _);
         }
 
         public SrmDocument ImportFasta(TextReader reader, IProgressMonitor progressMonitor, long lines, 
@@ -1433,11 +1431,7 @@ namespace pwiz.Skyline.Model
             List<string> columnPositions = null,
             bool hasHeaders = true)
         {
-            List<MeasuredRetentionTime> irtPeptides;
-            List<SpectrumMzInfo> librarySpectra;
-            List<TransitionImportErrorInfo> errorList;
-            List<PeptideGroupDocNode> peptideGroups;
-            return ImportMassList(inputs, importer, null, to, out firstAdded, out irtPeptides, out librarySpectra, out errorList, out peptideGroups, columnPositions, DOCUMENT_TYPE.none, hasHeaders);
+            return ImportMassList(inputs, importer, null, to, out firstAdded, out _, out _, out _, out _, columnPositions, DOCUMENT_TYPE.none, hasHeaders);
         }
 
         public SrmDocument ImportMassList(MassListInputs inputs,
@@ -1448,8 +1442,7 @@ namespace pwiz.Skyline.Model
                                           out List<TransitionImportErrorInfo> errorList,
                                           List<string> columnPositions = null)
         {
-            List<PeptideGroupDocNode> peptideGroups;
-            return ImportMassList(inputs, null, null, to, out firstAdded, out irtPeptides, out librarySpectra, out errorList, out peptideGroups, columnPositions);
+            return ImportMassList(inputs, null, null, to, out firstAdded, out irtPeptides, out librarySpectra, out errorList, out _, columnPositions);
         }
 
         public SrmDocument ImportMassList(MassListInputs inputs, 
@@ -1508,7 +1501,6 @@ namespace pwiz.Skyline.Model
                         importer = PreImportMassList(inputs, progressMonitor, false);
                     if (importer != null)
                     {
-                        IdentityPath nextAdd;
                         if (dictNameSeq == null)
                         {
                             dictNameSeq = new Dictionary<string, FastaSequence>();
@@ -1522,7 +1514,7 @@ namespace pwiz.Skyline.Model
                             return this;
                         }
                         peptideGroups = (List<PeptideGroupDocNode>) imported;
-                        docNew = AddPeptideGroups(peptideGroups, false, to, out firstAdded, out nextAdd);
+                        docNew = AddPeptideGroups(peptideGroups, false, to, out firstAdded, out _);
                         var pepModsNew = importer.GetModifications(docNew);
                         if (!ReferenceEquals(pepModsNew, Settings.PeptideSettings.Modifications))
                         {
@@ -1805,10 +1797,9 @@ namespace pwiz.Skyline.Model
                     throw new IdentityNotFoundException(groupPath.Child);
                 var lookupSequence = nodePep.SourceUnmodifiedTarget;
                 var lookupMods = nodePep.SourceExplicitMods;
-                IsotopeLabelType labelType;
                 double[] retentionTimes;
                 Settings.TryGetRetentionTimes(lookupSequence, nodeGroup.TransitionGroup.PrecursorAdduct, lookupMods,
-                                              filePath, out labelType, out retentionTimes);
+                                              filePath, out _, out retentionTimes);
                 if(ContainsTime(retentionTimes, startTime.Value, endTime.Value))
                 {
                     identified = PeakIdentification.TRUE;
@@ -2236,11 +2227,9 @@ namespace pwiz.Skyline.Model
         public void SerializeToFile(string tempName, string displayName, SkylineVersion skylineVersion, IProgressMonitor progressMonitor)
         {
             string hash;
-            using (var writer = new XmlTextWriter(HashingStream.CreateWriteStream(tempName), Encoding.UTF8)
+            using (var writer = new XmlTextWriter(HashingStream.CreateWriteStream(tempName), Encoding.UTF8))
             {
-                Formatting = Formatting.Indented
-            })
-            {
+                writer.Formatting = Formatting.Indented;
                 hash = Serialize(writer, displayName, skylineVersion, progressMonitor);
             }
 
@@ -2637,15 +2626,17 @@ namespace pwiz.Skyline.Model
 
             string textExpected;
             using (var stringWriterExpected = new StringWriter())
-            using (var xmlWriterExpected = new XmlTextWriter(stringWriterExpected){ Formatting = Formatting.Indented })
+            using (var xmlWriterExpected = new XmlTextWriter(stringWriterExpected))
             {
+                xmlWriterExpected.Formatting = Formatting.Indented;
                 expected.Serialize(xmlWriterExpected, null, SkylineVersion.CURRENT, null);
                 textExpected = stringWriterExpected.ToString();
             }
             string textActual;
             using (var stringWriterActual = new StringWriter())
-            using (var xmlWriterActual = new XmlTextWriter(stringWriterActual) { Formatting = Formatting.Indented })
+            using (var xmlWriterActual = new XmlTextWriter(stringWriterActual))
             {
+                xmlWriterActual.Formatting = Formatting.Indented;
                 actual.Serialize(xmlWriterActual, null, SkylineVersion.CURRENT, null);
                 textActual = stringWriterActual.ToString();
             }

--- a/pwiz_tools/Skyline/Model/Tools/ToolInstaller.cs
+++ b/pwiz_tools/Skyline/Model/Tools/ToolInstaller.cs
@@ -188,8 +188,7 @@ namespace pwiz.Skyline.Model.Tools
             {
                 string version = _properties.GetProperty(PropertiesConstants.VERSION);
                 //Check to see if the provided version is valid, if not return string.Empty
-                Version ver;
-                return System.Version.TryParse(version, out ver) ? version : string.Empty;
+                return System.Version.TryParse(version, out _) ? version : string.Empty;
             }
         }
         public string Identifier
@@ -843,10 +842,10 @@ namespace pwiz.Skyline.Model.Tools
             // Check we have the relevant report
             if (!string.IsNullOrWhiteSpace(reportTitle))
             {
-                if (reportRenameMapping.ContainsKey(reportTitle))
+                if (reportRenameMapping.TryGetValue(reportTitle, out var value))
                 {
                     //Apply report renaming if install in parallel was selectedd
-                    reportTitle = reportRenameMapping[reportTitle];
+                    reportTitle = value;
                 }
                 // Check if they are still missing the report they want
                 if (!ReportSharing.GetExistingReports().ContainsKey(PersistedViews.ExternalToolsGroup.Id.ViewName(reportTitle)))

--- a/pwiz_tools/Skyline/Model/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Transition.cs
@@ -438,8 +438,7 @@ namespace pwiz.Skyline.Model
 
         public static Adduct GetChargeFromIndicator(string text, int min, int max)
         {
-            int foundAt;
-            return GetChargeFromIndicator(text, min, max, out foundAt);
+            return GetChargeFromIndicator(text, min, max, out _);
         }
 
         public static Adduct GetChargeFromIndicator(string text, int min, int max, Adduct defaultVal)

--- a/pwiz_tools/Skyline/Model/TransitionCalc.cs
+++ b/pwiz_tools/Skyline/Model/TransitionCalc.cs
@@ -116,7 +116,7 @@ namespace pwiz.Skyline.Model
         }
 
         private static Adduct CalcProductCharge(TypedMass productMassH, int? productZ, double productMz, double tolerance, bool isCustomIon,
-                                             Adduct maxCharge, MassShiftType massShiftType, out int massShift, out int nearestCharge)
+                                             Adduct maxCharge, MassShiftType massShiftType, out int massShift)
         {
             return CalcCharge(productMassH, productMz, tolerance, isCustomIon,
                 productZ ?? Transition.MIN_PRODUCT_CHARGE,
@@ -124,7 +124,7 @@ namespace pwiz.Skyline.Model
                 Transition.MassShifts,
                 massShiftType,
                 out massShift,
-                out nearestCharge);
+                out _);
         }
 
         public enum MassShiftType { none, shift_only, either }
@@ -177,9 +177,8 @@ namespace pwiz.Skyline.Model
                     maxLoss = Math.Max(maxLoss ?? 0, lossesTrial.Mass);
                 }
                 int potentialMassShift;
-                int nearestCharge;
                 var charge = CalcProductCharge(productMass, productZ, productMz, tolerance, false, precursorCharge,
-                                               massShiftType, out potentialMassShift, out nearestCharge);
+                                               massShiftType, out potentialMassShift);
                 if (Equals(charge, precursorCharge))
                 {
                     double potentialMz = SequenceMassCalc.GetMZ(productMass, charge) + potentialMassShift;
@@ -232,9 +231,8 @@ namespace pwiz.Skyline.Model
                         if (lossesTrial != null)
                             productMass -= lossesTrial.Mass;
                         int potentialMassShift;
-                        int nearestCharge;
                         var chargeFound = CalcProductCharge(productMass, productZ, productMz, tolerance, false, precursorCharge,
-                                                       massShiftType, out potentialMassShift, out nearestCharge);
+                                                       massShiftType, out potentialMassShift);
                         if (!chargeFound.IsEmpty)
                         {
                             var charge = chargeFound;

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -941,8 +941,7 @@ namespace pwiz.Skyline.Model
             var transitionRanks = new Dictionary<double, LibraryRankedSpectrumInfo.RankedMI>();
             if (diff.DiffTransitionGroupProps)
             {
-                TypedMass mass;
-                precursorMz = CalcPrecursorMZ(settingsNew, mods, out isotopeDist, out mass);
+                precursorMz = CalcPrecursorMZ(settingsNew, mods, out isotopeDist, out _);
                 // Preserve reference equality if no change
                 Helpers.AssignIfEquals(ref isotopeDist, IsotopeDist);
                 relativeRT = CalcRelativeRT(settingsNew, mods);

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -232,13 +232,11 @@ namespace pwiz.Skyline
                     var toolsDirectory = ToolDescriptionHelpers.GetToolsDirectory();
                     if (!Directory.Exists(toolsDirectory))
                     {
-                        using (var longWaitDlg = new LongWaitDlg
+                        using (var longWaitDlg = new LongWaitDlg())
                         {
-                            Text = Name,
-                            Message = Resources.Program_Main_Copying_external_tools_from_a_previous_installation,
-                            ProgressValue = 0
-                        })
-                        {
+                            longWaitDlg.Text = Name;
+                            longWaitDlg.Message = Resources.Program_Main_Copying_external_tools_from_a_previous_installation;
+                            longWaitDlg.ProgressValue = 0;
                             longWaitDlg.PerformWork(null, 1000*3, broker => CopyOldTools(toolsDirectory, broker));
                         }
                     }

--- a/pwiz_tools/Skyline/Properties/Settings.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.cs
@@ -1382,8 +1382,9 @@ namespace pwiz.Skyline.Properties
 
         public override Enzyme EditItem(Control owner, Enzyme item, IEnumerable<Enzyme> existing, object tag)
         {
-            using (EditEnzymeDlg editEnzyme = new EditEnzymeDlg(existing ?? this) { Enzyme = item })
+            using (EditEnzymeDlg editEnzyme = new EditEnzymeDlg(existing ?? this))
             {
+                editEnzyme.Enzyme = item;
                 if (editEnzyme.ShowDialog(owner) == DialogResult.OK)
                     return editEnzyme.Enzyme;
 
@@ -1420,8 +1421,9 @@ namespace pwiz.Skyline.Properties
         public override PeptideExcludeRegex EditItem(Control owner, PeptideExcludeRegex item,
             IEnumerable<PeptideExcludeRegex> existing, object tag)
         {
-            using (EditExclusionDlg editExclusion = new EditExclusionDlg(existing ?? this) { Exclusion = item })
+            using (EditExclusionDlg editExclusion = new EditExclusionDlg(existing ?? this))
             {
+                editExclusion.Exclusion = item;
                 if (editExclusion.ShowDialog(owner) == DialogResult.OK)
                     return editExclusion.Exclusion;
 
@@ -1452,8 +1454,9 @@ namespace pwiz.Skyline.Properties
 
         public override Server EditItem(Control owner, Server item, IEnumerable<Server> existing, object tag)
         {
-            using (EditServerDlg editServer = new EditServerDlg(existing ?? this) {Server = item})
+            using (EditServerDlg editServer = new EditServerDlg(existing ?? this))
             {
+                editServer.Server = item;
                 bool instructionsRequired = false;
                 if (tag != null)
                      instructionsRequired = (bool) tag;
@@ -1468,8 +1471,9 @@ namespace pwiz.Skyline.Properties
 
         public Server EditCredentials(Control owner, Server item, IEnumerable<Server> existing, string username, string password)
         {
-            using (var editServerDlg = new EditServerDlg(existing ?? this) { Server = item })
+            using (var editServerDlg = new EditServerDlg(existing ?? this))
             {
+                editServerDlg.Server = item;
                 editServerDlg.Username = username;
                 editServerDlg.Password = password;
                 editServerDlg.textServerURL.Enabled = false;
@@ -1493,8 +1497,9 @@ namespace pwiz.Skyline.Properties
         public override LibrarySpec EditItem(Control owner, LibrarySpec item,
             IEnumerable<LibrarySpec> existing, object tag)
         {
-            using (EditLibraryDlg editLibrary = new EditLibraryDlg(existing ?? this) { LibrarySpec = item })
+            using (EditLibraryDlg editLibrary = new EditLibraryDlg(existing ?? this))
             {
+                editLibrary.LibrarySpec = item;
                 if (editLibrary.ShowDialog(owner) == DialogResult.OK)
                     return editLibrary.LibrarySpec;
 
@@ -1557,8 +1562,9 @@ namespace pwiz.Skyline.Properties
         public override BackgroundProteomeSpec EditItem(Control owner, BackgroundProteomeSpec item,
             IEnumerable<BackgroundProteomeSpec> existing, object tag)
         {
-            using (var editBackgroundProteomeDlg = new BuildBackgroundProteomeDlg(existing ?? this) { BackgroundProteomeSpec = item })
+            using (var editBackgroundProteomeDlg = new BuildBackgroundProteomeDlg(existing ?? this))
             {
+                editBackgroundProteomeDlg.BackgroundProteomeSpec = item;
                 if (editBackgroundProteomeDlg.ShowDialog(owner) == DialogResult.OK)
                 {
                     return editBackgroundProteomeDlg.BackgroundProteomeSpec;
@@ -1654,11 +1660,9 @@ namespace pwiz.Skyline.Properties
         public override StaticMod EditItem(Control owner, StaticMod item,
             IEnumerable<StaticMod> existing, object tag)
         {
-            using (EditStaticModDlg editMod = new EditStaticModDlg(item, existing ?? this, true)
-                                           {
-                                               Text = Resources.HeavyModList_EditItem_Edit_Isotope_Modification
-                                           })
+            using (EditStaticModDlg editMod = new EditStaticModDlg(item, existing ?? this, true))
             {
+                editMod.Text = Resources.HeavyModList_EditItem_Edit_Isotope_Modification;
                 if (editMod.ShowDialog(owner) == DialogResult.OK)
                     return editMod.Modification;
 
@@ -1914,8 +1918,9 @@ namespace pwiz.Skyline.Properties
         public override CollisionEnergyRegression EditItem(Control owner, CollisionEnergyRegression item,
             IEnumerable<CollisionEnergyRegression> existing, object tag)
         {
-            using (EditCEDlg editCE = new EditCEDlg(existing ?? this) { Regression = item })
+            using (EditCEDlg editCE = new EditCEDlg(existing ?? this))
             {
+                editCE.Regression = item;
                 if (editCE.ShowDialog(owner) == DialogResult.OK)
                     return editCE.Regression;
 
@@ -2030,8 +2035,9 @@ namespace pwiz.Skyline.Properties
         public override DeclusteringPotentialRegression EditItem(Control owner, DeclusteringPotentialRegression item,
             IEnumerable<DeclusteringPotentialRegression> existing, object tag)
         {
-            using (EditDPDlg editDP = new EditDPDlg(existing ?? this) { Regression = item })
+            using (EditDPDlg editDP = new EditDPDlg(existing ?? this))
             {
+                editDP.Regression = item;
                 if (editDP.ShowDialog(owner) == DialogResult.OK)
                     return editDP.Regression;
 
@@ -2472,8 +2478,9 @@ namespace pwiz.Skyline.Properties
         public override RetentionTimeRegression EditItem(Control owner, RetentionTimeRegression item,
             IEnumerable<RetentionTimeRegression> existing, object tag)
         {
-            using (EditRTDlg editRT = new EditRTDlg(existing ?? this) { Regression = item })
+            using (EditRTDlg editRT = new EditRTDlg(existing ?? this))
             {
+                editRT.Regression = item;
                 if (editRT.ShowDialog(owner) == DialogResult.OK)
                     return editRT.Regression;
             }
@@ -2545,8 +2552,9 @@ namespace pwiz.Skyline.Properties
         public override MeasuredIon EditItem(Control owner, MeasuredIon item,
             IEnumerable<MeasuredIon> existing, object tag)
         {
-            using (EditMeasuredIonDlg editIon = new EditMeasuredIonDlg(existing ?? this) { MeasuredIon = item })
+            using (EditMeasuredIonDlg editIon = new EditMeasuredIonDlg(existing ?? this))
             {
+                editIon.MeasuredIon = item;
                 if (editIon.ShowDialog(owner) == DialogResult.OK)
                     return editIon.MeasuredIon;
             }
@@ -2593,8 +2601,9 @@ namespace pwiz.Skyline.Properties
         public override IsotopeEnrichments EditItem(Control owner, IsotopeEnrichments item,
             IEnumerable<IsotopeEnrichments> existing, object tag)
         {
-            using (EditIsotopeEnrichmentDlg editEnrichment = new EditIsotopeEnrichmentDlg(existing ?? this) { Enrichments = item })
+            using (EditIsotopeEnrichmentDlg editEnrichment = new EditIsotopeEnrichmentDlg(existing ?? this))
             {
+                editEnrichment.Enrichments = item;
                 if (editEnrichment.ShowDialog(owner) == DialogResult.OK)
                     return editEnrichment.Enrichments;
             }
@@ -2908,8 +2917,9 @@ namespace pwiz.Skyline.Properties
         public override IsolationScheme EditItem(Control owner, IsolationScheme item,
             IEnumerable<IsolationScheme> existing, object tag)
         {
-            using (var editIsolationScheme = new EditIsolationSchemeDlg(existing ?? this) { IsolationScheme = item })
+            using (var editIsolationScheme = new EditIsolationSchemeDlg(existing ?? this))
             {
+                editIsolationScheme.IsolationScheme = item;
                 if (editIsolationScheme.ShowDialog(owner) == DialogResult.OK)
                     return editIsolationScheme.IsolationScheme;
             }

--- a/pwiz_tools/Skyline/SettingsUI/BuildBackgroundProteomeDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/BuildBackgroundProteomeDlg.cs
@@ -92,14 +92,12 @@ namespace pwiz.Skyline.SettingsUI
             string filterProtDb = TextUtil.FileDialogFiltersAll(FILTER_PROTDB);
             
             string fileName;
-            using (var openFileDialog = new OpenFileDialog
+            using (var openFileDialog = new OpenFileDialog())
             {
-                Filter = filterProtDb,
-                InitialDirectory = Settings.Default.ProteomeDbDirectory,
-                Title = Resources.BuildBackgroundProteomeDlg_btnOpen_Click_Open_Background_Protoeme,
-                CheckFileExists = true,
-            })
-            {
+                openFileDialog.Filter = filterProtDb;
+                openFileDialog.InitialDirectory = Settings.Default.ProteomeDbDirectory;
+                openFileDialog.Title = Resources.BuildBackgroundProteomeDlg_btnOpen_Click_Open_Background_Protoeme;
+                openFileDialog.CheckFileExists = true;
                 if (openFileDialog.ShowDialog(this) == DialogResult.Cancel)
                     return;
 
@@ -128,14 +126,12 @@ namespace pwiz.Skyline.SettingsUI
             string filterProtDb = TextUtil.FileDialogFilters(FILTER_PROTDB);
 
             string fileName;
-            using (var saveFileDialog = new SaveFileDialog
+            using (var saveFileDialog = new SaveFileDialog())
             {
-                Filter = filterProtDb,
-                InitialDirectory = Settings.Default.ProteomeDbDirectory,
-                Title = Resources.BuildBackgroundProteomeDlg_btnCreate_Click_Create_Background_Proteome,
-                OverwritePrompt = true,
-            })
-            {
+                saveFileDialog.Filter = filterProtDb;
+                saveFileDialog.InitialDirectory = Settings.Default.ProteomeDbDirectory;
+                saveFileDialog.Title = Resources.BuildBackgroundProteomeDlg_btnCreate_Click_Create_Background_Proteome;
+                saveFileDialog.OverwritePrompt = true;
                 if (saveFileDialog.ShowDialog(this) == DialogResult.Cancel)
                     return;
 
@@ -277,14 +273,11 @@ namespace pwiz.Skyline.SettingsUI
 
         private void btnAddFastaFile_Click(object sender, EventArgs e)
         {
-            using (var openFileDialog = new OpenFileDialog
+            using (var openFileDialog = new OpenFileDialog())
             {
-                Title = Resources.BuildBackgroundProteomeDlg_btnAddFastaFile_Click_Add_FASTA_File,
-                InitialDirectory = Settings.Default.FastaDirectory,
-                CheckPathExists = true
-                // FASTA files often have no extension as well as .fasta and others
-            })
-            {
+                openFileDialog.Title = Resources.BuildBackgroundProteomeDlg_btnAddFastaFile_Click_Add_FASTA_File;
+                openFileDialog.InitialDirectory = Settings.Default.FastaDirectory;
+                openFileDialog.CheckPathExists = true; // FASTA files often have no extension as well as .fasta and others
                 if (openFileDialog.ShowDialog(this) == DialogResult.Cancel)
                 {
                     return;
@@ -300,8 +293,9 @@ namespace pwiz.Skyline.SettingsUI
             String databasePath = textPath.Text;
             Settings.Default.FastaDirectory = Path.GetDirectoryName(fastaFilePath);
             int duplicateSequenceCount = 0;
-            using (var longWaitDlg = new LongWaitDlg { ProgressValue = 0 })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.ProgressValue = 0;
                 try
                 {
                     longWaitDlg.PerformWork(this, 0, progressMonitor =>
@@ -379,15 +373,12 @@ namespace pwiz.Skyline.SettingsUI
                 int proteinCount = 0;
                 try
                 {
-                    using (var longWaitDlg = new LongWaitDlg
+                    using (var longWaitDlg = new LongWaitDlg())
                     {
-                        Text = Resources.BuildBackgroundProteomeDlg_RefreshStatus_Loading_Proteome_File,
-                        Message =
-                            string.Format(
-                                Resources.BuildBackgroundProteomeDlg_RefreshStatus_Loading_protein_information_from__0__,
-                                textPath.Text)
-                    })
-                    {
+                        longWaitDlg.Text = Resources.BuildBackgroundProteomeDlg_RefreshStatus_Loading_Proteome_File;
+                        longWaitDlg.Message = string.Format(
+                            Resources.BuildBackgroundProteomeDlg_RefreshStatus_Loading_protein_information_from__0__,
+                            textPath.Text);
                         longWaitDlg.PerformWork(this, 1000, () =>
                         {
                             proteomeDb = ProteomeDb.OpenProteomeDb(textPath.Text);

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.cs
@@ -338,15 +338,13 @@ namespace pwiz.Skyline.SettingsUI
                 fileName = string.Empty;
             }
 
-            using (var dlg = new SaveFileDialog
-                {
-                    InitialDirectory = Settings.Default.LibraryDirectory,
-                    FileName = fileName,
-                    OverwritePrompt = true,
-                    DefaultExt = BiblioSpecLiteSpec.EXT,
-                    Filter = TextUtil.FileDialogFiltersAll(BiblioSpecLiteSpec.FILTER_BLIB)
-                })
+            using (var dlg = new SaveFileDialog())
             {
+                dlg.InitialDirectory = Settings.Default.LibraryDirectory;
+                dlg.FileName = fileName;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = BiblioSpecLiteSpec.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(BiblioSpecLiteSpec.FILTER_BLIB);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.LibraryDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -418,20 +416,18 @@ namespace pwiz.Skyline.SettingsUI
             var buttonText = parent is FormEx formEx ?
                 formEx.GetModeUIHelper().Translate(Resources.BuildLibraryDlg_btnAddFile_Click_Matched_Peptides) :
                 Resources.BuildLibraryDlg_btnAddFile_Click_Matched_Peptides;
-            using (var dlg = new OpenFileDialog
-                {
-                    Title = Resources.BuildLibraryDlg_btnAddFile_Click_Add_Input_Files,
-                    InitialDirectory = initialDirectory,
-                    CheckPathExists = true,
-                    SupportMultiDottedExtensions = true,
-                    Multiselect = true,
-                    DefaultExt = BiblioSpecLibSpec.EXT,
-                    Filter = TextUtil.FileDialogFiltersAll(
-                        buttonText + string.Join(@",", wildExts) + @")|" +
-                        string.Join(@";", wildExts),
-                        BiblioSpecLiteSpec.FILTER_BLIB)
-                })
+            using (var dlg = new OpenFileDialog())
             {
+                dlg.Title = Resources.BuildLibraryDlg_btnAddFile_Click_Add_Input_Files;
+                dlg.InitialDirectory = initialDirectory;
+                dlg.CheckPathExists = true;
+                dlg.SupportMultiDottedExtensions = true;
+                dlg.Multiselect = true;
+                dlg.DefaultExt = BiblioSpecLibSpec.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(
+                    buttonText + string.Join(@",", wildExts) + @")|" +
+                    string.Join(@";", wildExts),
+                    BiblioSpecLiteSpec.FILTER_BLIB);
                 if (dlg.ShowDialog(parent) == DialogResult.OK)
                 {
                     Settings.Default.LibraryResultsDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -444,13 +440,11 @@ namespace pwiz.Skyline.SettingsUI
 
         private void btnAddDirectory_Click(object sender, EventArgs e)
         {
-            using (var dlg = new FolderBrowserDialog
-                {
-                    Description = Resources.BuildLibraryDlg_btnAddDirectory_Click_Add_Input_Directory,
-                    ShowNewFolderButton = false,
-                    SelectedPath = Settings.Default.LibraryResultsDirectory
-                })
+            using (var dlg = new FolderBrowserDialog())
             {
+                dlg.Description = Resources.BuildLibraryDlg_btnAddDirectory_Click_Add_Input_Directory;
+                dlg.ShowNewFolderButton = false;
+                dlg.SelectedPath = Settings.Default.LibraryResultsDirectory;
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.LibraryResultsDirectory = dlg.SelectedPath;
@@ -462,11 +456,9 @@ namespace pwiz.Skyline.SettingsUI
 
         public void AddDirectory(string dirPath)
         {
-            using (var longWaitDlg = new LongWaitDlg
-                {
-                    Text = Resources.BuildLibraryDlg_AddDirectory_Find_Input_Files,
-                })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = Resources.BuildLibraryDlg_AddDirectory_Find_Input_Files;
                 try
                 {
                     var inputFiles = new List<string>();

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryNotification.cs
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryNotification.cs
@@ -385,8 +385,9 @@ namespace pwiz.Skyline.SettingsUI
                             {
                                 // Load library
                                 Library lib = null;
-                                using (var longWait = new LongWaitDlg {Text = Resources.LibraryBuildNotificationHandler_AddIrts_Loading_library})
+                                using (var longWait = new LongWaitDlg())
                                 {
+                                    longWait.Text = Resources.LibraryBuildNotificationHandler_AddIrts_Loading_library;
                                     var status = longWait.PerformWork(TopMostApplicationForm, 800, monitor =>
                                     {
                                         lib = NotificationContainer.LibraryManager.TryGetLibrary(buildState.LibrarySpec) ??
@@ -429,8 +430,9 @@ namespace pwiz.Skyline.SettingsUI
             List<IrtStandard> autoStandards = null;
             var cirtPeptides = new DbIrtPeptide[0];
 
-            using (var longWait = new LongWaitDlg {Text = Resources.LibraryBuildNotificationHandler_AddIrts_Loading_retention_time_providers})
+            using (var longWait = new LongWaitDlg())
             {
+                longWait.Text = Resources.LibraryBuildNotificationHandler_AddIrts_Loading_retention_time_providers;
                 var standard1 = standard;
                 var status = longWait.PerformWork(GetParent(), 800, monitor =>
                 {
@@ -477,8 +479,9 @@ namespace pwiz.Skyline.SettingsUI
             }
 
             ProcessedIrtAverages processed = null;
-            using (var longWait = new LongWaitDlg {Text = Resources.LibraryBuildNotificationHandler_AddIrts_Processing_retention_times})
+            using (var longWait = new LongWaitDlg())
             {
+                longWait.Text = Resources.LibraryBuildNotificationHandler_AddIrts_Processing_retention_times;
                 try
                 {
                     var status = longWait.PerformWork(GetParent(), 800, monitor =>
@@ -527,8 +530,9 @@ namespace pwiz.Skyline.SettingsUI
             if (!processed.DbIrtPeptides.Any())
                 return false;
 
-            using (var longWait = new LongWaitDlg {Text = Resources.LibraryBuildNotificationHandler_AddIrts_Adding_iRTs_to_library})
+            using (var longWait = new LongWaitDlg())
             {
+                longWait.Text = Resources.LibraryBuildNotificationHandler_AddIrts_Adding_iRTs_to_library;
                 try
                 {
                     var status = longWait.PerformWork(GetParent(), 800, monitor =>

--- a/pwiz_tools/Skyline/SettingsUI/EditCEDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditCEDlg.cs
@@ -237,20 +237,18 @@ namespace pwiz.Skyline.SettingsUI
 
         private static bool ValidateRegressionCellValues(string[] values, IWin32Window parent, int lineNumber)
         {
-            int tempInt;
-            double tempDouble;
             string message;
 
             // Parse charge
-            if (!int.TryParse(values[0].Trim(), out tempInt))
+            if (!int.TryParse(values[0].Trim(), out _))
                 message = string.Format(Resources.EditCEDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_charge_Charges_must_be_integer_values_between_1_and_5, values[0]);
 
             // Parse slope
-            else if (!double.TryParse(values[1].Trim(), out tempDouble))
+            else if (!double.TryParse(values[1].Trim(), out _))
                 message = string.Format(Resources.EditCEDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_slope, values[1]);
 
             // Parse intercept
-            else if (!double.TryParse(values[2].Trim(), out tempDouble))
+            else if (!double.TryParse(values[2].Trim(), out _))
                 message = string.Format(Resources.EditCEDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_intercept, values[2]);
 
             else

--- a/pwiz_tools/Skyline/SettingsUI/EditIsolationSchemeDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditIsolationSchemeDlg.cs
@@ -1026,11 +1026,9 @@ namespace pwiz.Skyline.SettingsUI
             try
             {
                 IsolationScheme isolationScheme = null;
-                using (var dlg = new LongWaitDlg
+                using (var dlg = new LongWaitDlg())
                 {
-                    Message = Resources.EditIsolationSchemeDlg_ImportRangesFromFiles_Reading_isolation_scheme___
-                })
-                {
+                    dlg.Message = Resources.EditIsolationSchemeDlg_ImportRangesFromFiles_Reading_isolation_scheme___;
                     var reader = new IsolationSchemeReader(dataSources);
                     dlg.PerformWork(this, 500, progressMonitor => isolationScheme = reader.Import(@"temp", progressMonitor));
                 }

--- a/pwiz_tools/Skyline/SettingsUI/EditLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditLibraryDlg.cs
@@ -109,8 +109,9 @@ namespace pwiz.Skyline.SettingsUI
             librarySpec = librarySpec.ChangeUseExplicitPeakBounds(cbxUseExplicitPeakBounds.Checked);
             if (librarySpec is ChromatogramLibrarySpec)
             {
-                using (var longWait = new LongWaitDlg{ Text = Resources.EditLibraryDlg_OkDialog_Loading_chromatogram_library })
+                using (var longWait = new LongWaitDlg())
                 {
+                    longWait.Text = Resources.EditLibraryDlg_OkDialog_Loading_chromatogram_library;
                     Library lib = null;
                     try
                     {
@@ -124,10 +125,10 @@ namespace pwiz.Skyline.SettingsUI
                         {
                             // Library failed to load
                         }
-                        LibraryRetentionTimes libRts;
+
                         // (ReSharper 2019.1 seems not to notice the check that's already here)
                         // ReSharper disable PossibleNullReferenceException
-                        if (lib != null && lib.TryGetIrts(out libRts) &&
+                        if (lib != null && lib.TryGetIrts(out _) &&
                         // ReSharper restore PossibleNullReferenceException
                             Settings.Default.RTScoreCalculatorList.All(calc => calc.PersistencePath != path))
                         {
@@ -217,17 +218,15 @@ namespace pwiz.Skyline.SettingsUI
 
         public static string GetLibraryPath(IWin32Window parent, string fileName)
         {
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                InitialDirectory = Settings.Default.LibraryDirectory,
-                CheckPathExists = true,
-                SupportMultiDottedExtensions = true,
-                DefaultExt = BiblioSpecLibSpec.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(Resources.EditLibraryDlg_GetLibraryPath_Spectral_Libraries,
-                                                                                 BiblioSpecLiteSpec.EXT, ChromatogramLibrarySpec.EXT, XHunterLibSpec.EXT, NistLibSpec.EXT, SpectrastSpec.EXT, MidasLibSpec.EXT, EncyclopeDiaSpec.EXT),
-                                                       TextUtil.FileDialogFilter(Resources.EditLibraryDlg_GetLibraryPath_Legacy_Libraries, BiblioSpecLibSpec.EXT))
-            })
-            {
+                dlg.InitialDirectory = Settings.Default.LibraryDirectory;
+                dlg.CheckPathExists = true;
+                dlg.SupportMultiDottedExtensions = true;
+                dlg.DefaultExt = BiblioSpecLibSpec.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(Resources.EditLibraryDlg_GetLibraryPath_Spectral_Libraries,
+                        BiblioSpecLiteSpec.EXT, ChromatogramLibrarySpec.EXT, XHunterLibSpec.EXT, NistLibSpec.EXT, SpectrastSpec.EXT, MidasLibSpec.EXT, EncyclopeDiaSpec.EXT),
+                    TextUtil.FileDialogFilter(Resources.EditLibraryDlg_GetLibraryPath_Legacy_Libraries, BiblioSpecLibSpec.EXT));
                 if (fileName != null)
                     dlg.FileName = fileName;
 

--- a/pwiz_tools/Skyline/SettingsUI/EditOptimizationLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditOptimizationLibraryDlg.cs
@@ -157,14 +157,12 @@ namespace pwiz.Skyline.SettingsUI
                     return;
             }
 
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.EditOptimizationLibraryDlg_btnOpen_Click_Open_Optimization_Library,
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                DefaultExt = OptimizationDb.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(OptimizationDb.FILTER_OPTDB)
-            })
-            {
+                dlg.Title = Resources.EditOptimizationLibraryDlg_btnOpen_Click_Open_Optimization_Library;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.DefaultExt = OptimizationDb.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(OptimizationDb.FILTER_OPTDB);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -213,15 +211,13 @@ namespace pwiz.Skyline.SettingsUI
                     return;
             }
 
-            using (var dlg = new SaveFileDialog
+            using (var dlg = new SaveFileDialog())
             {
-                Title = Resources.EditOptimizationLibraryDlg_btnCreate_Click_Create_Optimization_Library,
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                OverwritePrompt = true,
-                DefaultExt = OptimizationDb.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(OptimizationDb.FILTER_OPTDB)
-            })
-            {
+                dlg.Title = Resources.EditOptimizationLibraryDlg_btnCreate_Click_Create_Optimization_Library;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = OptimizationDb.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(OptimizationDb.FILTER_OPTDB);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -698,12 +694,11 @@ namespace pwiz.Skyline.SettingsUI
                 }
                 else
                 {
-                    double dVal;
                     if (string.IsNullOrWhiteSpace(val))
                     {
                         message = string.Format(Resources.PeptideGridViewDriver_ValidateRow_Missing_value_on_line__0_, lineNumber);
                     }
-                    else if (!double.TryParse(val, out dVal))
+                    else if (!double.TryParse(val, out _))
                     {
                         message = string.Format(Resources.PeptideGridViewDriver_ValidateRow_Invalid_decimal_number_format__0__on_line__1_, val, lineNumber);
                     }
@@ -966,13 +961,11 @@ namespace pwiz.Skyline.SettingsUI
             private void AddOptimizationLibrary(OptimizationLibrary optLibrary, SrmDocument document)
             {
                 IEnumerable<DbOptimization> optimizations = null;
-                using (var longWait = new LongWaitDlg
+                using (var longWait = new LongWaitDlg())
                 {
-                    Text = Resources.LibraryGridViewDriver_AddOptimizationLibrary_Adding_optimization_library,
-                    Message = string.Format(Resources.LibraryGridViewDriver_AddOptimizationLibrary_Adding_optimization_values_from__0_, optLibrary.DatabasePath),
-                    FormBorderStyle = FormBorderStyle.Sizable
-                })
-                {
+                    longWait.Text = Resources.LibraryGridViewDriver_AddOptimizationLibrary_Adding_optimization_library;
+                    longWait.Message = string.Format(Resources.LibraryGridViewDriver_AddOptimizationLibrary_Adding_optimization_values_from__0_, optLibrary.DatabasePath);
+                    longWait.FormBorderStyle = FormBorderStyle.Sizable;
                     try
                     {
                         var status = longWait.PerformWork(MessageParent, 800, monitor =>

--- a/pwiz_tools/Skyline/SettingsUI/EditPeakScoringModelDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditPeakScoringModelDlg.cs
@@ -132,8 +132,9 @@ namespace pwiz.Skyline.SettingsUI
                 scoringModel = new MProphetPeakScoringModel(UNNAMED, document);
             }
 
-            using (var longWaitDlg = new LongWaitDlg { Text = Resources.EditPeakScoringModelDlg_TrainModelClick_Scoring })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = Resources.EditPeakScoringModelDlg_TrainModelClick_Scoring;
                 longWaitDlg.PerformWork(owner, 800, progressMonitor =>
                     _targetDecoyGenerator = new TargetDecoyGenerator(document, scoringModel, scoreProvider, progressMonitor));
                 if (longWaitDlg.IsCanceled)
@@ -262,8 +263,9 @@ namespace pwiz.Skyline.SettingsUI
             var initialParams = new LinearModelParams(initialWeights);
 
             // Train the model.
-            using (var longWaitDlg = new LongWaitDlg { Text = Resources.EditPeakScoringModelDlg_TrainModel_Training})
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = Resources.EditPeakScoringModelDlg_TrainModel_Training;
                 longWaitDlg.PerformWork(this, 800, progressMonitor => 
                 {
                     _peakScoringModel = peakScoringModel.Train(targetTransitionGroups, decoyTransitionGroups, _targetDecoyGenerator, initialParams,
@@ -277,13 +279,11 @@ namespace pwiz.Skyline.SettingsUI
             _gridViewDriver.Items.RaiseListChangedEvents = false;
             try
             {
-                using (var longWaitDlg = new LongWaitDlg
+                using (var longWaitDlg = new LongWaitDlg())
                 {
-                    Text = Resources.EditPeakScoringModelDlg_TrainModel_Calculating,
-                    Message = Resources.EditPeakScoringModelDlg_TrainModel_Calculating_score_contributions,
-                    ProgressValue = 0
-                })
-                {
+                    longWaitDlg.Text = Resources.EditPeakScoringModelDlg_TrainModel_Calculating;
+                    longWaitDlg.Message = Resources.EditPeakScoringModelDlg_TrainModel_Calculating_score_contributions;
+                    longWaitDlg.ProgressValue = 0;
                     int seenContributingScores = 0;
                     int totalContributingScores = _peakScoringModel.Parameters.Weights.Count(w => !double.IsNaN(w));
                     longWaitDlg.PerformWork(this, 800, progressMonitor =>
@@ -1014,13 +1014,11 @@ namespace pwiz.Skyline.SettingsUI
         {
             // Create list of calculators and their corresponding weights.
             PeakCalculatorWeight[] peakCalculatorWeights = null;
-            using (var longWaitDlg = new LongWaitDlg
+            using (var longWaitDlg = new LongWaitDlg())
             {
-                Text = Resources.EditPeakScoringModelDlg_TrainModel_Calculating,
-                Message = Resources.EditPeakScoringModelDlg_TrainModel_Calculating_score_contributions,
-                ProgressValue = 0
-            })
-            {
+                longWaitDlg.Text = Resources.EditPeakScoringModelDlg_TrainModel_Calculating;
+                longWaitDlg.Message = Resources.EditPeakScoringModelDlg_TrainModel_Calculating_score_contributions;
+                longWaitDlg.ProgressValue = 0;
                 longWaitDlg.PerformWork(owner, 800, progressMonitor => peakCalculatorWeights =
                     _targetDecoyGenerator.GetPeakCalculatorWeights(_peakScoringModel, progressMonitor));
             }
@@ -1221,15 +1219,15 @@ namespace pwiz.Skyline.SettingsUI
 
         public int GetTargetCount()
         {
-            List<IList<FeatureScores>> targetGroups, decoyGroups;
-            _targetDecoyGenerator.GetTransitionGroups(out targetGroups, out decoyGroups);
+            List<IList<FeatureScores>> targetGroups;
+            _targetDecoyGenerator.GetTransitionGroups(out targetGroups, out _);
             return targetGroups.Count;
         }
 
         public int GetDecoyCount()
         {
-            List<IList<FeatureScores>> targetGroups, decoyGroups;
-            _targetDecoyGenerator.GetTransitionGroups(out targetGroups, out decoyGroups);
+            List<IList<FeatureScores>> decoyGroups;
+            _targetDecoyGenerator.GetTransitionGroups(out _, out decoyGroups);
             return decoyGroups.Count;
         }
 

--- a/pwiz_tools/Skyline/SettingsUI/EditRTDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditRTDlg.cs
@@ -364,12 +364,10 @@ namespace pwiz.Skyline.SettingsUI
 
             if (!calc.IsUsable)
             {
-                using (var longWait = new LongWaitDlg
+                using (var longWait = new LongWaitDlg())
                 {
-                    Text = Resources.EditRTDlg_ShowGraph_Initializing,
-                    Message = string.Format(Resources.EditRTDlg_ShowGraph_Initializing__0__calculator, calc.Name)
-                })
-                {
+                    longWait.Text = Resources.EditRTDlg_ShowGraph_Initializing;
+                    longWait.Message = string.Format(Resources.EditRTDlg_ShowGraph_Initializing__0__calculator, calc.Name);
                     try
                     {
                         var status = longWait.PerformWork(this, 800, monitor =>
@@ -506,9 +504,8 @@ namespace pwiz.Skyline.SettingsUI
                 RecalcRegression(calculator, activePeptides);
             }
 
-            int minCount;
             var usePeptides = new HashSet<Target>(calculator.ChooseRegressionPeptides(
-                activePeptides.Select(pep => pep.PeptideSequence), out minCount));
+                activePeptides.Select(pep => pep.PeptideSequence), out _));
             //now go back and get the MeasuredPeptides corresponding to the strings chosen by the calculator
             var tablePeptides = activePeptides.Where(measuredRT =>
                 usePeptides.Contains(measuredRT.PeptideSequence)).ToList();
@@ -595,8 +592,7 @@ namespace pwiz.Skyline.SettingsUI
                 r = statistics.R;
             }
 
-            int minCount;
-            var pepCount = calculatorSpec.ChooseRegressionPeptides(peptidesTimes.Select(mrt => mrt.PeptideSequence), out minCount).Count();
+            var pepCount = calculatorSpec.ChooseRegressionPeptides(peptidesTimes.Select(mrt => mrt.PeptideSequence), out _).Count();
 
             labelRValue.Text = string.Format(Resources.EditRTDlg_RecalcRegression__0__peptides_R__1__, pepCount,
                                              Math.Round(r, RetentionTimeRegression.ThresholdPrecision));

--- a/pwiz_tools/Skyline/SettingsUI/EditStaticModDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/EditStaticModDlg.cs
@@ -678,8 +678,9 @@ namespace pwiz.Skyline.SettingsUI
             var listFragmentLosses = new List<FragmentLoss>(Losses);
             listFragmentLosses.Remove(lossEdit);
 
-            using (var dlg = new EditFragmentLossDlg(listFragmentLosses) { Loss = lossEdit })
+            using (var dlg = new EditFragmentLossDlg(listFragmentLosses))
             {
+                dlg.Loss = lossEdit;
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     listFragmentLosses.Add(dlg.Loss);

--- a/pwiz_tools/Skyline/SettingsUI/FilterMidasLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FilterMidasLibraryDlg.cs
@@ -89,14 +89,12 @@ namespace pwiz.Skyline.SettingsUI
 
         private void btnBrowse_Click(object sender, System.EventArgs e)
         {
-            using (var saveDlg = new SaveFileDialog
+            using (var saveDlg = new SaveFileDialog())
             {
-                Title = Resources.FilterMidasLibraryDlg_btnBrowse_Click_Export_Filtered_MIDAS_Library,
-                OverwritePrompt = true,
-                DefaultExt = BiblioSpecLiteSpec.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(BiblioSpecLiteSpec.FILTER_BLIB)
-            })
-            {
+                saveDlg.Title = Resources.FilterMidasLibraryDlg_btnBrowse_Click_Export_Filtered_MIDAS_Library;
+                saveDlg.OverwritePrompt = true;
+                saveDlg.DefaultExt = BiblioSpecLiteSpec.EXT;
+                saveDlg.Filter = TextUtil.FileDialogFiltersAll(BiblioSpecLiteSpec.FILTER_BLIB);
                 if (saveDlg.ShowDialog(this) == DialogResult.OK)
                 {
                     FileName = saveDlg.FileName;

--- a/pwiz_tools/Skyline/SettingsUI/FormulaBox.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FormulaBox.cs
@@ -318,14 +318,12 @@ namespace pwiz.Skyline.SettingsUI
 
         public bool ValidateMonoText(MessageBoxHelper helper)
         {
-            double val;
-            return helper.ValidateDecimalTextBox(textMono, out val);
+            return helper.ValidateDecimalTextBox(textMono, out _);
         }
 
         public bool ValidateAverageText(MessageBoxHelper helper)
         {
-            double val;
-            return helper.ValidateDecimalTextBox(textAverage, out val);
+            return helper.ValidateDecimalTextBox(textAverage, out _);
         }
 
         public void ShowTextBoxErrorAverageMass(MessageBoxHelper helper, string message)

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/EditIonMobilityLibraryDlg.cs
@@ -166,15 +166,13 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
                     return;
             }
 
-            using (var dlg = new SaveFileDialog
+            using (var dlg = new SaveFileDialog())
             {
-                Title = Resources.EditIonMobilityLibraryDlg_btnCreateDb_Click_Create_Ion_Mobility_Library,
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                OverwritePrompt = true,
-                DefaultExt = IonMobilityDb.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(IonMobilityLibrarySpec.FILTER_IONMOBILITYLIBRARY) 
-            })
-            {
+                dlg.Title = Resources.EditIonMobilityLibraryDlg_btnCreateDb_Click_Create_Ion_Mobility_Library;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = IonMobilityDb.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(IonMobilityLibrarySpec.FILTER_IONMOBILITYLIBRARY);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     var fileName = dlg.FileName;
@@ -244,14 +242,12 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
                     return;
             }
 
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.EditIonMobilityLibraryDlg_btnBrowseDb_Click_Open_Ion_Mobility_Library,
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                DefaultExt = IonMobilityDb.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(IonMobilityLibrarySpec.FILTER_IONMOBILITYLIBRARY)
-            })
-            {
+                dlg.Title = Resources.EditIonMobilityLibraryDlg_btnBrowseDb_Click_Open_Ion_Mobility_Library;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.DefaultExt = IonMobilityDb.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(IonMobilityLibrarySpec.FILTER_IONMOBILITYLIBRARY);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -456,8 +452,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
                     valstrs[COLUMN_HIGH_ENERGY_OFFSET] = value.ToString(CultureInfo.InvariantCulture);
                     valstrs[COLUMN_TARGET] = (row.Cells[COLUMN_TARGET].FormattedValue ?? string.Empty).ToString();
                     string valstr = TextUtil.SpaceSeparate(valstrs);
-                    int oldrow;
-                    if (existingLines.TryGetValue(valstr, out oldrow))
+                    if (existingLines.TryGetValue(valstr, out _))
                     {
                         for (int col = 0; col < COLUMN_COUNT; col++)
                         {
@@ -582,13 +577,11 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
                 var document = Program.MainWindow.Document;
                 var documentFilePath = Program.MainWindow.DocumentFilePath;
                 bool useHighEnergyOffset = cbOffsetHighEnergySpectra.Checked;
-                using (var longWaitDlg = new LongWaitDlg
+                using (var longWaitDlg = new LongWaitDlg())
                 {
-                    Text = Resources.EditIonMobilityLibraryDlg_GetDriftTimesFromResults_Finding_ion_mobility_values_for_peaks,
-                    Message = string.Empty,
-                    ProgressValue = 0
-                })
-                {
+                    longWaitDlg.Text = Resources.EditIonMobilityLibraryDlg_GetDriftTimesFromResults_Finding_ion_mobility_values_for_peaks;
+                    longWaitDlg.Message = string.Empty;
+                    longWaitDlg.ProgressValue = 0;
                     Dictionary<LibKey, IonMobilityAndCCS> dict = null;
                     longWaitDlg.PerformWork(this, 100, broker =>
                     {
@@ -752,13 +745,11 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
             try
             {
                 library = libraryManager.TryGetLibrary(librarySpec);
-                using (var longWait = new LongWaitDlg  
+                using (var longWait = new LongWaitDlg())
                 {
-                    Text = Resources.CollisionalCrossSectionGridViewDriver_AddSpectralLibrary_Adding_Spectral_Library,
-                    Message = string.Format(Resources.CollisionalCrossSectionGridViewDriver_AddSpectralLibrary_Adding_ion_mobility_data_from__0_, librarySpec.FilePath),
-                    FormBorderStyle = FormBorderStyle.Sizable
-                })
-                {
+                    longWait.Text = Resources.CollisionalCrossSectionGridViewDriver_AddSpectralLibrary_Adding_Spectral_Library;
+                    longWait.Message = string.Format(Resources.CollisionalCrossSectionGridViewDriver_AddSpectralLibrary_Adding_ion_mobility_data_from__0_, librarySpec.FilePath);
+                    longWait.FormBorderStyle = FormBorderStyle.Sizable;
                     try
                     {
                         var status = longWait.PerformWork(MessageParent, 800, monitor =>
@@ -1096,8 +1087,7 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
                 }
             }
 
-            double dHighEnergyDriftTimeOffsetMsec;
-            if (!string.IsNullOrWhiteSpace(highEnergyOffset) && !double.TryParse(highEnergyOffset, out dHighEnergyDriftTimeOffsetMsec))
+            if (!string.IsNullOrWhiteSpace(highEnergyOffset) && !double.TryParse(highEnergyOffset, out _))
             {
                 messages.Add(string.Format(Resources.CollisionalCrossSectionGridViewDriverBase_ValidateRow_Cannot_read_high_energy_ion_mobility_offset_value___0___on_line__1__,
                     highEnergyOffset,

--- a/pwiz_tools/Skyline/SettingsUI/IonMobility/ImportIonMobilityFromSpectralLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/IonMobility/ImportIonMobilityFromSpectralLibraryDlg.cs
@@ -171,14 +171,12 @@ namespace pwiz.Skyline.SettingsUI.IonMobility
 
         private void btnBrowseFile_Click(object sender, EventArgs e)
         {
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                InitialDirectory = Settings.Default.LibraryDirectory,
-                CheckPathExists = true,
-                DefaultExt = BiblioSpecLiteSpec.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(BiblioSpecLiteSpec.FILTER_BLIB)
-            })
-            {
+                dlg.InitialDirectory = Settings.Default.LibraryDirectory;
+                dlg.CheckPathExists = true;
+                dlg.DefaultExt = BiblioSpecLiteSpec.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(BiblioSpecLiteSpec.FILTER_BLIB);
                 if (dlg.ShowDialog(this) != DialogResult.OK)
                     return;
 

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtCalculatorDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtCalculatorDlg.cs
@@ -135,13 +135,11 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
         private void btnBrowseFile_Click(object sender, EventArgs e)
         {
-            using (var dlg = new OpenFileDialog
-                                 {
-                                     CheckPathExists = true,
-                                     DefaultExt = BiblioSpecLibSpec.EXT,
-                                     Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB)
-                                 })
+            using (var dlg = new OpenFileDialog())
             {
+                dlg.CheckPathExists = true;
+                dlg.DefaultExt = BiblioSpecLibSpec.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB);
                 if (dlg.ShowDialog(this) != DialogResult.OK)
                     return;
 

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.cs
@@ -263,8 +263,10 @@ namespace pwiz.Skyline.SettingsUI.Irt
             if (!_regressionGraphData.TryGetValue(row, out data))
                 return;
 
-            using (var graph = new GraphRegression(data) {Width = 800, Height = 600})
+            using (var graph = new GraphRegression(data))
             {
+                graph.Width = 800;
+                graph.Height = 600;
                 graph.ShowDialog(this);
             }
         }

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtSpectralLibrary.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtSpectralLibrary.cs
@@ -160,17 +160,15 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
         private void btnBrowseFile_Click(object sender, EventArgs e)
         {
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                InitialDirectory = Settings.Default.LibraryDirectory,
-                CheckPathExists = true,
-                DefaultExt = BiblioSpecLiteSpec.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(
+                dlg.InitialDirectory = Settings.Default.LibraryDirectory;
+                dlg.CheckPathExists = true;
+                dlg.DefaultExt = BiblioSpecLiteSpec.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(
                     TextUtil.FileDialogFilter(Resources.AddIrtSpectralLibrary_btnBrowseFile_Click_Spectral_Libraries,
-                                              BiblioSpecLiteSpec.EXT, ChromatogramLibrarySpec.EXT, SpectrastSpec.EXT)
-                )
-            })
-            {
+                        BiblioSpecLiteSpec.EXT, ChromatogramLibrarySpec.EXT, SpectrastSpec.EXT)
+                );
                 if (dlg.ShowDialog(this) != DialogResult.OK)
                     return;
 

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtStandardsDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtStandardsDlg.cs
@@ -62,10 +62,10 @@ namespace pwiz.Skyline.SettingsUI.Irt
         {
             if (_graphData != null)
             {
-                using (var graph = new GraphRegression(new[] { _graphData }) { Width = 800, Height = 600 })
-                {
-                    graph.ShowDialog(this);
-                }
+                using var graph = new GraphRegression(new[] { _graphData });
+                graph.Width = 800;
+                graph.Height = 600;
+                graph.ShowDialog(this);
             }
         }
 

--- a/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/CalibrateIrtDlg.cs
@@ -577,8 +577,10 @@ namespace pwiz.Skyline.SettingsUI.Irt
                 RegressionLine = regression,
             };
 
-            using (var graph = new GraphRegression(new[] { data }) { Width = 800, Height = 600 })
+            using (var graph = new GraphRegression(new[] { data }))
             {
+                graph.Width = 800;
+                graph.Height = 600;
                 graph.ShowDialog(this);
             }
         }
@@ -725,8 +727,9 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
                 if (!_picker.HasScoredPeptides)
                 {
-                    using (var longWaitDlg = new LongWaitDlg {Text = Resources.CalibrationGridViewDriver_FindEvenlySpacedPeptides_Calculating_scores})
+                    using (var longWaitDlg = new LongWaitDlg())
                     {
+                        longWaitDlg.Text = Resources.CalibrationGridViewDriver_FindEvenlySpacedPeptides_Calculating_scores;
                         longWaitDlg.PerformWork(_parent, 1000, pm => _picker.ScorePeptides(doc, pm));
                         if (longWaitDlg.IsCanceled)
                             return null;

--- a/pwiz_tools/Skyline/SettingsUI/Irt/ChangeIrtPeptidesDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/ChangeIrtPeptidesDlg.cs
@@ -298,8 +298,9 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
             if (!_picker.HasScoredPeptides)
             {
-                using (var longWaitDlg = new LongWaitDlg { Text = Resources.CalibrationGridViewDriver_FindEvenlySpacedPeptides_Calculating_scores })
+                using (var longWaitDlg = new LongWaitDlg())
                 {
+                    longWaitDlg.Text = Resources.CalibrationGridViewDriver_FindEvenlySpacedPeptides_Calculating_scores;
                     longWaitDlg.PerformWork(this, 1000, pm => _picker.ScorePeptides(_document, pm));
                     if (longWaitDlg.IsCanceled)
                         return;

--- a/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/EditIrtCalcDlg.cs
@@ -235,15 +235,13 @@ namespace pwiz.Skyline.SettingsUI.Irt
                     return;
             }
 
-            using (var dlg = new SaveFileDialog
-                   {
-                       Title = Resources.EditIrtCalcDlg_btnCreateDb_Click_Create_iRT_Database,
-                       InitialDirectory = Settings.Default.ActiveDirectory,
-                       OverwritePrompt = true,
-                       DefaultExt = IrtDb.EXT,
-                       Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB) 
-                   })
+            using (var dlg = new SaveFileDialog())
             {
+                dlg.Title = Resources.EditIrtCalcDlg_btnCreateDb_Click_Create_iRT_Database;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = IrtDb.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -299,14 +297,12 @@ namespace pwiz.Skyline.SettingsUI.Irt
                     return;
             }
 
-            using (var dlg = new OpenFileDialog
-                   {
-                       Title = Resources.EditIrtCalcDlg_btnBrowseDb_Click_Open_iRT_Database,
-                       InitialDirectory = Settings.Default.ActiveDirectory,
-                       DefaultExt = IrtDb.EXT,
-                       Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB, BiblioSpecLiteSpec.FILTER_BLIB, ChromatogramLibrarySpec.FILTER_CLIB)
-                   })
+            using (var dlg = new OpenFileDialog())
             {
+                dlg.Title = Resources.EditIrtCalcDlg_btnBrowseDb_Click_Open_iRT_Database;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.DefaultExt = IrtDb.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(IrtDb.FILTER_IRTDB, BiblioSpecLiteSpec.FILTER_BLIB, ChromatogramLibrarySpec.FILTER_CLIB);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -337,8 +333,9 @@ namespace pwiz.Skyline.SettingsUI.Irt
 
             IrtDb db = null;
             IList<DbIrtPeptide> dbPeptides = null;
-            using (var dlg = new LongWaitDlg { Message = Resources.EditIrtCalcDlg_OpenDatabase_Opening_database })
+            using (var dlg = new LongWaitDlg())
             {
+                dlg.Message = Resources.EditIrtCalcDlg_OpenDatabase_Opening_database;
                 var status = dlg.PerformWork(this, 800, progressMonitor => db = IrtDb.GetIrtDb(path, progressMonitor, out dbPeptides));
                 if (status.IsError)
                 {
@@ -417,8 +414,9 @@ namespace pwiz.Skyline.SettingsUI.Irt
                     MessageDlg.Show(this, chromLib
                         ? Resources.EditIrtCalcDlg_OkDialog_Chromatogram_libraries_cannot_be_modified__You_must_save_this_iRT_calculator_as_a_new_file_
                         : Resources.EditIrtCalcDlg_OkDialog_Spectral_libraries_cannot_be_modified__You_must_save_this_iRT_calculator_as_a_new_file_);
-                    using (var saveDlg = new SaveFileDialog {Filter = IrtDb.FILTER_IRTDB})
+                    using (var saveDlg = new SaveFileDialog())
                     {
+                        saveDlg.Filter = IrtDb.FILTER_IRTDB;
                         if (saveDlg.ShowDialog(this) == DialogResult.Cancel)
                         {
                             return;
@@ -484,8 +482,9 @@ namespace pwiz.Skyline.SettingsUI.Irt
                         }
                         
                         db = db.SetRedundant(IsRedundant);
-                        using (var longWaitDlg = new LongWaitDlg { Text = Resources.EditIrtCalcDlg_OkDialog_Saving_to_database })
+                        using (var longWaitDlg = new LongWaitDlg())
                         {
+                            longWaitDlg.Text = Resources.EditIrtCalcDlg_OkDialog_Saving_to_database;
                             var dbCopy = db;
                             longWaitDlg.PerformWork(this, 800, monitor => db = dbCopy.UpdatePeptides(AllPeptides.ToArray(), monitor));
                         }
@@ -905,13 +904,11 @@ namespace pwiz.Skyline.SettingsUI.Irt
                 }
 
                 ProcessedIrtAverages irtAverages = null;
-                using (var longWait = new LongWaitDlg
-                       {
-                           Text = Resources.LibraryGridViewDriver_AddResults_Adding_Results,
-                           Message = Resources.LibraryGridViewDriver_AddResults_Adding_retention_times_from_imported_results,
-                           FormBorderStyle = FormBorderStyle.Sizable
-                       })
+                using (var longWait = new LongWaitDlg())
                 {
+                    longWait.Text = Resources.LibraryGridViewDriver_AddResults_Adding_Results;
+                    longWait.Message = Resources.LibraryGridViewDriver_AddResults_Adding_retention_times_from_imported_results;
+                    longWait.FormBorderStyle = FormBorderStyle.Sizable;
                     try
                     {
                         var status = longWait.PerformWork(MessageParent, 800, monitor =>
@@ -1008,13 +1005,11 @@ namespace pwiz.Skyline.SettingsUI.Irt
                 try
                 {
                     library = libraryManager.TryGetLibrary(librarySpec);
-                    using (var longWait = new LongWaitDlg
-                           {
-                               Text = Resources.LibraryGridViewDriver_AddSpectralLibrary_Adding_Spectral_Library,
-                               Message = string.Format(Resources.LibraryGridViewDriver_AddSpectralLibrary_Adding_retention_times_from__0__, librarySpec.FilePath),
-                               FormBorderStyle = FormBorderStyle.Sizable
-                           })
+                    using (var longWait = new LongWaitDlg())
                     {
+                        longWait.Text = Resources.LibraryGridViewDriver_AddSpectralLibrary_Adding_Spectral_Library;
+                        longWait.Message = string.Format(Resources.LibraryGridViewDriver_AddSpectralLibrary_Adding_retention_times_from__0__, librarySpec.FilePath);
+                        longWait.FormBorderStyle = FormBorderStyle.Sizable;
                         try
                         {
                             var status = longWait.PerformWork(MessageParent, 800, monitor =>
@@ -1085,13 +1080,11 @@ namespace pwiz.Skyline.SettingsUI.Irt
             private void AddIrtDatabase(RCalcIrt irtCalc)
             {
                 ProcessedIrtAverages irtAverages = null;
-                using (var longWait = new LongWaitDlg
-                       {
-                           Text = Resources.LibraryGridViewDriver_AddIrtDatabase_Adding_iRT_Database,
-                           Message = string.Format(Resources.LibraryGridViewDriver_AddSpectralLibrary_Adding_retention_times_from__0__, irtCalc.DatabasePath),
-                           FormBorderStyle = FormBorderStyle.Sizable
-                       })
+                using (var longWait = new LongWaitDlg())
                 {
+                    longWait.Text = Resources.LibraryGridViewDriver_AddIrtDatabase_Adding_iRT_Database;
+                    longWait.Message = string.Format(Resources.LibraryGridViewDriver_AddSpectralLibrary_Adding_retention_times_from__0__, irtCalc.DatabasePath);
+                    longWait.FormBorderStyle = FormBorderStyle.Sizable;
                     try
                     {
                         var status = longWait.PerformWork(MessageParent, 800, monitor =>
@@ -1187,12 +1180,10 @@ namespace pwiz.Skyline.SettingsUI.Irt
                             case DialogResult.Cancel:
                                 return;
                             case DialogResult.Yes:
-                                using (var longWait = new LongWaitDlg
-                                       {
-                                           Text = Resources.LibraryGridViewDriver_AddToLibrary_Recalibrate_iRT_Standard_Peptides,
-                                           Message = Resources.LibraryGridViewDriver_AddToLibrary_Recalibrating_iRT_standard_peptides_and_reprocessing_iRT_values
-                                       })
+                                using (var longWait = new LongWaitDlg())
                                 {
+                                    longWait.Text = Resources.LibraryGridViewDriver_AddToLibrary_Recalibrate_iRT_Standard_Peptides;
+                                    longWait.Message = Resources.LibraryGridViewDriver_AddToLibrary_Recalibrating_iRT_standard_peptides_and_reprocessing_iRT_values;
                                     try
                                     {
                                         newStandards = irtAverages.RecalibrateStandards(StandardPeptideList.ToArray());

--- a/pwiz_tools/Skyline/SettingsUI/Optimization/AddOptimizationLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Optimization/AddOptimizationLibraryDlg.cs
@@ -151,13 +151,11 @@ namespace pwiz.Skyline.SettingsUI.Optimization
 
         private void btnBrowseFile_Click(object sender, EventArgs e)
         {
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                CheckPathExists = true,
-                DefaultExt = OptimizationDb.FILTER_OPTDB,
-                Filter = TextUtil.FileDialogFiltersAll(OptimizationDb.FILTER_OPTDB)
-            })
-            {
+                dlg.CheckPathExists = true;
+                dlg.DefaultExt = OptimizationDb.FILTER_OPTDB;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(OptimizationDb.FILTER_OPTDB);
                 if (dlg.ShowDialog(this) != DialogResult.OK)
                     return;
 

--- a/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
@@ -728,14 +728,16 @@ namespace pwiz.Skyline.SettingsUI
 
             // Libraries built for full-scan filtering can have important retention time information,
             // and the redundant libraries are more likely to be desirable for showing spectra.
-            using (var dlg = new BuildLibraryDlg(_parent) { LibraryKeepRedundant = _parent.DocumentUI.Settings.TransitionSettings.FullScan.IsEnabled })
+            using (var dlg = new BuildLibraryDlg(_parent))
             {
+                dlg.LibraryKeepRedundant = _parent.DocumentUI.Settings.TransitionSettings.FullScan.IsEnabled;
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     if (!string.IsNullOrEmpty(dlg.AddLibraryFile))
                     {
-                        using (var editLibDlg = new EditLibraryDlg(Settings.Default.SpectralLibraryList) {LibraryPath = dlg.AddLibraryFile})
+                        using (var editLibDlg = new EditLibraryDlg(Settings.Default.SpectralLibraryList))
                         {
+                            editLibDlg.LibraryPath = dlg.AddLibraryFile;
                             if (editLibDlg.ShowDialog(this) == DialogResult.OK)
                             {
                                 _driverLibrary.List.Add(editLibDlg.LibrarySpec);
@@ -812,12 +814,10 @@ namespace pwiz.Skyline.SettingsUI
                 if (filterDlg.ShowDialog(this) == DialogResult.OK)
                 {
                     MidasLibrary midasLib = null;
-                    using (var longWait = new LongWaitDlg
-                           {
-                               Text = Resources.PeptideSettingsUI_ShowFilterMidasDlg_Loading_MIDAS_Library,
-                               Message = string.Format(Resources.PeptideSettingsUI_ShowFilterMidasDlg_Loading__0_, Path.GetFileName(midasLibSpec.FilePath))
-                           })
+                    using (var longWait = new LongWaitDlg())
                     {
+                        longWait.Text = Resources.PeptideSettingsUI_ShowFilterMidasDlg_Loading_MIDAS_Library;
+                        longWait.Message = string.Format(Resources.PeptideSettingsUI_ShowFilterMidasDlg_Loading__0_, Path.GetFileName(midasLibSpec.FilePath));
                         longWait.PerformWork(this, 800, monitor => midasLib =
                             _libraryManager.LoadLibrary(midasLibSpec, () => new DefaultFileLoadMonitor(monitor)) as MidasLibrary);
                     }
@@ -1804,12 +1804,10 @@ namespace pwiz.Skyline.SettingsUI
             public void EditList()
             {
                 var heavyMods = GetHeavyModifications().ToArray();
-                using (var dlg = new EditLabelTypeListDlg
-                              {
-                                  LabelTypes = from typedMods in heavyMods
-                                               select typedMods.LabelType
-                              })
+                using (var dlg = new EditLabelTypeListDlg())
                 {
+                    dlg.LabelTypes = from typedMods in heavyMods
+                        select typedMods.LabelType;
                     if (dlg.ShowDialog(Combo.TopLevelControl) == DialogResult.OK)
                     {
                         // Store existing values in dictionary by lowercase name.

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -404,8 +404,9 @@ namespace pwiz.Skyline.SettingsUI
                 if (selectedLibrarySpec == null)
                     return;
 
-                using (var longWait = new LongWaitDlg { Text = Resources.ViewLibraryDlg_LoadLibrary_Loading_Library })
+                using (var longWait = new LongWaitDlg())
                 {
+                    longWait.Text = Resources.ViewLibraryDlg_LoadLibrary_Loading_Library;
                     try
                     {
                         var status = longWait.PerformWork(this, 800, monitor =>
@@ -713,8 +714,7 @@ namespace pwiz.Skyline.SettingsUI
 
                 if (-1 != index)
                 {
-                    SpectrumPeaksInfo loadedSpectrum;
-                    if (_selectedLibrary.TryLoadSpectrum(_peptides[index].Key, out loadedSpectrum))
+                    if (_selectedLibrary.TryLoadSpectrum(_peptides[index].Key, out _))
                     {
                         SrmSettings settings = Program.ActiveDocumentUI.Settings;
 
@@ -2034,12 +2034,10 @@ namespace pwiz.Skyline.SettingsUI
 
             SrmDocument newDocument;
             var hasSmallMolecules = HasSmallMolecules;
-            using (var longWaitDlg = new LongWaitDlg
-                {
-                    Text = hasSmallMolecules ? Resources.ViewLibraryDlg_AddAllPeptides_Matching_Molecules : Resources.ViewLibraryDlg_AddAllPeptides_Matching_Peptides,
-                    Message = hasSmallMolecules ? Resources.ViewLibraryDlg_AddAllPeptides_Matching_molecules_to_the_current_document_settings : Resources.ViewLibraryDlg_AddAllPeptides_Matching_peptides_to_the_current_document_settings
-                })
+            using (var longWaitDlg = new LongWaitDlg())
             {
+                longWaitDlg.Text = hasSmallMolecules ? Resources.ViewLibraryDlg_AddAllPeptides_Matching_Molecules : Resources.ViewLibraryDlg_AddAllPeptides_Matching_Peptides;
+                longWaitDlg.Message = hasSmallMolecules ? Resources.ViewLibraryDlg_AddAllPeptides_Matching_molecules_to_the_current_document_settings : Resources.ViewLibraryDlg_AddAllPeptides_Matching_peptides_to_the_current_document_settings;
                 longWaitDlg.PerformWork(this, 1000, broker => pepMatcher.AddAllPeptidesToDocument(broker, entryCreatorList));
                 newDocument = pepMatcher.DocAllPeptides;
                 if (longWaitDlg.IsCanceled || newDocument == null)

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryPepMatching.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryPepMatching.cs
@@ -725,9 +725,9 @@ namespace pwiz.Skyline.SettingsUI
             }
             // Sort the proteins.
             nodePepGroupsSortedChildren.Sort((node1, node2) => Comparer<string>.Default.Compare(node1.Name, node2.Name));
-            IdentityPath selPathTemp = selectedPath, nextAdd;
+            IdentityPath selPathTemp = selectedPath;
             document = document.AddPeptideGroups(nodePepGroupsSortedChildren, false,
-                toPath, out selectedPath, out nextAdd);
+                toPath, out selectedPath, out _);
             selectedPath = PeptideMatches.Count == 1 ? selPathTemp : selectedPath;
             return document;
         }
@@ -806,9 +806,8 @@ namespace pwiz.Skyline.SettingsUI
                         string.Empty, listPeptides.ToArray());
                     if (hasVariable)
                         nodePepGroupNew = (PeptideGroupDocNode) nodePepGroupNew.ChangeAutoManageChildren(false);
-                    IdentityPath nextAdd;
                     document = document.AddPeptideGroups(new[] { nodePepGroupNew }, true,
-                        toPath, out selectedPath, out nextAdd);
+                        toPath, out selectedPath, out _);
                     selectedPath = new IdentityPath(selectedPath, nodePepGroupNew.Children[0].Id);
                 }
             }

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -303,12 +303,10 @@ namespace pwiz.Skyline
 
         public void OpenPasteFileDlg(PasteFormat pf)
         {
-            using (var pasteDlg = new PasteDlg(this)
+            using (var pasteDlg = new PasteDlg(this))
             {
-                SelectedPath = SelectedPath,
-                PasteFormat = pf
-            })
-            {
+                pasteDlg.SelectedPath = SelectedPath;
+                pasteDlg.PasteFormat = pf;
                 if (pasteDlg.ShowDialog(this) == DialogResult.OK)
                     SelectedPath = pasteDlg.SelectedPath;
             }
@@ -633,8 +631,9 @@ namespace pwiz.Skyline
                 docCurrent = DocumentUI;
                 docNew = docCurrent.ChangeSettings(docCurrent.Settings.ChangePeptideIntegration(i => i.ChangePeakScoringModel(newModel)));
                 var resultsHandler = new MProphetResultsHandler(docNew, newModel);
-                using (var longWaitDlg = new LongWaitDlg {Text = Resources.ReintegrateDlg_OkDialog_Reintegrating})
+                using (var longWaitDlg = new LongWaitDlg())
                 {
+                    longWaitDlg.Text = Resources.ReintegrateDlg_OkDialog_Reintegrating;
                     try
                     {
                         longWaitDlg.PerformWork(this, 1000, pm =>
@@ -2138,8 +2137,7 @@ namespace pwiz.Skyline
                 list.Clear();
                 list.Add(settingsDefault); // Add back default settings.
                 list.AddRange(listNew);
-                SrmSettings settings;
-                if (!list.TryGetValue(settingsCurrent.GetKey(), out settings))
+                if (!list.TryGetValue(settingsCurrent.GetKey(), out _))
                 {
                     // If the current settings were removed, then make
                     // them the default, and use them to avoid a shift
@@ -2489,13 +2487,11 @@ namespace pwiz.Skyline
                 {
                     var newSettings = changeSettings(Document.Settings);
                     bool success = false;
-                    using (var longWaitDlg = new LongWaitDlg(this)
+                    using (var longWaitDlg = new LongWaitDlg(this))
                     {
-                        Text = Text,    // Same as dialog box
-                        Message = message,
-                        ProgressValue = 0
-                    })
-                    {
+                        longWaitDlg.Text = Text; // Same as dialog box
+                        longWaitDlg.Message = message;
+                        longWaitDlg.ProgressValue = 0;
                         var undoState = GetUndoState();
                         longWaitDlg.PerformWork(parent, 800, progressMonitor =>
                         {

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -184,15 +184,13 @@ namespace pwiz.Skyline
         {
             if (!CheckSaveDocument())
                 return;
-            using (OpenFileDialog dlg = new OpenFileDialog
-                   {
-                       InitialDirectory = Settings.Default.ActiveDirectory,
-                       CheckPathExists = true,
-                       SupportMultiDottedExtensions = true,
-                       DefaultExt = SrmDocument.EXT,
-                       Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC_AND_SKY_ZIP, SrmDocumentSharing.FILTER_SHARING, SkypFile.FILTER_SKYP)
-                   })
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.CheckPathExists = true;
+                dlg.SupportMultiDottedExtensions = true;
+                dlg.DefaultExt = SrmDocument.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC_AND_SKY_ZIP, SrmDocumentSharing.FILTER_SHARING, SkypFile.FILTER_SKYP);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -219,11 +217,9 @@ namespace pwiz.Skyline
             {
                 var sharing = new SrmDocumentSharing(zipPath);
 
-                using (var longWaitDlg = new LongWaitDlg
+                using (var longWaitDlg = new LongWaitDlg())
                 {
-                    Text = Resources.SkylineWindow_OpenSharedFile_Extracting_Files,
-                })
-                {
+                    longWaitDlg.Text = Resources.SkylineWindow_OpenSharedFile_Extracting_Files;
                     longWaitDlg.PerformWork(parentWindow ?? this, 1000, sharing.Extract);
                     if (longWaitDlg.IsCanceled)
                         return false;
@@ -310,13 +306,11 @@ namespace pwiz.Skyline
 
             try
             {
-                using (var longWaitDlg = new LongWaitDlg(this)
+                using (var longWaitDlg = new LongWaitDlg(this))
                 {
-                    Text = Resources.SkylineWindow_OpenFile_Loading___,
-                    Message = Path.GetFileName(path),
-                    ProgressValue = 0
-                })
-                {
+                    longWaitDlg.Text = Resources.SkylineWindow_OpenFile_Loading___;
+                    longWaitDlg.Message = Path.GetFileName(path);
+                    longWaitDlg.ProgressValue = 0;
                     longWaitDlg.PerformWork(parentWindow ?? this, 500, progressMonitor =>
                     {
                         string skylineDocumentHash;
@@ -490,16 +484,14 @@ namespace pwiz.Skyline
                             return CreateLibrarySpec(library, librarySpec, pathLibrary, false);
                     }
 
-                    using (var dlg = new MissingFileDlg
-                                  {
-                                      ItemName = name,
-                                      ItemType = Resources.SkylineWindow_ConnectLibrarySpecs_Spectral_Library,
-                                      Filter = library != null ? library.SpecFilter : librarySpec.Filter,
-                                      FileHint = fileName,
-                                      FileDlgInitialPath = Path.GetDirectoryName(documentPath),
-                                      Title = Resources.SkylineWindow_ConnectLibrarySpecs_Find_Spectral_Library
-                                  })
+                    using (var dlg = new MissingFileDlg())
                     {
+                        dlg.ItemName = name;
+                        dlg.ItemType = Resources.SkylineWindow_ConnectLibrarySpecs_Spectral_Library;
+                        dlg.Filter = library != null ? library.SpecFilter : librarySpec.Filter;
+                        dlg.FileHint = fileName;
+                        dlg.FileDlgInitialPath = Path.GetDirectoryName(documentPath);
+                        dlg.Title = Resources.SkylineWindow_ConnectLibrarySpecs_Find_Spectral_Library;
                         if (dlg.ShowDialog(parent) == DialogResult.OK)
                         {
                             Settings.Default.LibraryDirectory = Path.GetDirectoryName(dlg.FilePath);
@@ -575,16 +567,14 @@ namespace pwiz.Skyline
 
             do
             {
-                using (var dlg = new MissingFileDlg
-                         {
-                             ItemName = irtCalc.Name,
-                             ItemType = Resources.SkylineWindow_FindIrtDatabase_iRT_Calculator,
-                             Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_FindIrtDatabase_iRT_Database_Files, IrtDb.EXT),
-                             FileHint = Path.GetFileName(irtCalc.DatabasePath),
-                             FileDlgInitialPath = Path.GetDirectoryName(documentPath),
-                             Title = Resources.SkylineWindow_FindIrtDatabase_Find_iRT_Calculator
-                         })
+                using (var dlg = new MissingFileDlg())
                 {
+                    dlg.ItemName = irtCalc.Name;
+                    dlg.ItemType = Resources.SkylineWindow_FindIrtDatabase_iRT_Calculator;
+                    dlg.Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_FindIrtDatabase_iRT_Database_Files, IrtDb.EXT);
+                    dlg.FileHint = Path.GetFileName(irtCalc.DatabasePath);
+                    dlg.FileDlgInitialPath = Path.GetDirectoryName(documentPath);
+                    dlg.Title = Resources.SkylineWindow_FindIrtDatabase_Find_iRT_Calculator;
                     if (dlg.ShowDialog(parent) == DialogResult.OK)
                     {
                         if (dlg.FilePath == null)
@@ -653,16 +643,14 @@ namespace pwiz.Skyline
 
             do
             {
-                using (var dlg = new MissingFileDlg
+                using (var dlg = new MissingFileDlg())
                 {
-                    ItemName = optLib.Name,
-                    ItemType = Resources.SkylineWindow_FindOptimizationDatabase_Optimization_Library,
-                    Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_FindOptimizationDatabase_Optimization_Library_Files, OptimizationDb.EXT),
-                    FileHint = Path.GetFileName(optLib.DatabasePath),
-                    FileDlgInitialPath = Path.GetDirectoryName(documentPath),
-                    Title = Resources.SkylineWindow_FindOptimizationDatabase_Find_Optimization_Library
-                })
-                {
+                    dlg.ItemName = optLib.Name;
+                    dlg.ItemType = Resources.SkylineWindow_FindOptimizationDatabase_Optimization_Library;
+                    dlg.Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_FindOptimizationDatabase_Optimization_Library_Files, OptimizationDb.EXT);
+                    dlg.FileHint = Path.GetFileName(optLib.DatabasePath);
+                    dlg.FileDlgInitialPath = Path.GetDirectoryName(documentPath);
+                    dlg.Title = Resources.SkylineWindow_FindOptimizationDatabase_Find_Optimization_Library;
                     if (dlg.ShowDialog(parent) == DialogResult.OK)
                     {
                         if (dlg.FilePath == null)
@@ -728,16 +716,14 @@ namespace pwiz.Skyline
 
             do
             {
-                using (var dlg = new MissingFileDlg
+                using (var dlg = new MissingFileDlg())
                 {
-                    ItemName = ionMobilityLibrary.Name,
-                    ItemType = Resources.SkylineWindow_FindIonMobilityLibrary_Ion_Mobility_Library,
-                    Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_FindIonMobilityDatabase_ion_mobility_library_files, IonMobilityDb.EXT),
-                    FileHint = Path.GetFileName(ionMobilityLibrary.FilePath),
-                    FileDlgInitialPath = Path.GetDirectoryName(documentPath),
-                    Title = Resources.SkylineWindow_FindIonMobilityLibrary_Find_Ion_Mobility_Library
-                })
-                {
+                    dlg.ItemName = ionMobilityLibrary.Name;
+                    dlg.ItemType = Resources.SkylineWindow_FindIonMobilityLibrary_Ion_Mobility_Library;
+                    dlg.Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_FindIonMobilityDatabase_ion_mobility_library_files, IonMobilityDb.EXT);
+                    dlg.FileHint = Path.GetFileName(ionMobilityLibrary.FilePath);
+                    dlg.FileDlgInitialPath = Path.GetDirectoryName(documentPath);
+                    dlg.Title = Resources.SkylineWindow_FindIonMobilityLibrary_Find_Ion_Mobility_Library;
                     if (dlg.ShowDialog(parent) == DialogResult.OK)
                     {
                         if (dlg.FilePath == null)
@@ -799,16 +785,14 @@ namespace pwiz.Skyline
             pathBackgroundProteome = Path.Combine(Settings.Default.ProteomeDbDirectory ?? string.Empty, fileName ?? string.Empty);
             if (File.Exists(pathBackgroundProteome))
                 return new BackgroundProteomeSpec(backgroundProteomeSpec.Name, pathBackgroundProteome);
-            using (var dlg = new MissingFileDlg
-                    {
-                        FileHint = fileName,
-                        ItemName = backgroundProteomeSpec.Name,
-                        ItemType = Resources.SkylineWindow_FindBackgroundProteome_Background_Proteome,
-                        Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_FindBackgroundProteome_Proteome_File, ProteomeDb.EXT_PROTDB),
-                        FileDlgInitialPath = Settings.Default.ProteomeDbDirectory,
-                        Title = Resources.SkylineWindow_FindBackgroundProteome_Find_Background_Proteome
-                    })
+            using (var dlg = new MissingFileDlg())
             {
+                dlg.FileHint = fileName;
+                dlg.ItemName = backgroundProteomeSpec.Name;
+                dlg.ItemType = Resources.SkylineWindow_FindBackgroundProteome_Background_Proteome;
+                dlg.Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_FindBackgroundProteome_Proteome_File, ProteomeDb.EXT_PROTDB);
+                dlg.FileDlgInitialPath = Settings.Default.ProteomeDbDirectory;
+                dlg.Title = Resources.SkylineWindow_FindBackgroundProteome_Find_Background_Proteome;
                 if (dlg.ShowDialog(parent) == DialogResult.OK)
                 {
                     if (dlg.FilePath == null)
@@ -948,11 +932,9 @@ namespace pwiz.Skyline
             try
             {
                 using var dlg = new PanoramaFilePicker(panoramaServers, state);
-                using (var longWaitDlg = new LongWaitDlg
-                       {
-                           Text = Resources.SkylineWindow_OpenFromPanorama_Loading_remote_server_folders,
-                       })
+                using (var longWaitDlg = new LongWaitDlg())
                 {
+                    longWaitDlg.Text = Resources.SkylineWindow_OpenFromPanorama_Loading_remote_server_folders;
                     longWaitDlg.PerformWork(this, 0,
                         () => dlg.InitializeDialog());
                     if (longWaitDlg.IsCanceled)
@@ -972,16 +954,14 @@ namespace pwiz.Skyline
                     var extension = dlg.FileName.EndsWith(SrmDocumentSharing.EXT) ? SrmDocumentSharing.EXT : SrmDocument.EXT;
                     if (downloadFilePath == null)
                     {
-                        using (var saveAsDlg = new SaveFileDialog
-                               {
-                                   FileName = dlg.FileName,
-                                   DefaultExt = extension,
-                                   SupportMultiDottedExtensions = true,
-                                   Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC_AND_SKY_ZIP, SrmDocumentSharing.FILTER_SHARING, SkypFile.FILTER_SKYP),
-                                   InitialDirectory = folderPath,
-                                   OverwritePrompt = true,
-                               })
+                        using (var saveAsDlg = new SaveFileDialog())
                         {
+                            saveAsDlg.FileName = dlg.FileName;
+                            saveAsDlg.DefaultExt = extension;
+                            saveAsDlg.SupportMultiDottedExtensions = true;
+                            saveAsDlg.Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC_AND_SKY_ZIP, SrmDocumentSharing.FILTER_SHARING, SkypFile.FILTER_SKYP);
+                            saveAsDlg.InitialDirectory = folderPath;
+                            saveAsDlg.OverwritePrompt = true;
                             if (saveAsDlg.ShowDialog(this) != DialogResult.OK)
                             {
                                 return;
@@ -1030,11 +1010,9 @@ namespace pwiz.Skyline
                 panoramaClient ??= new WebPanoramaClient(curServer.URI);
                 using (var fileSaver = new FileSaver(downloadPath))
                 {
-                    using (var longWaitDlg = new LongWaitDlg
-                           {
-                               Text = string.Format(Resources.SkylineWindow_OpenFromPanorama_Downloading_file__0_, fileName),
-                           })
+                    using (var longWaitDlg = new LongWaitDlg())
                     {
+                        longWaitDlg.Text = string.Format(Resources.SkylineWindow_OpenFromPanorama_Downloading_file__0_, fileName);
                         var progressStatus = longWaitDlg.PerformWork(this, 800,
                             progressMonitor => panoramaClient.DownloadFile(fileUrl, fileSaver.SafeName, size, fileName, curServer,
                                 progressMonitor, new ProgressStatus()));
@@ -1121,14 +1099,12 @@ namespace pwiz.Skyline
                 return false;
             }
 
-            using (var dlg = new SaveFileDialog
+            using (var dlg = new SaveFileDialog())
             {
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                OverwritePrompt = true,
-                DefaultExt = SrmDocument.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC)
-            })
-            {
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = SrmDocument.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC);
                 if (!string.IsNullOrEmpty(DocumentFilePath))
                     dlg.FileName = Path.GetFileName(DocumentFilePath);
 
@@ -1176,12 +1152,10 @@ namespace pwiz.Skyline
                 {
                     saver.CheckException();
 
-                    using (var longWaitDlg = new LongWaitDlg(this)
-                        {
-                            Text = Resources.SkylineWindow_SaveDocument_Saving___,
-                            Message = Path.GetFileName(fileName)
-                        })
+                    using (var longWaitDlg = new LongWaitDlg(this))
                     {
+                        longWaitDlg.Text = Resources.SkylineWindow_SaveDocument_Saving___;
+                        longWaitDlg.Message = Path.GetFileName(fileName);
                         longWaitDlg.PerformWork(this, 800, progressMonitor =>
                         {
                             document.SerializeToFile(saver.SafeName, fileName, SkylineVersion.CURRENT, progressMonitor);
@@ -1226,12 +1200,10 @@ namespace pwiz.Skyline
                 // CONSIDER: Is this really optional?
                 if (includingCacheFile)
                 {
-                    using (var longWaitDlg = new LongWaitDlg(this)
+                    using (var longWaitDlg = new LongWaitDlg(this))
                     {
-                        Text = Resources.SkylineWindow_SaveDocument_Optimizing_data_file___,
-                        Message = Path.GetFileName(fileName)
-                    })
-                    {
+                        longWaitDlg.Text = Resources.SkylineWindow_SaveDocument_Optimizing_data_file___;
+                        longWaitDlg.Message = Path.GetFileName(fileName);
                         longWaitDlg.PerformWork(this, 800, () =>
                             OptimizeCache(fileName, longWaitDlg));
                     }
@@ -1414,16 +1386,14 @@ namespace pwiz.Skyline
         /// </summary>
         private string GetShareFileName()
         {
-            using var dlg = new SaveFileDialog
-            {
-                Title = Resources.SkylineWindow_shareDocumentMenuItem_Click_Share_Document,
-                OverwritePrompt = true,
-                DefaultExt = SrmDocumentSharing.EXT_SKY_ZIP,
-                SupportMultiDottedExtensions = true,
-                Filter = TextUtil.FileDialogFilterAll(
-                    Resources.SkylineWindow_shareDocumentMenuItem_Click_Skyline_Shared_Documents,
-                    SrmDocumentSharing.EXT),
-            };
+            using var dlg = new SaveFileDialog();
+            dlg.Title = Resources.SkylineWindow_shareDocumentMenuItem_Click_Share_Document;
+            dlg.OverwritePrompt = true;
+            dlg.DefaultExt = SrmDocumentSharing.EXT_SKY_ZIP;
+            dlg.SupportMultiDottedExtensions = true;
+            dlg.Filter = TextUtil.FileDialogFilterAll(
+                Resources.SkylineWindow_shareDocumentMenuItem_Click_Skyline_Shared_Documents,
+                SrmDocumentSharing.EXT);
             string fileName = DocumentFilePath;
             if (fileName != null)
             {
@@ -1444,8 +1414,9 @@ namespace pwiz.Skyline
             try
             {
                 bool success;
-                using (var longWaitDlg = new LongWaitDlg { Text = Resources.SkylineWindow_ShareDocument_Compressing_Files, })
+                using (var longWaitDlg = new LongWaitDlg())
                 {
+                    longWaitDlg.Text = Resources.SkylineWindow_ShareDocument_Compressing_Files;
                     var sharing = new SrmDocumentSharing(DocumentUI, DocumentFilePath, fileDest, shareType);
                     if (shareType.MustSaveNewDocument)
                     {
@@ -1525,14 +1496,12 @@ namespace pwiz.Skyline
                 return;
             }
 
-            using (var dlg = new SaveFileDialog
+            using (var dlg = new SaveFileDialog())
             {
-                Title = Resources.SkylineWindow_ShowExportSpectralLibraryDialog_Export_Spectral_Library,
-                OverwritePrompt = true,
-                DefaultExt = BiblioSpecLiteSpec.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(BiblioSpecLiteSpec.FILTER_BLIB)
-            })
-            {
+                dlg.Title = Resources.SkylineWindow_ShowExportSpectralLibraryDialog_Export_Spectral_Library;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = BiblioSpecLiteSpec.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(BiblioSpecLiteSpec.FILTER_BLIB);
                 if (!string.IsNullOrEmpty(DocumentFilePath))
                     dlg.InitialDirectory = Path.GetDirectoryName(DocumentFilePath);
 
@@ -1541,12 +1510,10 @@ namespace pwiz.Skyline
 
                 try
                 {
-                    using (var longWaitDlg = new LongWaitDlg
+                    using (var longWaitDlg = new LongWaitDlg())
                     {
-                        Text = Resources.SkylineWindow_ShowExportSpectralLibraryDialog_Export_Spectral_Library,
-                        Message = string.Format(Resources.SkylineWindow_ShowExportSpectralLibraryDialog_Exporting_spectral_library__0____, Path.GetFileName(dlg.FileName))
-                    })
-                    {
+                        longWaitDlg.Text = Resources.SkylineWindow_ShowExportSpectralLibraryDialog_Export_Spectral_Library;
+                        longWaitDlg.Message = string.Format(Resources.SkylineWindow_ShowExportSpectralLibraryDialog_Exporting_spectral_library__0____, Path.GetFileName(dlg.FileName));
                         longWaitDlg.PerformWork(this, 800, monitor =>
                             new SpectralLibraryExporter(Document, DocumentFilePath).ExportSpectralLibrary(dlg.FileName, monitor));
                     }
@@ -1586,14 +1553,12 @@ namespace pwiz.Skyline
                 return;
             }
 
-            using (var dlg = new SaveFileDialog
+            using (var dlg = new SaveFileDialog())
             {
-                Title = Resources.SkylineWindow_ShowExportEspFeaturesDialog_Export_ESP_Features,
-                OverwritePrompt = true,
-                DefaultExt = EspFeatureCalc.EXT,
-                Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_ShowExportEspFeaturesDialog_ESP_Feature_Files,EspFeatureCalc.EXT),
-            })
-            {
+                dlg.Title = Resources.SkylineWindow_ShowExportEspFeaturesDialog_Export_ESP_Features;
+                dlg.OverwritePrompt = true;
+                dlg.DefaultExt = EspFeatureCalc.EXT;
+                dlg.Filter = TextUtil.FileDialogFilterAll(Resources.SkylineWindow_ShowExportEspFeaturesDialog_ESP_Feature_Files,EspFeatureCalc.EXT);
                 if (!string.IsNullOrEmpty(DocumentFilePath))
                 {
                     dlg.InitialDirectory = Path.GetDirectoryName(DocumentFilePath);
@@ -1677,12 +1642,10 @@ namespace pwiz.Skyline
             {
                 MessageDlg.Show(this, Resources.SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_imported_results_);
             }
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.SkylineWindow_ImportPeakBoundaries_Import_PeakBoundaries,
-                CheckPathExists = true
-            })
-            {
+                dlg.Title = Resources.SkylineWindow_ImportPeakBoundaries_Import_PeakBoundaries;
+                dlg.CheckPathExists = true;
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     ImportPeakBoundariesFile(dlg.FileName);
@@ -1717,8 +1680,9 @@ namespace pwiz.Skyline
             SrmDocument docNew = null;
 
             var peakBoundaryImporter = new PeakBoundaryImporter(docCurrent);
-            using (var longWaitDlg = new LongWaitDlg(this) { Text = description })
-            {       
+            using (var longWaitDlg = new LongWaitDlg(this))
+            {
+                longWaitDlg.Text = description;
                 longWaitDlg.PerformWork(this, 1000, longWaitBroker =>
                            docNew = peakBoundaryImporter.Import(fileName, longWaitBroker, lineCount));
 
@@ -1755,14 +1719,11 @@ namespace pwiz.Skyline
 
         private void importFASTAMenuItem_Click(object sender, EventArgs e)
         {
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.SkylineWindow_ImportFastaFile_Import_FASTA,
-                InitialDirectory = Settings.Default.FastaDirectory,
-                CheckPathExists = true
-                // FASTA files often have no extension as well as .fasta and others
-            })
-            {
+                dlg.Title = Resources.SkylineWindow_ImportFastaFile_Import_FASTA;
+                dlg.InitialDirectory = Settings.Default.FastaDirectory;
+                dlg.CheckPathExists = true; // FASTA files often have no extension as well as .fasta and others
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.FastaDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -1847,11 +1808,11 @@ namespace pwiz.Skyline
 
             SrmDocument docNew = null;
             int emptyPeptideGroups = 0;
-            using (var longWaitDlg = new LongWaitDlg(this) { Text = description })
+            using (var longWaitDlg = new LongWaitDlg(this))
             {
-                IdentityPath nextAdded;
+                longWaitDlg.Text = description;
                 longWaitDlg.PerformWork(this, 1000, longWaitBroker =>
-                    docNew = docCurrent.ImportFasta(reader, longWaitBroker, lineCount, matcher, to, out selectPath, out nextAdded, out emptyPeptideGroups));
+                    docNew = docCurrent.ImportFasta(reader, longWaitBroker, lineCount, matcher, to, out selectPath, out _, out emptyPeptideGroups));
 
                 if (docNew == null)
                     return;
@@ -1959,16 +1920,17 @@ namespace pwiz.Skyline
                 {
                     SrmDocument docNew = null;
                     selectPath = null;
-                    using (var longWaitDlg = new LongWaitDlg(this) {Text = description})
+                    using (var longWaitDlg = new LongWaitDlg(this))
                     {
+                        longWaitDlg.Text = description;
                         var smallMoleculeTransitionListReader = new SmallMoleculeTransitionListCSVReader(MassListInputs.ReadLinesFromText(csvText), columnPositions);
                         if (smallMoleculeTransitionListReader.RowCount == 0)
                         {
                             throw new InvalidDataException(Resources.MassListImporter_Import_Empty_transition_list);
                         }
-                        IdentityPath firstAdded;
+
                         longWaitDlg.PerformWork(this, 1000,
-                            () => docNew = smallMoleculeTransitionListReader.CreateTargets(doc, null, out firstAdded));
+                            () => docNew = smallMoleculeTransitionListReader.CreateTargets(doc, null, out _));
                             // CONSIDER: cancelable / progress monitor ?  This is normally pretty quick.
 
                         transitionCount = smallMoleculeTransitionListReader.RowCount - 1;
@@ -2018,17 +1980,15 @@ namespace pwiz.Skyline
 
         private void importAssayLibraryMenuItem_Click(object sender, EventArgs e)
         {
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                Title = Resources.SkylineWindow_importAssayLibraryMenuItem_Click_Import_Assay_Library,
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                CheckPathExists = true,
-                SupportMultiDottedExtensions = true,
-                DefaultExt = TextUtil.EXT_CSV,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
-                    Resources.SkylineWindow_importAssayLibraryMenuItem_Click_Assay_Library, TextUtil.EXT_CSV, TextUtil.EXT_TSV))
-            })
-            {
+                dlg.Title = Resources.SkylineWindow_importAssayLibraryMenuItem_Click_Import_Assay_Library;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.CheckPathExists = true;
+                dlg.SupportMultiDottedExtensions = true;
+                dlg.DefaultExt = TextUtil.EXT_CSV;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
+                    Resources.SkylineWindow_importAssayLibraryMenuItem_Click_Assay_Library, TextUtil.EXT_CSV, TextUtil.EXT_TSV));
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -2076,17 +2036,15 @@ namespace pwiz.Skyline
 
         private void importMassListMenuItem_Click(object sender, EventArgs e)
         {
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.SkylineWindow_importMassListMenuItem_Click_Import_Transition_List_title,
-                InitialDirectory = Settings.Default.ActiveDirectory,    // TODO: Better value?
-                CheckPathExists = true,
-                SupportMultiDottedExtensions = true,
-                DefaultExt = TextUtil.EXT_CSV,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
-                    Resources.SkylineWindow_importMassListMenuItem_Click_Transition_List, TextUtil.EXT_CSV, TextUtil.EXT_TSV)),
-            })
-            {
+                dlg.Title = Resources.SkylineWindow_importMassListMenuItem_Click_Import_Transition_List_title;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory; // TODO: Better value?
+                dlg.CheckPathExists = true;
+                dlg.SupportMultiDottedExtensions = true;
+                dlg.DefaultExt = TextUtil.EXT_CSV;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
+                    Resources.SkylineWindow_importMassListMenuItem_Click_Transition_List, TextUtil.EXT_CSV, TextUtil.EXT_TSV));
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.ActiveDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -2135,11 +2093,9 @@ namespace pwiz.Skyline
             Dictionary<string, FastaSequence> proteinAssociations = null;
             MassListImporter importer = null;
             var analyzingMessage = string.Format(Resources.SkylineWindow_ImportMassList_Analyzing_input__0_, inputs.InputFilename ?? string.Empty);
-            using (var longWaitDlg0 = new LongWaitDlg(this)
+            using (var longWaitDlg0 = new LongWaitDlg(this))
             {
-                Text = analyzingMessage,
-            })
-            {
+                longWaitDlg0.Text = analyzingMessage;
                 var current = docCurrent;
                 var status = longWaitDlg0.PerformWork(this, 1000, longWaitBroker =>
                 {
@@ -2538,8 +2494,9 @@ namespace pwiz.Skyline
                     return false;
                 overwriteExisting = overwriteResult == DialogResult.No;
             }
-            using (var longWaitDlg = new LongWaitDlg(this) { Text = Resources.SkylineWindow_ImportMassList_Adding_iRT_values_ })
+            using (var longWaitDlg = new LongWaitDlg(this))
             {
+                longWaitDlg.Text = Resources.SkylineWindow_ImportMassList_Adding_iRT_values_;
                 var newDoc = doc;
                 longWaitDlg.PerformWork(this, 100, progressMonitor => newDoc = newDoc.AddIrtPeptides(dbIrtPeptides, overwriteExisting, progressMonitor));
                 doc = newDoc;
@@ -2607,8 +2564,9 @@ namespace pwiz.Skyline
             using (var blibDb = BlibDb.CreateBlibDb(AssayLibraryFileName))
             {
                 docLibrarySpec = new BiblioSpecLiteSpec(AssayLibraryName ?? Path.GetFileNameWithoutExtension(AssayLibraryFileName), AssayLibraryFileName);
-                using (var longWaitDlg = new LongWaitDlg(this) { Text = Resources.SkylineWindow_ImportMassListIntensities_Creating_Spectral_Library })
+                using (var longWaitDlg = new LongWaitDlg(this))
                 {
+                    longWaitDlg.Text = Resources.SkylineWindow_ImportMassListIntensities_Creating_Spectral_Library;
                     var docNew = doc;
                     BiblioSpecLiteLibrary docLibraryNew = null;
                     var docLibrarySpec2 = docLibrarySpec;
@@ -2634,18 +2592,15 @@ namespace pwiz.Skyline
 
         private void importDocumentMenuItem_Click(object sender, EventArgs e)
         {
-            using (OpenFileDialog dlg = new OpenFileDialog
+            using (OpenFileDialog dlg = new OpenFileDialog())
             {
-                Title = Resources.SkylineWindow_importDocumentMenuItem_Click_Import_Skyline_Document,
-
-                InitialDirectory = Settings.Default.ActiveDirectory,
-                CheckPathExists = true,
-                Multiselect = true,
-                SupportMultiDottedExtensions = true,
-                DefaultExt = SrmDocument.EXT,
-                Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC),
-            })
-            {
+                dlg.Title = Resources.SkylineWindow_importDocumentMenuItem_Click_Import_Skyline_Document;
+                dlg.InitialDirectory = Settings.Default.ActiveDirectory;
+                dlg.CheckPathExists = true;
+                dlg.Multiselect = true;
+                dlg.SupportMultiDottedExtensions = true;
+                dlg.DefaultExt = SrmDocument.EXT;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(SrmDocument.FILTER_DOC);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     try
@@ -2688,11 +2643,9 @@ namespace pwiz.Skyline
 
             var docCurrent = DocumentUI;
             SrmDocument docNew = null;
-            using (var longWaitDlg = new LongWaitDlg(this)
-                {
-                    Text = Resources.SkylineWindow_ImportFiles_Import_Skyline_document_data,
-                })
+            using (var longWaitDlg = new LongWaitDlg(this))
             {
+                longWaitDlg.Text = Resources.SkylineWindow_ImportFiles_Import_Skyline_document_data;
                 longWaitDlg.PerformWork(this, 1000, longWaitBroker =>
                     docNew = ImportFiles(docCurrent,
                                          longWaitBroker,
@@ -2793,14 +2746,12 @@ namespace pwiz.Skyline
             string result = null;
             RunUIAction(() =>
                             {
-                                using (var dlg = new MissingFileDlg
+                                using (var dlg = new MissingFileDlg())
                                 {
-                                    ItemName = libraryName,
-                                    FileHint = fileName,
-                                    ItemType = Resources.SkylineWindow_ConnectLibrarySpecs_Spectral_Library,
-                                    Title = Resources.SkylineWindow_ConnectLibrarySpecs_Find_Spectral_Library
-                                })
-                                {
+                                    dlg.ItemName = libraryName;
+                                    dlg.FileHint = fileName;
+                                    dlg.ItemType = Resources.SkylineWindow_ConnectLibrarySpecs_Spectral_Library;
+                                    dlg.Title = Resources.SkylineWindow_ConnectLibrarySpecs_Find_Spectral_Library;
                                     if (dlg.ShowDialog(this) == DialogResult.OK)
                                         result = dlg.FilePath;
                                 }
@@ -3715,13 +3666,11 @@ namespace pwiz.Skyline
 
         private void importAnnotationsMenuItem_Click(object sender, EventArgs e)
         {
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                DefaultExt = TextUtil.EXT_CSV,
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FILTER_CSV),
-                InitialDirectory = Settings.Default.ExportDirectory,
-            })
-            {
+                dlg.DefaultExt = TextUtil.EXT_CSV;
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FILTER_CSV);
+                dlg.InitialDirectory = Settings.Default.ExportDirectory;
                 if (dlg.ShowDialog(this) != DialogResult.OK)
                 {
                     return;

--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -3298,7 +3298,7 @@ namespace pwiz.Skyline
                     regression = dlg.Regression;
                     listRegression.Add(regression);
 
-                    ModifyDocument(string.Format(Resources.SkylineWindow_CreateRegression_Set_regression__0__, regression?.Name),
+                    ModifyDocument(string.Format(Resources.SkylineWindow_CreateRegression_Set_regression__0__, regression!.Name),
                                    doc =>
                                    doc.ChangeSettings(
                                        doc.Settings.ChangePeptidePrediction(p => p.ChangeRetentionTime(regression))), AuditLogEntry.SettingsLogFunction);

--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -338,11 +338,10 @@ namespace pwiz.Skyline
                         // Look for matching chromatogram sets across the documents
                         ChromatogramSet chromSetOld;
                         ChromatogramSet chromSetNew;
-                        int index;
                         if (settingsOld.HasResults &&
-                            settingsOld.MeasuredResults.TryGetChromatogramSet(name, out chromSetOld, out index) &&
+                            settingsOld.MeasuredResults.TryGetChromatogramSet(name, out chromSetOld, out _) &&
                             settingsNew.HasResults &&
-                            settingsNew.MeasuredResults.TryGetChromatogramSet(chromSetOld.Id.GlobalIndex, out chromSetNew, out index))
+                            settingsNew.MeasuredResults.TryGetChromatogramSet(chromSetOld.Id.GlobalIndex, out chromSetNew, out _))
                         {
                             // If matching chromatogram found, but name has changed, then
                             // update the graph pane
@@ -1893,8 +1892,7 @@ namespace pwiz.Skyline
         {
             get
             {
-                MsDataFileUri temp;
-                return GetGraphChromStrings(SelectedResultsIndex, null, out temp);
+                return GetGraphChromStrings(SelectedResultsIndex, null, out _);
             }
         }
 
@@ -1952,8 +1950,7 @@ namespace pwiz.Skyline
             {
                 var graphPosition = GetGraphChrom(namePosition);
 
-                IDockableForm formBefore;
-                DockPane paneExisting = FindChromatogramPane(graphPosition, out formBefore);
+                DockPane paneExisting = FindChromatogramPane(graphPosition);
                 if (paneExisting == null)
                     graphChrom.Show(dockPanel.Panes[firstDocumentPane], DockPaneAlignment.Left, 0.5);
                 else if (!split)
@@ -1978,7 +1975,7 @@ namespace pwiz.Skyline
             }
         }
 
-        private DockPane FindChromatogramPane(GraphChromatogram graphChrom, out IDockableForm formBefore)
+        private DockPane FindChromatogramPane(GraphChromatogram graphChrom)
         {
             foreach (var pane in dockPanel.Panes)
             {
@@ -1987,12 +1984,10 @@ namespace pwiz.Skyline
                     if (form is GraphChromatogram &&
                         (graphChrom == null || graphChrom == form))
                     {
-                        formBefore = form;
                         return pane;
                     }
                 }
             }
-            formBefore = null;
             return null;
         }
 
@@ -2205,10 +2200,9 @@ namespace pwiz.Skyline
                 ? transitionGroupDocNode.Transitions.FirstOrDefault(tr => ReferenceEquals(tr.Id, args.Transition))
                 : null;
 
-            ChromatogramSet chromatograms;
             int indexSet;
             if (!Document.Settings.HasResults ||
-                !Document.Settings.MeasuredResults.TryGetChromatogramSet(args.NameSet, out chromatograms, out indexSet))
+                !Document.Settings.MeasuredResults.TryGetChromatogramSet(args.NameSet, out _, out indexSet))
                 return result;
 
             float? startTime = null;
@@ -2741,9 +2735,8 @@ namespace pwiz.Skyline
         public void ActivateReplicate(string name)
         {
             int index;
-            ChromatogramSet chromatogramSet;
 
-            if (DocumentUI.Settings.MeasuredResults.TryGetChromatogramSet(name, out chromatogramSet, out index))
+            if (DocumentUI.Settings.MeasuredResults.TryGetChromatogramSet(name, out _, out index))
             {
                 SelectedResultsIndex = index;
             }
@@ -3266,8 +3259,9 @@ namespace pwiz.Skyline
 
         public void ShowRegressionRTThresholdDlg()
         {
-            using (var dlg = new RegressionRTThresholdDlg {Threshold = Settings.Default.RTResidualRThreshold})
+            using (var dlg = new RegressionRTThresholdDlg())
             {
+                dlg.Threshold = Settings.Default.RTResidualRThreshold;
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     Settings.Default.RTResidualRThreshold = dlg.Threshold;
@@ -3295,15 +3289,16 @@ namespace pwiz.Skyline
             if (regression != null)
                 regression = (RetentionTimeRegression) regression.ChangeName(name);
 
-            using (var dlg = new EditRTDlg(listRegression) { Regression = regression })
+            using (var dlg = new EditRTDlg(listRegression))
             {
+                dlg.Regression = regression;
                 dlg.ShowPeptides(true);
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     regression = dlg.Regression;
                     listRegression.Add(regression);
 
-                    ModifyDocument(string.Format(Resources.SkylineWindow_CreateRegression_Set_regression__0__, regression.Name),
+                    ModifyDocument(string.Format(Resources.SkylineWindow_CreateRegression_Set_regression__0__, regression?.Name),
                                    doc =>
                                    doc.ChangeSettings(
                                        doc.Settings.ChangePeptidePrediction(p => p.ChangeRetentionTime(regression))), AuditLogEntry.SettingsLogFunction);
@@ -5650,6 +5645,7 @@ namespace pwiz.Skyline
             else
             {
                 rows = 1;
+                // ReSharper disable once PossibleLossOfFraction
                 while ((height / rows) / (width / (groups / rows + (groups % rows > 0 ? 1 : 0))) > MAX_TILED_ASPECT_RATIO)
                     rows++;
             }
@@ -5828,8 +5824,7 @@ namespace pwiz.Skyline
                 // already be.
                 foreach (var graph in listGraphs)
                 {
-                    int i;
-                    if (!dictOrder.TryGetValue(graph, out i))
+                    if (!dictOrder.TryGetValue(graph, out _))
                         dictOrder.Add(graph, iOrder++);
                 }
 

--- a/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.cs
+++ b/pwiz_tools/Skyline/SkylineNightly/SkylineNightly.cs
@@ -189,15 +189,12 @@ namespace SkylineNightly
 
         private void buttonFolder_Click(object sender, EventArgs e)
         {
-            using (var dlg = new FolderBrowserDialog
+            using (var dlg = new FolderBrowserDialog())
             {
                 // ReSharper disable LocalizableElement
-                Description = "Select or create a nightly build folder.", 
-                // ReSharper restore LocalizableElement
-                ShowNewFolderButton = true,
-                SelectedPath = textBoxFolder.Text
-            })
-            {
+                dlg.Description = "Select or create a nightly build folder."; // ReSharper restore LocalizableElement
+                dlg.ShowNewFolderButton = true;
+                dlg.SelectedPath = textBoxFolder.Text;
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     textBoxFolder.Text = dlg.SelectedPath;

--- a/pwiz_tools/Skyline/SkylineTester/CreateZipInstallerWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CreateZipInstallerWindow.cs
@@ -49,12 +49,10 @@ namespace SkylineTester
 
         private void buttonBrowse_Click(object sender, EventArgs e)
         {
-            using (var dlg = new FolderBrowserDialog
+            using (var dlg = new FolderBrowserDialog())
             {
-                Description = "Select a folder to contain the zip file.",
-                ShowNewFolderButton = true
-            })
-            {
+                dlg.Description = "Select a folder to contain the zip file.";
+                dlg.ShowNewFolderButton = true;
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                     textBoxZipDirectory.Text = dlg.SelectedPath;
             }

--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -496,9 +496,7 @@ namespace SkylineTester
 
         private bool GraphOnMouseMoveEvent(ZedGraphControl sender, MouseEventArgs e)
         {
-            CurveItem nearestCurve;
-            int index;
-            if (sender.GraphPane.FindNearestPoint(new PointF(e.X, e.Y), out nearestCurve, out index))
+            if (sender.GraphPane.FindNearestPoint(new PointF(e.X, e.Y), out _, out _))
                 sender.Cursor = Cursors.Hand;
             return false;
         }

--- a/pwiz_tools/Skyline/SkylineTester/Summary.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Summary.cs
@@ -70,8 +70,8 @@ namespace SkylineTester
                 run.CommittedMemory = committedMemory;
                 run.TotalMemory = totalMemory;
             }
-            int userHandles, gdiHandles, unexpected;
-            if (handlesIndex < parts.Length && ParseMemoryPart(parts[handlesIndex], out userHandles, out gdiHandles, out unexpected))
+            int userHandles, gdiHandles;
+            if (handlesIndex < parts.Length && ParseMemoryPart(parts[handlesIndex], out userHandles, out gdiHandles, out _))
             {
                 run.UserHandles = userHandles;
                 run.GdiHandles = gdiHandles;

--- a/pwiz_tools/Skyline/SkylineTester/TabBuild.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabBuild.cs
@@ -255,12 +255,10 @@ namespace SkylineTester
 
         public void BrowseBuild()
         {
-            using (var dlg = new FolderBrowserDialog
+            using (var dlg = new FolderBrowserDialog())
             {
-                Description = "Select or create a root folder for build source files.",
-                ShowNewFolderButton = true
-            })
-            {
+                dlg.Description = "Select or create a root folder for build source files.";
+                dlg.ShowNewFolderButton = true;
                 if (dlg.ShowDialog(MainWindow) == DialogResult.OK)
                     MainWindow.BuildRoot.Text = dlg.SelectedPath;
             }

--- a/pwiz_tools/Skyline/SkylineTester/TabNightly.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabNightly.cs
@@ -678,12 +678,10 @@ namespace SkylineTester
 
         public void BrowseBuild()
         {
-            using (var dlg = new FolderBrowserDialog
+            using (var dlg = new FolderBrowserDialog())
             {
-                Description = "Select or create a root folder for build source files.",
-                ShowNewFolderButton = true
-            })
-            {
+                dlg.Description = "Select or create a root folder for build source files.";
+                dlg.ShowNewFolderButton = true;
                 if (dlg.ShowDialog(MainWindow) == DialogResult.OK)
                 {
                     var nightlyRoot = dlg.SelectedPath;
@@ -733,10 +731,8 @@ namespace SkylineTester
 
         private bool GraphMouseMoveEvent(ZedGraphControl sender, MouseEventArgs e)
         {
-            CurveItem nearestCurve;
-            int index;
             if (_mouseDownLocation == Point.Empty &&
-                sender.GraphPane.FindNearestPoint(new PointF(e.X, e.Y), out nearestCurve, out index))
+                sender.GraphPane.FindNearestPoint(new PointF(e.X, e.Y), out _, out _))
             {
                 sender.Cursor = Cursors.Hand;
                 return true;

--- a/pwiz_tools/Skyline/SkylineTester/TabRunStats.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabRunStats.cs
@@ -143,12 +143,10 @@ namespace SkylineTester
         /// </summary>
         public void ExportCSV()
         {
-            using (var openFileDlg = new SaveFileDialog
-                   {
-                       Filter = @"CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-                       Title = @"Export Run Stats"
-                   })
+            using (var openFileDlg = new SaveFileDialog())
             {
+                openFileDlg.Filter = @"CSV files (*.csv)|*.csv|All files (*.*)|*.*";
+                openFileDlg.Title = @"Export Run Stats";
                 if (openFileDlg.ShowDialog() != DialogResult.OK)
                     return;
                 using (var report = new StreamWriter(openFileDlg.FileName))

--- a/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
+++ b/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
@@ -572,8 +572,8 @@ namespace pwiz.SkylineTest
                     var lines = content.Split('\n');
 
                     var lineNum = 0;
-                    var requiredPatternsObservedInThisFile = requiredPatternsByFileMask.ContainsKey(fileMask)
-                        ? requiredPatternsByFileMask[fileMask].Where(kvp =>
+                    var requiredPatternsObservedInThisFile = requiredPatternsByFileMask.TryGetValue(fileMask, out var value)
+                        ? value.Where(kvp =>
                         {
                             // Do we need to worry about this pattern for this file?
                             var patternDetails = kvp.Value;
@@ -583,9 +583,8 @@ namespace pwiz.SkylineTest
                         }).ToDictionary(k => k.Key, k => false)
                         : null;
                     var forbiddenPatternsForThisFile =
-                        forbiddenPatternsByFileMask
-                            .ContainsKey(fileMask) // Are there any forbidden patterns for this filemask?
-                            ? forbiddenPatternsByFileMask[fileMask].Where(kvp =>
+                        forbiddenPatternsByFileMask.TryGetValue(fileMask, out var patterns) // Are there any forbidden patterns for this filemask?
+                            ? patterns.Where(kvp =>
                             {
                                 // Do we need to worry about this pattern for this file?
                                 var patternDetails = kvp.Value;

--- a/pwiz_tools/Skyline/Test/IsotypeModTest.cs
+++ b/pwiz_tools/Skyline/Test/IsotypeModTest.cs
@@ -215,8 +215,7 @@ namespace pwiz.SkylineTest
         {
             var docImport = AssertEx.RoundTripTransitionList(exporter);
 
-            int countProteinTermTran, countProteinTerm;
-            VerifyMultiLabelContent(docFasta, docImport, out countProteinTerm, out countProteinTermTran);
+            VerifyMultiLabelContent(docFasta, docImport, out _, out _);
         }
 
         private static void VerifyMultiLabelContent(SrmDocument docFasta, SrmDocument docMulti,

--- a/pwiz_tools/Skyline/Test/LibrarySettingsTest.cs
+++ b/pwiz_tools/Skyline/Test/LibrarySettingsTest.cs
@@ -53,13 +53,13 @@ namespace pwiz.SkylineTest
         }
 
         private static SrmDocument CreateNISTLibraryDocument(out LibraryManager libraryManager,
-            out TestDocumentContainer docContainer, out int startRev)
+            out int startRev)
         {
             SrmDocument docLoaded = CreateNISTLibraryDocument(ExampleText.TEXT_FASTA_YEAST_LIB,
                                                               false,
                                                               LibraryLoadTest.TEXT_LIB_YEAST_NIST,
                                                               out libraryManager,
-                                                              out docContainer,
+                                                              out _,
                                                               out startRev);
             AssertEx.IsDocumentState(docLoaded, startRev, 2, 4, 12);
             return docLoaded;
@@ -130,9 +130,8 @@ namespace pwiz.SkylineTest
         public void LibraryOnlyPeptidesTest()
         {
             LibraryManager libraryManager;
-            TestDocumentContainer docContainer;
             int startRev;
-            SrmDocument docLoaded = CreateNISTLibraryDocument(out libraryManager, out docContainer, out startRev);
+            SrmDocument docLoaded = CreateNISTLibraryDocument(out libraryManager, out startRev);
             Assert.IsTrue(HasAllLibraryInfo(docLoaded));
             AssertEx.Serializable(docLoaded, (doc1, doc2) => ValidateLibraryDocs(doc1, doc2, libraryManager));
 
@@ -271,9 +270,8 @@ namespace pwiz.SkylineTest
         public void LibraryTransitionTest()
         {
             LibraryManager libraryManager;
-            TestDocumentContainer docContainer;
             int startRev;
-            SrmDocument docLoaded = CreateNISTLibraryDocument(out libraryManager, out docContainer, out startRev);
+            SrmDocument docLoaded = CreateNISTLibraryDocument(out libraryManager, out startRev);
 
             // Test tolerance range
             SrmSettings settings = docLoaded.Settings.ChangeTransitionLibraries(l =>

--- a/pwiz_tools/Skyline/Test/MProphetScoringModelTest.cs
+++ b/pwiz_tools/Skyline/Test/MProphetScoringModelTest.cs
@@ -385,9 +385,8 @@ namespace pwiz.SkylineTest
                 var dataIndex = 1;
                 foreach (var heading in Header)
                 {
-                    double d;
                     const NumberStyles numberStyle = NumberStyles.Float | NumberStyles.AllowThousands;
-                    if (!double.TryParse(heading, numberStyle, CultureInfo.InvariantCulture, out d))
+                    if (!double.TryParse(heading, numberStyle, CultureInfo.InvariantCulture, out _))
                     {
                         allNumeric = false;
                         break;

--- a/pwiz_tools/Skyline/Test/ModificationMatcherTest.cs
+++ b/pwiz_tools/Skyline/Test/ModificationMatcherTest.cs
@@ -89,10 +89,8 @@ namespace pwiz.SkylineTest
             // Updating the settings.
             // Peptide settings should change to include new mods.
             var docNew = new SrmDocument(SrmSettingsList.GetDefault());
-            IdentityPath firstAdded;
-            IdentityPath nextAdded;
             docNew = docNew.AddPeptideGroups(new[] { new PeptideGroupDocNode(new PeptideGroup(), "PepGroup1", "",
-                new[] {MATCHER.GetModifiedNode(STR_MOD_BY_NAME)})}, true, null, out firstAdded, out nextAdded);
+                new[] {MATCHER.GetModifiedNode(STR_MOD_BY_NAME)})}, true, null, out _, out _);
             var pepSetNew = MATCHER.GetDocModifications(docNew);
             Assert.IsTrue(pepSetNew.StaticModifications.Contains(UniMod.GetModification("Phospho (ST)", true).ChangeExplicit(true)));
             // Update the document to the new settings.
@@ -215,7 +213,7 @@ namespace pwiz.SkylineTest
             Assert.IsTrue(MATCHER.GetModifiedNode(STR_HEAVY_15_F).ExplicitMods.GetHeavyModifications().Contains(mod => Equals(mod.LabelType, heavyLabelType2)));
             // Peptide settings should not change.
             var docNew0 = new SrmDocument(settingsMultiLabel).AddPeptideGroups(new[] { new PeptideGroupDocNode(new PeptideGroup(), 
-                "PepGroup1", "", new[] {MATCHER.GetModifiedNode(STR_HEAVY_15_F)})}, true, null, out firstAdded, out nextAdded);
+                "PepGroup1", "", new[] {MATCHER.GetModifiedNode(STR_HEAVY_15_F)})}, true, null, out _, out _);
             var settingsNew = MATCHER.GetDocModifications(docNew0);
             Assert.AreEqual(settingsMultiLabel.PeptideSettings.Modifications.ChangeHasHeavyModifications(false), 
                 settingsNew.ChangeHasHeavyModifications(false));

--- a/pwiz_tools/Skyline/Test/PasteTest.cs
+++ b/pwiz_tools/Skyline/Test/PasteTest.cs
@@ -68,9 +68,8 @@ namespace pwiz.SkylineTest
             _yeastDoc = new SrmDocument(SrmSettingsList.GetDefault().ChangeTransitionInstrument(instrument => instrument.ChangeMaxMz(1600)));
             _yeastDoc = _yeastDoc.ChangeSettings(_yeastDoc.Settings.ChangeTransitionFilter(filter =>
                                                                                            filter.ChangeMeasuredIons(new MeasuredIon[0])));
-            IdentityPath path;
             _yeastDocReadOnly = _yeastDoc = _yeastDoc.ImportFasta(new StringReader(ExampleText.TEXT_FASTA_YEAST_LIB),
-                false, IdentityPath.ROOT, out path);
+                false, IdentityPath.ROOT, out _);
 
             _study7DocReadOnly = _study7Doc = CreateStudy7Doc();
 
@@ -206,12 +205,13 @@ namespace pwiz.SkylineTest
                 sourceDoc = sourceDoc.RemoveAllBut(nodes);
            
             var stringWriter = new XmlStringWriter();
-            using (var writer = new XmlTextWriter(stringWriter) { Formatting = Formatting.Indented })
+            using (var writer = new XmlTextWriter(stringWriter))
             {
+                writer.Formatting = Formatting.Indented;
                 XmlSerializer ser = new XmlSerializer(typeof(SrmDocument));
                 ser.Serialize(writer, sourceDoc);
             }
-            IdentityPath newPath, nextAdd;
+
             targetDoc = targetDoc.ImportDocumentXml(new StringReader(stringWriter.ToString()),
                                                     null,
                                                     MeasuredResults.MergeAction.remove,
@@ -220,8 +220,8 @@ namespace pwiz.SkylineTest
                                                     Settings.Default.StaticModList,
                                                     Settings.Default.HeavyModList,
                                                     to,
-                                                    out newPath,
-                                                    out nextAdd,
+                                                    out _,
+                                                    out _,
                                                     false);
             return targetDoc;
         }

--- a/pwiz_tools/Skyline/Test/SrmDocEditTest.cs
+++ b/pwiz_tools/Skyline/Test/SrmDocEditTest.cs
@@ -306,24 +306,23 @@ namespace pwiz.SkylineTest
         {
             // First try removals with no impact
             SrmDocument document = new SrmDocument(SrmSettingsList.GetDefault0_6());
-            IdentityPath path;
             SrmDocument docFasta = document.ImportFasta(new StringReader(string.Format(TEXT_FASTA_YEAST_FRAGMENT, 1)),
-                false, IdentityPath.ROOT, out path);
+                false, IdentityPath.ROOT, out _);
             AssertEx.IsDocumentState(docFasta, 1, 1, 11, 36);
             var refinementSettings = new RefinementSettings {RemoveDuplicatePeptides = true};
             SrmDocument docFasta2 = refinementSettings.Refine(docFasta);
             Assert.AreSame(docFasta, docFasta2);
 
             docFasta2 = docFasta.ImportFasta(new StringReader(string.Format(TEXT_FASTA_YEAST_FRAGMENT, 2)),
-                false, IdentityPath.ROOT, out path);
+                false, IdentityPath.ROOT, out _);
             // Adding same sequence twice, even with different custom names is ignored
             Assert.AreSame(docFasta, docFasta2);
 
             // Try a successful removal of duplicates that leaves no peptides
             SrmDocument docPeptides = document.ImportFasta(new StringReader(TEXT_BOVINE_PEPTIDES1),
-                true, IdentityPath.ROOT, out path);
+                true, IdentityPath.ROOT, out _);
             SrmDocument docPeptides2 = docPeptides.ImportFasta(new StringReader(TEXT_BOVINE_PEPTIDES1),
-                true, IdentityPath.ROOT, out path);            
+                true, IdentityPath.ROOT, out _);            
             AssertEx.IsDocumentState(docPeptides2, 2, 2, 26, 82);
             SrmDocument docPeptides3 = refinementSettings.Refine(docPeptides2);
             Assert.AreNotSame(docPeptides2, docPeptides3);
@@ -331,7 +330,7 @@ namespace pwiz.SkylineTest
 
             // Try again leaving a single peptide
             docPeptides2 = docPeptides.ImportFasta(new StringReader(TEXT_BOVINE_PEPTIDES1 + "\n" + TEXT_BOVINE_SINGLE_PEPTIDE),
-                true, IdentityPath.ROOT, out path);
+                true, IdentityPath.ROOT, out _);
             docPeptides3 = refinementSettings.Refine(docPeptides2);
             Assert.AreNotSame(docPeptides2, docPeptides3);
             AssertEx.IsDocumentState(docPeptides3, 3, 2, 1, 3);

--- a/pwiz_tools/Skyline/Test/SrmDocumentTest.cs
+++ b/pwiz_tools/Skyline/Test/SrmDocumentTest.cs
@@ -399,9 +399,8 @@ namespace pwiz.SkylineTest
                     AssertEx.NoDiff(targetList, actualList);
 
                 // Import the exported list
-                IdentityPath pathAdded;
                 var inputs = new MassListInputs(actualList, CultureInfo.InvariantCulture, TextUtil.SEPARATOR_CSV);
-                docImport = docImport.ImportMassList(inputs, null, IdentityPath.ROOT, out pathAdded);
+                docImport = docImport.ImportMassList(inputs, null, IdentityPath.ROOT, out _);
             }
 
             if (minTransition < 2)
@@ -453,12 +452,11 @@ namespace pwiz.SkylineTest
                 string actualList = exportedActual[key].ToString();
 
                 // Import the exported list
-                IdentityPath pathAdded;
                 try
                 {
                     var inputs = new MassListInputs(actualList, CultureInfo.InvariantCulture, TextUtil.SEPARATOR_CSV);
                     var importer = docImport.PreImportMassList(inputs, null, false);
-                    docImport = docImport.ImportMassList(inputs, importer, IdentityPath.ROOT, out pathAdded);
+                    docImport = docImport.ImportMassList(inputs, importer, IdentityPath.ROOT, out _);
                 }
                 catch
                 {
@@ -471,7 +469,7 @@ namespace pwiz.SkylineTest
                             RefinementSettings.TestingConvertedFromProteomicPeptideNameDecorator, string.Empty);
                     }
                     var inputs = new MassListInputs(actualList, CultureInfo.InvariantCulture, TextUtil.SEPARATOR_CSV);
-                    docImport = docImport.ImportMassList(inputs, null, IdentityPath.ROOT, out pathAdded);
+                    docImport = docImport.ImportMassList(inputs, null, IdentityPath.ROOT, out _);
                 }
             }
             return exportedActual.Count;

--- a/pwiz_tools/Skyline/Test/SrmSettingsChangeTest.cs
+++ b/pwiz_tools/Skyline/Test/SrmSettingsChangeTest.cs
@@ -409,14 +409,13 @@ namespace pwiz.SkylineTest
         private static SrmDocument CreateMixedDoc()
         {
             SrmDocument document = new SrmDocument(SrmSettingsList.GetDefault0_6());
-            IdentityPath path;
             // Add fasta sequences
             SrmDocument docFasta = document.ImportFasta(new StringReader(ExampleText.TEXT_FASTA_YEAST),
-                false, IdentityPath.ROOT, out path);
+                false, IdentityPath.ROOT, out _);
             AssertEx.IsDocumentState(docFasta, 1, 2, 98, 311);
             // Insert peptide list at beginnning
             SrmDocument docMixed = docFasta.ImportFasta(new StringReader(SrmDocEditTest.TEXT_BOVINE_PEPTIDES1),
-                true, docFasta.GetPathTo(0), out path);
+                true, docFasta.GetPathTo(0), out _);
             AssertEx.IsDocumentState(docMixed, 2, 3, 111, 352);
             return docMixed;            
         }

--- a/pwiz_tools/Skyline/Test/SrmSettingsTest.cs
+++ b/pwiz_tools/Skyline/Test/SrmSettingsTest.cs
@@ -1262,6 +1262,7 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(100, pred.FilterWindowWidthCalculator.ResolvingPower);
             CheckIonMobilitySettingsBackwardCompatibility(predictor3.Replace("20", "-1"),Resources.DriftTimeWindowWidthCalculator_Validate_Peak_width_must_be_non_negative_);
             CheckIonMobilitySettingsBackwardCompatibility(predictor3.Replace("500", "-1"), Resources.DriftTimeWindowWidthCalculator_Validate_Peak_width_must_be_non_negative_);
+            // ReSharper disable once PossibleLossOfFraction
             Assert.AreEqual(widthAtDt0 + (widthAtDtMax-widthAtDt0)*driftTime/driftTimeMax, pred.FilterWindowWidthCalculator.WidthAt(driftTime, driftTimeMax));
 
             // Test ability to roundtrip to older doc formats

--- a/pwiz_tools/Skyline/Test/TransitionSettings07Test.cs
+++ b/pwiz_tools/Skyline/Test/TransitionSettings07Test.cs
@@ -24,7 +24,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.Extensions;
-using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
 using pwiz.SkylineTestUtil;
@@ -99,9 +98,8 @@ namespace pwiz.SkylineTest
             Assert.AreEqual("CO2H", ParsedMolecule.Create("CO2").AdjustElementCount("H", 1).ToString());
 
             var docOriginal = new SrmDocument(SrmSettingsList.GetDefault().ChangeTransitionInstrument(instrument => instrument.ChangeMinMz(10)));  // H2O2 is not very heavy!
-            IdentityPath path;
             SrmDocument docPeptide = docOriginal.ImportFasta(new StringReader(">peptide1\nPEPMCIDEPR"),
-                true, IdentityPath.ROOT, out path);
+                true, IdentityPath.ROOT, out _);
             // One of the prolines should have caused an extra transition
             Assert.AreEqual(4, docPeptide.PeptideTransitionCount);
             Assert.IsTrue(docPeptide.PeptideTransitions.Contains(nodeTran => nodeTran.Transition.Ordinal == 8));
@@ -190,9 +188,8 @@ namespace pwiz.SkylineTest
                       .ChangeFragmentRangeFirstName("ion 1")
                       .ChangeFragmentRangeLastName("last ion"));
             var docOriginal = new SrmDocument(settings);
-            IdentityPath path;
             var docPeptides = docOriginal.ImportFasta(new StringReader(">peptides\nESTIGNSAFELLLEVAK\nTVYHAGTK"),
-                true, IdentityPath.ROOT, out path);
+                true, IdentityPath.ROOT, out _);
             AssertEx.IsDocumentState(docPeptides, revisionIndex++, 1, 2, 2, 40);
             // Both precursors should contain 1 and 2 ions
             foreach (var nodeGroup in docPeptides.PeptideTransitionGroups)
@@ -239,16 +236,13 @@ namespace pwiz.SkylineTest
         public void TransitionLibrary07Test()
         {
             // Create a document with the necessary library spectrum
-            LibraryManager libraryManager;
-            TestDocumentContainer docContainer;
-            int startRev;
             SrmDocument document = LibrarySettingsTest.CreateNISTLibraryDocument(
                 ">peptide1\nLECTDTLPDILENR",
                 true,
                 TEXT_LIB_YEAST_NIST_PRECURSOR,
-                out libraryManager,
-                out docContainer,
-                out startRev);
+                out _,
+                out _,
+                out _);
 
             // Open up the transition filter settings before testing the precursor m/z window
             var settings = document.Settings
@@ -330,16 +324,13 @@ namespace pwiz.SkylineTest
         public void TransitionLibraryDIAPrecursorExclusionTest()
         {
             // Create a document with the necessary library spectrum
-            LibraryManager libraryManager;
-            TestDocumentContainer docContainer;
-            int startRev;
             SrmDocument document = LibrarySettingsTest.CreateNISTLibraryDocument(
                 ">peptide1\nLECTDTLPDILENR",
                 true,
                 TEXT_LIB_YEAST_NIST_PRECURSOR,
-                out libraryManager,
-                out docContainer,
-                out startRev);
+                out _,
+                out _,
+                out _);
 
             // Open up the transition filter settings and add a new isolation window scheme 
             List<IsolationWindow> isolationWindows = new List<IsolationWindow>();

--- a/pwiz_tools/Skyline/Test/VariableModTest.cs
+++ b/pwiz_tools/Skyline/Test/VariableModTest.cs
@@ -234,15 +234,13 @@ namespace pwiz.SkylineTest
         [TestMethod]
         public void VariableModLibraryTest()
         {
-            LibraryManager libraryManager;
-            TestDocumentContainer docContainer;
             int startRev;
             SrmDocument document = LibrarySettingsTest.CreateNISTLibraryDocument(
                 TEXT_FASTA_YEAST_39,
                 false,
                 TEXT_LIB_YEAST_NIST,
-                out libraryManager,
-                out docContainer,
+                out _,
+                out _,
                 out startRev);
             AssertEx.IsDocumentState(document, startRev, 1, 1, 3);
 
@@ -266,15 +264,13 @@ namespace pwiz.SkylineTest
         public void VariableModPeptideListTest()
         {
             // Create a document with a peptide lists of 3 peptides
-            LibraryManager libraryManager;
-            TestDocumentContainer docContainer;
             int startRev;
             SrmDocument document = LibrarySettingsTest.CreateNISTLibraryDocument(
                 TEXT_PEPTIDES_YEAST,
                 true,
                 TEXT_LIB_YEAST_NIST,
-                out libraryManager,
-                out docContainer,
+                out _,
+                out _,
                 out startRev);
             AssertEx.IsDocumentState(document, startRev, 1, 3, 1, 3);
 
@@ -341,12 +337,9 @@ namespace pwiz.SkylineTest
                                     });
             document = document.ChangeSettings(document.Settings.ChangePeptideModifications(mods =>
                 mods.ChangeStaticModifications(staticMods)));
-            IdentityPath pathTo;
-            List<MeasuredRetentionTime> irtPeptides;
-            List<SpectrumMzInfo> librarySpectra;
             List<TransitionImportErrorInfo> errorList;
             var inputsPhospho = new MassListInputs(TEXT_PHOSPHO_TRANSITION_LIST, CultureInfo.InvariantCulture, TextUtil.SEPARATOR_CSV);
-            document.ImportMassList(inputsPhospho, null, out pathTo, out irtPeptides, out librarySpectra, out errorList);
+            document.ImportMassList(inputsPhospho, null, out _, out _, out _, out errorList);
             Assert.AreEqual(27, errorList.Count);
             AssertEx.AreComparableStrings(TextUtil.SpaceSeparate(Resources.MassListRowReader_CalcTransitionExplanations_The_product_m_z__0__is_out_of_range_for_the_instrument_settings__in_the_peptide_sequence__1_,
                                                 Resources.MassListRowReader_CalcPrecursorExplanations_Check_the_Instrument_tab_in_the_Transition_Settings),
@@ -356,7 +349,7 @@ namespace pwiz.SkylineTest
             Assert.AreEqual(40, errorList[0].LineNum);
 
             var docHighMax = document.ChangeSettings(document.Settings.ChangeTransitionInstrument(inst => inst.ChangeMaxMz(1800)));
-            var docList = docHighMax.ImportMassList(inputsPhospho, null, null, out pathTo);
+            var docList = docHighMax.ImportMassList(inputsPhospho, null, null, out _);
 
             AssertEx.Serializable(docList);
             AssertEx.IsDocumentState(docList, 3, 68, 134, 157, 481);
@@ -367,7 +360,7 @@ namespace pwiz.SkylineTest
             }
 
             var inputsMultiLoss = new MassListInputs(TEXT_PHOSPHO_MULTI_LOSS, CultureInfo.InvariantCulture, TextUtil.SEPARATOR_CSV);
-            docHighMax.ImportMassList(inputsMultiLoss, null, out pathTo, out irtPeptides, out librarySpectra, out errorList);
+            docHighMax.ImportMassList(inputsMultiLoss, null, out _, out _, out _, out errorList);
             Assert.AreEqual(5, errorList.Count);
             AssertEx.AreComparableStrings(Resources.MassListRowReader_CalcTransitionExplanations_Product_m_z_value__0__in_peptide__1__has_no_matching_product_ion,
                                          errorList[0].ErrorMessage,
@@ -377,7 +370,7 @@ namespace pwiz.SkylineTest
             
             var docMultiLos = docHighMax.ChangeSettings(docHighMax.Settings.ChangePeptideModifications(mods =>
                 mods.ChangeMaxNeutralLosses(2)));
-            docList = docMultiLos.ImportMassList(inputsMultiLoss, null, null, out pathTo);
+            docList = docMultiLos.ImportMassList(inputsMultiLoss, null, null, out _);
 
             AssertEx.IsDocumentState(docList, 4, 4, 4, 12);
         }

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -1762,8 +1762,7 @@ namespace pwiz.SkylineTestData
             doc = ResultsUtil.DeserializeDocument(outPath2);
             Assert.AreEqual(2, doc.Settings.MeasuredResults.Chromatograms.Count, msg);
             ChromatogramSet chromatSet;
-            int idx;
-            doc.Settings.MeasuredResults.TryGetChromatogramSet("160109_Mix1_calcurve_070", out chromatSet, out idx);
+            doc.Settings.MeasuredResults.TryGetChromatogramSet("160109_Mix1_calcurve_070", out chromatSet, out _);
             Assert.IsNotNull(chromatSet, msg);
             Assert.IsTrue(chromatSet.MSDataFilePaths.Contains(rawPath2));
 
@@ -1803,15 +1802,14 @@ namespace pwiz.SkylineTestData
             Assert.AreEqual(initialFileCount + 7, totalImportedFiles);
             // In the "REP01" replicate we should have 1 file
             ChromatogramSet chromatogramSet;
-            int index;
-            doc.Settings.MeasuredResults.TryGetChromatogramSet("REP01", out chromatogramSet, out index);
+            doc.Settings.MeasuredResults.TryGetChromatogramSet("REP01", out chromatogramSet, out _);
             Assert.IsNotNull(chromatogramSet);
             Assert.IsTrue(chromatogramSet.MSDataFilePaths.Count() == 1);
             Assert.IsTrue(chromatogramSet.MSDataFilePaths.Contains(
                 new MsDataFilePath(TestFilesDir.GetTestPath(@"REP01\CE_Vantage_15mTorr_0001_REP1_01" +
                                                             extRaw))));
             // REP012 should have the file REP01\CE_Vantage_15mTorr_0001_REP1_02.raw|mzML
-            doc.Settings.MeasuredResults.TryGetChromatogramSet("REP012", out chromatogramSet, out index);
+            doc.Settings.MeasuredResults.TryGetChromatogramSet("REP012", out chromatogramSet, out _);
             Assert.IsNotNull(chromatogramSet);
             Assert.IsTrue(chromatogramSet.MSDataFilePaths.Count() == 1);
             Assert.IsTrue(chromatogramSet.MSDataFilePaths.Contains(

--- a/pwiz_tools/Skyline/TestData/Results/ChromCacheMinimizerTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/ChromCacheMinimizerTest.cs
@@ -228,8 +228,9 @@ namespace pwiz.SkylineTestData.Results
                     fsScans.FileStream, fsPeaks.FileStream, fsScores.FileStream);
                 fs.Commit();
             }
-            using (var writer = new XmlTextWriter(skyFilePath, Encoding.UTF8) {Formatting = Formatting.Indented})
+            using (var writer = new XmlTextWriter(skyFilePath, Encoding.UTF8))
             {
+                writer.Formatting = Formatting.Indented;
                 var ser = new XmlSerializer(typeof (SrmDocument));
                 ser.Serialize(writer, document);
 

--- a/pwiz_tools/Skyline/TestData/Results/FullScanTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/FullScanTest.cs
@@ -51,9 +51,8 @@ namespace pwiz.SkylineTestData.Results
         [TestMethod]
         public void FullScanFilterTestCentroided()
         {
-            List<SrmDocument> docCheckpoints;
             if (ExtensionTestContext.CanImportThermoRaw)
-                DoFullScanFilterTest(RefinementSettings.ConvertToSmallMoleculesMode.none, out docCheckpoints, true);
+                DoFullScanFilterTest(RefinementSettings.ConvertToSmallMoleculesMode.none, out _, true);
         }
 
         [TestMethod]
@@ -410,8 +409,7 @@ namespace pwiz.SkylineTestData.Results
         [TestMethod]
         public void FullScanSettingsTest()
         {
-            List<SrmDocument> docCheckpoints;
-            DoFullScanSettingsTest(RefinementSettings.ConvertToSmallMoleculesMode.none, out docCheckpoints);
+            DoFullScanSettingsTest(RefinementSettings.ConvertToSmallMoleculesMode.none, out _);
         }
 
         [TestMethod]

--- a/pwiz_tools/Skyline/TestData/Results/MsxTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/MsxTest.cs
@@ -465,8 +465,7 @@ namespace pwiz.SkylineTestData.Results
             // Check that the caching worked correctly
             for (int spectrumIndex = firstSpectrum; spectrumIndex <= lastSpectrum; ++spectrumIndex)
             {
-                ScanCached specData;
-                Assert.IsTrue(spectrumProcessor.TryGetSpectrum(spectrumIndex, out specData));
+                Assert.IsTrue(spectrumProcessor.TryGetSpectrum(spectrumIndex, out _));
 
                 // Check that the cached processing results match the output of
                 // redoing the processing manually by extracting the spectrum from

--- a/pwiz_tools/Skyline/TestData/Results/SmallWiffTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/SmallWiffTest.cs
@@ -25,7 +25,6 @@ using pwiz.ProteowizardWrapper;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.DocSettings.Extensions;
-using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
@@ -235,19 +234,16 @@ namespace pwiz.SkylineTestData.Results
             settings = settings.ChangePeptideModifications(mods => mods.ChangeModifications(IsotopeLabelType.heavy, heavyMods));
             SrmDocument doc = new SrmDocument(settings);
 
-            IdentityPath selectPath;
             string path = testFilesDir.GetTestPath("051309_transition list.csv");
             // Product m/z out of range
             var docError = doc;
-            List<MeasuredRetentionTime> irtPeptides;
-            List<SpectrumMzInfo> librarySpectra;
             List<TransitionImportErrorInfo> errorList;
             var inputs = new MassListInputs(path)
             {
                 FormatProvider = CultureInfo.InvariantCulture,
                 Separator = TextUtil.SEPARATOR_CSV
             };
-            docError.ImportMassList(inputs, null, out selectPath, out irtPeptides, out librarySpectra, out errorList);
+            docError.ImportMassList(inputs, null, out _, out _, out _, out errorList);
             Assert.AreEqual(errorList.Count, 1);
             AssertEx.AreComparableStrings(TextUtil.SpaceSeparate(Resources.MassListRowReader_CalcTransitionExplanations_The_product_m_z__0__is_out_of_range_for_the_instrument_settings__in_the_peptide_sequence__1_,
                                                 Resources.MassListRowReader_CalcPrecursorExplanations_Check_the_Instrument_tab_in_the_Transition_Settings),
@@ -262,7 +258,7 @@ namespace pwiz.SkylineTestData.Results
                 FormatProvider = CultureInfo.InvariantCulture,
                 Separator = TextUtil.SEPARATOR_CSV
             };
-            doc = doc.ImportMassList(inputs, null, null, out selectPath);
+            doc = doc.ImportMassList(inputs, null, null, out _);
 
             AssertEx.IsDocumentState(doc, 2, 9, 9, 18, 54);
             return doc;

--- a/pwiz_tools/Skyline/TestData/XmlValidationTest.cs
+++ b/pwiz_tools/Skyline/TestData/XmlValidationTest.cs
@@ -291,8 +291,9 @@ namespace pwiz.SkylineTestData
 
         private static void WriteDocument(SrmDocument doc, string docPath)
         {
-            using (var writer = new XmlTextWriter(docPath, Encoding.UTF8) { Formatting = Formatting.Indented })
+            using (var writer = new XmlTextWriter(docPath, Encoding.UTF8))
             {
+                writer.Formatting = Formatting.Indented;
                 XmlSerializer ser = new XmlSerializer(typeof(SrmDocument));
                 ser.Serialize(writer, doc);
 

--- a/pwiz_tools/Skyline/TestFunctional/ChromUITest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ChromUITest.cs
@@ -25,7 +25,6 @@ using pwiz.Skyline;
 using pwiz.Skyline.Controls.Graphs;
 using pwiz.Skyline.EditUI;
 using pwiz.Skyline.Model;
-using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Model.Results.Scoring;
 using pwiz.SkylineTestUtil;
 using ZedGraph;
@@ -106,8 +105,7 @@ namespace pwiz.SkylineTestFunctional
         private void VerifyRawTimesCount(string chromName, TransitionDocNode transition, bool showing)
         {
             int resultIndex;
-            ChromatogramSet chromSet;
-            Assert.IsTrue(SkylineWindow.Document.Settings.MeasuredResults.TryGetChromatogramSet(chromName, out chromSet, out resultIndex));
+            Assert.IsTrue(SkylineWindow.Document.Settings.MeasuredResults.TryGetChromatogramSet(chromName, out _, out resultIndex));
 
             RunUI(() =>
             {

--- a/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditCustomMoleculeDlgTest.cs
@@ -73,13 +73,11 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() =>
                 SkylineWindow.ModifyDocument("", doc =>
                 {
-                    IdentityPath first;
-                    IdentityPath next;
                     return doc.AddPeptideGroups(new[]
                     {
                         new PeptideGroupDocNode(new PeptideGroup(), doc.Annotations, "Molecule Group", "",
                             new PeptideDocNode[0])
-                    }, true, IdentityPath.ROOT, out first, out next);
+                    }, true, IdentityPath.ROOT, out _, out _);
                 }));
             var docNext = WaitForDocumentChange(origDoc);
             TestAddingSmallMoleculeAsMasses();
@@ -99,13 +97,11 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() =>
                 SkylineWindow.ModifyDocument("", doc =>
                 {
-                    IdentityPath first;
-                    IdentityPath next;
                     return doc.AddPeptideGroups(new[]
                     {
                         new PeptideGroupDocNode(new PeptideGroup(), doc.Annotations, "Molecule Group", "",
                             new PeptideDocNode[0])
-                    }, true, IdentityPath.ROOT, out first, out next);
+                    }, true, IdentityPath.ROOT, out _, out _);
                 }));
             var docNext = WaitForDocumentChange(origDoc);
             TestAddingSmallMolecule();

--- a/pwiz_tools/Skyline/TestFunctional/EditCustomThemeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditCustomThemeTest.cs
@@ -155,6 +155,7 @@ namespace pwiz.SkylineTestFunctional
                 AssertColor(colors[18], Color.RoyalBlue);
                 OkDialog(editCustomThemeDlg, editCustomThemeDlg.save); // Now save changes
                 Assert.IsNull(ColorScheme.ColorSchemeDemo);
+                // ReSharper disable once HeuristicUnreachableCode
                 AssertColor(ColorScheme.CurrentColorScheme.TransitionColors[0], Color.Blue);
                 AssertColor(ColorScheme.CurrentColorScheme.TransitionColors[1], Color.Gray);
                 OkDialog(toolOptionsUI, toolOptionsUI.OkDialog);

--- a/pwiz_tools/Skyline/TestFunctional/ExplicitRTTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExplicitRTTest.cs
@@ -74,8 +74,7 @@ namespace pwiz.SkylineTestFunctional
         private void DoSubTest(TestFilesDir testFilesDir, string skyFile, double[] expectedRTs, string[] filenames, double? expectedRatio,
             Adduct[] expectedAdducts)
         {
-            string docPath;
-            var doc = InitExplicitRTDocument(testFilesDir, skyFile, out docPath);
+            var doc = InitExplicitRTDocument(testFilesDir, skyFile);
             
             // These test files are some of our oldest small molecule docs, let's see if we can roundtrip them
             AssertEx.Serializable(doc, 3, AssertEx.DocumentCloned);
@@ -145,9 +144,9 @@ namespace pwiz.SkylineTestFunctional
 
         }
 
-        private SrmDocument InitExplicitRTDocument(TestFilesDir testFilesDir, string fileName, out string docPath)
+        private SrmDocument InitExplicitRTDocument(TestFilesDir testFilesDir, string fileName)
         {
-            docPath = testFilesDir.GetTestPath(fileName);
+            var docPath = testFilesDir.GetTestPath(fileName);
 
             var documentFile = TestFilesDir.GetTestPath(docPath);
             WaitForCondition(() => File.Exists(documentFile));

--- a/pwiz_tools/Skyline/TestFunctional/ExportSpectralLibraryTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExportSpectralLibraryTest.cs
@@ -167,18 +167,22 @@ namespace pwiz.SkylineTestFunctional
         private static IList<DbIrtPeptide> GetIrtLibrary(SQLiteConnection connection)
         {
             var list = new List<DbIrtPeptide>();
-            using (var select = new SQLiteCommand(connection) { CommandText = "SELECT * FROM IrtLibrary" })
-            using (var reader = select.ExecuteReader())
+            using (var select = new SQLiteCommand(connection))
             {
-                while (reader.Read())
+                select.CommandText = "SELECT * FROM IrtLibrary";
+                using (var reader = select.ExecuteReader())
                 {
-                    list.Add(new DbIrtPeptide(
-                        new Target(reader["PeptideModSeq"].ToString()),
-                        double.Parse(reader["Irt"].ToString()),
-                        bool.Parse(reader["Standard"].ToString()),
-                        int.Parse(reader["TimeSource"].ToString())));
+                    while (reader.Read())
+                    {
+                        list.Add(new DbIrtPeptide(
+                            new Target(reader["PeptideModSeq"].ToString()),
+                            double.Parse(reader["Irt"].ToString()),
+                            bool.Parse(reader["Standard"].ToString()),
+                            int.Parse(reader["TimeSource"].ToString())));
+                    }
                 }
             }
+
             return list;
         }
 

--- a/pwiz_tools/Skyline/TestFunctional/ExpressionAnnotationsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExpressionAnnotationsTest.cs
@@ -110,8 +110,9 @@ namespace pwiz.SkylineTestFunctional
                 RemoveCalculatedAnnotationValues = false
             };
             using (var stream = File.Open(saveAsFileName, FileMode.Open))
-            using (var reader = new XmlTextReader(stream) {WhitespaceHandling = WhitespaceHandling.Significant})
+            using (var reader = new XmlTextReader(stream))
             {
+                reader.WhitespaceHandling = WhitespaceHandling.Significant;
                 while (reader.NodeType != XmlNodeType.Element)
                 {
                     reader.Read();

--- a/pwiz_tools/Skyline/TestFunctional/HighReplicateCountTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/HighReplicateCountTest.cs
@@ -63,8 +63,7 @@ namespace pwiz.SkylineTestFunctional
             var skyFile = "test_b.sky";
             var basename = "289_97";
             var sourceData = TestFilesDir.GetTestPath(basename + ExtensionTestContext.ExtMzml);
-            string docPath;
-            var doc = InitHighReplicateCountDocument(testFilesDir, skyFile, out docPath);
+            var doc = InitHighReplicateCountDocument(testFilesDir, skyFile);
             Settings.Default.ImportResultsSimultaneousFiles =
                 (int) MultiFileLoader.ImportResultsSimultaneousFileOptions
                     .many; // use maximum threads for multiple file import
@@ -93,9 +92,8 @@ namespace pwiz.SkylineTestFunctional
             {
                 for (var f = 0; f < filenames.Count; f++)
                 {
-                    ChromatogramGroupInfo[] chromGroupInfo;
                     Assert.IsTrue(document.Settings.MeasuredResults.TryLoadChromatogram(f, pair.NodePep, pair.NodeGroup,
-                        tolerance, out chromGroupInfo));
+                        tolerance, out _));
                 }
             }
 
@@ -145,9 +143,9 @@ namespace pwiz.SkylineTestFunctional
             return (count==Skyline.SkylineWindow.MAX_GRAPH_CHROM ? "distinct" : "R" + count) + ExtensionTestContext.ExtMzml;
         }
 
-        private SrmDocument InitHighReplicateCountDocument(TestFilesDir testFilesDir, string fileName, out string docPath)
+        private SrmDocument InitHighReplicateCountDocument(TestFilesDir testFilesDir, string fileName)
         {
-            docPath = testFilesDir.GetTestPath(fileName);
+            var docPath = testFilesDir.GetTestPath(fileName);
 
             var documentFile = TestFilesDir.GetTestPath(docPath);
             WaitForCondition(() => File.Exists(documentFile));

--- a/pwiz_tools/Skyline/TestFunctional/ImportResultsCancelTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ImportResultsCancelTest.cs
@@ -128,11 +128,10 @@ namespace pwiz.SkylineTestFunctional
                 foreach (var file in files)
                 {
                     int index;
-                    ChromatogramSet chromatogramSet;
                     var chromatogramSetName = file.Replace(mz5, "");
                     // Can we find a loaded chromatogram set by this name?
                     SkylineWindow.Document.Settings.MeasuredResults.TryGetChromatogramSet(chromatogramSetName,
-                        out chromatogramSet, out index);
+                        out _, out index);
                     if (!chromatogramSetName.Equals(cancelTarget))
                     {
                         // Should always find it since we didn't try to cancel this one

--- a/pwiz_tools/Skyline/TestFunctional/LabelPeakPickingTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LabelPeakPickingTest.cs
@@ -31,7 +31,6 @@ using pwiz.Skyline.Properties;
 using pwiz.Skyline.SettingsUI;
 using pwiz.Skyline.Util;
 using pwiz.SkylineTestUtil;
-using ZedGraph;
 
 namespace pwiz.SkylineTestFunctional
 {
@@ -348,15 +347,12 @@ namespace pwiz.SkylineTestFunctional
         protected EditPeakScoringModelDlg.HistogramGroup GetHistogramForScoreIndex(EditPeakScoringModelDlg editDlg, int scoreIndex)
         {
             EditPeakScoringModelDlg.HistogramGroup scoreHistograms;
-            EditPeakScoringModelDlg.HistogramGroup pValueHistograms;
-            EditPeakScoringModelDlg.HistogramGroup qValueHistograms;
-            PointPairList piZeroLine;
             editDlg.GetPoints(
                 scoreIndex,
                 out scoreHistograms,
-                out pValueHistograms,
-                out qValueHistograms,
-                out piZeroLine);
+                out _,
+                out _,
+                out _);
             return scoreHistograms;
         }
 
@@ -364,8 +360,7 @@ namespace pwiz.SkylineTestFunctional
                                     bool isPresent,
                                     Type[] scoreTypes)
         {
-            List<double?> scores;
-            VerifyScores(editDlg, isPresent, scoreTypes, out scores);
+            VerifyScores(editDlg, isPresent, scoreTypes, out _);
         }
 
         protected void VerifyScores(EditPeakScoringModelDlg editDlg, 

--- a/pwiz_tools/Skyline/TestFunctional/ManageResultsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ManageResultsTest.cs
@@ -75,9 +75,8 @@ namespace pwiz.SkylineTestFunctional
                 dictGraphPositions.Add(ptLeftTop, graphChrom);
 
                 int index;
-                ChromatogramSet chromSet;
                 Assert.IsTrue(docLoading.Settings.MeasuredResults.TryGetChromatogramSet(
-                    graphChrom.NameSet, out chromSet, out index));
+                    graphChrom.NameSet, out _, out index));
                 dictChromPositions.Add(ptLeftTop, index);
             }
             WaitForConditionUI(() => SkylineWindow.DocumentUI.Settings.MeasuredResults.IsLoaded);
@@ -174,9 +173,8 @@ namespace pwiz.SkylineTestFunctional
             foreach (var graphChrom in listGraphChroms)
             {
                 int index;
-                ChromatogramSet chromSet;
                 Assert.IsTrue(docRename.Settings.MeasuredResults.TryGetChromatogramSet(
-                    graphChrom.NameSet, out chromSet, out index));
+                    graphChrom.NameSet, out _, out index));
 
                 Point ptLeftTop = GetTopLeft(graphChrom.Parent);
                 // Pane order started out in reversed document order

--- a/pwiz_tools/Skyline/TestFunctional/MultiSelectRetentionTimeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MultiSelectRetentionTimeTest.cs
@@ -72,8 +72,7 @@ namespace pwiz.SkylineTestFunctional
                 }
                 Assert.AreEqual(curveCount, SkylineWindow.GraphRetentionTime.CurveCount);
                 Assert.AreEqual(BarType.SortedOverlay, SkylineWindow.GraphRetentionTime.GraphControl.GraphPane.BarSettings.Type);
-                SummaryReplicateGraphPane pane;
-                Assert.IsTrue(SkylineWindow.GraphRetentionTime.TryGetGraphPane(out pane));
+                Assert.IsTrue(SkylineWindow.GraphRetentionTime.TryGetGraphPane(out SummaryReplicateGraphPane _));
                 
                 // Select first indavidual peptide (not worth selecting them all - slows test for not much extra coverage)
                 SelectNode(peptideGroupTreeNode.Nodes[0]);

--- a/pwiz_tools/Skyline/TestFunctional/ShareDocumentTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ShareDocumentTest.cs
@@ -144,10 +144,9 @@ namespace pwiz.SkylineTestFunctional
             var doc = WaitForDocumentLoaded();
             AssertEx.IsDocumentState(doc, null, 1, 4, 4, 4); // int revision, int groups, int peptides, int tranGroups, int transitions
             SpectrumPeaksInfo spectrum;
-            IsotopeLabelType label;
             // ReSharper disable PossibleNullReferenceException
             doc.Settings.TryLoadSpectrum(doc.Molecules.FirstOrDefault().Target, Adduct.FromStringAssumeChargeOnly("M+NH4"),
-                null, out label, out spectrum);
+                null, out _, out spectrum);
             Assume.IsTrue(spectrum.Annotations.Count() == 1);
             var spectrumPeakAnnotations = (spectrum.Annotations.FirstOrDefault() ?? new SpectrumPeakAnnotation[0]).ToArray();
             Assume.IsTrue(spectrumPeakAnnotations.Length == 1);

--- a/pwiz_tools/Skyline/TestFunctional/TicNormalizationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/TicNormalizationTest.cs
@@ -233,8 +233,7 @@ namespace pwiz.SkylineTestFunctional
             {
                 foreach (var form in FormUtil.OpenForms.OfType<GraphSummary>())
                 {
-                    TGraphPane graphPane;
-                    if (form.TryGetGraphPane(out graphPane))
+                    if (form.TryGetGraphPane(out TGraphPane _))
                     {
                         result = form;
                         break;

--- a/pwiz_tools/Skyline/TestPerf/PerfImportAgilentSpectrumMillRampedIMSTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportAgilentSpectrumMillRampedIMSTest.cs
@@ -284,9 +284,9 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                     string errMsg = string.Empty;
                     var key = new LibKey(pair.NodePep.ModifiedSequence, pair.NodeGroup.PrecursorAdduct);
                     double tolerCCS = 5;
-                    if (expectedDiffs.ContainsKey(key))
+                    if (expectedDiffs.TryGetValue(key, out var diff))
                     {
-                        tolerCCS = expectedDiffs[key] + .1;
+                        tolerCCS = diff + .1;
                     }
                     if (!explicitDTs.ContainsKey(key))
                     {

--- a/pwiz_tools/Skyline/TestPerf/PerfMeasuredInverseK0.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfMeasuredInverseK0.cs
@@ -196,8 +196,9 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
 
             // Show anyone watching that work is being performed
             RunUI(() => {
-                using (var longWait = new LongWaitDlg(SkylineWindow) { Message = "Running command-line import" })
+                using (var longWait = new LongWaitDlg(SkylineWindow))
                 {
+                    longWait.Message = "Running command-line import";
                     longWait.PerformWork(SkylineWindow, 500, () =>
                         RunCommand("--in=" + skyFile,
                             "--import-file=" + TestFilesDir.GetTestPath(BSA_50fmol_TIMS_InfusionESI_10precd),

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -129,8 +129,8 @@ namespace TestRunner
 
         private static int GetLeakCheckIterations(TestInfo test)
         {
-            return LeakCheckIterationsOverrideByTestName.ContainsKey(test.TestMethod.Name)
-                ? LeakCheckIterationsOverrideByTestName[test.TestMethod.Name].Iterations
+            return LeakCheckIterationsOverrideByTestName.TryGetValue(test.TestMethod.Name, out var value)
+                ? value.Iterations
                 : LeakCheckIterations;
         }
 

--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
@@ -1286,9 +1286,8 @@ namespace pwiz.SkylineTestTutorial
         private static int GetChromIndex(string name)
         {
             int index;
-            ChromatogramSet chromatogramSet;
             Assert.IsTrue(SkylineWindow.Document.Settings.MeasuredResults.TryGetChromatogramSet(name,
-                out chromatogramSet, out index));
+                out _, out index));
             return index;
         }
 

--- a/pwiz_tools/Skyline/TestTutorial/MethodEditTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/MethodEditTutorialTest.cs
@@ -438,9 +438,8 @@ namespace pwiz.SkylineTestTutorial
                 ITipProvider nodeTip = SkylineWindow.SequenceTree.SelectedNode as ITipProvider;
                 Assert.IsTrue(nodeTip != null && nodeTip.HasTip);
                 var nodeName = SkylineWindow.SequenceTree.Nodes[1].Name;
-                IdentityPath selectPath;
                 SkylineWindow.ModifyDocument("Drag and drop", // Not L10N
-                    doc => doc.MoveNode(SkylineWindow.Document.GetPathTo(0, 1), SkylineWindow.Document.GetPathTo(0, 0), out selectPath));
+                    doc => doc.MoveNode(SkylineWindow.Document.GetPathTo(0, 1), SkylineWindow.Document.GetPathTo(0, 0), out _));
                 Assert.IsTrue(SkylineWindow.SequenceTree.Nodes[0].Name == nodeName);
             });
 

--- a/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
@@ -830,9 +830,7 @@ namespace pwiz.SkylineTestTutorial
                 {
                     var graph = GetGraphChromatogram(i);
                     var approxRT = ((i == 1) ? rt1 : rt0);
-                    TransitionGroupDocNode nodeGroupGraph;
-                    TransitionDocNode nodeTranGraph;
-                    var scaledRT = graph.FindAnnotatedPeakRetentionTime(approxRT, out nodeGroupGraph, out nodeTranGraph);
+                    var scaledRT = graph.FindAnnotatedPeakRetentionTime(approxRT, out _, out _);
                     graph.FirePickedPeak(nodeGroup, nodeTran, scaledRT);
                 }
             });

--- a/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
@@ -397,8 +397,7 @@ namespace pwiz.SkylineTestTutorial
                 while ((line = reader.ReadLine()) != null)
                 {
                     var fields = line.Split(TextUtil.CsvSeparator);
-                    double qvalue;
-                    if (double.TryParse(fields[qvalueColumnIndex], out qvalue))
+                    if (double.TryParse(fields[qvalueColumnIndex], out _))
                         qvalueCount++;
                 }
                 Assert.AreEqual(290, qvalueCount); // PrecursorResults field means 29 peptides * 5 replicates * 2 label types

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -788,10 +788,9 @@ namespace pwiz.SkylineTestUtil
             var docExport = exporter.Document;
             var docImport = new SrmDocument(docExport.Settings);
             string transitionList = exporter.MemoryOutput.Values.ToArray()[0].ToString();
-            IdentityPath pathAdded;
             var inputs = new MassListInputs(DuplicateAndReverseLines(transitionList, exporter.HasHeaders),
                 CultureInfo.InvariantCulture, TextUtil.SEPARATOR_CSV);
-            docImport = docImport.ImportMassList(inputs, null, IdentityPath.ROOT, out pathAdded);
+            docImport = docImport.ImportMassList(inputs, null, IdentityPath.ROOT, out _);
 
             IsDocumentState(docImport, 1,
                                      docExport.MoleculeGroupCount,

--- a/pwiz_tools/Skyline/TestUtil/PeakMatcherTestUtil.cs
+++ b/pwiz_tools/Skyline/TestUtil/PeakMatcherTestUtil.cs
@@ -81,8 +81,7 @@ namespace pwiz.SkylineTestUtil
             {
                 var chromSet = chromatograms[resultsIndex];
                 Assert.IsTrue(chromSet.FileCount == 1);
-                ChromatogramGroupInfo[] chromGroupInfos;
-                Assert.IsTrue(settings.MeasuredResults.TryLoadChromatogram(chromSet, null, nodeTranGroup, mzMatchTolerance, out chromGroupInfos));
+                Assert.IsTrue(settings.MeasuredResults.TryLoadChromatogram(chromSet, null, nodeTranGroup, mzMatchTolerance, out _));
                 var rt = nodeTranGroup.Results[resultsIndex][0].RetentionTime;
                 Assert.IsTrue(rt.HasValue);
                 var chromName = chromSet.Name;

--- a/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
+++ b/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
@@ -338,8 +338,7 @@ namespace pwiz.SkylineTestUtil
         {
             Assert.IsTrue(document.Settings.HasResults,"Expected document to have results.");
             int index;
-            ChromatogramSet chromatogramSet;
-            document.Settings.MeasuredResults.TryGetChromatogramSet(replicateName, out chromatogramSet, out index);
+            document.Settings.MeasuredResults.TryGetChromatogramSet(replicateName, out _, out index);
             Assert.AreNotEqual(-1, index, string.Format("Replicate {0} not found among -> {1} <-", replicateName,
                 TextUtil.LineSeparate(document.Settings.MeasuredResults.Chromatograms.Select(c => c.Name))));
             int peptidesActual = 0;

--- a/pwiz_tools/Skyline/ToolsUI/ConfigureToolsDlg.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ConfigureToolsDlg.cs
@@ -709,20 +709,18 @@ namespace pwiz.Skyline.ToolsUI
         public void CommandBtnClick()
         {
             int i = 0;
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                Filter = TextUtil.FileDialogFiltersAll(
-                               TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_All_Executables, ToolDescription.EXTENSIONS[i++]),
-                               TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Command_Files, ToolDescription.EXTENSIONS[i++]),
-                               TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Information_Files, ToolDescription.EXTENSIONS[i++]),
-                               TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Batch_Files, ToolDescription.EXTENSIONS[i++], ToolDescription.EXTENSIONS[i++]),
-                               TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Python_Scripts, ToolDescription.EXTENSIONS[i++]),
-                               TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Perl_Scripts, ToolDescription.EXTENSIONS[i])
-                               ),
-                FilterIndex = 1,
-                Multiselect = false
-            })
-            {
+                dlg.Filter = TextUtil.FileDialogFiltersAll(
+                    TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_All_Executables, ToolDescription.EXTENSIONS[i++]),
+                    TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Command_Files, ToolDescription.EXTENSIONS[i++]),
+                    TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Information_Files, ToolDescription.EXTENSIONS[i++]),
+                    TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Batch_Files, ToolDescription.EXTENSIONS[i++], ToolDescription.EXTENSIONS[i++]),
+                    TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Python_Scripts, ToolDescription.EXTENSIONS[i++]),
+                    TextUtil.FileDialogFilter(Resources.ConfigureToolsDlg_btnFindCommand_Click_Perl_Scripts, ToolDescription.EXTENSIONS[i])
+                );
+                dlg.FilterIndex = 1;
+                dlg.Multiselect = false;
                 if (dlg.ShowDialog(this) == DialogResult.OK)
                 {
                     textCommand.Text = dlg.FileName;

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.cs
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.cs
@@ -104,8 +104,9 @@ namespace pwiz.Skyline.ToolsUI
 
             var panoramaClient = PanoramaClient ?? new WebPanoramaClient(uriServer);
 
-            using (var waitDlg = new LongWaitDlg { Text = Resources.EditServerDlg_OkDialog_Verifying_server_information })
+            using (var waitDlg = new LongWaitDlg())
             {
+                waitDlg.Text = Resources.EditServerDlg_OkDialog_Verifying_server_information;
                 try
                 {
                     waitDlg.PerformWork(this, 1000, () => PanoramaUtil.VerifyServerInformation( panoramaClient, Username, Password));

--- a/pwiz_tools/Skyline/ToolsUI/PythonInstaller.cs
+++ b/pwiz_tools/Skyline/ToolsUI/PythonInstaller.cs
@@ -142,14 +142,16 @@ namespace pwiz.Skyline.ToolsUI
         {
             try
             {
-                using (var waitDlg = new LongWaitDlg{ProgressValue = 0})
+                using (var waitDlg = new LongWaitDlg())
                 {
+                    waitDlg.ProgressValue = 0;
                     // Short wait, because this can't possible happen fast enough to avoid
                     // showing progress, except in testing
                     waitDlg.PerformWork(this, 50, DownloadPython);
                 }
-                using (var waitDlg = new LongWaitDlg(null, false) {Message = Resources.PythonInstaller_GetPython_Installing_Python})
+                using (var waitDlg = new LongWaitDlg(null, false))
                 {
+                    waitDlg.Message = Resources.PythonInstaller_GetPython_Installing_Python;
                     waitDlg.PerformWork(this, 50, InstallPython);
                 }
                 MessageDlg.Show(this, Resources.PythonInstaller_GetPython_Python_installation_completed_);
@@ -208,8 +210,9 @@ namespace pwiz.Skyline.ToolsUI
             try
             {
                 // download packages
-                using (var waitDlg = new LongWaitDlg{ProgressValue = 0})
+                using (var waitDlg = new LongWaitDlg())
                 {
+                    waitDlg.ProgressValue = 0;
                     waitDlg.PerformWork(this, 500, longWaitBroker => packagePaths = DownloadPackages(longWaitBroker, downloadablePackages));
                 }
 
@@ -227,8 +230,9 @@ namespace pwiz.Skyline.ToolsUI
                 // first install executable packages, if any
                 if (exePaths.Count != 0)
                 {
-                    using (var waitDlg = new LongWaitDlg(null, false) { Message = Resources.PythonInstaller_GetPackages_Installing_Packages })
+                    using (var waitDlg = new LongWaitDlg(null, false))
                     {
+                        waitDlg.Message = Resources.PythonInstaller_GetPackages_Installing_Packages;
                         waitDlg.PerformWork(this, 500, () => InstallExecutablePackages(exePaths));
                     }   
                 }
@@ -258,8 +262,9 @@ namespace pwiz.Skyline.ToolsUI
                         }
                     }
 
-                    using (var waitDlg = new LongWaitDlg(null, false) { Message = Resources.PythonInstaller_GetPackages_Installing_Packages })
+                    using (var waitDlg = new LongWaitDlg(null, false))
                     {
+                        waitDlg.Message = Resources.PythonInstaller_GetPackages_Installing_Packages;
                         waitDlg.PerformWork(this, 500, () => InstallSourcePackages(sourcePaths, pipPath));
                     }   
                 }
@@ -395,14 +400,16 @@ namespace pwiz.Skyline.ToolsUI
         {   
             try
             {
-                using (var dlg = new LongWaitDlg{ProgressValue = 0})
+                using (var dlg = new LongWaitDlg())
                 {
+                    dlg.ProgressValue = 0;
                     // Short wait, because this can't possible happen fast enough to avoid
                     // showing progress, except in testing
                     dlg.PerformWork(this, 50, DownloadPip);
                 }
-                using (var dlg = new LongWaitDlg(null, false) {Message = Resources.PythonInstaller_GetPip_Installing_Pip})
+                using (var dlg = new LongWaitDlg(null, false))
                 {
+                    dlg.Message = Resources.PythonInstaller_GetPip_Installing_Pip;
                     dlg.PerformWork(this, 50, InstallPip);
                 }
             }

--- a/pwiz_tools/Skyline/ToolsUI/RInstaller.cs
+++ b/pwiz_tools/Skyline/ToolsUI/RInstaller.cs
@@ -131,14 +131,17 @@ namespace pwiz.Skyline.ToolsUI
         {
             try
             {
-                using (var dlg = new LongWaitDlg {Message = Resources.RInstaller_InstallR_Downloading_R, ProgressValue = 0})
+                using (var dlg = new LongWaitDlg())
                 {
+                    dlg.Message = Resources.RInstaller_InstallR_Downloading_R;
+                    dlg.ProgressValue = 0;
                     // Short wait, because this can't possible happen fast enough to avoid
                     // showing progress, except in testing
                     dlg.PerformWork(this, 50, DownloadR);
                 }
-                using (var dlg = new LongWaitDlg(null, false) {Message = Resources.RInstaller_GetR_Installing_R})
+                using (var dlg = new LongWaitDlg(null, false))
                 {
+                    dlg.Message = Resources.RInstaller_GetR_Installing_R;
                     dlg.PerformWork(this, 50, InstallR);
                 }
                 MessageDlg.Show(this, Resources.RInstaller_GetR_R_installation_complete_);
@@ -202,8 +205,9 @@ namespace pwiz.Skyline.ToolsUI
         {
             try
             {
-                using (var dlg = new LongWaitDlg(null, false) {Message = Resources.RInstaller_GetPAckages_Installing_Packages})
+                using (var dlg = new LongWaitDlg(null, false))
                 {
+                    dlg.Message = Resources.RInstaller_GetPAckages_Installing_Packages;
                     dlg.PerformWork(this, 1000, InstallPackages);
                 }
             }

--- a/pwiz_tools/Skyline/ToolsUI/ToolInstallUI.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ToolInstallUI.cs
@@ -43,13 +43,11 @@ namespace pwiz.Skyline.ToolsUI
      
         public static void InstallZipFromFile(Control parent, InstallProgram install)
         {
-            using (var dlg = new OpenFileDialog
+            using (var dlg = new OpenFileDialog())
             {
-                Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
-                    Resources.ConfigureToolsDlg_AddFromFile_Zip_Files, ToolDescription.EXT_INSTALL)),
-                Multiselect = false
-            })
-            {
+                dlg.Filter = TextUtil.FileDialogFiltersAll(TextUtil.FileDialogFilter(
+                    Resources.ConfigureToolsDlg_AddFromFile_Zip_Files, ToolDescription.EXT_INSTALL));
+                dlg.Multiselect = false;
                 if (dlg.ShowDialog(parent) == DialogResult.OK)
                     InstallZipTool(parent, dlg.FileName, install);
             }
@@ -60,8 +58,9 @@ namespace pwiz.Skyline.ToolsUI
             try
             {
                 IList<ToolStoreItem> toolStoreItems = null;
-                using (var dlg = new LongWaitDlg { Message = Resources.ConfigureToolsDlg_AddFromWeb_Contacting_the_server })
+                using (var dlg = new LongWaitDlg())
                 {
+                    dlg.Message = Resources.ConfigureToolsDlg_AddFromWeb_Contacting_the_server;
                     dlg.PerformWork(parent, 1000, () =>
                     {
                         toolStoreItems = ToolStoreUtil.ToolStoreClient.GetToolStoreItems();

--- a/pwiz_tools/Skyline/ToolsUI/ToolStoreDlg.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ToolStoreDlg.cs
@@ -162,8 +162,10 @@ namespace pwiz.Skyline.ToolsUI
             try
             {
                 string identifier = _tools[listBoxTools.SelectedIndex].Identifier;
-                using (var dlg = new LongWaitDlg {ProgressValue = 0, Message = string.Format(Resources.ToolStoreDlg_DownloadSelectedTool_Downloading__0_, _tools[listBoxTools.SelectedIndex].Name)})
+                using (var dlg = new LongWaitDlg())
                 {
+                    dlg.ProgressValue = 0;
+                    dlg.Message = string.Format(Resources.ToolStoreDlg_DownloadSelectedTool_Downloading__0_, _tools[listBoxTools.SelectedIndex].Name);
                     dlg.PerformWork(this, 500, progressMonitor => DownloadPath = _toolStoreClient.GetToolZipFile(progressMonitor, identifier, Path.GetTempPath()));
                     if (!dlg.IsCanceled)
                         DialogResult = DialogResult.OK;

--- a/pwiz_tools/Skyline/ToolsUI/ToolUpdatesDlg.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ToolUpdatesDlg.cs
@@ -123,8 +123,9 @@ namespace pwiz.Skyline.ToolsUI
             ICollection<ToolUpdateInfo> successfulDownloads = null;
             ICollection<string> failedDownloads = null;
 
-            using (var dlg = new LongWaitDlg {Message = Resources.ToolUpdatesDlg_GetToolsToUpdate_Downloading_Updates})
+            using (var dlg = new LongWaitDlg())
             {
+                dlg.Message = Resources.ToolUpdatesDlg_GetToolsToUpdate_Downloading_Updates;
                 dlg.PerformWork(this, 1000,
                                 longWaitBroker =>
                                 DownloadTools(longWaitBroker, toolsToDownload, out successfulDownloads,

--- a/pwiz_tools/Skyline/UpgradeManager.cs
+++ b/pwiz_tools/Skyline/UpgradeManager.cs
@@ -133,13 +133,11 @@ namespace pwiz.Skyline
                 if (!ShowUpgradeForm(_updateInfo.AvailableVersion, true, true))
                     return;
 
-                using (var longWaitUpdate = new LongWaitDlg
+                using (var longWaitUpdate = new LongWaitDlg())
                 {
-                    Text = string.Format(Resources.UpgradeManager_updateCheck_Complete_Upgrading__0_, Program.Name),
-                    Message = GetProgressMessage(0, _updateInfo.UpdateSizeBytes ?? 0),
-                    ProgressValue = 0
-                })
-                {
+                    longWaitUpdate.Text = string.Format(Resources.UpgradeManager_updateCheck_Complete_Upgrading__0_, Program.Name);
+                    longWaitUpdate.Message = GetProgressMessage(0, _updateInfo.UpdateSizeBytes ?? 0);
+                    longWaitUpdate.ProgressValue = 0;
                     AutoResetEvent endUpdateEvent = null;
                     try
                     {
@@ -199,8 +197,9 @@ namespace pwiz.Skyline
                 ? GetVersionDiff(AppDeployment.CurrentVersion, availableVersion)
                 : null;
 
-            using (var dlgUpgrade = new UpgradeDlg(versionText, automatic, updateFound) {Text = Program.Name})
+            using (var dlgUpgrade = new UpgradeDlg(versionText, automatic, updateFound))
             {
+                dlgUpgrade.Text = Program.Name;
                 try
                 {
                     return dlgUpgrade.ShowDialog(ParentWindow) == DialogResult.OK;

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -58,14 +58,7 @@ namespace pwiz.Skyline.Util
             }
             set
             {
-                if (!_dict.ContainsKey(a))
-                {
-                    _dict.Add(a, value);
-                }
-                else
-                {
-                    _dict[a] = value;
-                }
+                _dict[a] = value;
             }            
         }
 
@@ -229,9 +222,9 @@ namespace pwiz.Skyline.Util
                     {
                         return null;
                     }
-                    double test;
+
                     if (double.TryParse(input.Substring(posNext, limit - posNext),
-                        NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo, out test))
+                            NumberStyles.Float | NumberStyles.AllowThousands, NumberFormatInfo.InvariantInfo, out _))
                     {
                         return limit;  // Started with a mass label
                     }

--- a/pwiz_tools/Skyline/Util/AxisLabelScaler.cs
+++ b/pwiz_tools/Skyline/Util/AxisLabelScaler.cs
@@ -203,8 +203,7 @@ namespace pwiz.Skyline.Util
         {
             while (Helpers.RemoveRepeatedLabelText(Axis.Scale.TextLabels, FirstDataIndex))
             {
-                string maxLabel;
-                int maxWidth = MaxWidth(font, Axis.Scale.TextLabels, out maxLabel);
+                int maxWidth = MaxWidth(font, Axis.Scale.TextLabels, out _);
                 if (maxWidth <= dpAvailable)
                 {
                     return maxWidth;

--- a/pwiz_tools/Skyline/Util/Extensions/Text.cs
+++ b/pwiz_tools/Skyline/Util/Extensions/Text.cs
@@ -338,9 +338,8 @@ namespace pwiz.Skyline.Util.Extensions
                 string fieldConverted = field
                     .Replace(CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator,
                              CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
-                double fieldValue;
                 // Convert if the field is numeric or contains modifications
-                if (double.TryParse(fieldConverted, out fieldValue) || new Regex(@"\[[+-]\d+\.\d\]").IsMatch(field))
+                if (double.TryParse(fieldConverted, out _) || new Regex(@"\[[+-]\d+\.\d\]").IsMatch(field))
                     fields[i] = fieldConverted;
             }
             return string.Join(separator.ToString(), fields);

--- a/pwiz_tools/Skyline/Util/PanoramaPublishUtil.cs
+++ b/pwiz_tools/Skyline/Util/PanoramaPublishUtil.cs
@@ -315,8 +315,9 @@ namespace pwiz.Skyline.Util
             try
             {
                 var isCanceled = false;
-                using (var waitDlg = new LongWaitDlg { Text = Resources.PublishDocumentDlg_UploadSharedZipFile_Uploading_File })
+                using (var waitDlg = new LongWaitDlg())
                 {
+                    waitDlg.Text = Resources.PublishDocumentDlg_UploadSharedZipFile_Uploading_File;
                     waitDlg.PerformWork(parent, 1000, longWaitBroker =>
                     {
                         result = SendZipFile(server, folderPath,

--- a/pwiz_tools/Skyline/Util/SSRCalc3.cs
+++ b/pwiz_tools/Skyline/Util/SSRCalc3.cs
@@ -1046,9 +1046,9 @@ namespace pwiz.Skyline.Util
                 {
                     hc6 = hc.Substring(i, 6);
                     sc6 = 0.0;
-                    if (HlxScore6.ContainsKey(hc6))
+                    if (HlxScore6.TryGetValue(hc6, out var value))
                     {
-                        sc6 = HlxScore6[hc6];
+                        sc6 = value;
                     }
                 }
                 if (sc6 > 0)
@@ -1063,9 +1063,9 @@ namespace pwiz.Skyline.Util
                 {
                     hc5 = hc.Substring(i, 5);
                     sc5 = 0.0;
-                    if (HlxScore5.ContainsKey(hc5))
+                    if (HlxScore5.TryGetValue(hc5, out var value))
                     {
-                        sc5 = HlxScore5[hc5];
+                        sc5 = value;
                     }
                 }
                 if (sc5 > 0)
@@ -1080,9 +1080,9 @@ namespace pwiz.Skyline.Util
                 {
                     hc4 = hc.Substring(i, 4);
                     sc4 = 0.0;
-                    if (HlxScore4.ContainsKey(hc4))
+                    if (HlxScore4.TryGetValue(hc4, out var value))
                     {
-                        sc4 = HlxScore4[hc4];
+                        sc4 = value;
                     }
                 }
                 if (sc4 > 0)

--- a/pwiz_tools/Skyline/Util/SSRCalc3.cs
+++ b/pwiz_tools/Skyline/Util/SSRCalc3.cs
@@ -1045,11 +1045,7 @@ namespace pwiz.Skyline.Util
                 if (hc.Substring(i).Length >= 6)
                 {
                     hc6 = hc.Substring(i, 6);
-                    sc6 = 0.0;
-                    if (HlxScore6.TryGetValue(hc6, out var value))
-                    {
-                        sc6 = value;
-                    }
+                    HlxScore6.TryGetValue(hc6, out sc6);
                 }
                 if (sc6 > 0)
                 {
@@ -1062,11 +1058,7 @@ namespace pwiz.Skyline.Util
                 if (hc.Substring(i).Length >= 5)
                 {
                     hc5 = hc.Substring(i, 5);
-                    sc5 = 0.0;
-                    if (HlxScore5.TryGetValue(hc5, out var value))
-                    {
-                        sc5 = value;
-                    }
+                    HlxScore5.TryGetValue(hc5, out sc5);
                 }
                 if (sc5 > 0)
                 {
@@ -1079,11 +1071,7 @@ namespace pwiz.Skyline.Util
                 if (hc.Substring(i).Length >= 4)
                 {
                     hc4 = hc.Substring(i, 4);
-                    sc4 = 0.0;
-                    if (HlxScore4.TryGetValue(hc4, out var value))
-                    {
-                        sc4 = value;
-                    }
+                    HlxScore4.TryGetValue(hc4, out sc4);
                 }
                 if (sc4 > 0)
                 {

--- a/pwiz_tools/Skyline/Util/Util.cs
+++ b/pwiz_tools/Skyline/Util/Util.cs
@@ -1602,8 +1602,7 @@ namespace pwiz.Skyline.Util
         {
             for (int i = name.Length; i > 0; i--)
             {
-                int num;
-                if (!int.TryParse(name.Substring(i - 1), out num))
+                if (!int.TryParse(name.Substring(i - 1), out _))
                     return i;
             }
             return 0;


### PR DESCRIPTION
﻿* **Initialize object properties inside the 'using' statement to ensure that the object is disposed if an exception is thrown during initialization**

﻿﻿216 of these - ReSharper wants to change this, for example
```
                using (var graph = new GraphRegression(new[] { _graphData }) { Width = 800, Height = 600 })
                {
                    graph.ShowDialog(this);
                }
```
to
```
                using (var graph = new GraphRegression(new[] { _graphData }))
                {
                    graph.Width = 800;
                    graph.Height = 600;
                    graph.ShowDialog(this);
                }
```
No important effect in most cases, but if in this example assigning Width or Height involved creating a disposable object, that object would not have been disposed if GraphRegression() ctor threw an exception. I've cleaned these up. 

* **Local variable 'xxxx' is only used to discard 'out' parameter value.** 

204 of these. 

Resharper is saying that rather than declaring a variable we could just use the "out _" form in a function call. While the compiler is probably optimizing this away, I've gone ahead and cleaned up the unneeded declarations.

* **Redundant dictionary 'ContainsKey' before adding to the collection.** 

7 cases like this:
```
                if (!_dict.ContainsKey(a))
                {
                    _dict.Add(a, value);
                }
                else
                {
                    _dict[a] = value;
                }
```
where it could just be
`                _dict[a] = value;`
I've cleaned these up. Possibly a little performance boost here.

* **Dictionary lookup can be simplified with TryGetValue** 

23 cases like this
```
            return Matches.ContainsKey(key)
                ? Matches[key]
                : (AAModMatch?)null;
```
which could just be
```
            return Matches.TryGetValue(key, out var match)
                ? match
                : (AAModMatch?)null;
```
I've cleaned these up. Possibly a little performance boost here.