### PR TITLE
Improve failure messages when "TestPanoramaClient" or "PanoramaClientDownloadTest" fails.

### DIFF
--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.cs
@@ -712,7 +712,7 @@ namespace pwiz.PanoramaClient
 
         public string VersionsOption => versionOptions.Text;
 
-        public void ClickFile(string name)
+        public bool ClickFile(string name)
         {
             listView.SelectedItems.Clear();
             foreach (ListViewItem item in listView.Items)
@@ -723,8 +723,11 @@ namespace pwiz.PanoramaClient
                     item.Selected = true;
                     listView.Select();
                     ClickOpen();
+                    return true;
                 }
             }
+
+            return false;
         }
 
         #endregion

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
@@ -308,13 +308,16 @@ namespace pwiz.PanoramaClient
             return node is { IsSelected: true };
         }
 
-        public void SelectNode(string nodeName)
+        public bool SelectNode(string nodeName)
         {
             var node = SearchTree(treeView.Nodes, nodeName);
             if (node?.Tag is FolderInformation)
             {
                 UpdateNavButtons(node);
+                return true;
             }
+
+            return false;
         }
 
         public string SelectedNodeText => _selectedNode.Text;

--- a/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
@@ -122,10 +122,7 @@ namespace pwiz.SkylineTestConnected
                 SkylineWindow.DownloadPanoramaFile(path, TEST_FILE, null,
                     server, 1, panoramaTestClient);
             }));
-            string expectedMessage = new NullReferenceException().Message;
-            TryWaitForCondition(() => expectedMessage == errorDlg.Message);
-            Assert.AreEqual(expectedMessage, errorDlg.Message);
-            
+            Assert.AreEqual(new NullReferenceException().Message, errorDlg.Message);
             OkDialog(errorDlg, errorDlg.OkDialog);
 
             errorDlg = ShowDialog<MessageDlg>(() => RunUI(() =>

--- a/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
@@ -123,10 +123,9 @@ namespace pwiz.SkylineTestConnected
                     server, 1, panoramaTestClient);
             }));
             string expectedMessage = new NullReferenceException().Message;
-            if (!TryWaitForCondition(() => expectedMessage == errorDlg.Message))
-            {
-                Assert.AreEqual(expectedMessage, errorDlg.Message);
-            }
+            TryWaitForCondition(() => expectedMessage == errorDlg.Message);
+            Assert.AreEqual(expectedMessage, errorDlg.Message);
+            
             OkDialog(errorDlg, errorDlg.OkDialog);
 
             errorDlg = ShowDialog<MessageDlg>(() => RunUI(() =>

--- a/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
@@ -102,10 +102,10 @@ namespace pwiz.SkylineTestConnected
             WaitForCondition(9000, () => remoteDlg.IsLoaded);
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER);
-                remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER), "Unable to select {0}", TEST_FOLDER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER), "Unable to select {0}", PANORAMA_FOLDER);
             });
-            OkDialog(remoteDlg, () => remoteDlg.ClickFile(TEST_FILE));
+            OkDialog(remoteDlg, () => Assert.IsTrue(remoteDlg.ClickFile(TEST_FILE), "Unable to click file {0}", TEST_FILE));
             WaitForCondition(() => File.Exists(path));
             FileEx.SafeDelete(path, true);
             Assert.IsFalse(File.Exists(path));
@@ -122,7 +122,11 @@ namespace pwiz.SkylineTestConnected
                 SkylineWindow.DownloadPanoramaFile(path, TEST_FILE, null,
                     server, 1, panoramaTestClient);
             }));
-            Assert.AreEqual(new NullReferenceException().Message, errorDlg.Message);
+            string expectedMessage = new NullReferenceException().Message;
+            if (!TryWaitForCondition(() => expectedMessage == errorDlg.Message))
+            {
+                Assert.AreEqual(expectedMessage, errorDlg.Message);
+            }
             OkDialog(errorDlg, errorDlg.OkDialog);
 
             errorDlg = ShowDialog<MessageDlg>(() => RunUI(() =>
@@ -170,8 +174,8 @@ namespace pwiz.SkylineTestConnected
 
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER);
-                remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER), "Unable to select {0}", TEST_FOLDER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER), "Unable to select {0}", PANORAMA_FOLDER);
                 remoteDlg.Close();
                 state = remoteDlg.FolderBrowser.TreeState;
             });
