### PR TITLE
Honor explicit adduct charge declarations (e.g. the trailing "+" in "[M+2CH3+Cl]+")

### DIFF
--- a/pwiz_tools/Skyline/Test/AdductTest.cs
+++ b/pwiz_tools/Skyline/Test/AdductTest.cs
@@ -166,6 +166,13 @@ namespace pwiz.SkylineTest
             Assert.IsFalse(Adduct.EMPTY.IsProteomic);
             Assert.IsTrue(Adduct.EMPTY.IsEmpty);
 
+            // Honor explicit charges 
+            var mCh3Cl = "[M+2CH3+Cl]+";
+            var adductCH3 = Adduct.FromString(mCh3Cl, Adduct.ADDUCT_TYPE.non_proteomic, null);
+            Assert.AreEqual(1, adductCH3.AdductCharge);
+            Assert.AreEqual(mCh3Cl, adductCH3.ToString());
+            AssertEx.ThrowsException<InvalidDataException>(() => Adduct.FromStringAssumeProtonated("[M+2H]-")); // Try to declare wrong charge on common adduct
+
             // Exercise the ability to work with masses and isotope labels
             Assert.IsTrue(ReferenceEquals(Adduct.SINGLY_PROTONATED, Adduct.SINGLY_PROTONATED.Unlabeled));
             var nolabel = Adduct.FromStringAssumeProtonated("M-2Na");
@@ -409,6 +416,10 @@ namespace pwiz.SkylineTest
             TestException(PENTANE, "M2Cl37H+H"); // nonsense label ("2Cl37H2" would make sense, but regular H doesn't belong)
             TestException(PENTANE, "M+2H+"); // Trailing sign - we now understand this as a charge state declaration, but this one doesn't match described charge
             TestException(PENTANE, "[M-2H]3-"); // Declared charge doesn't match described charge
+            TestException(PENTANE, "[M-]3-"); // Declared charge doesn't match described charge
+            TestException(PENTANE, "[M+]-"); // Declared charge doesn't match described charge
+            TestException(PENTANE, "[M+2]-"); // Declared charge doesn't match described charge
+            TestException(PENTANE, "[M+2]+3"); // Declared charge doesn't match described charge
 
             // Test label stripping
             Assert.AreEqual("C5H9NO2S", (new IonInfo("C5H9H'3NO2S[M-3H]")).UnlabeledFormula.ToString());

--- a/pwiz_tools/Skyline/Test/AdductTest.cs
+++ b/pwiz_tools/Skyline/Test/AdductTest.cs
@@ -167,10 +167,20 @@ namespace pwiz.SkylineTest
             Assert.IsTrue(Adduct.EMPTY.IsEmpty);
 
             // Honor explicit charges 
-            var mCh3Cl = "[M+2CH3+Cl]+";
+            var mCh3Cl = "[M+2CH3+Cl]";
             var adductCH3 = Adduct.FromString(mCh3Cl, Adduct.ADDUCT_TYPE.non_proteomic, null);
-            Assert.AreEqual(1, adductCH3.AdductCharge);
+            Assert.AreEqual(1, adductCH3.AdductCharge); // CH3 is +1, Cl is -1
             Assert.AreEqual(mCh3Cl, adductCH3.ToString());
+
+            adductCH3 = Adduct.FromString(mCh3Cl+"+", Adduct.ADDUCT_TYPE.non_proteomic, null); // Declare correct charge
+            Assert.AreEqual(1, adductCH3.AdductCharge); // CH3 is +1, Cl is -1
+            Assert.AreEqual(mCh3Cl, adductCH3.ToString()); // We dropped the charge declaration since it's redundant
+
+            mCh3Cl += "++";  // Wrong charge, but since this is a non-canonical adduct, we will honor it
+            adductCH3 = Adduct.FromString(mCh3Cl, Adduct.ADDUCT_TYPE.non_proteomic, null);
+            Assert.AreEqual(2, adductCH3.AdductCharge);
+            Assert.AreEqual(mCh3Cl, adductCH3.ToString()); // We kept the charge declaration since it's weird
+
             AssertEx.ThrowsException<InvalidDataException>(() => Adduct.FromStringAssumeProtonated("[M+2H]-")); // Try to declare wrong charge on common adduct
 
             // Exercise the ability to work with masses and isotope labels
