### PR TITLE
- fixed MSConvertGUI to use the same invalid filename chars as msconvert

### DIFF
--- a/pwiz_tools/MSConvertGUI/MainLogic.cs
+++ b/pwiz_tools/MSConvertGUI/MainLogic.cs
@@ -81,7 +81,7 @@ namespace MSConvertGUI
                 // this list is for Windows; it's a superset of the POSIX list
                 const string illegalFilename = "\\/*:?<>|\"";
                 foreach (var t in illegalFilename)
-                    if (runId.Contains(t))
+                    if (t < 0x20 || t == 0x7F || runId.Contains(t))
                         runId = runId.Replace(t, '_');
 
                 var newFilename = runId + Extension;


### PR DESCRIPTION
- fixed MSConvertGUI to use the same invalid filename chars as msconvert (which was recently updated to replace all unprintable/control chars with underscore)

Closes #2786 