### PR TITLE
- fixed calculation of bogus WIFF2 isolation window offsets

### DIFF
--- a/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/SpectrumList_ABI.cpp
@@ -182,8 +182,11 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_ABI::spectrum(size_t index, DetailLevel d
             if (centerMz > 0)
             {
                 product.isolationWindow.set(MS_isolation_window_target_m_z, centerMz, MS_m_z);
-                product.isolationWindow.set(MS_isolation_window_lower_offset, centerMz - lowerLimit, MS_m_z);
-                product.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit - centerMz, MS_m_z);
+                if (lowerLimit > 0 && upperLimit > 0)
+                {
+	                product.isolationWindow.set(MS_isolation_window_lower_offset, centerMz - lowerLimit, MS_m_z);
+                	product.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit - centerMz, MS_m_z);
+                }
             }
 
             result->products.push_back(product);
@@ -196,8 +199,11 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_ABI::spectrum(size_t index, DetailLevel d
             if (centerMz > 0)
             {
                 precursor.isolationWindow.set(MS_isolation_window_target_m_z, centerMz, MS_m_z);
-                precursor.isolationWindow.set(MS_isolation_window_lower_offset, centerMz - lowerLimit, MS_m_z);
-                precursor.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit - centerMz, MS_m_z);
+                if (lowerLimit > 0 && upperLimit > 0)
+                {
+	                precursor.isolationWindow.set(MS_isolation_window_lower_offset, centerMz - lowerLimit, MS_m_z);
+                	precursor.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit - centerMz, MS_m_z);
+                }
             }
 
             selectedIon.set(MS_selected_ion_m_z, selectedMz, MS_m_z);

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -115,7 +115,7 @@ string Config::outputFilename(const string& filename, const MSData& msd) const
     // this list is for Windows; it's a superset of the POSIX list
     string illegalFilename = "\\/*:?<>|\"";
     for(char& c : runId)
-        if (illegalFilename.find(c) != string::npos)
+        if (c < 0x20 || c == 0x7F || illegalFilename.find(c) != string::npos)
             c = '_';
 
     bfs::path newFilename = runId + extension;


### PR DESCRIPTION
- fixed calculation of bogus isolation window offsets when WIFF2 file returns 0 for lower/upper window bounds
- changed msconvert to replace non-printable filename characters with underscore (like it already does for `\/*:?<>|"`) (reported by Robert)