### PR TITLE
AutoQC - enable importing annotations from a CSV file

### DIFF
--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AnnotationsFileWatcher.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AnnotationsFileWatcher.cs
@@ -74,6 +74,7 @@ namespace AutoQC
 
         private void FileChanged()
         {
+            _logger.Log("Annotations file was updated.");
             _configRunner.AnnotationsFileUpdated = true;
         }
 

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AnnotationsFileWatcher.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AnnotationsFileWatcher.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * Original author: Vagisha Sharma <vsharma .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * Copyright 2015 University of Washington - Seattle, WA
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.IO;
+using SharedBatch;
+
+namespace AutoQC
+{
+
+    public class AnnotationsFileWatcher
+    {
+        private readonly Logger _logger;
+        private readonly ConfigRunner _configRunner;
+
+        private readonly FileSystemWatcher _fileWatcher;
+
+        public AnnotationsFileWatcher(Logger logger, ConfigRunner configRunner)
+        {
+            _fileWatcher = InitFileSystemWatcher();
+
+            _logger = logger;
+            _configRunner = configRunner;
+        }
+
+        private FileSystemWatcher InitFileSystemWatcher()
+        {
+            var fileWatcher = new FileSystemWatcher();
+            fileWatcher.Created += (s, e) => FileChanged();
+            // fileWatcher.Renamed += (s, e) => FileRenamed(e);
+            fileWatcher.Deleted += (s, e) => FileChanged();
+            fileWatcher.Changed += (s, e) => FileChanged();
+            fileWatcher.Error += (s, e) => OnFileWatcherError(e);
+            return fileWatcher;
+        }
+
+        public void Init(AutoQcConfig config)
+        {
+            var mainSettings = config.MainSettings;
+
+            _fileWatcher.EnableRaisingEvents = false;
+
+            _fileWatcher.NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite;
+
+            _fileWatcher.Filter = Path.GetFileName(mainSettings.AnnotationsFilePath);
+
+            _fileWatcher.Path = Path.GetDirectoryName(mainSettings.AnnotationsFilePath);
+        }
+
+        public void StartWatching()
+        {
+            // Begin watching.
+            _fileWatcher.EnableRaisingEvents = true;
+        }
+
+        public void Stop()
+        {
+            _fileWatcher.EnableRaisingEvents = false;
+        }
+
+        private void FileChanged()
+        {
+            _configRunner.AnnotationsFileUpdated = true;
+        }
+
+        private void OnFileWatcherError(ErrorEventArgs e)
+        {
+            _logger.LogError(string.Format("There was an error watching the annotations file {0}.", _fileWatcher.Filter), e.GetException().ToString());
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQC.csproj
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQC.csproj
@@ -13,7 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>true</IsWebBootstrapper>
     <TargetFrameworkProfile />
-    <PublishUrl>Z:\labkey\static\software\AutoQC-test\</PublishUrl>
+    <PublishUrl>Z:\www\site\skyline.ms\html\software\AutoQC-test\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Web</InstallFrom>
     <UpdateEnabled>true</UpdateEnabled>
@@ -123,6 +123,7 @@
   <ItemGroup>
     <Compile Include="AutoQcConfig.cs" />
     <Compile Include="AutoQcConfigManager.cs" />
+    <Compile Include="AnnotationsFileWatcher.cs" />
     <Compile Include="InvalidConfigSetupForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQCConfigForm.Designer.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQCConfigForm.Designer.cs
@@ -35,9 +35,12 @@ namespace AutoQC
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.tabControl = new System.Windows.Forms.TabControl();
             this.tabSettings = new System.Windows.Forms.TabPage();
+            this.groupBoxMain = new System.Windows.Forms.GroupBox();
+            this.btnAnnotationsFile = new System.Windows.Forms.Button();
+            this.labelAnnotationsFile = new System.Windows.Forms.Label();
+            this.textAnnotationsFilePath = new System.Windows.Forms.TextBox();
             this.textConfigName = new System.Windows.Forms.TextBox();
             this.labelConfigName = new System.Windows.Forms.Label();
-            this.groupBoxMain = new System.Windows.Forms.GroupBox();
             this.checkBoxRemoveResults = new System.Windows.Forms.CheckBox();
             this.labelQcFilePattern = new System.Windows.Forms.Label();
             this.comboBoxFileFilter = new System.Windows.Forms.ComboBox();
@@ -120,19 +123,12 @@ namespace AutoQC
             this.tabSettings.Name = "tabSettings";
             this.tabSettings.Enter += new System.EventHandler(this.TabEnter);
             // 
-            // textConfigName
-            // 
-            resources.ApplyResources(this.textConfigName, "textConfigName");
-            this.textConfigName.Name = "textConfigName";
-            // 
-            // labelConfigName
-            // 
-            resources.ApplyResources(this.labelConfigName, "labelConfigName");
-            this.labelConfigName.Name = "labelConfigName";
-            // 
             // groupBoxMain
             // 
             resources.ApplyResources(this.groupBoxMain, "groupBoxMain");
+            this.groupBoxMain.Controls.Add(this.btnAnnotationsFile);
+            this.groupBoxMain.Controls.Add(this.labelAnnotationsFile);
+            this.groupBoxMain.Controls.Add(this.textAnnotationsFilePath);
             this.groupBoxMain.Controls.Add(this.textConfigName);
             this.groupBoxMain.Controls.Add(this.labelConfigName);
             this.groupBoxMain.Controls.Add(this.checkBoxRemoveResults);
@@ -157,6 +153,35 @@ namespace AutoQC
             this.groupBoxMain.Controls.Add(this.textSkylinePath);
             this.groupBoxMain.Name = "groupBoxMain";
             this.groupBoxMain.TabStop = false;
+            // 
+            // btnAnnotationsFile
+            // 
+            resources.ApplyResources(this.btnAnnotationsFile, "btnAnnotationsFile");
+            this.btnAnnotationsFile.AutoEllipsis = true;
+            this.btnAnnotationsFile.Name = "btnAnnotationsFile";
+            this.btnAnnotationsFile.UseVisualStyleBackColor = true;
+            this.btnAnnotationsFile.Click += new System.EventHandler(this.btnAnnotationsFilePath_Click);
+            // 
+            // labelAnnotationsFile
+            // 
+            resources.ApplyResources(this.labelAnnotationsFile, "labelAnnotationsFile");
+            this.labelAnnotationsFile.Name = "labelAnnotationsFile";
+            // 
+            // textAnnotationsFilePath
+            // 
+            resources.ApplyResources(this.textAnnotationsFilePath, "textAnnotationsFilePath");
+            this.textAnnotationsFilePath.Name = "textAnnotationsFilePath";
+            this.toolTip1.SetToolTip(this.textAnnotationsFilePath, resources.GetString("textAnnotationsFilePath.ToolTip"));
+            // 
+            // textConfigName
+            // 
+            resources.ApplyResources(this.textConfigName, "textConfigName");
+            this.textConfigName.Name = "textConfigName";
+            // 
+            // labelConfigName
+            // 
+            resources.ApplyResources(this.labelConfigName, "labelConfigName");
+            this.labelConfigName.Name = "labelConfigName";
             // 
             // checkBoxRemoveResults
             // 
@@ -486,5 +511,8 @@ namespace AutoQC
         private System.Windows.Forms.TextBox textAquisitionTime;
         private System.Windows.Forms.TabPage tabSkylineSettings;
         private System.Windows.Forms.Panel panelSkylineSettings;
+        private System.Windows.Forms.Button btnAnnotationsFile;
+        private System.Windows.Forms.Label labelAnnotationsFile;
+        private System.Windows.Forms.TextBox textAnnotationsFilePath;
     }
 }

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQCConfigForm.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQCConfigForm.cs
@@ -35,7 +35,8 @@ namespace AutoQC
         private readonly DateTime _initialCreated;
 
         private SkylineTypeControl _skylineTypeControl;
-        private string _lastEnteredPath;
+        private string _lastEnteredPath; // last entered path to Skyline .sky file
+        private string _lastEnteredAnnotationsFilePath;
         private TabPage _lastSelectedTab;
         private SkylineSettings _currentSkylineSettings;
 
@@ -130,6 +131,10 @@ namespace AutoQC
             textAquisitionTime.Text = mainSettings.AcquisitionTime.ToString();
             comboBoxInstrumentType.SelectedItem = mainSettings.InstrumentType;
             comboBoxInstrumentType.SelectedIndex = comboBoxInstrumentType.FindStringExact(mainSettings.InstrumentType);
+            if (mainSettings.AnnotationsFilePath != null)
+            {
+                textAnnotationsFilePath.Text = mainSettings.AnnotationsFilePath;
+            }
         }
 
         private void SetDefaultMainSettings()
