### PR TITLE
Skyline: Fix loss annotation in MS/MS spectra to work for mass-only losses

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
@@ -298,8 +298,8 @@ namespace pwiz.Skyline.Controls.Graphs
                     DocumentUI.Settings.PeptideSettings.Modifications.StaticModifications,
                     e.DocumentPrevious.Settings.PeptideSettings.Modifications.StaticModifications))
             {
-                var newMods = DocumentUI.Settings.PeptideSettings.Modifications.StaticModsFormulae;
-                var oldMods = e.DocumentPrevious.Settings.PeptideSettings.Modifications.StaticModsFormulae;
+                var newMods = DocumentUI.Settings.PeptideSettings.Modifications.StaticModsLosses;
+                var oldMods = e.DocumentPrevious.Settings.PeptideSettings.Modifications.StaticModsLosses;
                 var addedMods = newMods.ToList().FindAll(newMod => !oldMods.Contains(newMod)).ToList();
                 if (addedMods.Any())
                     Settings.Default.ShowLosses = Settings.Default.ShowLosses + @"," + addedMods.ToString(@",");
@@ -315,7 +315,7 @@ namespace pwiz.Skyline.Controls.Graphs
                                  e.DocumentPrevious.Settings.PeptideSettings.Libraries.Libraries))
             {
                 ZoomSpectrumToSettings();
-                Settings.Default.ShowLosses = DocumentUI.Settings.PeptideSettings.Modifications.StaticModsFormulae.ToString(@",");
+                Settings.Default.ShowLosses = DocumentUI.Settings.PeptideSettings.Modifications.StaticModsLosses.ToString(@",");
                 _updateManager.ClearPrecursors();
                 UpdateUI();
             }
@@ -1829,7 +1829,10 @@ namespace pwiz.Skyline.Controls.Graphs
             {
                 return Set.ShowLosses.IsNullOrEmpty() ? new string[] {} : Set.ShowLosses.Split(',');
             }
-            set { ActAndUpdate(() => Set.ShowLosses = value.ToList().ToString(@","));}
+            set
+            {
+                ActAndUpdate(() => Set.ShowLosses = value.ToList().ToString(@","));
+            }
         }
 
         public bool Koina

--- a/pwiz_tools/Skyline/Controls/IonTypeSelectorControl.cs
+++ b/pwiz_tools/Skyline/Controls/IonTypeSelectorControl.cs
@@ -342,7 +342,7 @@ namespace pwiz.Skyline.Controls
                         var cb = new IonSelectorButton(loss)
                         {
                             Text = string.Format(CultureInfo.CurrentCulture, @"-{0:F0}", loss.AverageMass),
-                            Checked = lossButtonStates.Contains(loss.FormulaNoNull)
+                            Checked = lossButtonStates.Contains(loss.PersistentName)
                         };
                         cb.CheckedChanged += LossButton_CheckedChanged;
                         cb.MouseHover += LossButton_MouseHover;
@@ -413,7 +413,7 @@ namespace pwiz.Skyline.Controls
             {
                 //get the list of formulas for the selected losses
                 var losses = Controls.OfType<CheckBox>().ToList().FindAll(cbox => cbox.Tag is FragmentLoss && cbox.Checked)
-                    .Select(cbox => ((FragmentLoss) cbox.Tag).Formula).ToArray();
+                    .Select(cbox => ((FragmentLoss) cbox.Tag).PersistentName).ToArray();
 
                 SetAllLossesButtonState();
                 LossChanged?.Invoke(losses);
@@ -426,7 +426,7 @@ namespace pwiz.Skyline.Controls
             {
                 if(cb.Tag is FragmentLoss loss)
                     _panelToolTip.Show(
-                        string.Format(ControlsResources.IonTypeSelector_LossesTooltip, loss.FormulaNoNull), cb);
+                        string.Format(ControlsResources.IonTypeSelector_LossesTooltip, loss.PersistentName), cb);
                 else if (ReferenceEquals(sender, _allLossesButton))
                 {
                     var msg = _allLossesButton.Checked ? ControlsResources.IonTypeSelector_DeselectAllLossesTooltip
@@ -453,7 +453,7 @@ namespace pwiz.Skyline.Controls
                 checkBox.Checked = state;
                 checkBox.CheckedChanged += LossButton_CheckedChanged;
                 if (state)
-                    res.Add((checkBox.Tag as FragmentLoss)?.FormulaNoNull);
+                    res.Add((checkBox.Tag as FragmentLoss)?.PersistentName);
             }
             return res.ToArray();
         }

