### PR TITLE
Attempt to fix EncyclopeDIA nightly failures

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/ProcessRunner.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/ProcessRunner.cs
@@ -167,7 +167,7 @@ namespace pwiz.Common.SystemUtil
                         {
                             proc.Kill();
                             progress.UpdateProgress(status = status.Cancel());
-                            CleanupTmpDir(); // Clean out any tempfiles left behind, if forceTempfilesCleanup was set
+                            CleanupTmpDir(psi); // Clean out any tempfiles left behind, if forceTempfilesCleanup was set
                             return;
                         }
 
@@ -249,7 +249,7 @@ namespace pwiz.Common.SystemUtil
                 if (!proc.HasExited)
                     try { proc.Kill(); } catch (InvalidOperationException) { }
 
-                CleanupTmpDir(); // Clean out any tempfiles left behind, if forceTempfilesCleanup was set
+                CleanupTmpDir(psi); // Clean out any tempfiles left behind, if forceTempfilesCleanup was set
             }
         }
 
@@ -264,7 +264,7 @@ namespace pwiz.Common.SystemUtil
         }
 
         // Clean out any tempfiles left behind, if forceTempfilesCleanup was set
-        private void CleanupTmpDir()
+        private void CleanupTmpDir(ProcessStartInfo psi)
         {
             if (!string.IsNullOrEmpty(_tmpDirForCleanup))
             {
@@ -273,7 +273,9 @@ namespace pwiz.Common.SystemUtil
                 {
                     try
                     {
-                        Directory.Delete(_tmpDirForCleanup, true);
+                        if (Directory.Exists(_tmpDirForCleanup))
+                            Directory.Delete(_tmpDirForCleanup, true);
+                        psi.Environment[@"TMP"] = Path.GetDirectoryName(_tmpDirForCleanup); // restore previous TMP value in case ProcessStartInfo is re-used
                         return;
                     }
                     catch (Exception e)

--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/ProcessRunner.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/ProcessRunner.cs
@@ -298,8 +298,7 @@ namespace pwiz.Common.SystemUtil
             {
                 try
                 {
-                    tmpDirForCleanup = Path.GetTempFileName(); // Creates a file
-                    File.Delete(tmpDirForCleanup); // But we want a directory
+                    tmpDirForCleanup = psi.Environment.TryGetValue(@"TMP", out var value) ? value : Path.GetTempPath();
                     var exeName = string.Empty;
                     if (!string.IsNullOrEmpty(psi.FileName))
                     {
@@ -307,7 +306,7 @@ namespace pwiz.Common.SystemUtil
                         exeName = Path.GetFileNameWithoutExtension(psi.FileName);
                         if (!string.IsNullOrEmpty(exeName))
                         {
-                            tmpDirForCleanup = Path.ChangeExtension(tmpDirForCleanup, exeName);
+                            tmpDirForCleanup = Path.Combine(tmpDirForCleanup, exeName + "_" + Path.GetRandomFileName());
                         }
                     }
 

--- a/pwiz_tools/Skyline/Model/Lib/EncyclopeDiaHelpers.cs
+++ b/pwiz_tools/Skyline/Model/Lib/EncyclopeDiaHelpers.cs
@@ -154,18 +154,17 @@ namespace pwiz.Skyline.Model.Lib
             if (!EnsureRequiredFilesDownloaded(FilesToDownload, progressMonitor))
                 throw new InvalidOperationException(Resources.EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_could_not_find_EncyclopeDia);
 
-            using var tmpTmp = new TemporaryEnvironmentVariable(@"TMP", JAVA_TMPDIR_PATH);
-
             long javaMaxHeapMB = Math.Min(4 * 1024L * 1024 * 1024, MemoryInfo.TotalBytes / 2) / 1024 / 1024;
             const string csvToLibraryClasspath = "edu.washington.gs.maccoss.encyclopedia.cli.ConvertFastaToPrositCSV";
 
             var pr = new ProcessRunner();
             var psi = new ProcessStartInfo(JavaBinary,
-                $" -Xmx{javaMaxHeapMB}M -cp {EncyclopeDiaBinary.Quote()} {csvToLibraryClasspath} {LOCALIZATION_PARAMS} {JAVA_TMPDIR} -i {fastaFilepath.Quote()} -o {koinaCsvFilepath.Quote()} {config}")
+                $" -Xmx{javaMaxHeapMB}M -cp {EncyclopeDiaBinary.Quote()} {csvToLibraryClasspath} {LOCALIZATION_PARAMS} -i {fastaFilepath.Quote()} -o {koinaCsvFilepath.Quote()} {config}")
             {
                 CreateNoWindow = true,
                 UseShellExecute = false
             };
+            psi.EnvironmentVariables[@"TMP"] = JAVA_TMPDIR_PATH;
 
             status = status.ChangeMessage(LibResources.EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_Converting_FASTA_to_Koina_input);
             if (progressMonitor.UpdateProgress(status) == UpdateProgressResponse.cancel)
@@ -183,18 +182,17 @@ namespace pwiz.Skyline.Model.Lib
             if (!EnsureRequiredFilesDownloaded(FilesToDownload, progressMonitor))
                 throw new InvalidOperationException(Resources.EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_could_not_find_EncyclopeDia);
 
-            using var tmpTmp = new TemporaryEnvironmentVariable(@"TMP", JAVA_TMPDIR_PATH);
-
             long javaMaxHeapMB = Math.Min(12 * 1024L * 1024 * 1024, MemoryInfo.TotalBytes / 2) / 1024 / 1024;
             const string csvToLibraryClasspath = "edu.washington.gs.maccoss.encyclopedia.cli.ConvertBLIBToLibrary";
 
             var pr = new ProcessRunner();
             var psi = new ProcessStartInfo(JavaBinary,
-                $" -Xmx{javaMaxHeapMB}M -cp {EncyclopeDiaBinary.Quote()} {csvToLibraryClasspath} {LOCALIZATION_PARAMS} {JAVA_TMPDIR} -i {koinaBlibFilepath.Quote()} -f {fastaFilepath.Quote()} -o {encyclopeDiaDlibFilepath.Quote()}")
+                $" -Xmx{javaMaxHeapMB}M -cp {EncyclopeDiaBinary.Quote()} {csvToLibraryClasspath} {LOCALIZATION_PARAMS} -i {koinaBlibFilepath.Quote()} -f {fastaFilepath.Quote()} -o {encyclopeDiaDlibFilepath.Quote()}")
             {
                 CreateNoWindow = true,
                 UseShellExecute = false
             };
+            psi.EnvironmentVariables[@"TMP"] = JAVA_TMPDIR_PATH;
 
             status = status.ChangeMessage(LibResources.EncyclopeDiaHelpers_ConvertKoinaOutputToDlib_Converting_Koina_output_to_EncyclopeDia_library);
             if (progressMonitor.UpdateProgress(status) == UpdateProgressResponse.cancel)
@@ -886,8 +884,6 @@ namespace pwiz.Skyline.Model.Lib
             if (!EnsureRequiredFilesDownloaded(FilesToDownload, progressMonitor))
                 throw new InvalidOperationException(Resources.EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_could_not_find_EncyclopeDia);
 
-            using var tmpTmp = new TemporaryEnvironmentVariable(@"TMP", JAVA_TMPDIR_PATH);
-
             long javaMaxHeapMB = Math.Min(12 * 1024L * 1024 * 1024, MemoryInfo.TotalBytes / 2) / 1024 / 1024;
             string extraParams = config.ToString();
             string subdir = quantLibrary ? @"elib_quant" : @"elib_chrom";
@@ -904,13 +900,16 @@ namespace pwiz.Skyline.Model.Lib
             if (progressMonitor.UpdateProgress(status) == UpdateProgressResponse.cancel)
                 return;
 
+            // if this function runs in parallel with the same JAVA_TMPDIR, there may be a race condition when EncyclopeDIA extracts the JAR dependencies (like SQLite)
+            string threadDir = @"Thread" + Thread.CurrentThread.ManagedThreadId;
             var pr = new ProcessRunner();
             var psi = new ProcessStartInfo(JavaBinary,
-                $" -Xmx{javaMaxHeapMB}M -jar {EncyclopeDiaBinary.Quote()} {LOCALIZATION_PARAMS} {JAVA_TMPDIR} {extraParams} -i {diaDataFilepath.Quote()} -f {fastaFilepath.Quote()} -l {encyclopeDiaLibInputFilepath.Quote()}")
+                $" -Xmx{javaMaxHeapMB}M -jar {EncyclopeDiaBinary.Quote()} {LOCALIZATION_PARAMS} {extraParams} -i {diaDataFilepath.Quote()} -f {fastaFilepath.Quote()} -l {encyclopeDiaLibInputFilepath.Quote()}")
             {
                 CreateNoWindow = true,
                 UseShellExecute = false
             };
+            psi.EnvironmentVariables[@"TMP"] = Path.Combine(JAVA_TMPDIR_PATH, threadDir);
             status = status.ChangeMessage(String.Format(Resources.EncyclopeDiaHelpers_GenerateLibrary_Running_command___0___1_,
                 psi.FileName, psi.Arguments));
             if (progressMonitor.UpdateProgress(status) == UpdateProgressResponse.cancel)
@@ -928,8 +927,6 @@ namespace pwiz.Skyline.Model.Lib
             if (!EnsureRequiredFilesDownloaded(FilesToDownload, progressMonitor))
                 throw new InvalidOperationException(Resources.EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_could_not_find_EncyclopeDia);
 
-            using var tmpTmp = new TemporaryEnvironmentVariable(@"TMP", JAVA_TMPDIR_PATH);
-
             long javaMaxHeapMB = Math.Min(12 * 1024L * 1024 * 1024, MemoryInfo.TotalBytes / 2) / 1024 / 1024;
             string extraParams = config.ToString();
             string subdir = quantLibrary ? @"elib_quant" : @"elib_chrom";
@@ -941,11 +938,12 @@ namespace pwiz.Skyline.Model.Lib
 
             var prMerge = new ProcessRunner();
             var psiMerge = new ProcessStartInfo(JavaBinary,
-                $" -Xmx{javaMaxHeapMB}M -jar {EncyclopeDiaBinary.Quote()} {LOCALIZATION_PARAMS} {JAVA_TMPDIR} {extraParams} -i {diaDataPath.Quote()} -libexport {aParam} -o {encyclopeDiaElibOutputFilepath.Quote()} -f {fastaFilepath.Quote()} -l {encyclopeDiaLibInputFilepath.Quote()}")
+                $" -Xmx{javaMaxHeapMB}M -jar {EncyclopeDiaBinary.Quote()} {LOCALIZATION_PARAMS} {extraParams} -i {diaDataPath.Quote()} -libexport {aParam} -o {encyclopeDiaElibOutputFilepath.Quote()} -f {fastaFilepath.Quote()} -l {encyclopeDiaLibInputFilepath.Quote()}")
             {
                 CreateNoWindow = true,
                 UseShellExecute = false
             };
+            psiMerge.EnvironmentVariables[@"TMP"] = JAVA_TMPDIR_PATH;
             status = status.ChangeMessage(String.Format(Resources.EncyclopeDiaHelpers_GenerateLibrary_Running_command___0___1_,
                 psiMerge.FileName, psiMerge.Arguments));
             progressMonitor.UpdateProgress(status);


### PR DESCRIPTION
* changed temp directory logic for EncyclopeDIA in an attempt to fix nightly failures (I have not been able to reproduce, but I suspect the failure to find sqlite files is due to some collision in temp directories when multiple ED processes run at the same time)
* changed ProcessRunner.SetTmpDirForCleanup to use ProcessStartInfo's TMP variable if set