### PR TITLE
Fixed IDPicker and pwiz Mascot DAT reader issues

### DIFF
--- a/pwiz/data/identdata/MascotReader.cpp
+++ b/pwiz/data/identdata/MascotReader.cpp
@@ -185,12 +185,12 @@ namespace
 }
 
 //
-// MascotReader::Impl
+// MascotReaderImpl
 //
-class MascotReader::Impl
+class MascotReaderImpl
 {
 public:
-    Impl()
+    MascotReaderImpl()
     {
         varmodPattern = bxp::sregex::compile("(.*) \\((Protein)?\\s*([NC]-term)?\\s*(.*?)\\)");
         varmodListOfChars = bxp::sregex::compile("([A-Z]+)");
@@ -1184,19 +1184,12 @@ private:
     static const char* error_id;
 };
 
-const char* MascotReader::Impl::owner_person_id = "doc_owner_person";
-const char* MascotReader::Impl::provider_id = "provider";
-const char* MascotReader::Impl::mz_id = "mz_id";
-const char* MascotReader::Impl::intensity_id = "intensity_id";
-const char* MascotReader::Impl::error_id = "error_id";
+const char* MascotReaderImpl::owner_person_id = "doc_owner_person";
+const char* MascotReaderImpl::provider_id = "provider";
+const char* MascotReaderImpl::mz_id = "mz_id";
+const char* MascotReaderImpl::intensity_id = "intensity_id";
+const char* MascotReaderImpl::error_id = "error_id";
 
-//
-// MascotReader::MascotReader
-//
-MascotReader::MascotReader()
-    : pimpl(new MascotReader::Impl())
-{
-}
 
 //
 // MascotReader::read
@@ -1206,7 +1199,8 @@ void MascotReader::read(const string& filename,
                         IdentData& result,
                         const Reader::Config& config) const
 {
-    pimpl->read(filename, head, result, config);
+    MascotReaderImpl reader;
+    reader.read(filename, head, result, config);
 }
 
 //
@@ -1245,10 +1239,6 @@ namespace pwiz {
 namespace identdata {
 
 
-PWIZ_API_DECL MascotReader::MascotReader()
-{
-}
-
 PWIZ_API_DECL void MascotReader::read(const std::string& filename,
                                       const std::string& head,
                                       IdentData& result,
@@ -1272,13 +1262,6 @@ PWIZ_API_DECL void MascotReader::read(const std::string& filename,
 {
     throw std::runtime_error("[MascotReader::read] no mascot support enabled.");
 }
-
-class MascotReader::Impl
-{
-    Impl() {}
-    ~Impl() {}
-};
-
 
 } // namespace identdata 
 } // namespace pwiz 

--- a/pwiz/data/identdata/MascotReader.hpp
+++ b/pwiz/data/identdata/MascotReader.hpp
@@ -33,9 +33,6 @@ namespace identdata {
 class PWIZ_API_DECL  MascotReader : public Reader
 {
 public:
-    MascotReader();
-    ~MascotReader() {}
-
     virtual std::string identify(const std::string& filename,
                                  const std::string& head) const;
 
@@ -55,11 +52,6 @@ public:
                       const Reader::Config&) const;
 
     virtual const char *getType() const { return "Mascot DAT"; }
-
-private:
-    class Impl;
-
-    Impl* pimpl;
 };
 
 } // namespace pwiz 

--- a/pwiz/data/identdata/Serializer_pepXML.cpp
+++ b/pwiz/data/identdata/Serializer_pepXML.cpp
@@ -419,7 +419,9 @@ void write_sample_enzyme(XMLWriter& xmlWriter, const IdentData& mzid)
     string enzymeName = bal::join(sip.enzymes.enzymes | boost::adaptors::transformed(EnzymePtr_name()), " + ");
 
     // find the minimum specificity
-    int minSpecificity = *boost::range::min_element(sip.enzymes.enzymes | boost::adaptors::transformed(EnzymePtr_specificity()));
+    int minSpecificity = 2;
+    if (!sip.enzymes.enzymes.empty())
+        minSpecificity = *boost::range::min_element(sip.enzymes.enzymes | boost::adaptors::transformed(EnzymePtr_specificity()));
 
     XMLWriter::Attributes attributes;
     attributes.add("name", enzymeName);
@@ -505,10 +507,14 @@ void write_search_summary(XMLWriter& xmlWriter, const IdentData& mzid, const str
         string enzymeName = bal::join(sip.enzymes.enzymes | boost::adaptors::transformed(EnzymePtr_name()), " + ");
 
         // find the maximum missed cleavages
-        int maxMissedCleavages = *boost::range::max_element(sip.enzymes.enzymes | boost::adaptors::transformed(EnzymePtr_missedCleavages()));
+        int maxMissedCleavages = 0;
+        if (!sip.enzymes.enzymes.empty())
+            maxMissedCleavages = *boost::range::max_element(sip.enzymes.enzymes | boost::adaptors::transformed(EnzymePtr_missedCleavages()));
 
         // find the minimum specificity
-        int minSpecificity = *boost::range::min_element(sip.enzymes.enzymes | boost::adaptors::transformed(EnzymePtr_specificity()));
+        int minSpecificity = 2;
+        if (!sip.enzymes.enzymes.empty())
+            minSpecificity = *boost::range::min_element(sip.enzymes.enzymes | boost::adaptors::transformed(EnzymePtr_specificity()));
 
         Formula nTerm(Formula_nTerm), cTerm(Formula_cTerm); 
 

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/CommandlineTest.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/CommandlineTest.cpp
@@ -36,6 +36,8 @@
 #include <boost/thread.hpp>
 #include <sqlite3pp.h>
 
+#include "Parser.hpp"
+
 
 using namespace pwiz::proteome;
 using namespace pwiz::chemistry;
@@ -136,9 +138,7 @@ void testIdpQonvert(const string& idpQonvertPath, const bfs::path& testDataPath)
     vector<bfs::path> idpDbFiles;
     for(const bfs::path& idFile : idFiles)
     {
-        idpDbFiles.push_back(idFile);
-        string idpDbFilepath = bal::replace_all_copy(idpDbFiles.back().string(), ".pep.xml", ".pepXML");
-        idpDbFiles.back() = bfs::path(idpDbFilepath).replace_extension(".idpDB");
+        idpDbFiles.push_back(IDPicker::Parser::outputFilepath(idFile.string()).string());
 
         unit_assert(bfs::exists(idpDbFiles.back()));
         sqlite3pp::database db(idpDbFiles.back().string());

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/Filter.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/Filter.cpp
@@ -497,9 +497,8 @@ struct Filter::Impl
             return;
 
         char buf[32768];
-
-        FILE* f = fopen(filepath.c_str(), "r");
-        while (fread(&buf, 32768, 1, f) > 0) {}
+        ifstream f(filepath.c_str());
+        while (f.readsome(reinterpret_cast<char*>(&buf), 32768) > 0) {}
     }
 
     void initializeConnection()

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/Jamfile.jam
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/Jamfile.jam
@@ -152,7 +152,7 @@ run CommandlineTest.cpp
     : # input-files
        [ SORT idpQonvert idpAssemble idpQuery ]
     : # requirements
-        $(TEAMCITY_TEST_DECORATION) <dependency>gene2protein.db3/<location-prefix>CommandlineTest.test <library>Qonverter
+        $(TEAMCITY_TEST_DECORATION) <dependency>gene2protein.db3/<location-prefix>CommandlineTest.test.test <library>Qonverter
     : # target name
         CommandlineTest
    : # default-build

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/Merger.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/Merger.cpp
@@ -482,10 +482,8 @@ struct Merger::Impl
             return;
 
         char buf[32768];
-
-        FILE* f = fopen(filepath.c_str(), "r");
-        while (fread(&buf, 32768, 1, f) > 0) {}
-        fclose(f);
+        ifstream f(filepath.c_str());
+        while (f.readsome(reinterpret_cast<char*>(&buf), 32768) > 0) {}
     }
 
     void initializeTarget(sqlite3pp::database& db)

--- a/pwiz_tools/Bumbershoot/idpicker/Qonverter/Parser.cpp
+++ b/pwiz_tools/Bumbershoot/idpicker/Qonverter/Parser.cpp
@@ -1778,6 +1778,8 @@ string Parser::parseSource(const string& inputFilepath)
 
 bfs::path Parser::outputFilepath(const string& inputFilepath)
 {
+    if (bal::iends_with(inputFilepath, ".dat")) // use parseSource for Mascot DAT input
+        return (bfs::path(inputFilepath).parent_path() / parseSource(inputFilepath)).replace_extension(".idpDB");
     if (bal::iends_with(inputFilepath, ".pep.xml"))
         return bal::ireplace_last_copy(inputFilepath, ".pep.xml", ".idpDB");
     return bfs::path(inputFilepath).replace_extension(".idpDB");


### PR DESCRIPTION
- fixed Mascot DAT reader to be thread safe (IDPicker will parse up to 2 input pepXML/mzIdentML/MascotDAT in parallel)
- fixed IDPicker not handling Mascot DAT renaming consistently
- fixed crashes converting to pepXML when mzIdentML has no enzymes
* fixed IDPicker's precacheFile() functions to work with UTF-8 filepaths
* fixed IDPicker CommandlineTest

NB: Doesn't affect BiblioSpec's Mascot DAT reader.