### PR TITLE
Fix TestTargetedMSMSTutorial and TestRedundantComboBox

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -289,7 +289,7 @@ namespace pwiz.Skyline.SettingsUI
         {
             textPeptide.Focus();
             if (_selectedLibrary is MidasLibrary || MatchModifications())
-                UpdateListPeptide(0);
+                UpdateListPeptide(listPeptide.SelectedIndex);
         }
 
         private void ViewLibraryDlg_Activated(object sender, EventArgs e)

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.cs
@@ -2410,7 +2410,7 @@ namespace pwiz.Skyline.SettingsUI
         public int SelectedLibIndex
         {
             get { return comboLibrary.SelectedIndex; }
-            set { listPeptide.SelectedIndex = value; }
+            set { comboLibrary.SelectedIndex = value; }
         }
 
         public bool HasSelectedLibrary => _selectedLibrary != null;

--- a/pwiz_tools/Skyline/TestFunctional/RedundantComboBoxTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/RedundantComboBoxTest.cs
@@ -93,11 +93,7 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() => dlg.SelectedIndex = i);
             // The peptide at index one does not have redundant spectra
             int waitMs = 1000;
-            if (!TryWaitForConditionUI(waitMs, () =>
-                {
-                    dlg.SelectedIndex = i; // keep setting the selected index in case it has been changed by "ViewLibraryDlg_Shown"
-                    return IsViewLibraryDlgState(dlg, i, visible, peakCount);
-                }))
+            if (!TryWaitForConditionUI(waitMs, () => IsViewLibraryDlgState(dlg, i, visible, peakCount)))
             {
                 RunUI(() =>
                 {

--- a/pwiz_tools/Skyline/TestFunctional/RedundantComboBoxTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/RedundantComboBoxTest.cs
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline.SettingsUI;
@@ -92,16 +93,24 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() => dlg.SelectedIndex = i);
             // The peptide at index one does not have redundant spectra
             int waitMs = 1000;
-            if (!TryWaitForConditionUI(waitMs, () => IsViewLibraryDlgState(dlg, i, visible, peakCount)))
+            if (!TryWaitForConditionUI(waitMs, () =>
+                {
+                    dlg.SelectedIndex = i; // keep setting the selected index in case it has been changed by "ViewLibraryDlg_Shown"
+                    return IsViewLibraryDlgState(dlg, i, visible, peakCount);
+                }))
             {
-                string redundantMessage = visible
-                    ? string.Format("Redundant list hidden with {0} selected",
-                        dlg.SelectedIndex)
-                    : string.Format("Redundant list visible with {0} selected, and {1} entries",
-                        dlg.SelectedIndex, dlg.RedundantComboBox.Items.Count);
-                string peaksMessage = string.Format("(peaks {0}, expected {1})", dlg.GraphItem.PeaksCount, peakCount);
-                string message = TextUtil.SpaceSeparate(redundantMessage, peaksMessage);
-                Assert.Fail(message);
+                RunUI(() =>
+                {
+                    string redundantMessage = visible
+                        ? string.Format("Redundant list hidden with {0} selected",
+                            dlg.SelectedIndex)
+                        : string.Format("Redundant list visible with {0} selected, and {1} entries",
+                            dlg.SelectedIndex, dlg.RedundantComboBox.Items.Count);
+                    string peaksMessage =
+                        string.Format("(peaks {0}, expected {1})", dlg.GraphItem.PeaksCount, peakCount);
+                    string message = TextUtil.SpaceSeparate(redundantMessage, peaksMessage);
+                    Assert.Fail(message);
+                });
             }
         }
         private static bool IsViewLibraryDlgState(ViewLibraryDlg dlg, int i, bool visible, int peakCount)

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -1087,11 +1087,7 @@ namespace pwiz.SkylineTestTutorial
             RunUI(() => dlg.SelectedIndex = i);
             // The peptide at index one does not have redundant spectra
             int waitMs = IsRecordMode ? 1000 : 10 * 1000;
-            if (!TryWaitForConditionUI(waitMs, () =>
-                {
-                    dlg.SelectedIndex = i; // reset SelectedIndex in case is has been changed by "ViewLibraryDlg_Shown"
-                    return IsViewLibraryDlgState(dlg, i, visible, peakCount) && !IsRecordMode;
-                }) )
+            if (!TryWaitForConditionUI(waitMs, () => IsViewLibraryDlgState(dlg, i, visible, peakCount)))
             {
                 RunUI(() =>
                 {

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -1087,7 +1087,7 @@ namespace pwiz.SkylineTestTutorial
             RunUI(() => dlg.SelectedIndex = i);
             // The peptide at index one does not have redundant spectra
             int waitMs = IsRecordMode ? 1000 : 10 * 1000;
-            if (!TryWaitForConditionUI(waitMs, () => IsViewLibraryDlgState(dlg, i, visible, peakCount)))
+            if (!TryWaitForConditionUI(waitMs, () => IsViewLibraryDlgState(dlg, i, visible, peakCount)) && !IsRecordMode)
             {
                 RunUI(() =>
                 {

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -1087,16 +1087,23 @@ namespace pwiz.SkylineTestTutorial
             RunUI(() => dlg.SelectedIndex = i);
             // The peptide at index one does not have redundant spectra
             int waitMs = IsRecordMode ? 1000 : 10 * 1000;
-            if (!TryWaitForConditionUI(waitMs, () => IsViewLibraryDlgState(dlg, i, visible, peakCount)) && !IsRecordMode)
+            if (!TryWaitForConditionUI(waitMs, () =>
+                {
+                    dlg.SelectedIndex = i; // reset SelectedIndex in case is has been changed by "ViewLibraryDlg_Shown"
+                    return IsViewLibraryDlgState(dlg, i, visible, peakCount) && !IsRecordMode;
+                }) )
             {
-                string redundantMessage = visible
-                    ? string.Format("Redundant list hidden with {0} selected",
-                        dlg.SelectedIndex)
-                    : string.Format("Redundant list visible with {0} selected, and {1} entries",
-                        dlg.SelectedIndex, dlg.RedundantComboBox.Items.Count);
-                string peaksMessage = string.Format("(peaks {0}, expected {1})", dlg.GraphItem.PeaksCount, peakCount);
-                string message = TextUtil.SpaceSeparate(redundantMessage, peaksMessage);
-                Assert.Fail(message);
+                RunUI(() =>
+                {
+                    string redundantMessage = visible
+                        ? string.Format("Redundant list hidden with {0} selected",
+                            dlg.SelectedIndex)
+                        : string.Format("Redundant list visible with {0} selected, and {1} entries",
+                            dlg.SelectedIndex, dlg.RedundantComboBox.Items.Count);
+                    string peaksMessage = string.Format("(peaks {0}, expected {1})", dlg.GraphItem.PeaksCount, peakCount);
+                    string message = TextUtil.SpaceSeparate(redundantMessage, peaksMessage);
+                    Assert.Fail(message);
+                });
             }
             if (IsRecordMode)
                 Console.Write(dlg.GraphItem.PeaksCount + @", ");


### PR DESCRIPTION
The contents of the ListBox in ViewLibraryDlg sometimes gets reset inside "ViewLibraryDlg_Shown" so it's best to continually set the SelectedIndex while waiting for the graph to update.