### PR TITLE
* fixed leak with EncyclopeDIA MultiProgressControl

### DIFF
--- a/pwiz_tools/Shared/Common/Controls/DataGridViewProgressBar.cs
+++ b/pwiz_tools/Shared/Common/Controls/DataGridViewProgressBar.cs
@@ -38,6 +38,12 @@ namespace CustomProgressCell
         {
             CellTemplate = new DataGridViewProgressCell();
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            CellTemplate.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }
 
@@ -133,6 +139,14 @@ namespace CustomProgressCell
             Warning = 3 // yellow
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            _progressBar.Dispose();
+            _animationStepTimer.Dispose();
+            _animationStopTimer.Dispose();
+            base.Dispose(disposing);
+        }
+
         private void SetProgressBarState(ProgressBarState state)
         {
             SendMessage(_progressBar.Handle, PBM_SETSTATE, (IntPtr)state, IntPtr.Zero);
@@ -179,7 +193,7 @@ namespace CustomProgressCell
             try
             {
                 // Draw the ProgressBar to an in-memory bitmap
-                Bitmap bmp = new Bitmap(cellBounds.Width, cellBounds.Height);
+                using Bitmap bmp = new Bitmap(cellBounds.Width, cellBounds.Height);
                 Rectangle bmpBounds = new Rectangle(0, 0, cellBounds.Width, cellBounds.Height);
                 _progressBar.Size = cellBounds.Size;
                 _progressBar.DrawToBitmap(bmp, bmpBounds);

--- a/pwiz_tools/Shared/Common/Controls/DataGridViewProgressBar.cs
+++ b/pwiz_tools/Shared/Common/Controls/DataGridViewProgressBar.cs
@@ -41,7 +41,8 @@ namespace CustomProgressCell
 
         protected override void Dispose(bool disposing)
         {
-            CellTemplate.Dispose();
+            if (disposing)
+                CellTemplate.Dispose();
             base.Dispose(disposing);
         }
     }
@@ -141,9 +142,12 @@ namespace CustomProgressCell
 
         protected override void Dispose(bool disposing)
         {
-            _progressBar.Dispose();
-            _animationStepTimer.Dispose();
-            _animationStopTimer.Dispose();
+            if (disposing)
+            {
+                _progressBar.Dispose();
+                _animationStepTimer.Dispose();
+                _animationStopTimer.Dispose();
+            }
             base.Dispose(disposing);
         }
 

--- a/pwiz_tools/Shared/Common/Controls/MultiProgressControl.Designer.cs
+++ b/pwiz_tools/Shared/Common/Controls/MultiProgressControl.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace pwiz.Common.Controls
+﻿
+namespace pwiz.Common.Controls
 {
     partial class MultiProgressControl
     {
@@ -13,6 +14,11 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
+            foreach(System.Windows.Forms.DataGridViewRow row in progressGridView.Rows)
+                foreach(System.Windows.Forms.DataGridViewCell cell in row.Cells)
+                    cell.Dispose();
+            NameColumn.Dispose();
+            ProgressColumn.Dispose();
             if (disposing && (components != null))
             {
                 components.Dispose();


### PR DESCRIPTION
With the cancelability aspect of the test enabled, some DataGridViewProgressCells were not being disposed.