### PR TITLE
Revert to macos-13 for GitHub actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
 #          }
         - {
             name: "macOS Latest Clang",
-            os: macos-latest,
+            os:	macos-13,
             compiler: 'latest clang',
             toolset: 'toolset=darwin'
           }

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
 #          }
         - {
             name: "macOS Latest Clang",
-            os:	macos-13,
+            os:	macos-12,
             compiler: 'latest clang',
             toolset: 'toolset=darwin'
           }


### PR DESCRIPTION
macos-latest is now M1/ARM, which is not fully compiling and I don't have a way to develop/debug it.