### PR TITLE
Library Explorer improvements inspired by larger small molecules libraries:

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/Collections/CollectionUtil.cs
+++ b/pwiz_tools/Shared/CommonUtil/Collections/CollectionUtil.cs
@@ -205,7 +205,7 @@ namespace pwiz.Common.Collections
             // Compare using natural non-lexicographical order for easier human readability.
             // Compatible with both numbers (which have priority) as well as letter
             // e.g. (a1b,a20b,a3b --> a1b,a3b,a20b).
-            return new NaturalStringComparer().Compare(o1.ToString(), o2.ToString()); 
+            return NaturalStringComparer.Compare(o1.ToString(), o2.ToString()); 
         }
 
         public static Comparer<object> ColumnValueComparer

--- a/pwiz_tools/Shared/CommonUtil/Collections/CollectionUtil.cs
+++ b/pwiz_tools/Shared/CommonUtil/Collections/CollectionUtil.cs
@@ -205,7 +205,7 @@ namespace pwiz.Common.Collections
             // Compare using natural non-lexicographical order for easier human readability.
             // Compatible with both numbers (which have priority) as well as letter
             // e.g. (a1b,a20b,a3b --> a1b,a3b,a20b).
-            return NaturalComparer.Compare(o1.ToString(), o2.ToString()); 
+            return new NaturalStringComparer().Compare(o1.ToString(), o2.ToString()); 
         }
 
         public static Comparer<object> ColumnValueComparer

--- a/pwiz_tools/Shared/CommonUtil/Collections/NaturalComparer.cs
+++ b/pwiz_tools/Shared/CommonUtil/Collections/NaturalComparer.cs
@@ -18,7 +18,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -50,12 +49,12 @@ namespace pwiz.Common.Collections
     // Similar to the filename comparer, except that decimals are understood
     // e.g. for the filename comparer, "123.4056" comes after "123.456" because 4056 > 456 -
     // it doesn't seem them as two parts of a decimal value
