### PR TITLE
small molecule chromatogram extraction wasn't using spectral library retention times …

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
@@ -1119,9 +1119,6 @@ namespace pwiz.Skyline.Model.DocSettings
 
         public double[] GetBestRetentionTimes(PeptideDocNode nodePep, MsDataFileUri filePath)
         {
-            if (!nodePep.IsProteomic)
-                return new double[0]; // No retention time prediction for small molecules
-
             var lookupSequence = nodePep.SourceUnmodifiedTarget;
             var lookupMods = nodePep.SourceExplicitMods;
             if (filePath != null)

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -93,7 +93,7 @@ namespace pwiz.SkylineTestTutorial
                 return;
             }
 
-            ForceMzml = true;   // 2-3x faster than raw files for this test.
+            ForceMzml = true;   // 2-3x faster than raw files for this test - and audit log expects it.
 
             AsSmallMoleculesTestMode = smallMoleculesTestMode;
 
@@ -468,8 +468,8 @@ namespace pwiz.SkylineTestTutorial
 
             const int expectedMoleculeCount = 9;
             const int expectedTransitionGroupCount = 10; // Expect this many with results
-            var expected20TransitionCount = UseRawFiles ? 87 : 88; // Expect this many with results
-            var expected80TransitionCount = UseRawFiles ? 86 : 87;
+            var expected20TransitionCount = AsSmallMoleculeMasses  ? 87 : 88; // Expect this many with results (note no library match possible for "as masses" version)
+            var expected80TransitionCount = AsSmallMoleculeMasses ? 88 : 87;
             AssertResult.IsDocumentResultsState(SkylineWindow.Document, shortLowRes20FileName, expectedMoleculeCount, expectedTransitionGroupCount, 0, expected20TransitionCount, 0);
             AssertResult.IsDocumentResultsState(SkylineWindow.Document, shortLowRes80FileName, expectedMoleculeCount, expectedTransitionGroupCount, 0, expected80TransitionCount, 0);
 

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -468,9 +468,8 @@ namespace pwiz.SkylineTestTutorial
 
             const int expectedMoleculeCount = 9;
             const int expectedTransitionGroupCount = 10; // Expect this many with results
-            var expected20TransitionCount = AsSmallMolecules || UseRawFiles ? 87 : 88; // Expect this many with results
-            var expected80TransitionCount = AsSmallMolecules ? 88 : UseRawFiles ? 86 : 87;
-
+            var expected20TransitionCount = UseRawFiles ? 87 : 88; // Expect this many with results
+            var expected80TransitionCount = UseRawFiles ? 86 : 87;
             AssertResult.IsDocumentResultsState(SkylineWindow.Document, shortLowRes20FileName, expectedMoleculeCount, expectedTransitionGroupCount, 0, expected20TransitionCount, 0);
             AssertResult.IsDocumentResultsState(SkylineWindow.Document, shortLowRes80FileName, expectedMoleculeCount, expectedTransitionGroupCount, 0, expected80TransitionCount, 0);
 


### PR DESCRIPTION
… (didn't initially have that capability, and the limitation was never lifted)