@@ -200,9 +204,9 @@ namespace pwiz.SkylineTestConnected
             WaitForCondition(9000, () => remoteDlg.IsLoaded);
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER);
-                remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER);
-                remoteDlg.ClickFile(DELETED_FILE);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER), "Unable to select {0}", TEST_FOLDER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER), "Unable to select {0}", PANORAMA_FOLDER);
+                Assert.IsTrue(remoteDlg.ClickFile(DELETED_FILE), "Unable to click file {0}", DELETED_FILE);
             });
             var errorDlg = ShowDialog<MessageDlg>(remoteDlg.ClickOpen);
             Assert.IsFalse(File.Exists(path));
@@ -222,9 +226,9 @@ namespace pwiz.SkylineTestConnected
 
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER);
-                remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER);
-                remoteDlg.ClickFile(RENAMED_FILE);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER), "Unable to select {0}", TEST_FOLDER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER), "Unable to select {0}", PANORAMA_FOLDER);
+                Assert.IsTrue(remoteDlg.ClickFile(RENAMED_FILE), "Unable to click file {0}", RENAMED_FILE);
                 Assert.AreNotEqual(RENAMED_FILE, remoteDlg.GetItemName(0));
             });
             WaitForClosedForm(remoteDlg);
@@ -265,9 +269,9 @@ namespace pwiz.SkylineTestConnected
 
             var remoteDlg = ShowDialog<PanoramaFilePicker>(() => ShowPanoramaFilePicker(serverList, selectedPath));
             WaitForConditionUI(() => remoteDlg.IsLoaded);
-            RunUI(() => remoteDlg.FolderBrowser.SelectNode("@files")); 
+            RunUI(() => Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode("@files"), "Unable to select @files")); 
             WaitForConditionUI(() => remoteDlg.FileNumber == 13);
-            RunUI(() => remoteDlg.FolderBrowser.SelectNode("FileRenamedOnServer"));
+            RunUI(() => Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode("FileRenamedOnServer"), "Unable to select FileRenamedOnServer"));
             WaitForConditionUI(() => remoteDlg.FileNumber == 6);
             OkDialog(remoteDlg, remoteDlg.Close);
         }

--- a/pwiz_tools/Skyline/TestFunctional/TestPanoramaClient.cs
+++ b/pwiz_tools/Skyline/TestFunctional/TestPanoramaClient.cs
@@ -93,9 +93,9 @@ namespace pwiz.SkylineTestFunctional
 
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(NO_TARGETED);
-                remoteDlg.FolderBrowser.SelectNode(TARGETED);
-                remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(NO_TARGETED), "Unable to select {0}", NO_TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED), "Unable to select {0}", TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY), "Unable to select {0}", TARGETED_LIBRARY);
                 Assert.IsTrue(remoteDlg.BackEnabled);
                 remoteDlg.ClickBack();
                 Assert.AreEqual(TARGETED, remoteDlg.FolderBrowser.SelectedNodeText);
@@ -106,7 +106,7 @@ namespace pwiz.SkylineTestFunctional
                 remoteDlg.ClickForward();
                 Assert.AreEqual(TARGETED, remoteDlg.FolderBrowser.SelectedNodeText);
                 remoteDlg.ClickUp();
-                remoteDlg.FolderBrowser.SelectNode(VALID_SERVER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(VALID_SERVER), "Unable to select {0}", VALID_SERVER);
                 Assert.IsFalse(remoteDlg.UpEnabled);
                 remoteDlg.Close();
             });
@@ -127,7 +127,7 @@ namespace pwiz.SkylineTestFunctional
 
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED), "Unable to select {0}", TARGETED);
                 Assert.IsTrue(remoteDlg.VersionsVisible);
                 Assert.AreEqual(PanoramaFilePicker.RECENT_VER, remoteDlg.VersionsOption);
                 Assert.AreEqual(1, remoteDlg.FileNumber);
