### PR TITLE
Fix a couple of NullReferenceException

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -1252,6 +1252,10 @@ namespace pwiz.Skyline.Controls.Graphs
             if (nodeGroup == null)
                 nodeTranSelected = null;
             var info = chromGroupInfo.GetTransitionInfo(null, 0, TransformChrom.raw);
+            if (info == null)
+            {
+                return;
+            }
 
             TransitionChromInfo tranPeakInfo = null;
             RetentionTimeValues bestQuantitativePeakTimes = null;

--- a/pwiz_tools/Skyline/Model/FullScanProperties.cs
+++ b/pwiz_tools/Skyline/Model/FullScanProperties.cs
@@ -78,10 +78,10 @@ namespace pwiz.Skyline.Model
             res.MSLevel = spectrum.Level.ToString();
             res.ScanId = spectrum.Id;
 
+            res.Instrument = new InstrumentInfo();
+            res.Instrument.InstrumentManufacturer = spectrum.InstrumentVendor;
             if (spectrum.InstrumentInfo != null)
             {
-                res.Instrument = new InstrumentInfo();
-                res.Instrument.InstrumentManufacturer = spectrum.InstrumentVendor;
                 res.Instrument.InstrumentModel = spectrum.InstrumentInfo.Model;
                 if (new[]
                     {
@@ -96,8 +96,8 @@ namespace pwiz.Skyline.Model
                     res.Instrument.InstrumentComponents.Detector = spectrum.InstrumentInfo.Detector;
                 }
             }
-
             res.Instrument.InstrumentSerialNumber = spectrum.InstrumentSerialNumber;
+
             res.IsCentroided = spectrum.Centroided.ToString(CultureInfo.CurrentCulture);
             return res;
         }


### PR DESCRIPTION
Fixed error bringing up Full Scan spectrum viewer on some datasets (reported by ece) Fixed error displaying TIC chromatogram when not available in some datasets (not reported by anyone)