### PR TITLE
Fix NRE in DetectionsPlotPane

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/DetectionsPlotPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/DetectionsPlotPane.cs
@@ -49,7 +49,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
         protected DetectionsPlotPane(GraphSummary graphSummary) : base(graphSummary)
         {
-            MaxRepCount = graphSummary.DocumentUIContainer.DocumentUI?.MeasuredResults.Chromatograms.Count ?? 0;
+            MaxRepCount = graphSummary.DocumentUIContainer.DocumentUI.MeasuredResults?.Chromatograms.Count ?? 0;
 
             Settings.RepCount = MaxRepCount / 2;
             if (GraphSummary.Toolbar is DetectionsToolbar toolbar)


### PR DESCRIPTION
Fixed error showing Detections graph when document has no results (reported by Hillary)