### PR TITLE
Fix Nightly failure in ConsoleVerboseExceptionsTest

### DIFF
--- a/pwiz_tools/Skyline/TestData/ConsoleVerboseExceptionsTest.cs
+++ b/pwiz_tools/Skyline/TestData/ConsoleVerboseExceptionsTest.cs
@@ -35,7 +35,7 @@ namespace pwiz.SkylineTestData
                     "--verbose-errors",
                     "--exception");
             const string exceptionLocation =
-                @"at pwiz.Skyline.CommandLine.HandleExceptions[T](CommandArgs commandArgs, Func`1 func, Action`1 outputFunc)";
+                @"pwiz.Skyline.CommandLine.HandleExceptions[T](CommandArgs commandArgs, Func`1 func, Action`1 outputFunc)";
             // The stack trace should be reported
             CheckRunCommandOutputContains(exceptionLocation, output);
             // Throw an exception without verbose errors


### PR DESCRIPTION
Remove localized portion of the stack trace message