### PR TITLE
MACS2 parallel testing fixes

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/InteractiveCommandLineToolTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/InteractiveCommandLineToolTest.cs
@@ -28,7 +28,7 @@ namespace pwiz.SkylineTestFunctional
     [TestClass]
     public class InteractiveCommandLineToolTest : AbstractFunctionalTest
     {
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.ZIP_INSIDE_ZIP)]
         public void TestInteractiveCommandLineTool()
         {
             TestFilesZip = @"TestFunctional\InteractiveCommandLineToolTest.zip";

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -36,6 +36,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Ionic.Zip;
+using Microsoft.Win32;
 using NetMQ;
 using NetMQ.Sockets;
 using Newtonsoft.Json.Linq;
@@ -681,7 +682,8 @@ namespace TestRunner
                     RunTests.RunCommand(Path.Combine(buildPath, "AlwaysUpCLT_licensed_binaries.exe"), $"-y \"-p{pass}\" \"-o{buildPath}\"", "Wrong password?");
                 }
 
-                var dockerBaseImage = Environment.OSVersion.Version.Build >= 22000
+                string productName = (string) Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion", "ProductName", null);
+                var dockerBaseImage = Environment.OSVersion.Version.Build >= 22000 || productName.Contains("Server")
                     ? string.Empty
                     : "--build-arg BASE_WINDOWS_IMAGE=mcr.microsoft.com/windows:1809-amd64";
                 RunTests.RunCommand("docker", $"build \"{buildPath}\" -t \"{RunTests.DOCKER_IMAGE_NAME}\" {dockerBaseImage}", RunTests.IS_DOCKER_RUNNING_MESSAGE, true);

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -151,6 +151,7 @@ namespace pwiz.SkylineTestUtil
         public const string MSFRAGGER_UNICODE_ISSUES = "MsFragger doesn't handle unicode paths";
         public const string JAVA_UNICODE_ISSUES = "Running Java processes with wild unicode temp paths is problematic";
         public const string HARDKLOR_UNICODE_ISSUES = "Hardklor doesn't handle unicode paths";
+        public const string ZIP_INSIDE_ZIP = "ZIP inside ZIP does not seem to work on MACS2";
     }
 
     /// <summary>


### PR DESCRIPTION
* fixed using wrong base image when building always_up_runner on MACS2
* set NoParalleTesting on TestInteractiveCommandLineTool because MACS2 has some issue unzipping the nested ZIP file