### PR TITLE
Fix NRE in MeasuredResults.QcTraceNames

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromHeaderInfo.cs
@@ -2246,18 +2246,9 @@ namespace pwiz.Skyline.Model.Results
 
         internal ChromGroupHeaderInfo Header { get { return _groupHeaderInfo; } }
         public SignedMz PrecursorMz { get { return new SignedMz(_groupHeaderInfo.Precursor, _groupHeaderInfo.NegativeCharge); } }
-        public ChromatogramGroupId ChromatogramGroupId
-        {
-            get; private set;
-        }
-
-        public string QcTraceName
-        {
-            get
-            {
-                return ChromatogramGroupId?.QcTraceName;
-            }
-        }
+        [CanBeNull]
+        public ChromatogramGroupId ChromatogramGroupId { get; private set; }
+        public string QcTraceName { get { return ChromatogramGroupId?.QcTraceName; } }
         public double? PrecursorCollisionalCrossSection { get { return _groupHeaderInfo.CollisionalCrossSection; } }
         public ChromCachedFile CachedFile { get { return _allFiles[_groupHeaderInfo.FileIndex]; } }
         public MsDataFileUri FilePath { get { return _allFiles[_groupHeaderInfo.FileIndex].FilePath; } }

--- a/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
+++ b/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
@@ -782,7 +782,7 @@ namespace pwiz.Skyline.Model.Results
                 var qcTraceInfos = Caches.SelectMany(cache=>cache.ChromGroupHeaderInfos
                                                                  .Where(header => header.Flags.HasFlag(ChromGroupHeaderInfo.FlagValues.extracted_qc_trace))
                                                                  .Select(header => cache.LoadChromatogramInfo(header)));
-                var qcTraceNames = qcTraceInfos.Select(info => info.ChromatogramGroupId.QcTraceName).Distinct()
+                var qcTraceNames = qcTraceInfos.Select(info => info.QcTraceName).Distinct()
                     .ToList();
                 qcTraceNames.Sort();
                 return qcTraceNames;


### PR DESCRIPTION
Fixed error right-clicking on chromatogram graph that happens with some documents where chromatograms had been extracted by Skyline-daily version 23.0.9.157 (reported by Mike)