### PR TITLE
Bug/fix msconvertgui mzmlb compression

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -621,12 +621,12 @@ if [ modules.peek : NT ]
 
     # overwrite the original header files because of MSVC looking in the current header's path with #include "foo"
 
-    # HACK: bug in boost::interprocess (up to at least 1.55) requires a patch to support opening memory-mapped files with UTF-8 filenames
-    # Boost bug ticket: https://svn.boost.org/trac/boost/ticket/4335
-    #SHELL "@IF NOT EXIST $(BOOST_SOURCE)\\boost\\interprocess\\detail\\os_file_functions.hpp.bak rename $(BOOST_SOURCE)\\boost\\interprocess\\detail\\os_file_functions.hpp os_file_functions.hpp.bak" ;
-    #SHELL "@IF NOT EXIST $(BOOST_SOURCE)\\boost\\interprocess\\detail\\win32_api.hpp.bak rename $(BOOST_SOURCE)\\boost\\interprocess\\detail\\win32_api.hpp win32_api.hpp.bak" ;
-    #SHELL "@copy /Y $(PWIZ_LIBRARIES_PATH)\\boost_aux\\boost\\interprocess\\detail\\os_file_functions.hpp $(BOOST_SOURCE)\\boost\\interprocess\\detail" ;
-    #SHELL "@copy /Y $(PWIZ_LIBRARIES_PATH)\\boost_aux\\boost\\interprocess\\detail\\win32_api.hpp $(BOOST_SOURCE)\\boost\\interprocess\\detail" ;
+    # HACK: fix program_options implicit_value eating adjacent positional tokens
+    # Reapplying commit: https://github.com/boostorg/program_options/commit/88dea3c6fdea8c9ea894911897b1770599c383e4 (which was later reverted but was the proper behavior IMO)
+    SHELL "@IF NOT EXIST $(BOOST_SOURCE)\\boost\\program_options\\value_semantic.hpp.bak rename $(BOOST_SOURCE)\\boost\\program_options\\value_semantic.hpp value_semantic.hpp.bak" ;
+    SHELL "@IF NOT EXIST $(BOOST_SOURCE)\\libs\\program_options\\src\\cmdline.cpp.bak rename $(BOOST_SOURCE)\\libs\\program_options\\src\\cmdline.cpp cmdline.cpp.bak" ;
+    SHELL "@copy /Y $(PWIZ_LIBRARIES_PATH)\\boost_aux\\boost\\program_options\\value_semantic.hpp $(BOOST_SOURCE)\\boost\\program_options" ;
+    SHELL "@copy /Y $(PWIZ_LIBRARIES_PATH)\\boost_aux\\libs\\program_options\\src\\cmdline.cpp $(BOOST_SOURCE)\\libs\\program_options\\src" ;
 }
 else
 {

--- a/libraries/boost_aux/boost/program_options/value_semantic.hpp
+++ b/libraries/boost_aux/boost/program_options/value_semantic.hpp
@@ -1,0 +1,432 @@
+// Copyright Vladimir Prus 2004.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_VALUE_SEMANTIC_HPP_VP_2004_02_24
+#define BOOST_VALUE_SEMANTIC_HPP_VP_2004_02_24
+
+#include <boost/program_options/config.hpp>
+#include <boost/program_options/errors.hpp>
+
+#include <boost/any.hpp>
+#include <boost/function/function1.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <string>
+#include <vector>
+#include <typeinfo>
+#include <limits>
+
+namespace boost { namespace program_options {
+
+    /** Class which specifies how the option's value is to be parsed
+        and converted into C++ types.
+    */
+    class BOOST_PROGRAM_OPTIONS_DECL value_semantic {
+    public:
+        /** Returns the name of the option. The name is only meaningful
+            for automatic help message.
+         */
+        virtual std::string name() const = 0;
+
+        /** The minimum number of tokens for this option that
+            should be present on the command line. */
+        virtual unsigned min_tokens() const = 0;
+
+        /** The maximum number of tokens for this option that
+            should be present on the command line. */
+        virtual unsigned max_tokens() const = 0;
+
+        /** Returns true if the option should only take adjacent token,
+            not one from further command-line arguments.
+        */
+        virtual bool adjacent_tokens_only() const = 0;
+
+        /** Returns true if values from different sources should be composed.
+            Otherwise, value from the first source is used and values from
+            other sources are discarded.
+        */
+        virtual bool is_composing() const = 0;
+
+        /** Returns true if value must be given. Non-optional value
+
+        */
+        virtual bool is_required() const = 0;
+        
+        /** Parses a group of tokens that specify a value of option.
+            Stores the result in 'value_store', using whatever representation
+            is desired. May be be called several times if value of the same
+            option is specified more than once.
+        */
+        virtual void parse(boost::any& value_store, 
+                           const std::vector<std::string>& new_tokens,
+                           bool utf8) const 
+            = 0;
+
+        /** Called to assign default value to 'value_store'. Returns
+            true if default value is assigned, and false if no default
+            value exists. */
+        virtual bool apply_default(boost::any& value_store) const = 0;
+                                   
+        /** Called when final value of an option is determined. 
+        */
+        virtual void notify(const boost::any& value_store) const = 0;
+        
+        virtual ~value_semantic() {}
+    };
+
+    /** Helper class which perform necessary character conversions in the 
+        'parse' method and forwards the data further.
+    */
+    template<class charT>
+    class value_semantic_codecvt_helper {
+        // Nothing here. Specializations to follow.
+    };
+
+    /** Helper conversion class for values that accept ascii
+        strings as input.
+        Overrides the 'parse' method and defines new 'xparse'
+        method taking std::string. Depending on whether input
+        to parse is ascii or UTF8, will pass it to xparse unmodified,
+        or with UTF8->ascii conversion.
+    */
+    template<>
+    class BOOST_PROGRAM_OPTIONS_DECL 
+    value_semantic_codecvt_helper<char> : public value_semantic {
+    private: // base overrides
+        void parse(boost::any& value_store, 
+                   const std::vector<std::string>& new_tokens,
+                   bool utf8) const;
+    protected: // interface for derived classes.
+        virtual void xparse(boost::any& value_store, 
+                            const std::vector<std::string>& new_tokens) 
+            const = 0;
+    };
+
+    /** Helper conversion class for values that accept ascii
+        strings as input.
+        Overrides the 'parse' method and defines new 'xparse'
+        method taking std::wstring. Depending on whether input
+        to parse is ascii or UTF8, will recode input to Unicode, or
+        pass it unmodified.
+    */
+    template<>
+    class BOOST_PROGRAM_OPTIONS_DECL
+    value_semantic_codecvt_helper<wchar_t> : public value_semantic {
+    private: // base overrides
+        void parse(boost::any& value_store, 
+                   const std::vector<std::string>& new_tokens,
+                   bool utf8) const;
+    protected: // interface for derived classes.
+#if !defined(BOOST_NO_STD_WSTRING)
+        virtual void xparse(boost::any& value_store, 
+                            const std::vector<std::wstring>& new_tokens) 
+            const = 0;
+#endif
+    };
+
+    /** Class which specifies a simple handling of a value: the value will
+        have string type and only one token is allowed. */    
+    class BOOST_PROGRAM_OPTIONS_DECL 
+    untyped_value : public value_semantic_codecvt_helper<char>  {
+    public:
+        untyped_value(bool zero_tokens = false)
+        : m_zero_tokens(zero_tokens)
+        {}
+
+        std::string name() const;
+
+        unsigned min_tokens() const;
+        unsigned max_tokens() const;
+        bool adjacent_tokens_only() const { return false; }
+
+        bool is_composing() const { return false; }
+
+        bool is_required() const { return false; }
+        
+        /** If 'value_store' is already initialized, or new_tokens
+            has more than one elements, throws. Otherwise, assigns
+            the first string from 'new_tokens' to 'value_store', without
+            any modifications.
+         */
+        void xparse(boost::any& value_store,
+                    const std::vector<std::string>& new_tokens) const;
+
+        /** Does nothing. */
+        bool apply_default(boost::any&) const { return false; }
+
+        /** Does nothing. */
+        void notify(const boost::any&) const {}        
+    private:
+        bool m_zero_tokens;
+    };
+
+#ifndef BOOST_NO_RTTI
+    /** Base class for all option that have a fixed type, and are
+        willing to announce this type to the outside world.
+        Any 'value_semantics' for which you want to find out the
+        type can be dynamic_cast-ed to typed_value_base. If conversion
+        succeeds, the 'type' method can be called.
+    */
+    class typed_value_base 
+    {
+    public:
+        // Returns the type of the value described by this
+        // object.
+        virtual const std::type_info& value_type() const = 0;
+        // Not really needed, since deletion from this
+        // class is silly, but just in case.
+        virtual ~typed_value_base() {}
+    };
+#endif
+
+
+    /** Class which handles value of a specific type. */
+    template<class T, class charT = char>
+    class typed_value : public value_semantic_codecvt_helper<charT>
+#ifndef BOOST_NO_RTTI
+                      , public typed_value_base
+#endif
+    {
+    public:
+        /** Ctor. The 'store_to' parameter tells where to store
+            the value when it's known. The parameter can be NULL. */
+        typed_value(T* store_to) 
+        : m_store_to(store_to), m_composing(false),
+          m_implicit(false), m_multitoken(false),
+          m_zero_tokens(false), m_required(false)
+        {} 
+
+        /** Specifies default value, which will be used
+            if none is explicitly specified. The type 'T' should
+            provide operator<< for ostream.
+        */
+        typed_value* default_value(const T& v)
+        {
+            m_default_value = boost::any(v);
+            m_default_value_as_text = boost::lexical_cast<std::string>(v);
+            return this;
+        }
+
+        /** Specifies default value, which will be used
+            if none is explicitly specified. Unlike the above overload,
+            the type 'T' need not provide operator<< for ostream,
+            but textual representation of default value must be provided
+            by the user.
+        */
+        typed_value* default_value(const T& v, const std::string& textual)
+        {
+            m_default_value = boost::any(v);
+            m_default_value_as_text = textual;
+            return this;
+        }
+
+        /** Specifies an implicit value, which will be used
+            if the option is given, but without an adjacent value.
+            Using this implies that an explicit value is optional,
+        */
+        typed_value* implicit_value(const T &v)
+        {
+            m_implicit_value = boost::any(v);
+            m_implicit_value_as_text =
+                boost::lexical_cast<std::string>(v);
+            return this;
+        }
+
+        /** Specifies the name used to to the value in help message.  */
+        typed_value* value_name(const std::string& name)
+        {
+            m_value_name = name;
+            return this;
+        }
+
+        /** Specifies an implicit value, which will be used
+            if the option is given, but without an adjacent value.
+            Using this implies that an explicit value is optional, but if
+            given, must be strictly adjacent to the option, i.e.: '-ovalue'
+            or '--option=value'.  Giving '-o' or '--option' will cause the
+            implicit value to be applied.
+            Unlike the above overload, the type 'T' need not provide
+            operator<< for ostream, but textual representation of default
+            value must be provided by the user.
+        */
+        typed_value* implicit_value(const T &v, const std::string& textual)
+        {
+            m_implicit_value = boost::any(v);
+            m_implicit_value_as_text = textual;
+            return this;
+        }
+
+        /** Specifies a function to be called when the final value
+            is determined. */
+        typed_value* notifier(function1<void, const T&> f)
+        {
+            m_notifier = f;
+            return this;
+        }
+
+        /** Specifies that the value is composing. See the 'is_composing' 
+            method for explanation. 
+        */
+        typed_value* composing()
+        {
+            m_composing = true;
+            return this;
+        }
+
+        /** Specifies that the value can span multiple tokens. 
+        */
+        typed_value* multitoken()
+        {
+            m_multitoken = true;
+            return this;
+        }
+
+        /** Specifies that no tokens may be provided as the value of
+            this option, which means that only presense of the option
+            is significant. For such option to be useful, either the
+            'validate' function should be specialized, or the 
+            'implicit_value' method should be also used. In most
+            cases, you can use the 'bool_switch' function instead of
+            using this method. */
+        typed_value* zero_tokens() 
+        {
+            m_zero_tokens = true;
+            return this;
+        }
+            
+        /** Specifies that the value must occur. */
+        typed_value* required()
+        {
+            m_required = true;
+            return this;
+        }
+
+    public: // value semantic overrides
+
+        std::string name() const;
+
+        bool is_composing() const { return m_composing; }
+
+        unsigned min_tokens() const
+        {
+            if (m_zero_tokens || !m_implicit_value.empty()) {
+                return 0;
+            } else {
+                return 1;
+            }
+        }
+
+        unsigned max_tokens() const {
+            if (m_multitoken) {
+                return std::numeric_limits<unsigned>::max BOOST_PREVENT_MACRO_SUBSTITUTION();
+            } else if (m_zero_tokens) {
+                return 0;
+            } else {
+                return 1;
+            }
+        }
+
+        bool adjacent_tokens_only() const { return !m_implicit_value.empty(); }
+
+        bool is_required() const { return m_required; }
+
+        /** Creates an instance of the 'validator' class and calls
+            its operator() to perform the actual conversion. */
+        void xparse(boost::any& value_store, 
+                    const std::vector< std::basic_string<charT> >& new_tokens) 
+            const;
+
+        /** If default value was specified via previous call to 
+            'default_value', stores that value into 'value_store'.
+            Returns true if default value was stored.
+        */
+        virtual bool apply_default(boost::any& value_store) const
+        {
+            if (m_default_value.empty()) {
+                return false;
+            } else {
+                value_store = m_default_value;
+                return true;
+            }
+        }
+
+        /** If an address of variable to store value was specified
+            when creating *this, stores the value there. Otherwise,
+            does nothing. */
+        void notify(const boost::any& value_store) const;
+
+    public: // typed_value_base overrides
+        
+#ifndef BOOST_NO_RTTI
+        const std::type_info& value_type() const
+        {
+            return typeid(T);
+        }
+#endif
+        
+
+    private:
+        T* m_store_to;
+        
+        // Default value is stored as boost::any and not
+        // as boost::optional to avoid unnecessary instantiations.
+        std::string m_value_name;
+        boost::any m_default_value;
+        std::string m_default_value_as_text;
+        boost::any m_implicit_value;
+        std::string m_implicit_value_as_text;
+        bool m_composing, m_implicit, m_multitoken, m_zero_tokens, m_required;
+        boost::function1<void, const T&> m_notifier;
+    };
+
+
+    /** Creates a typed_value<T> instance. This function is the primary
+        method to create value_semantic instance for a specific type, which
+        can later be passed to 'option_description' constructor.
+        The second overload is used when it's additionally desired to store the 
+        value of option into program variable.
+    */
+    template<class T>
+    typed_value<T>*
+    value();
+
+    /** @overload 
+    */
+    template<class T>
+    typed_value<T>*
+    value(T* v);
+
+    /** Creates a typed_value<T> instance. This function is the primary
+        method to create value_semantic instance for a specific type, which
+        can later be passed to 'option_description' constructor.
+    */
+    template<class T>
+    typed_value<T, wchar_t>*
+    wvalue();
+
+    /** @overload   
+    */
+    template<class T>
+    typed_value<T, wchar_t>*
+    wvalue(T* v);
+
+    /** Works the same way as the 'value<bool>' function, but the created
+        value_semantic won't accept any explicit value. So, if the option 
+        is present on the command line, the value will be 'true'.
+    */
+    BOOST_PROGRAM_OPTIONS_DECL typed_value<bool>*
+    bool_switch();
+
+    /** @overload
+    */
+    BOOST_PROGRAM_OPTIONS_DECL typed_value<bool>*    
+    bool_switch(bool* v);
+
+}}
+
+#include "boost/program_options/detail/value_semantic.hpp"
+
+#endif
+

--- a/libraries/boost_aux/libs/program_options/src/cmdline.cpp
+++ b/libraries/boost_aux/libs/program_options/src/cmdline.cpp
@@ -1,0 +1,718 @@
+// Copyright Vladimir Prus 2002-2004.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_PROGRAM_OPTIONS_SOURCE
+#include <boost/program_options/config.hpp>
+
+#include <boost/config.hpp>
+
+#include <boost/program_options/detail/cmdline.hpp>
+#include <boost/program_options/errors.hpp>
+#include <boost/program_options/value_semantic.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/positional_options.hpp>
+#include <boost/throw_exception.hpp>
+
+#include <boost/bind/bind.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+#include <cassert>
+#include <cstring>
+#include <cctype>
+#include <climits>
+
+#include <cstdio>
+
+#include <iostream>
+
+using namespace boost::placeholders;
+
+namespace boost { namespace program_options {
+
+    using namespace std;
+    using namespace boost::program_options::command_line_style;
+    
+    
+    string 
+    invalid_syntax::get_template(kind_t kind)
+    {
+        // Initially, store the message in 'const char*' variable,
+        // to avoid conversion to string in all cases.
+        const char* msg;
+        switch(kind)
+        {
+        case empty_adjacent_parameter:
+            msg = "the argument for option '%canonical_option%' should follow immediately after the equal sign";
+            break;
+        case missing_parameter:
+            msg = "the required argument for option '%canonical_option%' is missing";
+            break;
+        case unrecognized_line:
+            msg = "the options configuration file contains an invalid line '%invalid_line%'";
+            break;
+        // none of the following are currently used:
+        case long_not_allowed:
+            msg = "the unabbreviated option '%canonical_option%' is not valid";
+            break;
+        case long_adjacent_not_allowed:
+            msg = "the unabbreviated option '%canonical_option%' does not take any arguments";
+            break;
+        case short_adjacent_not_allowed:
+            msg = "the abbreviated option '%canonical_option%' does not take any arguments";
+            break;
+        case extra_parameter:
+            msg = "option '%canonical_option%' does not take any arguments";
+            break;
+        default:
+            msg = "unknown command line syntax error for '%s'";
+        }
+        return msg;
+    }
+
+
+}}
+
+
+namespace boost { namespace program_options { namespace detail {
+
+    // vc6 needs this, but borland chokes when this is added.
+#if BOOST_WORKAROUND(_MSC_VER, < 1300)
+    using namespace std;
+    using namespace program_options;
+#endif
+
+
+    cmdline::cmdline(const vector<string>& args)
+    {
+        init(args);
+    }
+
+    cmdline::cmdline(int argc, const char*const * argv)
+    {
+#if defined(BOOST_NO_TEMPLATED_ITERATOR_CONSTRUCTORS)
+        vector<string> args;
+        copy(argv+1, argv+argc+!argc, inserter(args, args.end()));
+        init(args);
+#else
+        init(vector<string>(argv+1, argv+argc+!argc));
+#endif
+    }
+
+    void
+    cmdline::init(const vector<string>& args)
+    {
+        this->m_args = args;        
+        m_style = command_line_style::default_style;
+        m_desc = 0;
+        m_positional = 0;
+        m_allow_unregistered = false;
+    }
+
+    void 
+    cmdline::style(int style)
+    {
+        if (style == 0) 
+            style = default_style;        
+
+        check_style(style);
+        this->m_style = style_t(style);
+    }
+    
+    void 
+    cmdline::allow_unregistered()
+    {
+        this->m_allow_unregistered = true;
+    }
+
+    void 
+    cmdline::check_style(int style) const
+    {
+        bool allow_some_long = 
+            (style & allow_long) || (style & allow_long_disguise);
+
+        const char* error = 0;
+        if (allow_some_long && 
+            !(style & long_allow_adjacent) && !(style & long_allow_next))
+            error = "boost::program_options misconfiguration: "
+                    "choose one or other of 'command_line_style::long_allow_next' "
+                    "(whitespace separated arguments) or "
+                    "'command_line_style::long_allow_adjacent' ('=' separated arguments) for "
+                    "long options.";
+
+        if (!error && (style & allow_short) &&
+            !(style & short_allow_adjacent) && !(style & short_allow_next))
+            error = "boost::program_options misconfiguration: "
+                    "choose one or other of 'command_line_style::short_allow_next' "
+                    "(whitespace separated arguments) or "
+                    "'command_line_style::short_allow_adjacent' ('=' separated arguments) for "
+                    "short options.";
+
+        if (!error && (style & allow_short) &&
+            !(style & allow_dash_for_short) && !(style & allow_slash_for_short))
+            error = "boost::program_options misconfiguration: "
+                    "choose one or other of 'command_line_style::allow_slash_for_short' "
+                    "(slashes) or 'command_line_style::allow_dash_for_short' (dashes) for "
+                    "short options.";
+
+        if (error)
+            boost::throw_exception(invalid_command_line_style(error));
+
+        // Need to check that if guessing and long disguise are enabled
+        // -f will mean the same as -foo
+    }
+    
+    bool 
+    cmdline::is_style_active(style_t style) const
+    {
+        return ((m_style & style) ? true : false);
+    }    
+
+    void 
+    cmdline::set_options_description(const options_description& desc)
+    {
+        m_desc = &desc;
+    }
+
+    void 
+    cmdline::set_positional_options(
+        const positional_options_description& positional)
+    {
+        m_positional = &positional;
+    }
+
+    int
+    cmdline::get_canonical_option_prefix()
+    {
+        if (m_style & allow_long)
+            return allow_long;
+
+        if (m_style & allow_long_disguise)
+            return allow_long_disguise;
+
+        if ((m_style & allow_short) && (m_style & allow_dash_for_short))
+            return allow_dash_for_short;
+
+        if ((m_style & allow_short) && (m_style & allow_slash_for_short))
+            return allow_slash_for_short;
+
+        return 0;
+    }
+
+    vector<option>
+    cmdline::run()
+    {
+        // The parsing is done by having a set of 'style parsers'
+        // and trying then in order. Each parser is passed a vector
+        // of unparsed tokens and can consume some of them (by
+        // removing elements on front) and return a vector of options.
+        //
+        // We try each style parser in turn, untill some input
+        // is consumed. The returned vector of option may contain the
+        // result of just syntactic parsing of token, say --foo will
+        // be parsed as option with name 'foo', and the style parser
+        // is not required to care if that option is defined, and how
+        // many tokens the value may take.
+        // So, after vector is returned, we validate them.
+        assert(m_desc);
+
+        vector<style_parser> style_parsers;      
+
+        if (m_style_parser)
+            style_parsers.push_back(m_style_parser);
+
+        if (m_additional_parser)
+            style_parsers.push_back(
+                boost::bind(&cmdline::handle_additional_parser, this, _1));
+
+        if (m_style & allow_long)
+            style_parsers.push_back(
+                boost::bind(&cmdline::parse_long_option, this, _1));
+
+        if ((m_style & allow_long_disguise))
+            style_parsers.push_back(
+                boost::bind(&cmdline::parse_disguised_long_option, this, _1));
+
+        if ((m_style & allow_short) && (m_style & allow_dash_for_short))
+            style_parsers.push_back(
+                boost::bind(&cmdline::parse_short_option, this, _1));
+
+        if ((m_style & allow_short) && (m_style & allow_slash_for_short))
+            style_parsers.push_back(boost::bind(&cmdline::parse_dos_option, this, _1));
+
+        style_parsers.push_back(boost::bind(&cmdline::parse_terminator, this, _1));
+
+        vector<option> result;
+        vector<string>& args = m_args;
+        while(!args.empty())
+        {
+            bool ok = false;
+            for(unsigned i = 0; i < style_parsers.size(); ++i)
+            {
+                unsigned current_size = static_cast<unsigned>(args.size());
+                vector<option> next = style_parsers[i](args);
+
+                // Check that option names
+                // are valid, and that all values are in place.
+                if (!next.empty())
+                {
+                    vector<string> e;
+                    for(unsigned k = 0; k < next.size()-1; ++k) {
+                        finish_option(next[k], e, style_parsers);
+                    }
+                    // For the last option, pass the unparsed tokens
+                    // so that they can be added to next.back()'s values
+                    // if appropriate.
+                    finish_option(next.back(), args, style_parsers);
+                    for (unsigned j = 0; j < next.size(); ++j)
+                        result.push_back(next[j]);                    
+                }
+                                
+                if (args.size() != current_size) {
+                    ok = true;
+                    break;                
+                } 
+            }
+            
+            if (!ok) {
+                option opt;
+                opt.value.push_back(args[0]);
+                opt.original_tokens.push_back(args[0]);
+                result.push_back(opt);
+                args.erase(args.begin());
+            }
+        }
+
+        /* If an key option is followed by a positional option,
+           can can consume more tokens (e.g. it's multitoken option),
+           give those tokens to it.  */
+        vector<option> result2;
+        for (unsigned i = 0; i < result.size(); ++i)
+        {
+            result2.push_back(result[i]);
+            option& opt = result2.back();
+
+            if (opt.string_key.empty())
+                continue;
+
+            const option_description* xd;
+            try
+            {
+                xd = m_desc->find_nothrow(opt.string_key, 
+                                            is_style_active(allow_guessing),
+                                            is_style_active(long_case_insensitive),
+                                            is_style_active(short_case_insensitive));
+            } 
+            catch(error_with_option_name& e)
+            {
+                // add context and rethrow
+                e.add_context(opt.string_key, opt.original_tokens[0], get_canonical_option_prefix());
+                throw;
+            }
+
+            if (!xd)
+                continue;
+
+            if (xd->semantic()->adjacent_tokens_only())
+                continue;
+
+            unsigned min_tokens = xd->semantic()->min_tokens();
+            unsigned max_tokens = xd->semantic()->max_tokens();
+            if (min_tokens < max_tokens && opt.value.size() < max_tokens)
+            {
+                // This option may grab some more tokens.
+                // We only allow to grab tokens that are not already
+                // recognized as key options.
+
+                int can_take_more = max_tokens - static_cast<int>(opt.value.size());
+                unsigned j = i+1;
+                for (; can_take_more && j < result.size(); --can_take_more, ++j)
+                {
+                    option& opt2 = result[j];
+                    if (!opt2.string_key.empty())
+                        break;
+
+                    if (opt2.position_key == INT_MAX)
+                    {
+                        // We use INT_MAX to mark positional options that
+                        // were found after the '--' terminator and therefore
+                        // should stay positional forever.
+                        break;
+                    }
+
+                    assert(opt2.value.size() == 1);
+                    
+                    opt.value.push_back(opt2.value[0]);
+
+                    assert(opt2.original_tokens.size() == 1);
+
+                    opt.original_tokens.push_back(opt2.original_tokens[0]);
+                }
+                i = j-1;
+            }
+        }
+        result.swap(result2);
+        
+
+        // Assign position keys to positional options.
+        int position_key = 0;
+        for(unsigned i = 0; i < result.size(); ++i) {
+            if (result[i].string_key.empty())
+                result[i].position_key = position_key++;
+        }
+
+        if (m_positional)
+        {
+            unsigned position = 0;
+            for (unsigned i = 0; i < result.size(); ++i) {
+                option& opt = result[i];
+                if (opt.position_key != -1) {
+                    if (position >= m_positional->max_total_count())
+                    {
+                        boost::throw_exception(too_many_positional_options_error());
+                    }
+                    opt.string_key = m_positional->name_for_position(position);
+                    ++position;
+                }
+            }
+        }
+        
+        // set case sensitive flag
+        for (unsigned i = 0; i < result.size(); ++i) {
+            if (result[i].string_key.size() > 2 ||
+                        (result[i].string_key.size() > 1 && result[i].string_key[0] != '-'))
+            {
+                // it is a long option
+                result[i].case_insensitive = is_style_active(long_case_insensitive);
+            }
+            else
+            {
+                // it is a short option
+                result[i].case_insensitive = is_style_active(short_case_insensitive);
+            }
+        }
+
+        return result;
+    }
+
+    void
+    cmdline::finish_option(option& opt,
+                           vector<string>& other_tokens,
+                           const vector<style_parser>& style_parsers)
+    {          
+        if (opt.string_key.empty())
+            return;
+
+        // 
+        // Be defensive:
+        // will have no original token if option created by handle_additional_parser()
+        std::string original_token_for_exceptions = opt.string_key;
+        if (opt.original_tokens.size())
+            original_token_for_exceptions = opt.original_tokens[0];
+
+        try
+        {
+            // First check that the option is valid, and get its description.
+            const option_description* xd = m_desc->find_nothrow(opt.string_key, 
+                    is_style_active(allow_guessing),
+                    is_style_active(long_case_insensitive),
+                    is_style_active(short_case_insensitive));
+
+            if (!xd)
+            {
+                if (m_allow_unregistered) {
+                    opt.unregistered = true;
+                    return;
+                } else {
+                    boost::throw_exception(unknown_option());
+                }                
+            }
+            const option_description& d = *xd;
+
+            // Canonize the name
+            opt.string_key = d.key(opt.string_key);
+
+            // We check that the min/max number of tokens for the option
+            // agrees with the number of tokens we have. The 'adjacent_value'
+            // (the value in --foo=1) counts as a separate token, and if present
+            // must be consumed. The following tokens on the command line may be
+            // left unconsumed.
+            unsigned min_tokens = d.semantic()->min_tokens();
+            unsigned max_tokens = d.semantic()->max_tokens();
+            
+            unsigned present_tokens = static_cast<unsigned>(opt.value.size() + other_tokens.size());
+            
+            if (present_tokens >= min_tokens)
+            {
+                if (!opt.value.empty() && max_tokens == 0) 
+                {
+                    boost::throw_exception(
+                        invalid_command_line_syntax(invalid_command_line_syntax::extra_parameter));
+                }
+                
+                // Grab min_tokens values from other_tokens, but only if those tokens
+                // are not recognized as options themselves.
+                if (opt.value.size() <= min_tokens) 
+                {
+                    min_tokens -= static_cast<unsigned>(opt.value.size());
+                }
+                else
+                {
+                    min_tokens = 0;
+                }
+
+                // Everything's OK, move the values to the result.
+                for(;!other_tokens.empty() && min_tokens--; ) 
+                {
+                    // check if extra parameter looks like a known option
+                    // we use style parsers to check if it is syntactically an option, 
+                    // additionally we check if an option_description exists
+                    vector<option> followed_option;  
+                    vector<string> next_token(1, other_tokens[0]);      
+                    for (unsigned i = 0; followed_option.empty() && i < style_parsers.size(); ++i)
+                    {
+                        followed_option = style_parsers[i](next_token);
+                    }
+                    if (!followed_option.empty()) 
+                    {
+                        original_token_for_exceptions = other_tokens[0];
+                        const option_description* od = m_desc->find_nothrow(other_tokens[0], 
+                                  is_style_active(allow_guessing),
+                                  is_style_active(long_case_insensitive),
+                                  is_style_active(short_case_insensitive));
+                        if (od) 
+                            boost::throw_exception(
+                                invalid_command_line_syntax(invalid_command_line_syntax::missing_parameter));
+                    }
+                    opt.value.push_back(other_tokens[0]);
+                    opt.original_tokens.push_back(other_tokens[0]);
+                    other_tokens.erase(other_tokens.begin());
+                }
+            }
+            else
+            {
+                boost::throw_exception(
+                            invalid_command_line_syntax(invalid_command_line_syntax::missing_parameter)); 
+
+            }
+        } 
+        // use only original token for unknown_option / ambiguous_option since by definition
+        //    they are unrecognised / unparsable
+        catch(error_with_option_name& e)
+        {
+            // add context and rethrow
+            e.add_context(opt.string_key, original_token_for_exceptions, get_canonical_option_prefix());
+            throw;
+        }
+
+    }
+
+    vector<option> 
+    cmdline::parse_long_option(vector<string>& args)
+    {
+        vector<option> result;
+        const string& tok = args[0];
+        if (tok.size() >= 3 && tok[0] == '-' && tok[1] == '-')
+        {   
+            string name, adjacent;
+
+            string::size_type p = tok.find('=');
+            if (p != tok.npos)
+            {
+                name = tok.substr(2, p-2);
+                adjacent = tok.substr(p+1);
+                if (adjacent.empty())
+                    boost::throw_exception( invalid_command_line_syntax(
+                                                      invalid_command_line_syntax::empty_adjacent_parameter, 
+                                                      name,
+                                                      name,
+                                                      get_canonical_option_prefix()) );
+            }
+            else
+            {
+                name = tok.substr(2);
+            }
+            option opt;
+            opt.string_key = name;
+            if (!adjacent.empty())
+                opt.value.push_back(adjacent);
+            opt.original_tokens.push_back(tok);
+            result.push_back(opt);
+            args.erase(args.begin());
+        }
+        return result;
+    }
+
+
+    vector<option> 
+    cmdline::parse_short_option(vector<string>& args)
+    {
+        const string& tok = args[0];
+        if (tok.size() >= 2 && tok[0] == '-' && tok[1] != '-')
+        {   
+            vector<option> result;
+
+            string name = tok.substr(0,2);
+            string adjacent = tok.substr(2);
+
+            // Short options can be 'grouped', so that
+            // "-d -a" becomes "-da". Loop, processing one
+            // option at a time. We exit the loop when either
+            // we've processed all the token, or when the remainder
+            // of token is considered to be value, not further grouped
+            // option.
+            for(;;) {
+                const option_description* d;
+                try
+                {
+                     
+                    d = m_desc->find_nothrow(name, false, false,
+                                                is_style_active(short_case_insensitive));
+                } 
+                catch(error_with_option_name& e)
+                {
+                    // add context and rethrow
+                    e.add_context(name, name, get_canonical_option_prefix());
+                    throw;
+                }
+
+
+                // FIXME: check for 'allow_sticky'.
+                if (d && (m_style & allow_sticky) &&
+                    d->semantic()->max_tokens() == 0 && !adjacent.empty()) {
+                    // 'adjacent' is in fact further option.
+                    option opt;
+                    opt.string_key = name;
+                    result.push_back(opt);
+
+                    if (adjacent.empty())
+                    {
+                        args.erase(args.begin());
+                        break;
+                    }
+
+                    name = string("-") + adjacent[0];
+                    adjacent.erase(adjacent.begin());
+                } else {
+                    
+                    option opt;
+                    opt.string_key = name;
+                    opt.original_tokens.push_back(tok);
+                    if (!adjacent.empty())
+                        opt.value.push_back(adjacent);
+                    result.push_back(opt);
+                    args.erase(args.begin());                    
+                    break;
+                }
+            }
+            return result;
+        }
+        return vector<option>();
+    }
+
+    vector<option> 
+    cmdline::parse_dos_option(vector<string>& args)
+    {
+        vector<option> result;
+        const string& tok = args[0];
+        if (tok.size() >= 2 && tok[0] == '/')
+        {   
+            string name = "-" + tok.substr(1,1);
+            string adjacent = tok.substr(2);
+
+            option opt;
+            opt.string_key = name;
+            if (!adjacent.empty())
+                opt.value.push_back(adjacent);
+            opt.original_tokens.push_back(tok);
+            result.push_back(opt);
+            args.erase(args.begin());
+        }
+        return result;
+    }
+
+    vector<option> 
+    cmdline::parse_disguised_long_option(vector<string>& args)
+    {
+        const string& tok = args[0];
+        if (tok.size() >= 2 && 
+            ((tok[0] == '-' && tok[1] != '-') ||
+             ((m_style & allow_slash_for_short) && tok[0] == '/')))            
+        {
+            try
+            {
+                if (m_desc->find_nothrow(tok.substr(1, tok.find('=')-1), 
+                                         is_style_active(allow_guessing),
+                                         is_style_active(long_case_insensitive),
+                                         is_style_active(short_case_insensitive)))
+                {
+                    args[0].insert(0, "-");
+                    if (args[0][1] == '/')
+                        args[0][1] = '-';
+                    return parse_long_option(args);
+                }
+            } 
+            catch(error_with_option_name& e)
+            {
+                // add context and rethrow
+                e.add_context(tok, tok, get_canonical_option_prefix());
+                throw;
+            }
+        }
+        return vector<option>();
+    }
+
+    vector<option> 
+    cmdline::parse_terminator(vector<string>& args)
+    {
+        vector<option> result;
+        const string& tok = args[0];
+        if (tok == "--")
+        {
+            for(unsigned i = 1; i < args.size(); ++i)
+            {
+                option opt;
+                opt.value.push_back(args[i]);
+                opt.original_tokens.push_back(args[i]);
+                opt.position_key = INT_MAX;
+                result.push_back(opt);
+            }
+            args.clear();
+        }
+        return result;
+    }
+
+    vector<option> 
+    cmdline::handle_additional_parser(vector<string>& args)
+    {
+        vector<option> result;
+        pair<string, string> r = m_additional_parser(args[0]);
+        if (!r.first.empty()) {
+            option next;
+            next.string_key = r.first;
+            if (!r.second.empty())
+                next.value.push_back(r.second);
+            result.push_back(next);
+            args.erase(args.begin());
+        }
+        return result;
+    }
+
+    void 
+    cmdline::set_additional_parser(additional_parser p)
+    {
+        m_additional_parser = p;
+    }
+
+    void 
+    cmdline::extra_style_parser(style_parser s)
+    {
+        m_style_parser = s;
+    }
+
+
+
+}}}

--- a/pwiz/data/msdata/DiffTest.cpp
+++ b/pwiz/data/msdata/DiffTest.cpp
@@ -518,6 +518,37 @@ void testBinaryDataArray()
 }
 
 
