### PR TITLE
* fixed Reader_Bruker_TSF not being included in FullReaderList

### DIFF
--- a/pwiz/data/msdata/ReaderTest.cpp
+++ b/pwiz/data/msdata/ReaderTest.cpp
@@ -262,7 +262,7 @@ void testIdentifyFileFormat()
         auto readerTypes = readerList.getTypes();
         set<string> readerTypeSet(readerTypes.begin(), readerTypes.end());
         set<string> expectedTypeSet{ "mzML", "mzMLb", "mzXML", "MS1", "MS2", "Mascot Generic", "Bruker Data Exchange", "MZ5",
-                                     "Sciex WIFF", "Sciex WIFF2", "AB/Sciex T2D", "Agilent MassHunter", "Bruker FID", "Bruker YEP", "Bruker BAF", "Bruker U2", "Bruker TDF",
+                                     "Sciex WIFF", "Sciex WIFF2", "AB/Sciex T2D", "Agilent MassHunter", "Bruker FID", "Bruker YEP", "Bruker BAF", "Bruker U2", "Bruker TDF", "Bruker TSF",
 #if defined(PWIZ_READER_MOBILION)
                                      "Mobilion MBI",
 #endif
@@ -280,7 +280,7 @@ void testIdentifyFileFormat()
         set<CVID> readerCvTypeSet(readerTypes.begin(), readerTypes.end());
         set<CVID> expectedCvTypeSet{ MS_mzML_format, MS_ISB_mzXML_format, MS_MS1_format, MS_MS2_format, MS_Mascot_MGF_format, MS_Bruker_XML_format, MS_mz5_format,
                                      MS_mzMLb_format, MS_ABI_WIFF_format, MS_SCIEX_TOF_TOF_T2D_format, MS_Agilent_MassHunter_format,
-                                     MS_Bruker_FID_format, MS_Bruker_Agilent_YEP_format, MS_Bruker_BAF_format, MS_Bruker_U2_format, MS_Bruker_TDF_format,
+                                     MS_Bruker_FID_format, MS_Bruker_Agilent_YEP_format, MS_Bruker_BAF_format, MS_Bruker_U2_format, MS_Bruker_TDF_format, MS_Bruker_TSF_format,
                                      MS_mass_spectrometer_file_format, MS_Thermo_RAW_format, MS_UIMF_format, MS_Waters_raw_format };
         auto expectedButNotFound = expectedCvTypeSet - readerCvTypeSet;
         auto foundButNotExpected = readerCvTypeSet - expectedCvTypeSet;

--- a/pwiz/data/vendor_readers/Bruker/Reader_Bruker.hpp
+++ b/pwiz/data/vendor_readers/Bruker/Reader_Bruker.hpp
@@ -101,7 +101,7 @@ class PWIZ_API_DECL Reader_Bruker_TDF : public Reader_Bruker_Dummy
 class PWIZ_API_DECL Reader_Bruker_TSF : public Reader_Bruker_Dummy
 {
     virtual const char* getType() const { return "Bruker TSF"; }
-    virtual CVID getCvType() const { return MS_Bruker_TDF_format; }
+    virtual CVID getCvType() const { return MS_Bruker_TSF_format; }
     virtual std::vector<std::string> getFileExtensions() const {return {".d", ".tsf"};}
 };
 

--- a/pwiz/data/vendor_readers/ExtendedReaderList.cpp
+++ b/pwiz/data/vendor_readers/ExtendedReaderList.cpp
@@ -49,6 +49,7 @@ PWIZ_API_DECL ExtendedReaderList::ExtendedReaderList()
     push_back(ReaderPtr(new Reader_Agilent));
     push_back(ReaderPtr(new Reader_Bruker_BAF));
     push_back(ReaderPtr(new Reader_Bruker_TDF));
+    push_back(ReaderPtr(new Reader_Bruker_TSF));
 #if !defined(PWIZ_READER_BRUKER) || defined(PWIZ_READER_BRUKER_WITH_COMPASSXTRACT)
     push_back(ReaderPtr(new Reader_Bruker_FID));
     push_back(ReaderPtr(new Reader_Bruker_YEP));


### PR DESCRIPTION
* fixed Reader_Bruker_TSF not being included in FullReaderList (so its supported file extensions did not get enumerated by SeeMS and MSConvertGUI)

Cherry picking to release so I can test it actually works...