### PR TITLE
Speed up "ModEquivalentTest".

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/Collections/ReferenceValue.cs
+++ b/pwiz_tools/Shared/CommonUtil/Collections/ReferenceValue.cs
@@ -42,7 +42,7 @@ namespace pwiz.Common.Collections
 
         public override bool Equals(object obj)
         {
-            return obj is ReferenceValue<T> other && Equals(other);
+            return obj is ReferenceValue<T> other && ReferenceEquals(Value, other.Value);
         }
 
         public override int GetHashCode()

--- a/pwiz_tools/Skyline/Test/ModEquivalentTest.cs
+++ b/pwiz_tools/Skyline/Test/ModEquivalentTest.cs
@@ -246,26 +246,20 @@ namespace pwiz.SkylineTest
             int totalCount = 0;
             for (int i = 0; i < dict.Length; i++)
             {
-                int count = 0;
                 StaticMod mod = dict[i].Value;
 
                 if (index != -1 && index == i)
                     Assert.IsTrue(mod.Equivalent(modToMatch));
 
                 if (mod.Equivalent(modToMatch))
-                    count++;
-                if (!equivMods.ContainsKey(mod.Name))
-                    equivMods.Add(mod.Name, count);
-                else
                 {
-                    equivMods[mod.Name] += count;
+                    equivMods.TryGetValue(mod.Name, out int count);
+                    count++;
+                    equivMods[mod.Name] = count;
+                    totalCount++;
                 }
-                totalCount += count;
             }
-
             return totalCount;
         }
-
-       
     }
 }


### PR DESCRIPTION
Also, fix incorrect implementation of "ReferenceValue.Equals" (unrelated to anything else).