### PR TITLE
* changed MSAmanda temporary directory to use ~SK temp prefix

### DIFF
--- a/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MSAmandaSearchWrapper.cs
@@ -68,13 +68,14 @@ namespace pwiz.Skyline.Model.DdaSearch
         private const string MAX_LOADED_SPECTRA_AT_ONCE = "MaxLoadedSpectraAtOnce";
         private const string CONSIDERED_CHARGES = "ConsideredCharges";
 
-        public const string MS_AMANDA_TMP = @"~SK_MSAmanda";
+        public static string MSAmandaTmp => Program.FunctionalTest ? TemporaryDirectory.TEMP_PREFIX : @"~SK_MSAmanda";
+
         private readonly TemporaryDirectory _baseDir; // Created as %TMP%/~SK_MSAmanda/<random dirname>
         // TODO(MattC): tidy up MSAmanda implementation so that we can distinguish intentional uses of tmp dir (caching potentially re-used files) from accidental directory creation and/or not-reused files within
 
         public MSAmandaSearchWrapper()
         {
-            _baseDir = new TemporaryDirectory(tempPrefix: MS_AMANDA_TMP + @"/"); // Creates %TMP%/~SK_MSAmanda/<random dirname>
+            _baseDir = new TemporaryDirectory(tempPrefix: MSAmandaTmp + @"/"); // Creates %TMP%/~SK_MSAmanda/<random dirname>
             Settings = new MSAmandaSettings();
             helper = new MSHelper();
             helper.InitLogWriter(_baseDir.DirPath);

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -622,7 +622,7 @@ namespace TestRunnerLib
             // MSAmanda intentionally leaves tempfiles behind (as caches in case of repeat runs)
             // But our test system wants a clean finish
             // TODO(MattC): tidy up MSAmanda implementation so that we can distinguish intentional uses of tmp dir (caching potentially re-used files) from accidental directory creation and/or not-reused files within
-            var msAmandaTmpDir = Path.Combine(Path.GetTempPath(), @"~SK_MSAmanda" /* must match MSAmandaSearchWrapper.MS_AMANDA_TMP */);
+            var msAmandaTmpDir = Path.Combine(Path.GetTempPath(), "~SK" /* must match MSAmandaSearchWrapper.MS_AMANDA_TMP */);
             try
             {
                 if (Directory.Exists(msAmandaTmpDir))


### PR DESCRIPTION
* changed MSAmanda temporary directory to use standard ~SK temp prefix instead of ~SK_MSAmanda which should bring the path length issues under control on KAIPO-DEV