+void testIntegerDataArray()
+{
+    if (os_) *os_ << "testIntegerDataArray()\n";
+
+    BinaryData<int64_t> data;
+    for (int i = 0; i < 10; i++) data.push_back(i);
+
+    IntegerDataArray a, b;
+    a.data = data;
+    a.dataProcessingPtr = DataProcessingPtr(new DataProcessing("dp1"));
+    b = a;
+
+    DiffConfig config;
+    config.precision = 1e-4;
+
+    a.data[9] = 10000000000;
+    b.data[9] = 10000000001;
+
+    Diff<IntegerDataArray, DiffConfig> diff(a, b, config);
+    if (diff && os_) *os_ << diff << endl;
+    unit_assert(!diff);
+
+    b.data[9] = 20000000000;
+
+    diff(a, b);
+
+    if (diff && os_) *os_ << diff << endl;
+    unit_assert(diff);
+}
+
+
 void testSpectrum()
 {
     if (os_) *os_ << "testSpectrum()\n";
@@ -1325,6 +1356,7 @@ void test()
     testScan();
     testScanList();
     testBinaryDataArray();
+    testIntegerDataArray();
     testSpectrum();
     testChromatogram();
     testSpectrumList();

--- a/pwiz/data/msdata/IO.cpp
+++ b/pwiz/data/msdata/IO.cpp
@@ -1816,6 +1816,40 @@ void writeMzMLbExtra<BinaryDataArray>(stream<Connection_mzMLb>* mzMLb_os, string
 #endif
 }
 
+template <>
+void writeMzMLbExtra<IntegerDataArray>(stream<Connection_mzMLb>* mzMLb_os, string& dataset, size_t& offset, const string& encoded, XMLWriter& writer, const IntegerDataArray& binaryDataArray, const BinaryDataEncoder::Config& usedConfig)
+{
+#ifndef WITHOUT_MZMLB
+
+    size_t encoded_size = encoded.size();
+
+    if (mzMLb_os)
+    {
+        dataset = (usedConfig.type == BinaryDataEncoder::Type_Spectrum ? "spectrum_" : (usedConfig.type == BinaryDataEncoder::Type_Chromatogram ? "chromatogram_" : ""));
+        dataset += cvTermInfo(binaryDataArray.cvParamChild(MS_binary_data_array).cvid).id;
+        replace(dataset.begin(), dataset.end(), ':', '_');
+
+        if (usedConfig.numpress != BinaryDataEncoder::Numpress_None)
+        {
+            if (usedConfig.numpress == BinaryDataEncoder::Numpress_Linear) dataset += "_numpress_linear";
+            else if (usedConfig.numpress == BinaryDataEncoder::Numpress_Pic) dataset += "_numpress_pic";
+            else dataset += "_numpress_slof";
+
+            offset = (*mzMLb_os)->seek(dataset, 0, std::ios_base::cur);
+            (*mzMLb_os)->write_opaque(dataset, (const unsigned char*)&encoded[0], encoded_size);
+        }
+        else
+        {
+            const vector<int64_t>& int_data = binaryDataArray.data;
+
+            dataset += "_int64";
+            offset = (*mzMLb_os)->seek(dataset, 0, std::ios_base::cur);
+            encoded_size = int_data.size() * sizeof(int64_t);
+            (*mzMLb_os)->write(dataset, &int_data[0], int_data.size());
+        }
+    }
+#endif
+}
 
 template <typename BinaryDataArrayType>
 void writeBinaryDataArray(minimxml::XMLWriter& writer, const BinaryDataArrayType& binaryDataArray, const BinaryDataEncoder::Config& config)

--- a/pwiz/data/msdata/MSData.cpp
+++ b/pwiz/data/msdata/MSData.cpp
@@ -642,6 +642,7 @@ PWIZ_API_DECL bool Spectrum::empty() const
            precursors.empty() && 
            products.empty() && 
            binaryDataArrayPtrs.empty() &&
+           integerDataArrayPtrs.empty() &&
            ParamContainer::empty();
 }
 
