### PR TITLE
Fixes for reading Sciex MRM3 files and better WIFF error handling

### DIFF
--- a/pwiz/data/msdata/Reader.cpp
+++ b/pwiz/data/msdata/Reader.cpp
@@ -76,6 +76,13 @@ Reader::Config::Config(const Config& rhs)
     globalChromatogramsAreMs1Only = rhs.globalChromatogramsAreMs1Only;
 }
 
+void Reader::Config::instrumentMetadataError(const std::string& msg) const
+{
+    if (unknownInstrumentIsError)
+        throw runtime_error(msg + string("; if want to convert the file anyway, use the ignoreUnknownInstrumentError flag"));
+    cerr << msg << endl;
+}
+
 // default implementation; most Readers don't need to worry about multi-run input files
 PWIZ_API_DECL void Reader::readIds(const string& filename, const string& head, vector<string>& results, const Config& config) const
 {

--- a/pwiz/data/msdata/Reader.hpp
+++ b/pwiz/data/msdata/Reader.hpp
@@ -98,6 +98,8 @@ class PWIZ_API_DECL Reader
 
         Config();
         Config(const Config& rhs);
+
+        void instrumentMetadataError(const std::string& msg) const;
     };
 
 

--- a/pwiz/data/vendor_readers/ABI/Reader_ABI.cpp
+++ b/pwiz/data/vendor_readers/ABI/Reader_ABI.cpp
@@ -33,11 +33,11 @@
 
 PWIZ_API_DECL std::string pwiz::msdata::Reader_ABI::identify(const std::string& filename, const std::string& head) const
 {
-	std::string result;
+    std::string result;
     // TODO: check header signature?
     for (const auto& ext : getFileExtensions())
-	    if (bal::iends_with(filename, ext))
-			result = getType();
+        if (bal::iends_with(filename, ext))
+            result = getType();
     return result;
 }
 
@@ -149,22 +149,36 @@ void fillInMetadata(const string& wiffpath, MSData& msd, WiffFilePtr wifffile,
     }
     catch (runtime_error& e)
     {
-        if (config.unknownInstrumentIsError)
-            throw runtime_error("[Reader_ABI::fillInMetadata] unable to determine instrument model (" + string(e.what()) + "); if want to convert the file anyway, use the ignoreUnknownInstrumentError flag");
+        config.instrumentMetadataError("[Reader_ABI::fillInMetadata] unable to determine instrument model (" + string(e.what()) + ")");
     }
 
     InstrumentConfigurationPtr ic = translateAsInstrumentConfiguration(instrumentModel, IonSpray);
     ic->softwarePtr = acquisitionSoftware;
 
-    auto serialNumber = wifffile->getInstrumentSerialNumber();
-    if (!serialNumber.empty())
-        ic->set(MS_instrument_serial_number, serialNumber);
+    try
+    {
+        auto serialNumber = wifffile->getInstrumentSerialNumber();
+        if (!serialNumber.empty())
+            ic->set(MS_instrument_serial_number, serialNumber);
+    }
+    catch (runtime_error& e)
+    {
+        config.instrumentMetadataError("[Reader_ABI::fillInMetadata] unable to read instrument serial number (" + string(e.what()) + ")");
+    }
 
     msd.instrumentConfigurationPtrs.push_back(ic);
     msd.run.defaultInstrumentConfigurationPtr = ic;
 
     msd.run.id = msd.id;
-    msd.run.startTimeStamp = encode_xml_datetime(wifffile->getSampleAcquisitionTime(sample, config.adjustUnknownTimeZonesToHostTimeZone));
+
+    try
+    {
+        msd.run.startTimeStamp = encode_xml_datetime(wifffile->getSampleAcquisitionTime(sample, config.adjustUnknownTimeZonesToHostTimeZone));
+    }
+    catch (runtime_error& e)
+    {
+        config.instrumentMetadataError("[Reader_ABI::fillInMetadata] unable to read sample acquisition time (" + string(e.what()) + ")");
+    }
 }
 
 void cacheExperiments(WiffFilePtr wifffile, ExperimentsMap& experimentsMap, int sample)

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo.cpp
@@ -238,9 +238,7 @@ void fillInMetadata(const string& filename, RawFile& rawfile, MSData& msd, const
 
     if (!instData.Model.empty() && !instData.Name.empty() && rawfile.getInstrumentModel() == InstrumentModelType_Unknown)
     {
-        if (config.unknownInstrumentIsError)
-            throw runtime_error("[Reader_Thermo::fillInMetadata] unable to parse instrument model; make sure you are using the latest version of ProteoWizard; if you are, please report this error to the ProteoWizard developers with this information: model(" + instData.Model + ") name(" + instData.Name + "); if want to convert the file anyway, use the ignoreUnknownInstrumentError flag");
-        // TODO: else log warning
+        config.instrumentMetadataError("[Reader_Thermo::fillInMetadata] unable to parse instrument model; make sure you are using the latest version of ProteoWizard; if you are, please report this error to the ProteoWizard developers with this information: model(" + instData.Model + ") name(" + instData.Name + ")");
     }
 
     msd.run.id = msd.id;

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -438,7 +438,7 @@ Config parseCommandLine(int argc, char** argv)
             po::value<bool>(&config.ignoreZeroIntensityPoints)->zero_tokens()->default_value(config.ignoreZeroIntensityPoints),
             ": some vendor readers do not include zero samples in their profile data; the default behavior is to add the zero samples but this option disables that")
         ("ignoreUnknownInstrumentError",
-            po::value<bool>(&config.unknownInstrumentIsError)->zero_tokens()->default_value(!config.unknownInstrumentIsError),
+            po::value<bool>(&config.unknownInstrumentIsError)->zero_tokens()->default_value(false),
             ": if true, if an instrument cannot be determined from a vendor file, it will not be an error")
         ("stripLocationFromSourceFiles",
             po::value<bool>(&config.stripLocationFromSourceFiles)->zero_tokens(),


### PR DESCRIPTION
- made failures reading WIFF metadata optionally fatal (depending on ignoreUnknownInstrumentError setting)
- fixed ignoreUnknownInstrumentError default value to be false
- fixed reading CE from WIFF file spectra
- added fallback handling for when calling centroiding or framing zeros on WIFF2 spectra throws exceptions but the profile/unframed spectra are available
- * added Reader::Config::instrumentMetadataError to encapsulate the "if(unknownInstrumentIsError) throw; else print warning" logic