@@ -163,15 +163,15 @@ namespace pwiz.SkylineTestFunctional
 
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(NO_TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(NO_TARGETED), "Unable to select {0}", NO_TARGETED);
                 Assert.AreEqual(3, remoteDlg.FolderBrowser.TreeviewIcon);
-                remoteDlg.FolderBrowser.SelectNode(TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED), "Unable to select {0}", TARGETED);
                 Assert.AreEqual(1, remoteDlg.FolderBrowser.TreeviewIcon);
-                remoteDlg.FolderBrowser.SelectNode(VALID_SERVER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(VALID_SERVER), "Unable to select {0}", VALID_SERVER);
                 Assert.AreEqual(-1, remoteDlg.FolderBrowser.TreeviewIcon);
-                remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY), "Unable to select {0}", TARGETED_LIBRARY);
                 Assert.AreEqual(2, remoteDlg.FolderBrowser.TreeviewIcon);
-                remoteDlg.FolderBrowser.SelectNode(TARGETED_COLLABORATION);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED_COLLABORATION), "Unable to select {0}", TARGETED_COLLABORATION);
                 Assert.AreEqual(1, remoteDlg.FolderBrowser.TreeviewIcon);
                 remoteDlg.Close();
             });
@@ -200,7 +200,7 @@ namespace pwiz.SkylineTestFunctional
 
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED), "Unable to select {0}", TARGETED);
                 //remoteDlg.FolderBrowser.ClickRight();
                 //Assert.IsTrue(remoteDlg.FolderBrowser.IsExpanded(TARGETED));
                 Assert.IsTrue(remoteDlg.VersionsVisible);
@@ -210,7 +210,7 @@ namespace pwiz.SkylineTestFunctional
                 remoteDlg.TestFileJson = fileJson;
                 remoteDlg.TestSizeJson = sizeJson;
 
-                remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY), "Unable to select {0}", TARGETED_LIBRARY);
                 //remoteDlg.FolderBrowser.ClickRight();
                 //Assert.IsTrue(remoteDlg.FolderBrowser.IsExpanded(TARGETED_LIBRARY));
                 Assert.IsFalse(remoteDlg.VersionsVisible);
@@ -220,7 +220,7 @@ namespace pwiz.SkylineTestFunctional
                 remoteDlg.TestFileJson = filesJson;
                 remoteDlg.TestSizeJson = sizesJson;
 
-                remoteDlg.FolderBrowser.SelectNode(TARGETED_COLLABORATION);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED_COLLABORATION), "Unable to select {0}", TARGETED_COLLABORATION);
                 Assert.IsTrue(remoteDlg.VersionsVisible);
                 Assert.AreEqual(PanoramaFilePicker.RECENT_VER, remoteDlg.VersionsOption);
                 Assert.AreEqual(1, remoteDlg.FileNumber);
@@ -247,8 +247,8 @@ namespace pwiz.SkylineTestFunctional
             var sizeString = sizeObj.Format(@"fs1", 3, sizeObj);
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(TARGETED);
-                remoteDlg.ClickFile("File1");
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED), "Unable to select {0}", TARGETED);
+                Assert.IsTrue(remoteDlg.ClickFile("File1"), "Unable to click 'File1'");
                 Assert.AreEqual("File1", remoteDlg.GetItemValue(0));
                 Assert.AreEqual(sizeString, remoteDlg.GetItemValue(1));
                 Assert.AreEqual(4.ToString(), remoteDlg.GetItemValue(2));
@@ -259,14 +259,14 @@ namespace pwiz.SkylineTestFunctional
 
                 remoteDlg.ClickVersions();
 
-                remoteDlg.ClickFile("File2");
+                Assert.IsTrue(remoteDlg.ClickFile("File2"), "Unable to click 'File2'");
                 Assert.AreEqual("File2", remoteDlg.GetItemValue(0));
                 Assert.AreEqual(sizeObj.Format(@"fs1", 200, sizeObj), remoteDlg.GetItemValue(1));
                 Assert.AreEqual(4.ToString(), remoteDlg.GetItemValue(2));
                 Assert.AreEqual("File1", remoteDlg.GetItemValue(3));
                 Assert.AreEqual(formattedDate.ToString(CultureInfo.CurrentCulture), remoteDlg.GetItemValue(4));
 
