### PR TITLE
Skyline: Fix Grpc.Core.Channel leaking during tests due to …

### DIFF
--- a/pwiz_tools/Skyline/Model/Prosit/Communication/PrositPredictionClient.cs
+++ b/pwiz_tools/Skyline/Model/Prosit/Communication/PrositPredictionClient.cs
@@ -79,18 +79,10 @@ namespace pwiz.Skyline.Model.Prosit.Communication
         // a set of cached predictions
         public static PrositPredictionClient FakeClient { get; set; }
 
-        void IDisposable.Dispose()
+        public virtual void Dispose()
         {
-            Dispose(true);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _channel?.ShutdownAsync().Wait();
-                _channel = null;
-            }
+            _channel?.ShutdownAsync().Wait();
+            _channel = null;
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/Prosit/Config/PrositConfig.cs
+++ b/pwiz_tools/Skyline/Model/Prosit/Config/PrositConfig.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Xml.Serialization;
 using Grpc.Core;
+using pwiz.Skyline.Model.Prosit.Communication;
 
 namespace pwiz.Skyline.Model.Prosit.Config
 {
@@ -67,6 +68,20 @@ namespace pwiz.Skyline.Model.Prosit.Config
                 }
                 var xmlSerializer = new XmlSerializer(typeof(PrositConfig));
                 return (PrositConfig) xmlSerializer.Deserialize(stream);
+            }
+        }
+
+        public void CallWithClient(Action<PrositPredictionClient> action)
+        {
+            var channel = CreateChannel();
+            try
+            {
+                var client = new PrositPredictionClient(channel, Server);
+                action(client);
+            }
+            finally
+            {
+                channel.ShutdownAsync().Wait();
             }
         }
     }

--- a/pwiz_tools/Skyline/TestConnected/PrositConnectionTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/PrositConnectionTest.cs
@@ -46,8 +46,10 @@ namespace pwiz.SkylineTestConnected
             {
                 return;
             }
-            PrositPredictionClient client = PrositPredictionClient.CreateClient(PrositConfig.GetPrositConfig());
-            Assert.IsTrue(TestClient(client));
+            PrositConfig.GetPrositConfig().CallWithClient(client =>
+            {
+                Assert.IsTrue(TestClient(client));
+            });
         }
 
         public bool TestClient(PrositPredictionClient client)

--- a/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
@@ -44,7 +44,7 @@ namespace pwiz.SkylineTestFunctional
         public void TestAccessServer()
         {
             TestFilesZip = @"TestFunctional\AccessServerTest.zip";
-            using (new FakeProsit())    // Avoid constructing a real PrositPredictionClient
+            using (new FakePrositPredictionClient(null))    // Avoid constructing a real PrositPredictionClient
             {
                 RunFunctionalTest();
             }

--- a/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
@@ -44,7 +44,7 @@ namespace pwiz.SkylineTestFunctional
         public void TestAccessServer()
         {
             TestFilesZip = @"TestFunctional\AccessServerTest.zip";
-            using (new FakePrositPredictionClient(null))    // Avoid constructing a real PrositPredictionClient
+            using (new FakeProsit(null))
             {
                 RunFunctionalTest();
             }

--- a/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AccessServerTest.cs
@@ -44,7 +44,10 @@ namespace pwiz.SkylineTestFunctional
         public void TestAccessServer()
         {
             TestFilesZip = @"TestFunctional\AccessServerTest.zip";
-            RunFunctionalTest();
+            using (new FakeProsit())    // Avoid constructing a real PrositPredictionClient
+            {
+                RunFunctionalTest();
+            }
         }
 
         private readonly IPanoramaPublishClient _testPublishClient = new TestPanoramaPublishClient();

--- a/pwiz_tools/Skyline/TestFunctional/PrositSkylineIntegrationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PrositSkylineIntegrationTest.cs
@@ -2160,11 +2160,11 @@ namespace pwiz.SkylineTestFunctional
                 Assert.Fail("Unknown model \"{0}\"", request.ModelSpec.Name);
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Dispose()
         {
             Assert.AreSame(this, FakeClient);
             FakeClient = null;
-            base.Dispose(disposing);
+            base.Dispose();
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/PrositSkylineIntegrationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PrositSkylineIntegrationTest.cs
@@ -2090,7 +2090,7 @@ namespace pwiz.SkylineTestFunctional
         public FakeProsit(IList<PrositQuery> expectedQueries)
         {
             _channel = PrositConfig.GetPrositConfig().CreateChannel();
-            _fakeClient = new FakePrositPredictionClient(expectedQueries);
+            _fakeClient = new FakePrositPredictionClient(_channel, expectedQueries);
             Assert.IsNull(PrositPredictionClient.FakeClient);
             PrositPredictionClient.FakeClient = _fakeClient;
         }
@@ -2112,8 +2112,8 @@ namespace pwiz.SkylineTestFunctional
     {
         private IList<PrositQuery> _expectedQueries;
 
-        public FakePrositPredictionClient(IList<PrositQuery> expectedQueries) :
-            base(PrositConfig.GetPrositConfig().CreateChannel(), PrositConfig.GetPrositConfig().Server)
+        public FakePrositPredictionClient(Channel channel, IList<PrositQuery> expectedQueries) :
+            base(channel, PrositConfig.GetPrositConfig().Server)
         {
             _expectedQueries = expectedQueries;
         }

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.cs
@@ -223,7 +223,7 @@ namespace pwiz.Skyline.ToolsUI
 
             try
             {
-                if (PrositIntensityModelCombo == null || PrositRetentionTimeModelCombo == null)
+                if (string.IsNullOrEmpty(PrositIntensityModelCombo) || string.IsNullOrEmpty(PrositRetentionTimeModelCombo))
                 {
                     _pingRequest?.Cancel();
                     SetServerStatus(ServerStatus.SELECT_MODEL);

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.cs
@@ -481,7 +481,18 @@ namespace pwiz.Skyline.ToolsUI
 
         private void ToolOptionsUI_Shown(object sender, EventArgs e)
         {
-            UpdateServerStatus();
+            if (tabControl.SelectedIndex == (int)TABS.Prosit)
+                UpdateServerStatus();
+            else
+            {
+                tabControl.SelectedIndexChanged += tabControl_SelectedIndexChanged;
+            }
+        }
+
+        private void tabControl_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (tabControl.SelectedIndex == (int)TABS.Prosit)
+                UpdateServerStatus();
         }
     }
 }


### PR DESCRIPTION
…  excessive Prosit initialization
- Improve ToolsOptionsUI to only initialize and query Prosit when the Prosit tab is activated