### PR TITLE
Add missing entries in "Settings.Settings"

### DIFF
--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace pwiz.Skyline.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.9.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -991,52 +991,43 @@ namespace pwiz.Skyline.Properties {
                 this["AreaLogScale"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool AreaProteinTargets
-        {
-            get
-            {
+        public bool AreaProteinTargets {
+            get {
                 return ((bool)(this["AreaProteinTargets"]));
             }
-            set
-            {
+            set {
                 this["AreaProteinTargets"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool ExcludePeptideListsFromAbundanceGraph
-        {
-            get
-            {
+        public bool ExcludePeptideListsFromAbundanceGraph {
+            get {
                 return ((bool)(this["ExcludePeptideListsFromAbundanceGraph"]));
             }
-            set
-            {
+            set {
                 this["ExcludePeptideListsFromAbundanceGraph"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool ExcludeStandardsFromAbundanceGraph
-        {
-            get
-            {
+        public bool ExcludeStandardsFromAbundanceGraph {
+            get {
                 return ((bool)(this["ExcludeStandardsFromAbundanceGraph"]));
             }
-            set
-            {
+            set {
                 this["ExcludeStandardsFromAbundanceGraph"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("document")]

--- a/pwiz_tools/Skyline/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Properties/Settings.settings
@@ -245,6 +245,15 @@
     <Setting Name="AreaLogScale" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="AreaProteinTargets" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ExcludePeptideListsFromAbundanceGraph" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ExcludeStandardsFromAbundanceGraph" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="AreaPeptideOrderEnum" Type="System.String" Scope="User">
       <Value Profile="(Default)">document</Value>
     </Setting>


### PR DESCRIPTION
Manual edits had made to the generated file "Settings.Designer.cs" instead of the correct thing of adding entries to "Settings.settings" and running the custom tool.