@@ -916,6 +917,7 @@ PWIZ_API_DECL bool Chromatogram::empty() const
            precursor.empty() &&
            product.empty() &&
            binaryDataArrayPtrs.empty() &&
+           integerDataArrayPtrs.empty() &&
            ParamContainer::empty();
 }
 

--- a/pwiz/data/msdata/MSDataFile.cpp
+++ b/pwiz/data/msdata/MSDataFile.cpp
@@ -245,7 +245,11 @@ void MSDataFile::write(const MSData& msd,
 #ifdef WITHOUT_MZMLB
             throw runtime_error("[MSDataFile::write()] library was not built with mzMLb support.");
 #else
-            Connection_mzMLb con(filename, config.mzMLb_chunk_size, config.mzMLb_compression_level);
+            int mzMLb_compression_level = config.mzMLb_compression_level;
+            if (config.binaryDataEncoderConfig.compression == BinaryDataEncoder::Compression_Zlib && mzMLb_compression_level == 0)
+                mzMLb_compression_level = 4;
+
+            Connection_mzMLb con(filename, config.mzMLb_chunk_size, mzMLb_compression_level);
             boost::iostreams::stream<Connection_mzMLb> mzMLb_os(con, config.mzMLb_chunk_size);
             writeStream(mzMLb_os, msd, config, iterationListenerRegistry);
 #endif

--- a/pwiz/data/msdata/MSDataFile.hpp
+++ b/pwiz/data/msdata/MSDataFile.hpp
@@ -57,7 +57,7 @@ struct PWIZ_API_DECL MSDataFile : public MSData
 		bool gzipped; // if true, file is written as .gz
         bool useWorkerThreads;
 
-        int mzMLb_compression_level = 0;
+        int mzMLb_compression_level = 4;
         int mzMLb_chunk_size = 1048576;
 
         /// when true, if an error is seen when enumerating a spectrum or chromatogram, it will be skipped and enumeration will continue;

--- a/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
+++ b/pwiz/utility/bindings/CLI/msdata/MSDataFile.cpp
@@ -112,6 +112,8 @@ static void translateConfig(MSDataFile::WriteConfig^ config, b::MSDataFile::Writ
     config2.indexed = config->indexed;
     config2.useWorkerThreads = config->useWorkerThreads;
     config2.continueOnError = config->continueOnError;
+    config2.mzMLb_compression_level = config->mzMLb_compression_level;
+    config2.mzMLb_chunk_size = config->mzMLb_chunk_size;
     config2.binaryDataEncoderConfig.precision = (b::BinaryDataEncoder::Precision) config->precision;
     config2.binaryDataEncoderConfig.byteOrder = (b::BinaryDataEncoder::ByteOrder) config->byteOrder;
     config2.binaryDataEncoderConfig.compression = (b::BinaryDataEncoder::Compression) config->compression;

--- a/pwiz/utility/bindings/CLI/msdata/MSDataFile.hpp
+++ b/pwiz/utility/bindings/CLI/msdata/MSDataFile.hpp
@@ -93,6 +93,9 @@ public ref class MSDataFile : public MSData
         property bool gzipped;
         property bool useWorkerThreads;
 
+        property int mzMLb_compression_level;
+        property int mzMLb_chunk_size;
+
         /// <summary>
         /// when true, if an error is seen when enumerating a spectrum or chromatogram, it will be skipped and enumeration will continue;
         /// when false an error will immediately stop enumeration
@@ -111,6 +114,8 @@ public ref class MSDataFile : public MSData
 			indexed = true;
             useWorkerThreads = true;
             continueOnError = false;
+            mzMLb_compression_level = 4;
+            mzMLb_chunk_size = 1048576;
         }
     };
 

