### PR TITLE
Skyline: Add string extension TextUtil.ToLines for line separation

### DIFF
--- a/pwiz_tools/Skyline/Test/MassListIonsTest.cs
+++ b/pwiz_tools/Skyline/Test/MassListIonsTest.cs
@@ -72,19 +72,20 @@ namespace pwiz.SkylineTest
             doc = doc.ChangeSettings(settings);
             VerifyImport(doc, text, 5, CUSTOM_IONS.Length, 0);
 
-            const string lineBreak = "\r\n";
             // Try precursor [M-1] first to make the importer decide
             // the product m/z column from the M-1 isotope m/z
-            var lines = text.Split(new[] { lineBreak }, StringSplitOptions.None).ToList();
+            var lines = text.ToLines();
+            Assert.AreEqual(13, lines.Count);
             (lines[1], lines[2]) = (lines[2], lines[1]);    // Swap lines 2 and 3 - leaving header
-            var textPMinusFirst = string.Join(lineBreak, lines);
+            var textPMinusFirst = TextUtil.LineSeparate(lines);
             VerifyImport(doc, textPMinusFirst, 5, CUSTOM_IONS.Length, 0);
 
             // Try only custom ions with no precursors to make the importer decide
             // the product m/z column from a custom ion mass
-            lines = text.Split(new[] { lineBreak }, StringSplitOptions.None).ToList();
-            lines.RemoveRange(1, PRECURSOR_COUNT);
-            var textNoP = string.Join(lineBreak, lines);
+            lines = text.ToLines();
+            var linesNoP = new List<string>(lines);
+            linesNoP.RemoveRange(1, PRECURSOR_COUNT);
+            var textNoP = TextUtil.LineSeparate(linesNoP);
             VerifyImport(doc, textNoP, 0, CUSTOM_IONS.Length, 0);
         }
 

--- a/pwiz_tools/Skyline/Test/MassListIonsTest.cs
+++ b/pwiz_tools/Skyline/Test/MassListIonsTest.cs
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -74,7 +73,7 @@ namespace pwiz.SkylineTest
 
             // Try precursor [M-1] first to make the importer decide
             // the product m/z column from the M-1 isotope m/z
-            var lines = text.ToLines();
+            var lines = text.ReadLines().ToList();
             Assert.AreEqual(13, lines.Count);
             (lines[1], lines[2]) = (lines[2], lines[1]);    // Swap lines 2 and 3 - leaving header
             var textPMinusFirst = TextUtil.LineSeparate(lines);
@@ -82,8 +81,7 @@ namespace pwiz.SkylineTest
 
             // Try only custom ions with no precursors to make the importer decide
             // the product m/z column from a custom ion mass
-            lines = text.ToLines();
-            var linesNoP = new List<string>(lines);
+            var linesNoP = text.ReadLines().ToList();
             linesNoP.RemoveRange(1, PRECURSOR_COUNT);
             var textNoP = TextUtil.LineSeparate(linesNoP);
             VerifyImport(doc, textNoP, 0, CUSTOM_IONS.Length, 0);

--- a/pwiz_tools/Skyline/Util/Extensions/Text.cs
+++ b/pwiz_tools/Skyline/Util/Extensions/Text.cs
@@ -381,6 +381,16 @@ namespace pwiz.Skyline.Util.Extensions
             return LineSeparate(lines.AsEnumerable());
         }
 
+        public static IList<string> ToLines(this string text)
+        {
+            using var reader = new StringReader(text);
+            var lines = new List<string>();
+            string line;
+            while ((line = reader.ReadLine()) != null)
+                lines.Add(line);
+            return lines;
+        }
+
         /// <summary>
         /// This function can be used as a replacement for String.Join(" ", ...)
         /// </summary>

--- a/pwiz_tools/Skyline/Util/Extensions/Text.cs
+++ b/pwiz_tools/Skyline/Util/Extensions/Text.cs
@@ -381,7 +381,12 @@ namespace pwiz.Skyline.Util.Extensions
             return LineSeparate(lines.AsEnumerable());
         }
 
-        public static IList<string> ToLines(this string text)
+        /// <summary>
+        /// Utility function for <see cref="string"/> like <see cref="File"/> ReadLines().
+        /// </summary>
+        /// <param name="text">Text possibly multi-line</param>
+        /// <returns>Enumerable lines without line endings</returns>
+        public static IEnumerable<string> ReadLines(this string text)
         {
             using var reader = new StringReader(text);
             var lines = new List<string>();


### PR DESCRIPTION
- Improve diagnostics to help understand why KAIPOT-PC1 fails MassListSpecialIonsTest