@@ -153,7 +158,8 @@ namespace AutoQC
             var resultsWindow = textResultsTimeWindow.Text;
             var instrumentType = comboBoxInstrumentType.SelectedItem.ToString();
             var acquisitionTime = textAquisitionTime.Text;
-            var mainSettings = new MainSettings(skylineFilePath, folderToWatch, includeSubfolders, qcFileFilter, removeResults, resultsWindow, instrumentType, acquisitionTime);
+            var annotationsFilePath = textAnnotationsFilePath.Text;
+            var mainSettings = new MainSettings(skylineFilePath, folderToWatch, includeSubfolders, qcFileFilter, removeResults, resultsWindow, instrumentType, acquisitionTime, annotationsFilePath);
             return mainSettings;
         }
 
@@ -179,6 +185,20 @@ namespace AutoQC
             {
                 textFolderToWatchPath.Text = dialog.SelectedPath;
                 _lastEnteredPath = dialog.SelectedPath;
+            }
+        }
+
+        private void btnAnnotationsFilePath_Click(object sender, EventArgs e)
+        {
+            var dialog = new OpenFileDialog
+            {
+                Filter = TextUtil.FileDialogFilter("CSV (Comma delimited)", TextUtil.EXT_CSV),
+                InitialDirectory = FileUtil.GetInitialDirectory(textSkylinePath.Text, _lastEnteredAnnotationsFilePath)
+            };
+            if (dialog.ShowDialog(this) == DialogResult.OK)
+            {
+                textAnnotationsFilePath.Text = dialog.FileName;
+                _lastEnteredAnnotationsFilePath = dialog.FileName;
             }
         }
 

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQCConfigForm.resx
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/AutoQCConfigForm.resx
@@ -134,6 +134,109 @@
   <data name="groupBoxMain.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="btnAnnotationsFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnAnnotationsFile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnAnnotationsFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>391, 342</value>