--- a/pwiz_tools/MSConvertGUI/MainLogic.cs
+++ b/pwiz_tools/MSConvertGUI/MainLogic.cs
@@ -447,7 +447,15 @@ namespace MSConvertGUI
                 config.WriteConfig.indexed = false;
 
             if (zlib)
+            {
                 config.WriteConfig.compression = MSDataFile.Compression.Compression_Zlib;
+                config.WriteConfig.mzMLb_compression_level = 4;
+            }
+            else
+            {
+                config.WriteConfig.compression = MSDataFile.Compression.Compression_None;
+                config.WriteConfig.mzMLb_compression_level = 0;
+            }
 
             return config;
         }

--- a/pwiz_tools/SeeMS/Dialogs/DataPointTableForm.Designer.cs
+++ b/pwiz_tools/SeeMS/Dialogs/DataPointTableForm.Designer.cs
@@ -52,7 +52,7 @@ namespace seems
             this.dataGridView = new System.Windows.Forms.DataGridView();
             this.mz = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Intensity = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            ( (System.ComponentModel.ISupportInitialize) ( this.dataGridView ) ).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).BeginInit();
             this.SuspendLayout();
             // 
             // dataGridView
@@ -61,18 +61,19 @@ namespace seems
             this.dataGridView.AllowUserToDeleteRows = false;
             this.dataGridView.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.dataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView.Columns.AddRange( new System.Windows.Forms.DataGridViewColumn[] {
+            this.dataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.mz,
-            this.Intensity} );
+            this.Intensity});
             this.dataGridView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dataGridView.Location = new System.Drawing.Point( 0, 0 );