-    public class NaturalStringComparer : IComparer<string>
+    public class NaturalStringComparer
     {
         // Regular expression pattern to match decimal parts - note it accepts both . and , decimal separator
         private static readonly Regex REGEX = new Regex(@"(\d+(?:[.,]\d+)?|\D+)", RegexOptions.Compiled);
 
-        public int Compare(string x, string y)
+        public static int Compare(string x, string y)
         {
             if (x == null)
             {

--- a/pwiz_tools/Shared/CommonUtil/Collections/NaturalComparer.cs
+++ b/pwiz_tools/Shared/CommonUtil/Collections/NaturalComparer.cs
@@ -17,7 +17,11 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 namespace pwiz.Common.Collections
 {
@@ -31,7 +35,7 @@ namespace pwiz.Common.Collections
     /// e.g. (1AC6, 1AC66, 1AC7, 4C47 --> 1AC6, 1AC7, 1AC66, 4C47)
     /// https://www.pinvoke.net/default.aspx/shlwapi.strcmplogicalw
     /// </summary>
-    public class NaturalComparer
+    public class NaturalFilenameComparer
     {
         [DllImport("shlwapi.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
         private static extern int StrCmpLogicalW(string x, string y);
@@ -40,6 +44,77 @@ namespace pwiz.Common.Collections
         public static int Compare(string x, string y)
         {
             return StrCmpLogicalW(x, y);
+        }
+    }
+
+    // Similar to the filename comparer, except that decimals are understood
+    // e.g. for the filename comparer, "123.4056" comes after "123.456" because 4056 > 456 -
+    // it doesn't seem them as two parts of a decimal value
+    public class NaturalStringComparer : IComparer<string>
+    {
+        // Regular expression pattern to match decimal parts - note it accepts both . and , decimal separator
+        private static readonly Regex REGEX = new Regex(@"(\d+(?:[.,]\d+)?|\D+)", RegexOptions.Compiled);
+
+        public int Compare(string x, string y)
+        {
+            if (x == null)
+            {
+                return y == null ? 0 : -1;
+            }
+            else if (y == null)
+            {
+                return 1;
+            }
+
+            // Match decimal parts of both strings
+            var matchesX = REGEX.Matches(x);
+            var matchesY = REGEX.Matches(y);
+
+            // Compare segments iteratively
+            var segmentCount = Math.Min(matchesX.Count, matchesY.Count);
+
+            for (var i = 0; i < segmentCount; i++)
+            {
+                // Compare non-decimal segments
+                var partX = matchesX[i].Groups[1].Value;
+                var partY = matchesY[i].Groups[1].Value;
+                var comparison = string.Compare(partX, partY, StringComparison.OrdinalIgnoreCase);
+                if (comparison != 0)
+                {
+                    // Compare as decimals
+                    var decimalX = ParseLocalizedDecimal(partX);
+                    var decimalY = ParseLocalizedDecimal(partY);
+
+                    if (decimalX == null || decimalY == null)
+                    {
+                        return comparison; // One or both could not be understood as a decimal, return the string comparison
+                    }
+
+                    comparison = decimal.Compare(decimalX.Value, decimalY.Value);
+                    if (comparison != 0)
+                    {
+                        return comparison;
+                    }
+                }
+            }
+
+            // If one string has more segments, it should come after
+            return matchesX.Count.CompareTo(matchesY.Count);
+        }
+
+        private static decimal? ParseLocalizedDecimal(string value)
+        {
+            // Attempt to parse the decimal value using invariant culture
+            if (decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+            // If parsing fails, attempt to parse  using  the current culture's settings
+            else if (decimal.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture , out result))
+            {
+                return result;
+            }
+            return null; // Didn't parse
         }
     }
 }

--- a/pwiz_tools/Skyline/Alerts/ShareResultsFilesDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/ShareResultsFilesDlg.cs
@@ -318,7 +318,7 @@ namespace pwiz.Skyline.Alerts
 
             // Update the UI with any matched files
             // CONSIDER: Seems not worth it to insert these into the checked list. Instead they are added to the end in sorted order.
-            matchedFiles.Sort(NaturalComparer.Compare);
+            matchedFiles.Sort(NaturalFilenameComparer.Compare);
             foreach (var matchedFile in matchedFiles)
             {
                 checkedListBox.Items.Add(matchedFile, true);
@@ -427,11 +427,11 @@ namespace pwiz.Skyline.Alerts
                     }
 
                     var repFiles = paths.ToList(); // Convert to list. Prevents duplicates from being present
-                    repFiles.Sort(NaturalComparer.Compare);
+                    repFiles.Sort(NaturalFilenameComparer.Compare);
                     FoundFiles = repFiles.Select(f => new FileChoice(f, true)).ToArray();
 
                     var missingRepFiles = missingPaths.ToList(); // Convert to list. Prevents duplicates from being present
-                    missingRepFiles.Sort(NaturalComparer.Compare);
+                    missingRepFiles.Sort(NaturalFilenameComparer.Compare);
                     MissingFiles = missingRepFiles.ToArray();
                 }
             }

--- a/pwiz_tools/Skyline/FileUI/OpenDataSourceDialog.cs
+++ b/pwiz_tools/Skyline/FileUI/OpenDataSourceDialog.cs
@@ -478,7 +478,7 @@ namespace pwiz.Skyline.FileUI
                 {
                     return x.isFolder ? -1 : 1; 
                 }
-                return NaturalComparer.Compare(x.name, y.name); // Use normal compare if both elements are of the same type (folder vs folder, file vs file)
+                return NaturalFilenameComparer.Compare(x.name, y.name); // Use normal compare if both elements are of the same type (folder vs folder, file vs file)
             }); // Sorts by natural sort order for easier more natural readability e.g. (A1.raw, A22.raw, A5.raw --> A1.raw, A5.raw, A22.raw)
 
 

--- a/pwiz_tools/Skyline/Model/Lib/ViewLibraryPepInfo.cs
+++ b/pwiz_tools/Skyline/Model/Lib/ViewLibraryPepInfo.cs
@@ -371,5 +371,10 @@ namespace pwiz.Skyline.Model.Lib
                 ModifiedMass = modifiedMass;
             }
         }
+
+        public override string ToString()
+        {
+            return KeyString; // For debugging convenience, not user facing
+        }
     }
 }

