### PR TITLE
Figure out why StackOverflowException on TeamCity is not a failure

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/StackOverflowExceptionTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/StackOverflowExceptionTest.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTestFunctional
+{
+    /// <summary>
+    /// Test which causes a StackOverflowException to be thrown, causing TestRunner.exe to exit immediately.
+    ///
+    /// This test should not be merged into the master branch. The only purpose of this test is to make sure that TeamCity is properly able
+    /// to see that the tests have failed when this test is part of the suite.
+    /// </summary>
+    [TestClass]
+    public class StackOverflowExceptionTest : AbstractFunctionalTest
+    {
+        [TestMethod]
+        public void TestStackOverflowException()
+        {
+            RunFunctionalTest();
+        }
+
+        protected override void DoTest()
+        {
+            RunUI(()=>OverflowStack());
+        }
+
+        private void OverflowStack()
+        {
+            OverflowStack();
+        }
+    }
+}

--- a/pwiz_tools/Skyline/TestFunctional/StackOverflowExceptionTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/StackOverflowExceptionTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTestFunctional
@@ -23,6 +24,7 @@ namespace pwiz.SkylineTestFunctional
             RunUI(()=>OverflowStack());
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         private void OverflowStack()
         {
             OverflowStack();

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -211,6 +211,7 @@
     <Compile Include="SaveAfterProteinAssociationTest.cs" />
     <Compile Include="SelectSpectrumTest.cs" />
     <Compile Include="SequenceTreeRatioTest.cs" />
+    <Compile Include="StackOverflowExceptionTest.cs" />
     <Compile Include="SurrogateCalibrationCurveTest.cs" />
     <Compile Include="TestPanoramaClient.cs" />
     <Compile Include="SkydFileModifiedTest.cs" />


### PR DESCRIPTION
Trying to track down why TeamCity does not notice that a StackOverflowException which causes TestRunner.exe to abruptly exit with exit code 2147943401 should be treated as a test failure.