+  </data>
+  <data name="btnAnnotationsFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="btnAnnotationsFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>32, 23</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="btnAnnotationsFile.TabIndex" type="System.Int32, mscorlib">
+    <value>70</value>
+  </data>
+  <data name="btnAnnotationsFile.Text" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="&gt;&gt;btnAnnotationsFile.Name" xml:space="preserve">
+    <value>btnAnnotationsFile</value>
+  </data>
+  <data name="&gt;&gt;btnAnnotationsFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAnnotationsFile.Parent" xml:space="preserve">
+    <value>groupBoxMain</value>
+  </data>
+  <data name="&gt;&gt;btnAnnotationsFile.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelAnnotationsFile.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelAnnotationsFile.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9pt</value>
+  </data>
+  <data name="labelAnnotationsFile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelAnnotationsFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 327</value>
+  </data>
+  <data name="labelAnnotationsFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
+  </data>
+  <data name="labelAnnotationsFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>148, 15</value>
+  </data>
+  <data name="labelAnnotationsFile.TabIndex" type="System.Int32, mscorlib">
+    <value>71</value>
+  </data>
+  <data name="labelAnnotationsFile.Text" xml:space="preserve">
+    <value>&amp;Annotations file (optional):</value>
+  </data>
+  <data name="&gt;&gt;labelAnnotationsFile.Name" xml:space="preserve">
+    <value>labelAnnotationsFile</value>
+  </data>
+  <data name="&gt;&gt;labelAnnotationsFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelAnnotationsFile.Parent" xml:space="preserve">
+    <value>groupBoxMain</value>
+  </data>
+  <data name="&gt;&gt;labelAnnotationsFile.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="textAnnotationsFilePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="textAnnotationsFilePath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 344</value>
+  </data>
+  <data name="textAnnotationsFilePath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="textAnnotationsFilePath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>375, 20</value>
+  </data>
+  <data name="textAnnotationsFilePath.TabIndex" type="System.Int32, mscorlib">
+    <value>69</value>
+  </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="textAnnotationsFilePath.ToolTip" xml:space="preserve">
+    <value>Path to a CSV file with Skyline annotations that will be imported when a change is detected in the file.</value>
+  </data>
+  <data name="&gt;&gt;textAnnotationsFilePath.Name" xml:space="preserve">
+    <value>textAnnotationsFilePath</value>
+  </data>
+  <data name="&gt;&gt;textAnnotationsFilePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textAnnotationsFilePath.Parent" xml:space="preserve">
+    <value>groupBoxMain</value>
+  </data>
+  <data name="&gt;&gt;textAnnotationsFilePath.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="textConfigName.Location" type="System.Drawing.Point, System.Drawing">
     <value>10, 30</value>
   </data>
