### PR TITLE
Skyline: Improve failure reporting in AssertEx.FileEquals

### DIFF
--- a/pwiz_tools/Skyline/Test/ChromatogramExporterTest.cs
+++ b/pwiz_tools/Skyline/Test/ChromatogramExporterTest.cs
@@ -94,11 +94,12 @@ namespace pwiz.SkylineTest
                 SaveChrom(docResults, fileActual2, FILE_NAMES_2.ToList(), LocalizationHelper.CurrentCulture, EXTRACTOR_2, SOURCES_2);
                 SaveChrom(docResults, fileActualAll, FILE_NAMES_ALL.ToList(), LocalizationHelper.CurrentCulture, EXTRACTOR_ALL, SOURCES_ALL);
 
-                var tolerance = new Dictionary<int, double>{{3,.0001}}; // Allow a little wiggle in mz column since we tweak the calculation with Adduct work
+                var columnTolerances = new AssertEx.ColumnTolerances();
+                columnTolerances.AddTolerance(3, 0.0001); // Allow a little wiggle in mz column since we tweak the calculation with Adduct work
 
-                AssertEx.FileEquals(fileExpected1, fileActual1, tolerance);
-                AssertEx.FileEquals(fileExpected2, fileActual2, tolerance);
-                AssertEx.FileEquals(fileExpectedAll, fileActualAll, tolerance);
+                AssertEx.FileEquals(fileExpected1, fileActual1, columnTolerances);
+                AssertEx.FileEquals(fileExpected2, fileActual2, columnTolerances);
+                AssertEx.FileEquals(fileExpectedAll, fileActualAll, columnTolerances);
             }
         }
 

--- a/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
+++ b/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
@@ -17,7 +17,6 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -70,7 +69,7 @@ namespace pwiz.SkylineTest
             string dlibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.dlib");
             string elibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.elib");
             string elibQuantFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-quant-elib.elib");
-            var columnTolerances = new Dictionary<int, double>() { { -1, 0.000005 } };  // Allow some numerical wiggle in any column numerical column ("-1" means all columns)
+            var columnTolerances = new AssertEx.ColumnTolerances(0.000005);  // Allow some numerical wiggle in any column numerical
             IProgressStatus status = new ProgressStatus();
 
             // test koina output to dlib

--- a/pwiz_tools/Skyline/TestPerf/FeatureDetectionTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/FeatureDetectionTest.cs
@@ -425,7 +425,7 @@ namespace TestPerf
             foreach (var hkExpectedFilePath in Directory.EnumerateFiles(expectedFilesPath))
             {
                 var hkActualFilePath = hkExpectedFilePath.Replace(expectedHardklorFiles, Path.Combine(expectedHardklorFiles, @".."));
-                var columnTolerances = new Dictionary<int, double>() { { -1, .00015 } }; // Allow a little rounding wiggle in the decimal values
+                var columnTolerances = new AssertEx.ColumnTolerances(0.00015, true); // Allow a little rounding wiggle in the numeric values
                 AssertEx.FileEquals(hkExpectedFilePath, hkActualFilePath, columnTolerances, true);
             }
 

--- a/pwiz_tools/Skyline/TestUtil/AssertEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AssertEx.cs
@@ -835,7 +835,7 @@ namespace pwiz.SkylineTestUtil
         }
 
         public static void NoDiff(string target, string actual, string helpMsg=null, 
-            Dictionary<int, double> columnTolerances = null, // Per-column numerical tolerances if strings can be read as TSV, "-1" means any column
+            ColumnTolerances columnTolerances = null,
             bool ignorePathDifferences = false)
         {
             if (helpMsg == null)
@@ -873,11 +873,52 @@ namespace pwiz.SkylineTestUtil
                         RemovePathDifferences(ref lineTarget, ref lineActual);
                     }
                     // If only difference appears to be generated GUIDs or timestamps, let it pass