--- a/pwiz_tools/Skyline/Properties/Resources.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Resources.Designer.cs
@@ -10553,6 +10553,18 @@ namespace pwiz.Skyline.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 
+        ///
+        ///This library entry only provides precursor
+        ///information, there is no spectrum to show.
+        /// </summary>
+        public static string SpectrumGraphItem_library_entry_provides_only_precursor_values {
+            get {
+                return ResourceManager.GetString("SpectrumGraphItem_library_entry_provides_only_precursor_values", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Data files.
         /// </summary>
         public static string SpectrumLibraryInfoDlg_SetDetailsText_Data_files {

--- a/pwiz_tools/Skyline/Properties/Resources.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.resx
@@ -4369,6 +4369,12 @@ If you choose Disable, you can enable Auto-select later with the "Refine &gt; Ad
   <data name="CommandLine_SetPeptideDigestSettings_Error__Could_not_find_background_proteome_file__0_" xml:space="preserve">
     <value>Error: Could not find background proteome file {0}</value>
   </data>
+  <data name="SpectrumGraphItem_library_entry_provides_only_precursor_values" xml:space="preserve">
+    <value>
+
+This library entry only provides precursor
+information, there is no spectrum to show</value>
+  </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Protein_Expression_Formatting" xml:space="preserve">
     <value>Relative Abundance Formatting</value>
   </data>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -376,7 +376,6 @@ namespace pwiz.Skyline.SettingsUI
             // Order matters!!
             LoadLibrary();
             InitializePeptides();
-            _currentRange = new RangeList(0, _peptides.Count);
             UpdatePageInfo();
             UpdateStatusArea();
             cbShowModMasses.Checked = Settings.Default.ShowModMassesInExplorer;
@@ -460,7 +459,7 @@ namespace pwiz.Skyline.SettingsUI
 
                         var info = new ViewLibraryPepInfo(key, libInfo);
                         // If there are any, set the ion mobility values of entry
-                        return key.IsSmallMoleculeKey ? SetIonMobilityCCSValues(info) : info; // Don't do this for peptides until we have performance issues worked out
+                        return SetIonMobilityCCSValues(info);
                     });
             }
 
@@ -559,7 +558,7 @@ namespace pwiz.Skyline.SettingsUI
                 string.Format(peptideCountFormat,
                               showStart.ToString(numFormat),
                               showEnd.ToString(numFormat),
-                                _peptides.Count.ToString(numFormat));
+                                _currentRange.Count.ToString(numFormat)); // Count the filtered items
 
             PageCount.Text = string.Format(SettingsUIResources.ViewLibraryDlg_UpdateStatusArea_Page__0__of__1__, _pageInfo.Page,
                                            _pageInfo.Pages);
@@ -1058,7 +1057,10 @@ namespace pwiz.Skyline.SettingsUI
         /// </summary>
         private void FilterAndUpdate()
         {
-            _currentRange = _peptides.Filter(textPeptide.Text, comboFilterCategory.SelectedItem.ToString());
+            var filterCategory = comboFilterCategory.SelectedItem.ToString();
+            _currentRange = _peptides.Filter(textPeptide.Text, filterCategory);
+            _filterTextPerFilterType[filterCategory] = textPeptide.Text; // Keep different text for each filter type
+            _previousFilterType = filterCategory;
             UpdatePageInfo();
             UpdateStatusArea();
             UpdateListPeptide(0);
@@ -1328,6 +1330,10 @@ namespace pwiz.Skyline.SettingsUI
             FilterAndUpdate();
         }
 
+        // Don't lose the user's search strings when flipping between filters
+        private Dictionary<string, string> _filterTextPerFilterType = new Dictionary<string, string>();
+        private string _previousFilterType;
+
         private void comboFilterCategory_SelectedIndexChanged(object sender, EventArgs e)
         {
             var cancelled = false;
@@ -1361,7 +1367,24 @@ namespace pwiz.Skyline.SettingsUI
             // when the user begins typing
             _peptides.CreateCachedList(propertyName);
 
-            FilterAndUpdate();
+            // Each filter type has a different search string, swap them in as needed
+            var filterType = comboFilterCategory.SelectedItem.ToString();
+            var needsUpdate = true;
+            if (!Equals(filterType, _previousFilterType))
+            {
+                var newText = _filterTextPerFilterType.TryGetValue(filterType, out var text) ? text : string.Empty;
+                if (!Equals(textPeptide.Text, newText))
+                {
+                    textPeptide.Text = newText;
+                    needsUpdate = false; // Update will file automatically
+                }
+            }
+            if (needsUpdate)
+            {
+                FilterAndUpdate();
+            }
+
+            textPeptide.Focus(); // Assume that the next thing the user wants to do is work with the filter value
         }
         private void listPeptide_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -2609,11 +2632,14 @@ namespace pwiz.Skyline.SettingsUI
                     {
                         return string.Format(SettingsUIResources.ViewLibSpectrumGraphItem_Title__0__1_, libraryNamePrefix, _key.PrecursorMz.GetValueOrDefault());
                     }
