### PR TITLE
Fix ToolService error

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -736,7 +736,7 @@ namespace pwiz.Skyline.Controls.Graphs
             get
             {
                 // CONSIDER: Is this really the selected file?
-                return ChromGroupInfos.FirstOrDefault(info => info != null);
+                return ChromGroupInfos?.FirstOrDefault(info => info != null);
             }
         }
 

--- a/pwiz_tools/Skyline/Model/ElementLocators/ElementLocator.cs
+++ b/pwiz_tools/Skyline/Model/ElementLocators/ElementLocator.cs
@@ -317,7 +317,7 @@ namespace pwiz.Skyline.Model.ElementLocators
                 switch (tk.Key)
                 {
                     case TokenType.String:
-                        if (keyName == null)
+                        if (string.IsNullOrEmpty(keyName))
                         {
                             keyName = tk.Value;
                         }
@@ -340,7 +340,7 @@ namespace pwiz.Skyline.Model.ElementLocators
                             attributes.Add(new KeyValuePair<string, string>(attributeName, attributeValue));
                         }
                         yield return new ElementLocator(keyName ?? string.Empty, attributes);
-                        keyName = null;
+                        keyName = string.Empty;
                         attributeName = null;
                         attributeValue = null;
                         attributes.Clear();

--- a/pwiz_tools/Skyline/Test/ElementLocatorTest.cs
+++ b/pwiz_tools/Skyline/Test/ElementLocatorTest.cs
@@ -50,6 +50,17 @@ namespace pwiz.SkylineTest
         }
 
         [TestMethod]
+        public void TestEmptyNameElementLocator()
+        {
+            var locatorProtein = new ElementLocator("", null).ChangeParent(DocumentRef.PROTOTYPE.ToElementLocator()).ChangeType("MoleculeGroup");
+            VerifyElementLocator(locatorProtein);
+            var locatorPeptide = new ElementLocator("ELVIS", null).ChangeParent(locatorProtein).ChangeType("Molecule");
+            VerifyElementLocator(locatorPeptide);
+            var locatorEmptyPeptide = new ElementLocator("", null).ChangeParent(locatorProtein).ChangeType("Molecule");
+            VerifyElementLocator(locatorEmptyPeptide);
+        }
+
+        [TestMethod]
         public void TestElementLocatorQuote()
         {
             Assert.AreEqual("a", ElementLocator.QuoteIfSpecial("a"));


### PR DESCRIPTION
Fixed error using tool service to delete protein whose locator is "MoleculeGroup:/" (reported by Philip) Fixed error doing "Apply Peak to All" when one replicate has missing chromatograms (reported anonymously on exception web)