### PR TITLE
Fix error integrating zero-width peak

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/TimeIntensities.cs
+++ b/pwiz_tools/Skyline/Model/Results/TimeIntensities.cs
@@ -439,7 +439,7 @@ namespace pwiz.Skyline.Model.Results
             {
                 // The element before the passed in value of "index" is not allowed to be greater than "time".
                 // If that happens, then it means that the times for which this function was called were not in order.
-                Assume.IsTrue(Times[index - 1] < time);
+                Assume.IsTrue(Times[index - 1] <= time);
             }
             if (Times.Count == 0)
             {


### PR DESCRIPTION
Fixed error that could happen if DIA-NN chosen peak was outside of extracted chromatogram range (reported by Michele)