### PR TITLE
Peptide digestion settings on commandline

### DIFF
--- a/pwiz_tools/Skyline/CommandArgUsage.Designer.cs
+++ b/pwiz_tools/Skyline/CommandArgUsage.Designer.cs
@@ -124,6 +124,24 @@ namespace pwiz.Skyline {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The path to the background proteome (protdb) file to apply to the opened document. The name may be optionally specified by --background-proteome-name..
+        /// </summary>
+        internal static string _background_proteome_file {
+            get {
+                return ResourceManager.GetString("_background_proteome_file", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of a background proteome to apply to the opened document. The background proteome specifies the full set of proteins that may be present in the sample matrix to be injected into the mass spectrometer. If the name is not already defined in Skyline, the path to the protdb file must also be set by --background-proteome-file..
+        /// </summary>
+        internal static string _background_proteome_name {
+            get {
+                return ResourceManager.GetString("_background_proteome_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Runs a file line by line treating each line like a SkylineRunner/Cmd input. Useful for automating the execution of multiple commands.  The open Skyline file remains active through all commands..
         /// </summary>
         internal static string _batch_commands {
@@ -1162,8 +1180,16 @@ namespace pwiz.Skyline {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exclude all peptides starting before this amino acid position
-        ///in each protein..
+        ///   Looks up a localized string similar to The protease enzyme used for digesting proteins into peptides prior to injection into the mass spectrometer..
+        /// </summary>
+        internal static string _pep_digest_enzyme {
+            get {
+                return ResourceManager.GetString("_pep_digest_enzyme", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exclude all peptides starting before this amino acid position in each protein..
         /// </summary>
         internal static string _pep_exclude_nterminal_aas {
             get {
@@ -1172,8 +1198,7 @@ namespace pwiz.Skyline {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exclude peptides resulting from cleavage sites with immediate
-        ///preceding or following cleavage sites. e.g. RR, KK, RK, KR for trypsin.
+        ///   Looks up a localized string similar to Exclude peptides resulting from cleavage sites with immediate preceding or following cleavage sites. e.g. RR, KK, RK, KR for trypsin.
         /// </summary>
         internal static string _pep_exclude_potential_ragged_ends {
             get {
@@ -1191,11 +1216,31 @@ namespace pwiz.Skyline {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The maximum number of missed cleavages allowed in a peptide when considering protein digestion..
+        /// </summary>
+        internal static string _pep_max_missed_cleavages {
+            get {
+                return ResourceManager.GetString("_pep_max_missed_cleavages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The minimum length of a peptide to add to the document..
         /// </summary>
         internal static string _pep_min_length {
             get {
                 return ResourceManager.GetString("_pep_min_length", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;Protein&quot; excludes any peptide that appears in more than one protein in the background proteome.  
+        ///&quot;Gene&quot; excludes any peptide that appears in proteins for more than one gene in the background proteome.  
+        ///&quot;Species&quot; excludes any peptide that appears in proteins for more than one species in the background proteome..
+        /// </summary>
+        internal static string _pep_unique_by {
+            get {
+                return ResourceManager.GetString("_pep_unique_by", resourceCulture);
             }
         }
         

--- a/pwiz_tools/Skyline/CommandArgUsage.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.resx
@@ -958,4 +958,21 @@ greater peak area.</value>
   <data name="_pep_min_length" xml:space="preserve">
     <value>The minimum length of a peptide to add to the document.</value>
   </data>
+  <data name="_background_proteome_file" xml:space="preserve">
+    <value>The path to the background proteome (protdb) file to apply to the opened document. The name may be optionally specified by --background-proteome-name.</value>
+  </data>
+  <data name="_background_proteome_name" xml:space="preserve">
+    <value>The name of a background proteome to apply to the opened document. The background proteome specifies the full set of proteins that may be present in the sample matrix to be injected into the mass spectrometer. If the name is not already defined in Skyline, the path to the protdb file must also be set by --background-proteome-file.</value>
+  </data>
+  <data name="_pep_digest_enzyme" xml:space="preserve">
+    <value>The protease enzyme used for digesting proteins into peptides prior to injection into the mass spectrometer.</value>
+  </data>
+  <data name="_pep_max_missed_cleavages" xml:space="preserve">
+    <value>The maximum number of missed cleavages allowed in a peptide when considering protein digestion.</value>
+  </data>
+  <data name="_pep_unique_by" xml:space="preserve">
+    <value>"Protein" excludes any peptide that appears in more than one protein in the background proteome.  
+"Gene" excludes any peptide that appears in proteins for more than one gene in the background proteome.  
+"Species" excludes any peptide that appears in proteins for more than one species in the background proteome.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -1404,8 +1404,7 @@ namespace pwiz.Skyline
         public static readonly Argument ARG_BGPROTEOME_NAME = new DocArgument(@"background-proteome-name", () => GetDisplayNames(Settings.Default.BackgroundProteomeList),
             (c, p) => c.BackgroundProteomeName = p.Value)
             { WrapValue = true };
-        public static readonly Argument ARG_BGPROTEOME_PATH = new DocArgument(@"background-proteome-file", PATH_TO_FILE,
-            (c, p) => c.BackgroundProteomePath = p.Value);
+        public static readonly Argument ARG_BGPROTEOME_PATH = new DocArgument(@"background-proteome-file", PATH_TO_FILE, (c, p) => c.BackgroundProteomePath = p.Value);
 
         public static readonly Argument ARG_IMS_LIBRARY_RES = new DocArgument(@"ims-library-res", RP_VALUE,
                 (c, p) => c.IonMobilityLibraryRes = p.ValueDouble);

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -1168,51 +1168,6 @@ namespace pwiz.Skyline
             }
         }
 
-        private bool SetPeptideFilterSettings(CommandArgs commandArgs)
-        {
-            try
-            {
-                ModifyDocumentWithLogging(d => d.ChangeSettings(d.Settings.ChangePeptideSettings(p =>
-                {
-                    var filterSettings = p.Filter;
-
-                    if (commandArgs.PeptideFilterMinLength.HasValue)
-                    {
-                        filterSettings = filterSettings.ChangeMinPeptideLength(commandArgs.PeptideFilterMinLength.Value);
-                        p = p.ChangeFilter(filterSettings);
-                    }
-
-                    if (commandArgs.PeptideFilterMaxLength.HasValue)
-                    {
-                        filterSettings = filterSettings.ChangeMaxPeptideLength(commandArgs.PeptideFilterMaxLength.Value);
-                        p = p.ChangeFilter(filterSettings);
-                    }
-
-                    if (commandArgs.PeptideFilterExcludeNTerminalAAs.HasValue)
-                    {
-                        filterSettings = filterSettings.ChangeExcludeNTermAAs(commandArgs.PeptideFilterExcludeNTerminalAAs.Value);
-                        p = p.ChangeFilter(filterSettings);
-                    }
-
-                    if (commandArgs.PeptideFilterExcludePotentialRaggedEnds.HasValue)
-                    {
-                        var digestSettings = p.DigestSettings;
-                        digestSettings = new DigestSettings(digestSettings.MaxMissedCleavages, commandArgs.PeptideFilterExcludePotentialRaggedEnds.Value);
-                        p = p.ChangeDigestSettings(digestSettings);
-                    }
-
-                    return p;
-                })), AuditLogEntry.SettingsLogFunction);
-                return true;
-            }
-            catch (Exception x)
-            {
-                _out.WriteLine(Resources.CommandLine_SetPeptideFilterSettings_Error__Failed_attempting_to_change_the_peptide_filter_settings_);
-                _out.WriteLine(x.Message);
-                return false;
-            }
-        }
-
         private bool SetPeptideDigestSettings(CommandArgs commandArgs)
         {
             try
@@ -1244,13 +1199,21 @@ namespace pwiz.Skyline
                         p = p.ChangeBackgroundProteome(new BackgroundProteome(bgProteome));
                     }
 
+                    if (commandArgs.BackgroundProteomePath != null)
+                    {
+                        string name = Path.GetFileNameWithoutExtension(commandArgs.BackgroundProteomePath);
+                        var bgProteome = new BackgroundProteomeSpec(name, commandArgs.BackgroundProteomePath);
+                        p = p.ChangeBackgroundProteome(new BackgroundProteome(bgProteome));
+                        Settings.Default.BackgroundProteomeList.Add(bgProteome);
+                    }
+
                     return p;
                 })), AuditLogEntry.SettingsLogFunction);
                 return true;
             }
             catch (Exception x)
             {
-                _out.WriteLine("Error: Failed attempting to change the peptide digestion settings.");
+                _out.WriteLine(Resources.CommandLine_SetPeptideDigestSettings_Error__Failed_attempting_to_change_the_peptide_digestion_settings_);
                 _out.WriteLine(x.Message);
                 return false;
             }

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -7127,6 +7127,16 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error: Failed attempting to change the peptide digestion settings..
+        /// </summary>
+        public static string CommandLine_SetPeptideDigestSettings_Error__Failed_attempting_to_change_the_peptide_digestion_settings_ {
+            get {
+                return ResourceManager.GetString("CommandLine_SetPeptideDigestSettings_Error__Failed_attempting_to_change_the_pepti" +
+                        "de_digestion_settings_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error: Failed attempting to change the peptide filter settings..
         /// </summary>
         public static string CommandLine_SetPeptideFilterSettings_Error__Failed_attempting_to_change_the_peptide_filter_settings_ {

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -13833,4 +13833,7 @@ If you choose Disable, you can enable Auto-select later with the "Refine &gt; Ad
   <data name="CommandLine_SetPeptideFilterSettings_Error__Failed_attempting_to_change_the_peptide_filter_settings_" xml:space="preserve">
     <value>Error: Failed attempting to change the peptide filter settings.</value>
   </data>
+  <data name="CommandLine_SetPeptideDigestSettings_Error__Failed_attempting_to_change_the_peptide_digestion_settings_" xml:space="preserve">
+    <value>Error: Failed attempting to change the peptide digestion settings.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Settings.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.cs
@@ -468,13 +468,25 @@ namespace pwiz.Skyline.Properties
             }
         }
 
-        public Enzyme GetEnzymeByName(string name)
+        public Enzyme GetEnzymeByName(string name, bool withoutRulesSuffix = false, bool ignoreCase = false)
         {
             Enzyme enzyme;
-            if (!EnzymeList.TryGetValue(name, out enzyme))
+            if (!withoutRulesSuffix && !EnzymeList.TryGetValue(name, out enzyme))
             {
                 enzyme = EnzymeList.Count == 0 ?
                     EnzymeList.GetDefault() : EnzymeList[0];
+            }
+            else if (EnzymeList.Count == 0)
+            {
+                enzyme = EnzymeList.GetDefault();
+            }
+            else
+            {
+                enzyme = EnzymeList.FirstOrDefault(e => e.Name.Equals(name,
+                             ignoreCase
+                                 ? StringComparison.InvariantCultureIgnoreCase
+                                 : StringComparison.InvariantCulture)) ??
+                         EnzymeList[0];
             }
             return enzyme;
         }

--- a/pwiz_tools/Skyline/Properties/Settings.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.cs
@@ -470,7 +470,7 @@ namespace pwiz.Skyline.Properties
 
         public Enzyme GetEnzymeByName(string name, bool withoutRulesSuffix = false, bool ignoreCase = false)
         {
-            Enzyme enzyme;
+            Enzyme enzyme = null;
             if (!withoutRulesSuffix && !EnzymeList.TryGetValue(name, out enzyme))
             {
                 enzyme = EnzymeList.Count == 0 ?
@@ -480,7 +480,7 @@ namespace pwiz.Skyline.Properties
             {
                 enzyme = EnzymeList.GetDefault();
             }
-            else
+            else if (withoutRulesSuffix || ignoreCase)
             {
                 enzyme = EnzymeList.FirstOrDefault(e => e.Name.Equals(name,
                              ignoreCase


### PR DESCRIPTION
Adds most settings from the Peptide Settings Digestion tab as command-line options.
Fixes command-line enum parsing to be case-insensitive. (e.g. gene or Gene or GENE)