@@ -143,7 +246,6 @@
   <data name="textConfigName.Size" type="System.Drawing.Size, System.Drawing">
     <value>324, 20</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="textConfigName.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -157,7 +259,7 @@
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;textConfigName.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <data name="labelConfigName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -190,13 +292,13 @@
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;labelConfigName.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="checkBoxRemoveResults.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="checkBoxRemoveResults.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 269</value>
+    <value>10, 240</value>
   </data>
   <data name="checkBoxRemoveResults.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -210,9 +312,6 @@
   <data name="checkBoxRemoveResults.Text" xml:space="preserve">
     <value>&amp;Remove Results</value>
   </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <data name="checkBoxRemoveResults.ToolTip" xml:space="preserve">
     <value>If checked, results imported into the Skyline document that are older than theResults time window will be removed. This is done to keep the document size small. 
 Results time window is a rolling window and only results acquired within the last ‘n’ days, where ‘n’ is the width of this window in days, will be retained in the document</value>
@@ -227,13 +326,13 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;checkBoxRemoveResults.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="labelQcFilePattern.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="labelQcFilePattern.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 195</value>
+    <value>157, 178</value>
   </data>
   <data name="labelQcFilePattern.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -257,10 +356,10 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;labelQcFilePattern.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="comboBoxFileFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 211</value>
+    <value>10, 194</value>
   </data>
   <data name="comboBoxFileFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -281,13 +380,13 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;comboBoxFileFilter.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>7</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 195</value>
+    <value>10, 178</value>
   </data>
   <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -311,7 +410,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>8</value>
   </data>
   <data name="includeSubfoldersCb.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -341,10 +440,10 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;includeSubfoldersCb.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="textQCFilePattern.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 211</value>
+    <value>158, 194</value>
   </data>
   <data name="textQCFilePattern.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -368,13 +467,13 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;textQCFilePattern.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="labelMinutes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="labelMinutes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>299, 336</value>
+    <value>299, 296</value>
   </data>
   <data name="labelMinutes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -398,13 +497,13 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;labelMinutes.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="labelAquisitionTime.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="labelAquisitionTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>216, 313</value>
+    <value>216, 273</value>
   </data>
   <data name="labelAquisitionTime.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -431,10 +530,10 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;labelAquisitionTime.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>12</value>
   </data>
   <data name="textAquisitionTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>218, 328</value>
+    <value>218, 288</value>
   </data>
   <data name="textAquisitionTime.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -458,13 +557,13 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;textAquisitionTime.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>13</value>
   </data>
   <data name="labelDays.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="labelDays.Location" type="System.Drawing.Point, System.Drawing">
-    <value>299, 275</value>
+    <value>299, 246</value>
   </data>
   <data name="labelDays.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -488,10 +587,10 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;labelDays.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>14</value>
   </data>
   <data name="textResultsTimeWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>218, 271</value>
+    <value>218, 242</value>
   </data>
   <data name="textResultsTimeWindow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -515,13 +614,13 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;textResultsTimeWindow.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="labelAccumulationTimeWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="labelAccumulationTimeWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>216, 254</value>
+    <value>216, 225</value>
   </data>
   <data name="labelAccumulationTimeWindow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -545,13 +644,13 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;labelAccumulationTimeWindow.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>16</value>
   </data>
   <data name="labelInstrumentType.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="labelInstrumentType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 313</value>
+    <value>10, 273</value>
   </data>
   <data name="labelInstrumentType.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -575,7 +674,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;labelInstrumentType.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>17</value>
   </data>
   <data name="comboBoxInstrumentType.Items" xml:space="preserve">
     <value>Thermo</value>
