### PR TITLE
Fix some small molecule tests which have been failing when run individually from TestRunner.

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/DataSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/DataSettings.cs
@@ -260,7 +260,7 @@ namespace pwiz.Skyline.Model.DocSettings
 //            Assume.IsFalse(string.IsNullOrEmpty(DocumentGuid)); // Should have a document GUID by this point
             if(!string.IsNullOrEmpty(DocumentGuid))
                 writer.WriteAttributeString(Attr.document_guid, DocumentGuid);
-            writer.WriteAttribute(Attr.audit_logging, AuditLogging);
+            writer.WriteAttribute(Attr.audit_logging, _auditLogging);
             var elements = AnnotationDefs.Cast<IXmlSerializable>()
                 .Concat(GroupComparisonDefs)
                 .Concat(Lists)


### PR DESCRIPTION
TestRunner sets "Program.FunctionalTest" to "true" at the beginning of the test run, but that typically gets set back to false by "MyTestCleanup". When Program.FunctionalTest is true, audit logging was getting turned on when saving a document as part of "convert to small molecules" which then, because of PR #2919, the document gets assigned a new GUID which causes an Assert.AreEqual to fail comparing the settings of a round-trip document.