### PR TITLE
Fix error choosing "Kernel Density Estimation" on run to run regression

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Prediction.cs
@@ -698,6 +698,10 @@ namespace pwiz.Skyline.Model.DocSettings
                     regressionFunction = new RegressionLineElement(statRT.Slope(stat), statRT.Intercept(stat));
                     break;
                 case RegressionMethodRT.kde:
+                    if (stat.Length <= 1)
+                    {
+                        return null;
+                    }
                     var kdeAligner = new KdeAligner();
                     kdeAligner.Train(stat.CopyList(), statRT.CopyList(), token);
 


### PR DESCRIPTION
Fixed error that sometimes happens choosing "Kernel Density Estimation" on run to run regression graph (reported on exception web)