### PR TITLE
Skyline: Fixes for new PanoramaClient UI in Skyline and SkylineBatch

### DIFF
--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.cs
@@ -35,27 +35,34 @@ namespace pwiz.PanoramaClient
         public string SelectedPath { get; private set; }
         public bool IsLoaded { get; private set; }
 
+        private readonly List<PanoramaServer> _servers;
+        private readonly bool _showWebDav;
         private string _treeState;
 
-        public PanoramaDirectoryPicker(List<PanoramaServer> servers, string state, bool showWebDavFolders = false, string selectedPath = null)
+        public PanoramaDirectoryPicker(List<PanoramaServer> servers, string stateString, bool showWebDavFolders = false, string selectedPath = null)
         {
             InitializeComponent();
 
-            if (showWebDavFolders)
-            {
-                FolderBrowser = new WebDavBrowser(servers.FirstOrDefault(), state, selectedPath);
-            }
-            else
-            {
-                FolderBrowser = new LKContainerBrowser(servers, state, false, selectedPath);
-            }
-            SelectedPath = selectedPath;
+            _servers = servers;
+            _treeState = stateString;
+            _showWebDav = showWebDavFolders;
 
-            InitializeDialog();
+            SelectedPath = selectedPath;
         }
 
-        private void InitializeDialog()
+        public void InitializeDialog()
         {
+            if (FolderBrowser == null)
+            {
+                if (_showWebDav)
+                {
+                    FolderBrowser = new WebDavBrowser(_servers.FirstOrDefault(), _treeState, SelectedPath);
+                }
+                else
+                {
+                    FolderBrowser = new LKContainerBrowser(_servers, _treeState, false, SelectedPath);
+                }
+            }
             FolderBrowser.Dock = DockStyle.Fill;
             folderPanel.Controls.Add(FolderBrowser);
             FolderBrowser.NodeClick += DirectoryPicker_MouseClick;

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/App.config
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <configSections>
-      <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+        <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler,log4net" />
         <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
             <section name="SkylineBatch.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
         </sectionGroup>
@@ -45,7 +45,7 @@
   <applicationSettings>
     <SkylineBatch.Properties.Settings>
       <setting name="XmlVersion" serializeAs="String">
-        <value>21.12</value>
+        <value>23.1</value>
       </setting>
     </SkylineBatch.Properties.Settings>
   </applicationSettings>

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteFileControl.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteFileControl.cs
@@ -250,14 +250,12 @@ namespace SkylineBatch
 
             try
             {
-
-
                 if (_fileRequired) // If file is required use PanoramaFilePicker
                 {
-
                     bool showWebdav = !_templateFile;
-                    using (PanoramaFilePicker dlg = new PanoramaFilePicker(panoramaServers, state, showWebdav, selectedPath))
+                    using (var dlg = new PanoramaFilePicker(panoramaServers, state, showWebdav, selectedPath))
                     {
+                        dlg.InitializeDialog(); // TODO: Should use a LongOperationRunner to show busy-wait UI
                         dlg.OkButtonText = "Select";
                         if (dlg.ShowDialog() != DialogResult.Cancel)
                         {
@@ -269,9 +267,9 @@ namespace SkylineBatch
                 }
                 else // if file not required use PanoramaDirectoryPicker
                 {
-                    using (PanoramaDirectoryPicker dlg = new PanoramaDirectoryPicker(panoramaServers, state, showWebDavFolders:true,selectedPath: selectedPath))
+                    using (var dlg = new PanoramaDirectoryPicker(panoramaServers, state, true, selectedPath))
                     {
-
+                        dlg.InitializeDialog(); // TODO: Should use a LongOperationRunner to show busy-wait UI
                         dlg.OkButtonText = "Select";
                         if (dlg.ShowDialog() != DialogResult.Cancel)
 

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteSourceForm.Designer.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteSourceForm.Designer.cs
@@ -141,8 +141,8 @@
             // 
             // btnOpenFromPanorama
             // 
-            this.btnOpenFromPanorama.Image = global::SkylineBatch.Properties.Resources.Panorama;
             resources.ApplyResources(this.btnOpenFromPanorama, "btnOpenFromPanorama");
+            this.btnOpenFromPanorama.Image = global::SkylineBatch.Properties.Resources.Panorama;
             this.btnOpenFromPanorama.Name = "btnOpenFromPanorama";
             this.btnOpenFromPanorama.UseVisualStyleBackColor = true;
             this.btnOpenFromPanorama.Click += new System.EventHandler(this.btn_OpenFromPanorama);

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteSourceForm.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteSourceForm.cs
@@ -9,7 +9,6 @@ using SkylineBatch.Properties;
 using pwiz.PanoramaClient;
 using PanoramaServer = pwiz.PanoramaClient.PanoramaServer;
 using AlertDlg = SharedBatch.AlertDlg;
-using Newtonsoft.Json.Linq;
 using PanoramaUtil = pwiz.PanoramaClient.PanoramaUtil;
 
 namespace SkylineBatch
@@ -137,15 +136,6 @@ namespace SkylineBatch
         }
 
 
-        public void OpenFromPanorama(string server, string user, string pass, JToken folderJson)
-        {
-            using var dlg = new PanoramaDirectoryPicker(new Uri(server), user, pass, folderJson);
-            if (dlg.ShowDialog() != DialogResult.Cancel)
-            {
-
-            }
-        }
-
         public void OpenFromPanorama()
         {
             PanoramaServer server;
@@ -170,8 +160,9 @@ namespace SkylineBatch
             try
             {
                 
-                using (PanoramaDirectoryPicker dlg = new PanoramaDirectoryPicker(panoramaServers, state, showWebDavFolders:false, selectedPath:decodedUrl))
+                using (var dlg = new PanoramaDirectoryPicker(panoramaServers, state, false, decodedUrl))
                 {
+                    dlg.InitializeDialog(); // TODO: Should use a LongOperationRunner to show busy-wait UI
                     if (dlg.ShowDialog() != DialogResult.Cancel)
                     {
                         dlg.OkButtonText = "Select";

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteSourceForm.resx
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatch/RemoteSourceForm.resx
@@ -555,6 +555,9 @@
   <data name="&gt;&gt;textServerName.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="btnOpenFromPanorama.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
   <data name="btnOpenFromPanorama.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>

--- a/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatchTest/RemoteFileSourceFunctionalTest.cs
+++ b/pwiz_tools/Skyline/Executables/SkylineBatch/SkylineBatchTest/RemoteFileSourceFunctionalTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using pwiz.PanoramaClient;
@@ -140,7 +141,7 @@ namespace SkylineBatchTest
             var testClient = new TestClientJson();
             var folderJson = testClient.GetInfoForFolders(new PanoramaServer(new Uri(VALID_SERVER), VALID_USER_NAME, VALID_PASSWORD),
                 TARGETED);
-            var remoteDlg = ShowDialog<PanoramaDirectoryPicker>(() => remoteSourceForm.OpenFromPanorama(VALID_SERVER, VALID_USER_NAME, VALID_PASSWORD,folderJson));
+            var remoteDlg = ShowDialog<PanoramaDirectoryPicker>(() => OpenFromPanorama(VALID_SERVER, VALID_USER_NAME, VALID_PASSWORD, folderJson));
             WaitForConditionUI(9000, () => remoteDlg.IsLoaded);
             RunUI(() =>
             {
@@ -156,7 +157,12 @@ namespace SkylineBatchTest
             });
             if (closeForm) CloseFormsInOrder(true,remoteSourceForm);
             WaitForClosedForm(remoteSourceForm);
+        }
 
+        public void OpenFromPanorama(string server, string user, string pass, JToken folderJson)
+        {
+            using var dlg = new PanoramaDirectoryPicker(new Uri(server), user, pass, folderJson);
+            dlg.ShowDialog();
         }
 
         public void TestPanoramaButtonVisibility(MainForm mainForm)
@@ -191,7 +197,7 @@ namespace SkylineBatchTest
             CloseFormsInOrder(true, remoteSourceForm);
         }
 
-        public void CloseFormsInOrder(bool save, params System.Windows.Forms.Form[] forms)
+        public void CloseFormsInOrder(bool save, params Form[] forms)
         {
             foreach (var form in forms)
             {
@@ -331,10 +337,10 @@ namespace SkylineBatchTest
             });
             RunUI(() => templateRemoteFileControl.comboRemoteFileSource.SelectedItem =
                 "panoramaweb.org Bruderer.sky.zip");
-            var RemoteSourceForm = ShowDialog<RemoteSourceForm>(() =>
+            var remoteSourceForm = ShowDialog<RemoteSourceForm>(() =>
                 templateRemoteFileControl.comboRemoteFileSource.SelectedItem = "<Edit current...>");
-            ChangeRemoteFileSource(RemoteSourceForm, BRUDERER_SOURCE_NAME, BRUDERER_FOLDER_LINK, closeForm: false);
-            RunDlg<AlertDlg>(() => RemoteSourceForm.btnSave.PerformClick(),
+            ChangeRemoteFileSource(remoteSourceForm, BRUDERER_SOURCE_NAME, BRUDERER_FOLDER_LINK, closeForm: false);
+            RunDlg<AlertDlg>(() => remoteSourceForm.btnSave.PerformClick(),
                 dlg =>
                 {
                     var expectedMessage =
@@ -377,10 +383,10 @@ namespace SkylineBatchTest
                 ShowDialog<DataServerForm>(() => configForm.dataControl.btnDownload.PerformClick());
             var dataRemoteFileControl = dataRemoteFileForm.remoteFileControl;
             CheckRemoteFileSourceList(dataRemoteFileControl, new HashSet<string> { BRUDERER_SOURCE_NAME });
-            RemoteSourceForm = ShowDialog<RemoteSourceForm>(() =>
+            remoteSourceForm = ShowDialog<RemoteSourceForm>(() =>
                 dataRemoteFileControl.comboRemoteFileSource.SelectedItem = "<Edit current...>");
-            ChangeRemoteFileSource(RemoteSourceForm, BRUDERER_SOURCE_NAME, SELEVSEK_FOLDER_LINK, closeForm: false);
-            RunDlg<AlertDlg>(() => RemoteSourceForm.btnSave.PerformClick(),
+            ChangeRemoteFileSource(remoteSourceForm, BRUDERER_SOURCE_NAME, SELEVSEK_FOLDER_LINK, closeForm: false);
+            RunDlg<AlertDlg>(() => remoteSourceForm.btnSave.PerformClick(),
                 dlg =>
                 {
                     var expectedMessage =
@@ -401,9 +407,9 @@ namespace SkylineBatchTest
             var rScriptRemoteFileForm =
                 ShowDialog<RemoteFileForm>(() => rScriptForm.fileControl.btnDownload.PerformClick());
             var reportRemoteFileControl = rScriptRemoteFileForm.RemoteFileControl;
-            RemoteSourceForm = ShowDialog<RemoteSourceForm>(() =>
+            remoteSourceForm = ShowDialog<RemoteSourceForm>(() =>
                 reportRemoteFileControl.comboRemoteFileSource.SelectedItem = "<Edit current...>");
-            CheckRemoteFileSource(RemoteSourceForm, BRUDERER_SOURCE_NAME, SELEVSEK_FOLDER_LINK);
+            CheckRemoteFileSource(remoteSourceForm, BRUDERER_SOURCE_NAME, SELEVSEK_FOLDER_LINK);
             CloseFormsInOrder(false, rScriptRemoteFileForm, rScriptForm, editReportForm, configForm);
 
             RunUI(() => mainForm.ClickConfig(0));
@@ -411,7 +417,7 @@ namespace SkylineBatchTest
             var annotationsRemoteFileForm =
                 ShowDialog<RemoteFileForm>(() => configForm.annotationsControl.btnDownload.PerformClick());
             var annotationsRemoteFileControl = annotationsRemoteFileForm.RemoteFileControl;
-            CheckRemoteFileSource(RemoteSourceForm, BRUDERER_SOURCE_NAME, SELEVSEK_FOLDER_LINK);
+            CheckRemoteFileSource(remoteSourceForm, BRUDERER_SOURCE_NAME, SELEVSEK_FOLDER_LINK);
             CloseFormsInOrder(false, annotationsRemoteFileForm, configForm);
 
             RunUI(() => FunctionalTestUtil.ClearConfigs(mainForm));
@@ -528,10 +534,9 @@ namespace SkylineBatchTest
             }
 
             //Only generating 3 nodes in the tree
-            public JToken GetInfoForFolders(pwiz.PanoramaClient.PanoramaServer server, string folder)
+            public JToken GetInfoForFolders(PanoramaServer server, string folder)
             {
-                JObject testFolders = new JObject();
-                testFolders = CreateFolder(TARGETED, true, true);
+                var testFolders = CreateFolder(TARGETED, true, true);
                 testFolders["children"] = new JArray(
                     CreateFolder(TARGETED_LIBRARY, true, true, false, true),
                     CreateFolder(TARGETED, true, true),

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -30328,6 +30328,15 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open From Panorama.
+        /// </summary>
+        public static string SkylineWindow_OpenFromPanorama_Open_From_Panorama {
+            get {
+                return ResourceManager.GetString("SkylineWindow_OpenFromPanorama_Open_From_Panorama", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Press &apos;Add&apos; to add a new server..
         /// </summary>
         public static string SkylineWindow_OpenFromPanorama_Press__Add__to_add_a_new_server_ {

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -13857,4 +13857,7 @@ If you choose Disable, you can enable Auto-select later with the "Refine &gt; Ad
   <data name="ProteinAssociation_CreateDocTree_Unmapped_Peptides" xml:space="preserve">
     <value>Unmapped Peptides</value>
   </data>
+  <data name="SkylineWindow_OpenFromPanorama_Open_From_Panorama" xml:space="preserve">
+    <value>Open From Panorama</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Skyline.resx
+++ b/pwiz_tools/Skyline/Skyline.resx
@@ -1357,7 +1357,7 @@
     <value>200, 22</value>
   </data>
   <data name="openPanoramaMenuItem.Text" xml:space="preserve">
-    <value>Open From Panorama...</value>
+    <value>Open From Panora&amp;ma...</value>
   </data>
   <data name="openContainingFolderMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>197, 22</value>

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -915,7 +915,15 @@ namespace pwiz.Skyline
 
             try
             {
-                using var dlg = new PanoramaFilePicker(panoramaServers, state);
+                using var dlg = new PanoramaFilePicker(panoramaServers, state) { Text = Resources.SkylineWindow_OpenFromPanorama_Open_From_Panorama };
+                var longOptionRunner = new LongOperationRunner
+                {
+                    ParentControl = this,
+                    JobTitle = Resources.SkylineWindow_OpenFromPanorama_Loading_remote_server_folders,
+                };
+                // TODO: This needs to be possible to cancel
+                longOptionRunner.Run(broker => dlg.InitializeDialog());
+
                 if (dlg.ShowDialog(this) != DialogResult.Cancel)
                 {
                     Settings.Default.PanoramaTreeState = dlg.FolderBrowser.TreeState;

--- a/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
@@ -279,6 +279,7 @@ namespace pwiz.SkylineTestConnected
         private void ShowPanoramaFilePicker(List<PanoramaServer> serverList, string selectedPath)
         {
             using var remoteDlg = new PanoramaFilePicker(serverList, string.Empty, true, selectedPath);
+            remoteDlg.InitializeDialog();   // CONSIDER: Should this be using LongOptionRunner like SkylineWindow?
             remoteDlg.ShowDialog();
         }
 


### PR DESCRIPTION
- Re-introduce a progress form during File > Open From Panorama with LongOperationRunner
- Add a mnemonic to File > Open From Panorama
- Change the form tile for File > Open From Panorama to "Open From Panorama" (was "Panorama Folders")
- Fix the panorama button in RemoteSourceForm to make it anchored right