### PR TITLE
Reduce the minimum ions required for a dot product from 3 to 2

### DIFF
--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -38,8 +38,8 @@ namespace pwiz.Skyline.Model
 {
     public class TransitionGroupDocNode : DocNodeParent
     {
-        public const int MIN_DOT_PRODUCT_TRANSITIONS = 3;
-        public const int MIN_DOT_PRODUCT_MS1_TRANSITIONS = 3;
+        public const int MIN_DOT_PRODUCT_TRANSITIONS = 2;
+        public const int MIN_DOT_PRODUCT_MS1_TRANSITIONS = 2;
 
         public const int MIN_TREND_REPLICATES = 4;
         public const int MAX_TREND_REPLICATES = 6;

--- a/pwiz_tools/Skyline/Test/MQuestScoringTest.cs
+++ b/pwiz_tools/Skyline/Test/MQuestScoringTest.cs
@@ -195,7 +195,7 @@ namespace pwiz.SkylineTest
             {
                 MQuestScoreEquals(calcProductMassError, 0.99112, peptideData);
                 MQuestScoreEquals(calcIntensity, 2.84732, peptideData);
-                MQuestScoreEquals(calcCrossCorr, double.NaN, peptideData);  // Not enough fragment ions
+                MQuestScoreEquals(calcCrossCorr, 0.92422, peptideData);
             }
             foreach (var peptideData in new[] {peptidePeakDataFull, peptidePeakDataMs1Full})
             {
@@ -205,7 +205,7 @@ namespace pwiz.SkylineTest
             MQuestScoreEquals(calcPrecursorMassError, double.NaN, peptidePeakData);
             MQuestScoreEquals(calcPrecursorMassError, 5.0, peptidePeakDataMs1);
             MQuestScoreEquals(calcIdotp, double.NaN, peptidePeakData);
-            MQuestScoreEquals(calcIdotp, double.NaN, peptidePeakDataMs1);   // Not enough MS1 transitions
+            MQuestScoreEquals(calcIdotp, 0.795167, peptidePeakDataMs1);
             MQuestScoreEquals(calcIdotp, 0.783653, peptidePeakDataMs1Full);
 
             var peakData1NoArea = new MockTranPeakData<ISummaryPeakData>(INTENS0, IonType.a, null, 2, 0.5);


### PR DESCRIPTION
Reduced the minimum number of values required for a dot product to be calculated from 3 to 2 (requested by Philip)

This change makes Skyline calculate the dot products even when there are only 2 transitions.

(An earlier email I sent said that this change caused about a dozen tests to fail, but I think it was just the one test "MQuestSummaryScoreTest". I had other changes on my machine which were causing other tests to fail)