### PR TITLE
Fix blank chromatogram graphs 

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/PeptidesAndTransitionGroups.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/PeptidesAndTransitionGroups.cs
@@ -74,14 +74,13 @@ namespace pwiz.Skyline.Controls.Graphs
                     nodeGroups.Add(nodeGroup);
                     groupPaths.Add(GroupPaths[i]);
                 }
+                NodePeps.Clear();
+                NodePeps.AddRange(nodePeps);
+                NodeGroups.Clear();
+                NodeGroups.AddRange(nodeGroups);
+                GroupPaths.Clear();
+                GroupPaths.AddRange(groupPaths);
             }
-
-            NodePeps.Clear();
-            NodePeps.AddRange(nodePeps);
-            NodeGroups.Clear();
-            NodeGroups.AddRange(nodeGroups);
-            GroupPaths.Clear();
-            GroupPaths.AddRange(groupPaths);
         }
 
         private double GetHeight(ChromInfoList<TransitionGroupChromInfo> transitionGroupChromInfos)

--- a/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromatogramCache.cs
@@ -449,7 +449,7 @@ namespace pwiz.Skyline.Model.Results
             }
             else
             {
-                if (chromatogramGroupId.Target.Sequence == null)
+                if (chromatogramGroupId.Target?.Sequence == null)
                 {
                     return false;
                 }


### PR DESCRIPTION
Fixed graphs are sometimes blank when displaying more than 100 precursors at the same time (reported by Q)