### PR TITLE
--associate-proteins-fasta argument

### DIFF
--- a/pwiz_tools/Skyline/CommandArgUsage.Designer.cs
+++ b/pwiz_tools/Skyline/CommandArgUsage.Designer.cs
@@ -133,6 +133,15 @@ namespace pwiz.Skyline {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Associate peptides in the document with proteins from the given FASTA. If this argument is not provided but other --associate-proteins options are, then the FASTA from --import-fasta will be used. If --import-fasta is not provided either, then the last FASTA used for protein association will be used..
+        /// </summary>
+        public static string _associate_proteins_fasta {
+            get {
+                return ResourceManager.GetString("_associate_proteins_fasta", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Associate peptides with genes (or gene groups) instead of proteins, and apply parsimony options to that association..
         /// </summary>
         public static string _associate_proteins_gene_level_parsimony {

--- a/pwiz_tools/Skyline/CommandArgUsage.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.resx
@@ -1043,4 +1043,7 @@ Useful in sample mixtures including multiple species.</value>
   <data name="ValueInvalidBoolException_ValueInvalidBoolException_The_value___0___is_not_valid_for_the_argument___1____it_must_be__2_" xml:space="preserve">
     <value>The value '{0}' is not valid for the argument '{1}': it must be {2}</value>
   </data>
+  <data name="_associate_proteins_fasta" xml:space="preserve">
+    <value>Associate peptides in the document with proteins from the given FASTA. If this argument is not provided but other --associate-proteins options are, then the FASTA from --import-fasta will be used. If --import-fasta is not provided either, then the last FASTA used for protein association will be used.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -1407,6 +1407,8 @@ namespace pwiz.Skyline
         }
 
 
+        public static readonly Argument ARG_AP_FASTA = new Argument(@"associate-proteins-fasta", PATH_TO_FILE,
+            (c, p) => c.AssociateProteinsFasta = p.Value);
         public static readonly Argument ARG_AP_GROUP_PROTEINS = new Argument(@"associate-proteins-group-proteins",
             (c, p) => c.AssociateProteinsGroupProteins = p.IsNameOnly || bool.Parse(p.Value));
         public static readonly Argument ARG_AP_GENE_LEVEL = new Argument(@"associate-proteins-gene-level-parsimony",
@@ -1418,19 +1420,21 @@ namespace pwiz.Skyline
         public static readonly Argument ARG_AP_REMOVE_SUBSETS = new Argument(@"associate-proteins-remove-subsets",
             (c, p) => c.AssociateProteinsRemoveSubsetProteins = p.IsNameOnly || bool.Parse(p.Value));
         public static readonly Argument ARG_AP_MIN_PEPTIDES = new Argument(@"associate-proteins-min-peptides", INT_VALUE,
-            (c, p) => c.AssociateProteinsMinPeptidesPerProtein = p.ValueInt) { WrapValue = true };
+            (c, p) => c.AssociateProteinsMinPeptidesPerProtein = p.GetValueInt(1, 10000)) { WrapValue = true };
 
         private static readonly ArgumentGroup GROUP_ASSOCIATE_PROTEINS = new ArgumentGroup(() => Resources.CommandLine_AssociateProteins_Associating_peptides_with_proteins, false,
-            ARG_AP_GROUP_PROTEINS, ARG_AP_GENE_LEVEL, ARG_AP_SHARED_PEPTIDES, ARG_AP_MINIMAL_LIST, ARG_AP_MIN_PEPTIDES, ARG_AP_REMOVE_SUBSETS)
+                ARG_AP_FASTA, ARG_AP_GROUP_PROTEINS, ARG_AP_GENE_LEVEL, ARG_AP_SHARED_PEPTIDES, ARG_AP_MINIMAL_LIST, ARG_AP_MIN_PEPTIDES, ARG_AP_REMOVE_SUBSETS)
             { LeftColumnWidth = 45 };
 
+        public string AssociateProteinsFasta { get; private set; }
         public bool? AssociateProteinsGroupProteins { get; private set; }
         public bool? AssociateProteinsGeneLevelParsimony { get; private set; }
         public bool? AssociateProteinsFindMinimalProteinList { get; private set; }
         public bool? AssociateProteinsRemoveSubsetProteins { get; private set; }
         public SharedPeptides? AssociateProteinsSharedPeptides { get; private set; }
         public int? AssociateProteinsMinPeptidesPerProtein { get; private set; }
-        public bool AssociatingProteins => AssociateProteinsFindMinimalProteinList.HasValue ||
+        public bool AssociatingProteins => !AssociateProteinsFasta.IsNullOrEmpty() ||
+                                           AssociateProteinsFindMinimalProteinList.HasValue ||
                                            AssociateProteinsGroupProteins.HasValue ||
                                            AssociateProteinsGeneLevelParsimony.HasValue ||
                                            AssociateProteinsMinPeptidesPerProtein.HasValue ||

--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -1408,7 +1408,7 @@ namespace pwiz.Skyline
 
 
         public static readonly Argument ARG_AP_FASTA = new Argument(@"associate-proteins-fasta", PATH_TO_FILE,
-            (c, p) => c.AssociateProteinsFasta = p.Value);
+            (c, p) => c.AssociateProteinsFasta = p.ValueFullPath);
         public static readonly Argument ARG_AP_GROUP_PROTEINS = new Argument(@"associate-proteins-group-proteins",
             (c, p) => c.AssociateProteinsGroupProteins = p.IsNameOnly || bool.Parse(p.Value));
         public static readonly Argument ARG_AP_GENE_LEVEL = new Argument(@"associate-proteins-gene-level-parsimony",

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -2219,8 +2219,8 @@ namespace pwiz.Skyline
         {
             return HandleExceptions(commandArgs, () => 
             {
-                var fastaPath = commandArgs.FastaPath ?? Settings.Default.LastProteinAssociationFastaFilepath;
-                if (fastaPath == null)
+                var fastaPath = commandArgs.AssociateProteinsFasta ?? commandArgs.FastaPath ?? Settings.Default.LastProteinAssociationFastaFilepath;
+                if (fastaPath.IsNullOrEmpty())
                     throw new ArgumentException(Resources.CommandLine_AssociateProteins_a_FASTA_file_must_be_imported_before_associating_proteins);
                 _out.WriteLine(Resources.CommandLine_AssociateProteins_Associating_peptides_with_proteins);
                 var progressMonitor = new CommandProgressMonitor(_out, new ProgressStatus(String.Empty));

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
@@ -243,7 +243,7 @@ namespace pwiz.Skyline.EditUI
         public int MinPeptidesPerProtein
         {
             get => (int) numMinPeptides.Value;
-            set => numMinPeptides.Value = value;
+            set => numMinPeptides.Value = Math.Max(numMinPeptides.Minimum, value);
         }
 
         private void UpdateTargetCounts()

--- a/pwiz_tools/Skyline/TestData/CommandLineTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineTest.cs
@@ -323,7 +323,8 @@ namespace pwiz.SkylineTestData
                 new TestFilesDir(TestContext, PROTDB_FILE)
             };
 
-            string docPath = TestFilesDirs[0].GetTestPath("BSA_Protea_label_free_20100323_meth3_multi.sky");
+            string existingDocPath = TestFilesDirs[0].GetTestPath("BSA_Protea_label_free_20100323_meth3_multi.sky");
+            string docPath = TestFilesDirs[0].GetTestPath("ConsoleNewDocumentTest.sky");
             string fastaPath = TestFilesDirs[0].GetTestPath("sample.fasta");
             string protdbPath = TestFilesDirs[1].GetTestPath("AssociateProteinMatches.protdb");
 
@@ -331,7 +332,6 @@ namespace pwiz.SkylineTestData
             var settings = new[]
             {
                 "--new=" + docPath,
-                "--overwrite",
                 "--full-scan-precursor-isotopes=Count",
                 "--full-scan-precursor-analyzer=centroided",
                 "--full-scan-precursor-res=5",
@@ -371,7 +371,6 @@ namespace pwiz.SkylineTestData
             };
 
             string output = RunCommand(settings);
-            StringAssert.Contains(output, string.Format(Resources.CommandLine_NewSkyFile_Deleting_existing_file___0__, docPath));
             AssertEx.DoesNotContain(output, Resources.CommandLineTest_ConsoleAddFastaTest_Error);
             AssertEx.DoesNotContain(output, Resources.CommandLineTest_ConsoleAddFastaTest_Warning);
 
@@ -423,6 +422,16 @@ namespace pwiz.SkylineTestData
             output = RunCommand(settings);
             StringAssert.Contains(output, Resources.CommandLine_AssociateProteins_Failed_to_associate_proteins);
             StringAssert.Contains(output, Resources.CommandLine_AssociateProteins_a_FASTA_file_must_be_imported_before_associating_proteins);
+
+            // test associating proteins with the dedicated argument for specifying the FASTA (rather than --import-fasta=)
+            Settings.Default.LastProteinAssociationFastaFilepath = null;
+            settings = new[]
+            {
+                "--in=" + existingDocPath,
+                "--associate-proteins-fasta=" + fastaPath,
+            };
+            output = RunCommand(settings);
+            StringAssert.Contains(output, Resources.CommandLine_AssociateProteins_Associating_peptides_with_proteins);
 
             // test importing FASTA and associating proteins and adding special ions
             settings = new[]


### PR DESCRIPTION
- added --associate-proteins-fasta argument for associating existing …document peptides with a FASTA (i.e. without having to use --import-fasta); --import-fasta will still be used if --associate-proteins-fasta is not provided
* fixed valid value range for --associate-proteins-min-peptides (1-1000) but added error handling in AssociateProteinsDlg's MinPeptidesPerProtein property to convert a '0' value to '1'