@@ -599,7 +698,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>Shimadzu</value>
   </data>
   <data name="comboBoxInstrumentType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 331</value>
+    <value>10, 291</value>
   </data>
   <data name="comboBoxInstrumentType.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -620,7 +719,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;comboBoxInstrumentType.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>18</value>
   </data>
   <data name="btnFolderToWatch.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -650,7 +749,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;btnFolderToWatch.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>19</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -683,7 +782,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>20</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -716,7 +815,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>21</value>
   </data>
   <data name="textFolderToWatchPath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -746,7 +845,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;textFolderToWatchPath.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>22</value>
   </data>
   <data name="btnSkylineFilePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -779,7 +878,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;btnSkylineFilePath.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>23</value>
   </data>
   <data name="textSkylinePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -809,7 +908,7 @@ Results time window is a rolling window and only results acquired within the las
     <value>groupBoxMain</value>
   </data>
   <data name="&gt;&gt;textSkylinePath.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>24</value>
   </data>
   <data name="groupBoxMain.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 5</value>

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/ConfigRunner.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/ConfigRunner.cs
@@ -611,8 +611,9 @@ namespace AutoQC
             var panoramaUploadArgs = PanoramaArgs(importContext);
             if (!string.IsNullOrEmpty(panoramaUploadArgs))
             {
-                if (importContext.ImportCount == 0)
+                if (importContext.ImportCount == 0 && DateTime.MinValue.Equals(LastAcquiredFileDate))
                 {
+                    // Nothing was imported, and the Skyline document did not have any imported results when the configuration was started.
                     LogError("No results were imported. Skipping upload to Panorama.");
                 }
                 else

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/InvalidConfigSetupForm.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/InvalidConfigSetupForm.cs
@@ -66,8 +66,16 @@ namespace AutoQC
                 mainSettings.SkylineFilePath, MainSettings.ValidateSkylineFile, TextUtil.FILTER_SKY, PathDialogOptions.File);
             var validFolderToWatch = await GetValidPath("folder to watch",
                 mainSettings.FolderToWatch, MainSettings.ValidateFolderToWatch, null, PathDialogOptions.Folder);
+
+            string validAnnotationsFilePath = null;
+            if (mainSettings.AnnotationsFilePath != null)
+            {
+                validAnnotationsFilePath = await GetValidPath("Annotations file", mainSettings.AnnotationsFilePath,
+                    MainSettings.ValidateAnnotationsFile, TextUtil.EXT_CSV, PathDialogOptions.File);
+            }
+            
             return new MainSettings(validSkylinePath, validFolderToWatch, mainSettings.IncludeSubfolders, mainSettings.QcFileFilter, mainSettings.RemoveResults, 
-                mainSettings.ResultsWindow.ToString(), mainSettings.InstrumentType, mainSettings.AcquisitionTime.ToString());
+                mainSettings.ResultsWindow.ToString(), mainSettings.InstrumentType, mainSettings.AcquisitionTime.ToString(), validAnnotationsFilePath);
         }
 
         private async Task <PanoramaSettings> FixInvalidPanoramaSettings()

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQCTest/TestUtils.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQCTest/TestUtils.cs
@@ -61,7 +61,7 @@ namespace AutoQCTest
             var instrumentType = MainSettings.GetDefaultInstrumentType();
             
             
-            return new MainSettings(skylineFilePath, folderToWatch, includeSubfolders, fileFilter, removeResults, resultsWindow, instrumentType, acquisitionTime);
+            return new MainSettings(skylineFilePath, folderToWatch, includeSubfolders, fileFilter, removeResults, resultsWindow, instrumentType, acquisitionTime, null);
         }
 
         public static PanoramaSettings GetTestPanoramaSettings(bool publishToPanorama = true)


### PR DESCRIPTION
This is a DRAFT pull request
- Added a text field for entering the path to an annotations file.
![image](https://github.com/ProteoWizard/pwiz/assets/76364/b6346226-31a4-4b75-9a88-cc94d6f99b63)
- Added a FileWatcher that watches for changes in the annotations file.
- Upload document to Panorama after the configuration is started if:
  - One or more existing raw files were imported
  - OR none of the existing raw files were imported but the document contains replicates
