### PR TITLE
Skyline: Fix LiteDropDownList use to set SelectedIndex to -1

### DIFF
--- a/pwiz_tools/Shared/Common/Controls/LiteDropDownList.cs
+++ b/pwiz_tools/Shared/Common/Controls/LiteDropDownList.cs
@@ -95,14 +95,7 @@ namespace pwiz.Common.Controls
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int SelectedIndex
         {
-            get
-            {
-                if (_selectedIndex < 0 || _selectedIndex >= Items.Count)
-                {
-                    return -1;
-                }
-                return _selectedIndex;
-            }
+            get => _selectedIndex;
             set
             {
                 var oldValue = _selectedIndex;

--- a/pwiz_tools/Skyline/EditUI/EditPepModsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/EditPepModsDlg.cs
@@ -419,6 +419,7 @@ namespace pwiz.Skyline.EditUI
             if (!EqualsItems(combo, listItems))
             {
                 combo.Items.Clear();
+                combo.SelectedIndex = -1;   // And reset selection - normal combos would do this
                 listItems.ForEach(item => combo.Items.Add(item));
             }
             if (select)

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -1507,6 +1507,7 @@ namespace pwiz.Skyline.FileUI
             foreach (var comboBox in ComboBoxes)
             {
                 comboBox.Items.Clear();
+                comboBox.SelectedIndex = -1;
                 UpdateCombo(comboBox);
             }
             checkBoxAssociateProteins.Visible = CheckboxVisible();

--- a/pwiz_tools/Skyline/TestFunctional/LiteDropdownListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LiteDropdownListTest.cs
@@ -127,6 +127,40 @@ namespace pwiz.SkylineTestFunctional
                 Assert.AreEqual(strNewModName, editPepModsDlg.GetComboBox(IsotopeLabelType.light, 1).SelectedItem);
                 Assert.AreEqual(strCarbonyl, editPepModsDlg.GetComboBox(IsotopeLabelType.light, 2).SelectedItem);
             });
+            var oxidationV = new StaticMod(@"Carboxidation (V)", "V", null, "CO");
+            RunDlg<EditStaticModDlg>(
+                () => editPepModsDlg.GetComboBox(IsotopeLabelType.light, 2).SelectedItem =
+                    Resources.SettingsListComboDriver_Add,
+                addModDlg =>
+                {
+                    addModDlg.Modification = oxidationV;
+                    addModDlg.OkDialog();
+                }
+            );
+
+            RunUI(() =>
+            {
+                var combo = editPepModsDlg.GetComboBox(IsotopeLabelType.light, 2);
+                Assert.AreEqual(oxidationV.Name, combo.SelectedItem);
+                Assert.AreEqual(oxidationV.Name, combo.Text);
+            });
+
+            RunDlg<EditListDlg<SettingsListBase<StaticMod>, StaticMod>>(
+                () => editPepModsDlg.GetComboBox(IsotopeLabelType.light, 2).SelectedItem =
+                    Resources.SettingsListComboDriver_Edit_list,
+                editListDlg =>
+                {
+                    editListDlg.SelectItem(oxidationV.Name);
+                    editListDlg.RemoveItem();
+                    editListDlg.OkDialog();
+                });
+
+            RunUI(() =>
+            {
+                var combo = editPepModsDlg.GetComboBox(IsotopeLabelType.light, 2);
+                Assert.IsNull(combo.SelectedItem);
+                Assert.AreEqual(string.Empty, combo.Text);
+            });
 
             OkDialog(editPepModsDlg, editPepModsDlg.OkDialog);
         }


### PR DESCRIPTION
 after list is cleared

- Remove Nick's prior attempt at a fix
- Expand LiteDropdownListTest to cover the problem case