### PR TITLE
Enable pass0 testing for tutorials on TeamCity

### DIFF
--- a/pwiz_tools/Skyline/TestPerf/EncyclopeDiaSearchTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/EncyclopeDiaSearchTutorialTest.cs
@@ -84,7 +84,7 @@ namespace TestPerf
             RunTest();
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoNightlyTesting(TestExclusionReason.EXCESSIVE_TIME), Timeout(36000000)] // 10 hours
+        //[TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoNightlyTesting(TestExclusionReason.EXCESSIVE_TIME), Timeout(36000000)] // 10 hours
         public void TestEncyclopeDiaSearchTutorialFullFileset()
         {
             if (!RunPerfTests)

--- a/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
@@ -75,7 +75,7 @@ namespace pwiz.SkylineTestTutorial
                 {
                     UseRawFiles
                         ? @"https://skyline.gs.washington.edu/tutorials/PeakPicking.zip"
-                        : @"https://skyline.gs.washington.edu/tutorials/PeakPickingMzml.zip",
+                        : @"https://skyline.gs.washington.edu/tutorials/PeakPickingMzml_2.zip",
                     @"TestTutorial\PeakPickingViews.zip"
                 };
             RunFunctionalTest();

--- a/scripts/misc/tc-perftests.bat
+++ b/scripts/misc/tc-perftests.bat
@@ -22,7 +22,7 @@ IF EXIST pwiz_tools\Skyline\TestResults rmdir /s /q pwiz_tools\Skyline\TestResul
 echo Cleaning downloads
 IF EXIST %SKYLINE_DOWNLOAD_PATH% rmdir /s /q %SKYLINE_DOWNLOAD_PATH%
 echo Cleaning temp
-IF EXIST z:\Temp del /f /s /q z:\Temp\*.* >nul
+IF EXIST z:\Temp del /f /s /q z:\Temp\*.* >nul 2>&1
 )
 
 FOR /F %%I IN (perfTestNames.txt) DO (
@@ -36,7 +36,7 @@ IF EXIST pwiz_tools\Skyline\TestResults rmdir /s /q pwiz_tools\Skyline\TestResul
 echo Cleaning downloads
 IF EXIST %SKYLINE_DOWNLOAD_PATH% rmdir /s /q %SKYLINE_DOWNLOAD_PATH%
 echo Cleaning temp
-IF EXIST z:\Temp del /f /s /q z:\Temp\*.* >nul
+IF EXIST z:\Temp del /f /s /q z:\Temp\*.* >nul 2>&1
 )
 
 echo %FailedTests% tests failed.

--- a/scripts/misc/tc-perftests.bat
+++ b/scripts/misc/tc-perftests.bat
@@ -5,11 +5,27 @@ set SKYLINE_DOWNLOAD_PATH=z:\download
 REM Remove C++ build artifacts to free up space
 rmdir /s /q build-nt-x86
 
-pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe test=TestTutorial.dll,TestPerf.dll listonly > tests.txt
-powershell "Get-Content tests.txt | ForEach-Object { $_.split(\"`t\")[1] }" > testNames.txt
+pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe test=TestTutorial.dll listonly > tests.txt
+powershell "Get-Content tests.txt | ForEach-Object { $_.split(\"`t\")[1] }" > tutorialTestNames.txt
+pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe test=TestPerf.dll listonly > tests.txt
+powershell "Get-Content tests.txt | ForEach-Object { $_.split(\"`t\")[1] }" > perfTestNames.txt
 
 set FailedTests=0
-FOR /F %%I IN (testNames.txt) DO (
+FOR /F %%I IN (tutorialTestNames.txt) DO (
+REM check if test is in skip list
+findstr /b /e %%I scripts\misc\tc-perftests-skiplist.txt >nul
+REM if test is in skiplist, ERRORLEVEL will be 0
+IF ERRORLEVEL 1 (pwiz_tools\Skyline\bin\x64\Release\TestRunner.exe test=%%I pass0=on loop=1 language=en perftests=on teamcitytestdecoration=on runsmallmoleculeversions=on showheader=off) ELSE echo Skipped %%I
+IF ERRORLEVEL 1 set /a FailedTests += 1
+echo Cleaning TestResults
+IF EXIST pwiz_tools\Skyline\TestResults rmdir /s /q pwiz_tools\Skyline\TestResults
+echo Cleaning downloads
+IF EXIST %SKYLINE_DOWNLOAD_PATH% rmdir /s /q %SKYLINE_DOWNLOAD_PATH%
+echo Cleaning temp
+IF EXIST z:\Temp del /f /s /q z:\Temp\*.* >nul
+)
+
+FOR /F %%I IN (perfTestNames.txt) DO (
 REM check if test is in skip list
 findstr /b /e %%I scripts\misc\tc-perftests-skiplist.txt >nul
 REM if test is in skiplist, ERRORLEVEL will be 0


### PR DESCRIPTION
* split tc-perftests.bat on TeamCity into tutorials and perftests and enabled pass0 testing for tutorials