### PR TITLE
Change the way developers can enable Prosit on local builds

### DIFF
--- a/pwiz_tools/Skyline/Jamfile.jam
+++ b/pwiz_tools/Skyline/Jamfile.jam
@@ -343,15 +343,15 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
         ) > "$(<)"
     }
 
+    constant SKYLINE_PROSIT_CONFIG : "$(SKYLINE_PATH)/Model/Prosit/Config/PrositConfig_production.xml" ;
     if --official in [ modules.peek : ARGV ]
     {
-        constant SKYLINE_PROSIT_CONFIG : "$(SKYLINE_PATH)/Model/Prosit/Config/PrositConfig_production.xml" ;
         if ! [ path.exists $(SKYLINE_PROSIT_CONFIG) ]
         {
             errors.user-error "PrositConfig_production.xml must be present for an official build" ;
         }
     }
-    else
+    else if ! [ path.exists $(SKYLINE_PROSIT_CONFIG) ]
     {
         constant SKYLINE_PROSIT_CONFIG : "$(SKYLINE_PATH)/Model/Prosit/Config/PrositConfig_development.xml" ;
     }

--- a/pwiz_tools/Skyline/Skyline.csproj
+++ b/pwiz_tools/Skyline/Skyline.csproj
@@ -3596,7 +3596,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="Model\Prosit\Config\PrositConfig_development.xml" />
-    <None Include="Model\Prosit\Config\UpdatePrositConfiguration.bat" />
     <None Include="ProtocolBuffers\google\protobuf\wrappers.proto" />
     <None Include="PreBuildEvents.bat" />
     <None Include="Resources\Locked.bmp" />


### PR DESCRIPTION
If a file "Model/Prosit/Config/PrositConfig_production.xml" is available, the Skyline Jamfile will always copy it to PrositConfig.xml for embedding in the exe. When the bjam commandline includes "--official" the build still fails if "Model/Prosit/Config/PrositConfig_production.xml" is not available.

Also, remove a stale reference to Model\Prosit\Config\UpdatePrositConfiguration.bat in the .csproj file.

I'll update the wiki page once this is merged to master.