### PR TITLE
Fix an exception thrown when reading a small molecule transition list  lacking anything like a "name" Column…

### DIFF
--- a/pwiz_tools/Skyline/Alerts/AlertDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/AlertDlg.cs
@@ -117,11 +117,16 @@ namespace pwiz.Skyline.Alerts
                 }
                 else
                 {
-                    DetailMessage = Install.ProgramNameAndVersion + // Show the Skyline version 
-                                    Environment.NewLine + Environment.NewLine + 
-                                    value.ToString();
+                    DetailMessage = FormatExceptionDetailMessage(value);
                 }
             }
+        }
+
+        public static string FormatExceptionDetailMessage(Exception value)
+        {
+            return Install.ProgramNameAndVersion + // Show the Skyline version 
+                   Environment.NewLine + Environment.NewLine + 
+                   value.ToString();
         }
 
         public DialogResult ShowAndDispose(IWin32Window parent)

--- a/pwiz_tools/Skyline/Alerts/AlertDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/AlertDlg.cs
@@ -117,7 +117,9 @@ namespace pwiz.Skyline.Alerts
                 }
                 else
                 {
-                    DetailMessage = value.ToString();
+                    DetailMessage = Install.ProgramNameAndVersion + // Show the Skyline version 
+                                    Environment.NewLine + Environment.NewLine + 
+                                    value.ToString();
                 }
             }
         }

--- a/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
+++ b/pwiz_tools/Skyline/Model/SmallMoleculeTransitionListReader.cs
@@ -446,7 +446,7 @@ namespace pwiz.Skyline.Model
                             if (!visited.Contains(row2))
                             {
                                 if (@group.Equals(GetCellTrimmed(row2, INDEX_MOLECULE_GROUP) ?? string.Empty) &&
-                                    name.Equals(ReadMoleculeAccessionNumberColumns(row2)) &&
+                                    Equals(name, ReadMoleculeAccessionNumberColumns(row2)) &&
                                     row2.GetCellAsDouble(INDEX_PRECURSOR_MZ, out var mzParsed2))
                                 {
                                     var zString2 = GetCellTrimmed(row2, INDEX_PRECURSOR_ADDUCT) ?? 

--- a/pwiz_tools/Skyline/TestFunctional/UpgradeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/UpgradeTest.cs
@@ -175,7 +175,7 @@ namespace pwiz.SkylineTestFunctional
             _deployment.UpdateCheckError = new Exception(errorText);
             var errorDlg = ShowDialog<MessageDlg>(SkylineWindow.CheckForUpdate);
             Assert.AreEqual(Skyline.Properties.Resources.UpgradeManager_updateCheck_Complete_Failed_attempting_to_check_for_an_upgrade_, errorDlg.Message);
-            Assert.AreEqual(_deployment.UpdateCheckError.ToString(), errorDlg.DetailMessage);
+            Assert.AreEqual(AlertDlg.FormatExceptionDetailMessage(_deployment.UpdateCheckError), errorDlg.DetailMessage);
             RunDlg<UpgradeDlg>(errorDlg.OkDialog, noUpdateDlg =>
             {
                 Assert.IsFalse(noUpdateDlg.UpdateFound);
@@ -191,7 +191,7 @@ namespace pwiz.SkylineTestFunctional
             RunDlg<MessageDlg>(upgradeDlg.AcceptButton.PerformClick, dlg =>
             {
                 Assert.AreEqual(Skyline.Properties.Resources.UpgradeManager_updateCheck_Complete_Failed_attempting_to_upgrade_, dlg.Message);
-                Assert.AreEqual(_deployment.UpdateError.ToString(), errorDlg.DetailMessage);
+                Assert.AreEqual(AlertDlg.FormatExceptionDetailMessage(_deployment.UpdateError), errorDlg.DetailMessage);
                 dlg.OkDialog();
             });
             upgradeDlg = WaitForOpenForm<UpgradeDlg>();


### PR DESCRIPTION
Also, add the Skyline version to the stack trace information behind the "More info" button for exception alert dialogs (we already do this for unhandled exceptions, the version number gives important context to the line numbers in the stack)

Not reported by any user