### PR TITLE
Fix going design view for "SkylineWindow"

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -449,6 +449,10 @@ namespace pwiz.Skyline.Model.Results
             }
             else
             {
+                if (chromatogramGroupId.Target.Sequence == null)
+                {
+                    return false;
+                }
                 var key1 = new PeptideLibraryKey(nodePep.ModifiedSequence, 0);
                 var key2 = new PeptideLibraryKey(chromatogramGroupId.Target.Sequence, 0);
                 return LibKeyIndex.KeysMatch(key1, key2);

--- a/pwiz_tools/Skyline/Skyline.Designer.cs
+++ b/pwiz_tools/Skyline/Skyline.Designer.cs
@@ -1331,13 +1331,11 @@ namespace pwiz.Skyline
             // abundanceTargetsProteinsMenuItem
             // 
             this.abundanceTargetsProteinsMenuItem.Name = "abundanceTargetsProteinsMenuItem";
-            this.abundanceTargetsPeptidesMenuItem.Checked = Settings.Default.AreaProteinTargets;
             resources.ApplyResources(this.abundanceTargetsProteinsMenuItem, "abundanceTargetsProteinsMenuItem");
             this.abundanceTargetsProteinsMenuItem.Click += new System.EventHandler(this.abundanceTargetsProteinsMenuItem_Click);
             // 
             // abundanceTargetsPeptidesMenuItem
             // 
-            this.abundanceTargetsPeptidesMenuItem.Checked = !Settings.Default.AreaProteinTargets;
             this.abundanceTargetsPeptidesMenuItem.Name = "abundanceTargetsPeptidesMenuItem";
             resources.ApplyResources(this.abundanceTargetsPeptidesMenuItem, "abundanceTargetsPeptidesMenuItem");
             this.abundanceTargetsPeptidesMenuItem.Click += new System.EventHandler(this.abundanceTargetsPeptidesMenuItem_Click);


### PR DESCRIPTION
Someone added code to Skyline.Designer.cs which uses "Settings.Default" which does not work in Visual Studio design viewToolStripMenuItem

Fixed rare unhandled error displaying chromatograms (reported a few times anonymously on exception web)