### PR TITLE
Fix using shared downloads folder on macs2

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/PathEx.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/PathEx.cs
@@ -101,12 +101,17 @@ namespace pwiz.Common.SystemUtil
             return string.Join(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), parts.ToArray());
         }
 
+        /// <summary>
+        /// Environment variable which can be used to override <see cref="GetDownloadsPath"/>.
+        /// </summary>
+        private const string SKYLINE_DOWNLOAD_PATH = @"SKYLINE_DOWNLOAD_PATH";
+
         // From http://stackoverflow.com/questions/3795023/downloads-folder-not-special-enough
         // Get the path for the Downloads directory, avoiding the assumption that it's under the 
         // user's personal directory (it's possible to relocate it under newer versions of Windows)
         public static string GetDownloadsPath()
         {
-            string path = Environment.GetEnvironmentVariable(@"SKYLINE_DOWNLOAD_PATH");
+            string path = Environment.GetEnvironmentVariable(SKYLINE_DOWNLOAD_PATH);
             if (path != null)
             {
                 return path;
@@ -127,6 +132,19 @@ namespace pwiz.Common.SystemUtil
                 path = string.Empty;
             path = Path.Combine(path, @"Downloads");
             return path;
+        }
+
+        /// <summary>
+        /// Returns true if the <see cref="GetDownloadsPath"/> is likely to be a folder
+        /// which is shared with other users on the computer
+        /// </summary>
+        public static bool IsDownloadsPathShared()
+        {
+            // If the "SKYLINE_DOWNLOAD_PATH" environment variable has been set in a system environment
+            // variable and not a user environment variable, then assume the folder is shared
+            // with other users
+            return null != Environment.GetEnvironmentVariable(SKYLINE_DOWNLOAD_PATH)
+                   && null == Environment.GetEnvironmentVariable(SKYLINE_DOWNLOAD_PATH, EnvironmentVariableTarget.User);
         }
 
         private static Guid FolderDownloads = new Guid(@"374DE290-123F-4565-9164-39C4925E467B");

--- a/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
@@ -19,10 +19,9 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Collections;
+using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
 
@@ -253,15 +252,7 @@ namespace pwiz.SkylineTestUtil
             // since it is essentially an extension of the test directory.
             if (!TestContext.Properties.Contains("ParallelTest")) // It is a shared directory in parallel tests, though, so leave it alone in parallel mode
             {
-                // Check for file locks on PersistentFilesDir
-
-                // but only if that folder is owned by the current user
-                var dirInfo = new DirectoryInfo(PersistentFilesDir);
-                DirectorySecurity dirSecurity = dirInfo.GetAccessControl();
-                IdentityReference ownerReference = dirSecurity.GetOwner(typeof(NTAccount));
-                WindowsIdentity currentUser = WindowsIdentity.GetCurrent();
-                
-                if (ownerReference.ToString().Equals(currentUser.Name, StringComparison.OrdinalIgnoreCase))
+                if (!PathEx.IsDownloadsPathShared())
                 {
                     CheckForFileLocks(PersistentFilesDir, desiredCleanupLevel != DesiredCleanupLevel.none);
                 }


### PR DESCRIPTION
On Macs2, the value of the system environment variable "SKYLINE_DOWNLOAD_PATH" is D:\Shared\SkylineDownloadPath.
Users can override that by setting their own value for that environment variable.
The cleanup code at the end of tests tries to rename some of the folders in there which fails because the folders are owned by someone else.

This change makes it so that this renaming does not happen if the folder path has been set in a system environment variable instead of a user level environment variable.

A different way that this could have been implemented would be to check whether the folder was owned by a different user, but the system/user environment variable seems more likely to work in all scenarios.