@@ -450,6 +460,9 @@ namespace pwiz.SkylineTest
             TestPentaneAdduct("MNH4", "C5H16N", 1, coverage); // implied pos mode seems to be fairly common in the wild
             TestPentaneAdduct("MNH4+", "C5H16N", 1, coverage); // implied pos mode seems to be fairly common in the wild
             TestPentaneAdduct("2MNH4+", "C10H28N", 1, coverage); // implied pos mode seems to be fairly common in the wild
+
+            // Methyl
+            TestPentaneAdduct("[M+2CH3]", "C7H18", 2, coverage); // Methyl is 2+
 
             // Explict charge states within the adduct
             TestPentaneAdduct("[M+S+]", "C5H12S", 1, coverage); // We're trusting the user to declare charge

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -517,7 +517,7 @@ namespace pwiz.Skyline.Util
                     }
                 }
             }
-            AdductCharge = calculatedCharge ?? declaredCharge ?? 0;
+            AdductCharge = declaredCharge ?? calculatedCharge ?? 0; // If user supplied a charge (e.g. [M+2CH3+Cl]+) believe them even if our calculation/guess disagrees
             if (!composition.Keys.All(k => BioMassCalc.MONOISOTOPIC.IsKnownSymbol(k)))
             {
                 throw new InvalidDataException(
@@ -548,11 +548,21 @@ namespace pwiz.Skyline.Util
             }
             if (declaredCharge.HasValue && calculatedCharge.HasValue && declaredCharge != calculatedCharge)
             {
-                throw new InvalidDataException(
-                    string.Format(
-                        UtilResources
-                            .BioMassCalc_ApplyAdductToFormula_Failed_parsing_adduct_description___0____declared_charge__1__does_not_agree_with_calculated_charge__2_,
-                        input, declaredCharge.Value, calculatedCharge));
+                // Only complain if this is an obvious error, like "[M+H]-"
+                foreach (var adducts in new[] { COMMON_PROTONATED_ADDUCTS, COMMON_SMALL_MOL_ADDUCTS})
+                {
+                    foreach (var adduct in adducts)
+                    {
+                        if (Equals(Composition, adduct.Composition))
+                        {
+                            throw new InvalidDataException(
+                                string.Format(
+                                    UtilResources
+                                        .BioMassCalc_ApplyAdductToFormula_Failed_parsing_adduct_description___0____declared_charge__1__does_not_agree_with_calculated_charge__2_,
+                                    input, declaredCharge.Value, calculatedCharge));
+                        }
+                    }
+                }
             }
         }
         public Adduct Unlabeled { get; private set; } // Version of this adduct without any isotope labels

--- a/pwiz_tools/Skyline/Util/Adduct.cs
+++ b/pwiz_tools/Skyline/Util/Adduct.cs
@@ -1170,7 +1170,8 @@ namespace pwiz.Skyline.Util
                 {BioMassCalc.F, -1},
                 {@"CH3COO", -1}, // Deprotonated Hac
                 {@"HCOO", -1}, // Formate (deprotonated FA)  
-                {@"NH4", 1}
+                {@"NH4", 1},
+                {@"CH3", 1} // Methyl
             };
 
         // Popular adducts (declared way down here because it has to follow some other statics)


### PR DESCRIPTION
Skyline may occasionally improperly calculate the ion charge of complicated adduct descriptions (e.g. "[M+2CH3+Cl]" where we did not pick up on the contributed charge +2 of 2CH3, and only used the -1 of Cl). Adding an explicit charge declaration (e.g. "[M+2CH3+Cl]**+**") would formerly just cause an error, with Skyline insisting on its own calculated charge. Now Skyline respects the declared charge.

Skyline will still complain about obviously wrong declarations like "[M+2H]-".

(Also, "CH3" is now understood as imparting a charge of +1, so  "[M+2CH3+Cl]" is now handled properly.)

Reported by user Alex