### PR TITLE
My previous change to allow for locally excluding some nightly tests accidentally turned them all off by default…

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -1653,6 +1653,10 @@ namespace TestRunner
                 var exclusions = (Environment.GetEnvironmentVariable(EnvVarSkylineNightlyTestExclusions) ?? string.Empty);
                 foreach (var bannedPatterns in exclusions.Split(','))
                 {
+                    if (string.IsNullOrEmpty(bannedPatterns))
+                    {
+                        continue;
+                    }
                     var pattern = new Regex(bannedPatterns.Trim());
                     foreach (var t in testList)
                     {


### PR DESCRIPTION
… (turns out an empty regex matches everything)