### PR TITLE
Provides a mechanism for omitting particular tests in Nightly runs on a per machine basis…

### DIFF
--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -1029,13 +1029,19 @@ namespace TestRunnerLib
         {
             lock (_logLock)
             {
-                Console.Write(info, args);
-                Console.Out.Flush(); // Get this info to TeamCity or SkylineTester ASAP
-                if (_log != null)
-                {
-                    _log.Write(info, args);
-                    _log.Flush();
-                }
+                Log(_log, info, args);
+            }
+        }
+
+        [StringFormatMethod("info")]
+        public static void Log(StreamWriter log, string info, object[] args)
+        {
+            Console.Write(info, args);
+            Console.Out.Flush(); // Get this info to TeamCity or SkylineTester ASAP
+            if (log != null)
+            {
+                log.Write(info, args ?? new object[] { });
+                log.Flush();
             }
         }
 

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -1034,7 +1034,9 @@ namespace TestRunnerLib
         }
 
         [StringFormatMethod("info")]
-        public static void Log(StreamWriter log, string info, object[] args)
+
+        // N.B. not thread safe, use the non-static version (which calls this) from any RunTests object
+        public static void Log(StreamWriter log, string info, object[] args) 
         {
             Console.Write(info, args);
             Console.Out.Flush(); // Get this info to TeamCity or SkylineTester ASAP


### PR DESCRIPTION
…  - environment variable SKYLINE_NIGHTLY_TEST_EXCLUSIONS can be set as a comma separated list of tests to be skipped (regex is supported)

e.g. this log output:

##teamcity[testSuiteStarted name='@C:\Dev\master_clean\pwiz_tools\Skyline\SkylineTester test list.txt'] 
\# Local environment variable $SKYLINE_NIGHTLY_TEST_EXCLUSIONS is set as \".\*Drift.\*\", skipping these tests: 
\# TestBlibDriftTimes
\# TestMeasuredDriftValues
\# TestMeasuredDriftValuesAsSmallMolecules
\# TestMeasuredDriftValuesNoRawData
\# WatersImsMseLibraryDriftTimesChromatogramTest
\# WatersImsMseLibraryDriftTimesChromatogramTestAsSmallMolecules 
\# WatersImsMseNoDriftTimesChromatogramTest
\# WatersImsMseNoDriftTimesChromatogramTestAsSmallMoleculeMasses 
\# WatersImsMseNoDriftTimesChromatogramTestAsSmallMolecules 
\# MeasuredDriftValuesPerfTest
\# TestDriftTimePredictorSmallMolecules
\# TestDriftTimePredictorTutorial