-                    if (!LinesEquivalentIgnoringTimeStampsAndGUIDs(lineTarget, lineActual, columnTolerances))
+                    if (!LinesEquivalentIgnoringTimeStampsAndGUIDs(lineTarget, lineActual, columnTolerances, out var failureMessage))
                     {
-                        int pos;
-                        for (pos = 0; pos < expectedLine?.Length && pos < actualLine?.Length && expectedLine[pos] == actualLine[pos];) {pos++;}
-                        Fail(helpMsg + $@" Diff found at line {count} position {pos}: expected{Environment.NewLine}{expectedLine}{Environment.NewLine}actual{Environment.NewLine}{actualLine}");
+                        var sbEnd = new StringBuilder();
+                        var sbStart = new StringBuilder();
+                        if (lineActual != null && lineTarget != null)
+                        {
+                            var sharedLen = Math.Min(lineActual.Length, lineTarget.Length);
+                            for (int i = 0; i < sharedLen; i++)
+                            {
+                                var endCh = lineActual[lineActual.Length - 1 - i];
+                                if (endCh != lineTarget[lineTarget.Length - 1 - i])
+                                    break;
+                                sbEnd.Insert(0, endCh);
+                            }
+                            for (int i = 0; i < sharedLen; i++)
+                            {
+                                var startCh = lineActual[i];
+                                if (startCh != lineTarget[i])
+                                    break;
+                                sbStart.Append(startCh);
+                            }
+                        }
+
+                        // Build an informative failure message
+                        string assertFailMessage = TextUtil.LineSeparate(
+                            helpMsg + $@" Diff found at line {count} position {sbStart.Length}:",
+                            "expected",
+                            expectedLine,
+                            "actual",
+                            actualLine);
+                        if (!Equals(expectedLine, lineTarget) || !Equals(actualLine, lineActual))
+                        {
+                            // Paths were removed, so report the text after removal
+                            assertFailMessage = TextUtil.LineSeparate(assertFailMessage,
+                                "expected with paths removed",
+                                lineTarget,
+                                "actual with paths removed",
+                                lineActual);
+                        }
+                        assertFailMessage = TextUtil.LineSeparate(assertFailMessage,
+                            $"matching prefix: '{sbStart}'",
+                            $"matching suffix: '{sbEnd}'");
+                        if (!string.IsNullOrEmpty(failureMessage))
+                            assertFailMessage = TextUtil.LineSeparate(assertFailMessage, "decimal matching: " + failureMessage);
+
+                        Fail(assertFailMessage);
                     }
                     lineEqualLast = expectedLine;
                     count++;
@@ -930,8 +971,11 @@ namespace pwiz.SkylineTestUtil
                     if (string.Equals(fileE, fileA) ||
                         (Path.GetExtension(fileE) == @".tmp") && Path.GetExtension(fileE) == Path.GetExtension(fileA)) // Tmp file names will always vary
                     {
-                        lineExpected = lineExpected.Replace(pathE, string.Empty);
-                        lineActual = lineActual.Replace(pathA, string.Empty);
+                        // Empty strings are harder to see as columns.
+                        // So, replace the matching paths with visible matching text.
+                        const string pathSubstitutionText = "path";
+                        lineExpected = lineExpected.Replace(pathE, pathSubstitutionText);
+                        lineActual = lineActual.Replace(pathA, pathSubstitutionText);
                     }
                 }
                 catch
