### PR TITLE
Make ConsoleXxxWithAuditLogging tests pass even when "Program.Functio…

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTestEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTestEx.cs
@@ -167,7 +167,7 @@ namespace pwiz.SkylineTestUtil
         public static void EnableAuditLogging(string path)
         {
             var doc = ResultsUtil.DeserializeDocument(path);
-            Assert.IsFalse(doc.Settings.DataSettings.AuditLogging);
+            Assert.IsFalse(doc.Settings.DataSettings.IsAuditLoggingEnabled);
             doc = AuditLogList.ToggleAuditLogging(doc, true);
             doc.SerializeToFile(path, path, SkylineVersion.CURRENT, new SilentProgressMonitor());
         }


### PR DESCRIPTION
…nalTest" is true

These tests were expecting the test document to have audit logging turned off. However, all documents say that they have audit logging enabled (i.e. DataSettings.AuditLog is true) when Program.FunctionalTest is true.