### PR TITLE
My previous change to allow for locally excluding some nightly tests …

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -1647,6 +1647,10 @@ namespace TestRunner
                 var exclusions = (Environment.GetEnvironmentVariable(EnvVarSkylineNightlyTestExclusions) ?? string.Empty);
                 foreach (var bannedPatterns in exclusions.Split(','))
                 {
+                    if (string.IsNullOrEmpty(bannedPatterns))
+                    {
+                        continue;
+                    }
                     var pattern = new Regex(bannedPatterns.Trim());
                     foreach (var t in testList)
                     {


### PR DESCRIPTION
…accidentally turned them all off by default (turns out an empty regex matches everything) (#2833)