### PR TITLE
Fix NRE in AutoQC

### DIFF
--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/MainForm.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/MainForm.cs
@@ -779,9 +779,12 @@ namespace AutoQC
 
         private void ListViewSizeChanged()
         {
-            listViewConfigs.ColumnWidthChanged -= listViewConfigs_ColumnWidthChanged;
-            _listViewColumnWidths.ListViewContainerResize();
-            listViewConfigs.ColumnWidthChanged += listViewConfigs_ColumnWidthChanged;
+            if (_listViewColumnWidths != null)
+            {
+                listViewConfigs.ColumnWidthChanged -= listViewConfigs_ColumnWidthChanged;
+                _listViewColumnWidths.ListViewContainerResize();
+                listViewConfigs.ColumnWidthChanged += listViewConfigs_ColumnWidthChanged;
+            }
         }
 
         private void listViewConfigs_ColumnWidthChanged(object sender, ColumnWidthChangedEventArgs e)


### PR DESCRIPTION
Fixed error starting AutoQC on some computers (reported by Hayoung)

A user reported an NRE in "MainForm.ListViewSizeChanged" on the Skyline support board:
https://skyline.ms/announcements/home/support/thread.view?rowId=63931

I did the same fix to Skyline Batch a couple of months ago in PR #2879.