### PR TITLE
Fix a hard to reproduce but often exception-web-reported problem with Skyline.Model.Results.MeasuredResults.IsPrefixToExtension(String name, String prefix)…

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
+++ b/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
@@ -399,6 +399,8 @@ namespace pwiz.Skyline.Model.Results
             // data files with the extension <basename>.c.mzXML.  So, this needs
             // to be able to match <basename> with <basename>.c, and Vanderbilt
             // has a pipeline that generates mzML files all uppercase
+            if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(prefix))
+                return false;
             if (!name.ToLower().StartsWith(prefix.ToLower()))
                 return false;
             if (name.Length == prefix.Length || name[prefix.Length] == '.')


### PR DESCRIPTION
… , as seen in https://skyline.ms/announcements/home/issues/exceptions/thread.view?entityId=5eeb4a3b-9bb2-103c-a05f-22f53556af9e&_anchor=63237