### PR TITLE
Fix chromatogram and report bugs

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -1241,11 +1241,11 @@ namespace pwiz.Skyline.Controls.Graphs
                                            out RetentionTimeValues bestRetentionTimes)
         {
             bestRetentionTimes = null;
-            if (ChromGroupInfos.Length == 0)
+            var chromGroupInfo = ChromGroupInfos?.FirstOrDefault();
+            if (chromGroupInfo == null)
             {
                 return;
             }
-            var chromGroupInfo = ChromGroupInfos[0];
             var fileId = chromatograms.FindFile(chromGroupInfo);
 
             var nodeGroup = _nodeGroups != null ? _nodeGroups.FirstOrDefault() : null;
@@ -2514,7 +2514,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                      out bool changedGroups)
         {
             bool qcTraceNameMatches = extractor != ChromExtractor.qc ||
-                                      _arrayChromInfo?[0]?[0].QcTraceName == Settings.Default.ShowQcTraceName;
+                                      _arrayChromInfo?[0]?[0]?.QcTraceName == Settings.Default.ShowQcTraceName;
 
             if (UpdateGroups(nodeGroups, groupPaths, out changedGroups) &&
                 _extractor == extractor &&

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Transition.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Transition.cs
@@ -174,13 +174,13 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             }
         }
         [Hidden(InUiMode = UiModes.SMALL_MOLECULES)]
-        public char? CleavageAa
+        public string CleavageAa
         {
             get
             {
                 return IsCustomTransition()
-                    ? default(char?) 
-                    : DocNode.Transition.AA;
+                    ? null 
+                    : DocNode.Transition.AA.ToString();
             }
         }
         [Format(NullValue = TextUtil.EXCEL_NA)]


### PR DESCRIPTION
Fixed unhandled error when selected QC trace is not present in a particular replicate (reported by Vyncent) Fixed truncation of report text copied to clipboard when report columns include "CleavageAa" (reported by Brendan)