### PR TITLE
Fix Bilinear Fit calibration curve error

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/RegressionFit.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/RegressionFit.cs
@@ -172,12 +172,20 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
                 {
                     return null;
                 }
-                var linearCalibrationCurve = LinearFit(linearPoints) as CalibrationCurve.Linear;
-                if (linearCalibrationCurve == null)
+
+                try
+                {
+                    var linearCalibrationCurve = LinearFit(linearPoints) as CalibrationCurve.Linear;
+                    if (linearCalibrationCurve == null)
+                    {
+                        return null;
+                    }
+                    return new CalibrationCurve.Bilinear(linearCalibrationCurve, lod);
+                }
+                catch (Exception)
                 {
                     return null;
                 }
-                return new CalibrationCurve.Bilinear(linearCalibrationCurve, lod);
             }
 
             /// <summary>


### PR DESCRIPTION
Fixed "Matrix must be positive definite" error that sometimes happened with bilinear fit calibration curves (reported by Oleg)