+            this.dataGridView.Location = new System.Drawing.Point(0, 0);
             this.dataGridView.Name = "dataGridView";
             this.dataGridView.ReadOnly = true;
             this.dataGridView.RowHeadersVisible = false;
-            this.dataGridView.Size = new System.Drawing.Size( 292, 273 );
+            this.dataGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.dataGridView.Size = new System.Drawing.Size(292, 273);
             this.dataGridView.TabIndex = 0;
             this.dataGridView.VirtualMode = true;
-            this.dataGridView.CellValueNeeded += new System.Windows.Forms.DataGridViewCellValueEventHandler( this.dataGridView_CellValueNeeded );
+            this.dataGridView.CellValueNeeded += new System.Windows.Forms.DataGridViewCellValueEventHandler(this.dataGridView_CellValueNeeded);
             // 
             // mz
             // 
@@ -88,14 +89,15 @@ namespace seems
             // 
             // DataPointTableForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF( 6F, 13F );
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size( 292, 273 );
-            this.Controls.Add( this.dataGridView );
+            this.ClientSize = new System.Drawing.Size(292, 273);
+            this.Controls.Add(this.dataGridView);
             this.Name = "DataPointTableForm";
+            this.TabText = "DataPointTableForm";
             this.Text = "DataPointTableForm";
