### PR TITLE
Avoid running TestToolService on machines where it is consistently flaky (just BRENDANX-UW7 for now)

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/ToolServiceTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ToolServiceTest.cs
@@ -52,6 +52,12 @@ namespace pwiz.SkylineTestFunctional
         private const int MAX_TEST_ATTEMPTS = 2;
         protected override void DoTest()
         {
+            if (SkipTestToolService) // This test is flaky on certain machines, avoid gumming up the logs
+            {
+                Console.Write(MSG_SKIPPING_TEST_TOOL_SERVICE); // Log this via console for TestRunner
+                return;
+            }
+
             List<Exception> accumulatedExceptions = new List<Exception>();
             for (int attemptNumber = 0; attemptNumber < MAX_TEST_ATTEMPTS; attemptNumber++)
             {

--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
@@ -122,6 +122,12 @@ namespace pwiz.SkylineTestUtil
         }
 
         /// <summary>
+        /// Controls whether or not certain machines run the often flaky TestToolService
+        /// </summary>
+        protected bool SkipTestToolService => Environment.MachineName.Equals(@"BRENDANX-UW7");
+        public const string MSG_SKIPPING_TEST_TOOL_SERVICE = @"AbstractUnitTest.SkipTestToolService is set for this machine, no test was actually performed";
+
+        /// <summary>
         /// Perf tests (long running, huge-data-downloading) should be declared
         /// in the TestPerf namespace so that they can be skipped when the RunPerfTests 
         /// flag is unset.


### PR DESCRIPTION
N.B. you can argue that placing the logic in AbstractUnitTest instead of the test itself is overly ornate, but I wanted it near other machine-specific test logic.