### PR TITLE
Fix adding/removing transitions with spectrum filter

### DIFF
--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -2960,7 +2960,9 @@ namespace pwiz.Skyline.Model
             // Only synchronize groups with the same adduct, ignoring any isotopes specified in the adducts for match purposes.
             if (!TransitionGroup.PrecursorAdduct.Unlabeled.Equals(nodeGroupSynch.TransitionGroup.PrecursorAdduct.Unlabeled))
                 return this;
-
+            // Only synchronize groups with the same Spectrum Filter
+            if (!SpectrumClassFilter.Equals(nodeGroupSynch.SpectrumClassFilter))
+                return this;
             // Start with the current node as the default
             var nodeResult = this;
 


### PR DESCRIPTION
Fixed bug where transitions get incorrectly added/removed from siblings when changing children of a precursor with a Spectrum Filter (not reported by anyone)