--- a/pwiz_tools/Skyline/Model/DocSettings/Loss.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/Loss.cs
@@ -18,6 +18,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -111,9 +112,9 @@ namespace pwiz.Skyline.Model.DocSettings
             }
         }
 
-        public string FormulaNoNull
+        public string PersistentName
         {
-            get { return ParsedMolecule.IsNullOrEmpty(_formula) ? DocSettingsResources.Loss_FormulaUnknown : _formula.ToString(); }
+            get { return ToString(CultureInfo.InvariantCulture); }
         }
 
         [Track]
@@ -305,14 +306,20 @@ namespace pwiz.Skyline.Model.DocSettings
 
         public override string ToString()
         {
-            return ToString(MassType.Monoisotopic);
+            return ToString(CultureInfo.CurrentCulture);
         }
 
-        public string ToString(MassType massType)
+        public string ToString(IFormatProvider formatProvider)
         {
+            return ToString(MassType.Monoisotopic, formatProvider);
+        }
+
+        public string ToString(MassType massType, IFormatProvider formatProvider = null)
+        {
+            formatProvider ??= CultureInfo.CurrentCulture;
             string str = Formula != null ?
-                string.Format(@"{0:F04} - {1}", GetMass(massType), Formula) :
-                string.Format(@"{0:F04}", GetMass(massType));
+                string.Format(formatProvider, @"{0:F04} - {1}", GetMass(massType), Formula) :
+                string.Format(formatProvider, @"{0:F04}", GetMass(massType));
             if (Charge != 0)
             {
                 str += Transition.GetChargeIndicator(Adduct.FromCharge(Charge, Adduct.ADDUCT_TYPE.charge_only));

--- a/pwiz_tools/Skyline/Model/DocSettings/PeptideSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/PeptideSettings.cs
@@ -1311,9 +1311,9 @@ namespace pwiz.Skyline.Model.DocSettings
             }
         }
 
-        public ImmutableList<string> StaticModsFormulae
+        public ImmutableList<string> StaticModsLosses
         {
-            get { return ImmutableList.ValueOf(StaticModsDeduped.Select(loss => loss.FormulaNoNull)); }
+            get { return ImmutableList.ValueOf(StaticModsDeduped.Select(loss => loss.PersistentName)); }
         }
 
         public bool HasVariableModifications

--- a/pwiz_tools/Skyline/Model/Lib/LibraryRankedSpectrumInfo.cs
+++ b/pwiz_tools/Skyline/Model/Lib/LibraryRankedSpectrumInfo.cs
@@ -251,7 +251,7 @@ namespace pwiz.Skyline.Model.Lib
         public bool HasVisibleLoss(ICollection<string> showLosses)
         {
             return showLosses == null || Losses == null ||
-                   Losses.Losses.Any(loss => showLosses.Contains(loss.Loss.Formula));
+                   Losses.Losses.Any(loss => showLosses.Contains(loss.Loss.PersistentName));
         }
 
     }

--- a/pwiz_tools/Skyline/TestFunctional/NeutralLossLibraryTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NeutralLossLibraryTest.cs
@@ -273,13 +273,15 @@ namespace pwiz.SkylineTestFunctional
             {
                 menuControl = new MenuControl<IonTypeSelectionPanel>(SkylineWindow.GraphSpectrumSettings,
                     SkylineWindow.DocumentUI.Settings.PeptideSettings);
-                //Make sure losses are visible by default after the document load
-                AssertLossLabelCount(12, 13);
+                // Make sure losses are visible by default after the document load
+                // This tests the mass-only loss of 20. If the counts go down by 1, then
+                // mass-only loss annotation may be broken.
+                AssertLossLabelCount(13, 14);
                 AssertLossControlButtonCount(menuControl, 13, 7);
             });
             RunUI(() =>
             {
-                SkylineWindow.ShowLosses(new[] { "H2O" });
+                SkylineWindow.ShowLosses(new[] { new FragmentLoss("H2O").PersistentName });
             });
             WaitForGraphs();
             RunUI(() =>


### PR DESCRIPTION
- Code to annotate MS/MS spectra based hide/show status on the formula keeping mass-only losses hidden always (fix requested by Dan - FragPipe team)