-                    if (_key.IsSmallMoleculeKey)
+                    var title = _key.IsSmallMoleculeKey ?
+                        string.Format(@"{0}{1}{2}", libraryNamePrefix, TransitionGroup.Peptide.CustomMolecule.DisplayName, TransitionGroup.PrecursorAdduct) :
+                        string.Format(SettingsUIResources.ViewLibSpectrumGraphItem_Title__0__1__Charge__2__, libraryNamePrefix, TransitionGroup.Peptide.Target, TransitionGroup.PrecursorAdduct);
+                    if (this.PeaksCount == 0)
                     {
-                        return string.Format(@"{0}{1}{2}", libraryNamePrefix, TransitionGroup.Peptide.CustomMolecule.DisplayName, TransitionGroup.PrecursorAdduct);
+                        title += Resources.SpectrumGraphItem_library_entry_provides_only_precursor_values;
                     }
-                    return string.Format(SettingsUIResources.ViewLibSpectrumGraphItem_Title__0__1__Charge__2__, libraryNamePrefix, TransitionGroup.Peptide.Target, TransitionGroup.PrecursorAdduct);
+                    return title;
                 }
             }
         }
@@ -2962,11 +2988,9 @@ namespace pwiz.Skyline.SettingsUI
         /// </summary>
         public IonMobilityAndCCS GetIonMobility(ViewLibraryPepInfo pepInfo)
         {
-            var bestSpectrum = _selectedLibrary.GetSpectra(pepInfo.Key,
-                IsotopeLabelType.light, LibraryRedundancy.best).FirstOrDefault();
-            if (bestSpectrum != null)
+            if (_selectedLibrary.TryGetIonMobilityInfos(new[] { pepInfo.Key }, out var ionMobilities))
             {
-                return bestSpectrum.IonMobilityInfo;
+                return ionMobilities.GetIonMobilityDict().Values.First().FirstOrDefault();
             }
             return IonMobilityAndCCS.EMPTY;
         }

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryPepInfoList.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryPepInfoList.cs
@@ -430,7 +430,7 @@ namespace pwiz.Skyline.SettingsUI
         // Natural sort (e.g. "xyz200.5" comes before "xyz1200.5")
         public static int ComparePepInfosNatural(ViewLibraryPepInfo info1, ViewLibraryPepInfo info2)
         {
-            var result = new NaturalStringComparer().Compare(info1.UnmodifiedTargetText, info2.UnmodifiedTargetText);
+            var result = NaturalStringComparer.Compare(info1.UnmodifiedTargetText, info2.UnmodifiedTargetText);
 
             if (result == 0)
             {
@@ -439,7 +439,7 @@ namespace pwiz.Skyline.SettingsUI
                 if (result == 0)
                 {
                     // Last try, natural sort on whatever Key.ToString() produced
-                    result = new NaturalStringComparer().Compare(info1.KeyString, info2.KeyString);
+                    result = NaturalStringComparer.Compare(info1.KeyString, info2.KeyString);
                 }
             }
             return result;

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryPepInfoList.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryPepInfoList.cs
@@ -31,7 +31,8 @@ namespace pwiz.Skyline.SettingsUI
 {
     public class ViewLibraryPepInfoList : AbstractReadOnlyList<ViewLibraryPepInfo>
     {
-        private readonly ImmutableList<ViewLibraryPepInfo> _allEntries;
+        private readonly ImmutableList<ViewLibraryPepInfo> _allEntries; // Alpha sorted
+        private readonly ImmutableList<int> _naturalSortIndex; // Natural sort order of the members of _allEntries
         private readonly LibKeyModificationMatcher _matcher;
         public bool _mzCalculated;
         public readonly List<string> _stringSearchFields;
@@ -71,6 +72,13 @@ namespace pwiz.Skyline.SettingsUI
         public ViewLibraryPepInfoList(IEnumerable<ViewLibraryPepInfo> items, LibKeyModificationMatcher matcher, string selectedFilterCategory, out bool allPeptides)
         {
             _allEntries = ImmutableList.ValueOf(items.OrderBy(item => item, Comparer<ViewLibraryPepInfo>.Create(ComparePepInfos)));
+            var naturalSort = Enumerable.Range(0, _allEntries.Count).OrderBy(i => _allEntries[i], Comparer<ViewLibraryPepInfo>.Create(ComparePepInfosNatural)).ToArray();
+            var naturalSortMap = new int[_allEntries.Count];
+            for (var order = 0; order < naturalSort.Length; order++)
+            {
+                naturalSortMap[naturalSort[order]] = order;
+            }
+            _naturalSortIndex = ImmutableList.ValueOf(naturalSortMap);
             _selectedFilterCategory = selectedFilterCategory;
             _matcher = matcher; // Used to calculate precursor m/z
             allPeptides = _allEntries.All(key => key.Key.IsProteomicKey); // Are there any non-proteomic entries in this library?
@@ -335,8 +343,8 @@ namespace pwiz.Skyline.SettingsUI
             if (string.IsNullOrEmpty(filterText))
             {
                 // Only return entries that have the selected property
-                var ret = _listCache.GetOrCreate(_selectedFilterCategory).OrderBy(info => info);
-                    return ImmutableList.ValueOf(ret);
+                var ret = _listCache.GetOrCreate(_selectedFilterCategory).OrderBy(info => _naturalSortIndex[info]);
+                return ImmutableList.ValueOf(ret);
             }
 
             // We have to deal with the UnmodifiedTargetText separately from the adduct because the
@@ -382,12 +390,12 @@ namespace pwiz.Skyline.SettingsUI
                             info.UnmodifiedTargetText.Length,
                             StringComparison.OrdinalIgnoreCase));
                     // Return the elements from the range whose DisplayText actually matches the filter text.
-                    return ImmutableList.ValueOf(new RangeList(range).Where(i => _allEntries[i].DisplayText
-                        .StartsWith(filterText, StringComparison.OrdinalIgnoreCase)));
+                    filteredIndices = new RangeList(range).Where(i => _allEntries[i].DisplayText
+                        .StartsWith(filterText, StringComparison.OrdinalIgnoreCase)).ToList();
                 }
             }
             // Return the indices of the matches sorted alphabetically by display text
