### PR TITLE
Rework a line of code that the "debug with code coverage" build rejected…

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/Spectra/Alignment/SimilarityGrid.cs
+++ b/pwiz_tools/Skyline/Model/Results/Spectra/Alignment/SimilarityGrid.cs
@@ -91,7 +91,7 @@ namespace pwiz.Skyline.Model.Results.Spectra.Alignment
             private double CalcScore(int x, int y)
             {
                 var key = new KeyValuePair<int, int>(x, y);
-                if (true == _similarityScores?.TryGetValue(key, out var value))
+                if (_similarityScores != null && _similarityScores.TryGetValue(key, out var value))
                 {
                     return value;
                 }


### PR DESCRIPTION
 (though others did not):

Z:\pwiz\pwiz_tools\Skyline\Model\Results\Spectra\Alignment\SimilarityGrid.cs(96, 28): error CS0165: Use of unassigned local variable 'value'