-            ( (System.ComponentModel.ISupportInitialize) ( this.dataGridView ) ).EndInit();
-            this.ResumeLayout( false );
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridView)).EndInit();
+            this.ResumeLayout(false);
 
         }
 

--- a/pwiz_tools/SeeMS/Dialogs/DataPointTableForm.cs
+++ b/pwiz_tools/SeeMS/Dialogs/DataPointTableForm.cs
@@ -50,15 +50,20 @@ namespace seems
             dataGridView.VirtualMode = true;
             //dataGridView.Rows.Insert( 0, pointList.Count );
 
-            Refresh();
+            RefreshData();
 
             if (mobilityArray != null)
-                dataGridView.Columns.Add("mobility", "Ion Mobility");
+                dataGridView.Columns.Add(new DataGridViewTextBoxColumn
+                {
+                    Name = "mobility",
+                    HeaderText = "Ion Mobility",
+                    ReadOnly = true
+                });
         }
 
         private void dataGridView_CellValueNeeded( object sender, DataGridViewCellValueEventArgs e )
         {
-            if( pointList == null  )
+            if( pointList == null )
                 throw new InvalidOperationException( "cell value needed but point list is null" );
 
             if( e.ColumnIndex == 0 )
@@ -66,9 +71,23 @@ namespace seems
             else if (e.ColumnIndex == 1)
                 e.Value = pointList[e.RowIndex].Y;
             else
-            {
                 e.Value = mobilityArray[e.RowIndex];
+        }
+
+        private void RefreshData()
+        {
+            if (item.Id.StartsWith("merged="))
+            {
+                pointList = spectrum.GetPointList(false);
+                var s = item.Source.Source.MSDataFile.run.spectrumList.spectrum(spectrum.Index, true);
+                mobilityArray = s.GetIonMobilityArray();
             }
+            else
+            {
+                pointList = item.Points;
+            }
+
+            dataGridView.RowCount = pointList.Count;
         }
 
         /// <summary>
@@ -76,14 +95,7 @@ namespace seems
         /// </summary>
         public override void Refresh()
         {
-            pointList = item.Points;
-            dataGridView.RowCount = pointList.Count;
-
-            if (item.Id.StartsWith("merged="))
-            {
-                var s = item.Source.Source.MSDataFile.run.spectrumList.spectrum(spectrum.Index, true);
-                mobilityArray = s.GetIonMobilityArray();
-            }
+            RefreshData();
             base.Refresh();
         }
 

--- a/pwiz_tools/SeeMS/Dialogs/DataPointTableForm.resx
+++ b/pwiz_tools/SeeMS/Dialogs/DataPointTableForm.resx
@@ -112,15 +112,15 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="mz.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="mz.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="Intensity.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="Intensity.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
 </root>

--- a/pwiz_tools/commandline/msconvert-help.txt
+++ b/pwiz_tools/commandline/msconvert-help.txt
@@ -5,15 +5,16 @@ Return value: # of failed files.
 
 Options:
   -f [ --filelist ] arg              : specify text file containing filenames
-  -o [ --outdir ] arg (=.)           : set output directory ('-' for stdout, 
-                                     '.' for current directory) [.]
+  -o [ --outdir ] arg (=.)           : set output directory ('-' for stdout, '.' for current directory) [.]
   -c [ --config ] arg                : configuration file (optionName=value)
   --outfile arg                      : Override the name of output file.
-  -e [ --ext ] arg                   : set extension for output files 
-                                     [mzML|mzXML|mgf|txt|mz5]
+  -e [ --ext ] arg                   : set extension for output files [mzML|mzXML|mgf|txt|mz5|mzMLb]
   --mzML                             : write mzML format [default]
   --mzXML                            : write mzXML format
   --mz5                              : write mz5 format
+  --mzMLb                            : write mzMLb format
+  --mzMLbChunkSize arg (=1048576)    : mzMLb dataset chunk size in bytes
+  --mzMLbCompressionLevel arg (=4)   : mzMLb GZIP compression level (0-9)
   --mgf                              : write Mascot generic format
   --text                             : write ProteoWizard internal text format
   --ms1                              : write MS1 format
@@ -21,99 +22,48 @@ Options:
   --ms2                              : write MS2 format
   --cms2                             : write CMS2 format
   -v [ --verbose ]                   : display detailed progress information
-  --64                               : set default binary encoding to 64-bit 
-                                     precision [default]
-  --32                               : set default binary encoding to 32-bit 
-                                     precision
-  --mz64                             : encode m/z values in 64-bit precision 
-                                     [default]
+  --64                               : set default binary encoding to 64-bit precision [default]
+  --32                               : set default binary encoding to 32-bit precision
+  --mz64                             : encode m/z values in 64-bit precision [default]
   --mz32                             : encode m/z values in 32-bit precision
-  --inten64                          : encode intensity values in 64-bit 
-                                     precision
-  --inten32                          : encode intensity values in 32-bit 
-                                     precision [default]
+  --inten64                          : encode intensity values in 64-bit precision
+  --inten32                          : encode intensity values in 32-bit precision [default]
+  --mzTruncation arg (=0)            : Number of mantissa precision bits to truncate for mz and rt, or if -1 will store integers only
+  --intenTruncation arg (=0)         : Number of mantissa precision bits to truncate for intensities, or if -1 will store integers only
+  --mzDelta                          : apply delta prediction to mz and rt values
+  --intenDelta                       : apple delta prediction to intensity values
+  --mzLinear                         : apply linear prediction to mz and rt values
+  --intenLinear                      : apply linear prediction to intensity values
   --noindex                          : do not write index
   -i [ --contactInfo ] arg           : filename for contact info
-  -z [ --zlib ]                      : use zlib compression for binary data
-  --numpressLinear [=arg(=2e-09)]    : use numpress linear prediction 
-                                     compression for binary mz and rt data 
-                                     (relative accuracy loss will not exceed 
-                                     given tolerance arg, unless set to 0)
-  --numpressLinearAbsTol [=arg(=-1)] : desired absolute tolerance for linear 
-                                     numpress prediction (e.g. use 1e-4 for a 
-                                     mass accuracy of 0.2 ppm at 500 m/z, 
-                                     default uses -1.0 for maximal accuracy). 
-                                     Note: setting this value may substantially
-                                     reduce file size, this overrides relative 
-                                     accuracy tolerance.
-  --numpressPic                      : use numpress positive integer 
-                                     compression for binary intensities 
-                                     (absolute accuracy loss will not exceed 
-                                     0.5)
-  --numpressSlof [=arg(=0.0002)]     : use numpress short logged float 
-                                     compression for binary intensities 
-                                     (relative accuracy loss will not exceed 
-                                     given tolerance arg, unless set to 0)
-  -n [ --numpressAll ]               : same as --numpressLinear --numpressSlof 
-                                     (see https://github.com/fickludd/ms-numpre
-                                     ss for more info)
-  -g [ --gzip ]                      : gzip entire output file (adds .gz to 
-                                     filename)
+  -z [ --zlib ]                      : use zlib compression for binary data (default)
+  -u [ --noZlib ]                    : disable zlib compression for binary data
+  --numpressLinear [=arg(=2e-09)]    : use numpress linear prediction compression for binary mz and rt data (relative accuracy loss will not exceed given tolerance arg, unless set to 0)
+  --numpressLinearAbsTol [=arg(=-1)] : desired absolute tolerance for linear numpress prediction (e.g. use 1e-4 for a mass accuracy of 0.2 ppm at 500 m/z, default uses -1.0 for maximal accuracy). Note: setting this value may substantially reduce file size, this overrides relative accuracy tolerance.
+  --numpressPic                      : use numpress positive integer compression for binary intensities (absolute accuracy loss will not exceed 0.5)
+  --numpressSlof [=arg(=0.0002)]     : use numpress short logged float compression for binary intensities (relative accuracy loss will not exceed given tolerance arg, unless set to 0)
+  -n [ --numpressAll ]               : same as --numpressLinear --numpressSlof (see https://github.com/fickludd/ms-numpress for more info)
+  -g [ --gzip ]                      : gzip entire output file (adds .gz to filename)
   --filter arg                       : add a spectrum list filter
   --chromatogramFilter arg           : add a chromatogram list filter
-  --merge                            : create a single output file from 
-                                     multiple input files by merging file-level
-                                     metadata and concatenating spectrum lists
-  --runIndexSet arg                  : for multi-run sources, select only the 
-                                     specified run indices
-  --simAsSpectra                     : write selected ion monitoring as 
-                                     spectra, not chromatograms
-  --srmAsSpectra                     : write selected reaction monitoring as 
-                                     spectra, not chromatograms
-  --combineIonMobilitySpectra        : write all ion mobility or Waters SONAR 
-                                     bins/scans in a frame/block as one 
-                                     spectrum instead of individual spectra
-  --ddaProcessing                    : if supported by vendor; combine MS2 
-                                     spectra referring to the same precursor 
-                                     and survey scan, and calculate accurate 
-                                     precursor masses.
-  --ignoreCalibrationScans           : do not process calibration scans 
-                                     (currently only applies to Waters lockmass
-                                     function)
-  --acceptZeroLengthSpectra          : some vendor readers have an efficient 
-                                     way of filtering out empty spectra, but it
-                                     takes more time to open the file
-  --ignoreMissingZeroSamples         : some vendor readers do not include zero 
-                                     samples in their profile data; the default
-                                     behavior is to add the zero samples but 
-                                     this option disables that
-  --ignoreUnknownInstrumentError     : if true, if an instrument cannot be 
-                                     determined from a vendor file, it will not
-                                     be an error
-  --stripLocationFromSourceFiles     : if true, sourceFile elements will be 
-                                     stripped of location information, so the 
-                                     same file converted from different 
-                                     locations will produce the same mzML
-  --stripVersionFromSoftware         : if true, software elements will be 
-                                     stripped of version information, so the 
-                                     same file converted with different 
-                                     versions will produce the same mzML
-  --singleThreaded [=arg(=1)] (=2)   : if true, reading and writing spectra 
-                                     will be done on a single thread
-  --continueOnError                  : if true, if an error is seen when 
-                                     enumerating a spectrum or chromatogram, it
-                                     is skipped and enumeration will attempt to
-                                     continue (but keep in mind a crash may 
-                                     follow, or the remaining data might be 
-                                     obviously or subtly incorrect)
-  --help                             : show this message, with extra detail on 
-                                     filter options
-  --help-filter arg                  : name of a single filter to get detailed 
-                                     help for
-  --show-examples                    : show examples of how to run 
-                                     msconvert.exe
-  --doc                              : writes output of --help and 
-                                     --show-examples, without version info
+  --merge                            : create a single output file from multiple input files by merging file-level metadata and concatenating spectrum lists
+  --runIndexSet arg                  : for multi-run sources, select only the specified run indices
+  --simAsSpectra                     : write selected ion monitoring as spectra, not chromatograms
+  --srmAsSpectra                     : write selected reaction monitoring as spectra, not chromatograms
+  --combineIonMobilitySpectra        : write all ion mobility or Waters SONAR bins/scans in a frame/block as one spectrum instead of individual spectra
+  --ddaProcessing                    : if supported by vendor; combine MS2 spectra referring to the same precursor and survey scan, and calculate accurate precursor masses.
+  --ignoreCalibrationScans           : do not process calibration scans (currently only applies to Waters lockmass function)
+  --acceptZeroLengthSpectra          : some vendor readers have an efficient way of filtering out empty spectra, but it takes more time to open the file
+  --ignoreMissingZeroSamples         : some vendor readers do not include zero samples in their profile data; the default behavior is to add the zero samples but this option disables that
+  --ignoreUnknownInstrumentError     : if true, if an instrument cannot be determined from a vendor file, it will not be an error
+  --stripLocationFromSourceFiles     : if true, sourceFile elements will be stripped of location information, so the same file converted from different locations will produce the same mzML
+  --stripVersionFromSoftware         : if true, software elements will be stripped of version information, so the same file converted with different versions will produce the same mzML
+  --singleThreaded [=arg(=1)] (=2)   : if true, reading and writing spectra will be done on a single thread
+  --continueOnError                  : if true, if an error is seen when enumerating a spectrum or chromatogram, it is skipped and enumeration will attempt to continue (but keep in mind a crash may follow, or the remaining data might be obviously or subtly incorrect)
+  --help                             : show this message, with extra detail on filter options
+  --help-filter arg                  : name of a single filter to get detailed help for
+  --show-examples                    : show examples of how to run msconvert.exe
+  --doc                              : writes output of --help and --show-examples, without version info
 
 Spectrum List Filters
 =====================
@@ -262,6 +212,12 @@ thermoScanFilter <exact|contains> <include|exclude> <match string>
                       If "exclude" is set, only spectra that do NOT match the filter will be kept.
                      used the filter drops data points that match the various criteria instead of keeping them.   <match string> specifies the search string to be compared to each scan filter (it may contain spaces)
 
+
+mzShift <m/z shift as number and units (e.g. 10ppm or 1Da)> [msLevels=int_set (1-)]
+Shifts all m/z values by the specified amount if a spectrum's ms level is in the msLevels set.
+Both metadata (e.g. scan window, base peak m/z) and binary data (m/z array) are shifted.
+Precursor metadata is only shifted if the spectrum's precursor ms level (ms level - 1) is in the msLevels set.
+This allows applying different shifts for different ms levels.
 
 MS2Denoise [<peaks_in_window> [<window_width_Da> [multicharge_fragment_relaxation]]]
 Noise peak removal for spectra with precursor ions.

--- a/pwiz_tools/commandline/msconvert-help.txt
+++ b/pwiz_tools/commandline/msconvert-help.txt
@@ -36,12 +36,11 @@ Options:
   --intenLinear                      : apply linear prediction to intensity values
   --noindex                          : do not write index
   -i [ --contactInfo ] arg           : filename for contact info
-  -z [ --zlib ]                      : use zlib compression for binary data (default)
-  -u [ --noZlib ]                    : disable zlib compression for binary data
-  --numpressLinear [=arg(=2e-09)]    : use numpress linear prediction compression for binary mz and rt data (relative accuracy loss will not exceed given tolerance arg, unless set to 0)
+  -z [ --zlib ] [=arg(=1)]           : use zlib compression for binary data (add =off to disable compression)
+  --numpressLinear [=arg(=2.0e-09)]  : use numpress linear prediction compression for binary mz and rt data (relative accuracy loss will not exceed given tolerance arg, unless set to 0)
   --numpressLinearAbsTol [=arg(=-1)] : desired absolute tolerance for linear numpress prediction (e.g. use 1e-4 for a mass accuracy of 0.2 ppm at 500 m/z, default uses -1.0 for maximal accuracy). Note: setting this value may substantially reduce file size, this overrides relative accuracy tolerance.
   --numpressPic                      : use numpress positive integer compression for binary intensities (absolute accuracy loss will not exceed 0.5)
-  --numpressSlof [=arg(=0.0002)]     : use numpress short logged float compression for binary intensities (relative accuracy loss will not exceed given tolerance arg, unless set to 0)
+  --numpressSlof [=arg(=2.0e-04)]    : use numpress short logged float compression for binary intensities (relative accuracy loss will not exceed given tolerance arg, unless set to 0)
   -n [ --numpressAll ]               : same as --numpressLinear --numpressSlof (see https://github.com/fickludd/ms-numpress for more info)
   -g [ --gzip ]                      : gzip entire output file (adds .gz to filename)
   --filter arg                       : add a spectrum list filter


### PR DESCRIPTION
- fixed Zlib checkbox not enabling zlib compression in mzMLb output (reported by Timo)
- fixed mzMLb not reading/writing integerDataArrayPtrs
- fixed SeeMS "Show data table" to work properly with 3-array ion mobility spectra
- changed zlib compression (including mzMLb) to default to on for msconvert.exe and added --noZlib flag to turn it off
* fixed Diff not checking integerDataArrayPtrs
* fixed line wrapping for --doc output of options_description

Closes #2838 