-            return ImmutableList.ValueOf(filteredIndices.OrderBy(info => info));
+            return ImmutableList.ValueOf(filteredIndices.OrderBy(info => _naturalSortIndex[info]));
         }
 
         public int IndexOf(LibraryKey libraryKey)
@@ -401,17 +409,38 @@ namespace pwiz.Skyline.SettingsUI
             return range.Length > 0 ? range.Start : -1;
         }
 
+        // Simple alphanumeric sort
         public static int ComparePepInfos(ViewLibraryPepInfo info1, ViewLibraryPepInfo info2)
         {
             int result = string.Compare(info1.UnmodifiedTargetText, info2.UnmodifiedTargetText,
                 StringComparison.OrdinalIgnoreCase);
             if (result == 0)
             {
+                // Same molecule, sort by adduct
                 result = info1.Adduct.CompareTo(info2.Adduct);
+                if (result == 0)
+                {
+                    // Last try, alpha sort on whatever Key.ToString() produced
+                    result = string.Compare(info1.KeyString, info2.KeyString, StringComparison.OrdinalIgnoreCase);
+                }
             }
+            return result;
+        }
+
+        // Natural sort (e.g. "xyz200.5" comes before "xyz1200.5")
+        public static int ComparePepInfosNatural(ViewLibraryPepInfo info1, ViewLibraryPepInfo info2)
+        {
+            var result = new NaturalStringComparer().Compare(info1.UnmodifiedTargetText, info2.UnmodifiedTargetText);
+
             if (result == 0)
             {
-                result = string.Compare(info1.KeyString, info2.KeyString, StringComparison.OrdinalIgnoreCase);
+                // Same molecule, sort by adduct
+                result = info1.Adduct.CompareTo(info2.Adduct);
+                if (result == 0)
+                {
+                    // Last try, natural sort on whatever Key.ToString() produced
+                    result = new NaturalStringComparer().Compare(info1.KeyString, info2.KeyString);
+                }
             }
             return result;
         }

