### PR TITLE
Fix unhandled access denied "share report" error

### DIFF
--- a/pwiz_tools/Skyline/Controls/Databinding/SkylineViewContext.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/SkylineViewContext.cs
@@ -648,12 +648,20 @@ namespace pwiz.Skyline.Controls.Databinding
 
         public override void ExportViewsToFile(Control owner, ViewSpecList viewSpecList, string fileName)
         {
-            XmlSerializer xmlSerializer = new XmlSerializer(typeof(ViewSpecList));
-            SafeWriteToFile(owner, fileName, stream =>
+            try
             {
-                xmlSerializer.Serialize(stream, viewSpecList);
-                return true;
-            });
+                XmlSerializer xmlSerializer = new XmlSerializer(typeof(ViewSpecList));
+                SafeWriteToFile(owner, fileName, stream =>
+                {
+                    xmlSerializer.Serialize(stream, viewSpecList);
+                    return true;
+                });
+            }
+            catch (Exception x)
+            {
+                MessageDlg.ShowWithException(owner,
+                    string.Format(DatabindingResources.ExportReportDlg_ExportReport_Failed_exporting_to, fileName, x.Message), x);
+            }
         }
 
         public override void ImportViews(Control owner, ViewGroup group)


### PR DESCRIPTION
Fixed unhandled error when exporting report definition to a .skyr file that cannot be written to (reported anonymously on exception web)
Also fixed to output a warning message to the Immediate Window if a single transition's chromatogram is being discarded because of the Explicit Retention Time.

![image](https://github.com/ProteoWizard/pwiz/assets/303203/46fa2962-039f-4dcc-b4b7-9974541e98ef)
![image](https://github.com/ProteoWizard/pwiz/assets/303203/413a9c6e-bfd0-4a44-b167-82824a91b733)