@@ -941,10 +985,11 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
-
         private static bool LinesEquivalentIgnoringTimeStampsAndGUIDs(string lineExpected, string lineActual,
-            Dictionary<int, double> columnTolerances = null) // Per-column numerical tolerances if strings can be read as TSV, "-1" means any column
+            ColumnTolerances columnTolerances, out string failureMessage) // Per-column numerical tolerances if strings can be read as TSV, "-1" means any column
         {
+            failureMessage = string.Empty;  // For all the return true cases
+
             if (string.Equals(lineExpected, lineActual))
             {
                 return true; // Identical
@@ -977,32 +1022,127 @@ namespace pwiz.SkylineTestUtil
             }
 
             if (columnTolerances != null)
+                return columnTolerances.LinesEquivalent(lineExpected, lineActual, out failureMessage);
+
+            return false; // Could not account for difference
+        }
+
+        public class ColumnTolerances
+        {
+            private ColumnToleranceValue _defaultTolerance { get; }
+            private Dictionary<int, ColumnToleranceValue> _explicitTolerances = new Dictionary<int, ColumnToleranceValue>();
+
+            public ColumnTolerances()
             {
+            }
+
+            public ColumnTolerances(double defaultTolerance, bool forceScientificNotation = false)
+            {
+                _defaultTolerance = new ColumnToleranceValue(defaultTolerance, forceScientificNotation);
+            }
+
+            public void AddTolerance(int column, double tolerance, bool forceScientificNotation = false)
+            {
+                _explicitTolerances.Add(column, new ColumnToleranceValue(tolerance, forceScientificNotation));
+            }
+
+            public bool LinesEquivalent(string lineExpected, string lineActual, out string failureMessage)
+            {
+                failureMessage = string.Empty;
+
                 // ReSharper disable PossibleNullReferenceException
                 var colsActual = lineActual.Split('\t');
                 var colsExpected = lineExpected.Split('\t');
                 // ReSharper restore PossibleNullReferenceException
-                if (colsExpected.Length == colsActual.Length)
+                if (colsExpected.Length != colsActual.Length)
+                    return false;
+                for (var c = 0; c < colsActual.Length; c++)
                 {
-                    for (var c = 0; c < colsActual.Length; c++)
-                    {
-                        if (colsActual[c] != colsExpected[c])
-                        {
-                            // See if there's a tolerance for this column, or a default tolerance (column "-1" in the dictionary)
-                            if ((!columnTolerances.TryGetValue(c, out var tolerance) && !columnTolerances.TryGetValue(-1, out tolerance)) || // No tolerance given for this column
-                                !(TextUtil.TryParseDoubleUncertainCulture(colsActual[c], out var valActual) &&
-                                  TextUtil.TryParseDoubleUncertainCulture(colsExpected[c], out var valExpected)) || // One or both don't parse as doubles
-                                (Math.Abs(valActual - valExpected) > tolerance + tolerance / 1000)) // Allow for rounding cruft
-                            {
-                                return false; // Can't account for difference
-                            }
-                        }
-                    }
-                    return true; // Differences accounted for
+                    if (!ColumnsEquivalent(c, colsExpected[c], colsActual[c], out failureMessage))
+                        return false;
                 }
+
+                return true; // Differences accounted for
             }
 
-            return false; // Could not account for difference
+            private bool ColumnsEquivalent(int i, string textExpected, string textActual, out string failureMessage)
+            {
+                failureMessage = string.Empty;
+                if (Equals(textExpected, textActual))
+                    return true;
+
+                // See if there's a tolerance for this column, or a default tolerance (column "-1" in the dictionary)
+                if (!_explicitTolerances.TryGetValue(i, out var toleranceValue))
+                {
+                    toleranceValue = _defaultTolerance;
+                    if (toleranceValue == null)
+                        return false; // No tolerance given for this column
+                }
+                if (!TextUtil.TryParseDoubleUncertainCulture(textActual, out var valActual) ||
+                    !TextUtil.TryParseDoubleUncertainCulture(textExpected, out var valExpected))
+                {
+                    return false;
+                }
+
+                char[] expChars = { 'E', 'e' };
+                var textSplitActual = textActual;
+                if (toleranceValue.ForceScientificNotation && textSplitActual.Split(expChars).Length != 2)
+                    textSplitActual = valActual.ToString("E");
+                var textSplitExpected = textExpected;
+                if (toleranceValue.ForceScientificNotation && textSplitExpected.Split(expChars).Length != 2)
+                    textSplitExpected = valExpected.ToString("E");
+
+                var actualParts = textSplitActual.Split(expChars);
+                var expectedParts = textSplitExpected.Split(expChars);
+
+                if (actualParts.Length == 2 && expectedParts.Length == 2)
+                {
+                    // Both strings have exponent, so check if they are equal
+                    if (!Equals(expectedParts[1], actualParts[1]) ||
+                        // Then check the mantissas match to the expected tolerance
+                        !TextUtil.TryParseDoubleUncertainCulture(actualParts[0], out valActual) ||
+                        !TextUtil.TryParseDoubleUncertainCulture(expectedParts[0], out valExpected))
+                    {
+                        failureMessage = string.Format(
+                            "Expected decimal value: {0} does not match actual {1}",
+                            textExpected, textActual);
+                        return false; // One or both mantissas don't parse as doubles
+                    }
+                }
+
+                double tolerance = toleranceValue.Tolerance;
+                tolerance += tolerance / 1000; // Allow for rounding cruft
+                if (Math.Abs(valActual - valExpected) > tolerance)
+                {
+                    if (expectedParts.Length == 2)
+                    {
+                        failureMessage = string.Format(
+                            "Expected decimal mantissa: {0} does not match actual {1} to within {2}",
+                            valExpected, valActual, tolerance);
+                    }
+                    else
+                    {
+                        failureMessage = string.Format(
+                            "Expected decimal value: {0} does not match actual {1} to within {2}",
+                            textSplitExpected, textSplitActual, tolerance);
+                    }
+                    return false; // Can't account for difference
+                }
+
+                return true;
+            }
+        }
+
+        private class ColumnToleranceValue
+        {
+            public ColumnToleranceValue(double tolerance, bool forceScientificNotation = false)
+            {
+                Tolerance = tolerance;
+                ForceScientificNotation = forceScientificNotation;
+            }
+
+            public double Tolerance { get; }
+            public bool ForceScientificNotation { get; }
         }
 
         private static string GetEarlyEndingMessage(string helpMsg, string name, int count, string lineEqualLast, string lineNext, TextReader reader)