--- a/pwiz_tools/Skyline/Test/TextUtilTest.cs
+++ b/pwiz_tools/Skyline/Test/TextUtilTest.cs
@@ -111,7 +111,8 @@ namespace pwiz.SkylineTest
         {   
             //Sample test strings
             var orderedSample = new List<string>() 
-            {   
+            {
+                "0a123.30561n","0a123.456n","0a123.4567n", // Note this isn't the order supported by the filename natural sort - it doesn't understand 123.30561 as a decimal, sees it as two distinct parts
                 "1NvWw","1U2t6","1uBYH","2E1fK","2V6La","3pxza","3sVDq","4tuzE",
                 "4VK2-","4ztTB","5QRmn","5Zcd7","6hkS_","6qvCh","6sAzR","7Z25C","8fMsb","8HRzI",
                 "8wqJy","9jz1y","a5E6p","a736Q","aL4lL","alpXu","B-2ag","BRrbj","bzUgj","c8qdT","CdaAF",
@@ -129,19 +130,21 @@ namespace pwiz.SkylineTest
                 "vscw3","W2ffg","waINu","wAYVn","wcnac","wgnCt","Whe2M","WHs9b","wj-Sy","woie2","WOrKF",
                 "XfWhr","XfY9w","xlt5k","XPCHC","XxgDy","Zdrnb","zXdQ1"
             };
+            var orderedSampleFilename = orderedSample.Select(s => s.Replace("30561n", "356n")).ToList(); // Make it amenable to windows filename sort tradtiion
 
             // Run test 12 time to ensure consistency 
             for (int i = 0; i < 12; i++)
             {
-                SortAndTest(orderedSample); // Test sort on a smaller sample set
+                SortAndTest(orderedSample, false); // Test sort on a smaller sample set, using the decimal-aware sort
+                SortAndTest(orderedSampleFilename, true); // Test sort on a smaller sample set, using the filename sort
             }
 
             // Shuffle an input list and sort. Compares against original in order version to ensure consistency
-            void SortAndTest(List<string> ordered)
+            void SortAndTest(List<string> ordered, bool useFilenameSort)
             {
                 List<string> misOrdered = Shuffle(ordered); // Shuffle
 
-                misOrdered.Sort((x, y) => NaturalComparer.Compare(x, y)); // Naturally sort
+                misOrdered.Sort((x, y) => useFilenameSort ? NaturalFilenameComparer.Compare(x, y) : new NaturalStringComparer().Compare(x, y)); // Naturally sort
 
                 // Compare with original. Prints out discrepancies between sort and original if they should occur
                 for (int i = 0; i < ordered.Count; i++)

--- a/pwiz_tools/Skyline/Test/TextUtilTest.cs
+++ b/pwiz_tools/Skyline/Test/TextUtilTest.cs
@@ -144,7 +144,7 @@ namespace pwiz.SkylineTest
             {
                 List<string> misOrdered = Shuffle(ordered); // Shuffle
 
-                misOrdered.Sort((x, y) => useFilenameSort ? NaturalFilenameComparer.Compare(x, y) : new NaturalStringComparer().Compare(x, y)); // Naturally sort
+                misOrdered.Sort((x, y) => useFilenameSort ? NaturalFilenameComparer.Compare(x, y) : NaturalStringComparer.Compare(x, y)); // Naturally sort
 
                 // Compare with original. Prints out discrepancies between sort and original if they should occur
                 for (int i = 0; i < ordered.Count; i++)


### PR DESCRIPTION
* Peptides and/or molecules are shown in natural sort order (i.e. aware of numerical values embedded in strings) - this matters more for molecules with constructed names like "mass123.456", "mass123.0456" etc. For peptides it generally amounts to the same thing as a plain alphanumeric sort.
* We now show the number of things that match the filter rather than always just giving the total count.
* We remember the user's search string for each filter type as they choose and return to different filters.
* Fixed a bottleneck that was preventing display of ion mobility values in the library explorer.

This required a new natural sort class to complement the existing one, which turns out to be filename specific. The original doesn't understand that "z123.4056" comes before "z123.456" because it doesn't see "123.4056" as a decimal value - it sees "123" and "4056" as two different numbers and is comparing 4056 to 456. No real surprise since it's just a wrapper for a windows call for sorting filenames.

This was all done in the service of the Feature Finding work but stands alone nicely so I've given it a separate PR.