### PR TITLE
Don't add 0.01 to Q3 m/z values for Agilent CE Opt transition lists

### DIFF
--- a/pwiz_tools/Skyline/Model/Export.cs
+++ b/pwiz_tools/Skyline/Model/Export.cs
@@ -3046,7 +3046,9 @@ namespace pwiz.Skyline.Model
             writer.Write(FieldSeparator);
             writer.Write(@"Unit");   // MS1 Res
             writer.Write(FieldSeparator);
-            writer.Write(GetProductMz(SequenceMassCalc.PersistentMZ(nodeTran.Mz), step).ToString(CultureInfo));
+            // For Agilent we do not call GetProductMz because we want all of the Q3 m/z values to be the same
+            // for all of the optimization step chromatograms
+            writer.Write(SequenceMassCalc.PersistentMZ(nodeTran.Mz).ToString(CultureInfo));
             writer.Write(FieldSeparator);
             writer.Write(@"Unit");   // MS2 Res
             writer.Write(FieldSeparator);

--- a/pwiz_tools/Skyline/Model/Export.cs
+++ b/pwiz_tools/Skyline/Model/Export.cs
@@ -3048,7 +3048,7 @@ namespace pwiz.Skyline.Model
             writer.Write(FieldSeparator);
             // For Agilent we do not call GetProductMz because we want all of the Q3 m/z values to be the same
             // for all of the optimization step chromatograms
-            writer.Write(SequenceMassCalc.PersistentMZ(nodeTran.Mz).ToString(CultureInfo));
+            writer.Write(GetProductMz(SequenceMassCalc.PersistentMZ(nodeTran.Mz), 0).ToString(CultureInfo));
             writer.Write(FieldSeparator);
             writer.Write(@"Unit");   // MS2 Res
             writer.Write(FieldSeparator);


### PR DESCRIPTION
When exporting Agilent CE Optimization Transition Lists, stop adding 0.01 to the Q3 m/z values (requested by Marilyn)