@@ -1015,7 +1155,7 @@ namespace pwiz.SkylineTestUtil
                 name, count, lineEqualLast, lineNext, linesRemaining);
         }
 
-        public static void FileEquals(string pathExpectedFile, string pathActualFile, Dictionary<int, double> columnTolerances = null, bool ignorePathDifferences = false )
+        public static void FileEquals(string pathExpectedFile, string pathActualFile, ColumnTolerances columnTolerances = null, bool ignorePathDifferences = false )
         {
             string file1 = File.ReadAllText(pathExpectedFile);
             string file2 = File.ReadAllText(pathActualFile);


### PR DESCRIPTION
This greatly improves failure reporting for AssertEx.FileEquals() where the old code used to just report the two lines where the comparison failed, the new code gives a lot more detail on the internal reasons when paths and column tolerances are involved. This code also adds a class ColumnTolerances to formalize the tolerance evaluation and introduces a tolerance that applies to the mantissa of the number in scientific notation to better capture limitations in precision and potential rounding error.

Before (mistakenly interpreted as a path difference):

Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: Assert.Fail failed.  Diff found at line 225 position 0: expected
Orbi3_SA_IP_pHis3_01.mzML  17836  17876  8  3  3495.7076  1166.5775  1.050319E+08  2.961274E+08  110.6513  110.8777  110.7155  0.9989  _  17848  H254C156N43O46S1[-2.150306]  mass3495.7076_RT110.7155
actual
z:\download\Perftests\Label-free\converted\Orbi3_SA_IP_pHis3_01.mzML  17836  17876  8  3  3495.7076  1166.5775  1.050319E+08  2.961275E+08  110.6513  110.8777  110.7155  0.9989  _  17848  H254C156N43O46S1[-2.150306]  mass3495.7076_RT110.7155

After (skipping thousands of lines that match by the specified precision and more clearly showing the problem):

Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: Assert.Fail failed.  Diff found at line 7723 position 5:
expected
Orbi3_SA_IP_pHis3_01.mzML  2350  2371  5  1  863.4852  864.4928  1732674  5650320  15.8053  15.9211  15.8631  0.9988  _  2361  H86C38N10O11[+4.837413]  mass863.4852_RT15.8631
actual
z:\download\Perftests\Label-free\converted\Orbi3_SA_IP_pHis3_01.mzML  8456  8477  6  2  1228.6413  615.3279  1732675  8681932  51.0093  51.1453  51.1453  0.9942  _  8477  H102C55N15O16[-0.121619]  mass1228.6413_RT51.1453
expected with paths removed
path  2350  2371  5  1  863.4852  864.4928  1732674  5650320  15.8053  15.9211  15.8631  0.9988  _  2361  H86C38N10O11[+4.837413]  mass863.4852_RT15.8631
actual with paths removed
path  8456  8477  6  2  1228.6413  615.3279  1732675  8681932  51.0093  51.1453  51.1453  0.9942  _  8477  H102C55N15O16[-0.121619]  mass1228.6413_RT51.1453
matching prefix: 'path  '
matching suffix: ''
decimal matching: Expected decimal mantissa: 2.35 does not match actual 8.456 to within 0.00015015