-                remoteDlg.ClickFile("File3");
+                Assert.IsTrue(remoteDlg.ClickFile("File3"), "Unable to click 'File3'");
                 Assert.AreEqual("File3", remoteDlg.GetItemValue(0));
                 Assert.AreEqual(sizeObj.Format(@"fs1", 6000, sizeObj), remoteDlg.GetItemValue(1));
                 Assert.AreEqual(4.ToString(), remoteDlg.GetItemValue(2));
@@ -301,7 +301,7 @@ namespace pwiz.SkylineTestFunctional
 
             RunUI(() =>
             {
-                remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY), "Unable to select {0}", TARGETED_LIBRARY);
                 Assert.AreEqual(1, remoteDlg.FileNumber);
                 Assert.IsFalse(remoteDlg.ColumnVisible(2));
                 Assert.IsFalse(remoteDlg.ColumnVisible(3));
@@ -309,7 +309,7 @@ namespace pwiz.SkylineTestFunctional
                 remoteDlg.TestFileJson = filesJson;
                 remoteDlg.TestSizeJson = sizesJson;
 
-                remoteDlg.FolderBrowser.SelectNode(TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED), "Unable to select {0}", TARGETED);
                 Assert.IsTrue(remoteDlg.ColumnVisible(2));
                 Assert.IsFalse(remoteDlg.ColumnVisible(3));
                 remoteDlg.ClickVersions();
@@ -332,15 +332,15 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() =>
             {
                 WaitForCondition(9000, () => remoteDlg.IsLoaded);
-                remoteDlg.FolderBrowser.SelectNode(NO_TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(NO_TARGETED), "Unable to select {0}", NO_TARGETED);
                 Assert.AreEqual(3, remoteDlg.FolderBrowser.TreeviewIcon);
-                remoteDlg.FolderBrowser.SelectNode(TARGETED);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED), "Unable to select {0}", TARGETED);
                 Assert.AreEqual(1, remoteDlg.FolderBrowser.TreeviewIcon);
-                remoteDlg.FolderBrowser.SelectNode(VALID_SERVER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(VALID_SERVER), "Unable to select {0}", VALID_SERVER);
                 Assert.AreEqual(-1, remoteDlg.FolderBrowser.TreeviewIcon);
-                remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED_LIBRARY), "Unable to select {0}", TARGETED_LIBRARY);
                 Assert.AreEqual(2, remoteDlg.FolderBrowser.TreeviewIcon);
-                remoteDlg.FolderBrowser.SelectNode(TARGETED_COLLABORATION);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TARGETED_COLLABORATION), "Unable to select {0}", TARGETED_COLLABORATION);
                 Assert.AreEqual(1, remoteDlg.FolderBrowser.TreeviewIcon);
             });
             OkDialog(remoteDlg, remoteDlg.OkDialog);

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1014,7 +1014,7 @@ namespace pwiz.SkylineTestUtil
             return WaitForCondition(WAIT_TIME, func, timeoutMessage);
         }
 
-        public static bool TryWaitForCondition([InstantHandle] Func<bool> func)
+        public static bool TryWaitForCondition(Func<bool> func)
         {
             return TryWaitForCondition(WAIT_TIME, func);
         }

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1014,7 +1014,7 @@ namespace pwiz.SkylineTestUtil
             return WaitForCondition(WAIT_TIME, func, timeoutMessage);
         }
 
-        public static bool TryWaitForCondition(Func<bool> func)
+        public static bool TryWaitForCondition([InstantHandle] Func<bool> func)
         {
             return TryWaitForCondition(WAIT_TIME, func);
         }


### PR DESCRIPTION
I made it so that PanoramaFilePicker.ClickFile and PanoramaFolderBrowser.SelectNode return a boolean so that the test can assert that the item to be clicked was actually there.

This should make it easier to figure out what is going wrong if this test ever fails in the future.