### PR TITLE
* added NoParallelTesting markup for Koina tests

### DIFF
--- a/pwiz_tools/Skyline/TestConnected/KoinaBuildLibraryFromCsvTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/KoinaBuildLibraryFromCsvTest.cs
@@ -22,7 +22,7 @@ namespace pwiz.SkylineTestConnected
     {
         const string TEST_ZIP_PATH = @"Test\PredictionBuildLibraryFromCsvTest.zip";
 
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.DOCKER_ROOT_CERTS)]
         public void TestKoinaBuildLibraryFromCsv()
         {
             if (!HasKoinaServer())

--- a/pwiz_tools/Skyline/TestConnected/KoinaBuildLibraryTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/KoinaBuildLibraryTest.cs
@@ -32,7 +32,7 @@ namespace pwiz.SkylineTestConnected
     [TestClass]
     public class KoinaBuildLibraryTest : AbstractFunctionalTest
     {
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.DOCKER_ROOT_CERTS)]
         public void TestKoinaBuildLibrary()
         {
             if (!HasKoinaServer())

--- a/pwiz_tools/Skyline/TestConnected/KoinaConnectionTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/KoinaConnectionTest.cs
@@ -39,7 +39,7 @@ namespace pwiz.SkylineTestConnected
         /// <summary>
         /// Tests that a connection can successfully be made to the server specified in KoinaConfig.GetKoinaConfig().
         /// </summary>
-        [TestMethod]
+        [TestMethod, NoParallelTesting(TestExclusionReason.DOCKER_ROOT_CERTS)]
         public void TestKoinaConnection()
         {
             if (!HasKoinaServer())

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -152,6 +152,7 @@ namespace pwiz.SkylineTestUtil
         public const string JAVA_UNICODE_ISSUES = "Running Java processes with wild unicode temp paths is problematic";
         public const string HARDKLOR_UNICODE_ISSUES = "Hardklor doesn't handle unicode paths";
         public const string ZIP_INSIDE_ZIP = "ZIP inside ZIP does not seem to work on MACS2";
+        public const string DOCKER_ROOT_CERTS = "Docker runners do not yet have access to the root certificates needed for Koina";
     }
 
     /// <summary>


### PR DESCRIPTION
* added NoParallelTesting markup for Koina tests due to Docker runner not having access to root certificates needed; at some point I will fix this by exporting those root certs on the host, copying them to the runner, and having Skyline read them from a file