### PR TITLE
Speed up reading SRM chromatograms

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromDataProvider.cs
@@ -335,7 +335,8 @@ namespace pwiz.Skyline.Model.Results
                     continue;
 
                 var chromKey = ChromKey.FromId(id, fixCEOptForShimadzu);
-                if (chromKey.CollisionEnergy == 0)
+                if (_optimizableRegression?.OptType == OptimizationType.collision_energy
+                    && chromKey.CollisionEnergy == 0)
                 {
                     var collisionEnergy = dataFile.GetChromatogramCollisionEnergy(i);
                     if (collisionEnergy.HasValue)


### PR DESCRIPTION
Reduce performance problems introduced by PR #2931. Only call "MsDataFileImpl.GetCollisionEnergy" if importing with collision energy optimization. This will speed up tests such as "TestLabelPeakPicking" which have SRM chromatograms but do not do CE optimization