### PR TITLE
Revert to English in .ja and .zh-CHS resx files when English text has changed

### DIFF
--- a/pwiz_tools/Shared/BiblioSpec/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/BiblioSpec/Properties/Resources.ja.resx
@@ -98,10 +98,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="LibraryBuildActionExtension_LOCALIZED_VALUES_Create">
-    <value xml:space="preserve">作成</value>
+    <value>作成</value>
   </data>
   <data name="LibraryBuildActionExtension_LOCALIZED_VALUES_Append">
-    <value xml:space="preserve">追加</value>
+    <value>追加</value>
   </data>
   <data name="LibraryBuildActionExtension_GetEnum_The_string___0___does_not_match_an_enum_value" xml:space="preserve">
     <value>文字列'{0}'がenum値と一致しません</value>
@@ -168,5 +168,8 @@
   </data>
   <data name="ScoreType_ScoreThresholdDescription_Score_threshold_maximum__score_is_probability_that_identification_is_incorrect_" xml:space="preserve">
     <value>最大スコア閾値（スコアは同定が正しくないという確率）</value>
+  </data>
+  <data name="BiblioSpecScoreType_DisplayName_Hardklor_idotp" xml:space="preserve">
+    <value>Hardklor idotp</value>
   </data>
 </root>

--- a/pwiz_tools/Shared/BiblioSpec/Properties/Resources.resx
+++ b/pwiz_tools/Shared/BiblioSpec/Properties/Resources.resx
@@ -98,10 +98,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="LibraryBuildActionExtension_LOCALIZED_VALUES_Create">
-    <value xml:space="preserve">Create</value>
+    <value>Create</value>
   </data>
   <data name="LibraryBuildActionExtension_LOCALIZED_VALUES_Append">
-    <value xml:space="preserve">Append</value>
+    <value>Append</value>
   </data>
   <data name="LibraryBuildActionExtension_GetEnum_The_string___0___does_not_match_an_enum_value" xml:space="preserve">
     <value>The string '{0}' does not match an enum value</value>

--- a/pwiz_tools/Shared/BiblioSpec/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/BiblioSpec/Properties/Resources.zh-CHS.resx
@@ -98,10 +98,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="LibraryBuildActionExtension_LOCALIZED_VALUES_Create">
-    <value xml:space="preserve">创建</value>
+    <value>创建</value>
   </data>
   <data name="LibraryBuildActionExtension_LOCALIZED_VALUES_Append">
-    <value xml:space="preserve">附加</value>
+    <value>附加</value>
   </data>
   <data name="LibraryBuildActionExtension_GetEnum_The_string___0___does_not_match_an_enum_value" xml:space="preserve">
     <value>字符串“{0}”不匹配枚举值</value>
@@ -168,5 +168,8 @@
   </data>
   <data name="ScoreType_ScoreThresholdDescription_Score_threshold_maximum__score_is_probability_that_identification_is_incorrect_" xml:space="preserve">
     <value>最大得分阈值(该得分是指鉴定为不正确的概率)</value>
+  </data>
+  <data name="BiblioSpecScoreType_DisplayName_Hardklor_idotp" xml:space="preserve">
+    <value>Hardklor idotp</value>
   </data>
 </root>

--- a/pwiz_tools/Shared/Common/Controls/MultiProgressControl.ja.resx
+++ b/pwiz_tools/Shared/Common/Controls/MultiProgressControl.ja.resx
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ProgressSplit.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ProgressSplit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="ProgressSplit.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <metadata name="NameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="NameColumn.HeaderText" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <metadata name="ProgressColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="ProgressColumn.HeaderText" xml:space="preserve">
+    <value>Progress</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ProgressColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>50</value>
+  </data>
+  <data name="progressGridView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="progressGridView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="progressGridView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 491</value>
+  </data>
+  <data name="progressGridView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Name" xml:space="preserve">
+    <value>progressGridView</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Parent" xml:space="preserve">
+    <value>ProgressSplit.Panel1</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Name" xml:space="preserve">
+    <value>ProgressSplit.Panel1</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Parent" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ProgressSplit.Panel1MinSize" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="progressLogTextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="progressLogTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="progressLogTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="progressLogTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 175</value>
+  </data>
+  <data name="progressLogTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Name" xml:space="preserve">
+    <value>progressLogTextBox</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Parent" xml:space="preserve">
+    <value>ProgressSplit.Panel2</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Name" xml:space="preserve">
+    <value>ProgressSplit.Panel2</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Parent" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ProgressSplit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 670</value>
+  </data>
+  <data name="ProgressSplit.SplitterDistance" type="System.Int32, mscorlib">
+    <value>491</value>
+  </data>
+  <data name="ProgressSplit.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Name" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 670</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Name" xml:space="preserve">
+    <value>NameColumn</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressColumn.Name" xml:space="preserve">
+    <value>ProgressColumn</value>
+  </data>
+  <data name="&gt;&gt;ProgressColumn.Type" xml:space="preserve">
+    <value>CustomProgressCell.DataGridViewProgressColumn, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MultiProgressControl</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/Common/Controls/MultiProgressControl.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/Controls/MultiProgressControl.zh-CHS.resx
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ProgressSplit.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ProgressSplit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="ProgressSplit.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <metadata name="NameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="NameColumn.HeaderText" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <metadata name="ProgressColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="ProgressColumn.HeaderText" xml:space="preserve">
+    <value>Progress</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ProgressColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>50</value>
+  </data>
+  <data name="progressGridView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="progressGridView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="progressGridView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 491</value>
+  </data>
+  <data name="progressGridView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Name" xml:space="preserve">
+    <value>progressGridView</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Parent" xml:space="preserve">
+    <value>ProgressSplit.Panel1</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Name" xml:space="preserve">
+    <value>ProgressSplit.Panel1</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Parent" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ProgressSplit.Panel1MinSize" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="progressLogTextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="progressLogTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="progressLogTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="progressLogTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 175</value>
+  </data>
+  <data name="progressLogTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Name" xml:space="preserve">
+    <value>progressLogTextBox</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Parent" xml:space="preserve">
+    <value>ProgressSplit.Panel2</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Name" xml:space="preserve">
+    <value>ProgressSplit.Panel2</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Parent" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ProgressSplit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 670</value>
+  </data>
+  <data name="ProgressSplit.SplitterDistance" type="System.Int32, mscorlib">
+    <value>491</value>
+  </data>
+  <data name="ProgressSplit.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Name" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 670</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Name" xml:space="preserve">
+    <value>NameColumn</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressColumn.Name" xml:space="preserve">
+    <value>ProgressColumn</value>
+  </data>
+  <data name="&gt;&gt;ProgressColumn.Type" xml:space="preserve">
+    <value>CustomProgressCell.DataGridViewProgressColumn, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MultiProgressControl</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.ja.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.ja.resx
@@ -117,13 +117,121 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="colHdrName.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="listView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>126, 150</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="listView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;listView.Name" xml:space="preserve">
+    <value>listView</value>
+  </data>
+  <data name="&gt;&gt;listView.Type" xml:space="preserve">
+    <value>pwiz.Common.DataBinding.Controls.ColumnListView, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;listView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;listView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="toolStrip1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="toolStrip1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="btnRemove.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnRemove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
+  <data name="btnRemove.Text" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="btnUp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnUp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
+  <data name="btnUp.Text" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="btnDown.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
+  <data name="btnDown.Text" xml:space="preserve">
+    <value>Down</value>
+  </data>
+  <data name="toolStrip1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>126, 0</value>
+  </data>
+  <data name="toolStrip1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 150</value>
+  </data>
+  <data name="toolStrip1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="toolStrip1.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Name" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="&gt;&gt;btnRemove.Name" xml:space="preserve">
+    <value>btnRemove</value>
+  </data>
+  <data name="&gt;&gt;btnRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnUp.Name" xml:space="preserve">
+    <value>btnUp</value>
+  </data>
+  <data name="&gt;&gt;btnUp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnDown.Name" xml:space="preserve">
+    <value>btnDown</value>
+  </data>
+  <data name="&gt;&gt;btnDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>ColumnListEditor</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.zh-CHS.resx
@@ -117,13 +117,121 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="colHdrName.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="listView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>126, 150</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="listView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;listView.Name" xml:space="preserve">
+    <value>listView</value>
+  </data>
+  <data name="&gt;&gt;listView.Type" xml:space="preserve">
+    <value>pwiz.Common.DataBinding.Controls.ColumnListView, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;listView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;listView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="toolStrip1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="toolStrip1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="btnRemove.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnRemove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
+  <data name="btnRemove.Text" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="btnUp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnUp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
+  <data name="btnUp.Text" xml:space="preserve">
+    <value>Up</value>
+  </data>
+  <data name="btnDown.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
+  <data name="btnDown.Text" xml:space="preserve">
+    <value>Down</value>
+  </data>
+  <data name="toolStrip1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>126, 0</value>
+  </data>
+  <data name="toolStrip1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 150</value>
+  </data>
+  <data name="toolStrip1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="toolStrip1.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Name" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="&gt;&gt;btnRemove.Name" xml:space="preserve">
+    <value>btnRemove</value>
+  </data>
+  <data name="&gt;&gt;btnRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnUp.Name" xml:space="preserve">
+    <value>btnUp</value>
+  </data>
+  <data name="&gt;&gt;btnUp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnDown.Name" xml:space="preserve">
+    <value>btnDown</value>
+  </data>
+  <data name="&gt;&gt;btnDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>ColumnListEditor</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/SourceTab.ja.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/SourceTab.ja.resx
@@ -117,4 +117,49 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="textBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="textBox1.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="textBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 150</value>
+  </data>
+  <data name="textBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
+    <value>textBox1</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 150</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SourceTab</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.DataBinding.Controls.Editor.ViewEditorWidget, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/SourceTab.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/SourceTab.zh-CHS.resx
@@ -117,4 +117,49 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="textBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="textBox1.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="textBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 150</value>
+  </data>
+  <data name="textBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
+    <value>textBox1</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 150</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SourceTab</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.DataBinding.Controls.Editor.ViewEditorWidget, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/Common/Properties/Resources.ja.resx
@@ -542,17 +542,8 @@
   <data name="ZScore_ZScore_Z_Score" xml:space="preserve">
     <value>Zスコア</value>
   </data>
-  <data name="Units_mz" xml:space="preserve">
-    <value>m/z</value>
-  </data>
-  <data name="Units_ppm" xml:space="preserve">
-    <value>ppm</value>
-  </data>
   <data name="DropImageNoBackground" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DropImageNoBackground.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="StreamEx_ReadOrThrow_Failed_reading__0__bytes__Source_may_be_corrupted_" xml:space="preserve">
-    <value>{0}バイトの読み込みに失敗しました。ソースが壊れている可能性があります。</value>
   </data>
   <data name="FilterClause_MakePredicate_Invalid_filter_column___0__" xml:space="preserve">
     <value>フィルタ列「{0}」が無効です</value>

--- a/pwiz_tools/Shared/Common/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/Properties/Resources.zh-CHS.resx
@@ -542,17 +542,8 @@
   <data name="ZScore_ZScore_Z_Score" xml:space="preserve">
     <value>Z-Score</value>
   </data>
-  <data name="Units_mz" xml:space="preserve">
-    <value>质荷比</value>
-  </data>
-  <data name="Units_ppm" xml:space="preserve">
-    <value>ppm</value>
-  </data>
   <data name="DropImageNoBackground" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DropImageNoBackground.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="StreamEx_ReadOrThrow_Failed_reading__0__bytes__Source_may_be_corrupted_" xml:space="preserve">
-    <value>读取 {0} 字节失败。源可能已损坏。</value>
   </data>
   <data name="FilterClause_MakePredicate_Invalid_filter_column___0__" xml:space="preserve">
     <value>过滤器列“{0}”无效</value>

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.ja.resx
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Abort" xml:space="preserve">
+    <value>Abort</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Ignore" xml:space="preserve">
+    <value>Ignore</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.zh-CHS.resx
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Abort" xml:space="preserve">
+    <value>Abort</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Ignore" xml:space="preserve">
+    <value>Ignore</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/Images.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/Images.ja.resx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/Images.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/Images.zh-CHS.resx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/CommonUtil/GUI/CommonAlertDlg.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/GUI/CommonAlertDlg.ja.resx
@@ -406,7 +406,7 @@
     <value>398, 126</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterScreen</value>
+    <value>CenterParent</value>
   </data>
   <data name="&gt;&gt;toolStripButtonCopy.Name" xml:space="preserve">
     <value>toolStripButtonCopy</value>

--- a/pwiz_tools/Shared/CommonUtil/GUI/CommonAlertDlg.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/GUI/CommonAlertDlg.zh-CHS.resx
@@ -406,7 +406,7 @@
     <value>398, 126</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterScreen</value>
+    <value>CenterParent</value>
   </data>
   <data name="&gt;&gt;toolStripButtonCopy.Name" xml:space="preserve">
     <value>toolStripButtonCopy</value>

--- a/pwiz_tools/Shared/CommonUtil/GUI/GuiMessages.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/GUI/GuiMessages.ja.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema
+
+    Version 1.3
+
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">1.3</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1">this is my long string</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+      [base64 mime encoded serialized .NET Framework object]
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+      [base64 mime encoded string representing a byte array form of the .NET Framework object]
+    </data>
+
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+      : System.Serialization.Formatters.Binary.BinaryFormatter
+      : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+      : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+      : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+      : using a System.ComponentModel.TypeConverter
+      : and then encoded with base64 encoding.
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AbstractAlertDlg_Message_truncated" xml:space="preserve">
+    <value>Message truncated. Press Ctrl+C to copy entire message to the clipboard.</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/CommonUtil/GUI/GuiMessages.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/GUI/GuiMessages.zh-CHS.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema
+
+    Version 1.3
+
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">1.3</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1">this is my long string</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+      [base64 mime encoded serialized .NET Framework object]
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+      [base64 mime encoded string representing a byte array form of the .NET Framework object]
+    </data>
+
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+      : System.Serialization.Formatters.Binary.BinaryFormatter
+      : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+      : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+      : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+      : using a System.ComponentModel.TypeConverter
+      : and then encoded with base64 encoding.
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AbstractAlertDlg_Message_truncated" xml:space="preserve">
+    <value>Message truncated. Press Ctrl+C to copy entire message to the clipboard.</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/CommonUtil/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/Properties/Resources.ja.resx
@@ -118,4 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Units_mz" xml:space="preserve">
+    <value>m/z</value>
+  </data>
+  <data name="Units_ppm" xml:space="preserve">
+    <value>ppm</value>
+  </data>
+  <data name="StreamEx_ReadOrThrow_Failed_reading__0__bytes__Source_may_be_corrupted_" xml:space="preserve">
+    <value>{0}バイトの読み込みに失敗しました。ソースが壊れている可能性があります。</value>
+  </data>
+  <data name="ProcessRunner_Run_Run_command_" xml:space="preserve">
+    <value>Run command:</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/CommonUtil/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/Properties/Resources.zh-CHS.resx
@@ -118,4 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Units_mz" xml:space="preserve">
+    <value>质荷比</value>
+  </data>
+  <data name="Units_ppm" xml:space="preserve">
+    <value>ppm</value>
+  </data>
+  <data name="StreamEx_ReadOrThrow_Failed_reading__0__bytes__Source_may_be_corrupted_" xml:space="preserve">
+    <value>读取 {0} 字节失败。源可能已损坏。</value>
+  </data>
+  <data name="ProcessRunner_Run_Run_command_" xml:space="preserve">
+    <value>Run command:</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.ja.resx
@@ -1,0 +1,418 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="folderPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 54</value>
+  </data>
+  <data name="folderPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 241</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Name" xml:space="preserve">
+    <value>folderPanel</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>360, 304</value>
+  </data>
+  <data name="cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="cancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Name" xml:space="preserve">
+    <value>cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cancel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="open.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="open.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 304</value>
+  </data>
+  <data name="open.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="open.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="open.Text" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="&gt;&gt;open.Name" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="&gt;&gt;open.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;open.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;open.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="toolStrip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="back.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAElSURBVFhH7Y6xSgNBEIbv0SxS2NqkSWEnpBBLSZCAZQqL
+        gI0oIiSEI4IIgqRJiCGFBDtLwVcZmb1/uM3eRg3sTAjkg5+53Zm9b7I9O0nn8YMGiy/C0RaWS3Blhy83
+        XyCUmy7QzpdOGFa0dWHZumBEj/PhO6UKLyz1afn99/LhD1IHmjixB6kDVZWzh7kb0Kwc6FaRpkWgLAkH
+        Tu/fVM/QFoRDFhXqgubtlKwDdYnf5A39s0agXeXkZuKax9djt4ScuUrkB/7dJpH3UFZhOQ+E1f9BeLdp
+        +D10cXhAO1CtJ/YoZaD5nUbvlTRyN/n83wLMUfeZ6lcv7iF/+xUj+rAwFrRtOLwcEYfF8o2WHSLe2gJM
+        rZOTBFf2HFwMqdWfbW+BPenIsh9lGoeCmcAw0gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="back.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="back.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="back.Text" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="forward.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEySURBVFhH7ZaxS0JRFMbfn+bQ0OrS0uAWNERjCPLA0aFB
+        aIkkgsIsQQRBWpSKhhK3xqB/5cSn39H39LyX+rz3IfiDj+s759z7u3cz2LPzPHz8SNgeCz/9A7mGJb9E
+        L5DLJSpPI1kMW36wLoCw7R5LruHI/3RGv1J+/DIPuWh+ZgoV6UQ3nN+9T8RYo/UsoSYZa9O2Q5UNXlu+
+        f5292tVK3TIY8BUq46BxdvsWG1z3e51QO0cPy7quGsxTPeX0Zii+Q/UUa2CT4GVWfTHUzkHx5HowaWLd
+        NKWrl8QztE5lHN2YdsAqSduLs6lbBk3XocrG2rDNUJNMY/Atx/W+k1DhjqPLnmggLNa6s5UjboHICtvu
+        Oaw+CwKp/mbLDyrNRQ4OwpZoWPIL/kcUKs185HuyEwR/UFmHnV3u2vkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="forward.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="forward.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="forward.Text" xml:space="preserve">
+    <value>Forward</value>
+  </data>
+  <data name="up.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="toolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 7</value>
+  </data>
+  <data name="toolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 31</value>
+  </data>
+  <data name="toolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="toolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Name" xml:space="preserve">
+    <value>toolStrip</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="urlLink.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="urlLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 309</value>
+  </data>
+  <data name="urlLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 13</value>
+  </data>
+  <data name="urlLink.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="urlLink.Text" xml:space="preserve">
+    <value>&lt;placeholder&gt;</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Name" xml:space="preserve">
+    <value>urlLink</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;urlLink.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>115, 17</value>
+  </metadata>
+  <data name="copyLinkAddressToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 22</value>
+  </data>
+  <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
+    <value>Copy link address</value>
+  </data>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 26</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="folderLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="folderLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="folderLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 38</value>
+  </data>
+  <data name="folderLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="folderLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="folderLabel.Text" xml:space="preserve">
+    <value>&amp;Remote folders:</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
+    <value>folderLabel</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>447, 336</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAMMOAADDDgAAAAAAAAAA
+        AAD1p3f/9ad3//Wnd//1p3f/9ad3//Smdv/uoHD/9KV1//Sldf/0pXX/9aZ3//Wnd//1p3f/9ad3//Wn
+        d//4vZn/7Z9v/+2fb//tn2//7qBw/++hcf/sn27/45Zj/9iMWP/YjFj/z4NO/8h8Rv/MgEv/7Z9v/+2f
+        b//tn2//8reT/+WYZv/MgUv/zIFL/8yBS//lmGb/5Zhm/9mNWf/MgUv/zIFL/8yBS//cj1z/zoNN////
+        ///lmGb/5Zhm/+yyjP/ekV7/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn/0IRO////
+        //8BwyX//////+u7m//56+H/08Gr/+vFq/+vZSv/5raW/9aKVv/Wilb/jEUF/4xFBf+sYij/rGIo////
+        //8BwyX/AcMl/wHDJf///////////8f1////////r2Ur//DYx//Xmm//zoJN/4xFBf+MRQX/nFMX////
+        //8BwyX/AcMl/wHDJf8BwyX/AcMl/+/4/f+H4P///////69lK//x3tD/1Jx0/8Z7Rf+3gVT/jEUF////
+        //8BwyX/AcMl/wHDJf8BwyX/AcMl/wHDJf8BwyX/h+D//4fg//+vZSv/79zO/86Xbf++dDz/79zO/4xF
+        Bf////////////////8BwyX/AcMl/wHDJf///////////+/8//+NyMv/r2Ur/+TIsv/Jkmf/t200/+3a
+        zP+MRQX/yaWG/7dtNP//////AcMl/wHDJf8BwyX//////7/i9///////09TK/69lK/+/rJT/06mJ/8SM
+        Yf/w4tf/n1ca/59XGv+9lXL//////wHDJf8BwyX/AcMl///////f8Pv/7uDV/5x+WP+nXiP/nH5Y/5jB
+        xP/P8v3/h+D///////////////////////8BwyX/AcMl/wHDJf//////it3//59XGv+fVxr/n1ca/59X
+        Gv+fVxr/DcX//w3F//+H4P//h+D//4fg/////////////////////////////4rd////////n1ca/5dP
+        Ef+fVxr/+fTw/4fg//+H4P//h+D//zLE//8yxP//F7n//xe5//8Xuf//F7n//xe5//9c0v//////////
+        //+fVxr//////////////////////4fg//+H4P//XNL//1zS//9c0v//XNL//1zS//+H4P//////////
+        ////////6dvP////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAA==
+</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Panorama Folders</value>
+  </data>
+  <data name="&gt;&gt;back.Name" xml:space="preserve">
+    <value>back</value>
+  </data>
+  <data name="&gt;&gt;back.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;forward.Name" xml:space="preserve">
+    <value>forward</value>
+  </data>
+  <data name="&gt;&gt;forward.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;up.Name" xml:space="preserve">
+    <value>up</value>
+  </data>
+  <data name="&gt;&gt;up.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyLinkAddressToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaDirectoryPicker</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.zh-CHS.resx
@@ -1,0 +1,418 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="folderPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 54</value>
+  </data>
+  <data name="folderPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 241</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Name" xml:space="preserve">
+    <value>folderPanel</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>360, 304</value>
+  </data>
+  <data name="cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="cancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Name" xml:space="preserve">
+    <value>cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cancel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="open.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="open.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 304</value>
+  </data>
+  <data name="open.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="open.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="open.Text" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="&gt;&gt;open.Name" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="&gt;&gt;open.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;open.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;open.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="toolStrip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="back.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAElSURBVFhH7Y6xSgNBEIbv0SxS2NqkSWEnpBBLSZCAZQqL
+        gI0oIiSEI4IIgqRJiCGFBDtLwVcZmb1/uM3eRg3sTAjkg5+53Zm9b7I9O0nn8YMGiy/C0RaWS3Blhy83
+        XyCUmy7QzpdOGFa0dWHZumBEj/PhO6UKLyz1afn99/LhD1IHmjixB6kDVZWzh7kb0Kwc6FaRpkWgLAkH
+        Tu/fVM/QFoRDFhXqgubtlKwDdYnf5A39s0agXeXkZuKax9djt4ScuUrkB/7dJpH3UFZhOQ+E1f9BeLdp
+        +D10cXhAO1CtJ/YoZaD5nUbvlTRyN/n83wLMUfeZ6lcv7iF/+xUj+rAwFrRtOLwcEYfF8o2WHSLe2gJM
+        rZOTBFf2HFwMqdWfbW+BPenIsh9lGoeCmcAw0gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="back.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="back.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="back.Text" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="forward.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEySURBVFhH7ZaxS0JRFMbfn+bQ0OrS0uAWNERjCPLA0aFB
+        aIkkgsIsQQRBWpSKhhK3xqB/5cSn39H39LyX+rz3IfiDj+s759z7u3cz2LPzPHz8SNgeCz/9A7mGJb9E
+        L5DLJSpPI1kMW36wLoCw7R5LruHI/3RGv1J+/DIPuWh+ZgoV6UQ3nN+9T8RYo/UsoSYZa9O2Q5UNXlu+
+        f5292tVK3TIY8BUq46BxdvsWG1z3e51QO0cPy7quGsxTPeX0Zii+Q/UUa2CT4GVWfTHUzkHx5HowaWLd
+        NKWrl8QztE5lHN2YdsAqSduLs6lbBk3XocrG2rDNUJNMY/Atx/W+k1DhjqPLnmggLNa6s5UjboHICtvu
+        Oaw+CwKp/mbLDyrNRQ4OwpZoWPIL/kcUKs185HuyEwR/UFmHnV3u2vkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="forward.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="forward.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="forward.Text" xml:space="preserve">
+    <value>Forward</value>
+  </data>
+  <data name="up.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="toolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 7</value>
+  </data>
+  <data name="toolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 31</value>
+  </data>
+  <data name="toolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="toolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Name" xml:space="preserve">
+    <value>toolStrip</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="urlLink.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="urlLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 309</value>
+  </data>
+  <data name="urlLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 13</value>
+  </data>
+  <data name="urlLink.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="urlLink.Text" xml:space="preserve">
+    <value>&lt;placeholder&gt;</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Name" xml:space="preserve">
+    <value>urlLink</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;urlLink.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>115, 17</value>
+  </metadata>
+  <data name="copyLinkAddressToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 22</value>
+  </data>
+  <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
+    <value>Copy link address</value>
+  </data>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 26</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="folderLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="folderLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="folderLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 38</value>
+  </data>
+  <data name="folderLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="folderLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="folderLabel.Text" xml:space="preserve">
+    <value>&amp;Remote folders:</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
+    <value>folderLabel</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>447, 336</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAMMOAADDDgAAAAAAAAAA
+        AAD1p3f/9ad3//Wnd//1p3f/9ad3//Smdv/uoHD/9KV1//Sldf/0pXX/9aZ3//Wnd//1p3f/9ad3//Wn
+        d//4vZn/7Z9v/+2fb//tn2//7qBw/++hcf/sn27/45Zj/9iMWP/YjFj/z4NO/8h8Rv/MgEv/7Z9v/+2f
+        b//tn2//8reT/+WYZv/MgUv/zIFL/8yBS//lmGb/5Zhm/9mNWf/MgUv/zIFL/8yBS//cj1z/zoNN////
+        ///lmGb/5Zhm/+yyjP/ekV7/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn/0IRO////
+        //8BwyX//////+u7m//56+H/08Gr/+vFq/+vZSv/5raW/9aKVv/Wilb/jEUF/4xFBf+sYij/rGIo////
+        //8BwyX/AcMl/wHDJf///////////8f1////////r2Ur//DYx//Xmm//zoJN/4xFBf+MRQX/nFMX////
+        //8BwyX/AcMl/wHDJf8BwyX/AcMl/+/4/f+H4P///////69lK//x3tD/1Jx0/8Z7Rf+3gVT/jEUF////
+        //8BwyX/AcMl/wHDJf8BwyX/AcMl/wHDJf8BwyX/h+D//4fg//+vZSv/79zO/86Xbf++dDz/79zO/4xF
+        Bf////////////////8BwyX/AcMl/wHDJf///////////+/8//+NyMv/r2Ur/+TIsv/Jkmf/t200/+3a
+        zP+MRQX/yaWG/7dtNP//////AcMl/wHDJf8BwyX//////7/i9///////09TK/69lK/+/rJT/06mJ/8SM
+        Yf/w4tf/n1ca/59XGv+9lXL//////wHDJf8BwyX/AcMl///////f8Pv/7uDV/5x+WP+nXiP/nH5Y/5jB
+        xP/P8v3/h+D///////////////////////8BwyX/AcMl/wHDJf//////it3//59XGv+fVxr/n1ca/59X
+        Gv+fVxr/DcX//w3F//+H4P//h+D//4fg/////////////////////////////4rd////////n1ca/5dP
+        Ef+fVxr/+fTw/4fg//+H4P//h+D//zLE//8yxP//F7n//xe5//8Xuf//F7n//xe5//9c0v//////////
+        //+fVxr//////////////////////4fg//+H4P//XNL//1zS//9c0v//XNL//1zS//+H4P//////////
+        ////////6dvP////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAA==
+</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Panorama Folders</value>
+  </data>
+  <data name="&gt;&gt;back.Name" xml:space="preserve">
+    <value>back</value>
+  </data>
+  <data name="&gt;&gt;back.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;forward.Name" xml:space="preserve">
+    <value>forward</value>
+  </data>
+  <data name="&gt;&gt;forward.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;up.Name" xml:space="preserve">
+    <value>up</value>
+  </data>
+  <data name="&gt;&gt;up.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyLinkAddressToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaDirectoryPicker</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.ja.resx
@@ -1,0 +1,799 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="folderLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 36</value>
+  </data>
+  <data name="folderLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="folderLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="folderLabel.Text" xml:space="preserve">
+    <value>&amp;Remote folders:</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
+    <value>folderLabel</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <metadata name="treeViewIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="treeViewIcons.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADy
+        CgAAAk1TRnQBSQFMAgEBBAEAARABBQEQAQUBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ABQAP1QHc
+        Av8B7QrsARwB/wH0BEYBlAT/ARcFRgFvAQAC/wz0Af8G1QO0AbMBrQGzA9UB3AH/AfcBvArwAZIB6wH/
+        AigBhgG2AZQBFwEWAfQBFwElASkEKAFQAQAB9AHzCvEC8gHzAbQDswO0A7MBtAGzAa0CtAHcAf8BbQLw
+        AQkBBwH3AbUC7wEHAQkB8gEHAesB/wKYAbUB5gGuAUsBlAHjASUBlAFPAZcEmAEAAfEG7AfrAbwBtAmt
+        AbMBtAKLAQkB9AH/AesB8AEJAbQBrgGLAYYCrgGRAbQB8AHvAesE/wHWAa0BiwEcARYBJQFzAZgBCAT/
+        AQACUgFMCioBEgHrAbsBCQGLAQkDtAH/AosBrQK0AZkBGgL/Au8BBwG1Aa4EhgGuAfcBvAH3AewF/wHW
+        Aa0BiwHzAWIBAgEIBf8BUgF6AVIBoAh6AVIBoAEqARIBwwH/AYsBGQG0AbMBtAH/AooBrQHxAf8BwwF6
+        AfYC/wHrAQcB8AGRBIYBrgG8Ae8B9wf/AdYByAEZAfwBSAEIBf8BUgF6AVIBoAh6AVIBoAEqARIBoAH/
+        AYsBGQG0Aa0BtAH/AqYBiwEZAv8BmgEaAv8B9wEHAbwBtAGuAoYB6wG1AfABkgHsB/8B1gHIAd0B/AFI
+        AQgF/wFSAXoBUgmgAVgBoAEqARIBoAHDAYsB8QG0Aa0B8QH/AbUCiwP/AZoBGgP/Ae0B7wHwAbQC6wG0
+        AfIB7wEHCP8B1gP8AUgBCAX/AVIBegFSCaABegGgASoB6gH2AZkBiwEJAbQBrQHxAf8BtQKmAv8B9gF6
+        ARoD/wH3AQcB8AO0AbUB8gHsAfcJ/wHWAvwBSAEIBf8BUgF6AVIJoAF6AaABKgHqAf8BvAGLArUBtAEZ
+        Av8BtAHxAv8BGgF6AcMD/wHzAu8E8gHvAQcB8gn/Ad0ByAHdAU8BCAX/AVIBegFSCf8BmgH/ASoBbQHy
+        Aa4BiwGuAZkBwwH2BP8B9gGaAXoBGgX/Ae8B9wT/AewBBwr/AbwBbAH/AU8BCAX/AVIBoAGaDFIB7AWL
+        AZoBegSaAXoBmgEaBv8B8AHvAQcC/wHvAfcB8Qr/AQgBAgKYAfIF/wFSBqAF/wEqAeoBBwL/AYsBpgGL
+        Af8B9gLDApoBGgHDAfYI/wEHAewC/wHqAbwL/wHxAXIBAgHyBv8BUgH/BKAB/wVSAUwDAAL/AYsR/wHz
+        Ae8B7QL/AesBBwH0C/8B8gECAfIG/wEAAVIE/wFSAf8BAAH/BgAC/wHxEf8B7wFtAZIC8wHsAesBvAv/
+        AfMBTwHzBv8CAARSAf8JABT/AQcBrgLrA0oBBxT/EAABQgFNAT4HAAE+AwABKAMAAUADAAEgAwABAQEA
+        AQEGAAEBFgAD/4cAAYAHAAGABwABgAcAAYBIAAEHBgABgAG/BgABwQH/BgAC/ws=
+</value>
+  </data>
+  <metadata name="fileIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>127, 17</value>
+  </metadata>
+  <data name="fileIcons.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAA0
+        CQAAAk1TRnQBSQFMAgEBAgEAAfABBAHwAQQBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAARADAAEBAQABCAYAAQQYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD/wIADu8FAAGuAWwKZiEA
+        AQcM8gHvBQAB9AH/CRkB1SEAAQcM/wHvBQAB9AH/BxkByAEZAdUhAAEHAf8K7AH/Ae8FAAH0Av8BGQP0
+        AYsBzgKnAdUhAAEHAf8BBwj0AewB/wHvBQAF/wH0Af8BxwHVAQkBGQHVIQABBwH/AQcC/wGTAv8CmAH0
+        AewB/wHvBQAG/wHHAc4BpwH0ARkB1SEAAQcB/wEHAf8BkwEWAf8B1gHhAdYB9AHsAf8B7wEABdUDtAL/
+        Ac0B3AH/AfQBGQHWIQABBwH/AQcB/wGgAZMC/wHWAf8B9AHsAf8B7wIAAgkBrQG0Aq0BswH/AfQB1QGt
+        Af8C9AEJIQABBwH/AQcH/wH0AewB/wHvAgACCQGtAbQCpgGtBv8B9AEJIQABBwH/AQcItQHsAf8B7wIA
+        AbsBCQKtAf8BiwG0Bv8B9AEJIQABBwH/AQcBtQGaBrUB7AH/Ae8CAAK0AQABtAH/AbsI/wEJIQABBwH/
+        CQcB7AHyAe8BAAG0AosBtAn/Aa4CbCEAAQcJ/wG8A+8CAAHPAbQBAAn/ARkB3QHyIQABBwn/AbwB/wHv
+        BgAJ/wEZAfIiAAEHCfQBvAHvBwAJ/wHyIwAKBwG8NAABQgFNAT4HAAE+AwABKAMAAUADAAEQAwABAQEA
+        AQEFAAGAFwAD/wEAAYABAQHwBQABgAEBAfAFAAGAAQEB8AUAAYABAQHwBQABgAEBAfAFAAGAAQEB8AUA
+        AYABAQYAAYABAQGABQABgAEBAYAFAAGAAQEBgAUAAYABAQGQBQABgAEBBgABgAEBAZAFAAGAAQMB8AEB
+        BAABgAEHAfABAwQAAYABDwL/BAAL
+</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="versionOptions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="versionOptions.Items" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="versionOptions.Items1" xml:space="preserve">
+    <value>Most recent</value>
+  </data>
+  <data name="versionOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>574, 26</value>
+  </data>
+  <data name="versionOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="versionOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="versionOptions.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Name" xml:space="preserve">
+    <value>versionOptions</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="open.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="open.Location" type="System.Drawing.Point, System.Drawing">
+    <value>556, 530</value>
+  </data>
+  <data name="open.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="open.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="open.Text" xml:space="preserve">
+    <value>&amp;Open</value>
+  </data>
+  <data name="&gt;&gt;open.Name" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="&gt;&gt;open.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;open.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;open.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>637, 530</value>
+  </data>
+  <data name="cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="cancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Name" xml:space="preserve">
+    <value>cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cancel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="versionLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="versionLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="versionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>571, 10</value>
+  </data>
+  <data name="versionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
+  </data>
+  <data name="versionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="versionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="versionLabel.Text" xml:space="preserve">
+    <value>&amp;Versions:</value>
+  </data>
+  <data name="versionLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Name" xml:space="preserve">
+    <value>versionLabel</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="browserSplitContainer.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="browserSplitContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="browserSplitContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Name" xml:space="preserve">
+    <value>browserSplitContainer.Panel1</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Parent" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="noFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="noFiles.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="noFiles.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9.75pt</value>
+  </data>
+  <data name="noFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>115, 209</value>
+  </data>
+  <data name="noFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 16</value>
+  </data>
+  <data name="noFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="noFiles.Text" xml:space="preserve">
+    <value>There are no Skyline files in this folder</value>
+  </data>
+  <data name="noFiles.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Name" xml:space="preserve">
+    <value>noFiles</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Parent" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;noFiles.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="colName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="colName.Width" type="System.Int32, mscorlib">
+    <value>175</value>
+  </data>
+  <data name="colSize.Text" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="colSize.Width" type="System.Int32, mscorlib">
+    <value>75</value>
+  </data>
+  <data name="colVersions.Text" xml:space="preserve">
+    <value>Versions</value>
+  </data>
+  <data name="colVersions.Width" type="System.Int32, mscorlib">
+    <value>52</value>
+  </data>
+  <data name="colReplacedBy.Text" xml:space="preserve">
+    <value>Replaced By</value>
+  </data>
+  <data name="colReplacedBy.Width" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
+  <data name="colCreated.Text" xml:space="preserve">
+    <value>Created</value>
+  </data>
+  <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="listView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="listView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>462, 472</value>
+  </data>
+  <data name="listView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;listView.Name" xml:space="preserve">
+    <value>listView</value>
+  </data>
+  <data name="&gt;&gt;listView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;listView.Parent" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;listView.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Name" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Parent" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="browserSplitContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>702, 472</value>
+  </data>
+  <data name="browserSplitContainer.SplitterDistance" type="System.Int32, mscorlib">
+    <value>237</value>
+  </data>
+  <data name="browserSplitContainer.SplitterWidth" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="browserSplitContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Name" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Parent" xml:space="preserve">
+    <value>browserPanel</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="browserPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="browserPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 52</value>
+  </data>
+  <data name="browserPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>702, 472</value>
+  </data>
+  <data name="browserPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Name" xml:space="preserve">
+    <value>browserPanel</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <metadata name="navToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>237, 17</value>
+  </metadata>
+  <data name="navToolStrip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="back.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAElSURBVFhH7Y6xSgNBEIbv0SxS2NqkSWEnpBBLSZCAZQqL
+        gI0oIiSEI4IIgqRJiCGFBDtLwVcZmb1/uM3eRg3sTAjkg5+53Zm9b7I9O0nn8YMGiy/C0RaWS3Blhy83
+        XyCUmy7QzpdOGFa0dWHZumBEj/PhO6UKLyz1afn99/LhD1IHmjixB6kDVZWzh7kb0Kwc6FaRpkWgLAkH
+        Tu/fVM/QFoRDFhXqgubtlKwDdYnf5A39s0agXeXkZuKax9djt4ScuUrkB/7dJpH3UFZhOQ+E1f9BeLdp
+        +D10cXhAO1CtJ/YoZaD5nUbvlTRyN/n83wLMUfeZ6lcv7iF/+xUj+rAwFrRtOLwcEYfF8o2WHSLe2gJM
+        rZOTBFf2HFwMqdWfbW+BPenIsh9lGoeCmcAw0gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="back.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="back.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="back.Text" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="forward.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEySURBVFhH7ZaxS0JRFMbfn+bQ0OrS0uAWNERjCPLA0aFB
+        aIkkgsIsQQRBWpSKhhK3xqB/5cSn39H39LyX+rz3IfiDj+s759z7u3cz2LPzPHz8SNgeCz/9A7mGJb9E
+        L5DLJSpPI1kMW36wLoCw7R5LruHI/3RGv1J+/DIPuWh+ZgoV6UQ3nN+9T8RYo/UsoSYZa9O2Q5UNXlu+
+        f5292tVK3TIY8BUq46BxdvsWG1z3e51QO0cPy7quGsxTPeX0Zii+Q/UUa2CT4GVWfTHUzkHx5HowaWLd
+        NKWrl8QztE5lHN2YdsAqSduLs6lbBk3XocrG2rDNUJNMY/Atx/W+k1DhjqPLnmggLNa6s5UjboHICtvu
+        Oaw+CwKp/mbLDyrNRQ4OwpZoWPIL/kcUKs185HuyEwR/UFmHnV3u2vkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="forward.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="forward.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="forward.Text" xml:space="preserve">
+    <value>Forward</value>
+  </data>
+  <data name="up.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADVSURBVFhH5ZXBDcIwEARdGqWklJSSF3XkTTV0ABzaQydn
+        gzhjs0JZaR4kwTOPSCl/vWlZbwZ+/nYul0TUcge3x46JI3hszJgwMgM83ndMyBgSwUQMl3eNmGYu26Nr
+        xFOeCKjlDo7L7ZSUOyzAwLGfzeSvgEQEE0dw/Pu1yh0mjkDD5/LWCCZkQLed3dwEPK5lqGU158s1/1Iy
+        EaOW4e/fj8n2kAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAGBKwrFzGcHnTZ/eAK+UO
+        mzeHG7y1XsoAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="up.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="up.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="navToolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 2</value>
+  </data>
+  <data name="navToolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 31</value>
+  </data>
+  <data name="navToolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="navToolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Name" xml:space="preserve">
+    <value>navToolStrip</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="urlLink.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>335, 17</value>
+  </metadata>
+  <data name="copyLinkAddressToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 22</value>
+  </data>
+  <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
+    <value>Copy link address</value>
+  </data>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 26</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="urlLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 535</value>
+  </data>
+  <data name="urlLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>538, 13</value>
+  </data>
+  <data name="urlLink.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="urlLink.Text" xml:space="preserve">
+    <value>&lt;placeholder&gt;</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Name" xml:space="preserve">
+    <value>urlLink</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;urlLink.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>52</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>724, 562</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAMMOAADDDgAAAAAAAAAA
+        AAD1p3f/9ad3//Wnd//1p3f/9ad3//Smdv/uoHD/9KV1//Sldf/0pXX/9aZ3//Wnd//1p3f/9ad3//Wn
+        d//4vZn/7Z9v/+2fb//tn2//7qBw/++hcf/sn27/45Zj/9iMWP/YjFj/z4NO/8h8Rv/MgEv/7Z9v/+2f
+        b//tn2//8reT/+WYZv/MgUv/zIFL/8yBS//lmGb/5Zhm/9mNWf/MgUv//////8yBS//cj1z/zoNN/8B1
+        Pv/lmGb/5Zhm/+yyjP/ekV7/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn//////wHDJf//////0IRO/9qO
+        Wv+kWx//rGMo/+u7m//56+H/08Gr/+vFq/+vZSv/5raW/9aKVv/Wilb//////wHDJf8BwyX/AcMl////
+        //+sYij/xHhB/5G/1v9Wxf///////1zS////////r2Ur//DYx//Xmm///////wHDJf8BwyX/AcMl/wHD
+        Jf8BwyX//////7htNP/f8fv/Gsr//+/4/f8ayv///////69lK//x3tD//////wHDJf8BwyX/AcMl/wHD
+        Jf8BwyX/AcMl/wHDJf///////////xrK//9c0v//Gsr//1zS//+vZSv/79zO/86Xbf///////////wHD
+        Jf8BwyX/AcMl////////////n1ca//////9Wxf//XNL//+/8//+NyMv/r2Ur/+TIsv/Jkmf/t200////
+        //8BwyX/AcMl/wHDJf//////k0sN/5NLDf/3/P7/Gsr//1zS////////09TK/69lK/+/rJT/06mJ/8SM
+        Yf//////AcMl/wHDJf8BwyX//////72Vcv/p3ND//////xrK///f8Pv/7uDV/5x+WP+nXiP/nH5Y/5jB
+        xP981P3/9/3//wHDJf8BwyX/AcMl///////v+f3//////1bF//8ayv///////59XGv+fVxr/n1ca/59X
+        Gv+fVxr/o+r//////////////////////////////////1bF//8ayv//VsX/////////////n1ca/5dP
+        Ef+fVxr/+fTw/xrK//8ayv//O83//03Q//87zf//O83//xrK//8ayv//VsX/////////////////////
+        //+fVxr/////////////////XNL//1bF//9c0v//XNL//1bF//9Wxf//////////////////////////
+        ////////6dvP////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAA==
+</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Panorama Folders</value>
+  </data>
+  <data name="&gt;&gt;treeViewIcons.Name" xml:space="preserve">
+    <value>treeViewIcons</value>
+  </data>
+  <data name="&gt;&gt;treeViewIcons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fileIcons.Name" xml:space="preserve">
+    <value>fileIcons</value>
+  </data>
+  <data name="&gt;&gt;fileIcons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colName.Name" xml:space="preserve">
+    <value>colName</value>
+  </data>
+  <data name="&gt;&gt;colName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colSize.Name" xml:space="preserve">
+    <value>colSize</value>
+  </data>
+  <data name="&gt;&gt;colSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colVersions.Name" xml:space="preserve">
+    <value>colVersions</value>
+  </data>
+  <data name="&gt;&gt;colVersions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colReplacedBy.Name" xml:space="preserve">
+    <value>colReplacedBy</value>
+  </data>
+  <data name="&gt;&gt;colReplacedBy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colCreated.Name" xml:space="preserve">
+    <value>colCreated</value>
+  </data>
+  <data name="&gt;&gt;colCreated.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;back.Name" xml:space="preserve">
+    <value>back</value>
+  </data>
+  <data name="&gt;&gt;back.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;forward.Name" xml:space="preserve">
+    <value>forward</value>
+  </data>
+  <data name="&gt;&gt;forward.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;up.Name" xml:space="preserve">
+    <value>up</value>
+  </data>
+  <data name="&gt;&gt;up.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyLinkAddressToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaFilePicker</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.zh-CHS.resx
@@ -1,0 +1,799 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="folderLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 36</value>
+  </data>
+  <data name="folderLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="folderLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="folderLabel.Text" xml:space="preserve">
+    <value>&amp;Remote folders:</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
+    <value>folderLabel</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <metadata name="treeViewIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="treeViewIcons.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADy
+        CgAAAk1TRnQBSQFMAgEBBAEAARABBQEQAQUBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ABQAP1QHc
+        Av8B7QrsARwB/wH0BEYBlAT/ARcFRgFvAQAC/wz0Af8G1QO0AbMBrQGzA9UB3AH/AfcBvArwAZIB6wH/
+        AigBhgG2AZQBFwEWAfQBFwElASkEKAFQAQAB9AHzCvEC8gHzAbQDswO0A7MBtAGzAa0CtAHcAf8BbQLw
+        AQkBBwH3AbUC7wEHAQkB8gEHAesB/wKYAbUB5gGuAUsBlAHjASUBlAFPAZcEmAEAAfEG7AfrAbwBtAmt
+        AbMBtAKLAQkB9AH/AesB8AEJAbQBrgGLAYYCrgGRAbQB8AHvAesE/wHWAa0BiwEcARYBJQFzAZgBCAT/
+        AQACUgFMCioBEgHrAbsBCQGLAQkDtAH/AosBrQK0AZkBGgL/Au8BBwG1Aa4EhgGuAfcBvAH3AewF/wHW
+        Aa0BiwHzAWIBAgEIBf8BUgF6AVIBoAh6AVIBoAEqARIBwwH/AYsBGQG0AbMBtAH/AooBrQHxAf8BwwF6
+        AfYC/wHrAQcB8AGRBIYBrgG8Ae8B9wf/AdYByAEZAfwBSAEIBf8BUgF6AVIBoAh6AVIBoAEqARIBoAH/
+        AYsBGQG0Aa0BtAH/AqYBiwEZAv8BmgEaAv8B9wEHAbwBtAGuAoYB6wG1AfABkgHsB/8B1gHIAd0B/AFI
+        AQgF/wFSAXoBUgmgAVgBoAEqARIBoAHDAYsB8QG0Aa0B8QH/AbUCiwP/AZoBGgP/Ae0B7wHwAbQC6wG0
+        AfIB7wEHCP8B1gP8AUgBCAX/AVIBegFSCaABegGgASoB6gH2AZkBiwEJAbQBrQHxAf8BtQKmAv8B9gF6
+        ARoD/wH3AQcB8AO0AbUB8gHsAfcJ/wHWAvwBSAEIBf8BUgF6AVIJoAF6AaABKgHqAf8BvAGLArUBtAEZ
+        Av8BtAHxAv8BGgF6AcMD/wHzAu8E8gHvAQcB8gn/Ad0ByAHdAU8BCAX/AVIBegFSCf8BmgH/ASoBbQHy
+        Aa4BiwGuAZkBwwH2BP8B9gGaAXoBGgX/Ae8B9wT/AewBBwr/AbwBbAH/AU8BCAX/AVIBoAGaDFIB7AWL
+        AZoBegSaAXoBmgEaBv8B8AHvAQcC/wHvAfcB8Qr/AQgBAgKYAfIF/wFSBqAF/wEqAeoBBwL/AYsBpgGL
+        Af8B9gLDApoBGgHDAfYI/wEHAewC/wHqAbwL/wHxAXIBAgHyBv8BUgH/BKAB/wVSAUwDAAL/AYsR/wHz
+        Ae8B7QL/AesBBwH0C/8B8gECAfIG/wEAAVIE/wFSAf8BAAH/BgAC/wHxEf8B7wFtAZIC8wHsAesBvAv/
+        AfMBTwHzBv8CAARSAf8JABT/AQcBrgLrA0oBBxT/EAABQgFNAT4HAAE+AwABKAMAAUADAAEgAwABAQEA
+        AQEGAAEBFgAD/4cAAYAHAAGABwABgAcAAYBIAAEHBgABgAG/BgABwQH/BgAC/ws=
+</value>
+  </data>
+  <metadata name="fileIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>127, 17</value>
+  </metadata>
+  <data name="fileIcons.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAA0
+        CQAAAk1TRnQBSQFMAgEBAgEAAfABBAHwAQQBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAARADAAEBAQABCAYAAQQYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD/wIADu8FAAGuAWwKZiEA
+        AQcM8gHvBQAB9AH/CRkB1SEAAQcM/wHvBQAB9AH/BxkByAEZAdUhAAEHAf8K7AH/Ae8FAAH0Av8BGQP0
+        AYsBzgKnAdUhAAEHAf8BBwj0AewB/wHvBQAF/wH0Af8BxwHVAQkBGQHVIQABBwH/AQcC/wGTAv8CmAH0
+        AewB/wHvBQAG/wHHAc4BpwH0ARkB1SEAAQcB/wEHAf8BkwEWAf8B1gHhAdYB9AHsAf8B7wEABdUDtAL/
+        Ac0B3AH/AfQBGQHWIQABBwH/AQcB/wGgAZMC/wHWAf8B9AHsAf8B7wIAAgkBrQG0Aq0BswH/AfQB1QGt
+        Af8C9AEJIQABBwH/AQcH/wH0AewB/wHvAgACCQGtAbQCpgGtBv8B9AEJIQABBwH/AQcItQHsAf8B7wIA
+        AbsBCQKtAf8BiwG0Bv8B9AEJIQABBwH/AQcBtQGaBrUB7AH/Ae8CAAK0AQABtAH/AbsI/wEJIQABBwH/
+        CQcB7AHyAe8BAAG0AosBtAn/Aa4CbCEAAQcJ/wG8A+8CAAHPAbQBAAn/ARkB3QHyIQABBwn/AbwB/wHv
+        BgAJ/wEZAfIiAAEHCfQBvAHvBwAJ/wHyIwAKBwG8NAABQgFNAT4HAAE+AwABKAMAAUADAAEQAwABAQEA
+        AQEFAAGAFwAD/wEAAYABAQHwBQABgAEBAfAFAAGAAQEB8AUAAYABAQHwBQABgAEBAfAFAAGAAQEB8AUA
+        AYABAQYAAYABAQGABQABgAEBAYAFAAGAAQEBgAUAAYABAQGQBQABgAEBBgABgAEBAZAFAAGAAQMB8AEB
+        BAABgAEHAfABAwQAAYABDwL/BAAL
+</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="versionOptions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="versionOptions.Items" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="versionOptions.Items1" xml:space="preserve">
+    <value>Most recent</value>
+  </data>
+  <data name="versionOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>574, 26</value>
+  </data>
+  <data name="versionOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="versionOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="versionOptions.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Name" xml:space="preserve">
+    <value>versionOptions</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="open.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="open.Location" type="System.Drawing.Point, System.Drawing">
+    <value>556, 530</value>
+  </data>
+  <data name="open.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="open.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="open.Text" xml:space="preserve">
+    <value>&amp;Open</value>
+  </data>
+  <data name="&gt;&gt;open.Name" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="&gt;&gt;open.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;open.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;open.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>637, 530</value>
+  </data>
+  <data name="cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="cancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Name" xml:space="preserve">
+    <value>cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cancel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="versionLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="versionLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="versionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>571, 10</value>
+  </data>
+  <data name="versionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
+  </data>
+  <data name="versionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="versionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="versionLabel.Text" xml:space="preserve">
+    <value>&amp;Versions:</value>
+  </data>
+  <data name="versionLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Name" xml:space="preserve">
+    <value>versionLabel</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="browserSplitContainer.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="browserSplitContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="browserSplitContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Name" xml:space="preserve">
+    <value>browserSplitContainer.Panel1</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Parent" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="noFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="noFiles.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="noFiles.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9.75pt</value>
+  </data>
+  <data name="noFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>115, 209</value>
+  </data>
+  <data name="noFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 16</value>
+  </data>
+  <data name="noFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="noFiles.Text" xml:space="preserve">
+    <value>There are no Skyline files in this folder</value>
+  </data>
+  <data name="noFiles.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Name" xml:space="preserve">
+    <value>noFiles</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Parent" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;noFiles.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="colName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="colName.Width" type="System.Int32, mscorlib">
+    <value>175</value>
+  </data>
+  <data name="colSize.Text" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="colSize.Width" type="System.Int32, mscorlib">
+    <value>75</value>
+  </data>
+  <data name="colVersions.Text" xml:space="preserve">
+    <value>Versions</value>
+  </data>
+  <data name="colVersions.Width" type="System.Int32, mscorlib">
+    <value>52</value>
+  </data>
+  <data name="colReplacedBy.Text" xml:space="preserve">
+    <value>Replaced By</value>
+  </data>
+  <data name="colReplacedBy.Width" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
+  <data name="colCreated.Text" xml:space="preserve">
+    <value>Created</value>
+  </data>
+  <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="listView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="listView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>462, 472</value>
+  </data>
+  <data name="listView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;listView.Name" xml:space="preserve">
+    <value>listView</value>
+  </data>
+  <data name="&gt;&gt;listView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;listView.Parent" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;listView.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Name" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Parent" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="browserSplitContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>702, 472</value>
+  </data>
+  <data name="browserSplitContainer.SplitterDistance" type="System.Int32, mscorlib">
+    <value>237</value>
+  </data>
+  <data name="browserSplitContainer.SplitterWidth" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="browserSplitContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Name" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Parent" xml:space="preserve">
+    <value>browserPanel</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="browserPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="browserPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 52</value>
+  </data>
+  <data name="browserPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>702, 472</value>
+  </data>
+  <data name="browserPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Name" xml:space="preserve">
+    <value>browserPanel</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <metadata name="navToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>237, 17</value>
+  </metadata>
+  <data name="navToolStrip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="back.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAElSURBVFhH7Y6xSgNBEIbv0SxS2NqkSWEnpBBLSZCAZQqL
+        gI0oIiSEI4IIgqRJiCGFBDtLwVcZmb1/uM3eRg3sTAjkg5+53Zm9b7I9O0nn8YMGiy/C0RaWS3Blhy83
+        XyCUmy7QzpdOGFa0dWHZumBEj/PhO6UKLyz1afn99/LhD1IHmjixB6kDVZWzh7kb0Kwc6FaRpkWgLAkH
+        Tu/fVM/QFoRDFhXqgubtlKwDdYnf5A39s0agXeXkZuKax9djt4ScuUrkB/7dJpH3UFZhOQ+E1f9BeLdp
+        +D10cXhAO1CtJ/YoZaD5nUbvlTRyN/n83wLMUfeZ6lcv7iF/+xUj+rAwFrRtOLwcEYfF8o2WHSLe2gJM
+        rZOTBFf2HFwMqdWfbW+BPenIsh9lGoeCmcAw0gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="back.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="back.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="back.Text" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="forward.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEySURBVFhH7ZaxS0JRFMbfn+bQ0OrS0uAWNERjCPLA0aFB
+        aIkkgsIsQQRBWpSKhhK3xqB/5cSn39H39LyX+rz3IfiDj+s759z7u3cz2LPzPHz8SNgeCz/9A7mGJb9E
+        L5DLJSpPI1kMW36wLoCw7R5LruHI/3RGv1J+/DIPuWh+ZgoV6UQ3nN+9T8RYo/UsoSYZa9O2Q5UNXlu+
+        f5292tVK3TIY8BUq46BxdvsWG1z3e51QO0cPy7quGsxTPeX0Zii+Q/UUa2CT4GVWfTHUzkHx5HowaWLd
+        NKWrl8QztE5lHN2YdsAqSduLs6lbBk3XocrG2rDNUJNMY/Atx/W+k1DhjqPLnmggLNa6s5UjboHICtvu
+        Oaw+CwKp/mbLDyrNRQ4OwpZoWPIL/kcUKs185HuyEwR/UFmHnV3u2vkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="forward.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="forward.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="forward.Text" xml:space="preserve">
+    <value>Forward</value>
+  </data>
+  <data name="up.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADVSURBVFhH5ZXBDcIwEARdGqWklJSSF3XkTTV0ABzaQydn
+        gzhjs0JZaR4kwTOPSCl/vWlZbwZ+/nYul0TUcge3x46JI3hszJgwMgM83ndMyBgSwUQMl3eNmGYu26Nr
+        xFOeCKjlDo7L7ZSUOyzAwLGfzeSvgEQEE0dw/Pu1yh0mjkDD5/LWCCZkQLed3dwEPK5lqGU158s1/1Iy
+        EaOW4e/fj8n2kAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAGBKwrFzGcHnTZ/eAK+UO
+        mzeHG7y1XsoAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="up.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="up.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="navToolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 2</value>
+  </data>
+  <data name="navToolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 31</value>
+  </data>
+  <data name="navToolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="navToolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Name" xml:space="preserve">
+    <value>navToolStrip</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="urlLink.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>335, 17</value>
+  </metadata>
+  <data name="copyLinkAddressToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 22</value>
+  </data>
+  <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
+    <value>Copy link address</value>
+  </data>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 26</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="urlLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 535</value>
+  </data>
+  <data name="urlLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>538, 13</value>
+  </data>
+  <data name="urlLink.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="urlLink.Text" xml:space="preserve">
+    <value>&lt;placeholder&gt;</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Name" xml:space="preserve">
+    <value>urlLink</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;urlLink.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>52</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>724, 562</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAMMOAADDDgAAAAAAAAAA
+        AAD1p3f/9ad3//Wnd//1p3f/9ad3//Smdv/uoHD/9KV1//Sldf/0pXX/9aZ3//Wnd//1p3f/9ad3//Wn
+        d//4vZn/7Z9v/+2fb//tn2//7qBw/++hcf/sn27/45Zj/9iMWP/YjFj/z4NO/8h8Rv/MgEv/7Z9v/+2f
+        b//tn2//8reT/+WYZv/MgUv/zIFL/8yBS//lmGb/5Zhm/9mNWf/MgUv//////8yBS//cj1z/zoNN/8B1
+        Pv/lmGb/5Zhm/+yyjP/ekV7/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn//////wHDJf//////0IRO/9qO
+        Wv+kWx//rGMo/+u7m//56+H/08Gr/+vFq/+vZSv/5raW/9aKVv/Wilb//////wHDJf8BwyX/AcMl////
+        //+sYij/xHhB/5G/1v9Wxf///////1zS////////r2Ur//DYx//Xmm///////wHDJf8BwyX/AcMl/wHD
+        Jf8BwyX//////7htNP/f8fv/Gsr//+/4/f8ayv///////69lK//x3tD//////wHDJf8BwyX/AcMl/wHD
+        Jf8BwyX/AcMl/wHDJf///////////xrK//9c0v//Gsr//1zS//+vZSv/79zO/86Xbf///////////wHD
+        Jf8BwyX/AcMl////////////n1ca//////9Wxf//XNL//+/8//+NyMv/r2Ur/+TIsv/Jkmf/t200////
+        //8BwyX/AcMl/wHDJf//////k0sN/5NLDf/3/P7/Gsr//1zS////////09TK/69lK/+/rJT/06mJ/8SM
+        Yf//////AcMl/wHDJf8BwyX//////72Vcv/p3ND//////xrK///f8Pv/7uDV/5x+WP+nXiP/nH5Y/5jB
+        xP981P3/9/3//wHDJf8BwyX/AcMl///////v+f3//////1bF//8ayv///////59XGv+fVxr/n1ca/59X
+        Gv+fVxr/o+r//////////////////////////////////1bF//8ayv//VsX/////////////n1ca/5dP
+        Ef+fVxr/+fTw/xrK//8ayv//O83//03Q//87zf//O83//xrK//8ayv//VsX/////////////////////
+        //+fVxr/////////////////XNL//1bF//9c0v//XNL//1bF//9Wxf//////////////////////////
+        ////////6dvP////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAA==
+</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Panorama Folders</value>
+  </data>
+  <data name="&gt;&gt;treeViewIcons.Name" xml:space="preserve">
+    <value>treeViewIcons</value>
+  </data>
+  <data name="&gt;&gt;treeViewIcons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fileIcons.Name" xml:space="preserve">
+    <value>fileIcons</value>
+  </data>
+  <data name="&gt;&gt;fileIcons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colName.Name" xml:space="preserve">
+    <value>colName</value>
+  </data>
+  <data name="&gt;&gt;colName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colSize.Name" xml:space="preserve">
+    <value>colSize</value>
+  </data>
+  <data name="&gt;&gt;colSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colVersions.Name" xml:space="preserve">
+    <value>colVersions</value>
+  </data>
+  <data name="&gt;&gt;colVersions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colReplacedBy.Name" xml:space="preserve">
+    <value>colReplacedBy</value>
+  </data>
+  <data name="&gt;&gt;colReplacedBy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colCreated.Name" xml:space="preserve">
+    <value>colCreated</value>
+  </data>
+  <data name="&gt;&gt;colCreated.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;back.Name" xml:space="preserve">
+    <value>back</value>
+  </data>
+  <data name="&gt;&gt;back.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;forward.Name" xml:space="preserve">
+    <value>forward</value>
+  </data>
+  <data name="&gt;&gt;forward.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;up.Name" xml:space="preserve">
+    <value>up</value>
+  </data>
+  <data name="&gt;&gt;up.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyLinkAddressToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaFilePicker</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.ja.resx
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="imageList1.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADy
+        CgAAAk1TRnQBSQFMAgEBBAEAAagBAAGoAQABEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ABQAP1QHc
+        Av8B7QrsARwB/wH0BEYBlAT/ARcFRgFvAQAC/wz0Af8G1QO0AbMBrQGzA9UB3AH/AfcBvArwAZIB6wH/
+        AigBhgG2AZQBFwEWAfQBFwElASkEKAFQAQAB9AHzCvEC8gHzAbQDswO0A7MBtAGzAa0CtAHcAf8BbQLw
+        AQkBBwH3AbUC7wEHAQkB8gEHAesB/wKYAbUB5gGuAUsBlAHjASUBlAFPAZcEmAEAAfEG7AfrAbwBtAmt
+        AbMBtAKLAQkB9AH/AesB8AEJAbQBrgGLAYYCrgGRAbQB8AHvAesE/wHWAa0BiwEcARYBJQFzAZgBCAT/
+        AQACUgFMCioBEgHrAbsBCQGLAQkDtAH/AosBrQK0AZkBGgL/Au8BBwG1Aa4EhgGuAfcBvAH3AewF/wHW
+        Aa0BiwHzAWIBAgEIBf8BUgF6AVIBoAh6AVIBoAEqARIBwwH/AYsBGQG0AbMBtAH/AooBrQHxAf8BwwF6
+        AfYC/wHrAQcB8AGRBIYBrgG8Ae8B9wf/AdYByAEZAfwBSAEIBf8BUgF6AVIBoAh6AVIBoAEqARIBoAH/
+        AYsBGQG0Aa0BtAH/AqYBiwEZAv8BmgEaAv8B9wEHAbwBtAGuAoYB6wG1AfABkgHsB/8B1gHIAd0B/AFI
+        AQgF/wFSAXoBUgmgAVgBoAEqARIBoAHDAYsB8QG0Aa0B8QH/AbUCiwP/AZoBGgP/Ae0B7wHwAbQC6wG0
+        AfIB7wEHCP8B1gP8AUgBCAX/AVIBegFSCaABegGgASoB6gH2AZkBiwEJAbQBrQHxAf8BtQKmAv8B9gF6
+        ARoD/wH3AQcB8AO0AbUB8gHsAfcJ/wHWAvwBSAEIBf8BUgF6AVIJoAF6AaABKgHqAf8BvAGLArUBtAEZ
+        Av8BtAHxAv8BGgF6AcMD/wHzAu8E8gHvAQcB8gn/Ad0ByAHdAU8BCAX/AVIBegFSCf8BmgH/ASoBbQHy
+        Aa4BiwGuAZkBwwH2BP8B9gGaAXoBGgX/Ae8B9wT/AewBBwr/AbwBbAH/AU8BCAX/AVIBoAGaDFIB7AWL
+        AZoBegSaAXoBmgEaBv8B8AHvAQcC/wHvAfcB8Qr/AQgBAgKYAfIF/wFSBqAF/wEqAeoBBwL/AYsBpgGL
+        Af8B9gLDApoBGgHDAfYI/wEHAewC/wHqAbwL/wHxAXIBAgHyBv8BUgH/BKAB/wVSAUwDAAL/AYsR/wHz
+        Ae8B7QL/AesBBwH0C/8B8gECAfIG/wEAAVIE/wFSAf8BAAH/BgAC/wHxEf8B7wFtAZIC8wHsAesBvAv/
+        AfMBTwHzBv8CAARSAf8JABT/AQcBrgLrA0oBBxT/EAABQgFNAT4HAAE+AwABKAMAAUADAAEgAwABAQEA
+        AQEGAAEBFgAD/4cAAYAHAAGABwABgAcAAYBIAAEHBgABgAG/BgABwQH/BgAC/ws=
+</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="treeView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="treeView.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="treeView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="treeView.SelectedImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="treeView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>425, 203</value>
+  </data>
+  <data name="treeView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;treeView.Name" xml:space="preserve">
+    <value>treeView</value>
+  </data>
+  <data name="&gt;&gt;treeView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;treeView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;treeView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>425, 203</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaFolderBrowser</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.zh-CHS.resx
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="imageList1.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADy
+        CgAAAk1TRnQBSQFMAgEBBAEAAagBAAGoAQABEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ABQAP1QHc
+        Av8B7QrsARwB/wH0BEYBlAT/ARcFRgFvAQAC/wz0Af8G1QO0AbMBrQGzA9UB3AH/AfcBvArwAZIB6wH/
+        AigBhgG2AZQBFwEWAfQBFwElASkEKAFQAQAB9AHzCvEC8gHzAbQDswO0A7MBtAGzAa0CtAHcAf8BbQLw
+        AQkBBwH3AbUC7wEHAQkB8gEHAesB/wKYAbUB5gGuAUsBlAHjASUBlAFPAZcEmAEAAfEG7AfrAbwBtAmt
+        AbMBtAKLAQkB9AH/AesB8AEJAbQBrgGLAYYCrgGRAbQB8AHvAesE/wHWAa0BiwEcARYBJQFzAZgBCAT/
+        AQACUgFMCioBEgHrAbsBCQGLAQkDtAH/AosBrQK0AZkBGgL/Au8BBwG1Aa4EhgGuAfcBvAH3AewF/wHW
+        Aa0BiwHzAWIBAgEIBf8BUgF6AVIBoAh6AVIBoAEqARIBwwH/AYsBGQG0AbMBtAH/AooBrQHxAf8BwwF6
+        AfYC/wHrAQcB8AGRBIYBrgG8Ae8B9wf/AdYByAEZAfwBSAEIBf8BUgF6AVIBoAh6AVIBoAEqARIBoAH/
+        AYsBGQG0Aa0BtAH/AqYBiwEZAv8BmgEaAv8B9wEHAbwBtAGuAoYB6wG1AfABkgHsB/8B1gHIAd0B/AFI
+        AQgF/wFSAXoBUgmgAVgBoAEqARIBoAHDAYsB8QG0Aa0B8QH/AbUCiwP/AZoBGgP/Ae0B7wHwAbQC6wG0
+        AfIB7wEHCP8B1gP8AUgBCAX/AVIBegFSCaABegGgASoB6gH2AZkBiwEJAbQBrQHxAf8BtQKmAv8B9gF6
+        ARoD/wH3AQcB8AO0AbUB8gHsAfcJ/wHWAvwBSAEIBf8BUgF6AVIJoAF6AaABKgHqAf8BvAGLArUBtAEZ
+        Av8BtAHxAv8BGgF6AcMD/wHzAu8E8gHvAQcB8gn/Ad0ByAHdAU8BCAX/AVIBegFSCf8BmgH/ASoBbQHy
+        Aa4BiwGuAZkBwwH2BP8B9gGaAXoBGgX/Ae8B9wT/AewBBwr/AbwBbAH/AU8BCAX/AVIBoAGaDFIB7AWL
+        AZoBegSaAXoBmgEaBv8B8AHvAQcC/wHvAfcB8Qr/AQgBAgKYAfIF/wFSBqAF/wEqAeoBBwL/AYsBpgGL
+        Af8B9gLDApoBGgHDAfYI/wEHAewC/wHqAbwL/wHxAXIBAgHyBv8BUgH/BKAB/wVSAUwDAAL/AYsR/wHz
+        Ae8B7QL/AesBBwH0C/8B8gECAfIG/wEAAVIE/wFSAf8BAAH/BgAC/wHxEf8B7wFtAZIC8wHsAesBvAv/
+        AfMBTwHzBv8CAARSAf8JABT/AQcBrgLrA0oBBxT/EAABQgFNAT4HAAE+AwABKAMAAUADAAEgAwABAQEA
+        AQEGAAEBFgAD/4cAAYAHAAGABwABgAcAAYBIAAEHBgABgAG/BgABwQH/BgAC/ws=
+</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="treeView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="treeView.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="treeView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="treeView.SelectedImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="treeView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>425, 203</value>
+  </data>
+  <data name="treeView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;treeView.Name" xml:space="preserve">
+    <value>treeView</value>
+  </data>
+  <data name="&gt;&gt;treeView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;treeView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;treeView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>425, 203</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaFolderBrowser</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/PanoramaClient/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/Properties/Resources.ja.resx
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
+    <value>サーバーは有効なJSON応答を返しませんでした。{0}はPanoramaサーバーではありません。</value>
+  </data>
+  <data name="GenericState_AppendErrorAndUri_URL___0_" xml:space="preserve">
+    <value>URL：{0}</value>
+  </data>
+  <data name="PanoramaUtil_VerifyFolder__0__is_not_a_Panorama_folder" xml:space="preserve">
+    <value>{0}はPanoramaフォルダではありません</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Folder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Folder.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
+    <value>サーバーからの予期しないJSON応答：{0}</value>
+  </data>
+  <data name="UserState_GetErrorMessage_The_username_and_password_could_not_be_authenticated_with_the_panorama_server_" xml:space="preserve">
+    <value>The username and password could not be authenticated with the panorama server.</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
+    <value>ユーザーを認証できませんでした。サーバーから受信した応答：{0} {1}</value>
+  </data>
+  <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
+    <value>サーバー{0}に接続できません。</value>
+  </data>
+  <data name="ChromLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ServerState_GetErrorMessage_The_server__0__does_not_exist_" xml:space="preserve">
+    <value>The server {0} does not exist.</value>
+  </data>
+  <data name="WebPanoramaClient_SaveFile_Select_the_folder_where_the_file_will_be_downloaded" xml:space="preserve">
+    <value>Select the folder where the file will be downloaded</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="UserState_GetErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
+    <value>There was an error authenticating user credentials on the server {0}.</value>
+  </data>
+  <data name="PanoramaUtil_VerifyFolder_Folder__0__does_not_exist_on_the_Panorama_server__1_" xml:space="preserve">
+    <value>フォルダ{0}はPanoramaサーバー{1}上に存在しません</value>
+  </data>
+  <data name="WebPanoramaClient_DownloadFile_Downloading__0_" xml:space="preserve">
+    <value>Downloading {0}</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-up2.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam_Blueberry_Basic_Arrow_left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="up_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\up-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Edit_Undo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Edit_Undo.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam_Blueberry_Basic_Arrow_right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PanoramaUtil_VerifyFolder_User__0__does_not_have_permissions_to_upload_to_the_Panorama_folder__1_" xml:space="preserve">
+    <value>ユーザー{0}には、Panoramaフォルダ{1}にアップロードする権限がありません</value>
+  </data>
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PanoramaFilePicker_Open_Click_You_must_select_a_file_first_" xml:space="preserve">
+    <value>You must select a file first!</value>
+  </data>
+  <data name="PanoramaFolderBrowser_InitializeServers_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password" xml:space="preserve">
+    <value>Go to Tools - Options - Panorama tab to update the username and password</value>
+  </data>
+  <data name="PanoramaFolderBrowser_InitializeServers_Failed_attempting_to_retrieve_information_from_the_following_servers" xml:space="preserve">
+    <value>Failed attempting to retrieve information from the following servers</value>
+  </data>
+  <data name="PanoramaDirectoryPicker_DirectoryPicker_Load_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="WebDavBrowser_AddWebDavFolders_Failed_attempting_to_retrieve_information_from_the_following_folders_" xml:space="preserve">
+    <value>Failed attempting to retrieve information from the following folders:</value>
+  </data>
+  <data name="PanoramaFilePicker_ShowFiles_There_are_no_files_in_this_folder" xml:space="preserve">
+    <value>There are no files in this folder</value>
+  </data>
+  <data name="PanoramaFilePicker_ShowFiles_There_are_no_Skyline_files_in_this_folder" xml:space="preserve">
+    <value>There are no Skyline files in this folder</value>
+  </data>
+  <data name="PanoramaFilePicker_ALL_VER_All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="PanoramaFilePicker_RECENT_VER_Most_recent" xml:space="preserve">
+    <value>Most recent</value>
+  </data>
+  <data name="LabKeyError_ToString_Response_status___0_" xml:space="preserve">
+    <value>Response status: {0}</value>
+  </data>
+  <data name="AbstractPanoramaClient_SendZipFile_Deleting_temporary_file_on_server" xml:space="preserve">
+    <value>Deleting temporary file on server</value>
+  </data>
+  <data name="AbstractPanoramaClient_SendZipFile_Waiting_for_data_import_completion___" xml:space="preserve">
+    <value>Waiting for data import completion...</value>
+  </data>
+  <data name="AbstractPanoramaClient_ValidateFolder_Error_validating_folder___0__" xml:space="preserve">
+    <value>Error validating folder '{0}'</value>
+  </data>
+  <data name="AbstractPanoramaClient_GetInfoForFolders_Error_getting_information_for_folder___0__" xml:space="preserve">
+    <value>Error getting information for folder '{0}'</value>
+  </data>
+  <data name="AbstractPanoramaClient_GetWebDavPath_There_was_an_error_getting_the_WebDAV_url_for_folder___0__" xml:space="preserve">
+    <value>There was an error getting the WebDAV url for folder '{0}'</value>
+  </data>
+  <data name="AbstractPanoramaClient_updateProgressAndWait_Importing_data___0___complete_" xml:space="preserve">
+    <value>Importing data. {0}% complete.</value>
+  </data>
+  <data name="AbstractPanoramaClient_updateProgressAndWait_Status_on_server_is___0_" xml:space="preserve">
+    <value>Status on server is: {0}</value>
+  </data>
+  <data name="AbstractPanoramaClient_webClient_UploadProgressChanged_Progress_Updated" xml:space="preserve">
+    <value>Progress Updated</value>
+  </data>
+  <data name="AbstractPanoramaClient_webClient_UploadProgressChanged_Uploaded__0_fs__of__1_fs_" xml:space="preserve">
+    <value>Uploaded {0:fs} of {1:fs}</value>
+  </data>
+  <data name="WebPanoramaClient_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
+    <value>Server did not return a valid JSON response. {0} is not a Panorama server.</value>
+  </data>
+  <data name="AbstractPanoramaClient_WaitForDocumentImportCompleted_There_was_an_error_getting_the_status_of_the_document_import_pipeline_job_" xml:space="preserve">
+    <value>There was an error getting the status of the document import pipeline job.</value>
+  </data>
+  <data name="AbstractPanoramaClient_QueueDocUploadPipelineJob_There_was_an_error_adding_the_document_import_job_on_the_server_" xml:space="preserve">
+    <value>There was an error adding the document import job on the server.</value>
+  </data>
+  <data name="AbstractPanoramaClient_UploadTempZipFile_There_was_an_error_uploading_the_file_" xml:space="preserve">
+    <value>There was an error uploading the file.</value>
+  </data>
+  <data name="AbstractPanoramaClient_RenameTempZipFile_There_was_an_error_renaming_the_temporary_zip_file_on_the_server_" xml:space="preserve">
+    <value>There was an error renaming the temporary zip file on the server.</value>
+  </data>
+  <data name="AbstractPanoramaClient_DeleteTempZipFile_There_was_an_error_deleting_the_temporary_zip_file_on_the_server_" xml:space="preserve">
+    <value>There was an error deleting the temporary zip file on the server.</value>
+  </data>
+  <data name="ServerStateErrors_Error_The_server__0__is_not_a_Panorama_server_" xml:space="preserve">
+    <value>The server {0} is not a Panorama server.</value>
+  </data>
+  <data name="ErrorMessageBuilder_Build_Response__" xml:space="preserve">
+    <value>Response: </value>
+  </data>
+  <data name="AbstractRequestHelper_DoRequest__0__request_was_unsuccessful_" xml:space="preserve">
+    <value>{0} request was unsuccessful.</value>
+  </data>
+  <data name="AbstractPanoramaClient_GetWebDavPath_Missing_webDavURL_in_response_" xml:space="preserve">
+    <value>Missing webDavURL in response.</value>
+  </data>
+  <data name="AbstractPanoramaClient_ConfirmFileOnServer_File_was_not_uploaded_to_the_server__Please_try_again__or_if_the_problem_persists__please_contact_your_Panorama_server_administrator_" xml:space="preserve">
+    <value>File was not uploaded to the server. Please try again, or if the problem persists, please contact your Panorama server administrator.</value>
+  </data>
+  <data name="AbstractRequestHelper_ParseJsonResponse_Error_parsing_response_as_JSON_" xml:space="preserve">
+    <value>Error parsing response as JSON.</value>
+  </data>
+  <data name="PanoramaRequestHelper_Post_There_was_an_error_getting_a_CSRF_token_from_the_server_" xml:space="preserve">
+    <value>There was an error getting a CSRF token from the server.</value>
+  </data>
+  <data name="ErrorMessageBuilder_Build_Error__" xml:space="preserve">
+    <value>Error: </value>
+  </data>
+  <data name="ErrorMessageBuilder_Build_Response_status___0_" xml:space="preserve">
+    <value>Response status: {0}</value>
+  </data>
+  <data name="FolderStateErrors_Error_Unrecognized_error_trying_to_get_the_status_for_folder__0__" xml:space="preserve">
+    <value>Unrecognized error trying to get the status for folder {0}.</value>
+  </data>
+  <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_contain_any_of_these_characters___0_" xml:space="preserve">
+    <value>File name may not contain any of these characters: {0}</value>
+  </data>
+  <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_begin_with_any_of_these_characters___0_" xml:space="preserve">
+    <value>File name may not begin with any of these characters: {0}</value>
+  </data>
+  <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_contain_space_followed_by_dash" xml:space="preserve">
+    <value>File name may not contain space followed by dash</value>
+  </data>
+  <data name="AbstractPanoramaClient_ParseUploadFileCompletedEventArgs_Request_cancelled" xml:space="preserve">
+    <value>Request cancelled</value>
+  </data>
+  <data name="AbstractPanoramaClient_ParseUploadFileCompletedEventArgs_There_was_an_error_reading_the_server_response_" xml:space="preserve">
+    <value>There was an error reading the server response.</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/PanoramaClient/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/Properties/Resources.zh-CHS.resx
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
+    <value>服务器未返回有效的 JSON 响应。{0} 并非 Panorama  服务器。</value>
+  </data>
+  <data name="GenericState_AppendErrorAndUri_URL___0_" xml:space="preserve">
+    <value>URL: {0}</value>
+  </data>
+  <data name="PanoramaUtil_VerifyFolder__0__is_not_a_Panorama_folder" xml:space="preserve">
+    <value>{0}不是 Panorama 文件夹</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Folder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Folder.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
+    <value>服务器 {0} 的JSON响应异常</value>
+  </data>
+  <data name="UserState_GetErrorMessage_The_username_and_password_could_not_be_authenticated_with_the_panorama_server_" xml:space="preserve">
+    <value>The username and password could not be authenticated with the panorama server.</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
+    <value>无法验证用户身份。服务器的反馈:{0} {1}</value>
+  </data>
+  <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
+    <value>无法连接到服务器 {0}。</value>
+  </data>
+  <data name="ChromLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ServerState_GetErrorMessage_The_server__0__does_not_exist_" xml:space="preserve">
+    <value>The server {0} does not exist.</value>
+  </data>
+  <data name="WebPanoramaClient_SaveFile_Select_the_folder_where_the_file_will_be_downloaded" xml:space="preserve">
+    <value>Select the folder where the file will be downloaded</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="UserState_GetErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
+    <value>There was an error authenticating user credentials on the server {0}.</value>
+  </data>
+  <data name="PanoramaUtil_VerifyFolder_Folder__0__does_not_exist_on_the_Panorama_server__1_" xml:space="preserve">
+    <value>文件夹{0}不存在于 Panorama 服务器{1}中</value>
+  </data>
+  <data name="WebPanoramaClient_DownloadFile_Downloading__0_" xml:space="preserve">
+    <value>Downloading {0}</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-up2.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam_Blueberry_Basic_Arrow_left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="up_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\up-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Edit_Undo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Edit_Undo.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam_Blueberry_Basic_Arrow_right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PanoramaUtil_VerifyFolder_User__0__does_not_have_permissions_to_upload_to_the_Panorama_folder__1_" xml:space="preserve">
+    <value>用户{0}没有权限上传至 Panorama 文件夹{1}</value>
+  </data>
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PanoramaFilePicker_Open_Click_You_must_select_a_file_first_" xml:space="preserve">
+    <value>You must select a file first!</value>
+  </data>
+  <data name="PanoramaFolderBrowser_InitializeServers_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password" xml:space="preserve">
+    <value>Go to Tools - Options - Panorama tab to update the username and password</value>
+  </data>
+  <data name="PanoramaFolderBrowser_InitializeServers_Failed_attempting_to_retrieve_information_from_the_following_servers" xml:space="preserve">
+    <value>Failed attempting to retrieve information from the following servers</value>
+  </data>
+  <data name="PanoramaDirectoryPicker_DirectoryPicker_Load_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="WebDavBrowser_AddWebDavFolders_Failed_attempting_to_retrieve_information_from_the_following_folders_" xml:space="preserve">
+    <value>Failed attempting to retrieve information from the following folders:</value>
+  </data>
+  <data name="PanoramaFilePicker_ShowFiles_There_are_no_files_in_this_folder" xml:space="preserve">
+    <value>There are no files in this folder</value>
+  </data>
+  <data name="PanoramaFilePicker_ShowFiles_There_are_no_Skyline_files_in_this_folder" xml:space="preserve">
+    <value>There are no Skyline files in this folder</value>
+  </data>
+  <data name="PanoramaFilePicker_ALL_VER_All" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="PanoramaFilePicker_RECENT_VER_Most_recent" xml:space="preserve">
+    <value>Most recent</value>
+  </data>
+  <data name="LabKeyError_ToString_Response_status___0_" xml:space="preserve">
+    <value>Response status: {0}</value>
+  </data>
+  <data name="AbstractPanoramaClient_SendZipFile_Deleting_temporary_file_on_server" xml:space="preserve">
+    <value>Deleting temporary file on server</value>
+  </data>
+  <data name="AbstractPanoramaClient_SendZipFile_Waiting_for_data_import_completion___" xml:space="preserve">
+    <value>Waiting for data import completion...</value>
+  </data>
+  <data name="AbstractPanoramaClient_ValidateFolder_Error_validating_folder___0__" xml:space="preserve">
+    <value>Error validating folder '{0}'</value>
+  </data>
+  <data name="AbstractPanoramaClient_GetInfoForFolders_Error_getting_information_for_folder___0__" xml:space="preserve">
+    <value>Error getting information for folder '{0}'</value>
+  </data>
+  <data name="AbstractPanoramaClient_GetWebDavPath_There_was_an_error_getting_the_WebDAV_url_for_folder___0__" xml:space="preserve">
+    <value>There was an error getting the WebDAV url for folder '{0}'</value>
+  </data>
+  <data name="AbstractPanoramaClient_updateProgressAndWait_Importing_data___0___complete_" xml:space="preserve">
+    <value>Importing data. {0}% complete.</value>
+  </data>
+  <data name="AbstractPanoramaClient_updateProgressAndWait_Status_on_server_is___0_" xml:space="preserve">
+    <value>Status on server is: {0}</value>
+  </data>
+  <data name="AbstractPanoramaClient_webClient_UploadProgressChanged_Progress_Updated" xml:space="preserve">
+    <value>Progress Updated</value>
+  </data>
+  <data name="AbstractPanoramaClient_webClient_UploadProgressChanged_Uploaded__0_fs__of__1_fs_" xml:space="preserve">
+    <value>Uploaded {0:fs} of {1:fs}</value>
+  </data>
+  <data name="WebPanoramaClient_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
+    <value>Server did not return a valid JSON response. {0} is not a Panorama server.</value>
+  </data>
+  <data name="AbstractPanoramaClient_WaitForDocumentImportCompleted_There_was_an_error_getting_the_status_of_the_document_import_pipeline_job_" xml:space="preserve">
+    <value>There was an error getting the status of the document import pipeline job.</value>
+  </data>
+  <data name="AbstractPanoramaClient_QueueDocUploadPipelineJob_There_was_an_error_adding_the_document_import_job_on_the_server_" xml:space="preserve">
+    <value>There was an error adding the document import job on the server.</value>
+  </data>
+  <data name="AbstractPanoramaClient_UploadTempZipFile_There_was_an_error_uploading_the_file_" xml:space="preserve">
+    <value>There was an error uploading the file.</value>
+  </data>
+  <data name="AbstractPanoramaClient_RenameTempZipFile_There_was_an_error_renaming_the_temporary_zip_file_on_the_server_" xml:space="preserve">
+    <value>There was an error renaming the temporary zip file on the server.</value>
+  </data>
+  <data name="AbstractPanoramaClient_DeleteTempZipFile_There_was_an_error_deleting_the_temporary_zip_file_on_the_server_" xml:space="preserve">
+    <value>There was an error deleting the temporary zip file on the server.</value>
+  </data>
+  <data name="ServerStateErrors_Error_The_server__0__is_not_a_Panorama_server_" xml:space="preserve">
+    <value>The server {0} is not a Panorama server.</value>
+  </data>
+  <data name="ErrorMessageBuilder_Build_Response__" xml:space="preserve">
+    <value>Response: </value>
+  </data>
+  <data name="AbstractRequestHelper_DoRequest__0__request_was_unsuccessful_" xml:space="preserve">
+    <value>{0} request was unsuccessful.</value>
+  </data>
+  <data name="AbstractPanoramaClient_GetWebDavPath_Missing_webDavURL_in_response_" xml:space="preserve">
+    <value>Missing webDavURL in response.</value>
+  </data>
+  <data name="AbstractPanoramaClient_ConfirmFileOnServer_File_was_not_uploaded_to_the_server__Please_try_again__or_if_the_problem_persists__please_contact_your_Panorama_server_administrator_" xml:space="preserve">
+    <value>File was not uploaded to the server. Please try again, or if the problem persists, please contact your Panorama server administrator.</value>
+  </data>
+  <data name="AbstractRequestHelper_ParseJsonResponse_Error_parsing_response_as_JSON_" xml:space="preserve">
+    <value>Error parsing response as JSON.</value>
+  </data>
+  <data name="PanoramaRequestHelper_Post_There_was_an_error_getting_a_CSRF_token_from_the_server_" xml:space="preserve">
+    <value>There was an error getting a CSRF token from the server.</value>
+  </data>
+  <data name="ErrorMessageBuilder_Build_Error__" xml:space="preserve">
+    <value>Error: </value>
+  </data>
+  <data name="ErrorMessageBuilder_Build_Response_status___0_" xml:space="preserve">
+    <value>Response status: {0}</value>
+  </data>
+  <data name="FolderStateErrors_Error_Unrecognized_error_trying_to_get_the_status_for_folder__0__" xml:space="preserve">
+    <value>Unrecognized error trying to get the status for folder {0}.</value>
+  </data>
+  <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_contain_any_of_these_characters___0_" xml:space="preserve">
+    <value>File name may not contain any of these characters: {0}</value>
+  </data>
+  <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_begin_with_any_of_these_characters___0_" xml:space="preserve">
+    <value>File name may not begin with any of these characters: {0}</value>
+  </data>
+  <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_contain_space_followed_by_dash" xml:space="preserve">
+    <value>File name may not contain space followed by dash</value>
+  </data>
+  <data name="AbstractPanoramaClient_ParseUploadFileCompletedEventArgs_Request_cancelled" xml:space="preserve">
+    <value>Request cancelled</value>
+  </data>
+  <data name="AbstractPanoramaClient_ParseUploadFileCompletedEventArgs_There_was_an_error_reading_the_server_response_" xml:space="preserve">
+    <value>There was an error reading the server response.</value>
+  </data>
+</root>

--- a/pwiz_tools/Shared/ProteomeDb/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/ProteomeDb/Properties/Resources.ja.resx
@@ -98,22 +98,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ProteomeDb_AddFastaFile_Added__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">{0}タンパク質を追加済み</value>
+    <value>{0}タンパク質を追加済み</value>
   </data>
   <data name="ProteomeDb_AddFastaFile_Finished_importing__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">{0}タンパク質のインポートが完了</value>
+    <value>{0}タンパク質のインポートが完了</value>
   </data>
   <data name="ProteomeDb_Digest_Listing_existing_peptides" xml:space="preserve">
-    <value xml:space="preserve">既存のペプチドをリスト中</value>
+    <value>既存のペプチドをリスト中</value>
   </data>
   <data name="ProteomeDb_Digest_Listing_proteins" xml:space="preserve">
-    <value xml:space="preserve">タンパク質をリスト中</value>
+    <value>タンパク質をリスト中</value>
   </data>
   <data name="ProteomeDb_Digest_Digesting__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">{0}タンパク質の消化中</value>
+    <value>{0}タンパク質の消化中</value>
   </data>
   <data name="ProteomeDb_Digest_Digested__0__proteins_into__1__unique_peptides" xml:space="preserve">
-    <value xml:space="preserve">{0}タンパク質を{1}ユニークペプチドに消化済み</value>
+    <value>{0}タンパク質を{1}ユニークペプチドに消化済み</value>
   </data>
   <data name="ProteomeDb_AddFastaFile_Saving_changes" xml:space="preserve">
     <value>変更を保存中</value>

--- a/pwiz_tools/Shared/ProteomeDb/Properties/Resources.resx
+++ b/pwiz_tools/Shared/ProteomeDb/Properties/Resources.resx
@@ -98,22 +98,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ProteomeDb_AddFastaFile_Added__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">Added {0} proteins</value>
+    <value>Added {0} proteins</value>
   </data>
   <data name="ProteomeDb_AddFastaFile_Finished_importing__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">Finished importing {0} proteins</value>
+    <value>Finished importing {0} proteins</value>
   </data>
   <data name="ProteomeDb_Digest_Listing_existing_peptides" xml:space="preserve">
-    <value xml:space="preserve">Listing existing peptides</value>
+    <value>Listing existing peptides</value>
   </data>
   <data name="ProteomeDb_Digest_Listing_proteins" xml:space="preserve">
-    <value xml:space="preserve">Listing proteins</value>
+    <value>Listing proteins</value>
   </data>
   <data name="ProteomeDb_Digest_Digesting__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">Digesting {0} proteins</value>
+    <value>Digesting {0} proteins</value>
   </data>
   <data name="ProteomeDb_Digest_Digested__0__proteins_into__1__unique_peptides" xml:space="preserve">
-    <value xml:space="preserve">Digested {0} proteins into {1} unique peptides</value>
+    <value>Digested {0} proteins into {1} unique peptides</value>
   </data>
   <data name="ProteomeDb_AddFastaFile_Saving_changes" xml:space="preserve">
     <value>Saving changes</value>

--- a/pwiz_tools/Shared/ProteomeDb/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/ProteomeDb/Properties/Resources.zh-CHS.resx
@@ -98,22 +98,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ProteomeDb_AddFastaFile_Added__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">添加 {0} 个蛋白质</value>
+    <value>添加 {0} 个蛋白质</value>
   </data>
   <data name="ProteomeDb_AddFastaFile_Finished_importing__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">已完成导入 {0} 个蛋白质</value>
+    <value>已完成导入 {0} 个蛋白质</value>
   </data>
   <data name="ProteomeDb_Digest_Listing_existing_peptides" xml:space="preserve">
-    <value xml:space="preserve">列出现有的肽段</value>
+    <value>列出现有的肽段</value>
   </data>
   <data name="ProteomeDb_Digest_Listing_proteins" xml:space="preserve">
-    <value xml:space="preserve">列出蛋白质</value>
+    <value>列出蛋白质</value>
   </data>
   <data name="ProteomeDb_Digest_Digesting__0__proteins" xml:space="preserve">
-    <value xml:space="preserve">消化 {0} 个蛋白质</value>
+    <value>消化 {0} 个蛋白质</value>
   </data>
   <data name="ProteomeDb_Digest_Digested__0__proteins_into__1__unique_peptides" xml:space="preserve">
-    <value xml:space="preserve">将 {0} 个蛋白质酶解成 {1} 个序列特异的肽段</value>
+    <value>将 {0} 个蛋白质酶解成 {1} 个序列特异的肽段</value>
   </data>
   <data name="ProteomeDb_AddFastaFile_Saving_changes" xml:space="preserve">
     <value>保存更改</value>

--- a/pwiz_tools/Skyline/Alerts/AboutDlg.ja.resx
+++ b/pwiz_tools/Skyline/Alerts/AboutDlg.ja.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="linkProteome.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -198,36 +201,6 @@
   <data name="&gt;&gt;pictureSkylineIcon.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="labelSoftwareVersion.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelSoftwareVersion.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 12pt, style=Bold</value>
-  </data>
-  <data name="labelSoftwareVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>162, 12</value>
-  </data>
-  <data name="labelSoftwareVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>461, 20</value>
-  </data>
-  <data name="labelSoftwareVersion.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="labelSoftwareVersion.Text" xml:space="preserve">
-    <value>Skyline (64ビット: 開発者ビルド) 22.0.0.000 (abc123456)</value>
-  </data>
-  <data name="&gt;&gt;labelSoftwareVersion.Name" xml:space="preserve">
-    <value>labelSoftwareVersion</value>
-  </data>
-  <data name="&gt;&gt;labelSoftwareVersion.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelSoftwareVersion.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;labelSoftwareVersion.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="textBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -248,26 +221,26 @@
   </data>
   <data name="textBox1.Text" xml:space="preserve">
     <value>Agilent Technologies
-Mass Hunterデータアクセスコンポーネント
-Copyright © 2017 by Agilent Technologies
+Mass Hunter Data Access Component
+Copyright © 2023 by Agilent Technologies
 https://www.agilent.com
 
 BiblioSpec
-スペクトルライブラリ構築
+Spectral Library Building
 https://skyline.ms/build-blib.url
 
 Bruker
-CompassXtractデータリーダーライブラリ
+CompassXtract Data Reader Library
 Copyright © 2020 by Bruker Daltonik GmbH.
-著作権所有。
+All rights reserved.
 https://www.bruker.com/
 
 DigitalRune Software
-ウィンドウズのドッキング
+Docking Windows
 https://github.com/DigitalRune
 
-DotNetZipライブラリ
-ZIP圧縮および展開
+DotNetZip Library
+ZIP compression &amp; extraction
 https://www.nuget.org/packages/DotNetZip/
 
 James Newton-King
@@ -275,60 +248,60 @@ Json.NET
 http://james.newtonking.com
 
 JetBrains Software
-開発ツール： ReSharper、dotTrace、dotCover
+Development tools: ReSharper, dotTrace and dotCover
 https://www.jetbrains.com/
 
 Matrix Science
-Mascotパーサー
+Mascot Parser
 https://www.matrixscience.com
 
 NHibernate
-オブジェクト関係写像
+Object Relational Mapping
 https://nhibernate.info/
 
 ProteoWizard
-質量分析データのインポート
+Mass Spectrometry Data Import
 https://github.com/ProteoWizard
 
 SCIEX
-WIFFファイルリーダーライブラリ
+WIFF File Reader Library
 Copyright © 2020 by AB Sciex LLC.
-著作権所有。
+All rights reserved.
 https://sciex.com/
 
-島津製作所
-島津製作所のファイルコンバータソフトウェア
+Shimadzu Corporation
+Shimadzu's file converter software
 Copyright © 2020 by Shimadzu Coporation
-著作権所有。
+All rights reserved.
 https://www.shimadzu.com
 
 SQLite
-単一ファイルおよびメモリ内RDBMS
+Single File and In-Memory RDBMS
 https://www.sqlite.org
 
 SQLite.NET
-SQLiteのADO.NETプロバイダ
+ADO.NET Provider for SQLite
 https://system.data.sqlite.org/
 
 Thermo Fisher Scientific
-MSFileReaderファイル読み出しツール
+MSFileReader file reading tool
 Copyright © 2019 by Thermo Fisher Scientific, Inc.
-著作権所有。
+All rights reserved.
 https://www.thermofisher.com/
 
 Waters Technologies Corporation
-メソッドエクスポートライブラリ
-ウォーターズローデータアクセスコンポーネント
+Method export library
+Waters Raw Data Access Component
 Copyright © 2021 by Waters Corporation.
-著作権所有。
+All rights reserved.
 https://www.waters.com/
 
 ZedGraph
-チャートのプロット
-https://sourceforge.net/projects/zedgraph/
+Chart Plotting
+http://zedgraph.org
 
 Zlib
-データ圧縮
+Data Compression
 https://www.zlib.net</value>
   </data>
   <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
@@ -341,7 +314,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -368,7 +341,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="pictureProteoWizardIcon.Location" type="System.Drawing.Point, System.Drawing">
     <value>15, 240</value>
@@ -392,7 +365,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureProteoWizardIcon.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="linkProteoWizard.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -419,7 +392,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;linkProteoWizard.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -446,7 +419,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="linkLabel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -484,6 +457,36 @@ Skylineウェブサイトをご覧ください。</value>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
+  <data name="textSoftwareVersion.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 12pt, style=Bold</value>
+  </data>
+  <data name="textSoftwareVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>164, 12</value>
+  </data>
+  <data name="textSoftwareVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="textSoftwareVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>461, 19</value>
+  </data>
+  <data name="textSoftwareVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="textSoftwareVersion.Text" xml:space="preserve">
+    <value>Skyline (64-bit : developer build) 22.0.0.000 (abc123456)</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Name" xml:space="preserve">
+    <value>textSoftwareVersion</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -498,6 +501,12 @@ Skylineウェブサイトをご覧ください。</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Skylineについて</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>AboutDlg</value>

--- a/pwiz_tools/Skyline/Alerts/AboutDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Alerts/AboutDlg.zh-CHS.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="linkProteome.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -198,36 +201,6 @@
   <data name="&gt;&gt;pictureSkylineIcon.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="labelSoftwareVersion.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelSoftwareVersion.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 12pt, style=Bold</value>
-  </data>
-  <data name="labelSoftwareVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>162, 12</value>
-  </data>
-  <data name="labelSoftwareVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>461, 20</value>
-  </data>
-  <data name="labelSoftwareVersion.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="labelSoftwareVersion.Text" xml:space="preserve">
-    <value>Skyline（ 64 位：开发者版本）22.0.0.000 (abc123456)</value>
-  </data>
-  <data name="&gt;&gt;labelSoftwareVersion.Name" xml:space="preserve">
-    <value>labelSoftwareVersion</value>
-  </data>
-  <data name="&gt;&gt;labelSoftwareVersion.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelSoftwareVersion.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;labelSoftwareVersion.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="textBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -248,26 +221,26 @@
   </data>
   <data name="textBox1.Text" xml:space="preserve">
     <value>Agilent Technologies
-Mass Hunter 数据访问组件
-© 2017 年 Agilent Technologies 版权所有
+Mass Hunter Data Access Component
+Copyright © 2023 by Agilent Technologies
 https://www.agilent.com
 
 BiblioSpec
-质谱图库组建
+Spectral Library Building
 https://skyline.ms/build-blib.url
 
 Bruker
-CompassXtract 数据阅读器库
-© 2020 年 Bruker Daltonik GmbH 版权所有。
-保留所有权利。
+CompassXtract Data Reader Library
+Copyright © 2020 by Bruker Daltonik GmbH.
+All rights reserved.
 https://www.bruker.com/
 
 DigitalRune Software
-视窗停靠
+Docking Windows
 https://github.com/DigitalRune
 
 DotNetZip Library
-用 ZIP 压缩及解压缩
+ZIP compression &amp; extraction
 https://www.nuget.org/packages/DotNetZip/
 
 James Newton-King
@@ -275,60 +248,60 @@ Json.NET
 http://james.newtonking.com
 
 JetBrains Software
-开发工具：ReSharper、dotTrace 和 dotCover
+Development tools: ReSharper, dotTrace and dotCover
 https://www.jetbrains.com/
 
 Matrix Science
-Mascot 解析器
+Mascot Parser
 https://www.matrixscience.com
 
 NHibernate
-物体关联构图
+Object Relational Mapping
 https://nhibernate.info/
 
 ProteoWizard
-质谱数据导入
+Mass Spectrometry Data Import
 https://github.com/ProteoWizard
 
 SCIEX
-WIFF文件阅读器库
-© 2020 年 AB Sciex LLC 版权所有。
-保留所有权利。
+WIFF File Reader Library
+Copyright © 2020 by AB Sciex LLC.
+All rights reserved.
 https://sciex.com/
 
 Shimadzu Corporation
-Shimadzu 的文件转换器软件
-© 2020 年 Shimadzu Corporation 版权所有
-保留所有权利。
+Shimadzu's file converter software
+Copyright © 2020 by Shimadzu Coporation
+All rights reserved.
 https://www.shimadzu.com
 
 SQLite
-Single File 和 In-Memory RDBMS
+Single File and In-Memory RDBMS
 https://www.sqlite.org
 
 SQLite.NET
-SQLite 的 ADO.NET 提供者
+ADO.NET Provider for SQLite
 https://system.data.sqlite.org/
 
 Thermo Fisher Scientific
-MSFileReader 文件读取工具
-© 2019 年 Thermo Fisher Scientific, Inc. 版权所有。
-保留所有权利。
+MSFileReader file reading tool
+Copyright © 2019 by Thermo Fisher Scientific, Inc.
+All rights reserved.
 https://www.thermofisher.com/
 
 Waters Technologies Corporation
-方法导出库
+Method export library
 Waters Raw Data Access Component
-© 2021 年 Waters Corporation 版权所有。
-保留所有权利。
+Copyright © 2021 by Waters Corporation.
+All rights reserved.
 https://www.waters.com/
 
 ZedGraph
-画图
-https://sourceforge.net/projects/zedgraph/
+Chart Plotting
+http://zedgraph.org
 
 Zlib
-数据压缩
+Data Compression
 https://www.zlib.net</value>
   </data>
   <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
@@ -341,7 +314,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -368,7 +341,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="pictureProteoWizardIcon.Location" type="System.Drawing.Point, System.Drawing">
     <value>15, 240</value>
@@ -392,7 +365,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pictureProteoWizardIcon.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="linkProteoWizard.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -419,7 +392,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;linkProteoWizard.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -446,7 +419,7 @@ https://www.zlib.net</value>
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="linkLabel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -483,6 +456,36 @@ https://www.zlib.net</value>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
+  <data name="textSoftwareVersion.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 12pt, style=Bold</value>
+  </data>
+  <data name="textSoftwareVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>164, 12</value>
+  </data>
+  <data name="textSoftwareVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="textSoftwareVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>461, 19</value>
+  </data>
+  <data name="textSoftwareVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="textSoftwareVersion.Text" xml:space="preserve">
+    <value>Skyline (64-bit : developer build) 22.0.0.000 (abc123456)</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Name" xml:space="preserve">
+    <value>textSoftwareVersion</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -497,6 +500,12 @@ https://www.zlib.net</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>关于 Skyline</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>AboutDlg</value>

--- a/pwiz_tools/Skyline/Alerts/AlertsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Alerts/AlertsResources.zh-CHS.resx
@@ -215,7 +215,7 @@
     <value>意外停机</value>
   </data>
   <data name="ShareResultsFilesDlg_LocateMissingFilesFromFolder_Please_select_the_folder_containing_the_missing_files_" xml:space="preserve">
-    <value>请选择缺失文件所属的文件夹。</value>
+    <value>请选择缺失文件的所属文件夹。</value>
   </data>
   <data name="SimpleFileDownloaderDlg_Show_Downloading_required_files___" xml:space="preserve">
     <value>正在下载所需的文件...</value>

--- a/pwiz_tools/Skyline/CommandArgUsage.ja.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.ja.resx
@@ -288,6 +288,12 @@
   <data name="_import_threads" xml:space="preserve">
     <value>多数のファイルが、メインプロセスのスレッド（ユーザーインターフェイスの[同時にインポートするファイル]に相当）を使用して並行にインポートされます。その後、それぞれの単一ファイルからの結果が結合されます。これにより、正しい条件の下では2～4倍に性能がアップされる可能性があります。お使いのシステムで必ずテストしてください。</value>
   </data>
+  <data name="_import_pep_list" xml:space="preserve">
+    <value>Import a list of peptides or peptide precursors (with charge state) with an optional list name specified by --import-pep-list-name.</value>
+  </data>
+  <data name="_import_pep_list_name" xml:space="preserve">
+    <value>Name of imported peptide list specified by --import-pep-list.</value>
+  </data>
   <data name="_import_transition_list" xml:space="preserve">
     <value>Q1、Q3とペプチドシーケンスがあるシンプルなトランジションリストをインポートします。  また、ヘッダーが適切な分子トランジションリストもCSV形式でサポートします。</value>
   </data>
@@ -529,8 +535,11 @@ http://localhost:8080</value>
   <data name="_tool_zip_overwrite_annotations" xml:space="preserve">
     <value>提供されたZIPファイルが原因で重複となったカスタム注釈が、既存の注釈を上書きすべき（True）かスキップすべき(False)かを指定します。</value>
   </data>
-  <data name="CommandArgs_GROUP_SETTINGS_Document_Settings" xml:space="preserve">
-    <value>ドキュメント設定</value>
+  <data name="CommandArgs_GROUP_SETTINGS_Transition_Settings" xml:space="preserve">
+    <value>Transition Settings</value>
+  </data>
+  <data name="CommandArgs_GROUP_SETTINGS_Peptide_Settings" xml:space="preserve">
+    <value>Peptide Settings</value>
   </data>
   <data name="CommandArgs_PATH_TO_FILE_path_to_file" xml:space="preserve">
     <value>path/to/file（ファイル）</value>
@@ -655,85 +664,57 @@ Waters</value>
     <value>--refine-add-label-typeも使用されている場合、指定されている同位体標識タイプのプリカーサーが削除される（デフォルト）か、追加されます。</value>
   </data>
   <data name="_refine_min_peptides" xml:space="preserve">
-    <value>ペプチドがこの数より少ないタンパク質は
-ドキュメントから削除されます。</value>
+    <value>Proteins with fewer than this number of peptides will be removed from the document.</value>
   </data>
   <data name="_refine_min_transitions" xml:space="preserve">
-    <value>トランジションがこの数より少ないプリカーサーは ドキュメントから削除されます。</value>
+    <value>Precursors with fewer than this number of transitions will be removed from the document.</value>
   </data>
   <data name="_refine_missing_library" xml:space="preserve">
     <value>ライブラリ一致に対応しないすべてのターゲットが削除されます。</value>
   </data>
   <data name="_refine_remove_duplicates" xml:space="preserve">
-    <value>ドキュメント内で一意でないペプチドはすべて
-削除されます。
-</value>
+    <value>All peptides that are not unique within the document will be removed.</value>
   </data>
   <data name="_refine_remove_repeats" xml:space="preserve">
-    <value>すべての重複ペプチドは削除され、
-最初に記載された各ペプチドだけが残ります。
-</value>
+    <value>All repeated peptides will be removed to leave only the first occurrence of any peptide.</value>
   </data>
   <data name="CommandArgs_LABEL_VALUE" xml:space="preserve">
     <value>&lt;標識タイプ&gt;</value>
   </data>
   <data name="_refine_max_peak_found_ratio" xml:space="preserve">
-    <value>次の数値を超えるピーク検出率を持つ全ての成分は
-ドキュメントから削除されます。
+    <value>All elements with peak found ratio above this number will be removed from the document:
 
-緑色 = 1.0
-橙色 &gt;= 0.5
-赤色 &lt; 0.5</value>
+Green = 1.0
+Orange &gt;= 0.5
+Red &lt; 0.5</value>
   </data>
   <data name="_refine_max_peptide_peak_rank" xml:space="preserve">
-    <value>平均面積ピークランクがこの数値より
-大きいトランジションは全てドキュメントから
-削除されます。
-
-</value>
+    <value>All transitions with an average area peak ranking greater than this number will be removed from the document.</value>
   </data>
   <data name="_refine_max_transition_peak_rank" xml:space="preserve">
-    <value>平均面積ピークランクがこの数値より
-大きいトランジションは全てドキュメントから
-削除されます。
-
-</value>
+    <value>All transitions with an average area peak ranking greater than this number will be removed from the document.</value>
   </data>
   <data name="_refine_min_dotp" xml:space="preserve">
-    <value>プロダクトイオンピーク面積を持つプリカーサーの
-ライブラリスペクトル内積がこの閾値を下回るものは全て
-ドキュメントから削除されます。
-</value>
+    <value>All precursors with a product ion peak area to library spectrum dot-product below this threshold will be removed from the document.</value>
   </data>
   <data name="_refine_min_idotp" xml:space="preserve">
-    <value>MS1プリカーサーピーク面積を持つプリカーサーの
-予測される同位体分布の内積がこの閾値を下回るものは全て
-ドキュメントから削除されます。
-</value>
+    <value>All precursors with a MS1 precursor peak area to expected isotope distribution dot-product below this threshold will be removed from the document.</value>
   </data>
   <data name="_refine_min_peak_found_ratio" xml:space="preserve">
-    <value>次の数値を下回るピーク検出率を持つ全ての成分は
-ドキュメントから削除されます。
+    <value>All elements with peak found ratio below this number will be removed from the document:
 
-緑色 = 1.0
-橙色 &amp;gt;= 0.5
-赤色 &amp;lt; 0.5</value>
+Green = 1.0
+Orange &gt;= 0.5
+Red &lt; 0.5</value>
   </data>
   <data name="_refine_min_time_correlation" xml:space="preserve">
-    <value>プリカーサーは、最適保持時間カルキュレータによる
-線形回帰の相関係数目標値が
-この閾値を超えるまで、ドキュメントから
-削除されます。</value>
+    <value>Precursors will be removed from the document until the target value for the correlation coefficient of a linear regression with the optimal retention time calculator exceed this threshold.</value>
   </data>
   <data name="_refine_missing_results" xml:space="preserve">
-    <value>測定結果の無い成分は全て
-ドキュメントから削除されます。
-</value>
+    <value>All elements without measured results will be removed from the document.</value>
   </data>
   <data name="_refine_prefer_larger_products" xml:space="preserve">
-    <value>小さく選択性が低いイオンが部分的により大きな
-ピーク面積になる場合のみ、
-大きいプロダクトイオンを選択するように修正します。</value>
+    <value>Causes refinement to choose larger product ions when smaller, less selective ions yeild only fractionally greater peak area.</value>
   </data>
   <data name="_refine_use_best_result" xml:space="preserve">
     <value>最適化値の計算では各ペプチドに対して、最良の繰り返し測定のみ使用します。（分割に使用する）</value>
@@ -936,7 +917,142 @@ Waters</value>
   <data name="CommandArgs_ARG_FULL_SCAN_PRODUCT_ISOLATION_SCHEME_path_to_result_file_to_import_the_isolation_scheme" xml:space="preserve">
     <value>単離スキームのインポート元となるpath/to/result-file</value>
   </data>
+  <data name="CommandArgs_GROUP_OTHER_FILE_TYPES" xml:space="preserve">
+    <value>Exporting other file types</value>
+  </data>
+  <data name="_exp_speclib_file" xml:space="preserve">
+    <value>Export experimental data in the current document to a spectral library file. Peak areas are used as spectrum intensities, peak apex times are used as retention times, and if the document has iRT values they will also be stored in the library.</value>
+  </data>
+  <data name="_exp_mprophet_exclude_feature" xml:space="preserve">
+    <value>Use to exclude a particular feature score by name from the exported file. Names can be found in the user interface. This argument may be used multiple times to exclude multiple features. Requires the --exp-mprophet-features argument.</value>
+  </data>
+  <data name="_exp_mprophet_features" xml:space="preserve">
+    <value>Export all the individual feature scores for each peptide, as well as the composite score, the p value, and the q value into the mProphet format.</value>
+  </data>
+  <data name="_exp_mprophet_best_peaks_only" xml:space="preserve">
+    <value>Include feature scores only for the best scoring peaks. Requires the --exp-mprophet-features argument.</value>
+  </data>
+  <data name="_exp_mprophet_targets_only" xml:space="preserve">
+    <value>Include feature scores only for targets. Requires the --exp-mprophet-features argument.</value>
+  </data>
+  <data name="_exp_annotations" xml:space="preserve">
+    <value>Export all the annotations in the document into a text file with an ElementLocator field in the format required by --import-annotations. Use --exp-annotations-include-properties to include properties as well.</value>
+  </data>
+  <data name="_exp_annotations_remove_blank_rows" xml:space="preserve">
+    <value>Use to remove blank rows from the exported annotations. Requires the --exp-annotations argument.</value>
+  </data>
+  <data name="_exp_annotations_include_object" xml:space="preserve">
+    <value>Use to specify which object types to include in the exported annotations. By default all object types are included. This argument can be used multiple times to specify multiple object types. Requires the --exp-annotations argument.</value>
+  </data>
+  <data name="_exp_annotations_include_properties" xml:space="preserve">
+    <value>Use to include all properties in the exported annotations. By default no properties are included. Requires the --exp-annotations argument.</value>
+  </data>
+  <data name="_pep_exclude_nterminal_aas" xml:space="preserve">
+    <value>Exclude all peptides starting before this amino acid position in each protein.</value>
+  </data>
+  <data name="_pep_exclude_potential_ragged_ends" xml:space="preserve">
+    <value>Exclude peptides resulting from cleavage sites with immediate preceding or following cleavage sites. e.g. RR, KK, RK, KR for trypsin</value>
+  </data>
+  <data name="_pep_max_length" xml:space="preserve">
+    <value>The maximum length of a peptide to add to the document.</value>
+  </data>
+  <data name="_pep_min_length" xml:space="preserve">
+    <value>The minimum length of a peptide to add to the document.</value>
+  </data>
+  <data name="CommandArgs_GROUP_DOCUMENT_SETTINGS" xml:space="preserve">
+    <value>Document settings</value>
+  </data>
+  <data name="_annotation_name" xml:space="preserve">
+    <value>Add an annotation to the document with the specified name. Existing annotations with the same name will be overwritten.</value>
+  </data>
+  <data name="_annotation_targets" xml:space="preserve">
+    <value>A comma-separated list of target types to apply the annotation to in an --annotation-name operation.</value>
+  </data>
+  <data name="_annotation_type" xml:space="preserve">
+    <value>Define the data type of the annotation in an --annotation-name operation. Defaults to text.</value>
+  </data>
+  <data name="_annotation_values" xml:space="preserve">
+    <value>A comma-separated list of values for a value_list type annotation in an --annotation-name operation. Required only in an --annotation-type=value_list operation.</value>
+  </data>
+  <data name="CommandArgs_ANNOTATION_VALUES_VALUE" xml:space="preserve">
+    <value>"&lt;value&gt;, &lt;value&gt;, &lt;value&gt;..."</value>
+  </data>
+  <data name="_annotation_conflict_resolution" xml:space="preserve">
+    <value>Specifies how to resolve annotation name conflicts, by either overwriting or skipping them, when using --annotation-name, --annotation-file, or --annotation-add-from-environment (default is to output an error message for conflicts).</value>
+  </data>
+  <data name="_annotation_file" xml:space="preserve">
+    <value>Add an annotation to the document and environment from an XML format file. For an example of an XML format file, view the user.config file specified in the user interface window Tools &gt;Options &gt; Miscellaneous. Existing annotations with the same name will be overwritten.</value>
+  </data>
+  <data name="_background_proteome_file" xml:space="preserve">
+    <value>The path to the background proteome (protdb) file to apply to the opened document. The name may be optionally specified by --background-proteome-name, and if not it defaults to the filename.</value>
+  </data>
+  <data name="_background_proteome_name" xml:space="preserve">
+    <value>The name of a background proteome to apply to the opened document. The background proteome specifies the full set of proteins that may be present in the sample matrix to be injected into the mass spectrometer. If the name is not already defined in Skyline, the path to the protdb file must also be set by --background-proteome-file.</value>
+  </data>
+  <data name="_pep_digest_enzyme" xml:space="preserve">
+    <value>The protease enzyme definition used to parse peptide sequences from protein sequences added as targets to the document. Peptide lists added as targets ignore this setting other than counting missed cleavages.</value>
+  </data>
+  <data name="_pep_max_missed_cleavages" xml:space="preserve">
+    <value>The maximum number of missed cleavages allowed in a peptide when considering protein digestion.</value>
+  </data>
+  <data name="_pep_unique_by" xml:space="preserve">
+    <value>"Protein" excludes any peptide that appears in more than one protein in the background proteome.  
+"Gene" excludes any peptide that appears in proteins for more than one gene in the background proteome.  
+"Species" excludes any peptide that appears in proteins for more than one species in the background proteome.
+Useful in sample mixtures including multiple species.</value>
+  </data>
+  <data name="_verbose_errors" xml:space="preserve">
+    <value>Adds additional information to the program output in the case of an error, that may be helpful to Skyline developers.</value>
+  </data>
+  <data name="_associate_proteins_gene_level_parsimony" xml:space="preserve">
+    <value>Associate peptides with genes (or gene groups) instead of proteins, and apply parsimony options to that association.</value>
+  </data>
+  <data name="CommandArgs_MOD_NAME_VALUE_full_name__e_g___Oxidation__M______short_name__Oxi_" xml:space="preserve">
+    <value>full name (e.g. "Oxidation (M)") | short name (Oxi)</value>
+  </data>
+  <data name="CommandArgs_MOD_UNIMOD_VALUE_UniMod_ID__e_g___35__" xml:space="preserve">
+    <value>UniMod ID (e.g. "35")</value>
+  </data>
+  <data name="_integrate_all" xml:space="preserve">
+    <value>When set all transitions contributing any signal between the integration boundaries are considered found. When not set, only transitions that are coeluting are considered found. Regardless of the setting all signal from the quantitative transitions between the integration boundaries is summed to produce the TotalArea for the precursor.</value>
+  </data>
+  <data name="_pep_add_mod" xml:space="preserve">
+    <value>Add a UniMod modification to the document. The modification must be specified by PSI-MS name and site together ("Oxidation (M)").</value>
+  </data>
+  <data name="_pep_add_unimod_aa" xml:space="preserve">
+    <value>Provides the amino acid specificity for the last peptide modification added by --pep-add-unimod.</value>
+  </data>
+  <data name="_pep_add_unimod_term" xml:space="preserve">
+    <value>Provides the terminus specificity for the last peptide modification added by --pep-add-unimod.</value>
+  </data>
+  <data name="_pep_add_unimod" xml:space="preserve">
+    <value>Add a UniMod modification to the document by its UniMod ID. If the modification has multiple specificities, you must use --pep-add-unimod-aa or --pep-add-unimod-term to choose which specificity you want to add to the document.</value>
+  </data>
+  <data name="_pep_clear_mods" xml:space="preserve">
+    <value>Clears all peptide modifications from the currently open document.</value>
+  </data>
+  <data name="_pep_max_losses" xml:space="preserve">
+    <value>The maximum number of neutral loss events allowed to occur in combination on any fragment instance.</value>
+  </data>
+  <data name="_pep_max_variable_mods" xml:space="preserve">
+    <value>The maximum number of variable modifications allowed to occur in combination on any peptide instance.</value>
+  </data>
+  <data name="CommandArgs_BOOL_VALUE__0__or__1_" xml:space="preserve">
+    <value>{0} or {1}</value>
+  </data>
   <data name="ValueInvalidException_ValueInvalidException_The_value___0___is_not_valid_for_the_argument__1___Use_one_of__2_" xml:space="preserve">
     <value>値「{0}」は引数{1}に対して有効ではありません。{2}の1つを使用します。</value>
+  </data>
+  <data name="ValueInvalidModException_ValueInvalidModException_Unable_to_add_peptide_modification___0_____1_" xml:space="preserve">
+    <value>Unable to add peptide modification '{0}': {1}</value>
+  </data>
+  <data name="ValueInvalidBoolException_ValueInvalidBoolException_The_value___0___is_not_valid_for_the_argument___1____it_must_be__2_" xml:space="preserve">
+    <value>The value '{0}' is not valid for the argument '{1}': it must be {2}</value>
+  </data>
+  <data name="_associate_proteins_fasta" xml:space="preserve">
+    <value>Associate peptides in the document with proteins from the given FASTA. If this argument is not provided but other --associate-proteins options are, then the FASTA from --import-fasta will be used. If --import-fasta is not provided either, then the last FASTA used for protein association will be used.</value>
+  </data>
+  <data name="_pep_add_mod_variable" xml:space="preserve">
+    <value>Adds a modification as variable if 'true' or static if 'false'. Only valid for structural modifications except for loss-only modifications(e.g. Ammonia and Water Loss).</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/CommandArgUsage.zh-CHS.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.zh-CHS.resx
@@ -288,6 +288,12 @@
   <data name="_import_threads" xml:space="preserve">
     <value>将使用主进程中的线程并行导入的文件数量（相当于用户界面中的“同时导入的文件”），之后各个文件的结果将被汇集。在适当的条件下，这可以带来 2-4 倍的性能提升。务必使用您的系统进行测试。</value>
   </data>
+  <data name="_import_pep_list" xml:space="preserve">
+    <value>Import a list of peptides or peptide precursors (with charge state) with an optional list name specified by --import-pep-list-name.</value>
+  </data>
+  <data name="_import_pep_list_name" xml:space="preserve">
+    <value>Name of imported peptide list specified by --import-pep-list.</value>
+  </data>
   <data name="_import_transition_list" xml:space="preserve">
     <value>导入包含 Q1、Q3 和肽段序列的简单离子对列表。 还支持 CSV 格式并具有合适标题的分子离子对列表。</value>
   </data>
@@ -529,8 +535,11 @@ http://localhost:8080</value>
   <data name="_tool_zip_overwrite_annotations" xml:space="preserve">
     <value>指定提供的 ZIP 文件中的冲突的自定义注释是否应覆盖（“true”）或跳过（“false”）现有注释。</value>
   </data>
-  <data name="CommandArgs_GROUP_SETTINGS_Document_Settings" xml:space="preserve">
-    <value>文档设置</value>
+  <data name="CommandArgs_GROUP_SETTINGS_Transition_Settings" xml:space="preserve">
+    <value>Transition Settings</value>
+  </data>
+  <data name="CommandArgs_GROUP_SETTINGS_Peptide_Settings" xml:space="preserve">
+    <value>Peptide Settings</value>
   </data>
   <data name="CommandArgs_PATH_TO_FILE_path_to_file" xml:space="preserve">
     <value>路径/到/文件</value>
@@ -655,77 +664,57 @@ Waters</value>
     <value>如果还使用了“--refine-add-label-type”，则将删除（默认）或添加指定同位素标记类型的母离子。</value>
   </data>
   <data name="_refine_min_peptides" xml:space="preserve">
-    <value>含有少于此数目肽段的蛋白质将
-被从文档中删除。</value>
+    <value>Proteins with fewer than this number of peptides will be removed from the document.</value>
   </data>
   <data name="_refine_min_transitions" xml:space="preserve">
-    <value>含有少于此数目离子对的母离子将
-被从文档中删除。</value>
+    <value>Precursors with fewer than this number of transitions will be removed from the document.</value>
   </data>
   <data name="_refine_missing_library" xml:space="preserve">
     <value>将删除与库匹配不对应的所有目标。</value>
   </data>
   <data name="_refine_remove_duplicates" xml:space="preserve">
-    <value>所有在文档中不是唯一的肽段
-将被删除。</value>
+    <value>All peptides that are not unique within the document will be removed.</value>
   </data>
   <data name="_refine_remove_repeats" xml:space="preserve">
-    <value>将删除所有重复的肽段以仅留下
-首次出现的任何肽段。</value>
+    <value>All repeated peptides will be removed to leave only the first occurrence of any peptide.</value>
   </data>
   <data name="CommandArgs_LABEL_VALUE" xml:space="preserve">
     <value>&lt;标记类型&gt;</value>
   </data>
   <data name="_refine_max_peak_found_ratio" xml:space="preserve">
-    <value>峰值发现率高于此数字的所有元素
-将从文件中删除：
+    <value>All elements with peak found ratio above this number will be removed from the document:
 
-绿色 = 1.0
-橙色 &amp;gt;= 0.5
-红色 &amp;lt; 0.5</value>
+Green = 1.0
+Orange &gt;= 0.5
+Red &lt; 0.5</value>
   </data>
   <data name="_refine_max_peptide_peak_rank" xml:space="preserve">
-    <value>所有平均峰面积值排名
-大于此数目的离子对将被
-从文档中删除。</value>
+    <value>All transitions with an average area peak ranking greater than this number will be removed from the document.</value>
   </data>
   <data name="_refine_max_transition_peak_rank" xml:space="preserve">
-    <value>所有平均峰面积值排名
-大于此数目的离子对将被
-从文档中删除。</value>
+    <value>All transitions with an average area peak ranking greater than this number will be removed from the document.</value>
   </data>
   <data name="_refine_min_dotp" xml:space="preserve">
-    <value>所有对库谱图点积的子离子峰面积
-小于此阈值的母离子都将被
-从文档中删除。</value>
+    <value>All precursors with a product ion peak area to library spectrum dot-product below this threshold will be removed from the document.</value>
   </data>
   <data name="_refine_min_idotp" xml:space="preserve">
-    <value>所有对预期同位素峰分布点积的 MS1 母离子
-峰面积小于此阈值的母离子都将
-被从文档中删除。</value>
+    <value>All precursors with a MS1 precursor peak area to expected isotope distribution dot-product below this threshold will be removed from the document.</value>
   </data>
   <data name="_refine_min_peak_found_ratio" xml:space="preserve">
-    <value>所有峰值检出比大于此数目的元素
-都将被从文档中删除：
+    <value>All elements with peak found ratio below this number will be removed from the document:
 
-绿色 = 1.0
-橙色 &amp;gt;= 0.5
-红色 &amp;lt; 0.5</value>
+Green = 1.0
+Orange &gt;= 0.5
+Red &lt; 0.5</value>
   </data>
   <data name="_refine_min_time_correlation" xml:space="preserve">
-    <value>母离子将被从文档中删除
-直到具有最佳保留时间计算的线性
-回归相关系数的目标值
-超过此阈值。</value>
+    <value>Precursors will be removed from the document until the target value for the correlation coefficient of a linear regression with the optimal retention time calculator exceed this threshold.</value>
   </data>
   <data name="_refine_missing_results" xml:space="preserve">
-    <value>没有测量结果的所有元素都将
-被从文档中删除。</value>
+    <value>All elements without measured results will be removed from the document.</value>
   </data>
   <data name="_refine_prefer_larger_products" xml:space="preserve">
-    <value>当较小的、选择性较低的离子仅产生少量
-更大的峰面积时，导致细化以选择更大的
-产物离子。</value>
+    <value>Causes refinement to choose larger product ions when smaller, less selective ions yeild only fractionally greater peak area.</value>
   </data>
   <data name="_refine_use_best_result" xml:space="preserve">
     <value>在细化值计算中仅使用每种肽段的最佳重复测定。（用于分段洗脱）</value>
@@ -928,7 +917,142 @@ Waters</value>
   <data name="CommandArgs_ARG_FULL_SCAN_PRODUCT_ISOLATION_SCHEME_path_to_result_file_to_import_the_isolation_scheme" xml:space="preserve">
     <value>用于从中导入分离方案的 path/to/result-file</value>
   </data>
+  <data name="CommandArgs_GROUP_OTHER_FILE_TYPES" xml:space="preserve">
+    <value>Exporting other file types</value>
+  </data>
+  <data name="_exp_speclib_file" xml:space="preserve">
+    <value>Export experimental data in the current document to a spectral library file. Peak areas are used as spectrum intensities, peak apex times are used as retention times, and if the document has iRT values they will also be stored in the library.</value>
+  </data>
+  <data name="_exp_mprophet_exclude_feature" xml:space="preserve">
+    <value>Use to exclude a particular feature score by name from the exported file. Names can be found in the user interface. This argument may be used multiple times to exclude multiple features. Requires the --exp-mprophet-features argument.</value>
+  </data>
+  <data name="_exp_mprophet_features" xml:space="preserve">
+    <value>Export all the individual feature scores for each peptide, as well as the composite score, the p value, and the q value into the mProphet format.</value>
+  </data>
+  <data name="_exp_mprophet_best_peaks_only" xml:space="preserve">
+    <value>Include feature scores only for the best scoring peaks. Requires the --exp-mprophet-features argument.</value>
+  </data>
+  <data name="_exp_mprophet_targets_only" xml:space="preserve">
+    <value>Include feature scores only for targets. Requires the --exp-mprophet-features argument.</value>
+  </data>
+  <data name="_exp_annotations" xml:space="preserve">
+    <value>Export all the annotations in the document into a text file with an ElementLocator field in the format required by --import-annotations. Use --exp-annotations-include-properties to include properties as well.</value>
+  </data>
+  <data name="_exp_annotations_remove_blank_rows" xml:space="preserve">
+    <value>Use to remove blank rows from the exported annotations. Requires the --exp-annotations argument.</value>
+  </data>
+  <data name="_exp_annotations_include_object" xml:space="preserve">
+    <value>Use to specify which object types to include in the exported annotations. By default all object types are included. This argument can be used multiple times to specify multiple object types. Requires the --exp-annotations argument.</value>
+  </data>
+  <data name="_exp_annotations_include_properties" xml:space="preserve">
+    <value>Use to include all properties in the exported annotations. By default no properties are included. Requires the --exp-annotations argument.</value>
+  </data>
+  <data name="_pep_exclude_nterminal_aas" xml:space="preserve">
+    <value>Exclude all peptides starting before this amino acid position in each protein.</value>
+  </data>
+  <data name="_pep_exclude_potential_ragged_ends" xml:space="preserve">
+    <value>Exclude peptides resulting from cleavage sites with immediate preceding or following cleavage sites. e.g. RR, KK, RK, KR for trypsin</value>
+  </data>
+  <data name="_pep_max_length" xml:space="preserve">
+    <value>The maximum length of a peptide to add to the document.</value>
+  </data>
+  <data name="_pep_min_length" xml:space="preserve">
+    <value>The minimum length of a peptide to add to the document.</value>
+  </data>
+  <data name="CommandArgs_GROUP_DOCUMENT_SETTINGS" xml:space="preserve">
+    <value>Document settings</value>
+  </data>
+  <data name="_annotation_name" xml:space="preserve">
+    <value>Add an annotation to the document with the specified name. Existing annotations with the same name will be overwritten.</value>
+  </data>
+  <data name="_annotation_targets" xml:space="preserve">
+    <value>A comma-separated list of target types to apply the annotation to in an --annotation-name operation.</value>
+  </data>
+  <data name="_annotation_type" xml:space="preserve">
+    <value>Define the data type of the annotation in an --annotation-name operation. Defaults to text.</value>
+  </data>
+  <data name="_annotation_values" xml:space="preserve">
+    <value>A comma-separated list of values for a value_list type annotation in an --annotation-name operation. Required only in an --annotation-type=value_list operation.</value>
+  </data>
+  <data name="CommandArgs_ANNOTATION_VALUES_VALUE" xml:space="preserve">
+    <value>"&lt;value&gt;, &lt;value&gt;, &lt;value&gt;..."</value>
+  </data>
+  <data name="_annotation_conflict_resolution" xml:space="preserve">
+    <value>Specifies how to resolve annotation name conflicts, by either overwriting or skipping them, when using --annotation-name, --annotation-file, or --annotation-add-from-environment (default is to output an error message for conflicts).</value>
+  </data>
+  <data name="_annotation_file" xml:space="preserve">
+    <value>Add an annotation to the document and environment from an XML format file. For an example of an XML format file, view the user.config file specified in the user interface window Tools &gt;Options &gt; Miscellaneous. Existing annotations with the same name will be overwritten.</value>
+  </data>
+  <data name="_background_proteome_file" xml:space="preserve">
+    <value>The path to the background proteome (protdb) file to apply to the opened document. The name may be optionally specified by --background-proteome-name, and if not it defaults to the filename.</value>
+  </data>
+  <data name="_background_proteome_name" xml:space="preserve">
+    <value>The name of a background proteome to apply to the opened document. The background proteome specifies the full set of proteins that may be present in the sample matrix to be injected into the mass spectrometer. If the name is not already defined in Skyline, the path to the protdb file must also be set by --background-proteome-file.</value>
+  </data>
+  <data name="_pep_digest_enzyme" xml:space="preserve">
+    <value>The protease enzyme definition used to parse peptide sequences from protein sequences added as targets to the document. Peptide lists added as targets ignore this setting other than counting missed cleavages.</value>
+  </data>
+  <data name="_pep_max_missed_cleavages" xml:space="preserve">
+    <value>The maximum number of missed cleavages allowed in a peptide when considering protein digestion.</value>
+  </data>
+  <data name="_pep_unique_by" xml:space="preserve">
+    <value>"Protein" excludes any peptide that appears in more than one protein in the background proteome.  
+"Gene" excludes any peptide that appears in proteins for more than one gene in the background proteome.  
+"Species" excludes any peptide that appears in proteins for more than one species in the background proteome.
+Useful in sample mixtures including multiple species.</value>
+  </data>
+  <data name="_verbose_errors" xml:space="preserve">
+    <value>Adds additional information to the program output in the case of an error, that may be helpful to Skyline developers.</value>
+  </data>
+  <data name="_associate_proteins_gene_level_parsimony" xml:space="preserve">
+    <value>Associate peptides with genes (or gene groups) instead of proteins, and apply parsimony options to that association.</value>
+  </data>
+  <data name="CommandArgs_MOD_NAME_VALUE_full_name__e_g___Oxidation__M______short_name__Oxi_" xml:space="preserve">
+    <value>full name (e.g. "Oxidation (M)") | short name (Oxi)</value>
+  </data>
+  <data name="CommandArgs_MOD_UNIMOD_VALUE_UniMod_ID__e_g___35__" xml:space="preserve">
+    <value>UniMod ID (e.g. "35")</value>
+  </data>
+  <data name="_integrate_all" xml:space="preserve">
+    <value>When set all transitions contributing any signal between the integration boundaries are considered found. When not set, only transitions that are coeluting are considered found. Regardless of the setting all signal from the quantitative transitions between the integration boundaries is summed to produce the TotalArea for the precursor.</value>
+  </data>
+  <data name="_pep_add_mod" xml:space="preserve">
+    <value>Add a UniMod modification to the document. The modification must be specified by PSI-MS name and site together ("Oxidation (M)").</value>
+  </data>
+  <data name="_pep_add_unimod_aa" xml:space="preserve">
+    <value>Provides the amino acid specificity for the last peptide modification added by --pep-add-unimod.</value>
+  </data>
+  <data name="_pep_add_unimod_term" xml:space="preserve">
+    <value>Provides the terminus specificity for the last peptide modification added by --pep-add-unimod.</value>
+  </data>
+  <data name="_pep_add_unimod" xml:space="preserve">
+    <value>Add a UniMod modification to the document by its UniMod ID. If the modification has multiple specificities, you must use --pep-add-unimod-aa or --pep-add-unimod-term to choose which specificity you want to add to the document.</value>
+  </data>
+  <data name="_pep_clear_mods" xml:space="preserve">
+    <value>Clears all peptide modifications from the currently open document.</value>
+  </data>
+  <data name="_pep_max_losses" xml:space="preserve">
+    <value>The maximum number of neutral loss events allowed to occur in combination on any fragment instance.</value>
+  </data>
+  <data name="_pep_max_variable_mods" xml:space="preserve">
+    <value>The maximum number of variable modifications allowed to occur in combination on any peptide instance.</value>
+  </data>
+  <data name="CommandArgs_BOOL_VALUE__0__or__1_" xml:space="preserve">
+    <value>{0} or {1}</value>
+  </data>
   <data name="ValueInvalidException_ValueInvalidException_The_value___0___is_not_valid_for_the_argument__1___Use_one_of__2_" xml:space="preserve">
     <value>值“{0}”对于参数 {1} 无效。使用 {2} 中的一个</value>
+  </data>
+  <data name="ValueInvalidModException_ValueInvalidModException_Unable_to_add_peptide_modification___0_____1_" xml:space="preserve">
+    <value>Unable to add peptide modification '{0}': {1}</value>
+  </data>
+  <data name="ValueInvalidBoolException_ValueInvalidBoolException_The_value___0___is_not_valid_for_the_argument___1____it_must_be__2_" xml:space="preserve">
+    <value>The value '{0}' is not valid for the argument '{1}': it must be {2}</value>
+  </data>
+  <data name="_associate_proteins_fasta" xml:space="preserve">
+    <value>Associate peptides in the document with proteins from the given FASTA. If this argument is not provided but other --associate-proteins options are, then the FASTA from --import-fasta will be used. If --import-fasta is not provided either, then the last FASTA used for protein association will be used.</value>
+  </data>
+  <data name="_pep_add_mod_variable" xml:space="preserve">
+    <value>Adds a modification as variable if 'true' or static if 'false'. Only valid for structural modifications except for loss-only modifications(e.g. Ammonia and Water Loss).</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.ja.resx
@@ -632,18 +632,6 @@
   <data name="textBoxError.Text" xml:space="preserve">
     <value></value>
   </data>
-  <data name="&gt;&gt;textBoxError.Name" xml:space="preserve">
-    <value>textBoxError</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Controls.Graphs.DisabledRichTextBox, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnCopyText.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -659,18 +647,6 @@
   <data name="btnCopyText.Text" xml:space="preserve">
     <value>テキストをコピー(&amp;T)</value>
   </data>
-  <data name="&gt;&gt;btnCopyText.Name" xml:space="preserve">
-    <value>btnCopyText</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="cbMoreInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -685,18 +661,6 @@
   </data>
   <data name="cbMoreInfo.Text" xml:space="preserve">
     <value>詳細(&amp;M)</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Name" xml:space="preserve">
-    <value>cbMoreInfo</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>468, 17</value>
@@ -851,18 +815,6 @@
   <data name="flowFileStatus.WrapContents" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;flowFileStatus.Name" xml:space="preserve">
-    <value>flowFileStatus</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.Parent" xml:space="preserve">
-    <value>panelFileList</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="&gt;&gt;panel2.Name" xml:space="preserve">
     <value>panel2</value>
   </data>
@@ -938,18 +890,6 @@
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
-    <value>panelStatus</value>
-  </data>
-  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lblDuration.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -968,18 +908,6 @@
   <data name="lblDuration.Text" xml:space="preserve">
     <value>00：00：00</value>
   </data>
-  <data name="&gt;&gt;lblDuration.Name" xml:space="preserve">
-    <value>lblDuration</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="progressBarTotal.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -997,18 +925,6 @@
   </data>
   <data name="progressBarTotal.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Name" xml:space="preserve">
-    <value>progressBarTotal</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="graphChromatograms.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.resx
@@ -632,18 +632,6 @@
   <data name="textBoxError.Text" xml:space="preserve">
     <value></value>
   </data>
-  <data name="&gt;&gt;textBoxError.Name" xml:space="preserve">
-    <value>textBoxError</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Controls.Graphs.DisabledRichTextBox, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnCopyText.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -659,18 +647,6 @@
   <data name="btnCopyText.Text" xml:space="preserve">
     <value>Copy &amp;Text</value>
   </data>
-  <data name="&gt;&gt;btnCopyText.Name" xml:space="preserve">
-    <value>btnCopyText</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="cbMoreInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -685,18 +661,6 @@
   </data>
   <data name="cbMoreInfo.Text" xml:space="preserve">
     <value>&amp;More info</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Name" xml:space="preserve">
-    <value>cbMoreInfo</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>468, 17</value>
@@ -851,18 +815,6 @@
   <data name="flowFileStatus.WrapContents" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;flowFileStatus.Name" xml:space="preserve">
-    <value>flowFileStatus</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.Parent" xml:space="preserve">
-    <value>panelFileList</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="&gt;&gt;panel2.Name" xml:space="preserve">
     <value>panel2</value>
   </data>
@@ -938,18 +890,6 @@
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
-    <value>panelStatus</value>
-  </data>
-  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lblDuration.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -968,18 +908,6 @@
   <data name="lblDuration.Text" xml:space="preserve">
     <value>00:00:00</value>
   </data>
-  <data name="&gt;&gt;lblDuration.Name" xml:space="preserve">
-    <value>lblDuration</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="progressBarTotal.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -997,18 +925,6 @@
   </data>
   <data name="progressBarTotal.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Name" xml:space="preserve">
-    <value>progressBarTotal</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="graphChromatograms.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.zh-CHS.resx
@@ -632,18 +632,6 @@
   <data name="textBoxError.Text" xml:space="preserve">
     <value></value>
   </data>
-  <data name="&gt;&gt;textBoxError.Name" xml:space="preserve">
-    <value>textBoxError</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Controls.Graphs.DisabledRichTextBox, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;textBoxError.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnCopyText.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -659,18 +647,6 @@
   <data name="btnCopyText.Text" xml:space="preserve">
     <value>复制文本(&amp;T)</value>
   </data>
-  <data name="&gt;&gt;btnCopyText.Name" xml:space="preserve">
-    <value>btnCopyText</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;btnCopyText.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="cbMoreInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -685,18 +661,6 @@
   </data>
   <data name="cbMoreInfo.Text" xml:space="preserve">
     <value>更多信息(&amp;M)</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Name" xml:space="preserve">
-    <value>cbMoreInfo</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.Parent" xml:space="preserve">
-    <value>panelError</value>
-  </data>
-  <data name="&gt;&gt;cbMoreInfo.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>468, 17</value>
@@ -851,18 +815,6 @@
   <data name="flowFileStatus.WrapContents" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;flowFileStatus.Name" xml:space="preserve">
-    <value>flowFileStatus</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.Parent" xml:space="preserve">
-    <value>panelFileList</value>
-  </data>
-  <data name="&gt;&gt;flowFileStatus.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="&gt;&gt;panel2.Name" xml:space="preserve">
     <value>panel2</value>
   </data>
@@ -938,18 +890,6 @@
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
-    <value>panelStatus</value>
-  </data>
-  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lblDuration.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -968,18 +908,6 @@
   <data name="lblDuration.Text" xml:space="preserve">
     <value>00:00:00</value>
   </data>
-  <data name="&gt;&gt;lblDuration.Name" xml:space="preserve">
-    <value>lblDuration</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;lblDuration.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="progressBarTotal.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -997,18 +925,6 @@
   </data>
   <data name="progressBarTotal.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Name" xml:space="preserve">
-    <value>progressBarTotal</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;progressBarTotal.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="graphChromatograms.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/DetectionToolbarProperties.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/DetectionToolbarProperties.ja.resx
@@ -699,9 +699,6 @@
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
   </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>検出プロットプロパティ</value>
   </data>

--- a/pwiz_tools/Skyline/Controls/Graphs/DetectionToolbarProperties.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/DetectionToolbarProperties.zh-CHS.resx
@@ -699,9 +699,6 @@
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
   </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>检测图属性</value>
   </data>

--- a/pwiz_tools/Skyline/Controls/Graphs/DetectionsToolbar.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/DetectionsToolbar.ja.resx
@@ -164,9 +164,8 @@
   <data name="toolStripLabel2.Size" type="System.Drawing.Size, System.Drawing">
     <value>63, 27</value>
   </data>
-  <!-- ReSharper disable once OverriddenWithEmptyValue -->
   <data name="toolStripLabel2.Text" xml:space="preserve">
-    <value></value>
+    <value>At least </value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="toolStripAtLeastN.AutoSize" type="System.Boolean, mscorlib">

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.ja.resx
@@ -162,7 +162,7 @@
     <value>24, 15</value>
   </data>
   <data name="ceLabel.Text" xml:space="preserve">
-    <value>NCE：</value>
+    <value>NCE:</value>
   </data>
   <data name="comboCE.Size" type="System.Drawing.Size, System.Drawing">
     <value>92, 25</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.zh-CHS.resx
@@ -162,7 +162,7 @@
     <value>24, 15</value>
   </data>
   <data name="ceLabel.Text" xml:space="preserve">
-    <value>NCE：</value>
+    <value>NCE:</value>
   </data>
   <data name="comboCE.Size" type="System.Drawing.Size, System.Drawing">
     <value>92, 25</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.ja.resx
@@ -247,6 +247,9 @@
   <data name="AreaReplicateGraphPane_UpdateGraph_Step__0_" xml:space="preserve">
     <value>ステップ{0}</value>
   </data>
+  <data name="AreaReplicateGraphPane_Tooltip_Total" xml:space="preserve">
+    <value>Total:</value>
+  </data>
   <data name="AsyncChromatogramsGraph_AsyncChromatogramsGraph_Intensity" xml:space="preserve">
     <value>強度</value>
   </data>
@@ -711,6 +714,27 @@
   </data>
   <data name="UnavailableMSGraphItem_UnavailableMSGraphItem_Spectrum_information_unavailable" xml:space="preserve">
     <value>スペクトル情報が利用不可</value>
+  </data>
+  <data name="AreaPeptideGraphPane_UpdateAxes_Peptide_Rank" xml:space="preserve">
+    <value>Peptide Rank</value>
+  </data>
+  <data name="Extensions_CustomToString_Relative_Abundance" xml:space="preserve">
+    <value>Relative Abundance</value>
+  </data>
+  <data name="SummaryIntensityGraphPane_SummaryIntensityGraphPane_Protein_Rank" xml:space="preserve">
+    <value>Protein Rank</value>
+  </data>
+  <data name="SummaryRelativeAbundanceGraphPane_UpdateAxes_Molecule_Rank" xml:space="preserve">
+    <value>Molecule Rank</value>
+  </data>
+  <data name="FoldChangeVolcanoPlot_BuildContextMenu_Auto_Arrange_Labels" xml:space="preserve">
+    <value>Auto Arrange Labels</value>
+  </data>
+  <data name="FoldChangeVolcanoPlot_BuildContextMenu_PauseLabelLayout" xml:space="preserve">
+    <value>Suspend Label Layout</value>
+  </data>
+  <data name="FoldChangeVolcanoPlot_BuildContextMenu_RestartLabelLayout" xml:space="preserve">
+    <value>Resume Label Layout</value>
   </data>
   <data name="AlignmentForm_UpdateGraph_Peptides" xml:space="preserve">
     <value>ペプチド</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.zh-CHS.resx
@@ -247,6 +247,9 @@
   <data name="AreaReplicateGraphPane_UpdateGraph_Step__0_" xml:space="preserve">
     <value>步骤 {0}</value>
   </data>
+  <data name="AreaReplicateGraphPane_Tooltip_Total" xml:space="preserve">
+    <value>Total:</value>
+  </data>
   <data name="AsyncChromatogramsGraph_AsyncChromatogramsGraph_Intensity" xml:space="preserve">
     <value>强度</value>
   </data>
@@ -711,6 +714,27 @@
   </data>
   <data name="UnavailableMSGraphItem_UnavailableMSGraphItem_Spectrum_information_unavailable" xml:space="preserve">
     <value>谱图信息不可用</value>
+  </data>
+  <data name="AreaPeptideGraphPane_UpdateAxes_Peptide_Rank" xml:space="preserve">
+    <value>Peptide Rank</value>
+  </data>
+  <data name="Extensions_CustomToString_Relative_Abundance" xml:space="preserve">
+    <value>Relative Abundance</value>
+  </data>
+  <data name="SummaryIntensityGraphPane_SummaryIntensityGraphPane_Protein_Rank" xml:space="preserve">
+    <value>Protein Rank</value>
+  </data>
+  <data name="SummaryRelativeAbundanceGraphPane_UpdateAxes_Molecule_Rank" xml:space="preserve">
+    <value>Molecule Rank</value>
+  </data>
+  <data name="FoldChangeVolcanoPlot_BuildContextMenu_Auto_Arrange_Labels" xml:space="preserve">
+    <value>Auto Arrange Labels</value>
+  </data>
+  <data name="FoldChangeVolcanoPlot_BuildContextMenu_PauseLabelLayout" xml:space="preserve">
+    <value>Suspend Label Layout</value>
+  </data>
+  <data name="FoldChangeVolcanoPlot_BuildContextMenu_RestartLabelLayout" xml:space="preserve">
+    <value>Resume Label Layout</value>
   </data>
   <data name="AlignmentForm_UpdateGraph_Peptides" xml:space="preserve">
     <value>肽段</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.ja.resx
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="proteinsTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="proteinsTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 31</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="proteinsTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="proteinsTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>432, 381</value>
+  </data>
+  <data name="proteinsTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Name" xml:space="preserve">
+    <value>proteinsTextBox</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Type" xml:space="preserve">
+    <value>pwiz.Common.Controls.AutoScrollTextBox, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 12</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>201, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Enter a list of identifiers on separate lines.</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="buttonOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonOk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>288, 418</value>
+  </data>
+  <data name="buttonOk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonOk.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Name" xml:space="preserve">
+    <value>buttonOk</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>369, 418</value>
+  </data>
+  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="buttonCancel.Text" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Name" xml:space="preserve">
+    <value>buttonCancel</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>66</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>456, 450</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Enter List</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MatchExpressionListDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.ModeUIInvariantFormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.zh-CHS.resx
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="proteinsTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="proteinsTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 31</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="proteinsTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="proteinsTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>432, 381</value>
+  </data>
+  <data name="proteinsTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Name" xml:space="preserve">
+    <value>proteinsTextBox</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Type" xml:space="preserve">
+    <value>pwiz.Common.Controls.AutoScrollTextBox, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 12</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>201, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Enter a list of identifiers on separate lines.</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="buttonOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonOk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>288, 418</value>
+  </data>
+  <data name="buttonOk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonOk.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonOk.Text" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Name" xml:space="preserve">
+    <value>buttonOk</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>369, 418</value>
+  </data>
+  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="buttonCancel.Text" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Name" xml:space="preserve">
+    <value>buttonCancel</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>66</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>456, 450</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Enter List</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MatchExpressionListDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.ModeUIInvariantFormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.ja.resx
@@ -117,376 +117,397 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&gt;&gt;foldChangeComboBox.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;bindingSource1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.BindingSource, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;expressionTextBox.Name" xml:space="preserve">
-    <value>expressionTextBox</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
-    <value>modeUIHandler</value>
-  </data>
-  <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>402, 309</value>
-  </data>
-  <data name="&gt;&gt;expressionTextBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 13</value>
-  </data>
-  <data name="matchComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>331, 24</value>
-  </data>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="matchComboBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;matchComboBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;pValueComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="expressionTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pValueComboBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="expressionTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="label3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;pValueComboBox.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nameColumn.Name" xml:space="preserve">
-    <value>nameColumn</value>
-  </data>
-  <data name="expressionTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>315, 20</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;okButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="linkRegex.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 8</value>
-  </data>
-  <data name="dataGridView1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;matchComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
-  </data>
-  <data name="&gt;&gt;matchComboBox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="matchComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="cancelButton.Text" xml:space="preserve">
-    <value>キャンセル</value>
-  </data>
-  <data name="dataGridView1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="groupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="&gt;&gt;foldChangeComboBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>328, 8</value>
-  </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="groupBox1.Text" xml:space="preserve">
-    <value>フィルタ</value>
-  </data>
-  <data name="&gt;&gt;foldChangeComboBox.Name" xml:space="preserve">
-    <value>foldChangeComboBox</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataGridView1.Name" xml:space="preserve">
-    <value>dataGridView1</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+  <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
-  </data>
-  <data name="expressionTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 25</value>
-  </data>
-  <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="linkRegex.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;expressionTextBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="linkRegex.Text" xml:space="preserve">
-    <value>正規表現(&amp;R)：</value>
-  </data>
-  <data name="&gt;&gt;dataGridView1.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="label4.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;linkRegex.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterScreen</value>
-  </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>倍率変化カットオフ(&amp;F)：</value>
-  </data>
-  <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.ModeUIInvariantFormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>321, 309</value>
-  </data>
-  <data name="label5.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 22</value>
-  </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>合致(&amp;M)：</value>
-  </data>
-  <data name="&gt;&gt;okButton.Name" xml:space="preserve">
-    <value>okButton</value>
-  </data>
-  <data name="pValueComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 51</value>
-  </data>
-  <data name="&gt;&gt;dataGridView1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;matchComboBox.Name" xml:space="preserve">
-    <value>matchComboBox</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>462, 73</value>
-  </data>
-  <data name="&gt;&gt;dataGridView1.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;linkRegex.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bindingSource1.Name" xml:space="preserve">
-    <value>bindingSource1</value>
-  </data>
-  <data name="&gt;&gt;linkRegex.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;okButton.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
   </data>
   <data name="cancelButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="expressionTextBox.AutoCompleteCustomSource" xml:space="preserve">
-    <value>テスト</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>402, 309</value>
   </data>
-  <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+  <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
   </data>
-  <data name="pValueComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="dataGridView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>465, 173</value>
-  </data>
-  <data name="okButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>P値カットオフ(&amp;P)：</value>
-  </data>
-  <data name="linkRegex.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="linkRegex.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
+  <data name="cancelButton.Text" xml:space="preserve">
+    <value>キャンセル</value>
   </data>
   <data name="&gt;&gt;cancelButton.Name" xml:space="preserve">
     <value>cancelButton</value>
   </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>一致式を作成します</value>
+  <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="foldChangeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
-  </data>
-  <data name="nameColumn.HeaderText" xml:space="preserve">
-    <value>一致したルール</value>
-  </data>
-  <data name="&gt;&gt;nameColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewLinkColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="okButton.Text" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
-  </data>
-  <data name="&gt;&gt;pValueComboBox.Name" xml:space="preserve">
-    <value>pValueComboBox</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;foldChangeComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="&gt;&gt;okButton.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
   </data>
-  <data name="&gt;&gt;expressionTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="okButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>321, 309</value>
   </data>
-  <data name="dataGridView1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 130</value>
-  </data>
-  <data name="pValueComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>177, 38</value>
-  </data>
-  <data name="foldChangeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 38</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>489, 345</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>CreateMatchExpressionDlg</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="foldChangeComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;linkRegex.Name" xml:space="preserve">
-    <value>linkRegex</value>
+  <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
   </data>
   <data name="okButton.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
+  <data name="okButton.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="&gt;&gt;okButton.Name" xml:space="preserve">
+    <value>okButton</value>
+  </data>
+  <data name="&gt;&gt;okButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;okButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;okButton.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="dataGridView1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <metadata name="nameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="nameColumn.HeaderText" xml:space="preserve">
+    <value>一致したルール</value>
+  </data>
+  <metadata name="bindingSource1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
+  </metadata>
+  <data name="dataGridView1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 130</value>
+  </data>
+  <data name="dataGridView1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>465, 173</value>
+  </data>
+  <data name="dataGridView1.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;dataGridView1.Name" xml:space="preserve">
+    <value>dataGridView1</value>
+  </data>
+  <data name="&gt;&gt;dataGridView1.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;dataGridView1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;dataGridView1.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="expressionTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="expressionTextBox.AutoCompleteCustomSource" xml:space="preserve">
+    <value>テスト</value>
+  </data>
+  <data name="expressionTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>99, 25</value>
+  </data>
+  <data name="expressionTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 20</value>
+  </data>
+  <data name="expressionTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;expressionTextBox.Name" xml:space="preserve">
+    <value>expressionTextBox</value>
+  </data>
+  <data name="&gt;&gt;expressionTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;expressionTextBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;expressionTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="groupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 13</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>P値カットオフ(&amp;P)：</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="pValueComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>177, 38</value>
+  </data>
+  <data name="pValueComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="pValueComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;pValueComboBox.Name" xml:space="preserve">
+    <value>pValueComboBox</value>
+  </data>
+  <data name="&gt;&gt;pValueComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pValueComboBox.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;pValueComboBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 22</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="label4.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>倍率変化カットオフ(&amp;F)：</value>
+  </data>
+  <data name="&gt;&gt;label4.Name" xml:space="preserve">
+    <value>label4</value>
+  </data>
+  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="foldChangeComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 38</value>
+  </data>
+  <data name="foldChangeComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="foldChangeComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;foldChangeComboBox.Name" xml:space="preserve">
+    <value>foldChangeComboBox</value>
+  </data>
+  <data name="&gt;&gt;foldChangeComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;foldChangeComboBox.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;foldChangeComboBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 51</value>
+  </data>
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>462, 73</value>
+  </data>
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="groupBox1.Text" xml:space="preserve">
+    <value>フィルタ</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>328, 8</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 13</value>
+  </data>
+  <data name="label3.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>合致(&amp;M)：</value>
+  </data>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
+  </data>
   <data name="&gt;&gt;label3.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="matchComboBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="matchComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 24</value>
   </data>
   <data name="matchComboBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>147, 21</value>
   </data>
-  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="nameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="matchComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;matchComboBox.Name" xml:space="preserve">
+    <value>matchComboBox</value>
+  </data>
+  <data name="&gt;&gt;matchComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;matchComboBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;matchComboBox.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="linkRegex.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
+  <data name="linkRegex.Location" type="System.Drawing.Point, System.Drawing">
+    <value>96, 8</value>
+  </data>
+  <data name="linkRegex.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="linkRegex.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="linkRegex.Text" xml:space="preserve">
+    <value>正規表現(&amp;R)：</value>
+  </data>
+  <data name="&gt;&gt;linkRegex.Name" xml:space="preserve">
+    <value>linkRegex</value>
+  </data>
+  <data name="&gt;&gt;linkRegex.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkRegex.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;linkRegex.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="enterListButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 22</value>
+  </data>
+  <data name="enterListButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="enterListButton.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="enterListButton.Text" xml:space="preserve">
+    <value>&amp;Enter List...</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Name" xml:space="preserve">
+    <value>enterListButton</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="bindingSource1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>155, 17</value>
-  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>489, 345</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterScreen</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>一致式を作成します</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nameColumn.Name" xml:space="preserve">
+    <value>nameColumn</value>
+  </data>
+  <data name="&gt;&gt;nameColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewLinkColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;bindingSource1.Name" xml:space="preserve">
+    <value>bindingSource1</value>
+  </data>
+  <data name="&gt;&gt;bindingSource1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.BindingSource, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>CreateMatchExpressionDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.ModeUIInvariantFormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.zh-CHS.resx
@@ -117,376 +117,397 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&gt;&gt;foldChangeComboBox.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;bindingSource1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.BindingSource, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;expressionTextBox.Name" xml:space="preserve">
-    <value>expressionTextBox</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
-    <value>modeUIHandler</value>
-  </data>
-  <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>402, 309</value>
-  </data>
-  <data name="&gt;&gt;expressionTextBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 13</value>
-  </data>
-  <data name="matchComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>331, 24</value>
-  </data>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="matchComboBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;matchComboBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;pValueComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="expressionTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;pValueComboBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="expressionTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="label3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;pValueComboBox.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;nameColumn.Name" xml:space="preserve">
-    <value>nameColumn</value>
-  </data>
-  <data name="expressionTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>315, 20</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;okButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="linkRegex.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 8</value>
-  </data>
-  <data name="dataGridView1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;matchComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
-  </data>
-  <data name="&gt;&gt;matchComboBox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="matchComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="cancelButton.Text" xml:space="preserve">
-    <value>取消</value>
-  </data>
-  <data name="dataGridView1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="groupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="&gt;&gt;foldChangeComboBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>328, 8</value>
-  </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="groupBox1.Text" xml:space="preserve">
-    <value>过滤器</value>
-  </data>
-  <data name="&gt;&gt;foldChangeComboBox.Name" xml:space="preserve">
-    <value>foldChangeComboBox</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataGridView1.Name" xml:space="preserve">
-    <value>dataGridView1</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+  <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
-  </data>
-  <data name="expressionTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 25</value>
-  </data>
-  <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="linkRegex.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;expressionTextBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="linkRegex.Text" xml:space="preserve">
-    <value>正则表达式(&amp;R)：</value>
-  </data>
-  <data name="&gt;&gt;dataGridView1.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="label4.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;linkRegex.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterScreen</value>
-  </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>倍数变化截止值(&amp;F)：</value>
-  </data>
-  <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.ModeUIInvariantFormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>321, 309</value>
-  </data>
-  <data name="label5.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 22</value>
-  </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>匹配(&amp;M)：</value>
-  </data>
-  <data name="&gt;&gt;okButton.Name" xml:space="preserve">
-    <value>okButton</value>
-  </data>
-  <data name="pValueComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 51</value>
-  </data>
-  <data name="&gt;&gt;dataGridView1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;matchComboBox.Name" xml:space="preserve">
-    <value>matchComboBox</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>462, 73</value>
-  </data>
-  <data name="&gt;&gt;dataGridView1.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;linkRegex.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;bindingSource1.Name" xml:space="preserve">
-    <value>bindingSource1</value>
-  </data>
-  <data name="&gt;&gt;linkRegex.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;okButton.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
   </data>
   <data name="cancelButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="expressionTextBox.AutoCompleteCustomSource" xml:space="preserve">
-    <value>测试</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>402, 309</value>
   </data>
-  <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+  <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
   </data>
-  <data name="pValueComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="dataGridView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>465, 173</value>
-  </data>
-  <data name="okButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label5.Text" xml:space="preserve">
-    <value>P 值截止(&amp;P)：</value>
-  </data>
-  <data name="linkRegex.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="linkRegex.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
+  <data name="cancelButton.Text" xml:space="preserve">
+    <value>取消</value>
   </data>
   <data name="&gt;&gt;cancelButton.Name" xml:space="preserve">
     <value>cancelButton</value>
   </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>创建匹配表达式</value>
+  <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="foldChangeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
-  </data>
-  <data name="nameColumn.HeaderText" xml:space="preserve">
-    <value>匹配的</value>
-  </data>
-  <data name="&gt;&gt;nameColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewLinkColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="okButton.Text" xml:space="preserve">
-    <value>确定</value>
-  </data>
-  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
-  </data>
-  <data name="&gt;&gt;pValueComboBox.Name" xml:space="preserve">
-    <value>pValueComboBox</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;foldChangeComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="&gt;&gt;okButton.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
   </data>
-  <data name="&gt;&gt;expressionTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="okButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>321, 309</value>
   </data>
-  <data name="dataGridView1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 130</value>
-  </data>
-  <data name="pValueComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>177, 38</value>
-  </data>
-  <data name="foldChangeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 38</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>489, 345</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>CreateMatchExpressionDlg</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="foldChangeComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;linkRegex.Name" xml:space="preserve">
-    <value>linkRegex</value>
+  <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
   </data>
   <data name="okButton.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
+  <data name="okButton.Text" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="&gt;&gt;okButton.Name" xml:space="preserve">
+    <value>okButton</value>
+  </data>
+  <data name="&gt;&gt;okButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;okButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;okButton.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="dataGridView1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <metadata name="nameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="nameColumn.HeaderText" xml:space="preserve">
+    <value>匹配的</value>
+  </data>
+  <metadata name="bindingSource1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
+  </metadata>
+  <data name="dataGridView1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 130</value>
+  </data>
+  <data name="dataGridView1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>465, 173</value>
+  </data>
+  <data name="dataGridView1.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;dataGridView1.Name" xml:space="preserve">
+    <value>dataGridView1</value>
+  </data>
+  <data name="&gt;&gt;dataGridView1.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;dataGridView1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;dataGridView1.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="expressionTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="expressionTextBox.AutoCompleteCustomSource" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="expressionTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>99, 25</value>
+  </data>
+  <data name="expressionTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 20</value>
+  </data>
+  <data name="expressionTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;expressionTextBox.Name" xml:space="preserve">
+    <value>expressionTextBox</value>
+  </data>
+  <data name="&gt;&gt;expressionTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;expressionTextBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;expressionTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="groupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 13</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>P 值截止(&amp;P)：</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="pValueComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>177, 38</value>
+  </data>
+  <data name="pValueComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="pValueComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;pValueComboBox.Name" xml:space="preserve">
+    <value>pValueComboBox</value>
+  </data>
+  <data name="&gt;&gt;pValueComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pValueComboBox.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;pValueComboBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 22</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="label4.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>倍数变化截止值(&amp;F)：</value>
+  </data>
+  <data name="&gt;&gt;label4.Name" xml:space="preserve">
+    <value>label4</value>
+  </data>
+  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="foldChangeComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 38</value>
+  </data>
+  <data name="foldChangeComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="foldChangeComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;foldChangeComboBox.Name" xml:space="preserve">
+    <value>foldChangeComboBox</value>
+  </data>
+  <data name="&gt;&gt;foldChangeComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;foldChangeComboBox.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;foldChangeComboBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 51</value>
+  </data>
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>462, 73</value>
+  </data>
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="groupBox1.Text" xml:space="preserve">
+    <value>过滤器</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>328, 8</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>40, 13</value>
+  </data>
+  <data name="label3.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>匹配(&amp;M)：</value>
+  </data>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
+  </data>
   <data name="&gt;&gt;label3.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="matchComboBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="matchComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 24</value>
   </data>
   <data name="matchComboBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>147, 21</value>
   </data>
-  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="nameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="matchComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;matchComboBox.Name" xml:space="preserve">
+    <value>matchComboBox</value>
+  </data>
+  <data name="&gt;&gt;matchComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;matchComboBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;matchComboBox.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="linkRegex.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
+  <data name="linkRegex.Location" type="System.Drawing.Point, System.Drawing">
+    <value>96, 8</value>
+  </data>
+  <data name="linkRegex.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="linkRegex.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="linkRegex.Text" xml:space="preserve">
+    <value>正则表达式(&amp;R)：</value>
+  </data>
+  <data name="&gt;&gt;linkRegex.Name" xml:space="preserve">
+    <value>linkRegex</value>
+  </data>
+  <data name="&gt;&gt;linkRegex.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkRegex.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;linkRegex.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="enterListButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 22</value>
+  </data>
+  <data name="enterListButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="enterListButton.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="enterListButton.Text" xml:space="preserve">
+    <value>&amp;Enter List...</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Name" xml:space="preserve">
+    <value>enterListButton</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="bindingSource1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>155, 17</value>
-  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>489, 345</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterScreen</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>创建匹配表达式</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;nameColumn.Name" xml:space="preserve">
+    <value>nameColumn</value>
+  </data>
+  <data name="&gt;&gt;nameColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewLinkColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;bindingSource1.Name" xml:space="preserve">
+    <value>bindingSource1</value>
+  </data>
+  <data name="&gt;&gt;bindingSource1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.BindingSource, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>CreateMatchExpressionDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.ModeUIInvariantFormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/GroupComparisonResources.ja.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/GroupComparisonResources.ja.resx
@@ -130,4 +130,7 @@
   <data name="FoldChangeForm_BuildContextMenu_Volcano_Plot" xml:space="preserve">
     <value>ボルケーノプロット</value>
   </data>
+  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Protein_Expression_Formatting" xml:space="preserve">
+    <value>Relative Abundance Formatting</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/GroupComparisonResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/GroupComparisonResources.zh-CHS.resx
@@ -130,4 +130,7 @@
   <data name="FoldChangeForm_BuildContextMenu_Volcano_Plot" xml:space="preserve">
     <value>火山图</value>
   </data>
+  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Protein_Expression_Formatting" xml:space="preserve">
+    <value>Relative Abundance Formatting</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.ja.resx
@@ -117,8 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="colorDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>154, 17</value>
+    <value>155, 17</value>
   </metadata>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="button1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -126,7 +129,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 264</value>
+    <value>494, 264</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -154,7 +157,7 @@
     <value>Bottom, Right</value>
   </data>
   <data name="button2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>371, 264</value>
+    <value>575, 264</value>
   </data>
   <data name="button2.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -184,7 +187,7 @@
     <value>12, 12</value>
   </data>
   <data name="regexColorRowGrid1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>434, 235</value>
+    <value>638, 235</value>
   </data>
   <data name="regexColorRowGrid1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -208,7 +211,7 @@
     <value>True</value>
   </data>
   <data name="advancedCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>371, 230</value>
+    <value>575, 230</value>
   </data>
   <data name="advancedCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 17</value>
@@ -231,6 +234,39 @@
   <data name="&gt;&gt;advancedCheckBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="layoutLabelsBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="layoutLabelsBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="layoutLabelsBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>430, 223</value>
+  </data>
+  <data name="layoutLabelsBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>139, 24</value>
+  </data>
+  <data name="layoutLabelsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="layoutLabelsBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="layoutLabelsBox.Text" xml:space="preserve">
+    <value>Auto arrange labels</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Name" xml:space="preserve">
+    <value>layoutLabelsBox</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -238,16 +274,19 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>458, 299</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+    <value>662, 299</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>ボルケーノプロット形式</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;colorDialog1.Name" xml:space="preserve">
     <value>colorDialog1</value>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.zh-CHS.resx
@@ -117,8 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="colorDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>154, 17</value>
+    <value>155, 17</value>
   </metadata>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="button1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -126,7 +129,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>290, 264</value>
+    <value>494, 264</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -154,7 +157,7 @@
     <value>Bottom, Right</value>
   </data>
   <data name="button2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>371, 264</value>
+    <value>575, 264</value>
   </data>
   <data name="button2.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -184,7 +187,7 @@
     <value>12, 12</value>
   </data>
   <data name="regexColorRowGrid1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>434, 235</value>
+    <value>638, 235</value>
   </data>
   <data name="regexColorRowGrid1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -208,7 +211,7 @@
     <value>True</value>
   </data>
   <data name="advancedCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>371, 230</value>
+    <value>575, 230</value>
   </data>
   <data name="advancedCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 17</value>
@@ -231,6 +234,39 @@
   <data name="&gt;&gt;advancedCheckBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="layoutLabelsBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="layoutLabelsBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="layoutLabelsBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>430, 223</value>
+  </data>
+  <data name="layoutLabelsBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>139, 24</value>
+  </data>
+  <data name="layoutLabelsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="layoutLabelsBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="layoutLabelsBox.Text" xml:space="preserve">
+    <value>Auto arrange labels</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Name" xml:space="preserve">
+    <value>layoutLabelsBox</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -238,16 +274,19 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>458, 299</value>
-  </data>
-  <data name="$this.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+    <value>662, 299</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>火山图格式</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;colorDialog1.Name" xml:space="preserve">
     <value>colorDialog1</value>

--- a/pwiz_tools/Skyline/Controls/SeqNode/SeqNodeResources.ja.resx
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SeqNodeResources.ja.resx
@@ -118,6 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="NodeTip_Timer_Tick_An_error_occurred_displaying_a_tooltip_" xml:space="preserve">
+    <value>An error occurred displaying a tooltip.</value>
+  </data>
   <data name="PeptideGroupTreeNode_ChildHeading__0__" xml:space="preserve">
     <value>{0}個のペプチド</value>
   </data>

--- a/pwiz_tools/Skyline/Controls/SeqNode/SeqNodeResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SeqNodeResources.zh-CHS.resx
@@ -118,6 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="NodeTip_Timer_Tick_An_error_occurred_displaying_a_tooltip_" xml:space="preserve">
+    <value>An error occurred displaying a tooltip.</value>
+  </data>
   <data name="PeptideGroupTreeNode_ChildHeading__0__" xml:space="preserve">
     <value>{0} 个肽段</value>
   </data>

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectraResources.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectraResources.ja.resx
@@ -128,7 +128,7 @@
     <value>フィルタの調査</value>
   </data>
   <data name="SpectraGridForm_AddSpectrumFilters_No_spectrum_filters_were_added_to_the_document_" xml:space="preserve">
-    <value>ドキュメントにはスペクトルフィルタが追加されませんでした。</value>
+    <value>スペクトルフィルタはドキュメントに追加されませんでした。</value>
   </data>
   <data name="SpectraGridForm_AddSpectrumFilters_One_spectrum_filter_will_be_added_to_the_document_" xml:space="preserve">
     <value>1個のスペクトルフィルタがドキュメントに追加されます。</value>

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectraResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectraResources.zh-CHS.resx
@@ -140,7 +140,7 @@
     <value>所选行没有任何过滤器</value>
   </data>
   <data name="SpectraGridForm_AddSpectrumFilters_There_were_no_matching_precursors_to_add_any_filters_to_" xml:space="preserve">
-    <value>没有匹配的母离子可添加任何过滤器。</value>
+    <value>没有匹配的母离子来使用任何过滤器。</value>
   </data>
   <data name="SpectraGridForm_GetDefaultViewSpec_Default" xml:space="preserve">
     <value>默认</value>
@@ -149,7 +149,7 @@
     <value>显示所有谱图</value>
   </data>
   <data name="SpectraGridForm_GetSummaryMessage_Showing_spectra_near__0__precursors_between__1__and__2_" xml:space="preserve">
-    <value>显示 {1} 和 {2} 之间靠近 {0} 母离子的谱图</value>
+    <value>显示 {1} 和 {2} 之间并靠近 {0} 母离子的谱图</value>
   </data>
   <data name="SpectraGridForm_GetSummaryMessage_Showing_spectra_near_precursor_m_z__0_" xml:space="preserve">
     <value>显示接近母离子质荷比 {0} 的谱图</value>

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.ja.resx
@@ -117,9 +117,39 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="databoundGridControl.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="databoundGridControl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 123</value>
+  </data>
+  <data name="databoundGridControl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>765, 286</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Name" xml:space="preserve">
+    <value>databoundGridControl</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.Databinding.DataboundGridControl, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="ModeUIExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="btnCancelReadingFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="btnCancelReadingFile.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>160, 17</value>
   </metadata>
@@ -128,7 +158,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAAI
-        CAAAAk1TRnQBSQFMAwEBAAEoAQABKAEAARABAAEQAQAE/wEJAQAI/wFCAU0BNgEEBgABNgEEAgABKAMA
+        CAAAAk1TRnQBSQFMAwEBAAEwAQABMAEAARABAAEQAQAE/wEJAQAI/wFCAU0BNgEEBgABNgEEAgABKAMA
         AUADAAEQAwABAQEAAQgGAAEEGAABgAIAAYADAAKAAQABgAMAAYABAAGAAQACgAIAA8ABAAHAAdwBwAEA
         AfABygGmAQABMwUAATMBAAEzAQABMwEAAjMCAAMWAQADHAEAAyIBAAMpAQADVQEAA00BAANCAQADOQEA
         AYABfAH/AQACUAH/AQABkwEAAdYBAAH/AewBzAEAAcYB1gHvAQAB1gLnAQABkAGpAa0CAAH/ATMDAAFm
@@ -165,10 +195,379 @@
         AeMGAAGHAfMGAAGPAf8GAAL/BgAL
 </value>
   </data>
+  <data name="btnCancelReadingFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>767, 6</value>
+  </data>
+  <data name="btnCancelReadingFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnCancelReadingFile.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>270, 17</value>
+  </metadata>
+  <data name="btnCancelReadingFile.ToolTip" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Name" xml:space="preserve">
+    <value>btnCancelReadingFile</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="progressBar1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>547, 6</value>
+  </data>
+  <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>217, 23</value>
+  </data>
+  <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Name" xml:space="preserve">
+    <value>progressBar1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="lblStatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 6</value>
+  </data>
+  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>538, 23</value>
+  </data>
+  <data name="lblStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblStatus.Text" xml:space="preserve">
+    <value>File reading status</value>
+  </data>
+  <data name="lblStatus.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Name" xml:space="preserve">
+    <value>lblStatus</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="statusPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="statusPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 415</value>
+  </data>
+  <data name="statusPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>800, 35</value>
+  </data>
+  <data name="statusPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="statusPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Name" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="splitContainer1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="splitContainer1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="splitContainer1.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <data name="lblSummary.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="lblSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 100</value>
+  </data>
+  <data name="lblSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 23</value>
+  </data>
+  <data name="lblSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="lblSummary.Text" xml:space="preserve">
+    <value>Summary</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
+    <value>lblSummary</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnRemoveFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnRemoveFile.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnRemoveFile.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnRemoveFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 3</value>
+  </data>
+  <data name="btnRemoveFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnRemoveFile.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="btnRemoveFile.ToolTip" xml:space="preserve">
+    <value>Remove from list</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Name" xml:space="preserve">
+    <value>btnRemoveFile</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnBrowse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnBrowse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>675, 3</value>
+  </data>
+  <data name="btnBrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 28</value>
+  </data>
+  <data name="btnBrowse.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="btnBrowse.Text" xml:space="preserve">
+    <value>参照...</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Name" xml:space="preserve">
+    <value>btnBrowse</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 96</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>149, 23</value>
+  </data>
+  <data name="btnAddSpectrumFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Text" xml:space="preserve">
+    <value>Add Spectrum Filter...</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Name" xml:space="preserve">
+    <value>btnAddSpectrumFilter</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>285, 93</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Name" xml:space="preserve">
+    <value>checkedListBoxSpectrumClassColumns</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckedListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="listBoxFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="listBoxFiles.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="listBoxFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>294, 3</value>
+  </data>
+  <data name="listBoxFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>339, 93</value>
+  </data>
+  <data name="listBoxFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="listBoxFiles.ToolTip" xml:space="preserve">
+    <value>Remove from list</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Name" xml:space="preserve">
+    <value>listBoxFiles</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Name" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Name" xml:space="preserve">
+    <value>splitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="splitContainer1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>800, 415</value>
+  </data>
+  <data name="splitContainer1.SplitterDistance" type="System.Int32, mscorlib">
+    <value>122</value>
+  </data>
+  <data name="splitContainer1.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Name" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>77</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>800, 450</value>
+  </data>
+  <data name="$this.TabText" xml:space="preserve">
+    <value>SpectraGridForm</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>SpectraGridForm</value>
+  </data>
+  <data name="&gt;&gt;ModeUIExtender.Name" xml:space="preserve">
+    <value>ModeUIExtender</value>
+  </data>
+  <data name="&gt;&gt;ModeUIExtender.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SpectrumGridForm</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.Databinding.DataboundGridForm, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
@@ -117,9 +117,39 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="databoundGridControl.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="databoundGridControl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 123</value>
+  </data>
+  <data name="databoundGridControl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>765, 286</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Name" xml:space="preserve">
+    <value>databoundGridControl</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.Databinding.DataboundGridControl, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="ModeUIExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="btnCancelReadingFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="btnCancelReadingFile.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>160, 17</value>
   </metadata>
@@ -128,7 +158,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAAI
-        CAAAAk1TRnQBSQFMAwEBAAEoAQABKAEAARABAAEQAQAE/wEJAQAI/wFCAU0BNgEEBgABNgEEAgABKAMA
+        CAAAAk1TRnQBSQFMAwEBAAEwAQABMAEAARABAAEQAQAE/wEJAQAI/wFCAU0BNgEEBgABNgEEAgABKAMA
         AUADAAEQAwABAQEAAQgGAAEEGAABgAIAAYADAAKAAQABgAMAAYABAAGAAQACgAIAA8ABAAHAAdwBwAEA
         AfABygGmAQABMwUAATMBAAEzAQABMwEAAjMCAAMWAQADHAEAAyIBAAMpAQADVQEAA00BAANCAQADOQEA
         AYABfAH/AQACUAH/AQABkwEAAdYBAAH/AewBzAEAAcYB1gHvAQAB1gLnAQABkAGpAa0CAAH/ATMDAAFm
@@ -165,10 +195,379 @@
         AeMGAAGHAfMGAAGPAf8GAAL/BgAL
 </value>
   </data>
+  <data name="btnCancelReadingFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>767, 6</value>
+  </data>
+  <data name="btnCancelReadingFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnCancelReadingFile.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>270, 17</value>
+  </metadata>
+  <data name="btnCancelReadingFile.ToolTip" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Name" xml:space="preserve">
+    <value>btnCancelReadingFile</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="progressBar1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>547, 6</value>
+  </data>
+  <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>217, 23</value>
+  </data>
+  <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Name" xml:space="preserve">
+    <value>progressBar1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="lblStatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 6</value>
+  </data>
+  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>538, 23</value>
+  </data>
+  <data name="lblStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblStatus.Text" xml:space="preserve">
+    <value>File reading status</value>
+  </data>
+  <data name="lblStatus.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Name" xml:space="preserve">
+    <value>lblStatus</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="statusPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="statusPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 415</value>
+  </data>
+  <data name="statusPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>800, 35</value>
+  </data>
+  <data name="statusPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="statusPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Name" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="splitContainer1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="splitContainer1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="splitContainer1.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <data name="lblSummary.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="lblSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 100</value>
+  </data>
+  <data name="lblSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 23</value>
+  </data>
+  <data name="lblSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="lblSummary.Text" xml:space="preserve">
+    <value>Summary</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
+    <value>lblSummary</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnRemoveFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnRemoveFile.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnRemoveFile.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnRemoveFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 3</value>
+  </data>
+  <data name="btnRemoveFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnRemoveFile.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="btnRemoveFile.ToolTip" xml:space="preserve">
+    <value>Remove from list</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Name" xml:space="preserve">
+    <value>btnRemoveFile</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnBrowse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnBrowse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>675, 3</value>
+  </data>
+  <data name="btnBrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 28</value>
+  </data>
+  <data name="btnBrowse.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="btnBrowse.Text" xml:space="preserve">
+    <value>浏览…</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Name" xml:space="preserve">
+    <value>btnBrowse</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 96</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>149, 23</value>
+  </data>
+  <data name="btnAddSpectrumFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Text" xml:space="preserve">
+    <value>Add Spectrum Filter...</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Name" xml:space="preserve">
+    <value>btnAddSpectrumFilter</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>285, 93</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Name" xml:space="preserve">
+    <value>checkedListBoxSpectrumClassColumns</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckedListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="listBoxFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="listBoxFiles.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="listBoxFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>294, 3</value>
+  </data>
+  <data name="listBoxFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>339, 93</value>
+  </data>
+  <data name="listBoxFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="listBoxFiles.ToolTip" xml:space="preserve">
+    <value>Remove from list</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Name" xml:space="preserve">
+    <value>listBoxFiles</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Name" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Name" xml:space="preserve">
+    <value>splitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="splitContainer1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>800, 415</value>
+  </data>
+  <data name="splitContainer1.SplitterDistance" type="System.Int32, mscorlib">
+    <value>122</value>
+  </data>
+  <data name="splitContainer1.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Name" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>77</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>800, 450</value>
+  </data>
+  <data name="$this.TabText" xml:space="preserve">
+    <value>SpectraGridForm</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>SpectraGridForm</value>
+  </data>
+  <data name="&gt;&gt;ModeUIExtender.Name" xml:space="preserve">
+    <value>ModeUIExtender</value>
+  </data>
+  <data name="&gt;&gt;ModeUIExtender.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SpectrumGridForm</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.Databinding.DataboundGridForm, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/Startup/StartPage.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Startup/StartPage.ja.resx
@@ -117,8 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>189, 17</value>
+    <value>294, 17</value>
   </metadata>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="flowLayoutPanelWizard.AutoScroll" type="System.Boolean, mscorlib">
@@ -430,13 +433,13 @@
     <value>19, 2</value>
   </data>
   <data name="openFileLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 15</value>
+    <value>69, 15</value>
   </data>
   <data name="openFileLabel.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
   </data>
   <data name="openFileLabel.Text" xml:space="preserve">
-    <value>ファイルを開く</value>
+    <value>Open File...</value>
   </data>
   <data name="&gt;&gt;openFileLabel.Name" xml:space="preserve">
     <value>openFileLabel</value>
@@ -520,7 +523,7 @@
     <value>1</value>
   </data>
   <metadata name="tooStripModeUI.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>279, 0</value>
+    <value>155, 17</value>
   </metadata>
   <data name="tooStripModeUI.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -532,16 +535,16 @@
     <value>White</value>
   </data>
   <data name="toolStripButtonModeUI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 22</value>
+    <value>29, 22</value>
   </data>
   <data name="toolStripButtonModeUI.Text" xml:space="preserve">
     <value>ユーザーインターフェイスの選択</value>
   </data>
   <data name="tooStripModeUI.Location" type="System.Drawing.Point, System.Drawing">
-    <value>509, 0</value>
+    <value>526, 0</value>
   </data>
   <data name="tooStripModeUI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 25</value>
+    <value>41, 25</value>
   </data>
   <data name="tooStripModeUI.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -576,23 +579,23 @@
   <data name="$this.Text" xml:space="preserve">
     <value>開始ページ</value>
   </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
   <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
     <value>toolTip</value>
   </data>
   <data name="&gt;&gt;toolTip.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripButtonProteomicModeUI.Name" xml:space="preserve">
-    <value>toolStripButtonProteomicModeUI</value>
+  <data name="&gt;&gt;toolStripButtonModeUI.Name" xml:space="preserve">
+    <value>toolStripButtonModeUI</value>
   </data>
-  <data name="&gt;&gt;toolStripButtonProteomicModeUI.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripButtonSmallMoleculeModeUI.Name" xml:space="preserve">
-    <value>toolStripButtonSmallMoleculeModeUI</value>
-  </data>
-  <data name="&gt;&gt;toolStripButtonSmallMoleculeModeUI.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;toolStripButtonModeUI.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripDropDownButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>StartPage</value>

--- a/pwiz_tools/Skyline/Controls/Startup/StartPage.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Startup/StartPage.zh-CHS.resx
@@ -117,8 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>189, 17</value>
+    <value>294, 17</value>
   </metadata>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="flowLayoutPanelWizard.AutoScroll" type="System.Boolean, mscorlib">
@@ -430,13 +433,13 @@
     <value>19, 2</value>
   </data>
   <data name="openFileLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 15</value>
+    <value>69, 15</value>
   </data>
   <data name="openFileLabel.TabIndex" type="System.Int32, mscorlib">
     <value>54</value>
   </data>
   <data name="openFileLabel.Text" xml:space="preserve">
-    <value>打开文件</value>
+    <value>Open File...</value>
   </data>
   <data name="&gt;&gt;openFileLabel.Name" xml:space="preserve">
     <value>openFileLabel</value>
@@ -520,7 +523,7 @@
     <value>1</value>
   </data>
   <metadata name="tooStripModeUI.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>279, 0</value>
+    <value>155, 17</value>
   </metadata>
   <data name="tooStripModeUI.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -532,16 +535,16 @@
     <value>White</value>
   </data>
   <data name="toolStripButtonModeUI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 22</value>
+    <value>29, 22</value>
   </data>
   <data name="toolStripButtonModeUI.Text" xml:space="preserve">
     <value>用户界面选择</value>
   </data>
   <data name="tooStripModeUI.Location" type="System.Drawing.Point, System.Drawing">
-    <value>509, 0</value>
+    <value>526, 0</value>
   </data>
   <data name="tooStripModeUI.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 25</value>
+    <value>41, 25</value>
   </data>
   <data name="tooStripModeUI.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -576,23 +579,23 @@
   <data name="$this.Text" xml:space="preserve">
     <value>开始页面</value>
   </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
   <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
     <value>toolTip</value>
   </data>
   <data name="&gt;&gt;toolTip.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripButtonProteomicModeUI.Name" xml:space="preserve">
-    <value>toolStripButtonProteomicModeUI</value>
+  <data name="&gt;&gt;toolStripButtonModeUI.Name" xml:space="preserve">
+    <value>toolStripButtonModeUI</value>
   </data>
-  <data name="&gt;&gt;toolStripButtonProteomicModeUI.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripButtonSmallMoleculeModeUI.Name" xml:space="preserve">
-    <value>toolStripButtonSmallMoleculeModeUI</value>
-  </data>
-  <data name="&gt;&gt;toolStripButtonSmallMoleculeModeUI.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;toolStripButtonModeUI.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripDropDownButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>StartPage</value>

--- a/pwiz_tools/Skyline/EditUI/AreaChartPropertyDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/AreaChartPropertyDlg.ja.resx
@@ -312,18 +312,6 @@
   <data name="cbDecimalCvs.Text" xml:space="preserve">
     <value>十進数のCV値を表示(&amp;D)</value>
   </data>
-  <data name="&gt;&gt;cbDecimalCvs.Name" xml:space="preserve">
-    <value>cbDecimalCvs</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="labelCvPercent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -339,18 +327,6 @@
   <data name="labelCvPercent.Text" xml:space="preserve">
     <value>%</value>
   </data>
-  <data name="&gt;&gt;labelCvPercent.Name" xml:space="preserve">
-    <value>labelCvPercent</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="textMaxCv.Location" type="System.Drawing.Point, System.Drawing">
     <value>19, 115</value>
   </data>
@@ -359,18 +335,6 @@
   </data>
   <data name="textMaxCv.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Name" xml:space="preserve">
-    <value>textMaxCv</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -386,18 +350,6 @@
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>最大CV(&amp;C)：</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="textSizeComboBox.Items" xml:space="preserve">
     <value>極小</value>

--- a/pwiz_tools/Skyline/EditUI/AreaChartPropertyDlg.resx
+++ b/pwiz_tools/Skyline/EditUI/AreaChartPropertyDlg.resx
@@ -312,18 +312,6 @@
   <data name="cbDecimalCvs.Text" xml:space="preserve">
     <value>&amp;Display decimal CV values</value>
   </data>
-  <data name="&gt;&gt;cbDecimalCvs.Name" xml:space="preserve">
-    <value>cbDecimalCvs</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="labelCvPercent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -339,18 +327,6 @@
   <data name="labelCvPercent.Text" xml:space="preserve">
     <value>%</value>
   </data>
-  <data name="&gt;&gt;labelCvPercent.Name" xml:space="preserve">
-    <value>labelCvPercent</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="textMaxCv.Location" type="System.Drawing.Point, System.Drawing">
     <value>19, 115</value>
   </data>
@@ -359,18 +335,6 @@
   </data>
   <data name="textMaxCv.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Name" xml:space="preserve">
-    <value>textMaxCv</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -386,18 +350,6 @@
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>Maximum &amp;CV:</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="textSizeComboBox.Items" xml:space="preserve">
     <value>x-small</value>

--- a/pwiz_tools/Skyline/EditUI/AreaChartPropertyDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/AreaChartPropertyDlg.zh-CHS.resx
@@ -312,18 +312,6 @@
   <data name="cbDecimalCvs.Text" xml:space="preserve">
     <value>显示十进位 CV 值(&amp;D)</value>
   </data>
-  <data name="&gt;&gt;cbDecimalCvs.Name" xml:space="preserve">
-    <value>cbDecimalCvs</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;cbDecimalCvs.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="labelCvPercent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -339,18 +327,6 @@
   <data name="labelCvPercent.Text" xml:space="preserve">
     <value>%</value>
   </data>
-  <data name="&gt;&gt;labelCvPercent.Name" xml:space="preserve">
-    <value>labelCvPercent</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;labelCvPercent.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="textMaxCv.Location" type="System.Drawing.Point, System.Drawing">
     <value>19, 115</value>
   </data>
@@ -359,18 +335,6 @@
   </data>
   <data name="textMaxCv.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Name" xml:space="preserve">
-    <value>textMaxCv</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;textMaxCv.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -386,18 +350,6 @@
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>最大 CV 值(&amp;C)：</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="textSizeComboBox.Items" xml:space="preserve">
     <value>超小</value>

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.ja.resx
@@ -129,7 +129,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>420, 507</value>
+    <value>420, 523</value>
   </data>
   <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -190,7 +190,7 @@
     <value>NoControl</value>
   </data>
   <data name="btnOk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>339, 507</value>
+    <value>339, 523</value>
   </data>
   <data name="btnOk.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -315,6 +315,75 @@
   <data name="&gt;&gt;lnkHelpProteinGroups.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbGeneLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbGeneLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbGeneLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 23</value>
+  </data>
+  <data name="cbGeneLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="cbGeneLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 14</value>
+  </data>
+  <data name="cbGeneLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="cbGeneLevel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Name" xml:space="preserve">
+    <value>cbGeneLevel</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 23</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Text" xml:space="preserve">
+    <value>Group at g&amp;ene level</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.ToolTip" xml:space="preserve">
+    <value>Peptides will be associated and grouped by gene instead of by protein.</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Name" xml:space="preserve">
+    <value>lblGroupAtGeneLevel</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="lblSharedPeptides.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -322,7 +391,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblSharedPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 26</value>
+    <value>0, 46</value>
   </data>
   <data name="lblSharedPeptides.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 6, 0, 3</value>
@@ -352,7 +421,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblSharedPeptides.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="lnkHelpSharedPeptides.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -364,7 +433,7 @@
     <value>NoControl</value>
   </data>
   <data name="lnkHelpSharedPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>105, 20</value>
+    <value>105, 40</value>
   </data>
   <data name="lnkHelpSharedPeptides.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 3, 0</value>
@@ -388,7 +457,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lnkHelpSharedPeptides.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="cbMinimalProteinList.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -397,7 +466,7 @@
     <value>NoControl</value>
   </data>
   <data name="cbMinimalProteinList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 75</value>
+    <value>3, 95</value>
   </data>
   <data name="cbMinimalProteinList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 6, 0, 3</value>
@@ -421,13 +490,13 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cbMinimalProteinList.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="lblMinimalProteinList.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="lblMinimalProteinList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 75</value>
+    <value>18, 95</value>
   </data>
   <data name="lblMinimalProteinList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 6, 0, 3</value>
@@ -454,7 +523,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblMinimalProteinList.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="lnkHelpFindMinimalProteinList.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -466,7 +535,7 @@
     <value>NoControl</value>
   </data>
   <data name="lnkHelpFindMinimalProteinList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>250, 69</value>
+    <value>250, 89</value>
   </data>
   <data name="lnkHelpFindMinimalProteinList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 3, 0</value>
@@ -490,7 +559,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lnkHelpFindMinimalProteinList.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="cbRemoveSubsetProteins.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -499,7 +568,7 @@
     <value>NoControl</value>
   </data>
   <data name="cbRemoveSubsetProteins.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 95</value>
+    <value>3, 115</value>
   </data>
   <data name="cbRemoveSubsetProteins.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 0, 3</value>
@@ -523,7 +592,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cbRemoveSubsetProteins.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="lblRemoveSubsetProteins.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -532,7 +601,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblRemoveSubsetProteins.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 95</value>
+    <value>18, 115</value>
   </data>
   <data name="lblRemoveSubsetProteins.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 0, 3</value>
@@ -559,7 +628,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblRemoveSubsetProteins.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="lnkHelpRemoveSubsetProteins.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -571,7 +640,7 @@
     <value>NoControl</value>
   </data>
   <data name="lnkHelpRemoveSubsetProteins.Location" type="System.Drawing.Point, System.Drawing">
-    <value>139, 92</value>
+    <value>139, 112</value>
   </data>
   <data name="lnkHelpRemoveSubsetProteins.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 3, 0</value>
@@ -595,7 +664,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lnkHelpRemoveSubsetProteins.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>13</value>
   </data>
   <data name="lblMinPeptides.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -604,7 +673,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblMinPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 118</value>
+    <value>0, 138</value>
   </data>
   <data name="lblMinPeptides.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 6, 3, 3</value>
@@ -634,10 +703,10 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblMinPeptides.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>14</value>
   </data>
   <data name="numMinPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 135</value>
+    <value>3, 155</value>
   </data>
   <data name="numMinPeptides.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 3</value>
@@ -658,7 +727,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;numMinPeptides.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>15</value>
   </data>
   <data name="flowLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -667,7 +736,7 @@
     <value>3, 16</value>
   </data>
   <data name="flowLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>477, 164</value>
+    <value>477, 182</value>
   </data>
   <data name="flowLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -685,7 +754,7 @@
     <value>0</value>
   </data>
   <data name="comboSharedPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 45</value>
+    <value>3, 65</value>
   </data>
   <data name="comboSharedPeptides.Size" type="System.Drawing.Size, System.Drawing">
     <value>341, 21</value>
@@ -703,7 +772,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;comboSharedPeptides.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="gbParsimonyOptions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -712,7 +781,7 @@
     <value>12, 177</value>
   </data>
   <data name="gbParsimonyOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>483, 183</value>
+    <value>483, 201</value>
   </data>
   <data name="gbParsimonyOptions.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -904,7 +973,7 @@
     <value>ターゲット</value>
   </data>
   <data name="dgvAssociateResults.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 387</value>
+    <value>12, 403</value>
   </data>
   <data name="dgvAssociateResults.Size" type="System.Drawing.Size, System.Drawing">
     <value>483, 89</value>
@@ -934,7 +1003,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblResults.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 369</value>
+    <value>12, 385</value>
   </data>
   <data name="lblResults.Size" type="System.Drawing.Size, System.Drawing">
     <value>132, 13</value>
@@ -1024,7 +1093,7 @@
     <value>RightToLeft</value>
   </data>
   <data name="panelStatusBarResult.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 481</value>
+    <value>12, 497</value>
   </data>
   <data name="panelStatusBarResult.Size" type="System.Drawing.Size, System.Drawing">
     <value>483, 20</value>
@@ -1075,7 +1144,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>507, 542</value>
+    <value>507, 558</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>468, 554</value>

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.zh-CHS.resx
@@ -129,7 +129,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>420, 507</value>
+    <value>420, 523</value>
   </data>
   <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -190,7 +190,7 @@
     <value>NoControl</value>
   </data>
   <data name="btnOk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>339, 507</value>
+    <value>339, 523</value>
   </data>
   <data name="btnOk.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -315,6 +315,75 @@
   <data name="&gt;&gt;lnkHelpProteinGroups.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbGeneLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbGeneLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbGeneLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 23</value>
+  </data>
+  <data name="cbGeneLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="cbGeneLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 14</value>
+  </data>
+  <data name="cbGeneLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="cbGeneLevel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Name" xml:space="preserve">
+    <value>cbGeneLevel</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 23</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Text" xml:space="preserve">
+    <value>Group at g&amp;ene level</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.ToolTip" xml:space="preserve">
+    <value>Peptides will be associated and grouped by gene instead of by protein.</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Name" xml:space="preserve">
+    <value>lblGroupAtGeneLevel</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <data name="lblSharedPeptides.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -322,7 +391,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblSharedPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 26</value>
+    <value>0, 46</value>
   </data>
   <data name="lblSharedPeptides.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 6, 0, 3</value>
@@ -352,7 +421,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblSharedPeptides.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="lnkHelpSharedPeptides.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -364,7 +433,7 @@
     <value>NoControl</value>
   </data>
   <data name="lnkHelpSharedPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>105, 20</value>
+    <value>105, 40</value>
   </data>
   <data name="lnkHelpSharedPeptides.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 3, 0</value>
@@ -388,7 +457,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lnkHelpSharedPeptides.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="cbMinimalProteinList.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -397,7 +466,7 @@
     <value>NoControl</value>
   </data>
   <data name="cbMinimalProteinList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 75</value>
+    <value>3, 95</value>
   </data>
   <data name="cbMinimalProteinList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 6, 0, 3</value>
@@ -421,13 +490,13 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cbMinimalProteinList.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="lblMinimalProteinList.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="lblMinimalProteinList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 75</value>
+    <value>18, 95</value>
   </data>
   <data name="lblMinimalProteinList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 6, 0, 3</value>
@@ -454,7 +523,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblMinimalProteinList.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="lnkHelpFindMinimalProteinList.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -466,7 +535,7 @@
     <value>NoControl</value>
   </data>
   <data name="lnkHelpFindMinimalProteinList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>250, 69</value>
+    <value>250, 89</value>
   </data>
   <data name="lnkHelpFindMinimalProteinList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 3, 0</value>
@@ -490,7 +559,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lnkHelpFindMinimalProteinList.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>10</value>
   </data>
   <data name="cbRemoveSubsetProteins.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -499,7 +568,7 @@
     <value>NoControl</value>
   </data>
   <data name="cbRemoveSubsetProteins.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 95</value>
+    <value>3, 115</value>
   </data>
   <data name="cbRemoveSubsetProteins.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 0, 3</value>
@@ -523,7 +592,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cbRemoveSubsetProteins.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>11</value>
   </data>
   <data name="lblRemoveSubsetProteins.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -532,7 +601,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblRemoveSubsetProteins.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 95</value>
+    <value>18, 115</value>
   </data>
   <data name="lblRemoveSubsetProteins.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 3, 0, 3</value>
@@ -559,7 +628,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblRemoveSubsetProteins.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>12</value>
   </data>
   <data name="lnkHelpRemoveSubsetProteins.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -571,7 +640,7 @@
     <value>NoControl</value>
   </data>
   <data name="lnkHelpRemoveSubsetProteins.Location" type="System.Drawing.Point, System.Drawing">
-    <value>139, 92</value>
+    <value>139, 112</value>
   </data>
   <data name="lnkHelpRemoveSubsetProteins.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 3, 0</value>
@@ -595,7 +664,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lnkHelpRemoveSubsetProteins.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>13</value>
   </data>
   <data name="lblMinPeptides.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -604,7 +673,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblMinPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 118</value>
+    <value>0, 138</value>
   </data>
   <data name="lblMinPeptides.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 6, 3, 3</value>
@@ -634,10 +703,10 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblMinPeptides.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>14</value>
   </data>
   <data name="numMinPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 135</value>
+    <value>3, 155</value>
   </data>
   <data name="numMinPeptides.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 0, 3, 3</value>
@@ -658,7 +727,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;numMinPeptides.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>15</value>
   </data>
   <data name="flowLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -667,7 +736,7 @@
     <value>3, 16</value>
   </data>
   <data name="flowLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>477, 164</value>
+    <value>477, 182</value>
   </data>
   <data name="flowLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -685,7 +754,7 @@
     <value>0</value>
   </data>
   <data name="comboSharedPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 45</value>
+    <value>3, 65</value>
   </data>
   <data name="comboSharedPeptides.Size" type="System.Drawing.Size, System.Drawing">
     <value>341, 21</value>
@@ -703,7 +772,7 @@
     <value>flowLayoutPanel</value>
   </data>
   <data name="&gt;&gt;comboSharedPeptides.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="gbParsimonyOptions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -712,7 +781,7 @@
     <value>12, 177</value>
   </data>
   <data name="gbParsimonyOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>483, 183</value>
+    <value>483, 201</value>
   </data>
   <data name="gbParsimonyOptions.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -904,7 +973,7 @@
     <value>目标</value>
   </data>
   <data name="dgvAssociateResults.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 387</value>
+    <value>12, 403</value>
   </data>
   <data name="dgvAssociateResults.Size" type="System.Drawing.Size, System.Drawing">
     <value>483, 89</value>
@@ -934,7 +1003,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblResults.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 369</value>
+    <value>12, 385</value>
   </data>
   <data name="lblResults.Size" type="System.Drawing.Size, System.Drawing">
     <value>132, 13</value>
@@ -1024,7 +1093,7 @@
     <value>RightToLeft</value>
   </data>
   <data name="panelStatusBarResult.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 481</value>
+    <value>12, 497</value>
   </data>
   <data name="panelStatusBarResult.Size" type="System.Drawing.Size, System.Drawing">
     <value>483, 20</value>
@@ -1075,7 +1144,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>507, 542</value>
+    <value>507, 558</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>468, 554</value>

--- a/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.ja.resx
@@ -117,10 +117,177 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="propertyColumn.HeaderText" xml:space="preserve">
+    <value>Property</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="propertyColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="operationColumn.HeaderText" xml:space="preserve">
+    <value>Operation</value>
+  </data>
+  <data name="operationColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="valueColumn.HeaderText" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="dataGridViewEx1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="dataGridViewEx1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="dataGridViewEx1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>682, 181</value>
+  </data>
+  <data name="dataGridViewEx1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Name" xml:space="preserve">
+    <value>dataGridViewEx1</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Parent" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cbCreateCopy.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cbCreateCopy.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbCreateCopy.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbCreateCopy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>714, 84</value>
+  </data>
+  <data name="cbCreateCopy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 17</value>
+  </data>
+  <data name="cbCreateCopy.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cbCreateCopy.Text" xml:space="preserve">
+    <value>コピーを作成(&amp;C)</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Name" xml:space="preserve">
+    <value>cbCreateCopy</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnReset.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnReset.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnReset.Location" type="System.Drawing.Point, System.Drawing">
+    <value>714, 200</value>
+  </data>
+  <data name="btnReset.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnReset.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="btnReset.Text" xml:space="preserve">
+    <value>リセット(&amp;R)</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Name" xml:space="preserve">
+    <value>btnReset</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnReset.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>713, 41</value>
+  </data>
+  <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="btnCancel.Text" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Name" xml:space="preserve">
+    <value>btnCancel</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnOk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>713, 12</value>
+  </data>
+  <data name="btnOk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnOk.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="btnOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Name" xml:space="preserve">
+    <value>btnOk</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnOk.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <metadata name="toolStripFilter.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="toolStripFilter.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
   <data name="btnDeleteFilter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -133,7 +300,196 @@
         RpBSo3HrM0G6Uq7pl2zvhvNDBcClE8YH4HDv2/A/SKV6BYojAxyEJtLJAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="btnDeleteFilter.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnDeleteFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
+  <data name="btnDeleteFilter.Text" xml:space="preserve">
+    <value>削除</value>
+  </data>
+  <data name="toolStripFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>682, 0</value>
+  </data>
+  <data name="toolStripFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 181</value>
+  </data>
+  <data name="toolStripFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="toolStripFilter.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Name" xml:space="preserve">
+    <value>toolStripFilter</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Parent" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelClauses.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panelClauses.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 55</value>
+  </data>
+  <data name="panelClauses.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 181</value>
+  </data>
+  <data name="panelClauses.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Name" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblDescription.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblDescription.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="lblDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="lblDescription.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="lblDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 19</value>
+  </data>
+  <data name="lblDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="lblDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="lblDescription.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Name" xml:space="preserve">
+    <value>lblDescription</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelPages.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelPages.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 19</value>
+  </data>
+  <data name="panelPages.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 36</value>
+  </data>
+  <data name="panelPages.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Name" xml:space="preserve">
+    <value>panelPages</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelPages.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1, -1</value>
+  </data>
+  <data name="panelEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 236</value>
+  </data>
+  <data name="panelEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Name" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>280, 17</value>
   </metadata>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>800, 235</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Edit Spectrum Filter</value>
+  </data>
+  <data name="&gt;&gt;propertyColumn.Name" xml:space="preserve">
+    <value>propertyColumn</value>
+  </data>
+  <data name="&gt;&gt;propertyColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewComboBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;operationColumn.Name" xml:space="preserve">
+    <value>operationColumn</value>
+  </data>
+  <data name="&gt;&gt;operationColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewComboBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;valueColumn.Name" xml:space="preserve">
+    <value>valueColumn</value>
+  </data>
+  <data name="&gt;&gt;valueColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnDeleteFilter.Name" xml:space="preserve">
+    <value>btnDeleteFilter</value>
+  </data>
+  <data name="&gt;&gt;btnDeleteFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>EditSpectrumFilterDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.zh-CHS.resx
@@ -117,13 +117,177 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolStripFilter.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>155, 17</value>
-  </metadata>
-  <metadata name="toolStripFilter.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>155, 17</value>
-  </metadata>
+  <data name="propertyColumn.HeaderText" xml:space="preserve">
+    <value>Property</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="propertyColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="operationColumn.HeaderText" xml:space="preserve">
+    <value>Operation</value>
+  </data>
+  <data name="operationColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
+  <data name="valueColumn.HeaderText" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="dataGridViewEx1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="dataGridViewEx1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="dataGridViewEx1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>682, 181</value>
+  </data>
+  <data name="dataGridViewEx1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Name" xml:space="preserve">
+    <value>dataGridViewEx1</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Parent" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cbCreateCopy.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cbCreateCopy.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbCreateCopy.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbCreateCopy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>714, 84</value>
+  </data>
+  <data name="cbCreateCopy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 17</value>
+  </data>
+  <data name="cbCreateCopy.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cbCreateCopy.Text" xml:space="preserve">
+    <value>创建副本(&amp;C)</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Name" xml:space="preserve">
+    <value>cbCreateCopy</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnReset.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnReset.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnReset.Location" type="System.Drawing.Point, System.Drawing">
+    <value>714, 200</value>
+  </data>
+  <data name="btnReset.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnReset.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="btnReset.Text" xml:space="preserve">
+    <value>重置(&amp;R)</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Name" xml:space="preserve">
+    <value>btnReset</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnReset.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>713, 41</value>
+  </data>
+  <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="btnCancel.Text" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Name" xml:space="preserve">
+    <value>btnCancel</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnOk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>713, 12</value>
+  </data>
+  <data name="btnOk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnOk.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="btnOk.Text" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Name" xml:space="preserve">
+    <value>btnOk</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnOk.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <metadata name="toolStripFilter.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
+  </metadata>
+  <data name="toolStripFilter.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
   <data name="btnDeleteFilter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -136,7 +300,196 @@
         RpBSo3HrM0G6Uq7pl2zvhvNDBcClE8YH4HDv2/A/SKV6BYojAxyEJtLJAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="btnDeleteFilter.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnDeleteFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
+  <data name="btnDeleteFilter.Text" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="toolStripFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>682, 0</value>
+  </data>
+  <data name="toolStripFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 181</value>
+  </data>
+  <data name="toolStripFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="toolStripFilter.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Name" xml:space="preserve">
+    <value>toolStripFilter</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Parent" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelClauses.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panelClauses.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 55</value>
+  </data>
+  <data name="panelClauses.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 181</value>
+  </data>
+  <data name="panelClauses.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Name" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblDescription.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblDescription.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="lblDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="lblDescription.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="lblDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 19</value>
+  </data>
+  <data name="lblDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="lblDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="lblDescription.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Name" xml:space="preserve">
+    <value>lblDescription</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelPages.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelPages.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 19</value>
+  </data>
+  <data name="panelPages.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 36</value>
+  </data>
+  <data name="panelPages.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Name" xml:space="preserve">
+    <value>panelPages</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelPages.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1, -1</value>
+  </data>
+  <data name="panelEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 236</value>
+  </data>
+  <data name="panelEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Name" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>280, 17</value>
   </metadata>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>800, 235</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Edit Spectrum Filter</value>
+  </data>
+  <data name="&gt;&gt;propertyColumn.Name" xml:space="preserve">
+    <value>propertyColumn</value>
+  </data>
+  <data name="&gt;&gt;propertyColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewComboBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;operationColumn.Name" xml:space="preserve">
+    <value>operationColumn</value>
+  </data>
+  <data name="&gt;&gt;operationColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewComboBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;valueColumn.Name" xml:space="preserve">
+    <value>valueColumn</value>
+  </data>
+  <data name="&gt;&gt;valueColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnDeleteFilter.Name" xml:space="preserve">
+    <value>btnDeleteFilter</value>
+  </data>
+  <data name="&gt;&gt;btnDeleteFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>EditSpectrumFilterDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/EditUI/EditUIResources.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/EditUIResources.ja.resx
@@ -462,4 +462,13 @@ Example: Looplink: T [4]
   <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_These_proteins_include_" xml:space="preserve">
     <value>これらのタンパク質に含まれるもの：</value>
   </data>
+  <data name="AssociateProteinsDlg_Find_minimal_gene_group_list_that_explains_all_peptides" xml:space="preserve">
+    <value>Find &amp;minimal gene group list that explains all peptides</value>
+  </data>
+  <data name="AssociateProteinsDlg_Min_peptides_per_gene" xml:space="preserve">
+    <value>Mi&amp;n peptides per gene</value>
+  </data>
+  <data name="AssociateProteinsDlg_Remove_subset_genes" xml:space="preserve">
+    <value>&amp;Remove subset genes</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/EditUI/EditUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/EditUIResources.zh-CHS.resx
@@ -462,4 +462,13 @@ Example: Looplink: T [4]
   <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_These_proteins_include_" xml:space="preserve">
     <value>这些蛋白质包含：</value>
   </data>
+  <data name="AssociateProteinsDlg_Find_minimal_gene_group_list_that_explains_all_peptides" xml:space="preserve">
+    <value>Find &amp;minimal gene group list that explains all peptides</value>
+  </data>
+  <data name="AssociateProteinsDlg_Min_peptides_per_gene" xml:space="preserve">
+    <value>Mi&amp;n peptides per gene</value>
+  </data>
+  <data name="AssociateProteinsDlg_Remove_subset_genes" xml:space="preserve">
+    <value>&amp;Remove subset genes</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/EditUI/FindNodeDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/FindNodeDlg.ja.resx
@@ -291,18 +291,6 @@
   <data name="radioDown.Text" xml:space="preserve">
     <value>下(&amp;D)</value>
   </data>
-  <data name="&gt;&gt;radioDown.Name" xml:space="preserve">
-    <value>radioDown</value>
-  </data>
-  <data name="&gt;&gt;radioDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioDown.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;radioDown.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioUp.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -317,18 +305,6 @@
   </data>
   <data name="radioUp.Text" xml:space="preserve">
     <value>上へ(&amp;U)</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Name" xml:space="preserve">
-    <value>radioUp</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;radioUp.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="cbCaseSensitive.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/EditUI/FindNodeDlg.resx
+++ b/pwiz_tools/Skyline/EditUI/FindNodeDlg.resx
@@ -291,18 +291,6 @@
   <data name="radioDown.Text" xml:space="preserve">
     <value>&amp;Down</value>
   </data>
-  <data name="&gt;&gt;radioDown.Name" xml:space="preserve">
-    <value>radioDown</value>
-  </data>
-  <data name="&gt;&gt;radioDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioDown.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;radioDown.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioUp.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -317,18 +305,6 @@
   </data>
   <data name="radioUp.Text" xml:space="preserve">
     <value>&amp;Up</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Name" xml:space="preserve">
-    <value>radioUp</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;radioUp.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="cbCaseSensitive.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/EditUI/FindNodeDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/FindNodeDlg.zh-CHS.resx
@@ -291,18 +291,6 @@
   <data name="radioDown.Text" xml:space="preserve">
     <value>向下(&amp;D)</value>
   </data>
-  <data name="&gt;&gt;radioDown.Name" xml:space="preserve">
-    <value>radioDown</value>
-  </data>
-  <data name="&gt;&gt;radioDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioDown.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;radioDown.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioUp.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -317,18 +305,6 @@
   </data>
   <data name="radioUp.Text" xml:space="preserve">
     <value>向上(&amp;U)</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Name" xml:space="preserve">
-    <value>radioUp</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioUp.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;radioUp.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="cbCaseSensitive.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.ja.resx
@@ -1717,4 +1717,128 @@ Skylineで制御されないトランジション値に対しては、単一の�
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>pwiz.Skyline.Util.CreateHandleDebugBase, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
+  <data name="cbExportSciexOSQuantMethod.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 9</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>254, 24</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Text" xml:space="preserve">
+    <value>Create SCIEX &amp;OS 
+    Quant method</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.ToolTip" xml:space="preserve">
+    <value>Exports a SCIEX OS Quant compatible analysis method to the same directory and base name as the Analyst acquisition method.</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Name" xml:space="preserve">
+    <value>cbExportSciexOSQuantMethod</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelXICWidth.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelXICWidth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 40</value>
+  </data>
+  <data name="labelXICWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 6, 0</value>
+  </data>
+  <data name="labelXICWidth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="labelXICWidth.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelXICWidth.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="labelXICWidth.Text" xml:space="preserve">
+    <value>XIC Width (Da):</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Name" xml:space="preserve">
+    <value>labelXICWidth</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="textXICWidth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 58</value>
+  </data>
+  <data name="textXICWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 8, 6, 8</value>
+  </data>
+  <data name="textXICWidth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 26</value>
+  </data>
+  <data name="textXICWidth.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="textXICWidth.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Name" xml:space="preserve">
+    <value>textXICWidth</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelAbiSciexOS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>500, 211</value>
+  </data>
+  <data name="panelAbiSciexOS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 9, 6, 9</value>
+  </data>
+  <data name="panelAbiSciexOS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 90</value>
+  </data>
+  <data name="panelAbiSciexOS.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="panelAbiSciexOS.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Name" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.zh-CHS.resx
@@ -1720,4 +1720,128 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>pwiz.Skyline.Util.CreateHandleDebugBase, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
+  <data name="cbExportSciexOSQuantMethod.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 9</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>254, 24</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Text" xml:space="preserve">
+    <value>Create SCIEX &amp;OS 
+    Quant method</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.ToolTip" xml:space="preserve">
+    <value>Exports a SCIEX OS Quant compatible analysis method to the same directory and base name as the Analyst acquisition method.</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Name" xml:space="preserve">
+    <value>cbExportSciexOSQuantMethod</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelXICWidth.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelXICWidth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 40</value>
+  </data>
+  <data name="labelXICWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 6, 0</value>
+  </data>
+  <data name="labelXICWidth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="labelXICWidth.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelXICWidth.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="labelXICWidth.Text" xml:space="preserve">
+    <value>XIC Width (Da):</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Name" xml:space="preserve">
+    <value>labelXICWidth</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="textXICWidth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 58</value>
+  </data>
+  <data name="textXICWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 8, 6, 8</value>
+  </data>
+  <data name="textXICWidth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 26</value>
+  </data>
+  <data name="textXICWidth.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="textXICWidth.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Name" xml:space="preserve">
+    <value>textXICWidth</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelAbiSciexOS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>500, 211</value>
+  </data>
+  <data name="panelAbiSciexOS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 9, 6, 9</value>
+  </data>
+  <data name="panelAbiSciexOS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 90</value>
+  </data>
+  <data name="panelAbiSciexOS.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="panelAbiSciexOS.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Name" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/FileUIResources.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/FileUIResources.ja.resx
@@ -184,8 +184,11 @@
   <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_a_Bruker_TOF_method_template___The_folder_is_expected_to_have_a__m_extension__and_contain_the_file_submethods_xml_" xml:space="preserve">
     <value>選択したフォルダにBruker TOFメソッドテンプレートが含まれていないようです。フォルダは、.m拡張子が付き、submethods.xmlファイルを含むと予測されています。</value>
   </data>
+  <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
+    <value>The chosen folder does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+  </data>
   <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_an_Agilent_QQQ_method_template_The_folder_is_expected_to_have_a_m_extension_and_contain_the_file_qqqacqmethod_xsd" xml:space="preserve">
-    <value>選択したフォルダには、Agilent QQQメソッドテンプレートが含まれていないようです。フォルダには.m拡張子が付き、qqqacqmethod.xsdファイルを含むと予測されています。</value>
+    <value>Agilent 6400 series instrument type methods are expected to have a .m extension, and contain the file qqqacqmethod.xsd. If this is an Agilent TQ method, please choose "Agilent MassHunter 12 or higher" as your instrument type.</value>
   </data>
   <data name="ExportMethodDlg_btnGraph_Click_An_error_occurred_" xml:space="preserve">
     <value>エラーが発生しました。</value>
@@ -279,6 +282,9 @@
   </data>
   <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_a_Bruker_TOF_method_template___The_folder_is_expected_to_have_a__m_extension__and_contain_the_file_submethods_xml_" xml:space="preserve">
     <value>フォルダ{0}にBruker TOFメソッドテンプレートが含まれていないようです。フォルダは、.m拡張子が付き、submethods.xmlファイルを含むと予測されています。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
+    <value>The folder {0} does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
   </data>
   <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_an_Agilent_QQQ_method_template_The_folder_is_expected_to_have_a_m_extension_and_contain_the_file_qqqacqmethod_xsd" xml:space="preserve">
     <value>フォルダ{0}には、Agilent QQQメソッドテンプレートが含まれていないようです。フォルダには.m拡張子が付き、qqqacqmethod.xsdファイルを含むと予測されています。</value>

--- a/pwiz_tools/Skyline/FileUI/FileUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/FileUIResources.zh-CHS.resx
@@ -184,8 +184,11 @@
   <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_a_Bruker_TOF_method_template___The_folder_is_expected_to_have_a__m_extension__and_contain_the_file_submethods_xml_" xml:space="preserve">
     <value>选定的文件夹无 Bruker TOF 方法模板。文件夹应包括一个 .m 文件，以及 submethods.xml。</value>
   </data>
+  <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
+    <value>The chosen folder does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+  </data>
   <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_an_Agilent_QQQ_method_template_The_folder_is_expected_to_have_a_m_extension_and_contain_the_file_qqqacqmethod_xsd" xml:space="preserve">
-    <value>选定的文件夹无 Agilent QQQ 方法模板。文件夹预计将拥有 .m 扩展名，并且包含文件 qqqacqmethod.xsd。</value>
+    <value>Agilent 6400 series instrument type methods are expected to have a .m extension, and contain the file qqqacqmethod.xsd. If this is an Agilent TQ method, please choose "Agilent MassHunter 12 or higher" as your instrument type.</value>
   </data>
   <data name="ExportMethodDlg_btnGraph_Click_An_error_occurred_" xml:space="preserve">
     <value>发生了错误。</value>
@@ -280,6 +283,9 @@
   <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_a_Bruker_TOF_method_template___The_folder_is_expected_to_have_a__m_extension__and_contain_the_file_submethods_xml_" xml:space="preserve">
     <value>文件夹{0}无 Bruker TOF 方法模板。文件夹应包括一个 .m 文件，以及 submethods.xml。</value>
   </data>
+  <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
+    <value>The folder {0} does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+  </data>
   <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_an_Agilent_QQQ_method_template_The_folder_is_expected_to_have_a_m_extension_and_contain_the_file_qqqacqmethod_xsd" xml:space="preserve">
     <value>文件夹{0}无 Agilent QQQ 方法模板。文件夹预计将拥有 .m 扩展名，并且包含文件 qqqacqmethod.xsd。</value>
   </data>
@@ -293,7 +299,7 @@
     <value>模板文件{0}不存在。</value>
   </data>
   <data name="ExportMethodDlg_OkDialog_The_transition_prediction_settings_for_this_document_are_set_to_use_optimized_values_by_transition_" xml:space="preserve">
-    <value>本文档的离子对预测设置设定为通过离子对使用优化值。</value>
+    <value>本文档的离子对预测设置设定为使用离子对的优化值。</value>
   </data>
   <data name="ExportMethodDlg_OkDialog_TOF" xml:space="preserve">
     <value>TOF</value>
@@ -302,7 +308,7 @@
     <value>离子对列表</value>
   </data>
   <data name="ExportMethodDlg_OkDialog_Using_optimized_values_by_transition_is_invalid_for_this_instrument_type__Would_you_like_to_use_optimized_values_by_precursor_instead_" xml:space="preserve">
-    <value>通过离子对使用优化值对此类仪器无效。您想改为通过母离子使用优化值吗?</value>
+    <value>使用离子对的优化值对此类仪器无效。您想改为使用母离子的优化值吗?</value>
   </data>
   <data name="ExportMethodDlg_OkDialog_Would_you_like_to_use_the_defaults_instead" xml:space="preserve">
     <value>您是否愿意使用默认值替代？</value>

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.ja.resx
@@ -184,7 +184,7 @@
     <value>1</value>
   </data>
   <data name="buttonOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+    <value>Bottom, Right</value>
   </data>
   <data name="buttonOk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -214,7 +214,7 @@
     <value>2</value>
   </data>
   <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+    <value>Bottom, Right</value>
   </data>
   <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
     <value>770, 331</value>

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListErrorDlg.zh-CHS.resx
@@ -184,7 +184,7 @@
     <value>1</value>
   </data>
   <data name="buttonOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+    <value>Bottom, Right</value>
   </data>
   <data name="buttonOk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -214,7 +214,7 @@
     <value>2</value>
   </data>
   <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+    <value>Bottom, Right</value>
   </data>
   <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
     <value>770, 331</value>

--- a/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.ja.resx
@@ -231,6 +231,9 @@
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="checkBoxBestOnly.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
   <data name="checkBoxBestOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -260,6 +263,9 @@
   </data>
   <data name="&gt;&gt;checkBoxBestOnly.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="checkBoxTargetsOnly.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
   </data>
   <data name="checkBoxTargetsOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.zh-CHS.resx
@@ -231,6 +231,9 @@
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="checkBoxBestOnly.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
   <data name="checkBoxBestOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -260,6 +263,9 @@
   </data>
   <data name="&gt;&gt;checkBoxBestOnly.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="checkBoxTargetsOnly.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
   </data>
   <data name="checkBoxTargetsOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.ja.resx
@@ -138,6 +138,12 @@
   <data name="radioDIA.Text" xml:space="preserve">
     <value>&amp;DIA</value>
   </data>
+  <metadata name="helpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="radioDIA.ToolTip" xml:space="preserve">
+    <value>Library spectra from DDA MS/MS with chromatograms from separate DIA runs</value>
+  </data>
   <data name="&gt;&gt;radioDIA.Name" xml:space="preserve">
     <value>radioDIA</value>
   </data>
@@ -167,6 +173,9 @@
   </data>
   <data name="radioPRM.Text" xml:space="preserve">
     <value>&amp;PRM</value>
+  </data>
+  <data name="radioPRM.ToolTip" xml:space="preserve">
+    <value>Library spectra and chromatograms from the same PRM runs</value>
   </data>
   <data name="&gt;&gt;radioPRM.Name" xml:space="preserve">
     <value>radioPRM</value>
@@ -198,6 +207,9 @@
   <data name="radioDDA.Text" xml:space="preserve">
     <value>MS&amp;1フィルタを用いたDDA</value>
   </data>
+  <data name="radioDDA.ToolTip" xml:space="preserve">
+    <value>Library spectra from DDA MS/MS with chromatograms from MS1</value>
+  </data>
   <data name="&gt;&gt;radioDDA.Name" xml:space="preserve">
     <value>radioDDA</value>
   </data>
@@ -214,13 +226,13 @@
     <value>Bottom</value>
   </data>
   <data name="grpWorkflow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 529</value>
+    <value>0, 561</value>
   </data>
   <data name="grpWorkflow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 93</value>
+    <value>381, 91</value>
   </data>
   <data name="grpWorkflow.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="grpWorkflow.Text" xml:space="preserve">
     <value>ワークフロー</value>
@@ -235,7 +247,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpWorkflow.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>0</value>
   </data>
   <data name="radioButtonNewLibrary.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -254,6 +266,10 @@
   </data>
   <data name="radioButtonNewLibrary.Text" xml:space="preserve">
     <value>構築(&amp;B)</value>
+  </data>
+  <data name="radioButtonNewLibrary.ToolTip" xml:space="preserve">
+    <value>Build a new library from existing search results files,
+like TPP pepXML, Mascot .dat, SEQUEST SQT, etc.</value>
   </data>
   <data name="&gt;&gt;radioButtonNewLibrary.Name" xml:space="preserve">
     <value>radioButtonNewLibrary</value>
@@ -319,19 +335,23 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="tbxLibraryPath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
   <data name="tbxLibraryPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 39</value>
+    <value>11, 39</value>
   </data>
   <data name="tbxLibraryPath.Size" type="System.Drawing.Size, System.Drawing">
     <value>275, 20</value>
   </data>
   <data name="tbxLibraryPath.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
+  </data>
+  <data name="tbxLibraryPath.ToolTip" xml:space="preserve">
+    <value>Path to an existing library in a recognized format,
+like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
   </data>
   <data name="&gt;&gt;tbxLibraryPath.Name" xml:space="preserve">
     <value>tbxLibraryPath</value>
@@ -382,7 +402,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblLibraryPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 20</value>
+    <value>11, 23</value>
   </data>
   <data name="lblLibraryPath.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 13</value>
@@ -430,19 +450,19 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panelChooseFile.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="gridSearchFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="gridSearchFiles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 70</value>
+    <value>11, 26</value>
   </data>
   <data name="gridSearchFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 147</value>
+    <value>261, 270</value>
   </data>
   <data name="gridSearchFiles.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;gridSearchFiles.Name" xml:space="preserve">
     <value>gridSearchFiles</value>
@@ -456,57 +476,6 @@
   <data name="&gt;&gt;gridSearchFiles.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 3</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
-  </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>開始位置(&amp;M)：</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>panelPeptideSearch</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="comboInputFileType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 19</value>
-  </data>
-  <data name="comboInputFileType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>245, 21</value>
-  </data>
-  <data name="comboInputFileType.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;comboInputFileType.Name" xml:space="preserve">
-    <value>comboInputFileType</value>
-  </data>
-  <data name="&gt;&gt;comboInputFileType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboInputFileType.Parent" xml:space="preserve">
-    <value>panelPeptideSearch</value>
-  </data>
-  <data name="&gt;&gt;comboInputFileType.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="lblStandardPeptides.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -517,13 +486,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblStandardPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 242</value>
+    <value>11, 321</value>
   </data>
   <data name="lblStandardPeptides.Size" type="System.Drawing.Size, System.Drawing">
     <value>114, 13</value>
   </data>
   <data name="lblStandardPeptides.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>4</value>
   </data>
   <data name="lblStandardPeptides.Text" xml:space="preserve">
     <value>iRT標準ペプチド(&amp;T)：</value>
@@ -538,19 +507,22 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;lblStandardPeptides.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>1</value>
   </data>
   <data name="comboStandards.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
   <data name="comboStandards.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 258</value>
+    <value>11, 337</value>
   </data>
   <data name="comboStandards.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 21</value>
   </data>
   <data name="comboStandards.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>5</value>
+  </data>
+  <data name="comboStandards.ToolTip" xml:space="preserve">
+    <value>Choose a set of know iRT standard peptides to use for retention time normalization.</value>
   </data>
   <data name="&gt;&gt;comboStandards.Name" xml:space="preserve">
     <value>comboStandards</value>
@@ -562,7 +534,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;comboStandards.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>2</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -574,16 +546,19 @@
     <value>NoControl</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 285</value>
+    <value>11, 364</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.Size" type="System.Drawing.Size, System.Drawing">
     <value>158, 17</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>6</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.Text" xml:space="preserve">
     <value>曖昧な一致を含む(&amp;I)</value>
+  </data>
+  <data name="cbIncludeAmbiguousMatches.ToolTip" xml:space="preserve">
+    <value>Check to keep spectra that match multiple peptides.</value>
   </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.Name" xml:space="preserve">
     <value>cbIncludeAmbiguousMatches</value>
@@ -595,7 +570,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="cbFilterForDocumentPeptides.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -607,16 +582,19 @@
     <value>NoControl</value>
   </data>
   <data name="cbFilterForDocumentPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 308</value>
+    <value>11, 387</value>
   </data>
   <data name="cbFilterForDocumentPeptides.Size" type="System.Drawing.Size, System.Drawing">
     <value>156, 17</value>
   </data>
   <data name="cbFilterForDocumentPeptides.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>7</value>
   </data>
   <data name="cbFilterForDocumentPeptides.Text" xml:space="preserve">
     <value>ドキュメント内のペプチドをフィルタリング(&amp;E)</value>
+  </data>
+  <data name="cbFilterForDocumentPeptides.ToolTip" xml:space="preserve">
+    <value>Check to filter matches for only the peptides in the document.</value>
   </data>
   <data name="&gt;&gt;cbFilterForDocumentPeptides.Name" xml:space="preserve">
     <value>cbFilterForDocumentPeptides</value>
@@ -628,7 +606,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;cbFilterForDocumentPeptides.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>4</value>
   </data>
   <data name="btnRemFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -640,13 +618,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnRemFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>258, 99</value>
+    <value>278, 55</value>
   </data>
   <data name="btnRemFile.Size" type="System.Drawing.Size, System.Drawing">
     <value>113, 23</value>
   </data>
   <data name="btnRemFile.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>3</value>
   </data>
   <data name="btnRemFile.Text" xml:space="preserve">
     <value>ファイルを削除(&amp;O)</value>
@@ -661,7 +639,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;btnRemFile.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>5</value>
   </data>
   <data name="lblFileCaption.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -670,13 +648,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblFileCaption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 52</value>
+    <value>11, 8</value>
   </data>
   <data name="lblFileCaption.Size" type="System.Drawing.Size, System.Drawing">
     <value>61, 13</value>
   </data>
   <data name="lblFileCaption.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="lblFileCaption.Text" xml:space="preserve">
     <value>結果ファイル(&amp;R)：</value>
@@ -691,7 +669,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;lblFileCaption.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="btnAddFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -700,13 +678,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnAddFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>258, 70</value>
+    <value>278, 26</value>
   </data>
   <data name="btnAddFile.Size" type="System.Drawing.Size, System.Drawing">
     <value>113, 23</value>
   </data>
   <data name="btnAddFile.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>2</value>
   </data>
   <data name="btnAddFile.Text" xml:space="preserve">
     <value>ファイルを追加(&amp;A)...</value>
@@ -721,94 +699,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;btnAddFile.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="panelSearchThreshold.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="panelSearchThreshold.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="panelSearchThreshold.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 6</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 13</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>カットオフスコア(&amp;C)：</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>panelSearchThreshold</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="textCutoff.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="textCutoff.Location" type="System.Drawing.Point, System.Drawing">
-    <value>79, 3</value>
-  </data>
-  <data name="textCutoff.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 20</value>
-  </data>
-  <data name="textCutoff.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;textCutoff.Name" xml:space="preserve">
-    <value>textCutoff</value>
-  </data>
-  <data name="&gt;&gt;textCutoff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textCutoff.Parent" xml:space="preserve">
-    <value>panelSearchThreshold</value>
-  </data>
-  <data name="&gt;&gt;textCutoff.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panelSearchThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 46</value>
-  </data>
-  <data name="panelSearchThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 26</value>
-  </data>
-  <data name="panelSearchThreshold.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;panelSearchThreshold.Name" xml:space="preserve">
-    <value>panelSearchThreshold</value>
-  </data>
-  <data name="&gt;&gt;panelSearchThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelSearchThreshold.Parent" xml:space="preserve">
-    <value>panelPeptideSearch</value>
-  </data>
-  <data name="&gt;&gt;panelSearchThreshold.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>7</value>
   </data>
   <data name="panelPeptideSearch.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -817,10 +708,10 @@
     <value>0, 140</value>
   </data>
   <data name="panelPeptideSearch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 389</value>
+    <value>381, 512</value>
   </data>
   <data name="panelPeptideSearch.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;panelPeptideSearch.Name" xml:space="preserve">
     <value>panelPeptideSearch</value>
@@ -832,7 +723,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panelPeptideSearch.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="dataGridViewTextBoxColumn1.HeaderText" xml:space="preserve">
     <value>ファイル</value>
@@ -849,11 +740,20 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>140</value>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 622</value>
+    <value>381, 652</value>
+  </data>
+  <data name="&gt;&gt;helpTip.Name" xml:space="preserve">
+    <value>helpTip</value>
+  </data>
+  <data name="&gt;&gt;helpTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;dataGridViewTextBoxColumn1.Name" xml:space="preserve">
     <value>dataGridViewTextBoxColumn1</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.zh-CHS.resx
@@ -138,6 +138,12 @@
   <data name="radioDIA.Text" xml:space="preserve">
     <value>&amp;DIA（数据非依赖性采集）</value>
   </data>
+  <metadata name="helpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="radioDIA.ToolTip" xml:space="preserve">
+    <value>Library spectra from DDA MS/MS with chromatograms from separate DIA runs</value>
+  </data>
   <data name="&gt;&gt;radioDIA.Name" xml:space="preserve">
     <value>radioDIA</value>
   </data>
@@ -167,6 +173,9 @@
   </data>
   <data name="radioPRM.Text" xml:space="preserve">
     <value>&amp;PRM</value>
+  </data>
+  <data name="radioPRM.ToolTip" xml:space="preserve">
+    <value>Library spectra and chromatograms from the same PRM runs</value>
   </data>
   <data name="&gt;&gt;radioPRM.Name" xml:space="preserve">
     <value>radioPRM</value>
@@ -198,6 +207,9 @@
   <data name="radioDDA.Text" xml:space="preserve">
     <value>含有 MS&amp;1 筛选器的 DDA</value>
   </data>
+  <data name="radioDDA.ToolTip" xml:space="preserve">
+    <value>Library spectra from DDA MS/MS with chromatograms from MS1</value>
+  </data>
   <data name="&gt;&gt;radioDDA.Name" xml:space="preserve">
     <value>radioDDA</value>
   </data>
@@ -214,13 +226,13 @@
     <value>Bottom</value>
   </data>
   <data name="grpWorkflow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 529</value>
+    <value>0, 561</value>
   </data>
   <data name="grpWorkflow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 93</value>
+    <value>381, 91</value>
   </data>
   <data name="grpWorkflow.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="grpWorkflow.Text" xml:space="preserve">
     <value>工作流程</value>
@@ -235,7 +247,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;grpWorkflow.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>0</value>
   </data>
   <data name="radioButtonNewLibrary.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -254,6 +266,10 @@
   </data>
   <data name="radioButtonNewLibrary.Text" xml:space="preserve">
     <value>构建(&amp;B)</value>
+  </data>
+  <data name="radioButtonNewLibrary.ToolTip" xml:space="preserve">
+    <value>Build a new library from existing search results files,
+like TPP pepXML, Mascot .dat, SEQUEST SQT, etc.</value>
   </data>
   <data name="&gt;&gt;radioButtonNewLibrary.Name" xml:space="preserve">
     <value>radioButtonNewLibrary</value>
@@ -319,19 +335,23 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="tbxLibraryPath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
   <data name="tbxLibraryPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 39</value>
+    <value>11, 39</value>
   </data>
   <data name="tbxLibraryPath.Size" type="System.Drawing.Size, System.Drawing">
     <value>275, 20</value>
   </data>
   <data name="tbxLibraryPath.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
+  </data>
+  <data name="tbxLibraryPath.ToolTip" xml:space="preserve">
+    <value>Path to an existing library in a recognized format,
+like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
   </data>
   <data name="&gt;&gt;tbxLibraryPath.Name" xml:space="preserve">
     <value>tbxLibraryPath</value>
@@ -382,7 +402,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblLibraryPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 20</value>
+    <value>11, 23</value>
   </data>
   <data name="lblLibraryPath.Size" type="System.Drawing.Size, System.Drawing">
     <value>32, 13</value>
@@ -430,19 +450,19 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panelChooseFile.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="gridSearchFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="gridSearchFiles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 70</value>
+    <value>11, 26</value>
   </data>
   <data name="gridSearchFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>261, 147</value>
+    <value>261, 270</value>
   </data>
   <data name="gridSearchFiles.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;gridSearchFiles.Name" xml:space="preserve">
     <value>gridSearchFiles</value>
@@ -456,57 +476,6 @@
   <data name="&gt;&gt;gridSearchFiles.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 3</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 13</value>
-  </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>开始(&amp;M)：</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>panelPeptideSearch</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="comboInputFileType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 19</value>
-  </data>
-  <data name="comboInputFileType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>265, 21</value>
-  </data>
-  <data name="comboInputFileType.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;comboInputFileType.Name" xml:space="preserve">
-    <value>comboInputFileType</value>
-  </data>
-  <data name="&gt;&gt;comboInputFileType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboInputFileType.Parent" xml:space="preserve">
-    <value>panelPeptideSearch</value>
-  </data>
-  <data name="&gt;&gt;comboInputFileType.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="lblStandardPeptides.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -517,13 +486,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblStandardPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 242</value>
+    <value>11, 321</value>
   </data>
   <data name="lblStandardPeptides.Size" type="System.Drawing.Size, System.Drawing">
     <value>114, 13</value>
   </data>
   <data name="lblStandardPeptides.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>4</value>
   </data>
   <data name="lblStandardPeptides.Text" xml:space="preserve">
     <value>iRT 标准肽段(&amp;T)：</value>
@@ -538,19 +507,22 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;lblStandardPeptides.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>1</value>
   </data>
   <data name="comboStandards.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
   <data name="comboStandards.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 258</value>
+    <value>11, 337</value>
   </data>
   <data name="comboStandards.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 21</value>
   </data>
   <data name="comboStandards.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>5</value>
+  </data>
+  <data name="comboStandards.ToolTip" xml:space="preserve">
+    <value>Choose a set of know iRT standard peptides to use for retention time normalization.</value>
   </data>
   <data name="&gt;&gt;comboStandards.Name" xml:space="preserve">
     <value>comboStandards</value>
@@ -562,7 +534,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;comboStandards.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>2</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -574,16 +546,19 @@
     <value>NoControl</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 285</value>
+    <value>11, 364</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.Size" type="System.Drawing.Size, System.Drawing">
     <value>158, 17</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>6</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.Text" xml:space="preserve">
     <value>包含模糊的匹配项(&amp;I)</value>
+  </data>
+  <data name="cbIncludeAmbiguousMatches.ToolTip" xml:space="preserve">
+    <value>Check to keep spectra that match multiple peptides.</value>
   </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.Name" xml:space="preserve">
     <value>cbIncludeAmbiguousMatches</value>
@@ -595,7 +570,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>3</value>
   </data>
   <data name="cbFilterForDocumentPeptides.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -607,16 +582,19 @@
     <value>NoControl</value>
   </data>
   <data name="cbFilterForDocumentPeptides.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 308</value>
+    <value>11, 387</value>
   </data>
   <data name="cbFilterForDocumentPeptides.Size" type="System.Drawing.Size, System.Drawing">
     <value>156, 17</value>
   </data>
   <data name="cbFilterForDocumentPeptides.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>7</value>
   </data>
   <data name="cbFilterForDocumentPeptides.Text" xml:space="preserve">
     <value>文档中肽段的筛选器(&amp;E)</value>
+  </data>
+  <data name="cbFilterForDocumentPeptides.ToolTip" xml:space="preserve">
+    <value>Check to filter matches for only the peptides in the document.</value>
   </data>
   <data name="&gt;&gt;cbFilterForDocumentPeptides.Name" xml:space="preserve">
     <value>cbFilterForDocumentPeptides</value>
@@ -628,7 +606,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;cbFilterForDocumentPeptides.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>4</value>
   </data>
   <data name="btnRemFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -640,13 +618,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnRemFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>278, 99</value>
+    <value>278, 55</value>
   </data>
   <data name="btnRemFile.Size" type="System.Drawing.Size, System.Drawing">
     <value>93, 23</value>
   </data>
   <data name="btnRemFile.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>3</value>
   </data>
   <data name="btnRemFile.Text" xml:space="preserve">
     <value>删除文件(&amp;O)</value>
@@ -661,7 +639,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;btnRemFile.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>5</value>
   </data>
   <data name="lblFileCaption.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -670,13 +648,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblFileCaption.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 52</value>
+    <value>11, 8</value>
   </data>
   <data name="lblFileCaption.Size" type="System.Drawing.Size, System.Drawing">
     <value>61, 13</value>
   </data>
   <data name="lblFileCaption.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="lblFileCaption.Text" xml:space="preserve">
     <value>结果文件(&amp;R)：</value>
@@ -691,7 +669,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;lblFileCaption.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="btnAddFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -700,13 +678,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnAddFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>278, 70</value>
+    <value>278, 26</value>
   </data>
   <data name="btnAddFile.Size" type="System.Drawing.Size, System.Drawing">
     <value>93, 23</value>
   </data>
   <data name="btnAddFile.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>2</value>
   </data>
   <data name="btnAddFile.Text" xml:space="preserve">
     <value>添加文件(&amp;A)…</value>
@@ -721,94 +699,7 @@
     <value>panelPeptideSearch</value>
   </data>
   <data name="&gt;&gt;btnAddFile.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="panelSearchThreshold.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="panelSearchThreshold.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="panelSearchThreshold.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 6</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 13</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>截止得分(&amp;C)：</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>panelSearchThreshold</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="textCutoff.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="textCutoff.Location" type="System.Drawing.Point, System.Drawing">
-    <value>79, 3</value>
-  </data>
-  <data name="textCutoff.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 20</value>
-  </data>
-  <data name="textCutoff.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;textCutoff.Name" xml:space="preserve">
-    <value>textCutoff</value>
-  </data>
-  <data name="&gt;&gt;textCutoff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textCutoff.Parent" xml:space="preserve">
-    <value>panelSearchThreshold</value>
-  </data>
-  <data name="&gt;&gt;textCutoff.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="panelSearchThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>160, 46</value>
-  </data>
-  <data name="panelSearchThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 26</value>
-  </data>
-  <data name="panelSearchThreshold.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;panelSearchThreshold.Name" xml:space="preserve">
-    <value>panelSearchThreshold</value>
-  </data>
-  <data name="&gt;&gt;panelSearchThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelSearchThreshold.Parent" xml:space="preserve">
-    <value>panelPeptideSearch</value>
-  </data>
-  <data name="&gt;&gt;panelSearchThreshold.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>7</value>
   </data>
   <data name="panelPeptideSearch.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -817,10 +708,10 @@
     <value>0, 140</value>
   </data>
   <data name="panelPeptideSearch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 389</value>
+    <value>381, 512</value>
   </data>
   <data name="panelPeptideSearch.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;panelPeptideSearch.Name" xml:space="preserve">
     <value>panelPeptideSearch</value>
@@ -832,7 +723,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panelPeptideSearch.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="dataGridViewTextBoxColumn1.HeaderText" xml:space="preserve">
     <value>文件</value>
@@ -849,11 +740,20 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>140</value>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>381, 622</value>
+    <value>381, 652</value>
+  </data>
+  <data name="&gt;&gt;helpTip.Name" xml:space="preserve">
+    <value>helpTip</value>
+  </data>
+  <data name="&gt;&gt;helpTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;dataGridViewTextBoxColumn1.Name" xml:space="preserve">
     <value>dataGridViewTextBoxColumn1</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.ja.resx
@@ -478,7 +478,7 @@
     <value>20</value>
   </data>
   <data name="ceLabel.Text" xml:space="preserve">
-    <value>デフォルト&amp;NCE：</value>
+    <value>デフォルトNCE(&amp;N)：</value>
   </data>
   <data name="&gt;&gt;ceLabel.Name" xml:space="preserve">
     <value>ceLabel</value>
@@ -616,7 +616,7 @@
     <value>0</value>
   </data>
   <data name="lblKoinaPrediction.Text" xml:space="preserve">
-    <value>Koina設定</value>
+    <value>Koina Settings</value>
   </data>
   <data name="&gt;&gt;lblKoinaPrediction.Name" xml:space="preserve">
     <value>lblKoinaPrediction</value>
@@ -667,7 +667,7 @@
     <value>1</value>
   </data>
   <data name="koinaPage.Text" xml:space="preserve">
-    <value>Koina予測</value>
+    <value>Koina Prediction</value>
   </data>
   <data name="&gt;&gt;koinaPage.Name" xml:space="preserve">
     <value>koinaPage</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.zh-CHS.resx
@@ -223,7 +223,7 @@
     <value>23</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>默认电荷：</value>
+    <value>默认电荷:</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -397,7 +397,7 @@
     <value>25</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>最大电荷：</value>
+    <value>最大电荷:</value>
   </data>
   <data name="&gt;&gt;label3.Name" xml:space="preserve">
     <value>label3</value>
@@ -448,7 +448,7 @@
     <value>21</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>最小电荷：</value>
+    <value>最小电荷:</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -478,7 +478,7 @@
     <value>20</value>
   </data>
   <data name="ceLabel.Text" xml:space="preserve">
-    <value>默认 &amp;NCE：</value>
+    <value>默认 NCE(&amp;C):</value>
   </data>
   <data name="&gt;&gt;ceLabel.Name" xml:space="preserve">
     <value>ceLabel</value>
@@ -616,7 +616,7 @@
     <value>0</value>
   </data>
   <data name="lblKoinaPrediction.Text" xml:space="preserve">
-    <value>Koina 设置</value>
+    <value>Koina Settings</value>
   </data>
   <data name="&gt;&gt;lblKoinaPrediction.Name" xml:space="preserve">
     <value>lblKoinaPrediction</value>
@@ -667,7 +667,7 @@
     <value>1</value>
   </data>
   <data name="koinaPage.Text" xml:space="preserve">
-    <value>Koina 预测</value>
+    <value>Koina Prediction</value>
   </data>
   <data name="&gt;&gt;koinaPage.Name" xml:space="preserve">
     <value>koinaPage</value>
@@ -913,7 +913,7 @@
     <value>36</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
-    <value>单位：</value>
+    <value>单位:</value>
   </data>
   <data name="&gt;&gt;label6.Name" xml:space="preserve">
     <value>label6</value>
@@ -943,7 +943,7 @@
     <value>35</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
-    <value>单位：</value>
+    <value>单位:</value>
   </data>
   <data name="&gt;&gt;label7.Name" xml:space="preserve">
     <value>label7</value>
@@ -1024,7 +1024,7 @@
     <value>31</value>
   </data>
   <data name="lblMs2Tolerance.Text" xml:space="preserve">
-    <value>MS2 耐受性(&amp;2)：</value>
+    <value>MS2 耐受性(&amp;2):</value>
   </data>
   <data name="&gt;&gt;lblMs2Tolerance.Name" xml:space="preserve">
     <value>lblMs2Tolerance</value>
@@ -1096,7 +1096,7 @@
     <value>28</value>
   </data>
   <data name="lblMs1Tolerance.Text" xml:space="preserve">
-    <value>MS1 耐受性(&amp;1)：</value>
+    <value>MS1 耐受性(&amp;1):</value>
   </data>
   <data name="&gt;&gt;lblMs1Tolerance.Name" xml:space="preserve">
     <value>lblMs1Tolerance</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.ja.resx
@@ -577,7 +577,7 @@
     <value>282, 59</value>
   </data>
   <data name="panelDecoys.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;panelDecoys.Name" xml:space="preserve">
     <value>panelDecoys</value>
@@ -604,7 +604,7 @@
     <value>238, 17</value>
   </data>
   <data name="cbImportFromSeparateFasta.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>0</value>
   </data>
   <data name="cbImportFromSeparateFasta.Text" xml:space="preserve">
     <value>別のFASTAからターゲットタンパク質をインポート(&amp;M)</value>
@@ -634,7 +634,7 @@
     <value>282, 20</value>
   </data>
   <data name="tbxFastaTargets.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
+    <value>1</value>
   </data>
   <data name="tbxFastaTargets.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -667,7 +667,7 @@
     <value>75, 23</value>
   </data>
   <data name="browseFastaTargetsBtn.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
+    <value>2</value>
   </data>
   <data name="browseFastaTargetsBtn.Text" xml:space="preserve">
     <value>参照(&amp;W)...</value>
@@ -700,7 +700,7 @@
     <value>381, 45</value>
   </data>
   <data name="targetFastaPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;targetFastaPanel.Name" xml:space="preserve">
     <value>targetFastaPanel</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportFastaControl.zh-CHS.resx
@@ -578,7 +578,7 @@
     <value>282, 59</value>
   </data>
   <data name="panelDecoys.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;panelDecoys.Name" xml:space="preserve">
     <value>panelDecoys</value>
@@ -605,7 +605,7 @@
     <value>238, 17</value>
   </data>
   <data name="cbImportFromSeparateFasta.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>0</value>
   </data>
   <data name="cbImportFromSeparateFasta.Text" xml:space="preserve">
     <value>从单独的 FASTA 导入目标蛋白质(&amp;M)</value>
@@ -635,7 +635,7 @@
     <value>282, 20</value>
   </data>
   <data name="tbxFastaTargets.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
+    <value>1</value>
   </data>
   <data name="tbxFastaTargets.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -668,7 +668,7 @@
     <value>75, 23</value>
   </data>
   <data name="browseFastaTargetsBtn.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
+    <value>2</value>
   </data>
   <data name="browseFastaTargetsBtn.Text" xml:space="preserve">
     <value>浏览(&amp;W)…</value>
@@ -701,7 +701,7 @@
     <value>381, 45</value>
   </data>
   <data name="targetFastaPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;targetFastaPanel.Name" xml:space="preserve">
     <value>targetFastaPanel</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.ja.resx
@@ -544,13 +544,13 @@
     <value>True</value>
   </data>
   <data name="label14.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 9</value>
   </data>
   <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
-    <value>137, 18</value>
+    <value>119, 20</value>
   </data>
   <data name="label14.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -625,13 +625,13 @@
     <value>True</value>
   </data>
   <data name="label20.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label20.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
   <data name="label20.Size" type="System.Drawing.Size, System.Drawing">
-    <value>199, 18</value>
+    <value>177, 20</value>
   </data>
   <data name="label20.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -706,13 +706,13 @@
     <value>True</value>
   </data>
   <data name="label16.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label16.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
   <data name="label16.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 18</value>
+    <value>135, 20</value>
   </data>
   <data name="label16.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -787,7 +787,7 @@
     <value>True</value>
   </data>
   <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -796,7 +796,7 @@
     <value>12, 9</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>240, 18</value>
+    <value>214, 20</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -820,10 +820,10 @@
     <value>Top</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 3</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>576, 43</value>
+    <value>570, 43</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -842,6 +842,9 @@
   </data>
   <data name="transitionSettingsUiPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
+  </data>
+  <data name="transitionSettingsUiPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="transitionSettingsUiPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
@@ -868,13 +871,13 @@
     <value>True</value>
   </data>
   <data name="label19.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label19.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
   <data name="label19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>234, 18</value>
+    <value>212, 20</value>
   </data>
   <data name="label19.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -945,14 +948,17 @@
   <data name="&gt;&gt;ms1FullScanSettingsPage.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="lblFasta.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblFasta.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="lblFasta.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
   <data name="lblFasta.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 18</value>
+    <value>111, 20</value>
   </data>
   <data name="lblFasta.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1023,8 +1029,11 @@
   <data name="&gt;&gt;importFastaPage.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="label2.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1033,13 +1042,13 @@
     <value>12, 9</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 18</value>
+    <value>200, 20</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>変換設定を調整</value>
+    <value>Conversion Settings</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -1104,8 +1113,11 @@
   <data name="&gt;&gt;converterSettingsPage.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="lblSearchSettings.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblSearchSettings.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="lblSearchSettings.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1114,13 +1126,13 @@
     <value>12, 9</value>
   </data>
   <data name="lblSearchSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 18</value>
+    <value>172, 20</value>
   </data>
   <data name="lblSearchSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="lblSearchSettings.Text" xml:space="preserve">
-    <value>検索設定の調整</value>
+    <value>Search Settings</value>
   </data>
   <data name="&gt;&gt;lblSearchSettings.Name" xml:space="preserve">
     <value>lblSearchSettings</value>
@@ -1138,10 +1150,10 @@
     <value>Top</value>
   </data>
   <data name="searchSettingsTitlePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 3</value>
   </data>
   <data name="searchSettingsTitlePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>576, 43</value>
+    <value>570, 43</value>
   </data>
   <data name="searchSettingsTitlePanel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -1160,6 +1172,9 @@
   </data>
   <data name="ddaSearchSettingsPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
+  </data>
+  <data name="ddaSearchSettingsPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="ddaSearchSettingsPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
@@ -1182,8 +1197,11 @@
   <data name="&gt;&gt;ddaSearchSettingsPage.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="lblDDASearch.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblDDASearch.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="lblDDASearch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1192,7 +1210,7 @@
     <value>12, 9</value>
   </data>
   <data name="lblDDASearch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 18</value>
+    <value>99, 20</value>
   </data>
   <data name="lblDDASearch.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1216,10 +1234,10 @@
     <value>Top</value>
   </data>
   <data name="ddaSearchTitlePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 3</value>
   </data>
   <data name="ddaSearchTitlePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>576, 43</value>
+    <value>570, 43</value>
   </data>
   <data name="ddaSearchTitlePanel.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -1231,33 +1249,36 @@
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ddaSearchTitlePanel.Parent" xml:space="preserve">
-    <value>ddaSearch</value>
+    <value>ddaSearchPage</value>
   </data>
   <data name="&gt;&gt;ddaSearchTitlePanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="ddaSearch.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ddaSearchPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="ddaSearch.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ddaSearchPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="ddaSearchPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
   </data>
-  <data name="ddaSearch.TabIndex" type="System.Int32, mscorlib">
+  <data name="ddaSearchPage.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
-  <data name="ddaSearch.Text" xml:space="preserve">
+  <data name="ddaSearchPage.Text" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="&gt;&gt;ddaSearch.Name" xml:space="preserve">
-    <value>ddaSearch</value>
+  <data name="&gt;&gt;ddaSearchPage.Name" xml:space="preserve">
+    <value>ddaSearchPage</value>
   </data>
-  <data name="&gt;&gt;ddaSearch.Type" xml:space="preserve">
+  <data name="&gt;&gt;ddaSearchPage.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;ddaSearch.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ddaSearchPage.Parent" xml:space="preserve">
     <value>wizardPagesImportPeptideSearch</value>
   </data>
-  <data name="&gt;&gt;ddaSearch.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ddaSearchPage.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
   <data name="wizardPagesImportPeptideSearch.Location" type="System.Drawing.Point, System.Drawing">

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.zh-CHS.resx
@@ -548,13 +548,13 @@
     <value>True</value>
   </data>
   <data name="label14.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 9</value>
   </data>
   <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
-    <value>137, 18</value>
+    <value>119, 20</value>
   </data>
   <data name="label14.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -629,13 +629,13 @@
     <value>True</value>
   </data>
   <data name="label20.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label20.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
   <data name="label20.Size" type="System.Drawing.Size, System.Drawing">
-    <value>199, 18</value>
+    <value>177, 20</value>
   </data>
   <data name="label20.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -710,13 +710,13 @@
     <value>True</value>
   </data>
   <data name="label16.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label16.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
   <data name="label16.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 18</value>
+    <value>135, 20</value>
   </data>
   <data name="label16.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -791,7 +791,7 @@
     <value>True</value>
   </data>
   <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -800,7 +800,7 @@
     <value>12, 9</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>240, 18</value>
+    <value>214, 20</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -824,10 +824,10 @@
     <value>Top</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 3</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>576, 43</value>
+    <value>570, 43</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -846,6 +846,9 @@
   </data>
   <data name="transitionSettingsUiPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
+  </data>
+  <data name="transitionSettingsUiPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="transitionSettingsUiPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
@@ -872,13 +875,13 @@
     <value>True</value>
   </data>
   <data name="label19.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label19.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
   <data name="label19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>234, 18</value>
+    <value>212, 20</value>
   </data>
   <data name="label19.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -949,14 +952,17 @@
   <data name="&gt;&gt;ms1FullScanSettingsPage.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="lblFasta.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblFasta.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="lblFasta.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 9</value>
   </data>
   <data name="lblFasta.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 18</value>
+    <value>111, 20</value>
   </data>
   <data name="lblFasta.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1027,8 +1033,11 @@
   <data name="&gt;&gt;importFastaPage.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="label2.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1037,13 +1046,13 @@
     <value>12, 9</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 18</value>
+    <value>200, 20</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>调整转换设置</value>
+    <value>Conversion Settings</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -1108,8 +1117,11 @@
   <data name="&gt;&gt;converterSettingsPage.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="lblSearchSettings.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblSearchSettings.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="lblSearchSettings.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1118,13 +1130,13 @@
     <value>12, 9</value>
   </data>
   <data name="lblSearchSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 18</value>
+    <value>172, 20</value>
   </data>
   <data name="lblSearchSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="lblSearchSettings.Text" xml:space="preserve">
-    <value>调整搜索设置</value>
+    <value>Search Settings</value>
   </data>
   <data name="&gt;&gt;lblSearchSettings.Name" xml:space="preserve">
     <value>lblSearchSettings</value>
@@ -1142,10 +1154,10 @@
     <value>Top</value>
   </data>
   <data name="searchSettingsTitlePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 3</value>
   </data>
   <data name="searchSettingsTitlePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>576, 43</value>
+    <value>570, 43</value>
   </data>
   <data name="searchSettingsTitlePanel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -1164,6 +1176,9 @@
   </data>
   <data name="ddaSearchSettingsPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
+  </data>
+  <data name="ddaSearchSettingsPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="ddaSearchSettingsPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
@@ -1186,8 +1201,11 @@
   <data name="&gt;&gt;ddaSearchSettingsPage.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="lblDDASearch.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblDDASearch.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Arial Rounded MT Bold, 12pt</value>
+    <value>Microsoft Sans Serif, 12pt</value>
   </data>
   <data name="lblDDASearch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1196,7 +1214,7 @@
     <value>12, 9</value>
   </data>
   <data name="lblDDASearch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 18</value>
+    <value>99, 20</value>
   </data>
   <data name="lblDDASearch.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1220,10 +1238,10 @@
     <value>Top</value>
   </data>
   <data name="ddaSearchTitlePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+    <value>3, 3</value>
   </data>
   <data name="ddaSearchTitlePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>576, 43</value>
+    <value>570, 43</value>
   </data>
   <data name="ddaSearchTitlePanel.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -1235,33 +1253,36 @@
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ddaSearchTitlePanel.Parent" xml:space="preserve">
-    <value>ddaSearch</value>
+    <value>ddaSearchPage</value>
   </data>
   <data name="&gt;&gt;ddaSearchTitlePanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="ddaSearch.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="ddaSearchPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="ddaSearch.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="ddaSearchPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="ddaSearchPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
   </data>
-  <data name="ddaSearch.TabIndex" type="System.Int32, mscorlib">
+  <data name="ddaSearchPage.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
-  <data name="ddaSearch.Text" xml:space="preserve">
+  <data name="ddaSearchPage.Text" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="&gt;&gt;ddaSearch.Name" xml:space="preserve">
-    <value>ddaSearch</value>
+  <data name="&gt;&gt;ddaSearchPage.Name" xml:space="preserve">
+    <value>ddaSearchPage</value>
   </data>
-  <data name="&gt;&gt;ddaSearch.Type" xml:space="preserve">
+  <data name="&gt;&gt;ddaSearchPage.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;ddaSearch.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ddaSearchPage.Parent" xml:space="preserve">
     <value>wizardPagesImportPeptideSearch</value>
   </data>
-  <data name="&gt;&gt;ddaSearch.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;ddaSearchPage.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
   <data name="wizardPagesImportPeptideSearch.Location" type="System.Drawing.Point, System.Drawing">

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.ja.resx
@@ -158,7 +158,7 @@
     <value>スコアタイプが見つかりません。</value>
   </data>
   <data name="BuildLibraryGridView_OnCellPainting_Score_threshold___0___is_invalid__must_be_a_decimal_value_between__1__and__2___" xml:space="preserve">
-    <value>スコアしきい値「{0}」が無効です(10進値は{1}から{2}の間である必要があります)。</value>
+    <value>スコア閾値「{0}」が無効です(10進値は{1}から{2}の間である必要があります)。</value>
   </data>
   <data name="BuildLibraryGridView_OnRowPrepaint_Error_getting_score_type_for_this_file_" xml:space="preserve">
     <value>このファイルのスコアタイプを取得中にエラーが発生しました。</value>
@@ -218,13 +218,13 @@
     <value>検索を開始しています...</value>
   </data>
   <data name="EncyclopeDiaSearchControl_Search_Reusing_Koina_predictions_from___0_" xml:space="preserve">
-    <value>Koina予測の再利用元：{0}</value>
+    <value>Reusing Koina predictions from: {0}</value>
   </data>
   <data name="EncyclopeDiaSearchDlg_ImportEncyclopediaLibrary_Ran_EncyclopeDIA_Search" xml:space="preserve">
     <value>EncyclopeDIA検索実行済み</value>
   </data>
   <data name="EncyclopeDiaSearchDlg_NextPage_A_FASTA_file_is_required_for_an_EncyclopeDia_Koina_search_" xml:space="preserve">
-    <value>EncyclopeDIA Koina検索には、FASTAファイルが必要です。</value>
+    <value>A FASTA file is required for an EncyclopeDIA Koina search.</value>
   </data>
   <data name="EncyclopeDiaSearchDlg_NextPage_Run" xml:space="preserve">
     <value>実行</value>
@@ -286,6 +286,9 @@
   <data name="ImportPeptideSearchDlg_NextPage_Some_results_files_are_still_missing__Are_you_sure_you_want_to_continue_" xml:space="preserve">
     <value>まだ欠損している結果ファイルがあります。本当に続行しますか？</value>
   </data>
+  <data name="ImportPeptideSearchDlg_ImportPeptideSearchDlg_Feature_Detection" xml:space="preserve">
+    <value>Feature Detection</value>
+  </data>
   <data name="ImportPeptideSearchDlg_UpdateFullScanSettings_Full_scan_MS1_filtering_must_be_enabled_in_order_to_import_a_peptide_search_" xml:space="preserve">
     <value>ペプチド検索をインポートするには、フルスキャンMS1フィルタを有効にする必要があります。</value>
   </data>
@@ -294,6 +297,9 @@
   </data>
   <data name="ImportResultsControl_browseToResultsFileButton_Click_Import_Peptide_Search" xml:space="preserve">
     <value>ペプチド検索のインポート</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_btnAddFile_Click_Select_Files_to_Search" xml:space="preserve">
+    <value>Select Files to Search</value>
   </data>
   <data name="ImportResultsControl_findResultsFilesButton_Click_Could_not_find_all_the_missing_results_files_" xml:space="preserve">
     <value>欠損したすべての結果ファイルを見つけることができませんでした。</value>
@@ -346,5 +352,14 @@
   <data name="VendorIssueHelper_ShowLibraryMissingExternalSpectraError_ButtonDescriptions" xml:space="preserve">
     <value>埋め込みスペクトルを使用するには、「埋め込み」をクリックしてください。
 上記にリストしたディレクトリの1つにオリジナルのスペクトルファイルを入れた後、もう一度構築を試みるには「再試行」をクリックしてください。</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Add_spectral_library" xml:space="preserve">
+    <value>Add spectral library</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_Detected_Features_Library" xml:space="preserve">
+    <value>Building detected features library</value>
+  </data>
+  <data name="ImportPeptideSearchDlg_NextPage_Adding_detected_features_to_document" xml:space="preserve">
+    <value>Adding detected features to document</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.zh-CHS.resx
@@ -158,7 +158,7 @@
     <value>找不到得分类型。</value>
   </data>
   <data name="BuildLibraryGridView_OnCellPainting_Score_threshold___0___is_invalid__must_be_a_decimal_value_between__1__and__2___" xml:space="preserve">
-    <value>得分阈值“{0}”无效(必须为介于 {1} 和 {2} 之间的十进制值)。</value>
+    <value>得分阈值“{0}”无效(须为介于 {1} 和 {2} 之间的小数值)。</value>
   </data>
   <data name="BuildLibraryGridView_OnRowPrepaint_Error_getting_score_type_for_this_file_" xml:space="preserve">
     <value>获取此文件的得分类型时出错。</value>
@@ -218,13 +218,13 @@
     <value>正在启动搜索...</value>
   </data>
   <data name="EncyclopeDiaSearchControl_Search_Reusing_Koina_predictions_from___0_" xml:space="preserve">
-    <value>再次使用来自 {0} 的 Koina 预测</value>
+    <value>Reusing Koina predictions from: {0}</value>
   </data>
   <data name="EncyclopeDiaSearchDlg_ImportEncyclopediaLibrary_Ran_EncyclopeDIA_Search" xml:space="preserve">
     <value>运行  EncyclopeDIA 搜索</value>
   </data>
   <data name="EncyclopeDiaSearchDlg_NextPage_A_FASTA_file_is_required_for_an_EncyclopeDia_Koina_search_" xml:space="preserve">
-    <value>执行 EncyclopeDIA Koina 搜索需要用到 FASTA 文件。</value>
+    <value>A FASTA file is required for an EncyclopeDIA Koina search.</value>
   </data>
   <data name="EncyclopeDiaSearchDlg_NextPage_Run" xml:space="preserve">
     <value>运行</value>
@@ -286,6 +286,9 @@
   <data name="ImportPeptideSearchDlg_NextPage_Some_results_files_are_still_missing__Are_you_sure_you_want_to_continue_" xml:space="preserve">
     <value>部分结果文件仍然缺失。您确定想要继续？</value>
   </data>
+  <data name="ImportPeptideSearchDlg_ImportPeptideSearchDlg_Feature_Detection" xml:space="preserve">
+    <value>Feature Detection</value>
+  </data>
   <data name="ImportPeptideSearchDlg_UpdateFullScanSettings_Full_scan_MS1_filtering_must_be_enabled_in_order_to_import_a_peptide_search_" xml:space="preserve">
     <value>全扫描 MS1 过滤必须被启用，以导入一个肽段搜索。</value>
   </data>
@@ -294,6 +297,9 @@
   </data>
   <data name="ImportResultsControl_browseToResultsFileButton_Click_Import_Peptide_Search" xml:space="preserve">
     <value>导入肽段搜索</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_btnAddFile_Click_Select_Files_to_Search" xml:space="preserve">
+    <value>Select Files to Search</value>
   </data>
   <data name="ImportResultsControl_findResultsFilesButton_Click_Could_not_find_all_the_missing_results_files_" xml:space="preserve">
     <value>无法找到所有缺失结果文件。</value>
@@ -346,5 +352,14 @@
   <data name="VendorIssueHelper_ShowLibraryMissingExternalSpectraError_ButtonDescriptions" xml:space="preserve">
     <value>单击 "嵌入" 即可使用嵌入的谱图。
 将原始谱图文件放在上面列出的其中一个目录后，单击 "重试" 再次尝试构建。</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Add_spectral_library" xml:space="preserve">
+    <value>Add spectral library</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_Detected_Features_Library" xml:space="preserve">
+    <value>Building detected features library</value>
+  </data>
+  <data name="ImportPeptideSearchDlg_NextPage_Adding_detected_features_to_document" xml:space="preserve">
+    <value>Adding detected features to document</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.ja.resx
@@ -148,7 +148,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="lblProgress.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -157,7 +157,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblProgress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 10</value>
+    <value>9, 6</value>
   </data>
   <data name="lblProgress.Size" type="System.Drawing.Size, System.Drawing">
     <value>87, 13</value>
@@ -178,7 +178,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblProgress.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="progressBar.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
@@ -208,7 +208,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;progressBar.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="showTimestampsCheckbox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -241,7 +241,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;showTimestampsCheckbox.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="txtSearchProgress.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -256,7 +256,7 @@
     <value>Vertical</value>
   </data>
   <data name="txtSearchProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>324, 347</value>
+    <value>324, 343</value>
   </data>
   <data name="txtSearchProgress.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -273,17 +273,14 @@
   <data name="&gt;&gt;txtSearchProgress.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="panelTextBoxBorder.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+  <data name="panelTextBoxBorder.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="panelTextBoxBorder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 26</value>
-  </data>
-  <data name="panelTextBoxBorder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>0, 0</value>
   </data>
   <data name="panelTextBoxBorder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 357</value>
+    <value>334, 353</value>
   </data>
   <data name="panelTextBoxBorder.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -295,10 +292,64 @@
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panelTextBoxBorder.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>progressSplitContainer.Panel2</value>
   </data>
   <data name="&gt;&gt;panelTextBoxBorder.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>0</value>
+  </data>
+  <data name="progressSplitContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="progressSplitContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 32</value>
+  </data>
+  <data name="progressSplitContainer.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Name" xml:space="preserve">
+    <value>progressSplitContainer.Panel1</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Parent" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Name" xml:space="preserve">
+    <value>progressSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Parent" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="progressSplitContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 353</value>
+  </data>
+  <data name="progressSplitContainer.SplitterDistance" type="System.Int32, mscorlib">
+    <value>96</value>
+  </data>
+  <data name="progressSplitContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Name" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.zh-CHS.resx
@@ -148,7 +148,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="lblProgress.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -157,7 +157,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblProgress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 10</value>
+    <value>9, 6</value>
   </data>
   <data name="lblProgress.Size" type="System.Drawing.Size, System.Drawing">
     <value>87, 13</value>
@@ -178,7 +178,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblProgress.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="progressBar.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
@@ -208,7 +208,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;progressBar.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="showTimestampsCheckbox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -241,7 +241,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;showTimestampsCheckbox.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="txtSearchProgress.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -256,7 +256,7 @@
     <value>Vertical</value>
   </data>
   <data name="txtSearchProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>324, 347</value>
+    <value>324, 343</value>
   </data>
   <data name="txtSearchProgress.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -273,17 +273,14 @@
   <data name="&gt;&gt;txtSearchProgress.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="panelTextBoxBorder.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+  <data name="panelTextBoxBorder.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="panelTextBoxBorder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 26</value>
-  </data>
-  <data name="panelTextBoxBorder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>0, 0</value>
   </data>
   <data name="panelTextBoxBorder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 357</value>
+    <value>334, 353</value>
   </data>
   <data name="panelTextBoxBorder.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -295,10 +292,64 @@
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panelTextBoxBorder.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>progressSplitContainer.Panel2</value>
   </data>
   <data name="&gt;&gt;panelTextBoxBorder.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>0</value>
+  </data>
+  <data name="progressSplitContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="progressSplitContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 32</value>
+  </data>
+  <data name="progressSplitContainer.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Name" xml:space="preserve">
+    <value>progressSplitContainer.Panel1</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Parent" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Name" xml:space="preserve">
+    <value>progressSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Parent" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="progressSplitContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 353</value>
+  </data>
+  <data name="progressSplitContainer.SplitterDistance" type="System.Int32, mscorlib">
+    <value>96</value>
+  </data>
+  <data name="progressSplitContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Name" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.ja.resx
@@ -126,7 +126,7 @@
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cbMS1TolUnit.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="&gt;&gt;cbMS1TolUnit.Name" xml:space="preserve">
     <value>cbMS1TolUnit</value>
@@ -138,7 +138,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbMS1TolUnit.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>21</value>
   </data>
   <data name="lblMs1Tolerance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -150,7 +150,7 @@
     <value>79, 13</value>
   </data>
   <data name="lblMs1Tolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="lblMs1Tolerance.Text" xml:space="preserve">
     <value>MS1許容誤差(&amp;1)：</value>
@@ -165,7 +165,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMs1Tolerance.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>20</value>
   </data>
   <data name="txtMS1Tolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 106</value>
@@ -174,7 +174,7 @@
     <value>121, 20</value>
   </data>
   <data name="txtMS1Tolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;txtMS1Tolerance.Name" xml:space="preserve">
     <value>txtMS1Tolerance</value>
@@ -186,7 +186,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txtMS1Tolerance.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>19</value>
   </data>
   <data name="txtMS2Tolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 146</value>
@@ -195,7 +195,7 @@
     <value>121, 20</value>
   </data>
   <data name="txtMS2Tolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="&gt;&gt;txtMS2Tolerance.Name" xml:space="preserve">
     <value>txtMS2Tolerance</value>
@@ -207,7 +207,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txtMS2Tolerance.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>16</value>
   </data>
   <data name="lblMs2Tolerance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -219,7 +219,7 @@
     <value>79, 13</value>
   </data>
   <data name="lblMs2Tolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="lblMs2Tolerance.Text" xml:space="preserve">
     <value>MS2許容誤差(&amp;2)：</value>
@@ -234,7 +234,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMs2Tolerance.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>17</value>
   </data>
   <data name="cbMS2TolUnit.Location" type="System.Drawing.Point, System.Drawing">
     <value>153, 146</value>
@@ -243,7 +243,7 @@
     <value>70, 21</value>
   </data>
   <data name="cbMS2TolUnit.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;cbMS2TolUnit.Name" xml:space="preserve">
     <value>cbMS2TolUnit</value>
@@ -255,7 +255,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbMS2TolUnit.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>18</value>
   </data>
   <data name="lblFragmentIons.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -267,7 +267,7 @@
     <value>76, 13</value>
   </data>
   <data name="lblFragmentIons.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="lblFragmentIons.Text" xml:space="preserve">
     <value>断片イオン(&amp;F)：</value>
@@ -282,7 +282,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblFragmentIons.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>15</value>
   </data>
   <data name="cbFragmentIons.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 190</value>
@@ -291,7 +291,7 @@
     <value>210, 21</value>
   </data>
   <data name="cbFragmentIons.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;cbFragmentIons.Name" xml:space="preserve">
     <value>cbFragmentIons</value>
@@ -303,7 +303,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbFragmentIons.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>14</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btnAdditionalSettings.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -316,7 +316,7 @@
     <value>107, 23</value>
   </data>
   <data name="btnAdditionalSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>19</value>
   </data>
   <data name="btnAdditionalSettings.Text" xml:space="preserve">
     <value>その他の設定</value>
@@ -331,7 +331,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnAdditionalSettings.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>13</value>
   </data>
   <data name="pBLogo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -355,7 +355,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pBLogo.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>12</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -367,7 +367,7 @@
     <value>29, 13</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
+    <value>4</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>単位：</value>
@@ -382,7 +382,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>11</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -394,7 +394,7 @@
     <value>29, 13</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>27</value>
+    <value>8</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
     <value>単位：</value>
@@ -409,7 +409,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>10</value>
   </data>
   <data name="lblMaxVariableMods.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -418,13 +418,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblMaxVariableMods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 274</value>
+    <value>13, 274</value>
   </data>
   <data name="lblMaxVariableMods.Size" type="System.Drawing.Size, System.Drawing">
     <value>98, 13</value>
   </data>
   <data name="lblMaxVariableMods.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>14</value>
   </data>
   <data name="lblMaxVariableMods.Text" xml:space="preserve">
     <value>最大可変修飾数(&amp;V)：</value>
@@ -439,7 +439,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMaxVariableMods.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="cbMaxVariableMods.Items" xml:space="preserve">
     <value>0</value>
@@ -478,7 +478,7 @@
     <value>44, 21</value>
   </data>
   <data name="cbMaxVariableMods.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;cbMaxVariableMods.Name" xml:space="preserve">
     <value>cbMaxVariableMods</value>
@@ -490,7 +490,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbMaxVariableMods.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="searchEngineComboBox.Items" xml:space="preserve">
     <value>MSAmanda</value>
@@ -508,7 +508,7 @@
     <value>118, 21</value>
   </data>
   <data name="searchEngineComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>28</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;searchEngineComboBox.Name" xml:space="preserve">
     <value>searchEngineComboBox</value>
@@ -520,7 +520,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;searchEngineComboBox.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>7</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -535,7 +535,7 @@
     <value>79, 13</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
+    <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>検索エンジン(&amp;S)：</value>
@@ -550,7 +550,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="cbMs2Analyzer.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 239</value>
@@ -559,7 +559,7 @@
     <value>210, 21</value>
   </data>
   <data name="cbMs2Analyzer.TabIndex" type="System.Int32, mscorlib">
-    <value>31</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;cbMs2Analyzer.Name" xml:space="preserve">
     <value>cbMs2Analyzer</value>
@@ -571,7 +571,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbMs2Analyzer.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="lblMs2Analyzer.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -586,7 +586,7 @@
     <value>74, 13</value>
   </data>
   <data name="lblMs2Analyzer.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
+    <value>12</value>
   </data>
   <data name="lblMs2Analyzer.Text" xml:space="preserve">
     <value>MS2アナライザー(&amp;a)：</value>
@@ -601,7 +601,305 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMs2Analyzer.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="labelPPM.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>66, 138</value>
+  </data>
+  <data name="labelPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 13</value>
+  </data>
+  <data name="labelPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="labelPPM.Text" xml:space="preserve">
+    <value>PPM</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Name" xml:space="preserve">
+    <value>labelPPM</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 135</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 20</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="textHardklorMinIntensityPPM.ToolTip" xml:space="preserve">
+    <value>Ignore features whose intensity relative to the sum of all detected feature intensities in a sample is less than this</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Name" xml:space="preserve">
+    <value>textHardklorMinIntensityPPM</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="labelMinIntensityPPM.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelMinIntensityPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 119</value>
+  </data>
+  <data name="labelMinIntensityPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 13</value>
+  </data>
+  <data name="labelMinIntensityPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="labelMinIntensityPPM.Text" xml:space="preserve">
+    <value>Min &amp;intensity proportion:</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Name" xml:space="preserve">
+    <value>labelMinIntensityPPM</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="textHardklorMinIdotP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 36</value>
+  </data>
+  <data name="textHardklorMinIdotP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="textHardklorMinIdotP.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Name" xml:space="preserve">
+    <value>textHardklorMinIdotP</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="labelHardklorMinIdotP.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelHardklorMinIdotP.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 20</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 13</value>
+  </data>
+  <data name="labelHardklorMinIdotP.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Text" xml:space="preserve">
+    <value>Min isotope &amp;dot product:</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Name" xml:space="preserve">
+    <value>labelHardklorMinIdotP</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="textHardklorSignalToNoise.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 85</value>
+  </data>
+  <data name="textHardklorSignalToNoise.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="textHardklorSignalToNoise.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="textHardklorSignalToNoise.ToolTip" xml:space="preserve">
+    <value>Sets Hardklor configuration's signal-to-noise threshold, i.e. the relative abundance a peak must exceed in the spectrum window to be considered in the scoring algorithm.
+Note that this is a local noise threshold for the area of the spectrum that the peptide was identified in.</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Name" xml:space="preserve">
+    <value>textHardklorSignalToNoise</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 69</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Size" type="System.Drawing.Size, System.Drawing">
+    <value>97, 13</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Text" xml:space="preserve">
+    <value>Min &amp;signal to noise:</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Name" xml:space="preserve">
+    <value>lblHardklorSignalToNoise</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="groupBoxHardklor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>178, 254</value>
+  </data>
+  <data name="groupBoxHardklor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 168</value>
+  </data>
+  <data name="groupBoxHardklor.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="groupBoxHardklor.Text" xml:space="preserve">
+    <value>Search parameters</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Name" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="textCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 339</value>
+  </data>
+  <data name="textCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 20</value>
+  </data>
+  <data name="textCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="textCutoff.ToolTip" xml:space="preserve">
+    <value>A score from 1.0 - 0, with 1.0 most likely to be correct,
+used to provide a cut-off for spectra in the results that will
+be included in the library.
+
+For TPP pepXML this is the minimum PeptideProphet probability.
+For Mascot this is 1 - the maximum expectation value.
+For SEQUEST SQT this is 1 - the maximum FDR.</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Name" xml:space="preserve">
+    <value>textCutoff</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelCutoff.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelCutoff.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 323</value>
+  </data>
+  <data name="labelCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 13</value>
+  </data>
+  <data name="labelCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="labelCutoff.Text" xml:space="preserve">
+    <value>&amp;Cut-off score:</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Name" xml:space="preserve">
+    <value>labelCutoff</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Location" type="System.Drawing.Point, System.Drawing">
+    <value>348, 57</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Size" type="System.Drawing.Size, System.Drawing">
+    <value>36, 230</value>
+  </data>
+  <data name="lblSearchEngineBlurb.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Text" xml:space="preserve">
+    <value>(blurb)</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Name" xml:space="preserve">
+    <value>lblSearchEngineBlurb</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -611,6 +909,12 @@
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>381, 425</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SearchSettingsControl</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.zh-CHS.resx
@@ -126,7 +126,7 @@
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="cbMS1TolUnit.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="&gt;&gt;cbMS1TolUnit.Name" xml:space="preserve">
     <value>cbMS1TolUnit</value>
@@ -138,7 +138,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbMS1TolUnit.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>21</value>
   </data>
   <data name="lblMs1Tolerance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -150,7 +150,7 @@
     <value>79, 13</value>
   </data>
   <data name="lblMs1Tolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="lblMs1Tolerance.Text" xml:space="preserve">
     <value>MS1 耐受性(&amp;)：</value>
@@ -165,7 +165,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMs1Tolerance.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>20</value>
   </data>
   <data name="txtMS1Tolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 106</value>
@@ -174,7 +174,7 @@
     <value>121, 20</value>
   </data>
   <data name="txtMS1Tolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="&gt;&gt;txtMS1Tolerance.Name" xml:space="preserve">
     <value>txtMS1Tolerance</value>
@@ -186,7 +186,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txtMS1Tolerance.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>19</value>
   </data>
   <data name="txtMS2Tolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 146</value>
@@ -195,7 +195,7 @@
     <value>121, 20</value>
   </data>
   <data name="txtMS2Tolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="&gt;&gt;txtMS2Tolerance.Name" xml:space="preserve">
     <value>txtMS2Tolerance</value>
@@ -207,7 +207,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;txtMS2Tolerance.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>16</value>
   </data>
   <data name="lblMs2Tolerance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -219,7 +219,7 @@
     <value>79, 13</value>
   </data>
   <data name="lblMs2Tolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="lblMs2Tolerance.Text" xml:space="preserve">
     <value>MS2 耐受性(&amp;2)：</value>
@@ -234,7 +234,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMs2Tolerance.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>17</value>
   </data>
   <data name="cbMS2TolUnit.Location" type="System.Drawing.Point, System.Drawing">
     <value>153, 146</value>
@@ -243,7 +243,7 @@
     <value>70, 21</value>
   </data>
   <data name="cbMS2TolUnit.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;cbMS2TolUnit.Name" xml:space="preserve">
     <value>cbMS2TolUnit</value>
@@ -255,7 +255,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbMS2TolUnit.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>18</value>
   </data>
   <data name="lblFragmentIons.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -267,7 +267,7 @@
     <value>76, 13</value>
   </data>
   <data name="lblFragmentIons.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="lblFragmentIons.Text" xml:space="preserve">
     <value>碎片离子(&amp;F)：</value>
@@ -282,7 +282,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblFragmentIons.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>15</value>
   </data>
   <data name="cbFragmentIons.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 190</value>
@@ -291,7 +291,7 @@
     <value>210, 21</value>
   </data>
   <data name="cbFragmentIons.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;cbFragmentIons.Name" xml:space="preserve">
     <value>cbFragmentIons</value>
@@ -303,7 +303,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbFragmentIons.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>14</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btnAdditionalSettings.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -316,7 +316,7 @@
     <value>107, 23</value>
   </data>
   <data name="btnAdditionalSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>19</value>
   </data>
   <data name="btnAdditionalSettings.Text" xml:space="preserve">
     <value>其他设置(&amp;D)</value>
@@ -331,7 +331,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnAdditionalSettings.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>13</value>
   </data>
   <data name="pBLogo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -355,7 +355,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;pBLogo.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>12</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -367,7 +367,7 @@
     <value>29, 13</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
+    <value>4</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>单位：</value>
@@ -382,7 +382,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>11</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -394,7 +394,7 @@
     <value>29, 13</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>27</value>
+    <value>8</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
     <value>单位：</value>
@@ -409,7 +409,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>10</value>
   </data>
   <data name="lblMaxVariableMods.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -418,13 +418,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblMaxVariableMods.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 274</value>
+    <value>13, 274</value>
   </data>
   <data name="lblMaxVariableMods.Size" type="System.Drawing.Size, System.Drawing">
     <value>98, 13</value>
   </data>
   <data name="lblMaxVariableMods.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>14</value>
   </data>
   <data name="lblMaxVariableMods.Text" xml:space="preserve">
     <value>最大可变修饰数(&amp;V)：</value>
@@ -439,7 +439,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMaxVariableMods.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="cbMaxVariableMods.Items" xml:space="preserve">
     <value>0</value>
@@ -478,7 +478,7 @@
     <value>44, 21</value>
   </data>
   <data name="cbMaxVariableMods.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;cbMaxVariableMods.Name" xml:space="preserve">
     <value>cbMaxVariableMods</value>
@@ -490,7 +490,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbMaxVariableMods.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="searchEngineComboBox.Items" xml:space="preserve">
     <value>MSAmanda</value>
@@ -508,7 +508,7 @@
     <value>118, 21</value>
   </data>
   <data name="searchEngineComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>28</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;searchEngineComboBox.Name" xml:space="preserve">
     <value>searchEngineComboBox</value>
@@ -520,7 +520,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;searchEngineComboBox.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>7</value>
   </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -535,7 +535,7 @@
     <value>79, 13</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
+    <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>搜索引擎(&amp;S)：</value>
@@ -550,7 +550,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="cbMs2Analyzer.Location" type="System.Drawing.Point, System.Drawing">
     <value>13, 239</value>
@@ -559,7 +559,7 @@
     <value>210, 21</value>
   </data>
   <data name="cbMs2Analyzer.TabIndex" type="System.Int32, mscorlib">
-    <value>31</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;cbMs2Analyzer.Name" xml:space="preserve">
     <value>cbMs2Analyzer</value>
@@ -571,7 +571,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbMs2Analyzer.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="lblMs2Analyzer.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -586,7 +586,7 @@
     <value>74, 13</value>
   </data>
   <data name="lblMs2Analyzer.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
+    <value>12</value>
   </data>
   <data name="lblMs2Analyzer.Text" xml:space="preserve">
     <value>MS2 分析仪(&amp;A)：</value>
@@ -601,7 +601,305 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblMs2Analyzer.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="labelPPM.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>66, 138</value>
+  </data>
+  <data name="labelPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 13</value>
+  </data>
+  <data name="labelPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="labelPPM.Text" xml:space="preserve">
+    <value>PPM</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Name" xml:space="preserve">
+    <value>labelPPM</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 135</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 20</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="textHardklorMinIntensityPPM.ToolTip" xml:space="preserve">
+    <value>Ignore features whose intensity relative to the sum of all detected feature intensities in a sample is less than this</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Name" xml:space="preserve">
+    <value>textHardklorMinIntensityPPM</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="labelMinIntensityPPM.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelMinIntensityPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 119</value>
+  </data>
+  <data name="labelMinIntensityPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 13</value>
+  </data>
+  <data name="labelMinIntensityPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="labelMinIntensityPPM.Text" xml:space="preserve">
+    <value>Min &amp;intensity proportion:</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Name" xml:space="preserve">
+    <value>labelMinIntensityPPM</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="textHardklorMinIdotP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 36</value>
+  </data>
+  <data name="textHardklorMinIdotP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="textHardklorMinIdotP.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Name" xml:space="preserve">
+    <value>textHardklorMinIdotP</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="labelHardklorMinIdotP.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelHardklorMinIdotP.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 20</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 13</value>
+  </data>
+  <data name="labelHardklorMinIdotP.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Text" xml:space="preserve">
+    <value>Min isotope &amp;dot product:</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Name" xml:space="preserve">
+    <value>labelHardklorMinIdotP</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="textHardklorSignalToNoise.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 85</value>
+  </data>
+  <data name="textHardklorSignalToNoise.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="textHardklorSignalToNoise.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="textHardklorSignalToNoise.ToolTip" xml:space="preserve">
+    <value>Sets Hardklor configuration's signal-to-noise threshold, i.e. the relative abundance a peak must exceed in the spectrum window to be considered in the scoring algorithm.
+Note that this is a local noise threshold for the area of the spectrum that the peptide was identified in.</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Name" xml:space="preserve">
+    <value>textHardklorSignalToNoise</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 69</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Size" type="System.Drawing.Size, System.Drawing">
+    <value>97, 13</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Text" xml:space="preserve">
+    <value>Min &amp;signal to noise:</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Name" xml:space="preserve">
+    <value>lblHardklorSignalToNoise</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="groupBoxHardklor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>178, 254</value>
+  </data>
+  <data name="groupBoxHardklor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 168</value>
+  </data>
+  <data name="groupBoxHardklor.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="groupBoxHardklor.Text" xml:space="preserve">
+    <value>Search parameters</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Name" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="textCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 339</value>
+  </data>
+  <data name="textCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 20</value>
+  </data>
+  <data name="textCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="textCutoff.ToolTip" xml:space="preserve">
+    <value>A score from 1.0 - 0, with 1.0 most likely to be correct,
+used to provide a cut-off for spectra in the results that will
+be included in the library.
+
+For TPP pepXML this is the minimum PeptideProphet probability.
+For Mascot this is 1 - the maximum expectation value.
+For SEQUEST SQT this is 1 - the maximum FDR.</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Name" xml:space="preserve">
+    <value>textCutoff</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelCutoff.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelCutoff.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 323</value>
+  </data>
+  <data name="labelCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 13</value>
+  </data>
+  <data name="labelCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="labelCutoff.Text" xml:space="preserve">
+    <value>&amp;Cut-off score:</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Name" xml:space="preserve">
+    <value>labelCutoff</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Location" type="System.Drawing.Point, System.Drawing">
+    <value>348, 57</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Size" type="System.Drawing.Size, System.Drawing">
+    <value>36, 230</value>
+  </data>
+  <data name="lblSearchEngineBlurb.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Text" xml:space="preserve">
+    <value>(blurb)</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Name" xml:space="preserve">
+    <value>lblSearchEngineBlurb</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -611,6 +909,12 @@
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>381, 425</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SearchSettingsControl</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.ja.resx
@@ -225,7 +225,7 @@
     <value>53, 13</value>
   </data>
   <data name="lblIonTypes.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="lblIonTypes.Text" xml:space="preserve">
     <value>イオンタイプ(&amp;T)：</value>
@@ -249,7 +249,7 @@
     <value>76, 20</value>
   </data>
   <data name="txtIonTypes.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="&gt;&gt;txtIonTypes.Name" xml:space="preserve">
     <value>txtIonTypes</value>
@@ -277,7 +277,7 @@
     <value>104, 13</value>
   </data>
   <data name="lblTolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>8</value>
   </data>
   <data name="lblTolerance.Text" xml:space="preserve">
     <value>イオン許容誤差(&amp;M)：</value>
@@ -301,7 +301,7 @@
     <value>76, 20</value>
   </data>
   <data name="txtTolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;txtTolerance.Name" xml:space="preserve">
     <value>txtTolerance</value>
@@ -328,7 +328,7 @@
     <value>31, 13</value>
   </data>
   <data name="lblIonCount.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>12</value>
   </data>
   <data name="lblIonCount.Text" xml:space="preserve">
     <value>選択(&amp;P)：</value>
@@ -382,7 +382,7 @@
     <value>76, 20</value>
   </data>
   <data name="txtIonCount.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;txtIonCount.Name" xml:space="preserve">
     <value>txtIonCount</value>
@@ -409,7 +409,7 @@
     <value>214, 17</value>
   </data>
   <data name="cbExclusionUseDIAWindow.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>7</value>
   </data>
   <data name="cbExclusionUseDIAWindow.Text" xml:space="preserve">
     <value>DIAのプリカーサーウィンドウをexclusionに使用(&amp;U)</value>
@@ -457,13 +457,13 @@
     <value>3</value>
   </data>
   <data name="txtMinIonCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>163, 266</value>
+    <value>164, 266</value>
   </data>
   <data name="txtMinIonCount.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 20</value>
   </data>
   <data name="txtMinIonCount.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;txtMinIonCount.Name" xml:space="preserve">
     <value>txtMinIonCount</value>
@@ -748,7 +748,7 @@
     <value>335, 100</value>
   </data>
   <data name="panelIonFilter.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;panelIonFilter.Name" xml:space="preserve">
     <value>panelIonFilter</value>
@@ -775,7 +775,7 @@
     <value>76, 21</value>
   </data>
   <data name="comboMatchToleranceUnit.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;comboMatchToleranceUnit.Name" xml:space="preserve">
     <value>comboMatchToleranceUnit</value>
@@ -799,7 +799,7 @@
     <value>124, 13</value>
   </data>
   <data name="label7.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+    <value>10</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>イオン許容誤差単位(&amp;C)：</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.zh-CHS.resx
@@ -225,7 +225,7 @@
     <value>53, 13</value>
   </data>
   <data name="lblIonTypes.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>4</value>
   </data>
   <data name="lblIonTypes.Text" xml:space="preserve">
     <value>离子类型(&amp;T)：</value>
@@ -249,7 +249,7 @@
     <value>76, 20</value>
   </data>
   <data name="txtIonTypes.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="&gt;&gt;txtIonTypes.Name" xml:space="preserve">
     <value>txtIonTypes</value>
@@ -277,7 +277,7 @@
     <value>104, 13</value>
   </data>
   <data name="lblTolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>8</value>
   </data>
   <data name="lblTolerance.Text" xml:space="preserve">
     <value>离子匹配耐受性(&amp;M)：</value>
@@ -301,7 +301,7 @@
     <value>76, 20</value>
   </data>
   <data name="txtTolerance.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;txtTolerance.Name" xml:space="preserve">
     <value>txtTolerance</value>
@@ -328,7 +328,7 @@
     <value>31, 13</value>
   </data>
   <data name="lblIonCount.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>12</value>
   </data>
   <data name="lblIonCount.Text" xml:space="preserve">
     <value>选择(&amp;P)：</value>
@@ -382,7 +382,7 @@
     <value>76, 20</value>
   </data>
   <data name="txtIonCount.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;txtIonCount.Name" xml:space="preserve">
     <value>txtIonCount</value>
@@ -409,7 +409,7 @@
     <value>214, 17</value>
   </data>
   <data name="cbExclusionUseDIAWindow.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>7</value>
   </data>
   <data name="cbExclusionUseDIAWindow.Text" xml:space="preserve">
     <value>使用 DIA 母离子窗口进行排除(&amp;U)</value>
@@ -457,13 +457,13 @@
     <value>3</value>
   </data>
   <data name="txtMinIonCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>163, 266</value>
+    <value>164, 266</value>
   </data>
   <data name="txtMinIonCount.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 20</value>
   </data>
   <data name="txtMinIonCount.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>15</value>
   </data>
   <data name="&gt;&gt;txtMinIonCount.Name" xml:space="preserve">
     <value>txtMinIonCount</value>
@@ -748,7 +748,7 @@
     <value>335, 100</value>
   </data>
   <data name="panelIonFilter.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;panelIonFilter.Name" xml:space="preserve">
     <value>panelIonFilter</value>
@@ -775,7 +775,7 @@
     <value>76, 21</value>
   </data>
   <data name="comboMatchToleranceUnit.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
+    <value>11</value>
   </data>
   <data name="&gt;&gt;comboMatchToleranceUnit.Name" xml:space="preserve">
     <value>comboMatchToleranceUnit</value>
@@ -799,7 +799,7 @@
     <value>124, 13</value>
   </data>
   <data name="label7.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+    <value>10</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>离子匹配耐受性单位(&amp;C)：</value>

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.ja.resx
@@ -144,7 +144,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblPanoramaFolders.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="treeViewFolders.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -169,7 +169,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;treeViewFolders.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -196,7 +196,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="btnOK.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -223,7 +223,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="lblFile.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -250,7 +250,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblFile.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="tbFilePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -274,7 +274,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;tbFilePath.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="btnBrowse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -301,6 +301,42 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cbAnonymousServers.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="cbAnonymousServers.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAnonymousServers.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 296</value>
+  </data>
+  <data name="cbAnonymousServers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 17</value>
+  </data>
+  <data name="cbAnonymousServers.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cbAnonymousServers.Text" xml:space="preserve">
+    <value>Show anonymous servers</value>
+  </data>
+  <metadata name="toolTipShowAnonymous.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
+  </metadata>
+  <data name="cbAnonymousServers.ToolTip" xml:space="preserve">
+    <value>Anonymous servers are not associated with a user account. A user account is required to upload documents to a server.</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Name" xml:space="preserve">
+    <value>cbAnonymousServers</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -317,6 +353,12 @@
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>ドキュメントをアップロード</value>
+  </data>
+  <data name="&gt;&gt;toolTipShowAnonymous.Name" xml:space="preserve">
+    <value>toolTipShowAnonymous</value>
+  </data>
+  <data name="&gt;&gt;toolTipShowAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PublishDocumentDlg</value>

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.zh-CHS.resx
@@ -144,7 +144,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblPanoramaFolders.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="treeViewFolders.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -169,7 +169,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;treeViewFolders.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -196,7 +196,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="btnOK.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -223,7 +223,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="lblFile.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -250,7 +250,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;lblFile.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="tbFilePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -274,7 +274,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;tbFilePath.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="btnBrowse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -301,6 +301,42 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cbAnonymousServers.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="cbAnonymousServers.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAnonymousServers.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 296</value>
+  </data>
+  <data name="cbAnonymousServers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 17</value>
+  </data>
+  <data name="cbAnonymousServers.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cbAnonymousServers.Text" xml:space="preserve">
+    <value>Show anonymous servers</value>
+  </data>
+  <metadata name="toolTipShowAnonymous.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
+  </metadata>
+  <data name="cbAnonymousServers.ToolTip" xml:space="preserve">
+    <value>Anonymous servers are not associated with a user account. A user account is required to upload documents to a server.</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Name" xml:space="preserve">
+    <value>cbAnonymousServers</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -317,6 +353,12 @@
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>上传文档</value>
+  </data>
+  <data name="&gt;&gt;toolTipShowAnonymous.Name" xml:space="preserve">
+    <value>toolTipShowAnonymous</value>
+  </data>
+  <data name="&gt;&gt;toolTipShowAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PublishDocumentDlg</value>

--- a/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.ja.resx
+++ b/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.ja.resx
@@ -217,6 +217,12 @@
   <data name="transitionsContextMenuItem.Text" xml:space="preserve">
     <value>トランジション</value>
   </data>
+  <data name="relativeAbundanceFormattingMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>212, 22</value>
+  </data>
+  <data name="relativeAbundanceFormattingMenuItem.Text" xml:space="preserve">
+    <value>Formatting...</value>
+  </data>
   <data name="transformChromContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>212, 22</value>
   </data>

--- a/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.zh-CHS.resx
@@ -217,6 +217,12 @@
   <data name="transitionsContextMenuItem.Text" xml:space="preserve">
     <value>离子对</value>
   </data>
+  <data name="relativeAbundanceFormattingMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>212, 22</value>
+  </data>
+  <data name="relativeAbundanceFormattingMenuItem.Text" xml:space="preserve">
+    <value>Formatting...</value>
+  </data>
   <data name="transformChromContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>212, 22</value>
   </data>

--- a/pwiz_tools/Skyline/Menus/MenusResources.ja.resx
+++ b/pwiz_tools/Skyline/Menus/MenusResources.ja.resx
@@ -319,4 +319,17 @@
   <data name="SkylineWindow_Unexpected_character__0__found_on_line__1__" xml:space="preserve">
     <value>予期しない文字「{0}」が{1}行目で見つかりました。</value>
   </data>
+  <data name="RefineMenu_ShowGenerateDecoysDlg_Are_you_sure_you_want_to_add_decoys_to_this_document_" xml:space="preserve">
+    <value>Are you sure you want to add decoys to this document?
+    
+This document uses peak boundaries from spectral libraries. When these boundaries are used, Skyline does not perform its own peak detection.
+
+To be ready to train a peak scoring model effectively, follow these steps:
+
+1. Navigate to the "Settings &gt; Peptide Settings - Libraries" tab and click "Edit List".
+2. Select a library item, click "Edit", and uncheck the "Use explicit peak bounds" checkbox.</value>
+  </data>
+  <data name="RefineMenu_ShowGenerateDecoysDlg_Add_Decoys" xml:space="preserve">
+    <value>Add Decoys</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Menus/MenusResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/MenusResources.zh-CHS.resx
@@ -319,4 +319,17 @@
   <data name="SkylineWindow_Unexpected_character__0__found_on_line__1__" xml:space="preserve">
     <value>第 {1} 行发现意外字符“{0}”。</value>
   </data>
+  <data name="RefineMenu_ShowGenerateDecoysDlg_Are_you_sure_you_want_to_add_decoys_to_this_document_" xml:space="preserve">
+    <value>Are you sure you want to add decoys to this document?
+    
+This document uses peak boundaries from spectral libraries. When these boundaries are used, Skyline does not perform its own peak detection.
+
+To be ready to train a peak scoring model effectively, follow these steps:
+
+1. Navigate to the "Settings &gt; Peptide Settings - Libraries" tab and click "Edit List".
+2. Select a library item, click "Edit", and uncheck the "Use explicit peak bounds" checkbox.</value>
+  </data>
+  <data name="RefineMenu_ShowGenerateDecoysDlg_Add_Decoys" xml:space="preserve">
+    <value>Add Decoys</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Menus/ViewMenu.ja.resx
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.ja.resx
@@ -702,6 +702,12 @@
   <data name="areaPeptideComparisonMenuItem.Text" xml:space="preserve">
     <value>ペプチドの比較(&amp;P)</value>
   </data>
+  <data name="areaRelativeAbundanceMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 22</value>
+  </data>
+  <data name="areaRelativeAbundanceMenuItem.Text" xml:space="preserve">
+    <value>Relative &amp;Abundance</value>
+  </data>
   <data name="areaCVHistogramMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>228, 22</value>
   </data>

--- a/pwiz_tools/Skyline/Menus/ViewMenu.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.zh-CHS.resx
@@ -702,6 +702,12 @@
   <data name="areaPeptideComparisonMenuItem.Text" xml:space="preserve">
     <value>肽段比较(&amp;P)</value>
   </data>
+  <data name="areaRelativeAbundanceMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 22</value>
+  </data>
+  <data name="areaRelativeAbundanceMenuItem.Text" xml:space="preserve">
+    <value>Relative &amp;Abundance</value>
+  </data>
   <data name="areaCVHistogramMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>228, 22</value>
   </data>

--- a/pwiz_tools/Skyline/Model/AuditLog/EnumNames.ja.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/EnumNames.ja.resx
@@ -372,6 +372,9 @@
   <data name="Workflow_prm" xml:space="preserve">
     <value>PRM</value>
   </data>
+  <data name="Workflow_feature_detection" xml:space="preserve">
+    <value>Feature Detection</value>
+  </data>
   <data name="TransitionLibraryPick_none" xml:space="preserve">
     <value>なし</value>
   </data>
@@ -633,6 +636,9 @@
   <data name="SearchEngine_MSGFPlus" xml:space="preserve">
     <value>MS-GF+</value>
   </data>
+  <data name="SearchEngine_Hardklor" xml:space="preserve">
+    <value>Hardklör</value>
+  </data>
   <data name="SharedPeptides_AssignedToBestProtein" xml:space="preserve">
     <value>ペプチドの最も多いタンパク質に割当て</value>
   </data>
@@ -713,5 +719,17 @@
   </data>
   <data name="Simple_ratio_to_light" xml:space="preserve">
     <value>Lightに対する比率</value>
+  </data>
+  <data name="SharedPeptidesGene_AssignedToBestProtein" xml:space="preserve">
+    <value>Assigned to the gene with the most peptides</value>
+  </data>
+  <data name="SharedPeptidesGene_AssignedToFirstProtein" xml:space="preserve">
+    <value>Assigned to the first gene</value>
+  </data>
+  <data name="SharedPeptidesGene_DuplicatedBetweenProteins" xml:space="preserve">
+    <value>Duplicated between genes</value>
+  </data>
+  <data name="SharedPeptidesGene_Removed" xml:space="preserve">
+    <value>Removed (peptides must be unique to a single gene)</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/AuditLog/EnumNames.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/EnumNames.zh-CHS.resx
@@ -372,6 +372,9 @@
   <data name="Workflow_prm" xml:space="preserve">
     <value>PRM（并行反应离子监测）</value>
   </data>
+  <data name="Workflow_feature_detection" xml:space="preserve">
+    <value>Feature Detection</value>
+  </data>
   <data name="TransitionLibraryPick_none" xml:space="preserve">
     <value>无</value>
   </data>
@@ -633,6 +636,9 @@
   <data name="SearchEngine_MSGFPlus" xml:space="preserve">
     <value>MS-GF+</value>
   </data>
+  <data name="SearchEngine_Hardklor" xml:space="preserve">
+    <value>Hardklör</value>
+  </data>
   <data name="SharedPeptides_AssignedToBestProtein" xml:space="preserve">
     <value>已分配给肽段最多的蛋白质</value>
   </data>
@@ -713,5 +719,17 @@
   </data>
   <data name="Simple_ratio_to_light" xml:space="preserve">
     <value>相对于轻的比率</value>
+  </data>
+  <data name="SharedPeptidesGene_AssignedToBestProtein" xml:space="preserve">
+    <value>Assigned to the gene with the most peptides</value>
+  </data>
+  <data name="SharedPeptidesGene_AssignedToFirstProtein" xml:space="preserve">
+    <value>Assigned to the first gene</value>
+  </data>
+  <data name="SharedPeptidesGene_DuplicatedBetweenProteins" xml:space="preserve">
+    <value>Duplicated between genes</value>
+  </data>
+  <data name="SharedPeptidesGene_Removed" xml:space="preserve">
+    <value>Removed (peptides must be unique to a single gene)</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.ja.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.ja.resx
@@ -1103,6 +1103,24 @@
   <data name="ExplicitTransitionValues_SLens" xml:space="preserve">
     <value>S-レンズ</value>
   </data>
+  <data name="HardklorSettings_Charges" xml:space="preserve">
+    <value>Charges</value>
+  </data>
+  <data name="HardklorSettings_MinIntensityPPM" xml:space="preserve">
+    <value>Min intensity PPM</value>
+  </data>
+  <data name="HardklorSettings_MinIdotP" xml:space="preserve">
+    <value>Min idotp</value>
+  </data>
+  <data name="HardklorSettings_Instrument" xml:space="preserve">
+    <value>Instrument</value>
+  </data>
+  <data name="HardklorSettings_Resolution" xml:space="preserve">
+    <value>Resolution</value>
+  </data>
+  <data name="HardklorSettings_SignalToNoise" xml:space="preserve">
+    <value>Signal to noise</value>
+  </data>
   <data name="ImportFastaSettings_AutoTrain" xml:space="preserve">
     <value>mProphetのモデルを自動的にトレーニングする</value>
   </data>
@@ -1129,6 +1147,9 @@
   </data>
   <data name="ImportPeptideSearchSettings_FullScanSettings" xml:space="preserve">
     <value>フルスキャン設定を行う</value>
+  </data>
+  <data name="ImportPeptideSearchSettings_HardklorSearchSettings" xml:space="preserve">
+    <value>Hardklor Search Settings</value>
   </data>
   <data name="ImportPeptideSearchSettings_ImportFastaSettings" xml:space="preserve">
     <value>FASTAをインポート</value>
@@ -1734,33 +1755,51 @@
     <value>狭いウィンドウ結果</value>
   </data>
   <data name="EncyclopeDiaSettings_KoinaSettings" xml:space="preserve">
-    <value>Koina設定</value>
+    <value>Koina settings</value>
   </data>
   <data name="EncyclopeDiaSettings_WideWindowResults" xml:space="preserve">
     <value>広いウィンドウ結果</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_DefaultCharge" xml:space="preserve">
-    <value>デフォルト電荷</value>
+    <value>Default charge</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_DefaultNCE" xml:space="preserve">
-    <value>デフォルトNCE</value>
+    <value>Default NCE</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MaxCharge" xml:space="preserve">
-    <value>最大電荷</value>
+    <value>Max charge</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MaxMissedCleavage" xml:space="preserve">
-    <value>最大未切断数</value>
+    <value>Max missed cleavages</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MinCharge" xml:space="preserve">
-    <value>最小電荷</value>
+    <value>Min charge</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_Enzyme" xml:space="preserve">
-    <value>酵素</value>
+    <value>Enzyme</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MaxMz" xml:space="preserve">
-    <value>最大m/z</value>
+    <value>Max m/z</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MinMz" xml:space="preserve">
-    <value>最小m/z</value>
+    <value>Min m/z</value>
+  </data>
+  <data name="ParsimonySettings_GeneLevelParsimony" xml:space="preserve">
+    <value>Group at gene level</value>
+  </data>
+  <data name="DataSettings_RelativeAbundanceFormatting" xml:space="preserve">
+    <value>Relative Abundance Formatting</value>
+  </data>
+  <data name="RelativeAbundanceFormatting_ColorRows" xml:space="preserve">
+    <value>Formatting rows</value>
+  </data>
+  <data name="CutoffScore_PERCOLATOR_QVALUE" xml:space="preserve">
+    <value>Max q-value</value>
+  </data>
+  <data name="DdaSearchSettings_ScoreThreshold" xml:space="preserve">
+    <value>Score threshold</value>
+  </data>
+  <data name="DdaSearchSettings_ScoreType" xml:space="preserve">
+    <value>Score type</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.zh-CHS.resx
@@ -1103,6 +1103,24 @@
   <data name="ExplicitTransitionValues_SLens" xml:space="preserve">
     <value>S-Lens</value>
   </data>
+  <data name="HardklorSettings_Charges" xml:space="preserve">
+    <value>Charges</value>
+  </data>
+  <data name="HardklorSettings_MinIntensityPPM" xml:space="preserve">
+    <value>Min intensity PPM</value>
+  </data>
+  <data name="HardklorSettings_MinIdotP" xml:space="preserve">
+    <value>Min idotp</value>
+  </data>
+  <data name="HardklorSettings_Instrument" xml:space="preserve">
+    <value>Instrument</value>
+  </data>
+  <data name="HardklorSettings_Resolution" xml:space="preserve">
+    <value>Resolution</value>
+  </data>
+  <data name="HardklorSettings_SignalToNoise" xml:space="preserve">
+    <value>Signal to noise</value>
+  </data>
   <data name="ImportFastaSettings_AutoTrain" xml:space="preserve">
     <value>自动训练 mProphet 模型</value>
   </data>
@@ -1129,6 +1147,9 @@
   </data>
   <data name="ImportPeptideSearchSettings_FullScanSettings" xml:space="preserve">
     <value>配置全扫描设置</value>
+  </data>
+  <data name="ImportPeptideSearchSettings_HardklorSearchSettings" xml:space="preserve">
+    <value>Hardklor Search Settings</value>
   </data>
   <data name="ImportPeptideSearchSettings_ImportFastaSettings" xml:space="preserve">
     <value>导入 FASTA</value>
@@ -1734,33 +1755,51 @@
     <value>窄窗口结果</value>
   </data>
   <data name="EncyclopeDiaSettings_KoinaSettings" xml:space="preserve">
-    <value>Koina 设置</value>
+    <value>Koina settings</value>
   </data>
   <data name="EncyclopeDiaSettings_WideWindowResults" xml:space="preserve">
     <value>宽窗口结果</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_DefaultCharge" xml:space="preserve">
-    <value>默认电荷</value>
+    <value>Default charge</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_DefaultNCE" xml:space="preserve">
-    <value>默认 NCE</value>
+    <value>Default NCE</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MaxCharge" xml:space="preserve">
-    <value>最大电荷</value>
+    <value>Max charge</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MaxMissedCleavage" xml:space="preserve">
-    <value>最大的漏切酶解位点数</value>
+    <value>Max missed cleavages</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MinCharge" xml:space="preserve">
-    <value>最小电荷</value>
+    <value>Min charge</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_Enzyme" xml:space="preserve">
-    <value>酶</value>
+    <value>Enzyme</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MaxMz" xml:space="preserve">
-    <value>最大质荷比</value>
+    <value>Max m/z</value>
   </data>
   <data name="FastaToKoinaInputCsvConfig_MinMz" xml:space="preserve">
-    <value>最小质荷比</value>
+    <value>Min m/z</value>
+  </data>
+  <data name="ParsimonySettings_GeneLevelParsimony" xml:space="preserve">
+    <value>Group at gene level</value>
+  </data>
+  <data name="DataSettings_RelativeAbundanceFormatting" xml:space="preserve">
+    <value>Relative Abundance Formatting</value>
+  </data>
+  <data name="RelativeAbundanceFormatting_ColorRows" xml:space="preserve">
+    <value>Formatting rows</value>
+  </data>
+  <data name="CutoffScore_PERCOLATOR_QVALUE" xml:space="preserve">
+    <value>Max q-value</value>
+  </data>
+  <data name="DdaSearchSettings_ScoreThreshold" xml:space="preserve">
+    <value>Score threshold</value>
+  </data>
+  <data name="DdaSearchSettings_ScoreType" xml:space="preserve">
+    <value>Score type</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.ja.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.ja.resx
@@ -219,6 +219,15 @@
   <data name="CalculatedConcentration">
     <value>計算濃度</value>
   </data>
+  <data name="CalculatedConcentrationMessage">
+    <value>Calculated Concentration Message</value>
+  </data>
+  <data name="CalculatedConcentrationRaw">
+    <value>Calculated Concentration Raw</value>
+  </data>
+  <data name="CalculatedConcentrationStrict">
+    <value>Calculated Concentration Strict</value>
+  </data>
   <data name="CalibrationCurve">
     <value>校正曲線</value>
   </data>
@@ -708,6 +717,9 @@
   <data name="MedianPeakArea">
     <value>ピーク面積の中央値</value>
   </data>
+  <data name="Message">
+    <value>Message</value>
+  </data>
   <data name="Min">
     <value>最小</value>
   </data>
@@ -767,6 +779,18 @@
   </data>
   <data name="MoleculeListAbundance">
     <value>分子リスト存在量</value>
+  </data>
+  <data name="MoleculeListAbundanceMessage">
+    <value>Molecule List Abundance Message</value>
+  </data>
+  <data name="MoleculeListAbundanceStrict">
+    <value>Molecule List Abundance Strict</value>
+  </data>
+  <data name="MoleculeListAbundanceTransitionAveraged">
+    <value>Molecule List Abundance Transition Averaged</value>
+  </data>
+  <data name="MoleculeListAbundanceTransitionSummed">
+    <value>Molecule List Abundance Transition Summed</value>
   </data>
   <data name="MoleculeListLocator">
     <value>分子リストロケーター</value>
@@ -836,6 +860,15 @@
   </data>
   <data name="NormalizedArea">
     <value>正規化面積</value>
+  </data>
+  <data name="NormalizedAreaMessage">
+    <value>Normalized Area Message</value>
+  </data>
+  <data name="NormalizedAreaRaw">
+    <value>Normalized Area Raw</value>
+  </data>
+  <data name="NormalizedAreaStrict">
+    <value>Normalized Area Strict</value>
   </data>
   <data name="NumberOfPoints">
     <value>ポイント数</value>
@@ -933,6 +966,9 @@
   <data name="PeptideSequenceLength">
     <value>ペプチドシーケンス長</value>
   </data>
+  <data name="PeptideSpectrumMatchCount">
+    <value>Peptide Spectrum Match Count</value>
+  </data>
   <data name="PointCount">
     <value>点数</value>
   </data>
@@ -950,6 +986,15 @@
   </data>
   <data name="PrecursorCalculatedConcentration">
     <value>プリカーサー計算濃度</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationMessage">
+    <value>Precursor Calculated Concentration Message</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationRaw">
+    <value>Precursor Calculated Concentration Raw</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationStrict">
+    <value>Precursor Calculated Concentration Strict</value>
   </data>
   <data name="PrecursorCharge">
     <value>プリカーサー電荷</value>
@@ -980,6 +1025,15 @@
   </data>
   <data name="PrecursorNormalizedArea">
     <value>プリカーサー正規化面積</value>
+  </data>
+  <data name="PrecursorNormalizedAreaMessage">
+    <value>Precursor Normalized Area Message</value>
+  </data>
+  <data name="PrecursorNormalizedAreaRaw">
+    <value>Precursor Normalized Area Raw</value>
+  </data>
+  <data name="PrecursorNormalizedAreaStrict">
+    <value>Precursor Normalized Area Strict</value>
   </data>
   <data name="PrecursorNote">
     <value>プリカーサーメモ</value>
@@ -1046,6 +1100,18 @@
   </data>
   <data name="ProteinAbundance">
     <value>タンパク質存在量</value>
+  </data>
+  <data name="ProteinAbundanceMessage">
+    <value>Protein Abundance Message</value>
+  </data>
+  <data name="ProteinAbundanceStrict">
+    <value>Protein Abundance Strict</value>
+  </data>
+  <data name="ProteinAbundanceTransitionAveraged">
+    <value>Protein Abundance Transition Averaged</value>
+  </data>
+  <data name="ProteinAbundanceTransitionSummed">
+    <value>Protein Abundance Transition Summed</value>
   </data>
   <data name="ProteinAccession">
     <value>タンパク質アクセッション</value>
@@ -1118,6 +1184,9 @@
   </data>
   <data name="RatioToStandard">
     <value>標準に対する比率</value>
+  </data>
+  <data name="Raw">
+    <value>Raw</value>
   </data>
   <data name="RawData">
     <value>生データ</value>
@@ -1299,8 +1368,14 @@
   <data name="StdevTotalAreaRatio">
     <value>Stdev総面積比</value>
   </data>
+  <data name="Strict">
+    <value>Strict</value>
+  </data>
   <data name="SummaryMessage">
     <value>概要に関するメッセージ</value>
+  </data>
+  <data name="SurrogateExternalStandard">
+    <value>Surrogate External Standard</value>
   </data>
   <data name="TargetQualitativeIonRatio">
     <value>ターゲット定性イオン比</value>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.zh-CHS.resx
@@ -219,6 +219,15 @@
   <data name="CalculatedConcentration">
     <value>计算的浓度</value>
   </data>
+  <data name="CalculatedConcentrationMessage">
+    <value>Calculated Concentration Message</value>
+  </data>
+  <data name="CalculatedConcentrationRaw">
+    <value>Calculated Concentration Raw</value>
+  </data>
+  <data name="CalculatedConcentrationStrict">
+    <value>Calculated Concentration Strict</value>
+  </data>
   <data name="CalibrationCurve">
     <value>校准曲线</value>
   </data>
@@ -708,6 +717,9 @@
   <data name="MedianPeakArea">
     <value>中位数峰面积</value>
   </data>
+  <data name="Message">
+    <value>Message</value>
+  </data>
   <data name="Min">
     <value>最小</value>
   </data>
@@ -767,6 +779,18 @@
   </data>
   <data name="MoleculeListAbundance">
     <value>分子列表丰度</value>
+  </data>
+  <data name="MoleculeListAbundanceMessage">
+    <value>Molecule List Abundance Message</value>
+  </data>
+  <data name="MoleculeListAbundanceStrict">
+    <value>Molecule List Abundance Strict</value>
+  </data>
+  <data name="MoleculeListAbundanceTransitionAveraged">
+    <value>Molecule List Abundance Transition Averaged</value>
+  </data>
+  <data name="MoleculeListAbundanceTransitionSummed">
+    <value>Molecule List Abundance Transition Summed</value>
   </data>
   <data name="MoleculeListLocator">
     <value>分子列表定位器</value>
@@ -836,6 +860,15 @@
   </data>
   <data name="NormalizedArea">
     <value>校准后面积</value>
+  </data>
+  <data name="NormalizedAreaMessage">
+    <value>Normalized Area Message</value>
+  </data>
+  <data name="NormalizedAreaRaw">
+    <value>Normalized Area Raw</value>
+  </data>
+  <data name="NormalizedAreaStrict">
+    <value>Normalized Area Strict</value>
   </data>
   <data name="NumberOfPoints">
     <value>点数</value>
@@ -933,6 +966,9 @@
   <data name="PeptideSequenceLength">
     <value>肽段序列长度</value>
   </data>
+  <data name="PeptideSpectrumMatchCount">
+    <value>Peptide Spectrum Match Count</value>
+  </data>
   <data name="PointCount">
     <value>计数点</value>
   </data>
@@ -950,6 +986,15 @@
   </data>
   <data name="PrecursorCalculatedConcentration">
     <value>母离子计算的浓度</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationMessage">
+    <value>Precursor Calculated Concentration Message</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationRaw">
+    <value>Precursor Calculated Concentration Raw</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationStrict">
+    <value>Precursor Calculated Concentration Strict</value>
   </data>
   <data name="PrecursorCharge">
     <value>母离子电荷</value>
@@ -980,6 +1025,15 @@
   </data>
   <data name="PrecursorNormalizedArea">
     <value>母离子校准后面积</value>
+  </data>
+  <data name="PrecursorNormalizedAreaMessage">
+    <value>Precursor Normalized Area Message</value>
+  </data>
+  <data name="PrecursorNormalizedAreaRaw">
+    <value>Precursor Normalized Area Raw</value>
+  </data>
+  <data name="PrecursorNormalizedAreaStrict">
+    <value>Precursor Normalized Area Strict</value>
   </data>
   <data name="PrecursorNote">
     <value>母离子注释</value>
@@ -1046,6 +1100,18 @@
   </data>
   <data name="ProteinAbundance">
     <value>蛋白质丰度</value>
+  </data>
+  <data name="ProteinAbundanceMessage">
+    <value>Protein Abundance Message</value>
+  </data>
+  <data name="ProteinAbundanceStrict">
+    <value>Protein Abundance Strict</value>
+  </data>
+  <data name="ProteinAbundanceTransitionAveraged">
+    <value>Protein Abundance Transition Averaged</value>
+  </data>
+  <data name="ProteinAbundanceTransitionSummed">
+    <value>Protein Abundance Transition Summed</value>
   </data>
   <data name="ProteinAccession">
     <value>蛋白质检索号</value>
@@ -1118,6 +1184,9 @@
   </data>
   <data name="RatioToStandard">
     <value>相对于标准品比率</value>
+  </data>
+  <data name="Raw">
+    <value>Raw</value>
   </data>
   <data name="RawData">
     <value>原始数据</value>
@@ -1299,8 +1368,14 @@
   <data name="StdevTotalAreaRatio">
     <value>总面积比标准偏差</value>
   </data>
+  <data name="Strict">
+    <value>Strict</value>
+  </data>
   <data name="SummaryMessage">
     <value>总结消息</value>
+  </data>
+  <data name="SurrogateExternalStandard">
+    <value>Surrogate External Standard</value>
   </data>
   <data name="TargetQualitativeIonRatio">
     <value>目标定性离子比</value>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.ja.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.ja.resx
@@ -107,7 +107,7 @@
     <value>倍率変化の計算に使用されたこの繰り返し測定の値です。数値は正規化メソッドの他、倍率変化がタンパク質レベルで計算されているかペプチドレベルで計算されているかに依存します。</value>
   </data>
   <data name="Accuracy">
-    <value>アナライトの濃度と算出される濃度の比率（繰り返し測定で指定）</value>
+    <value>Ratio of Calculated Concentration to the specified Analyte Concentration</value>
   </data>
   <data name="AcquiredTime">
     <value>質量分析計が前回この繰り返し測定データの取得を開始した日時です。1.1より古いバージョンでファイルがインポートされた場合には#N/Aとなります。</value>
@@ -198,9 +198,18 @@
     <value>プリカーサーに対し、最も強度が高いトランジションの 保持時間の値です。</value>
   </data>
   <data name="CalculatedConcentration">
-    <value>アナライト濃度は、以下のいずれかによって計算されます：  
-1. 校正曲線を使用する（[ペプチド設定] &gt; [定量]に[回帰式に合わせる]が指定されている場合）  
-2. 内標準（またはサロゲート）に対する比率を使用し、内標準物質の濃度を乗じる</value>
+    <value>The concentration of the analyte calculated using either:
+1. The calibration curve (if the Peptide Settings &gt; Quantification has a Regression Fit specified)
+2. The ratio to internal standard (or surrogate) and multiplying by the Internal Standard Concentration</value>
+  </data>
+  <data name="CalculatedConcentrationMessage">
+    <value>Warning if missing data impacts comparisons of the "Calculated Concentration" between replicates</value>
+  </data>
+  <data name="CalculatedConcentrationRaw">
+    <value>Calculated concentration value available even when missing data impacts comparisons between replicates</value>
+  </data>
+  <data name="CalculatedConcentrationStrict">
+    <value>Calculated concentration value unavailable when missing data impacts comparisons between replicates</value>
   </data>
   <data name="CalibrationCurve">
     <value>試料タイプが[標準]で[アナライト濃度]が指定されている繰り返し測定を使用して計算された校正曲線です。</value>
@@ -557,7 +566,13 @@
     <value>イオン移動度ライブラリからのプリカーサーの衝突断面積</value>
   </data>
   <data name="LibraryDotProduct">
-    <value>プリカーサーの各トランジションのピーク面積と一致したMS/MSスペクトルライブラリスペクトルにおける一致するイオンピークの強度との内積です（注：v1.4同様、 これは現在1 – Arcos(dotp)/(Pi/2)となっています。ここでdotpが上記に説明する値であり、 正規化スペクトルコントラスト角度とも言います）。プリカーサーに一致するライブラリスペクトルがない 場合やトランジションが4個未満の場合には#N/Aとなります。これは35であり、 メソッドの最適化に使用します。トランジションが6個以上ある場合に最もうまく機能します。</value>
+    <value>Equivalent to "dotp" displayed in the user interface. The dot-product between the individual transition peak areas
+of the precursor and the intensities of the matching ion peaks in the matched MS/MS
+spectral library spectrum (Note: as of v1.4, this is now 1 – Arcos(dotp)/(Pi/2) where dotp
+is the value described above. a.k.a. Normalize Spectrum Contrast Angle), or #N/A if the
+precursor has not matching library spectrum or has fewer than 4 transitions. This is a 35
+useful value for method refinement. It works best when 6 or more transitions are
+present.</value>
   </data>
   <data name="LibraryIntensity">
     <value>一致するライブラリスペクトルでトランジションのプロダクトイオンに該当するMS/MSのピーク強度です。</value>
@@ -617,7 +632,7 @@
     <value>このフラグメントからのすべてのニュートラルロスの合計質量</value>
   </data>
   <data name="MassErrorPPM">
-    <value>質量誤差（ppm）</value>
+    <value>The difference between the expected and measured m/z values expressed in parts per million (PPM)</value>
   </data>
   <data name="MassErrors">
     <value>クロマトグラムの質量誤差です。</value>
@@ -697,6 +712,9 @@
 内標準標識タイプがある場合、ピーク面積の中央値はプリカーサー標識タイプが内標準のトランジションで示されるピーク面積のみを使って計算されます。
 内標準ピーク面積がない場合はすべてのトランジションピーク面積からトランジションピーク面積の中央値が計算されます。</value>
   </data>
+  <data name="Message">
+    <value>Warning, if any, of missing values that might impact comparisons of the "Raw" value between replicates.</value>
+  </data>
   <data name="Min">
     <value>最小値</value>
   </data>
@@ -755,9 +773,22 @@
     <value>Skylineドキュメントにある分子のグループ化です。</value>
   </data>
   <data name="MoleculeListAbundance">
-    <value>分子リストの存在量を表す数値です。この数値は、分子リストの下にある正規化面積を平均して得られます。
-面積は分子定量化設定で指定される正規化メソッドに従って正規化されます。
-この繰り返し測定中に値のないトランジションがある場合には、正規化メソッドが標識に対する比率でない限り、分子リスト存在量は空白となります。</value>
+    <value>A number representing the abundance of the molecule list, calculated according to the "Normalization Method" specified in the Molecule Quantification settings</value>
+  </data>
+  <data name="MoleculeListAbundanceMessage">
+    <value>Warning if missing data impacts comparisons of "Molecule List Abundance" between replicates</value>
+  </data>
+  <data name="MoleculeListAbundanceStrict">
+    <value>A number representing the abundance of the molecule list, calculated according to the "Normalization Method" specified in the Molecule Quantification settings.
+Unavailable when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="MoleculeListAbundanceTransitionAveraged">
+    <value>Average of the normalized areas of the transitions under the Molecule List.
+The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings.</value>
+  </data>
+  <data name="MoleculeListAbundanceTransitionSummed">
+    <value>Sum of the normalized areas of the transitions under the Molecule List.
+The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings</value>
   </data>
   <data name="MoleculeListLocator">
     <value>ドキュメント内の分子リストの一意の識別子です。これは「MoleculeGroup:」で始まります。</value>
@@ -820,7 +851,7 @@
     <value>プリカーサーの強度（MS1レベル）かプロダクトの強度（MS2レベル）のみを使用して結果を取得したかを示します。</value>
   </data>
   <data name="NextAa">
-    <value>次のAa</value>
+    <value>The amino acid residue found immediately after the peptide in the protein sequence.</value>
   </data>
   <data name="NormalizationDivisor">
     <value>デフォルトの正規化メソッドの使用時に観測値を割った数字。
@@ -830,7 +861,24 @@
     <value>絶対定量とグループ比較のために、特定の分子で使用する正規化のメソッドを無効にします。</value>
   </data>
   <data name="NormalizedArea">
-    <value>そのペプチド/分子に指定された「正規化メソッド」または  [設定] &gt; [ペプチド設定] &gt; [定量化]で指定される正規化メソッドを使用したペプチド/分子の強度の正規化によって取得される値です。</value>
+    <value>Value obtained by normalizing the peptide/molecule intensity according to either
+the explicit "Normalization Method" for the peptide/molecule 
+or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification</value>
+  </data>
+  <data name="NormalizedAreaMessage">
+    <value>Warning if missing data impacts of the "Normalized Area" value between replicates</value>
+  </data>
+  <data name="NormalizedAreaRaw">
+    <value>Value obtained by normalizing the peptide/molecule intensity according to either
+the explicit "Normalization Method" for the peptide/molecule
+or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification.
+Available even when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="NormalizedAreaStrict">
+    <value>Value obtained by normalizing the peptide/molecule intensity according to either
+the explicit "Normalization Method" for the peptide/molecule
+or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification.
+Unavailable when missing data impacts comparisons between replicates.</value>
   </data>
   <data name="NumberOfPoints">
     <value>クロマトグラムにある点の数です。</value>
@@ -930,6 +978,9 @@
   <data name="PeptideSequenceLength">
     <value>ペプチドシークエンスのアミノ酸数です。</value>
   </data>
+  <data name="PeptideSpectrumMatchCount">
+    <value>Number of spectra in the spectral library which match the peptide and result file.</value>
+  </data>
   <data name="PointCount">
     <value>曲線のフィッティングで使用されたデータポイント数です。</value>
   </data>
@@ -948,8 +999,19 @@
   <data name="PrecursorCalculatedConcentration">
     <value>アイソトポログ反応曲線を使用して計算されたプリカーサー結果の濃度です。</value>
   </data>
+  <data name="PrecursorCalculatedConcentrationMessage">
+    <value>Warning if missing data impacts comparisons of "Precursor Calculated Concentration" between replicates</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationRaw">
+    <value>The concentration of the Precursor Result calculated using the isotopolog response curve.
+Available even when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationStrict">
+    <value>The concentration of the Precursor Result calculated using the isotopolog response curve.
+Unavailable when missing data impacts comparisons between replicates.</value>
+  </data>
   <data name="PrecursorCharge">
-    <value>  プリカーサーイオンと関連付けられた電荷。</value>
+    <value>The charge associated with the precursor ion.</value>
   </data>
   <data name="PrecursorConcentration">
     <value>このプリカーサーが試料にスパイクされた濃度です。これを使用してアイソトポログ反応曲線を作成します。</value>
@@ -977,9 +1039,24 @@
     <value>プリカーサーのニュートラルな質量（Da）</value>
   </data>
   <data name="PrecursorNormalizedArea">
-    <value>プリカーサー結果の正規化面積。
-これはペプチドの正規化メソッドに従い正規化されたプリカーサー結果の合計面積と同じです。
-ペプチド正規化メソッドが「なし」または標識に対する比率である場合、プリカーサー正規化面積はプリカーサー合計面積と同じです。</value>
+    <value>Normalized area of the Precursor Result.
+Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
+If Peptide Normalization Method is "None" or ratio to a label, then Precursor Normalized Area will be equal to the Total Area of the Precursor.</value>
+  </data>
+  <data name="PrecursorNormalizedAreaMessage">
+    <value>Warning if missing values impacts comparisons of the "Precursor Normalized Area" value between replicates</value>
+  </data>
+  <data name="PrecursorNormalizedAreaRaw">
+    <value>Normalized area of the Precursor Result.
+Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
+If the Peptide Normalization Method is "None" or ratio to a label, then the Precursor Normalized Area will be equal to the Total Area of the Precursor.
+Available even when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="PrecursorNormalizedAreaStrict">
+    <value>Normalized area of the Precursor Result.
+Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
+If the Peptide Normalization Method is "None" or ratio to a label, then the Precursor Normalized Area will be equal to the Total Area of the Precursor.
+Unavailable when missing data impacts comparisons between replicates.</value>
   </data>
   <data name="PrecursorNote">
     <value>編集メニューで[メモを編集]をクリックすると表示される、プリカーサーに関連付けられるフリーテキストのメモ</value>
@@ -1046,10 +1123,22 @@
     <value>タンパク質</value>
   </data>
   <data name="ProteinAbundance">
-    <value>特定の繰り返し測定のタンパク質の存在量を表す数値です。
-タンパク質存在量は、タンパク質に帰属するすべてのトランジションの正規化面積の平均を使用して計算されます。
-トランジション面積はペプチド定量設定で指定される正規化メソッドに従って正規化されます。
-この繰り返し測定中にピーク面積のないトランジションがある場合、又は正規化メソッドが標識に対する比率でない限り、タンパク質リスト存在量は空白となります。</value>
+    <value>A number representing the abundance of the protein, calculated according to the "Normalization Method" specified in the Peptide Quantification settings.</value>
+  </data>
+  <data name="ProteinAbundanceMessage">
+    <value>Warning if missing data impacts comparisons of "Protein Abundance" between replicates</value>
+  </data>
+  <data name="ProteinAbundanceStrict">
+    <value>A number representing the abundance of the protein, calculated according to the "Normalization Method" specified in the Peptide Quantification settings.
+Unavailable when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="ProteinAbundanceTransitionAveraged">
+    <value>Average of the normalized areas of the transitions under the Protein.
+The areas are normalized according to the Normalization Method specified in the Peptide Quantification settings.</value>
+  </data>
+  <data name="ProteinAbundanceTransitionSummed">
+    <value>Sum of the normalized areas of the transitions under the Protein.
+The areas are normalized according to the Normalization Method specified in the Peptide Quantification settings.</value>
   </data>
   <data name="ProteinAccession">
     <value>タンパク質アクセッション番号</value>
@@ -1121,10 +1210,13 @@
     <value>MaxRetentionTimeとMinRetentionTime との差です。これを使用すると測定された保持時間の広がりの幅を評価できます。</value>
   </data>
   <data name="RatioDotProduct">
-    <value>内積比率</value>
+    <value>Equivalent to "rdotp" displayed in the user interface. The dot-product calculation described for Library Dot Product, but between the peak areas of the precursor (e.g. light) and the peak areas of the standard type precursor (e.g. heavy), or #N/A if there is either no standard type or the precursor is the standard type.</value>
   </data>
   <data name="RatioToStandard">
     <value>LightのHeavyに対するペプチドの面積比</value>
+  </data>
+  <data name="Raw">
+    <value>Calculated value available even when missing data impacts comparisons between replicates.</value>
   </data>
   <data name="RawData">
     <value>生（未補間）のクロマトグラムデータです。クロマトグラムの間隔が均一でなく、各トランジションのクロマトグラムにはそれぞれ異なる点の数があります。</value>
@@ -1317,8 +1409,14 @@ Double Blank（ダブルブランク）</value>
   <data name="StdevTotalAreaRatio">
     <value>プリカーサーのTotalAreaNormalized値の標準偏差。</value>
   </data>
+  <data name="Strict">
+    <value>Calculated value unavailable when missing data could comparisons between replicates.</value>
+  </data>
   <data name="SummaryMessage">
     <value>変更の説明</value>
+  </data>
+  <data name="SurrogateExternalStandard">
+    <value>Name of another peptide or molecule whose fitted calibration curve will be used for quantification of this peptide or molecule</value>
   </data>
   <data name="TargetQualitativeIonRatio">
     <value>校正から除外されていない外部標準繰り返し測定全体での定性イオン比の平均値です。</value>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.zh-CHS.resx
@@ -107,7 +107,7 @@
     <value>重复测定的值是用于计算倍数的变化。此数值取决于归一化方法以及是基于蛋白质还是肽段级别来计算倍数的变化。</value>
   </data>
   <data name="Accuracy">
-    <value>分析物浓度（在重复测定中指定的）与计算浓度比</value>
+    <value>Ratio of Calculated Concentration to the specified Analyte Concentration</value>
   </data>
   <data name="AcquiredTime">
     <value>质谱仪上一次开始获取此重复测定数据的时间
@@ -207,9 +207,18 @@
 离子对的保留时间值。</value>
   </data>
   <data name="CalculatedConcentration">
-    <value>分析物的浓度由以下任一一种方式计算：
-    1.使用校正曲线（前提是“肽段设定 &gt; 定量”指定了回归拟合）
-    2.使用与内标（或替代）的比，并乘以内标浓度</value>
+    <value>The concentration of the analyte calculated using either:
+1. The calibration curve (if the Peptide Settings &gt; Quantification has a Regression Fit specified)
+2. The ratio to internal standard (or surrogate) and multiplying by the Internal Standard Concentration</value>
+  </data>
+  <data name="CalculatedConcentrationMessage">
+    <value>Warning if missing data impacts comparisons of the "Calculated Concentration" between replicates</value>
+  </data>
+  <data name="CalculatedConcentrationRaw">
+    <value>Calculated concentration value available even when missing data impacts comparisons between replicates</value>
+  </data>
+  <data name="CalculatedConcentrationStrict">
+    <value>Calculated concentration value unavailable when missing data impacts comparisons between replicates</value>
   </data>
   <data name="CalibrationCurve">
     <value>校正曲线，其使用样品类型为“标准”并标明“分析物浓度”的重复测定计算。</value>
@@ -591,13 +600,13 @@
     <value>离子迁移库中母离子的碰撞横截面</value>
   </data>
   <data name="LibraryDotProduct">
-    <value>母离子的单个离子对峰面积与匹配的串联质谱谱图库谱图
-中匹配离子峰的强度之间的点积（注释：截止版本 v1.4，为 1 – Arcos(dotp)/(Pi/2)，
-其中 dotp 是上文所述的值，
-又称归一化谱图对比角度）；或者如果母离子没有匹配的
-库谱图或离子对少于 4 个，则为 #N/A。这是用于
-方法调整的 35 个有用值。当存在 6 个或更多离子对时，
-效果最佳。</value>
+    <value>Equivalent to "dotp" displayed in the user interface. The dot-product between the individual transition peak areas
+of the precursor and the intensities of the matching ion peaks in the matched MS/MS
+spectral library spectrum (Note: as of v1.4, this is now 1 – Arcos(dotp)/(Pi/2) where dotp
+is the value described above. a.k.a. Normalize Spectrum Contrast Angle), or #N/A if the
+precursor has not matching library spectrum or has fewer than 4 transitions. This is a 35
+useful value for method refinement. It works best when 6 or more transitions are
+present.</value>
   </data>
   <data name="LibraryIntensity">
     <value>对应匹配库谱图中离子对子离子的
@@ -666,7 +675,7 @@
     <value>此片段中所有中性丢失的总质量。</value>
   </data>
   <data name="MassErrorPPM">
-    <value>质量误差 PPM</value>
+    <value>The difference between the expected and measured m/z values expressed in parts per million (PPM)</value>
   </data>
   <data name="MassErrors">
     <value>色谱图的质量误差。</value>
@@ -748,6 +757,9 @@
 如果有内标标签类型，则仅使用母离子标签类型为内标的离子对峰面积来计算中位数峰面积。
 如果没有内标峰面积，则根据所有离子对峰面积计算中位数离子对峰面积。</value>
   </data>
+  <data name="Message">
+    <value>Warning, if any, of missing values that might impact comparisons of the "Raw" value between replicates.</value>
+  </data>
   <data name="Min">
     <value>最小</value>
   </data>
@@ -809,9 +821,22 @@
     <value>Skyline 文档中的一组分子。</value>
   </data>
   <data name="MoleculeListAbundance">
-    <value>表示分子列表丰度的数值。对该分子列表下所有离子对的归一化面积求平均值，即可得出该数值。
-根据“分子定量”设置中指定的归一化方法对面积进行归一化处理。
-如果该重复测定中有任何离子对缺少值，则除非归一化方法是与标记之间的比率，否则分子列表丰度将为空白</value>
+    <value>A number representing the abundance of the molecule list, calculated according to the "Normalization Method" specified in the Molecule Quantification settings</value>
+  </data>
+  <data name="MoleculeListAbundanceMessage">
+    <value>Warning if missing data impacts comparisons of "Molecule List Abundance" between replicates</value>
+  </data>
+  <data name="MoleculeListAbundanceStrict">
+    <value>A number representing the abundance of the molecule list, calculated according to the "Normalization Method" specified in the Molecule Quantification settings.
+Unavailable when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="MoleculeListAbundanceTransitionAveraged">
+    <value>Average of the normalized areas of the transitions under the Molecule List.
+The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings.</value>
+  </data>
+  <data name="MoleculeListAbundanceTransitionSummed">
+    <value>Sum of the normalized areas of the transitions under the Molecule List.
+The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings</value>
   </data>
   <data name="MoleculeListLocator">
     <value>文档内的分子列表特殊标识符。以“MoleculeGroup：”开头。</value>
@@ -874,7 +899,7 @@
     <value>指明该结果是否仅使用母离子强度（一级质谱）或子离子强度（二级质谱）获得。</value>
   </data>
   <data name="NextAa">
-    <value>下一个氨基酸</value>
+    <value>The amino acid residue found immediately after the peptide in the protein sequence.</value>
   </data>
   <data name="NormalizationDivisor">
     <value>使用默认归一化方法时观察值除以的数字。
@@ -884,8 +909,24 @@
     <value>覆盖与该特定分子一起使用的归一化方法，进行绝对定量和组间比较。</value>
   </data>
   <data name="NormalizedArea">
-    <value>根据明示的肽段/分子“归一化方法”或在“设定 &gt; 肽段设定 &gt; 定量”中指定的归一化方法:
-    归一化肽段/分子强度而得的值</value>
+    <value>Value obtained by normalizing the peptide/molecule intensity according to either
+the explicit "Normalization Method" for the peptide/molecule 
+or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification</value>
+  </data>
+  <data name="NormalizedAreaMessage">
+    <value>Warning if missing data impacts of the "Normalized Area" value between replicates</value>
+  </data>
+  <data name="NormalizedAreaRaw">
+    <value>Value obtained by normalizing the peptide/molecule intensity according to either
+the explicit "Normalization Method" for the peptide/molecule
+or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification.
+Available even when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="NormalizedAreaStrict">
+    <value>Value obtained by normalizing the peptide/molecule intensity according to either
+the explicit "Normalization Method" for the peptide/molecule
+or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification.
+Unavailable when missing data impacts comparisons between replicates.</value>
   </data>
   <data name="NumberOfPoints">
     <value>色谱图中的点数。</value>
@@ -992,6 +1033,9 @@
   <data name="PeptideSequenceLength">
     <value>肽段序列中的氨基酸计数。</value>
   </data>
+  <data name="PeptideSpectrumMatchCount">
+    <value>Number of spectra in the spectral library which match the peptide and result file.</value>
+  </data>
   <data name="PointCount">
     <value>在曲线拟合中使用的数据点数。</value>
   </data>
@@ -1010,8 +1054,19 @@
   <data name="PrecursorCalculatedConcentration">
     <value>使用同位素响应曲线所计算母离子结果浓度。</value>
   </data>
+  <data name="PrecursorCalculatedConcentrationMessage">
+    <value>Warning if missing data impacts comparisons of "Precursor Calculated Concentration" between replicates</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationRaw">
+    <value>The concentration of the Precursor Result calculated using the isotopolog response curve.
+Available even when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="PrecursorCalculatedConcentrationStrict">
+    <value>The concentration of the Precursor Result calculated using the isotopolog response curve.
+Unavailable when missing data impacts comparisons between replicates.</value>
+  </data>
   <data name="PrecursorCharge">
-    <value>与母离子相关的电荷。</value>
+    <value>The charge associated with the precursor ion.</value>
   </data>
   <data name="PrecursorConcentration">
     <value>将该母离子掺入样品时的浓度。用于产生同位素响应曲线。</value>
@@ -1039,9 +1094,24 @@
     <value>母离子的中性质量（以道尔顿为单位）</value>
   </data>
   <data name="PrecursorNormalizedArea">
-    <value>母离子结果的校准后面积。
-其等同于根据肽段校准方法所校准的母离子结果总面积。
-若肽段校准方法为“无”或相对于标记的比率。那么母离子校准后面积将等于母离子总面积。</value>
+    <value>Normalized area of the Precursor Result.
+Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
+If Peptide Normalization Method is "None" or ratio to a label, then Precursor Normalized Area will be equal to the Total Area of the Precursor.</value>
+  </data>
+  <data name="PrecursorNormalizedAreaMessage">
+    <value>Warning if missing values impacts comparisons of the "Precursor Normalized Area" value between replicates</value>
+  </data>
+  <data name="PrecursorNormalizedAreaRaw">
+    <value>Normalized area of the Precursor Result.
+Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
+If the Peptide Normalization Method is "None" or ratio to a label, then the Precursor Normalized Area will be equal to the Total Area of the Precursor.
+Available even when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="PrecursorNormalizedAreaStrict">
+    <value>Normalized area of the Precursor Result.
+Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
+If the Peptide Normalization Method is "None" or ratio to a label, then the Precursor Normalized Area will be equal to the Total Area of the Precursor.
+Unavailable when missing data impacts comparisons between replicates.</value>
   </data>
   <data name="PrecursorNote">
     <value>点击“编辑”菜单中的“编辑注释”后显示的与母离子相关的
@@ -1115,11 +1185,22 @@
     <value>蛋白质</value>
   </data>
   <data name="ProteinAbundance">
-    <value>表示特定重复测定中蛋白质丰度的数值。
-对蛋白质下所有离子对的归一化面积取平均值，即可计算出蛋白质丰度。
-离子对面积根据“肽段定量”设置中指定的归一化方法进行归一化处理。
-如果任何离子对在“重复测定”中缺少峰面积，蛋白质丰度将为空白，除非归一化方法是与标记的比率设置中指定的归一化方法进行归一化处理。
-如果该重复测定中有任何离子对缺少峰面积，则除非归一化方法是与标记之间的比率，否则蛋白质丰度将为空白。</value>
+    <value>A number representing the abundance of the protein, calculated according to the "Normalization Method" specified in the Peptide Quantification settings.</value>
+  </data>
+  <data name="ProteinAbundanceMessage">
+    <value>Warning if missing data impacts comparisons of "Protein Abundance" between replicates</value>
+  </data>
+  <data name="ProteinAbundanceStrict">
+    <value>A number representing the abundance of the protein, calculated according to the "Normalization Method" specified in the Peptide Quantification settings.
+Unavailable when missing data impacts comparisons between replicates.</value>
+  </data>
+  <data name="ProteinAbundanceTransitionAveraged">
+    <value>Average of the normalized areas of the transitions under the Protein.
+The areas are normalized according to the Normalization Method specified in the Peptide Quantification settings.</value>
+  </data>
+  <data name="ProteinAbundanceTransitionSummed">
+    <value>Sum of the normalized areas of the transitions under the Protein.
+The areas are normalized according to the Normalization Method specified in the Peptide Quantification settings.</value>
   </data>
   <data name="ProteinAccession">
     <value>蛋白质检索号</value>
@@ -1202,10 +1283,13 @@
 漂移范围。</value>
   </data>
   <data name="RatioDotProduct">
-    <value>比率点积</value>
+    <value>Equivalent to "rdotp" displayed in the user interface. The dot-product calculation described for Library Dot Product, but between the peak areas of the precursor (e.g. light) and the peak areas of the standard type precursor (e.g. heavy), or #N/A if there is either no standard type or the precursor is the standard type.</value>
   </data>
   <data name="RatioToStandard">
     <value>肽段的轻标/重标面积比</value>
+  </data>
+  <data name="Raw">
+    <value>Calculated value available even when missing data impacts comparisons between replicates.</value>
   </data>
   <data name="RawData">
     <value>原始（未内插）的色谱图数据。色谱图的间隔时间不均匀，每个离子对的色谱图可能具有不同的点数。</value>
@@ -1403,8 +1487,14 @@
     <value>母离子总面积归一化值的标准
 偏差。</value>
   </data>
+  <data name="Strict">
+    <value>Calculated value unavailable when missing data could comparisons between replicates.</value>
+  </data>
   <data name="SummaryMessage">
     <value>更改的描述</value>
+  </data>
+  <data name="SurrogateExternalStandard">
+    <value>Name of another peptide or molecule whose fitted calibration curve will be used for quantification of this peptide or molecule</value>
   </data>
   <data name="TargetQualitativeIonRatio">
     <value>所有未从校准排除的外部标准重复测定中定性离子比值的平均值。</value>

--- a/pwiz_tools/Skyline/Model/DdaSearch/DdaSearchResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/DdaSearch/DdaSearchResources.ja.resx
@@ -172,4 +172,34 @@
   <data name="MsconvertDdaConverter_Run_Starting_msconvert_conversion_" xml:space="preserve">
     <value>msconvert変換を開始しています</value>
   </data>
+  <data name="HardklorSearchEngine_PerformAllAlignments_Performing_retention_time_alignment__0__vs__1_" xml:space="preserve">
+    <value>Retention time alignment: {0} vs {1}</value>
+  </data>
+  <data name="HardklorSearchEngine_FindSimilarFeatures_Looking_for_features_occurring_in_multiple_replicates" xml:space="preserve">
+    <value>Looking for features occurring in multiple replicates</value>
+  </data>
+  <data name="HardklorSearchEngine_Run_See_Hardklor_Bullseye_log_for_details" xml:space="preserve">
+    <value>See Hardklor/Bullseye log for details</value>
+  </data>
+  <data name="HardklorSearchEngine_PerformAllAlignments_Error_performing_alignment_between__0__and__1____2_" xml:space="preserve">
+    <value>Error performing alignment between {0} and {1}: {2}</value>
+  </data>
+  <data name="HardklorSearchEngine_PerformAllAlignments_Preparing_for_retention_time_alignment_on___0__" xml:space="preserve">
+    <value>Preparing for retention time alignment on "{0}"</value>
+  </data>
+  <data name="HardklorSearchEngine_Run_Searching_for_peptide_like_features_with__0_" xml:space="preserve">
+    <value>Searching for peptide-like features with {0}</value>
+  </data>
+  <data name="HardklorSearchEngine_Run_Searching_for_persistent_features_in_Hardklor_results_with__0_" xml:space="preserve">
+    <value>Searching for persistent features in Hardklor results with {0}</value>
+  </data>
+  <data name="MsconvertDdaConverter_Run_Converting_file___0___to__1_" xml:space="preserve">
+    <value>Converting file "{0}" to {1}</value>
+  </data>
+  <data name="HardklorSearchEngine_CutoffScoreLabel_Min_isotope__dot_product_" xml:space="preserve">
+    <value>Min isotope &amp;dot product:</value>
+  </data>
+  <data name="HardklorSearchEngine_SearchEngineBlurb" xml:space="preserve">
+    <value>Hardklor searches for peptide-like features in MS1 scans using an averagine model. Features found by Hardklor are represented in Skyline as small molecules with the chemical formula that Hardklor used to generate the isotope distribution it matched to the feature, plus a mass offset to match the high-res peak mass to charge ratio. This is not the actual formula of the molecule responsible for the MS1 peaks in the mass spectrometer, but rather an approximation with a matching isotope distribution.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DdaSearch/DdaSearchResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/DdaSearch/DdaSearchResources.zh-CHS.resx
@@ -172,4 +172,34 @@
   <data name="MsconvertDdaConverter_Run_Starting_msconvert_conversion_" xml:space="preserve">
     <value>正在启动 msconvert 转换。</value>
   </data>
+  <data name="HardklorSearchEngine_PerformAllAlignments_Performing_retention_time_alignment__0__vs__1_" xml:space="preserve">
+    <value>Retention time alignment: {0} vs {1}</value>
+  </data>
+  <data name="HardklorSearchEngine_FindSimilarFeatures_Looking_for_features_occurring_in_multiple_replicates" xml:space="preserve">
+    <value>Looking for features occurring in multiple replicates</value>
+  </data>
+  <data name="HardklorSearchEngine_Run_See_Hardklor_Bullseye_log_for_details" xml:space="preserve">
+    <value>See Hardklor/Bullseye log for details</value>
+  </data>
+  <data name="HardklorSearchEngine_PerformAllAlignments_Error_performing_alignment_between__0__and__1____2_" xml:space="preserve">
+    <value>Error performing alignment between {0} and {1}: {2}</value>
+  </data>
+  <data name="HardklorSearchEngine_PerformAllAlignments_Preparing_for_retention_time_alignment_on___0__" xml:space="preserve">
+    <value>Preparing for retention time alignment on "{0}"</value>
+  </data>
+  <data name="HardklorSearchEngine_Run_Searching_for_peptide_like_features_with__0_" xml:space="preserve">
+    <value>Searching for peptide-like features with {0}</value>
+  </data>
+  <data name="HardklorSearchEngine_Run_Searching_for_persistent_features_in_Hardklor_results_with__0_" xml:space="preserve">
+    <value>Searching for persistent features in Hardklor results with {0}</value>
+  </data>
+  <data name="MsconvertDdaConverter_Run_Converting_file___0___to__1_" xml:space="preserve">
+    <value>Converting file "{0}" to {1}</value>
+  </data>
+  <data name="HardklorSearchEngine_CutoffScoreLabel_Min_isotope__dot_product_" xml:space="preserve">
+    <value>Min isotope &amp;dot product:</value>
+  </data>
+  <data name="HardklorSearchEngine_SearchEngineBlurb" xml:space="preserve">
+    <value>Hardklor searches for peptide-like features in MS1 scans using an averagine model. Features found by Hardklor are represented in Skyline as small molecules with the chemical formula that Hardklor used to generate the isotope distribution it matched to the feature, plus a mass offset to match the high-res peak mass to charge ratio. This is not the actual formula of the molecule responsible for the MS1 peaks in the mass spectrometer, but rather an approximation with a matching isotope distribution.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationStrings.ja.resx
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationStrings.ja.resx
@@ -335,4 +335,8 @@
   <data name="MsLevelOption_DEFAULT_Default" xml:space="preserve">
     <value>デフォルト</value>
   </data>
+  <data name="CalibrationForm_DisplayCalibrationCurve_QualifiedSampleType" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>Example: Standard (MyMolecule)</comment>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationStrings.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/QuantificationStrings.zh-CHS.resx
@@ -335,4 +335,8 @@
   <data name="MsLevelOption_DEFAULT_Default" xml:space="preserve">
     <value>默认</value>
   </data>
+  <data name="CalibrationForm_DisplayCalibrationCurve_QualifiedSampleType" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>Example: Standard (MyMolecule)</comment>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/DocSettingsResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/DocSettings/DocSettingsResources.ja.resx
@@ -680,4 +680,7 @@
   <data name="XmlNamedElement_Validate_Name_property_may_not_be_missing_or_empty" xml:space="preserve">
     <value>名前のプロパティが欠落している、または空にしておくことはできません。</value>
   </data>
+  <data name="StaticMod_DoValidate_Isotope_modifications_may_not_be_variable_" xml:space="preserve">
+    <value>Isotope modifications may not be variable.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/DocSettingsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/DocSettings/DocSettingsResources.zh-CHS.resx
@@ -681,4 +681,7 @@
   <data name="XmlNamedElement_Validate_Name_property_may_not_be_missing_or_empty" xml:space="preserve">
     <value>名称属性不得缺失或为空。</value>
   </data>
+  <data name="StaticMod_DoValidate_Isotope_modifications_may_not_be_variable_" xml:space="preserve">
+    <value>Isotope modifications may not be variable.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Find/FindResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Find/FindResources.zh-CHS.resx
@@ -141,7 +141,7 @@
     <value>无法找到{0}。</value>
   </data>
   <data name="FindOptions_GetNotFoundMessage_Nothing_could_be_found_matching_any_of_the__0__criteria" xml:space="preserve">
-    <value>找不到与任何 {0} 条件相匹配的内容</value>
+    <value>找不到任何与 {0} 条件相匹配的内容</value>
     <comment>{0} is an integer greater than 1</comment>
   </data>
   <data name="FindOptions_GetNotFoundMessage_The_text__0__could_not_be_found" xml:space="preserve">

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonResources.ja.resx
@@ -124,4 +124,22 @@
   <data name="RatioToSurrogate_ToString_Ratio_to_surrogate__0_" xml:space="preserve">
     <value>サロゲート{0}に対する比率</value>
   </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_Transition___0___is_missing" xml:space="preserve">
+    <value>Transition '{0}' is missing</value>
+  </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_Missing_values_for__0___1__transitions" xml:space="preserve">
+    <value>Missing values for {0}/{1} transitions</value>
+    <comment>{0} and {1} are numbers</comment>
+  </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_Transition___0___is_truncated" xml:space="preserve">
+    <value>Transition '{0}' is truncated</value>
+  </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_All__0__peaks_are_truncated" xml:space="preserve">
+    <value>All {0} peaks are truncated</value>
+    <comment>{0} is a number</comment>
+  </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_Truncated_peaks_for__0___1__transitions" xml:space="preserve">
+    <value>Truncated peaks for {0}/{1} transitions</value>
+    <comment>{0} and {1} are numbers</comment>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonResources.zh-CHS.resx
@@ -124,4 +124,22 @@
   <data name="RatioToSurrogate_ToString_Ratio_to_surrogate__0_" xml:space="preserve">
     <value>与替代的比例 {0}</value>
   </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_Transition___0___is_missing" xml:space="preserve">
+    <value>Transition '{0}' is missing</value>
+  </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_Missing_values_for__0___1__transitions" xml:space="preserve">
+    <value>Missing values for {0}/{1} transitions</value>
+    <comment>{0} and {1} are numbers</comment>
+  </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_Transition___0___is_truncated" xml:space="preserve">
+    <value>Transition '{0}' is truncated</value>
+  </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_All__0__peaks_are_truncated" xml:space="preserve">
+    <value>All {0} peaks are truncated</value>
+    <comment>{0} is a number</comment>
+  </data>
+  <data name="PeptideQuantifier_SumTransitionQuantities_Truncated_peaks_for__0___1__transitions" xml:space="preserve">
+    <value>Truncated peaks for {0}/{1} transitions</value>
+    <comment>{0} and {1} are numbers</comment>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Koina/KoinaResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Koina/KoinaResources.ja.resx
@@ -98,22 +98,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="KoinaPeptideTooLongException_KoinaPeptideTooLongException_Peptide_Sequence___0_____1___is_longer_than_the_maximum_supported_length_by_Koina___2__" xml:space="preserve">
-    <value>ペプチドシークエンス「{0}」({1})はKoina ({2})でサポートされる最大長より長くなります</value>
+    <value>Peptide Sequence '{0}' ({1}) is longer than the maximum supported length by Koina ({2})</value>
   </data>
   <data name="KoinaPeptideTooLongException_KoinaUnsupportedAminoAcidException_Amino_acid___0___in___1___is_not_supported_by_Koina" xml:space="preserve">
-    <value>「{1}」内のアミノ酸「{0}」はKoinaでサポートされません</value>
+    <value>Amino acid '{0}' in '{1}' is not supported by Koina</value>
   </data>
   <data name="KoinaUnsupportedModificationException_KoinaUnsupportedModificationException_Modifcation___0___at_index___1___in___2___is_not_supported_by_Koina" xml:space="preserve">
-    <value>「{2}」内のインデックス「{1}」における修飾「{0}」はKoinaでサポートされません。</value>
+    <value>Modifcation '{0}' at index '{1}' in '{2}' is not supported by Koina</value>
   </data>
   <data name="KoinaModel_BatchPredict_Constructing_Koina_inputs" xml:space="preserve">
-    <value>Koina入力を構築しています</value>
+    <value>Constructing Koina inputs</value>
   </data>
   <data name="KoinaModel_BatchPredict_Requesting_predictions_from_Koina" xml:space="preserve">
-    <value>Koinaから予測を要求しています</value>
+    <value>Requesting predictions from Koina</value>
   </data>
   <data name="KoinaIntensityModel_KoinaIntensityModel_Intensity_model__0__does_not_exist" xml:space="preserve">
-    <value>強度モデル「{0}」が存在しません</value>
+    <value>Intensity model '{0}' does not exist</value>
   </data>
   <data name="ToolOptionsUI_ToolOptionsUI_Server_online" xml:space="preserve">
     <value>サーバーオンライン</value>
@@ -122,28 +122,28 @@
     <value>サーバーオフライン</value>
   </data>
   <data name="KoinaPredictionClient_Current_No_Koina_server_set" xml:space="preserve">
-    <value>Koinaサーバーが設定されていません</value>
+    <value>No Koina server set</value>
   </data>
   <data name="ToolOptionsUI_UpdateServerStatus_Server_unavailable" xml:space="preserve">
     <value>サーバーが利用できません</value>
   </data>
   <data name="KoinaSmallMoleculeException_KoinaSmallMoleculeException_Koina_only_supports_peptides____0___is_a_small_molecule_" xml:space="preserve">
-    <value>Koinaはペプチドのみをサポートします。「{0}」は小さい分子です。</value>
+    <value>Koina only supports peptides. '{0}' is a small molecule.</value>
   </data>
   <data name="BuildLibraryDlg_dataSourceFilesRadioButton_CheckedChanged_Some_Koina_settings_are_not_set__Would_you_like_to_set_them_now_" xml:space="preserve">
-    <value>Koinaが正しく設定されていません。今すぐKoinaの設定を変更しますか？</value>
+    <value>Koina is not properly configured. Would you like to change Koina settings now?</value>
   </data>
   <data name="GraphSpectrum_UpdateUI_Some_Koina_settings_are_not_set_" xml:space="preserve">
-    <value>Koinaが正しく設定されていません。</value>
+    <value>Koina is not properly configured.</value>
   </data>
   <data name="GraphSpectrum_UpdateUI__0__vs___1_" xml:space="preserve">
     <value>{0}対{1}</value>
   </data>
   <data name="KoinaRetentionTimeModel_KoinaRetentionTimeModel_Retention_time_model___0___does_not_exist" xml:space="preserve">
-    <value>保持時間モデル「{0}」は存在しません</value>
+    <value>Retention time model '{0}' does not exist</value>
   </data>
   <data name="KoinaPredictingException_KoinaPredictingException_Making_predictions___" xml:space="preserve">
-    <value>予測を作成中...</value>
+    <value>Making predictions...</value>
   </data>
   <data name="ToolOptionsUI_UpdateServerStatus_Querying_server___" xml:space="preserve">
     <value>サーバーをクエリ中...</value>
@@ -155,7 +155,7 @@
     <value>サーバーを選択</value>
   </data>
   <data name="ToolOptionsUI_SetServerStatus_Select_both_models" xml:space="preserve">
-    <value>両方のモデルを選択</value>
+    <value>Select both models to connect</value>
   </data>
   <data name="GraphSpectrum_UpdateUI_No_spectral_library_match" xml:space="preserve">
     <value>スペクトルライブラリの一致がありません</value>

--- a/pwiz_tools/Skyline/Model/Koina/KoinaResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Koina/KoinaResources.zh-CHS.resx
@@ -98,22 +98,22 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="KoinaPeptideTooLongException_KoinaPeptideTooLongException_Peptide_Sequence___0_____1___is_longer_than_the_maximum_supported_length_by_Koina___2__" xml:space="preserve">
-    <value>肽段序列'{0}' ({1}) 长于 Koina ({2}) 所支持的最大长度</value>
+    <value>Peptide Sequence '{0}' ({1}) is longer than the maximum supported length by Koina ({2})</value>
   </data>
   <data name="KoinaPeptideTooLongException_KoinaUnsupportedAminoAcidException_Amino_acid___0___in___1___is_not_supported_by_Koina" xml:space="preserve">
-    <value>Koina 不支持“{1}” 中氨基酸“{0}”</value>
+    <value>Amino acid '{0}' in '{1}' is not supported by Koina</value>
   </data>
   <data name="KoinaUnsupportedModificationException_KoinaUnsupportedModificationException_Modifcation___0___at_index___1___in___2___is_not_supported_by_Koina" xml:space="preserve">
-    <value>Koina 不支持“{2}” 中指数“{1}”内的修改“{0}”</value>
+    <value>Modifcation '{0}' at index '{1}' in '{2}' is not supported by Koina</value>
   </data>
   <data name="KoinaModel_BatchPredict_Constructing_Koina_inputs" xml:space="preserve">
-    <value>构建 Koina 输入</value>
+    <value>Constructing Koina inputs</value>
   </data>
   <data name="KoinaModel_BatchPredict_Requesting_predictions_from_Koina" xml:space="preserve">
-    <value>向 Koina 请求预测</value>
+    <value>Requesting predictions from Koina</value>
   </data>
   <data name="KoinaIntensityModel_KoinaIntensityModel_Intensity_model__0__does_not_exist" xml:space="preserve">
-    <value>强度模型“{0}”不存在</value>
+    <value>Intensity model '{0}' does not exist</value>
   </data>
   <data name="ToolOptionsUI_ToolOptionsUI_Server_online" xml:space="preserve">
     <value>在线服务器</value>
@@ -122,28 +122,28 @@
     <value>离线服务器</value>
   </data>
   <data name="KoinaPredictionClient_Current_No_Koina_server_set" xml:space="preserve">
-    <value>无 Koina 服务器设定</value>
+    <value>No Koina server set</value>
   </data>
   <data name="ToolOptionsUI_UpdateServerStatus_Server_unavailable" xml:space="preserve">
     <value>服务器不可用</value>
   </data>
   <data name="KoinaSmallMoleculeException_KoinaSmallMoleculeException_Koina_only_supports_peptides____0___is_a_small_molecule_" xml:space="preserve">
-    <value>Koina 仅支持肽段。“{0}” 是一个小分子。</value>
+    <value>Koina only supports peptides. '{0}' is a small molecule.</value>
   </data>
   <data name="BuildLibraryDlg_dataSourceFilesRadioButton_CheckedChanged_Some_Koina_settings_are_not_set__Would_you_like_to_set_them_now_" xml:space="preserve">
-    <value>Koina 配置不正确。您现在是否想要更改 Koina 设置？</value>
+    <value>Koina is not properly configured. Would you like to change Koina settings now?</value>
   </data>
   <data name="GraphSpectrum_UpdateUI_Some_Koina_settings_are_not_set_" xml:space="preserve">
-    <value>Koina 配置不正确。</value>
+    <value>Koina is not properly configured.</value>
   </data>
   <data name="GraphSpectrum_UpdateUI__0__vs___1_" xml:space="preserve">
     <value>{0} 与 {1}</value>
   </data>
   <data name="KoinaRetentionTimeModel_KoinaRetentionTimeModel_Retention_time_model___0___does_not_exist" xml:space="preserve">
-    <value>保留时间模型“{0}”不存在</value>
+    <value>Retention time model '{0}' does not exist</value>
   </data>
   <data name="KoinaPredictingException_KoinaPredictingException_Making_predictions___" xml:space="preserve">
-    <value>进行预测...</value>
+    <value>Making predictions...</value>
   </data>
   <data name="ToolOptionsUI_UpdateServerStatus_Querying_server___" xml:space="preserve">
     <value>查询服务器...</value>
@@ -155,7 +155,7 @@
     <value>选择一个服务器</value>
   </data>
   <data name="ToolOptionsUI_SetServerStatus_Select_both_models" xml:space="preserve">
-    <value>选择两个模型</value>
+    <value>Select both models to connect</value>
   </data>
   <data name="GraphSpectrum_UpdateUI_No_spectral_library_match" xml:space="preserve">
     <value>无谱图库匹配</value>

--- a/pwiz_tools/Skyline/Model/Koina/Models/ModelsResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Koina/Models/ModelsResources.ja.resx
@@ -119,15 +119,15 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="KoinaHelpers_ExportKoinaSpectraToBlib_Exporting_Koina_spectra_to_BiblioSpec_library" xml:space="preserve">
-    <value>KoinaスペクトルのBiblioSpecライブラリへのエクスポート</value>
+    <value>Exporting Koina spectra to BiblioSpec library</value>
   </data>
   <data name="KoinaHelpers_ExportKoinaSpectraToBlib_failed_to_write_Koina_output_to_blib" xml:space="preserve">
-    <value>Koina出力をblibに書き込めませんでした</value>
+    <value>failed to write Koina output to blib</value>
   </data>
   <data name="KoinaHelpers_PredictBatchesFromKoinaCsv_Reading_Koina_CSV_input" xml:space="preserve">
-    <value>Koina CSV入力の読み取り</value>
+    <value>Reading Koina CSV input</value>
   </data>
   <data name="KoinaIntensityModel_CreateKoinaInputRow_UnsupportedCharge" xml:space="preserve">
-    <value>Koinaでは電荷{0}に対応していません。対応最大電荷は{1}です。</value>
+    <value>The charge {0} is not supported by Koina. The maximum supported charge is {1}.</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Koina/Models/ModelsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Koina/Models/ModelsResources.zh-CHS.resx
@@ -119,15 +119,15 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="KoinaHelpers_ExportKoinaSpectraToBlib_Exporting_Koina_spectra_to_BiblioSpec_library" xml:space="preserve">
-    <value>将 Koina 谱图导出到 BiblioSpec 库</value>
+    <value>Exporting Koina spectra to BiblioSpec library</value>
   </data>
   <data name="KoinaHelpers_ExportKoinaSpectraToBlib_failed_to_write_Koina_output_to_blib" xml:space="preserve">
-    <value>无法将 Koina 输出写入 blib</value>
+    <value>failed to write Koina output to blib</value>
   </data>
   <data name="KoinaHelpers_PredictBatchesFromKoinaCsv_Reading_Koina_CSV_input" xml:space="preserve">
-    <value>正在读取  Koina CSV 输入</value>
+    <value>Reading Koina CSV input</value>
   </data>
   <data name="KoinaIntensityModel_CreateKoinaInputRow_UnsupportedCharge" xml:space="preserve">
-    <value>Koina 不支持电荷 {0}。支持的最大电荷为 {1}。</value>
+    <value>The charge {0} is not supported by Koina. The maximum supported charge is {1}.</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Lib/LibResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Lib/LibResources.ja.resx
@@ -191,10 +191,13 @@
     <value>ライブラリエントリが見つかりません{0}。</value>
   </data>
   <data name="EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_Converting_FASTA_to_Koina_input" xml:space="preserve">
-    <value>FASTAのKoina入力への変換</value>
+    <value>Converting FASTA to Koina input</value>
   </data>
   <data name="EncyclopeDiaHelpers_ConvertKoinaOutputToDlib_Converting_Koina_output_to_EncyclopeDia_library" xml:space="preserve">
-    <value>Koina出力のEncyclopeDIAライブラリへの変換</value>
+    <value>Converting Koina output to EncyclopeDIA library</value>
+  </data>
+  <data name="EncyclopeDiaHelpers_Generate_Waiting_for_chromatogram_library" xml:space="preserve">
+    <value>Waiting for chromatogram library</value>
   </data>
   <data name="EncyclopeDiaHelpers_GenerateLibrary_Generating_chromatogram_library_0_of_1_2" xml:space="preserve">
     <value>クロマトグラムライブラリ({1}の{0})：{2}の生成</value>
@@ -212,13 +215,13 @@
     <value>EncyclopeDIAライブラリ</value>
   </data>
   <data name="FastaToKoina_Enzyme_unsupported_enzyme___0____allowed_values_are___1_" xml:space="preserve">
-    <value>対応していない酵素「{0}」、許可されている値：{1}</value>
+    <value>unsupported enzyme '{0}'; allowed values are: {1}</value>
   </data>
   <data name="Library_ReadComplete_Data_truncation_in_library_header_File_may_be_corrupted" xml:space="preserve">
     <value>ライブラリヘッダーでのデータ切り捨て。ファイルが破損している可能性があります。</value>
   </data>
   <data name="LibrarySpec_ItemDescription_Ignore_explicit_peak_boundaries" xml:space="preserve">
-    <value>明示的なピーク境界を無視</value>
+    <value>表示されたピーク境界を無視</value>
   </data>
   <data name="LibrarySpec_PEP_RANK_COPIES_Spectrum_count" xml:space="preserve">
     <value>スペクトル数</value>
@@ -286,6 +289,12 @@
   </data>
   <data name="NistLibSpecBase_PEP_RANK_TFRATIO_TFRatio" xml:space="preserve">
     <value>TFRatio</value>
+  </data>
+  <data name="ParallelRunner_Generate_An_EncyclopeDIA_task_failed_" xml:space="preserve">
+    <value>An EncyclopeDIA task failed.</value>
+  </data>
+  <data name="ProgressMonitorForFile_UpdateProgress_Demultiplexing_spectra___0___1_" xml:space="preserve">
+    <value>Demultiplexing spectra: {0}/{1}</value>
   </data>
   <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Average_mass" xml:space="preserve">
     <value>平均質量</value>

--- a/pwiz_tools/Skyline/Model/Lib/LibResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Lib/LibResources.zh-CHS.resx
@@ -191,10 +191,13 @@
     <value>未发现库条目{0}。</value>
   </data>
   <data name="EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_Converting_FASTA_to_Koina_input" xml:space="preserve">
-    <value>正在将 FASTA 转换为 Koina 输入</value>
+    <value>Converting FASTA to Koina input</value>
   </data>
   <data name="EncyclopeDiaHelpers_ConvertKoinaOutputToDlib_Converting_Koina_output_to_EncyclopeDia_library" xml:space="preserve">
-    <value>正在将 Koina 输出转换为 EncyclopeDIA 库</value>
+    <value>Converting Koina output to EncyclopeDIA library</value>
+  </data>
+  <data name="EncyclopeDiaHelpers_Generate_Waiting_for_chromatogram_library" xml:space="preserve">
+    <value>Waiting for chromatogram library</value>
   </data>
   <data name="EncyclopeDiaHelpers_GenerateLibrary_Generating_chromatogram_library_0_of_1_2" xml:space="preserve">
     <value>正在生成色谱图库 ({0}/{1}): {2}</value>
@@ -212,7 +215,7 @@
     <value>EncyclopeDIA 库</value>
   </data>
   <data name="FastaToKoina_Enzyme_unsupported_enzyme___0____allowed_values_are___1_" xml:space="preserve">
-    <value>不受支持的酶“{0}”; 允许的值为: {1}</value>
+    <value>unsupported enzyme '{0}'; allowed values are: {1}</value>
   </data>
   <data name="Library_ReadComplete_Data_truncation_in_library_header_File_may_be_corrupted" xml:space="preserve">
     <value>库标题中的数据缺损。文件可能已损坏。</value>
@@ -286,6 +289,12 @@
   </data>
   <data name="NistLibSpecBase_PEP_RANK_TFRATIO_TFRatio" xml:space="preserve">
     <value>TF 比率</value>
+  </data>
+  <data name="ParallelRunner_Generate_An_EncyclopeDIA_task_failed_" xml:space="preserve">
+    <value>An EncyclopeDIA task failed.</value>
+  </data>
+  <data name="ProgressMonitorForFile_UpdateProgress_Demultiplexing_spectra___0___1_" xml:space="preserve">
+    <value>Demultiplexing spectra: {0}/{1}</value>
   </data>
   <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Average_mass" xml:space="preserve">
     <value>平均质量</value>

--- a/pwiz_tools/Skyline/Model/ModelResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/ModelResources.ja.resx
@@ -117,7 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="AbiMethodExporter_EnsureAnalyst_Failed_to_find_a_valid_Analyst_installation" xml:space="preserve">
     <value>有効なAnalystのインストールが見つかりませんでした</value>
   </data>
@@ -797,5 +796,20 @@
   </data>
   <data name="ZipFileShare_AddFile_The_name___0___is_already_in_use_from_the_path__1_" xml:space="preserve">
     <value>「{0}」という名前は既にパス{1}で使用されています。</value>
+  </data>
+  <data name="ModificationMatcher_GetStaticMod_found_more_than_one_UniMod_match__add_terminus_and_or_amino_acid_specificity_to_choose_a_single_match" xml:space="preserve">
+    <value>found more than one UniMod match; add terminus and/or amino acid specificity to choose a single match</value>
+    <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.</comment>
+  </data>
+  <data name="ModificationMatcher_GetStaticMod_found_more_than_one_UniMod_match_but_the_given_specificity___0___does_not_match_any_of_them_" xml:space="preserve">
+    <value>found more than one UniMod match but the given specificity ({0}) does not match any of them.</value>
+    <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.</comment>
+  </data>
+  <data name="ModificationMatcher_GetStaticMod_no_UniMod_match" xml:space="preserve">
+    <value>no UniMod match</value>
+    <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.</comment>
+  </data>
+  <data name="ImportPeptideSearch_GetLibBuilder_detected_features" xml:space="preserve">
+    <value>detected features</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/ModelResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/ModelResources.zh-CHS.resx
@@ -117,7 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="AbiMethodExporter_EnsureAnalyst_Failed_to_find_a_valid_Analyst_installation" xml:space="preserve">
     <value>未能发现有效的 Analyst 安装</value>
   </data>
@@ -179,7 +178,7 @@
     <value>{0} ({1} - {2})</value>
   </data>
   <data name="BrukerTimsTofIsolationListExporter_CheckIonMobilities_All_targets_must_have_an_ion_mobility_between__0__and__1__as_specified_in_the_template_method__Either_use_a_different_template_method__or_change_the_ion_mobility_values_for_the_following_targets_" xml:space="preserve">
-    <value>所有目标的离子迁移必须介于此模板方法中指定的 {0} 和 {1} 之间。请使用其他模板方法，或更改以下目标的离子迁移值:</value>
+    <value>所有目标的离子迁移值必须介于此模板方法中指定的 {0} 和 {1} 之间。请使用其他模板方法，或更改下列目标的离子迁移值:</value>
   </data>
   <data name="BrukerTimsTofMethodExporter_ExportMethod_Getting_scheduling___" xml:space="preserve">
     <value>正在获取时序安排...</value>
@@ -797,5 +796,20 @@
   </data>
   <data name="ZipFileShare_AddFile_The_name___0___is_already_in_use_from_the_path__1_" xml:space="preserve">
     <value>在路径 {1} 中已经使用了名称“{0}”</value>
+  </data>
+  <data name="ModificationMatcher_GetStaticMod_found_more_than_one_UniMod_match__add_terminus_and_or_amino_acid_specificity_to_choose_a_single_match" xml:space="preserve">
+    <value>found more than one UniMod match; add terminus and/or amino acid specificity to choose a single match</value>
+    <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.</comment>
+  </data>
+  <data name="ModificationMatcher_GetStaticMod_found_more_than_one_UniMod_match_but_the_given_specificity___0___does_not_match_any_of_them_" xml:space="preserve">
+    <value>found more than one UniMod match but the given specificity ({0}) does not match any of them.</value>
+    <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.</comment>
+  </data>
+  <data name="ModificationMatcher_GetStaticMod_no_UniMod_match" xml:space="preserve">
+    <value>no UniMod match</value>
+    <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.</comment>
+  </data>
+  <data name="ImportPeptideSearch_GetLibBuilder_detected_features" xml:space="preserve">
+    <value>detected features</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Proteome/ProteomeResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Proteome/ProteomeResources.ja.resx
@@ -160,4 +160,7 @@
   <data name="ProteinMetadataManager_LookupProteinMetadata_resolving_protein_details" xml:space="preserve">
     <value>タンパク質詳細の分解中</value>
   </data>
+  <data name="ProteinAssociation_CalculateProteinOrGeneGroups_Calculating_gene_groups" xml:space="preserve">
+    <value>Calculating gene groups</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Proteome/ProteomeResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Proteome/ProteomeResources.zh-CHS.resx
@@ -160,4 +160,7 @@
   <data name="ProteinMetadataManager_LookupProteinMetadata_resolving_protein_details" xml:space="preserve">
     <value>蛋白质细节分辨中</value>
   </data>
+  <data name="ProteinAssociation_CalculateProteinOrGeneGroups_Calculating_gene_groups" xml:space="preserve">
+    <value>Calculating gene groups</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Results/ResultsResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Results/ResultsResources.ja.resx
@@ -296,6 +296,9 @@ Skylineがもう一度生データファイルからクロマトグラムを抽�
   <data name="ResultsGrid_ChangeChromInfo_Element_not_found" xml:space="preserve">
     <value>成分が見つかりません</value>
   </data>
+  <data name="ScanProvider_GetMsDataFileSpectraWithCommonRetentionTime_The_scan_ID___0___could_not_be_found_in_the_file___1___" xml:space="preserve">
+    <value>The scan ID '{0}' could not be found in the file '{1}'.</value>
+  </data>
   <data name="ScanProvider_GetScans_The_data_file__0__could_not_be_found__either_at_its_original_location_or_in_the_document_or_document_parent_folder_" xml:space="preserve">
     <value>データファイル{0}が元の場所、ドキュメント内、ドキュメント親フォルダ内のどこにも見つかりませんでした。</value>
   </data>
@@ -325,5 +328,20 @@ Skylineがもう一度生データファイルからクロマトグラムを抽�
   </data>
   <data name="VendorIssueHelper_ConvertPilotFiles_Unable_to_find__0__or__1__in_directory__2____Please_reinstall_ProteinPilot_software_to_be_able_to_handle__group_files_" xml:space="preserve">
     <value>ディレクトリ{2}で{0}または{1}を見つけられません。 .groupファイルの処理を可能にするため、ProteinPilotソフトウェアを再インストールしてください。</value>
+  </data>
+  <data name="PeptideChromDataSets_FilterByRetentionTime_Discarding_chromatograms_for___0___because_the_explicit_retention_time__1__is_not_between__2__and__3_" xml:space="preserve">
+    <value>Discarding chromatograms for '{0}' because the explicit retention time {1} is not between {2} and {3}</value>
+  </data>
+  <data name="IonMobilityFinder_EvaluateBestIonMobilityValue_need_a_value_for_Transition_Settings___ion_mobility_filtering___Window_type" xml:space="preserve">
+    <value>need a value for  Transition Settings  Ion mobility filtering  Window type</value>
+  </data>
+  <data name="IonMobilityFinder_FindIonMobilityPeaks_mixed_ion_mobility_types_are_not_supported" xml:space="preserve">
+    <value>mixed ion mobility types are not supported</value>
+  </data>
+  <data name="DataFileInstrumentInfo_CCSFromIonMobility_no_conversion" xml:space="preserve">
+    <value>Vendor-supplied library is unable to determine CCS for {0} with mobility={1:0.###}, mz={2:0.####}, and charge={3}.</value>
+  </data>
+  <data name="DataFileInstrumentInfo_IonMobilityFromCCS_no_conversion" xml:space="preserve">
+    <value>Vendor-supplied library is unable to determine ion mobility for {0} with CCS={1:0.###}, mz={2:0.####}, and charge={3}.</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Results/ResultsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Results/ResultsResources.zh-CHS.resx
@@ -296,6 +296,9 @@
   <data name="ResultsGrid_ChangeChromInfo_Element_not_found" xml:space="preserve">
     <value>未发现元素</value>
   </data>
+  <data name="ScanProvider_GetMsDataFileSpectraWithCommonRetentionTime_The_scan_ID___0___could_not_be_found_in_the_file___1___" xml:space="preserve">
+    <value>The scan ID '{0}' could not be found in the file '{1}'.</value>
+  </data>
   <data name="ScanProvider_GetScans_The_data_file__0__could_not_be_found__either_at_its_original_location_or_in_the_document_or_document_parent_folder_" xml:space="preserve">
     <value>数据文件{0}无法找到，无论是在原始位置还是在文档或文档父文件夹中。</value>
   </data>
@@ -325,5 +328,20 @@
   </data>
   <data name="VendorIssueHelper_ConvertPilotFiles_Unable_to_find__0__or__1__in_directory__2____Please_reinstall_ProteinPilot_software_to_be_able_to_handle__group_files_" xml:space="preserve">
     <value>无法在目录{2}中找到 {0}或{1}。 请重新安装 ProteinPilot 软件以便处理 .group 文件。</value>
+  </data>
+  <data name="PeptideChromDataSets_FilterByRetentionTime_Discarding_chromatograms_for___0___because_the_explicit_retention_time__1__is_not_between__2__and__3_" xml:space="preserve">
+    <value>Discarding chromatograms for '{0}' because the explicit retention time {1} is not between {2} and {3}</value>
+  </data>
+  <data name="IonMobilityFinder_EvaluateBestIonMobilityValue_need_a_value_for_Transition_Settings___ion_mobility_filtering___Window_type" xml:space="preserve">
+    <value>need a value for  Transition Settings  Ion mobility filtering  Window type</value>
+  </data>
+  <data name="IonMobilityFinder_FindIonMobilityPeaks_mixed_ion_mobility_types_are_not_supported" xml:space="preserve">
+    <value>mixed ion mobility types are not supported</value>
+  </data>
+  <data name="DataFileInstrumentInfo_CCSFromIonMobility_no_conversion" xml:space="preserve">
+    <value>Vendor-supplied library is unable to determine CCS for {0} with mobility={1:0.###}, mz={2:0.####}, and charge={3}.</value>
+  </data>
+  <data name="DataFileInstrumentInfo_IonMobilityFromCCS_no_conversion" xml:space="preserve">
+    <value>Vendor-supplied library is unable to determine ion mobility for {0} with CCS={1:0.###}, mz={2:0.####}, and charge={3}.</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Results/Spectra/SpectraResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Results/Spectra/SpectraResources.ja.resx
@@ -134,13 +134,13 @@
       x + y = 7 AND x * y &lt; 20</comment>
   </data>
   <data name="SpectrumClassFilter_Ms1FilterPage_Criteria_which_MS1_spectra_must_satisfy_to_be_included_in_extracted_chromatogram" xml:space="preserve">
-    <value>MS1スペクトルを抽出されたクロマトグラムに含むために満たさなければならない基準</value>
+    <value>MS1スペクトルが抽出クロマトグラムに含まれるために満たさなければならない基準</value>
   </data>
   <data name="SpectrumClassFilter_Ms1FilterPage_MS1" xml:space="preserve">
     <value>MS1</value>
   </data>
   <data name="SpectrumClassFilter_Ms2FilterPage_Criteria_which_spectra_with_MS_level_2_or_higher_must_satisfy_to_be_included_in_extracted_chromatogram" xml:space="preserve">
-    <value>MSレベル2以上のスペクトルを抽出されたクロマトグラムに含むために満たさなければならない基準</value>
+    <value>MSレベル2以上のスペクトルが抽出クロマトグラムに含まれるために満たさなければならない基準</value>
   </data>
   <data name="SpectrumClassFilter_Ms2FilterPage_MS2_" xml:space="preserve">
     <value>MS2+</value>

--- a/pwiz_tools/Skyline/Model/Results/Spectra/SpectraResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Results/Spectra/SpectraResources.zh-CHS.resx
@@ -134,13 +134,13 @@
       x + y = 7 AND x * y &lt; 20</comment>
   </data>
   <data name="SpectrumClassFilter_Ms1FilterPage_Criteria_which_MS1_spectra_must_satisfy_to_be_included_in_extracted_chromatogram" xml:space="preserve">
-    <value>MS1 谱图必须满足才能包含在提取的色谱图中的条件</value>
+    <value>MS1 谱图能够被包含在提取的色谱图中的必要条件</value>
   </data>
   <data name="SpectrumClassFilter_Ms1FilterPage_MS1" xml:space="preserve">
     <value>MS1</value>
   </data>
   <data name="SpectrumClassFilter_Ms2FilterPage_Criteria_which_spectra_with_MS_level_2_or_higher_must_satisfy_to_be_included_in_extracted_chromatogram" xml:space="preserve">
-    <value>MS 级别为 2 或以上的谱图必须满足才能包含在所提取的色谱图中的条件</value>
+    <value>MS 级别为 2 或以上的谱图能够被包含在所提取的色谱图中的必要条件</value>
   </data>
   <data name="SpectrumClassFilter_Ms2FilterPage_MS2_" xml:space="preserve">
     <value>MS2+</value>

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimesResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimesResources.ja.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema
+
+    Version 1.3
+
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">1.3</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1">this is my long string</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+      [base64 mime encoded serialized .NET Framework object]
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+      [base64 mime encoded string representing a byte array form of the .NET Framework object]
+    </data>
+
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+      : System.Serialization.Formatters.Binary.BinaryFormatter
+      : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+      : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+      : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+      : using a System.ComponentModel.TypeConverter
+      : and then encoded with base64 encoding.
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DocumentRetentionTimes_RecalculateAlignments_Aligning_retention_times" xml:space="preserve">
+    <value>Aligning retention times</value>
+  </data>
+</root>

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimesResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimesResources.zh-CHS.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema
+
+    Version 1.3
+
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">1.3</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1">this is my long string</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+      [base64 mime encoded serialized .NET Framework object]
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+      [base64 mime encoded string representing a byte array form of the .NET Framework object]
+    </data>
+
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+      : System.Serialization.Formatters.Binary.BinaryFormatter
+      : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+      : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+      : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+      : using a System.ComponentModel.TypeConverter
+      : and then encoded with base64 encoding.
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DocumentRetentionTimes_RecalculateAlignments_Aligning_retention_times" xml:space="preserve">
+    <value>Aligning retention times</value>
+  </data>
+</root>

--- a/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.ja.resx
+++ b/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.ja.resx
@@ -121,8 +121,14 @@
   <data name="Description_Charge" xml:space="preserve">
     <value>選択されたイオンのプリカーサー電荷</value>
   </data>
+  <data name="Description_Adduct" xml:space="preserve">
+    <value>Adduct of the selected ion</value>
+  </data>
   <data name="Description_FileName" xml:space="preserve">
     <value>ファイル名およびスペクトルの元データとなるファイルへのフルパス</value>
+  </data>
+  <data name="Description_Formula" xml:space="preserve">
+    <value>Neutral chemical formula of the selected ion</value>
   </data>
   <data name="Description_IdFileName" xml:space="preserve">
     <value>ファイル名およびターゲットイオンがスペクトルに一致したファイルへのフルパス</value>
@@ -151,11 +157,17 @@
   <data name="Description_SpectrumCount" xml:space="preserve">
     <value>ライブラリ内にあるこのペプチドに対して測定されたスペクトルの数</value>
   </data>
+  <data name="Adduct" xml:space="preserve">
+    <value>Adduct</value>
+  </data>
   <data name="FileName" xml:space="preserve">
     <value>ファイル名</value>
   </data>
   <data name="FilePath" xml:space="preserve">
     <value>ファイルパス</value>
+  </data>
+  <data name="Formula" xml:space="preserve">
+    <value>Formula</value>
   </data>
   <data name="IdFileName" xml:space="preserve">
     <value>IDファイル名</value>

--- a/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.zh-CHS.resx
@@ -121,8 +121,14 @@
   <data name="Description_Charge" xml:space="preserve">
     <value>所选离子的母离子电荷</value>
   </data>
+  <data name="Description_Adduct" xml:space="preserve">
+    <value>Adduct of the selected ion</value>
+  </data>
   <data name="Description_FileName" xml:space="preserve">
     <value>作为谱图源的文件的文件名和可能的完整路径</value>
+  </data>
+  <data name="Description_Formula" xml:space="preserve">
+    <value>Neutral chemical formula of the selected ion</value>
   </data>
   <data name="Description_IdFileName" xml:space="preserve">
     <value>目标离子与谱图相匹配的文件的文件名以及可能的完整路径</value>
@@ -151,11 +157,17 @@
   <data name="Description_SpectrumCount" xml:space="preserve">
     <value>谱图库中该肽段的测量谱图数量</value>
   </data>
+  <data name="Adduct" xml:space="preserve">
+    <value>Adduct</value>
+  </data>
   <data name="FileName" xml:space="preserve">
     <value>文件名</value>
   </data>
   <data name="FilePath" xml:space="preserve">
     <value>文件路径</value>
+  </data>
+  <data name="Formula" xml:space="preserve">
+    <value>Formula</value>
   </data>
   <data name="IdFileName" xml:space="preserve">
     <value>Id 文件名</value>

--- a/pwiz_tools/Skyline/Model/Tools/ToolsResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Tools/ToolsResources.ja.resx
@@ -155,7 +155,7 @@
     <value>エラー： {0}.zipが欠損しているファイルがあります</value>
   </data>
   <data name="ToolInstaller_UnpackZipTool_The_selected_zip_file_did_not_specify_any_items_to_add_to_the_Tools_menu_" xml:space="preserve">
-    <value>選択されたzipファイルはToolsメニューに追加するアイテムを指定しませんでした。</value>
+    <value>選択されたzipファイルはツールメニューに追加するアイテムを指定しませんでした。</value>
   </data>
   <data name="ToolInstaller_UnpackZipTool_The_selected_zip_file_is_not_an_installable_tool_" xml:space="preserve">
     <value>選択したzipファイルはインストール可能なツールではありません。</value>

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -118,1877 +118,57 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="AbstractModificationMatcherFoundMatches__0__equals__1__" xml:space="preserve">
-    <value>{0} = {1}</value>
-  </data>
-  <data name="AbstractSpectrumGraphItem_AddAnnotations_" xml:space="preserve">
-    <value>スコア = {0:F06}</value>
-  </data>
-  <data name="AbstractSpectrumGraphItem_GetLabel_rank__0__" xml:space="preserve">
-    <value>ランク{0}</value>
-  </data>
-  <data name="add_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\add-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="AddIrtCalculatorDlg_OkDialog_Please_choose_the_iRT_calculator_you_would_like_to_add" xml:space="preserve">
-    <value>追加するiRTカルキュレータを選択してください。</value>
-  </data>
-  <data name="AddIrtCalculatorDlg_OkDialog_Please_specify_a_path_to_an_existing_iRT_database" xml:space="preserve">
-    <value>既存のiRTデータベースのパスを指定してください。</value>
-  </data>
-  <data name="AddIrtCalculatorDlg_OkDialog_The_file__0__is_not_an_iRT_database" xml:space="preserve">
-    <value>ファイル{0}はiRTデータベースではありません。</value>
-  </data>
-  <data name="AddIrtCalculatorDlgOkDialogThe_file__0__does_not_exist" xml:space="preserve">
-    <value>ファイル{0}は存在しません。</value>
-  </data>
-  <data name="AddIrtPeptidesDlg_AddIrtPeptidesDlg_Success" xml:space="preserve">
-    <value>成功</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_Comparison_name_cannot_be_empty_" xml:space="preserve">
-    <value>比較名は空にできません。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_Error_applying_imported_peak_boundaries___0_" xml:space="preserve">
-    <value>インポートされたピーク境界の適用エラー：{0}</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_File_path_cannot_be_empty_" xml:space="preserve">
-    <value>ファイルパスは空にできません。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_File_path_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
-    <value>ファイルパスには有効なファイルに対するパスが含まれていなければなりません。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_Model_must_be_trained_before_it_can_be_used_for_peak_boundary_comparison_" xml:space="preserve">
-    <value>ピーク境界比較に使用する前にモデルがトレーニングされている必要があります。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_The_current_file_or_model_has_no_q_values_or_scores_to_analyze___Either_q_values_or_scores_are_necessary_to_compare_peak_picking_tools_" xml:space="preserve">
-    <value>現在のファイルまたはモデルには分析するためのq値かスコアがありません。 ピーク選択ツールを比較するためにq値またはスコアのどちらかが必要です。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_The_imported_file_does_not_contain_any_peak_boundaries_for__0__transition_group___file_pairs___These_chromatograms_will_be_treated_as_if_no_boundary_was_selected_" xml:space="preserve">
-    <value>インポートされたファイルには{0}トランジショングループ/ファイルペアに対するピーク境界が含まれていません。 境界が選択されていない場合、これらのクロマトグラムが処理されます。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_The_selected_file_or_model_does_not_assign_peak_boundaries_to_any_chromatograms_in_the_document___Please_select_a_different_model_or_file_" xml:space="preserve">
-    <value>選択ファイルまたはモデルはドキュメント内のクロマトグラムに対するピーク境界を割り当てていません。 別のモデルまたはファイルを選択してください。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_The_selected_model_is_already_included_in_the_list_of_comparisons__Please_choose_another_model_" xml:space="preserve">
-    <value>選択モデルは既に比較リストに含まれています。別のモデルを選択してください。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_There_is_already_an_imported_file_with_the_current_name___Please_choose_another_name" xml:space="preserve">
-    <value>現在の名前を持つインポートされたファイルが既にあります。 別の名前を選択してください</value>
-  </data>
-  <data name="Adduct_ApplyToMolecule_Adduct___0___calls_for_removing_more__1__atoms_than_are_found_in_the_molecule__2_" xml:space="preserve">
-    <value>付加物「{0}」によって、分子{2}で見つかったものよりも多くの{1}の原子を削除する必要があります。</value>
-  </data>
-  <data name="AddZipToolHelper_FindProgramPath_A_tool_requires_Program__0__Version__1__and_it_is_not_specified_with_the___tool_program_macro_and___tool_program_path_commands__Tool_Installation_Canceled_" xml:space="preserve">
-    <value>ツールにはプログラムが必要です：{0} バージョン：{1}、--tool-program-macro、--tool-program-pathコマンドを使用して指定されていません。ツールのインストールがキャンセルされました。</value>
-  </data>
-  <data name="AddZipToolHelper_InstallProgram_Error__Package_installation_not_handled_in_SkylineRunner___If_you_have_already_handled_package_installation_use_the___tool_ignore_required_packages_flag" xml:space="preserve">
-    <value>エラー： SkylineRunner内で処理されないパッケージインストール。 既にパッケージインストールが処理されている場合、--tool-ignore-required-packagesフラグを使用します</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwrite__in_the_file__0_" xml:space="preserve">
-    <value> なおかつ競合するツールがあります{0}</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwrite_Error__There_is_a_conflicting_tool" xml:space="preserve">
-    <value>エラー： 競合するツールがあります。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwrite_Overwriting_tool___0_" xml:space="preserve">
-    <value>上書きツール：{0}</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwrite_Please_specify__overwrite__or__parallel__with_the___tool_zip_conflict_resolution_command_" xml:space="preserve">
-    <value>--tool-zip-conflict-resolutionコマンドとともに「上書き」または「並列」を指定してください。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_annotations_with_conflicting_names__Please_use_the___tool_zip_overwrite_annotations_command_" xml:space="preserve">
-    <value>競合名のある注釈があります。--tool-zip-overwrite-annotationsコマンドを使用してください。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_conflicting_annotations__Keeping_existing_" xml:space="preserve">
-    <value>競合する注釈があります。既存の保持中。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_conflicting_annotations__Overwriting_" xml:space="preserve">
-    <value>競合する注釈があります。上書き中。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_Warning__the_annotation__0__is_being_overwritten" xml:space="preserve">
-    <value>警告：注釈{0}は上書きされています</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_Warning__the_annotation__0__may_not_be_what_your_tool_requires_" xml:space="preserve">
-    <value>警告：注釈{0}は、ツールに必要な注釈でない可能性があります。</value>
-  </data>
-  <data name="AlertDlg_GetDefaultButtonText__Abort" xml:space="preserve">
-    <value>中断(&amp;A)</value>
-  </data>
-  <data name="AlertDlg_GetDefaultButtonText__Ignore" xml:space="preserve">
-    <value>無視(&amp;I)</value>
-  </data>
-  <data name="AlertDlg_GetDefaultButtonText_Cancel" xml:space="preserve">
-    <value>キャンセル</value>
-  </data>
-  <data name="AlertDlg_GetDefaultButtonText_OK" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="AlertDlg_TruncateMessage_Message_truncated__Press_Ctrl_C_to_copy_entire_message_to_the_clipboard_" xml:space="preserve">
-    <value>メッセージが途切れています。Ctrl+Cを押してメッセージ全体をクリップボードにコピーしてください。</value>
-  </data>
-  <data name="AlignmentForm_UpdateGraph_Outliers" xml:space="preserve">
-    <value>異常値</value>
-  </data>
-  <data name="AlignmentForm_UpdateGraph_Peptides_Refined" xml:space="preserve">
-    <value>ペプチドの精製</value>
-  </data>
-  <data name="AlignmentForm_UpdateGraph_Time_from__0__" xml:space="preserve">
-    <value>{0}からの時間</value>
-  </data>
-  <data name="AllChromatogramsGraph_btnCancelFile_Click_Cancel_file" xml:space="preserve">
-    <value>ファイルをキャンセル</value>
-  </data>
-  <data name="AllChromatogramsGraph_UpdateStatus__0__of__1__files" xml:space="preserve">
-    <value>ファイル{1}個中{0}個</value>
-  </data>
-  <data name="AllChromatogramsGraph_UpdateStatus_Joining_chromatograms___" xml:space="preserve">
-    <value>クロマトグラムの結合中...</value>
-  </data>
-  <data name="AllIonsStatusButton" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\AllIonsStatusButton.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="AnnotatedSpectum" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\AnnotatedSpectum.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="AnnotationDef_AnnotationTarget_Peptides" xml:space="preserve">
-    <value>ペプチド</value>
-  </data>
-  <data name="AnnotationDef_AnnotationTarget_Precursors" xml:space="preserve">
-    <value>プリカーサー</value>
-  </data>
-  <data name="AnnotationDef_AnnotationTarget_Proteins" xml:space="preserve">
-    <value>タンパク質</value>
-  </data>
-  <data name="AnnotationDef_AnnotationTarget_Transitions" xml:space="preserve">
-    <value>トランジション</value>
-  </data>
-  <data name="AnnotationHelper_GetReplicateIndicices_False" xml:space="preserve">
-    <value>False</value>
-  </data>
-  <data name="AnnotationHelper_GetReplicateIndicices_True" xml:space="preserve">
-    <value>True</value>
-  </data>
-  <data name="AreaChartPropertyDlg_ValidateDotpDecimal__0__must_contain_a_decimal_value" xml:space="preserve">
-    <value>{0}には十進数が含まれなければなりません。</value>
-  </data>
-  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_CV_cutoff_entered" xml:space="preserve">
-    <value>入力されたCVカットオフが無効です</value>
-  </data>
-  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_maximum_CV_entered" xml:space="preserve">
-    <value>入力された最大CVが無効です</value>
-  </data>
-  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_maximum_frequency_entered" xml:space="preserve">
-    <value>入力された最大頻度が無効です</value>
-  </data>
-  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_maximum_log_10_area_entered" xml:space="preserve">
-    <value>入力された最大Log10面積は無効です</value>
-  </data>
-  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_minimum_log_10_area_entered" xml:space="preserve">
-    <value>入力された最小Log10面積は無効です</value>
-  </data>
-  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_Q_value_entered" xml:space="preserve">
-    <value>入力されたQ値が無効です</value>
-  </data>
-  <data name="AreaReplicateGraphPane_InitFromData_Expected" xml:space="preserve">
-    <value>期待値</value>
-    <comment>expected value</comment>
-  </data>
-  <data name="AreaReplicateGraphPane_UpdateGraph_Peak_Area" xml:space="preserve">
-    <value>ピーク面積</value>
-  </data>
-  <data name="AreaReplicateGraphPane_UpdateGraph_Peak_Area_Ratio_To__0_" xml:space="preserve">
-    <value>{0}に対するピーク面積比</value>
-  </data>
-  <data name="AssociateProteinsDlg_ApplyChanges_Associated_proteins" xml:space="preserve">
-    <value>関連付けられたタンパク質</value>
-  </data>
-  <data name="AssociateProteinsDlg_UseBackgroundProteome_No_background_proteome_defined" xml:space="preserve">
-    <value>バックグラウンドプロテオームは定義されていません。詳細は[ペプチド設定]の[消化]タブを参照してください。</value>
-    <comment>If background proteome is set to "None" and user attempts to "Use background proteome" when associating proteins</comment>
-  </data>
-  <data name="AssociateProteinsDlg_UseFastaFile_An_error_occurred_during_protein_association_" xml:space="preserve">
-    <value>タンパク質の関連付け中にエラーが発生しました。</value>
-  </data>
-  <data name="AssociateProteinsDlg_UseFastaFile_There_was_an_error_reading_from_the_file_" xml:space="preserve">
-    <value>ファイルから読み込み中にエラーが発生しました。</value>
-  </data>
-  <data name="AsyncChromatogramsGraph_Render__0___sample__1_" xml:space="preserve">
-    <value>{0}、試料{1}</value>
-  </data>
-  <data name="BiblioSpecLiteBuilder_AmbiguousMatches_The_library_built_successfully__Spectra_matching_the_following_peptides_had_multiple_ambiguous_peptide_matches_and_were_excluded_" xml:space="preserve">
-    <value>ライブラリが正常に構築されました。 以下のペプチドに一致するスペクトルにペプチドのあいまい一致が複数あり、これらのスペクトルは除外されました：</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_CreateCache_No_spectra_were_found_in_the_library__0__" xml:space="preserve">
-    <value>ライブラリ{0}でスペクトルが見つかりませんでした</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_Load_Failed_loading_library__0__" xml:space="preserve">
-    <value>ライブラリ「{0}」の読み込みに失敗しました。</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_Load_Invalid_precursor_charge__0__found__File_may_be_corrupted" xml:space="preserve">
-    <value>無効なプリカーサー電荷{0}が見つかりました。ファイルが破損している可能性があります。</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_ReadRedundantSpectrum_Spectrum_peaks__0__excede_the_maximum_allowed__1__" xml:space="preserve">
-    <value>スペクトルピーク{0}が最大許容値{1}を超えています。</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_ReadSpectrum_Unexpected_SQLite_failure_reading__0__" xml:space="preserve">
-    <value>{0}読み込み中の予期せぬSQLiteの不具合。</value>
-  </data>
-  <data name="BioMassCalc_ApplyAdductToFormula_Failed_parsing_adduct_description___0__" xml:space="preserve">
-    <value>付加物の説明「{0}」の解析に失敗しました</value>
-  </data>
-  <data name="BioMassCalc_ApplyAdductToFormula_Unknown_symbol___0___in_adduct_description___1__" xml:space="preserve">
-    <value>付加物の説明「{1}」にある記号「{0}」は未知です</value>
-  </data>
-  <data name="BioMassCalc_CalculateMass_The_expression__0__is_not_a_valid_chemical_formula" xml:space="preserve">
-    <value>式「{0}」は有効な化学式ではありません。</value>
-  </data>
-  <data name="BioMassCalc_SynchMasses_Fixing_isotope_abundance_masses_requires_a_monoisotopic_mass_calculator" xml:space="preserve">
-    <value>同位体存在質量の確定には、モノアイソトピック質量カルキュレータが必要です</value>
-  </data>
-  <data name="Blank" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\blank.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="BlibDb_CreateLibraryFromSpectra_Creating_spectral_library_for_imported_transition_list" xml:space="preserve">
-    <value>インポート済みトランジションリストのスペクトルライブラリを作成中</value>
-  </data>
-  <data name="BookmarkEnumerator_Current_No_such_chrominfo__0__" xml:space="preserve">
-    <value>以下のchrominfoがありません：{0}</value>
-  </data>
-  <data name="BookmarkEnumerator_Current_No_such_node__0__" xml:space="preserve">
-    <value>以下のノードがありません：{0}</value>
-  </data>
-  <data name="BrukerTimsTofMethodExporter_ExportMethod_Error_copying_template_file_" xml:space="preserve">
-    <value>テンプレートファイルをコピーできませんでした。</value>
-  </data>
-  <data name="BuildBackgroundProteomeDlg_AddFastaFile_The_added_file_included__0__repeated_protein_sequences__Their_names_were_added_as_aliases_to_ensure_the_protein_list_contains_only_one_copy_of_each_sequence_" xml:space="preserve">
-    <value>追加されたファイルには、{0}個の反復タンパク質シークエンスが含まれていました。タンパク質リストに各シークエンスのコピーが1つしか含まれないようにするために、これらの名前はエイリアスとして追加されました。</value>
-  </data>
-  <data name="BuildBackgroundProteomeDlg_RefreshStatus_Click_the_Add_File_button_to_add_a_FASTA_file_and_create_a_new_proteome_file" xml:space="preserve">
-    <value>「ファイルを追加」ボタンをクリックしてFASTAファイルを追加し、新しいプロテオームファイルを作成します。</value>
-  </data>
-  <data name="BuildBackgroundProteomeDlg_RefreshStatus_The_proteome_has_already_been_digested" xml:space="preserve">
-    <value>プロテオームはすでに消化されています。</value>
-  </data>
-  <data name="BuildLibraryDlg_btnPrevious_Click__Next__" xml:space="preserve">
-    <value>次へ(&amp;N) &gt;</value>
-  </data>
-  <data name="BuildLibraryDlg_OkWizardPage_Finish" xml:space="preserve">
-    <value>完了</value>
-  </data>
-  <data name="BuildLibraryDlg_ValidateBuilder_The_lab_authority_name__0__is_not_valid_This_should_look_like_an_internet_server_address_e_g_mylab_myu_edu_and_be_unlikely_to_be_used_by_any_other_lab_but_need_not_refer_to_an_actual_server" xml:space="preserve">
-    <value>研究室管轄者名{0}が有効ではありません。これはインターネットサーバーアドレス（mylab.myu.eduなど）のようなもので、他の研究室で使用される可能性は低いものの、実際のサーバーアドレスである必要はありません。</value>
-  </data>
-  <data name="BuildLibraryDlg_ValidateBuilder_The_library_identifier__0__is_not_valid_Identifiers_start_with_a_letter_number_or_underscore_and_contain_only_letters_numbers_underscores_and_dashes" xml:space="preserve">
-    <value>ライブラリ識別子{0}が有効ではありません。識別子は英数字またはアンダースコアから始まり、英数字、アンダースコア、ダッシュのみを含みます。</value>
-    <comment>Letters restricted to English alphabet</comment>
-  </data>
-  <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_An_error_occurred_while_processing_retention_times_" xml:space="preserve">
-    <value>保持時間の処理中にエラーが発生しました。</value>
-  </data>
-  <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_Processing_Retention_Times" xml:space="preserve">
-    <value>保持時間を処理しています</value>
-  </data>
-  <data name="CachedLibrary_WarnInvalidEntries_" xml:space="preserve">
-    <value>ライブラリ「{0}」に無効なエントリが見つかりました。
-{2}個のペプチドまたは分子のうち、{3}を含む{1}個が無効でした。 </value>
-  </data>
-  <data name="CalculateIsolationSchemeDlg_OkDialog_Start_value_must_be_less_than_End_value" xml:space="preserve">
-    <value>開始値は終値より小さい値でなければなりません。</value>
-  </data>
-  <data name="CalculateIsolationSchemeDlg_OkDialog_Window_width_must_be_less_than_or_equal_to_the_isolation_range" xml:space="preserve">
-    <value>ウィンドウ幅は単離範囲以下でなければなりません。</value>
-  </data>
-  <data name="CalculateIsolationSchemeDlg_OkDialog_Window_width_not_even" xml:space="preserve">
-    <value>奇数の番号が付いたウィンドウの幅は、最適化されたウィンドウの配置が選択された際、重複した逆多重化ではサポートされません。</value>
-  </data>
-  <data name="Calculator" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Calculator.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="CalibrateIrtDlg_TryGetLine_The_standard_must_have_two_fixed_points" xml:space="preserve">
-    <value>標準は2つの固定点を持つ必要があります。</value>
-  </data>
-  <data name="CalibrationCurveFitter_GetCalibrationCurve_Unable_to_calculate_the_calibration_curve_for_the_because_there_are_different_Precursor_Concentrations_specified_for_the_label__0__" xml:space="preserve">
-    <value>標識{0}に異なるプリカーサー濃度が指定されているため、校正曲線を計算できません。</value>
-  </data>
-  <data name="CalibrationGridViewDriver_CiRT_option_name" xml:space="preserve">
-    <value>CiRT（検出）</value>
-  </data>
-  <data name="ChooseAnnotationsDlg_OkDialog_Change_Annotation_Settings" xml:space="preserve">
-    <value>注釈設定を変更</value>
-  </data>
-  <data name="ChooseSchedulingReplicatesDlg_btnOk_Click_Choose_retention_time_filter_replicates" xml:space="preserve">
-    <value>保持時間フィルタ繰り返し測定を選択</value>
-  </data>
-  <data name="ChromatogramCache_LoadStructs_Please_check_for_a_newer_release_" xml:space="preserve">
-    <value>さらに新しいリリースを確認してください。</value>
-  </data>
-  <data name="ChromatogramCache_LoadStructs_The_SKYD_file_format__0__is_not_supported_by_Skyline__1__" xml:space="preserve">
-    <value>SKYDファイル形式{0}はSkyline{1}ではサポートされていません。</value>
-  </data>
-  <data name="ChromatogramCache_WriteStructs_Failure_writing_cache___Specified__0__peaks_exceed_total_peak_count__1_" xml:space="preserve">
-    <value>キャッシュの書き込み失敗。指定した{0}個のピークがピーク総数{1}を超えています</value>
-  </data>
-  <data name="ChromatogramDataProvider_GetChromatogram_This_import_appears_to_be_taking_longer_than_expected__If_importing_from_a_network_drive__consider_canceling_this_import__copying_to_local_disk_and_retrying_" xml:space="preserve">
-    <value>このインポートは予測より長くかかっています。ネットワークドライブからインポート中である場合、このインポートをキャンセルしてローカルディスクをコピーし再試行することを検討してください。</value>
-  </data>
-  <data name="ChromatogramExporter_Export_Corrupted_chromatogram_data_at_charge__0__state_of_peptide__1_" xml:space="preserve">
-    <value>ペプチド{1}の荷電{0}状態での破損したクロマトグラムデータ</value>
-  </data>
-  <data name="ChromatogramLibrary_LoadLibraryFromDatabase_Reading_precursors_from__0_" xml:space="preserve">
-    <value>{0}からプリカーサーを読み取り中</value>
-  </data>
-  <data name="ChromCacheBuilder_BuildCache_This_document_contains_only_negative_ion_mode_transitions__and_the_imported_file_contains_only_positive_ion_mode_data_so_nothing_can_be_loaded_" xml:space="preserve">
-    <value>このドキュメントには陰イオンモードのトランジションのみが含まれ、インポート済みのファイルには陽イオンモードのデータのみが含まれているので、他のものが読み込めないようになっています。</value>
-  </data>
-  <data name="ChromCacheBuilder_BuildCache_This_document_contains_only_positive_ion_mode_transitions__and_the_imported_file_contains_only_negative_ion_mode_data_so_nothing_can_be_loaded___Negative_ion_mode_transitions_need_to_have_negative_charge_values_" xml:space="preserve">
-    <value>このドキュメントには陽イオンモードのトランジションのみが含まれ、インポート済みのファイルには陰イオンモードのデータのみが含まれているので、他のものが読み込めないようになっています。  陰イオンモードのトランジションには、負電荷の値が必要です。</value>
-  </data>
-  <data name="ChromCacheBuilder_BuildNextFileInner_The_file__0__does_not_exist" xml:space="preserve">
-    <value>ファイル{0}は存在しません。</value>
-  </data>
-  <data name="ChromCacheBuilder_WriteLoop_Existing_write_threads___0_" xml:space="preserve">
-    <value>既存の書き込みスレッド：{0}</value>
-  </data>
-  <data name="ChromCacheJoiner_FinishRead_Unexpected_end_of_file_in__0__" xml:space="preserve">
-    <value>{0}での予期しないファイルの終了。</value>
-  </data>
-  <data name="ChromLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Close" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Close.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Collapse" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\minus.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_DoRowValidating_The_sequence__0__is_already_present_in_the_list_" xml:space="preserve">
-    <value>シークエンス{0}が既にリストに存在しています。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow__0__is_not_a_valid_charge__Precursor_charges_must_be_integers_with_absolute_value_between_1_and__1__" xml:space="preserve">
-    <value>{0}は有効な電荷ではありません。プリカーサー電荷は1から{1}の絶対値を持つ整数である必要があります。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Cannot_read_high_energy_ion_mobility_offset_value___0___on_line__1__" xml:space="preserve">
-    <value>{1}行目の高エネルギーイオン移動度オフセット値「{0}」が読み取れません。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Could_not_parse_adduct_description___0___on_line__1_" xml:space="preserve">
-    <value>{1}行目の付加物の説明「{0}」を解析できませんでした</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_adduct_description_on_line__0_" xml:space="preserve">
-    <value>{0}行目に付加物の説明がありません</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_collisional_cross_section_value_on_line__0__" xml:space="preserve">
-    <value>{0}行目の欠損している衝突断面積。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_ion_mobility_value_on_line__0__" xml:space="preserve">
-    <value>{0}行目にイオン移動度値がありません。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_peptide_sequence_on_line__0__" xml:space="preserve">
-    <value>{0}行目の欠損しているペプチドシークエンス。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_The_pasted_text_must_at_a_minimum_contain_columns_for_peptide_and_adduct__along_with_collisional_cross_section_and_or_ion_mobility_" xml:space="preserve">
-    <value>貼り付けられるテキストには、最低でもペプチドと付加物の他、衝突断面積やイオン移動度の列が含まれている必要があります。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_The_text__0__is_not_a_valid_peptide_sequence_on_line__1__" xml:space="preserve">
-    <value>{1}行目のテキスト{0}は有効なペプチドシークエンスではありません。</value>
-  </data>
-  <data name="ColorSchemeList_GetDefaults_Distinct" xml:space="preserve">
-    <value>クリア</value>
-  </data>
-  <data name="Columns_Columns_Duplicate_column___0__" xml:space="preserve">
-    <value>列「{0}」が重複しています</value>
-  </data>
-  <data name="Columns_Columns_Unrecognized_column___0__" xml:space="preserve">
-    <value>列「{0}」が認識できません</value>
-  </data>
-  <data name="ColumnSet_GetColumnInfos_Unable_to_find_table_for__0_" xml:space="preserve">
-    <value>{0}の表が見つかりません</value>
-  </data>
-  <data name="ColumnSet_GetColumnInfos_Unexpected_report_type" xml:space="preserve">
-    <value>予期しないレポートタイプ</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Peptide" xml:space="preserve">
-    <value>ペプチド</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Peptides" xml:space="preserve">
-    <value>ペプチド</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Precursor" xml:space="preserve">
-    <value>プリカーサー</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Precursors" xml:space="preserve">
-    <value>プリカーサー</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Protein" xml:space="preserve">
-    <value>タンパク質</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Transition" xml:space="preserve">
-    <value>トランジション</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Transitions" xml:space="preserve">
-    <value>トランジション</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
-    <value>エラー：ドキュメントをPanoramaにアップロードするため必要な以下の引数に値を指定してください：
-{0}</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
-    <value>エラー：ドキュメントをPanormaにアップロードするため必要な以下の引数に値を指定してください：
-{0}</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Defaulting_to_none_" xml:space="preserve">
-    <value>なしにデフォルト中。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Defaulting_to_standard_" xml:space="preserve">
-    <value>標準にデフォルト中。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Error____0___is_not_a_valid_value_for__1___It_must_be_one_of_the_following___2_" xml:space="preserve">
-    <value>エラー：「{0}」は{1}の有効な値ではありません。次のいずれかでなければなりません：{2}</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Error__Attempting_to_exclude_an_unknown_feature_name___0____Try_one_of_the_following_" xml:space="preserve">
-    <value>エラー：不明なフィーチャー名「{0}」を除外しようとしています。次のいずれかを試してみてください。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Error__Regular_expression___0___does_not_have_any_groups___String" xml:space="preserve">
-    <value>エラー： 正規表現「{0}」にはグループがありません。 1つのグループが必要です。ファイルの一部、または正規表現内の最初のグループに一致するサブディレクトリ名が繰り返し測定名として使用されます。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Error__Use___in_to_specify_a_Skyline_document_to_open_" xml:space="preserve">
-    <value>エラー： 開くSkylineドキュメントを指定するために--inを使用します。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_It_must_be_a_number__Defaulting_to__0__" xml:space="preserve">
-    <value>数値でなければなりません。{0}にデフォルト中。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Warning__Invalid_max_transitions_per_injection_parameter___0___" xml:space="preserve">
-    <value>警告： インジェクションパラメータ毎の無効な最大トランジション ({0})。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Warning__Invalid_optimization_parameter___0____Use__ce____dp___or__none__" xml:space="preserve">
-    <value>警告： 無効な最適化パラメータ ({0})。「ce」、「dp」、「なし」を使用。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Warning__The_export_strategy__0__is_not_valid__It_must_be_one_of_the_following___string" xml:space="preserve">
-    <value>警告： エクスポート方法{0}が有効ではありません。以下の中の1つでなければなりません：「単一」、「タンパク質」、「バケット」。単一にデフォルト中。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Warning__The_method_type__0__is_invalid__It_must_be_one_of_the_following___standard____scheduled__or__triggered__" xml:space="preserve">
-    <value>警告： メソッドタイプ{0}が無効です。以下の中の1つでなければなりません：「標準」、「スケジュール」、「トリガー」。</value>
-  </data>
-  <data name="CommandArgs_ParseRegexArgument_Error__Regular_expression___0___for__1__cannot_be_parsed_" xml:space="preserve">
-    <value>エラー：{1}の正規表現「{0}」が解析できません。</value>
-  </data>
-  <data name="CommandArgs_WarnArgRequirment_Warning__Use_of_the_argument__0__requires_the_argument__1_" xml:space="preserve">
-    <value>警告：引数{0}を使用するには引数{1}が必要です</value>
-  </data>
-  <data name="CommandLine_AddDecoys_Added__0__decoy_peptides_using___1___method" xml:space="preserve">
-    <value>「{1}」メソッドを使用して{0}個のデコイペプチドを追加しました</value>
-  </data>
-  <data name="CommandLine_AddDecoys_Decoys_discarded" xml:space="preserve">
-    <value>デコイが破棄されました</value>
-  </data>
-  <data name="CommandLine_AddDecoys_Error__Attempting_to_add_decoys_to_document_with_decoys_" xml:space="preserve">
-    <value>エラー：デコイを有するドキュメントにデコイを追加しようとしています。</value>
-  </data>
-  <data name="CommandLine_AddDecoys_Error_The_number_of_peptides" xml:space="preserve">
-    <value>エラー：ペプチド{0}の数は、デコイ{1}のペプチドプリカーサーモデルの数より少なくなければなりません。でなければ、{2}={3}のデコイ生成法を使用してください。</value>
-  </data>
-  <data name="CommandLine_ApplyFileAndSampleNameRegex_Error__No_files_match_the_file_name_pattern___0___" xml:space="preserve">
-    <value>エラー：ファイル名パターン「{0}」に一致するファイルがありません。</value>
-  </data>
-  <data name="CommandLine_ApplyFileAndSampleNameRegex_Error__No_files_match_the_sample_name_pattern___0___" xml:space="preserve">
-    <value>エラー：サンプル名パターン「{0}」に一致するファイルがありません。</value>
-  </data>
-  <data name="CommandLine_ApplyFileNameRegex_File_name___0___does_not_match_the_pattern___1____Ignoring__2_" xml:space="preserve">
-    <value>ファイル名「{0}」がパターン「{1}」と一致しません。 {2}を無視します</value>
-  </data>
-  <data name="CommandLine_ApplyNamingPattern_Error__Duplicate_replicate_name___0___after_applying_regular_expression_" xml:space="preserve">
-    <value>エラー： 正規表現の適用後に繰り返し測定名'{0}'が重複しています。</value>
-  </data>
-  <data name="CommandLine_ApplySampleNameRegex_File___0___does_not_have_a_sample__Cannot_apply_sample_name_pattern__Ignoring_" xml:space="preserve">
-    <value>ファイル「{0}」に試料が含まれていません。試料名のパターンを適用できません。無視します。</value>
-  </data>
-  <data name="CommandLine_AssociateProteins_a_FASTA_file_must_be_imported_before_associating_proteins" xml:space="preserve">
-    <value>エラー：タンパク質を関連付けする前に、FASTAファイルをインポートする必要があります</value>
-  </data>
-  <data name="CommandLine_AssociateProteins_Failed_to_associate_proteins" xml:space="preserve">
-    <value>タンパク質の関連付けに失敗しました</value>
-  </data>
-  <data name="CommandLine_CanReadFile_Error__File_does_not_exist___0__" xml:space="preserve">
-    <value>エラー： ファイルが存在していません：{0}。</value>
-  </data>
-  <data name="CommandLine_CheckReplicateFiles_Error__Replicate__0__in_the_document_has_an_unexpected_file__1__" xml:space="preserve">
-    <value>エラー： ドキュメント内の繰り返し測定{0}には予測しないファイル{1}があります。</value>
-  </data>
-  <data name="CommandLine_ConnectLibrarySpecs_Error__Could_not_find_the_spectral_library__0__for_this_document_" xml:space="preserve">
-    <value>エラー： このドキュメントのスペクトルライブラリ{0}が見つかりませんでした。</value>
-  </data>
-  <data name="CommandLine_ConnectLibrarySpecs_Warning__Could_not_find_the_spectral_library__0_" xml:space="preserve">
-    <value>警告： スペクトルライブラリ{0}が見つかりませんでした</value>
-  </data>
-  <data name="CommandLine_CreateIrtDatabase_Error__Importing_an_assay_library_to_a_document_without_an_iRT_calculator_cannot_create__0___because_it_exists_" xml:space="preserve">
-    <value>エラー： iRTカルキュレーターなしでドキュメントをアッセイライブラリにインポートすると、{0}が既に存在するためにこれを作成できません。</value>
-  </data>
-  <data name="CommandLine_CreateIrtDatabase_Use_the__0__argument_to_specify_a_file_to_create_" xml:space="preserve">
-    <value>作成するファイルを指定するために{0}引数を使用します。</value>
-  </data>
-  <data name="CommandLine_CreateScoringModel_Creating_scoring_model__0_" xml:space="preserve">
-    <value>スコアモデル{0}を作成中</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__A_template_file_is_required_to_export_a_method_" xml:space="preserve">
-    <value>エラー： メソッドをエクスポートするにはテンプレートファイルが必要です。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__The_current_document_contains_peptides_without_enough_information_to_rank_transitions_for_triggered_acquisition_" xml:space="preserve">
-    <value>エラー： 現在のドキュメントには、トリガーされた取得のトランジションをランクするのに十分な情報のないペプチドが含まれています。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__the_specified_instrument__0__is_not_compatible_with_scheduled_methods_" xml:space="preserve">
-    <value>エラー：指定された装置{0}にはスケジュールメソッドとの互換性がありません。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__The_template_file__0__does_not_exist_" xml:space="preserve">
-    <value>エラー： テンプレートファイル{0}がありません。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__to_export_a_scheduled_method__you_must_first_choose_a_retention_time_predictor_in_Peptide_Settings___Prediction__or_import_results_for_all_peptides_in_the_document_" xml:space="preserve">
-    <value>エラー：スケジュールメソッドをエクスポートするには、まず [ペプチド設定/予測] で保持時間予測を選択するか、ドキュメント内のすべてのペプチドに対する結果をインポートする必要があります。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__triggered_acquistion_requires_a_spectral_library_or_imported_results_in_order_to_rank_transitions_" xml:space="preserve">
-    <value>エラー：トランジションをランクするために、トリガーされた取得には、スペクトルライブラリまたはインポートされた結果が必要です。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_List__0__exported_successfully_" xml:space="preserve">
-    <value>リスト{0}が正常にエクスポートされました。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Method__0__exported_successfully_" xml:space="preserve">
-    <value>メソッド{0}が正常にエクスポートされました。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_No_list_will_be_exported_" xml:space="preserve">
-    <value>リストはエクスポートされません。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_No_method_will_be_exported_" xml:space="preserve">
-    <value>メソッドはエクスポートされません。</value>
-  </data>
-  <data name="CommandLine_ExportReport_" xml:space="preserve">
-    <value>エラー： レポートを指定した場合、--report-file=path/to/file.csvパラメータを指定しなければなりません。</value>
-  </data>
-  <data name="CommandLine_ExportReport_Error__Failure_attempting_to_save__0__report_to__1__" xml:space="preserve">
-    <value>エラー： {0}レポートの{1}への保存に失敗しました。</value>
-  </data>
-  <data name="CommandLine_ExportReport_Error__The_report__0__could_not_be_saved_to__1____Check_to_make_sure_it_is_not_read_only_" xml:space="preserve">
-    <value>エラー： レポート{0}を{1}に保存できませんでした。 読み取り専用でないことを確認します。</value>
-  </data>
-  <data name="CommandLine_ExportReport_Error__The_report__0__does_not_exist__If_it_has_spaces_in_its_name__use__double_quotes__around_the_entire_list_of_command_parameters_" xml:space="preserve">
-    <value>エラー： レポート{0}が存在していません。名前に空白がある場合、コマンドパラメータのリスト全体に「二重引用符」を使用します。</value>
-  </data>
-  <data name="CommandLine_ExportReport_Exporting_report__0____" xml:space="preserve">
-    <value>レポート{0}のエクスポート中...</value>
-  </data>
-  <data name="CommandLine_ExportReport_Report__0__exported_successfully_" xml:space="preserve">
-    <value>レポート{0}が正常にエクスポートされました。</value>
-  </data>
-  <data name="CommandLine_ImportDataFilesWithAppend_Error__The_replicate__0__already_exists_in_the_given_document_and_the___import_append_option_is_not_specified___The_replicate_will_not_be_added_to_the_document_" xml:space="preserve">
-    <value>エラー：指定のドキュメントには繰り返し測定{0}がすでに存在し、--import-appendオプションが指定されていません。この繰り返し測定はドキュメントに追加されません。</value>
-  </data>
-  <data name="CommandLine_ImportFasta_Importing_FASTA_file__0____" xml:space="preserve">
-    <value>FASTAファイル{0}のインポート中...</value>
-  </data>
-  <data name="CommandLine_ImportResults_Error__No_files_left_to_import_" xml:space="preserve">
-    <value>エラー：インポートするファイルが残っていません。</value>
-  </data>
-  <data name="CommandLine_ImportResultsFile_Error__Failed_importing_the_results_file__0__" xml:space="preserve">
-    <value>エラー： 結果ファイル{0}のインポートに失敗しました。</value>
-  </data>
-  <data name="CommandLine_ImportResultsFile_Results_added_from__0__to_replicate__1__" xml:space="preserve">
-    <value>結果が{0}から繰り返し測定{1}に追加されました。</value>
-  </data>
-  <data name="CommandLine_ImportResultsFile_Warning__Failed_importing_the_results_file__0____Ignoring___" xml:space="preserve">
-    <value>警告： 結果ファイル{0}のインポートに失敗しました。 無視...</value>
-  </data>
-  <data name="CommandLine_ImportSearch_Adding__0__modifications_" xml:space="preserve">
-    <value>{0}修飾を追加中。</value>
-  </data>
-  <data name="CommandLine_ImportSearch_Creating_spectral_library_from_files_" xml:space="preserve">
-    <value>以下のファイルからのスペクトルライブラリを作成中：</value>
-  </data>
-  <data name="CommandLine_ImportSearchInternal_Error___0__must_be_set_when_using_CiRT_peptides_" xml:space="preserve">
-    <value>エラー：CiRTペプチドを使用する際は、{0}を設定する必要があります。</value>
-  </data>
-  <data name="CommandLine_ImportSkyr_Success__Imported_Reports_from__0_" xml:space="preserve">
-    <value>成功しました！ {0}からインポートされたレポート</value>
-  </data>
-  <data name="CommandLine_ImportTool_" xml:space="preserve">
-    <value>エラー： {0}というタイトルのツールが既に存在しています。--tool-conflict-resolution=&amp;lt; overwrite | skip &gt;を使用してください。{0}というタイトルのツールは追加されませんでした。</value>
-  </data>
-  <data name="CommandLine_ImportTool__0__was_added_to_the_Tools_Menu_" xml:space="preserve">
-    <value>{0}がツールメニューに追加されました。</value>
-  </data>
-  <data name="CommandLine_ImportTool_Error__If__0__is_and_argument_the_tool_must_have_a_Report_Title__Use_the___tool_report_parameter_to_specify_a_report_" xml:space="preserve">
-    <value>エラー： {0}があり、かつ引数の場合、ツールにはレポートタイトルが必要です。レポートを指定するには、--tool-reportパラメータを使用します。</value>
-  </data>
-  <data name="CommandLine_ImportTool_Error__Please_import_the_report_format_for__0____Use_the___report_add_parameter_to_add_the_missing_custom_report_" xml:space="preserve">
-    <value>エラー： {0}のレポート形式をインポートしてください。 欠損しているカスタムレポートを追加するには、--report-addパラメータを使用します。</value>
-  </data>
-  <data name="CommandLine_ImportTool_Error__the_provided_command_for_the_tool__0__is_not_of_a_supported_type___Supported_Types_are___1_" xml:space="preserve">
-    <value>エラー：ツール{0}に提供されたコマンドはサポートされているタイプではありません。 サポートされているタイプ：{1}</value>
-  </data>
-  <data name="CommandLine_ImportTool_Error__to_import_a_tool_it_must_have_a_name_and_a_command___Use___tool_add_to_specify_a_name_and_use___tool_command_to_specify_a_command___The_tool_was_not_imported___" xml:space="preserve">
-    <value>エラー：ツールをインポートするには、名前とコマンドがなければなりません。 名前を指定するには--tool-addを使用し、コマンドを指定するには--tool-commandを使用します。 ツールがインポートされませんでした...</value>
-  </data>
-  <data name="CommandLine_ImportTool_The_tool_was_not_imported___" xml:space="preserve">
-    <value>ツールがインポートされませんでした...</value>
-  </data>
-  <data name="CommandLine_ImportTool_Warning__skipping_tool__0__due_to_a_name_conflict_" xml:space="preserve">
-    <value>警告：名前が競合したためツール{0}をスキップ中。</value>
-  </data>
-  <data name="CommandLine_ImportTool_Warning__the_tool__0__was_overwritten" xml:space="preserve">
-    <value>警告：ツール{0}は上書きされました</value>
-  </data>
-  <data name="CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_does_not_exist__Please_verify_the_file_location_and_try_again_" xml:space="preserve">
-    <value>エラー：--tool-add-zipコマンドで指定されたファイルが存在していません。ファイルの場所を確認してからもう一度お試しください。</value>
-  </data>
-  <data name="CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_is_not_a__zip_file__Please_specify_a_valid__zip_file_" xml:space="preserve">
-    <value>エラー：--tool-add-zipコマンドで指定されたファイルは.zipファイルではありません。有効な.zipファイルを指定してください。</value>
-  </data>
-  <data name="CommandLine_ImportToolsFromZip_Installed_tool__0_" xml:space="preserve">
-    <value>ツール{0}がインストールされました</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Adding__0__spectra_to_the_library__1_" xml:space="preserve">
-    <value>{0}個のスペクトルをライブラリ{1}に追加中</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Error___line__0___column__1____2_" xml:space="preserve">
-    <value>エラー：（行{0}、列{1}）{2}</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Error__The_name__0__specified_with__1__was_not_found_in_the_imported_assay_library_" xml:space="preserve">
-    <value>エラー：{1}で指定された名前{0}が、インポート済みのアッセイライブラリに見つかりませんでした。</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Error__There_is_an_existing_library_with_the_same_name__0__as_the_document_library_to_be_created_" xml:space="preserve">
-    <value>エラー：作成しようとするドキュメントライブラリと同じ名前{0}の既存ライブラリがあります。</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Error__To_create_the_iRT_database___0___for_this_assay_library__you_must_specify_the_iRT_standards_using_either_of_the_arguments__1__or__2_" xml:space="preserve">
-    <value>エラー：このアッセイライブラリのiRTデータベース「{0}」を作成するには、引数{1}または{2}のいずれかを用いてiRT標準を指定する必要があります。</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Finishing_up_import" xml:space="preserve">
-    <value>インポートの終了中</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Importing__0__iRT_values_into_the_iRT_calculator__1_" xml:space="preserve">
-    <value>{0}個のiRT値をiRTカルキュレータ{1}にインポート中</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Importing_transiton_list__0____" xml:space="preserve">
-    <value>トランジションリスト{0}をインポート中...</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Warning___line__0___column__1____2_" xml:space="preserve">
-    <value>警告：（行{0}、列{1}）{2}</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Warning__The_document_is_missing_iRT_standards" xml:space="preserve">
-    <value>警告：ドキュメントにiRT標準がありません</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Warning__The_iRT_calculator_already_contains__0__with_the_value__1___Ignoring__2_" xml:space="preserve">
-    <value>警告：iRTカルキュレータには値{1}を含む{0}が既にあります。 {2}を無視します</value>
-  </data>
-  <data name="CommandLine_LogNewEntries_Document_unchanged" xml:space="preserve">
-    <value>ドキュメントは変更されていません</value>
-  </data>
-  <data name="CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_document__using___1___instead_" xml:space="preserve">
-    <value>繰り返し測定「{0}」は既にドキュメントに存在します。代わりに「{1}」を使用します。</value>
-  </data>
-  <data name="CommandLine_NewSkyFile_Deleting_existing_file___0__" xml:space="preserve">
-    <value>既存のファイル「{0}」を削除</value>
-  </data>
-  <data name="CommandLine_NewSkyFile_FileAlreadyExists" xml:space="preserve">
-    <value>ファイル「{0}」は既に存在します。--overwriteを追加して、Skylineに上書きを許可します。</value>
-  </data>
-  <data name="CommandLine_OpenSkyFile_Error__The_Skyline_file__0__does_not_exist_" xml:space="preserve">
-    <value>エラー： Skylineファイル{0}は存在しません。</value>
-  </data>
-  <data name="CommandLine_OpenSkyFile_Error__There_was_an_error_opening_the_file__0_" xml:space="preserve">
-    <value>エラー： ファイル{0}を開く際にエラーがありました</value>
-  </data>
-  <data name="CommandLine_OpenSkyFile_File__0__opened_" xml:space="preserve">
-    <value>ファイル{0}が開きました。</value>
-  </data>
-  <data name="CommandLine_OpenSkyFile_Opening_file___" xml:space="preserve">
-    <value>ファイルを開いています...</value>
-  </data>
-  <data name="CommandLine_ProcessDocument_Error_saving_file" xml:space="preserve">
-    <value>エラー：ファイルの保存</value>
-  </data>
-  <data name="CommandLine_RefineDocument_Refining_document___" xml:space="preserve">
-    <value>ドキュメントの最適化中...</value>
-  </data>
-  <data name="CommandLine_RemoveImportedFiles__0______1___Note__The_file_has_already_been_imported__Ignoring___" xml:space="preserve">
-    <value>{0} -&gt; {1} メモ： ファイルは既にインポートされています。無視...</value>
-  </data>
-  <data name="CommandLine_Run_Error__Failed_importing_the_file__0____1_" xml:space="preserve">
-    <value>エラー： ファイル{0}のインポートに失敗しました。{1}</value>
-  </data>
-  <data name="CommandLine_SaveFile_Error__The_file_could_not_be_saved_to__0____Check_that_the_directory_exists_and_is_not_read_only_" xml:space="preserve">
-    <value>エラー： ファイルを{0}に保存できませんでした。 ディレクトリが存在し、読み取り専用でないことを確認します。</value>
-  </data>
-  <data name="CommandLine_SaveFile_File__0__saved_" xml:space="preserve">
-    <value>ファイル{0}が保存されました。</value>
-  </data>
-  <data name="CommandLine_SetLibrary_Error__Cannot_set_library_name_without_path_" xml:space="preserve">
-    <value>エラー： パスなしでライブラリ名を設定することはできません。</value>
-  </data>
-  <data name="CommandLine_SetLibrary_Error__The_file__0__does_not_exist_" xml:space="preserve">
-    <value>エラー： ファイル{0}は存在しません。</value>
-  </data>
-  <data name="CommandLine_SetLibrary_Error__The_file__0__is_not_a_supported_spectral_library_file_format_" xml:space="preserve">
-    <value>エラー： ファイル{0}はサポートされているスペクトルライブラリファイル形式ではありません。</value>
-  </data>
-  <data name="CommandLine_SetLibrary_Error__The_library_you_are_trying_to_add_conflicts_with_a_library_already_in_the_file_" xml:space="preserve">
-    <value>エラー： 追加しようとしているライブラリはファイル内に既にあるライブラリと競合しています。</value>
-  </data>
-  <data name="CommandLine_ShowLibraryMissingExternalSpectraError_Description" xml:space="preserve">
-    <value>引数 --import-search-prefer-embedded-spectraを使用し、ライブラリビルドを強制して埋め込みスペクトルを使用するか、上記にリストしたディレクトリの1つにオリジナルのスペクトルファイルを入れて再実行します。</value>
-  </data>
-  <data name="CommandLineTest_ConsoleAddFastaTest_Error" xml:space="preserve">
-    <value>エラー</value>
-  </data>
-  <data name="CommandLineTest_ConsoleAddFastaTest_Warning" xml:space="preserve">
-    <value>警告</value>
-  </data>
-  <data name="CommandLineTest_ConsolePathCoverage_successfully_" xml:space="preserve">
-    <value>正常。</value>
-    <comment>Context: something finished "successfully".</comment>
-  </data>
-  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
-    <value>エラー：</value>
-  </data>
-  <data name="Comment" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\comment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="CompareElement_CompareElement__Compare____" xml:space="preserve">
-    <value>&lt;比較...&gt;</value>
-  </data>
-  <data name="ComparePeakBoundaries_ComputeMatches_Documents_have_different_number_of_transition_groups___0__vs__1__" xml:space="preserve">
-    <value>ドキュメントにはトランジショングループである{0}対{1}の異なる番号があります。</value>
-  </data>
-  <data name="ComparePeakBoundaries_ComputeMatches_Number_of_results_in_transition_group__0__does_not_match_between_the_two_documents" xml:space="preserve">
-    <value>トランジショングループ{0}内の結果数が2つのドキュメント間で一致しません</value>
-  </data>
-  <data name="ComparePeakBoundaries_GenerateComparison_Missing_q_value_for_peptide__0__of_file__1_" xml:space="preserve">
-    <value>ファイル{1}のペプチド{0}に対する欠損したq値</value>
-  </data>
-  <data name="ComparePeakPickingDlg_ComparePeakPickingDlg_Fraction_of_Manual_ID_s" xml:space="preserve">
-    <value>手動IDの割合</value>
-  </data>
-  <data name="ComparePeakPickingDlg_SaveData_Save_Model_Comparison_Data" xml:space="preserve">
-    <value>モデル比較データを保存</value>
-  </data>
-  <data name="ComparePeakPickingDlg_SaveGraph_Either_the_ROC_or_Q_q_plot_tab_must_be_selected_to_save_a_graph_" xml:space="preserve">
-    <value>グラフを保存するには、ROCまたはQ-qプロットタブのどちらかを選択しなければなりません。</value>
-  </data>
-  <data name="ComparePeakPickingDlg_SaveGraph_Save_Model_Comparison_Graph" xml:space="preserve">
-    <value>モデル比較グラフを保存</value>
-  </data>
-  <data name="ConfigureToolsDlg_Cancel_Do_you_wish_to_Save_changes_" xml:space="preserve">
-    <value>変更を保存しますか？</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool__The_command_for__0__may_not_exist_in_that_location__Would_you_like_to_edit_it__" xml:space="preserve">
-    <value>{0}のコマンドがその場所に存在しない可能性があります。編集しますか？</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_if_you_would_like_the_command_to_launch_a_link__make_sure_to_include_http____or_https___" xml:space="preserve">
-    <value>コマンドを使ってリンクを立ち上げる場合、必ずhttp://またはhttps://を含みます</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_Supported_Types___1_" xml:space="preserve">
-    <value>サポートされているタイプ：{1}</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_The_command_cannot_be_blank__please_enter_a_valid_command_for__0_" xml:space="preserve">
-    <value>コマンドは空にできません。{0}に対する有効なコマンドを入力してください</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_The_command_for__0__must_be_of_a_supported_type" xml:space="preserve">
-    <value>{0}に対するコマンドはサポートされたタイプでなければなりません。</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_You_must_enter_a_valid_title_for_the_tool" xml:space="preserve">
-    <value>ツールの有効なタイトルを入力する必要があります。</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassToolInternal_" xml:space="preserve">
-    <value>インストールされていないためにツールディレクトリのないツールに対し、$(ToolDir) は有効なマクロではありません。</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassToolInternal__ToolDir__is_not_a_valid_macro_for_a_tool_that_was_not_installed_and_therefore_does_not_have_a_Tool_Directory_" xml:space="preserve">
-    <value>インストールされていないためにツールディレクトリのないツールに対し、$(ToolDir) は有効なマクロではありません。</value>
-  </data>
-  <data name="ConfigureToolsDlg_CopyinFile_A_file_named_0_already_exists_that_isn_t_identical_to_the_one_for_tool__1" xml:space="preserve">
-    <value>ツール{1}に対するファイルとは同一でない{0}という名前のファイルが既に存在しています</value>
-  </data>
-  <data name="ConfigureToolsDlg_CopyinFile_Missing_the_file_0_Tool_1_Import_Failed" xml:space="preserve">
-    <value>ファイル{0}がありません。ツール ({1}) のインポートに失敗しました</value>
-  </data>
-  <data name="ConfigureToolsDlg_CopyinFile_Not_importing_this_tool" xml:space="preserve">
-    <value>このツールのインポート中ではありません...</value>
-  </data>
-  <data name="ConfigureToolsDlg_GetTitle__New_Tool_0__" xml:space="preserve">
-    <value>[新しいツール{0}]</value>
-  </data>
-  <data name="ConfigureToolsDlg_GetZipFromWeb_Error_connecting_to_the_Tool_Store___0_" xml:space="preserve">
-    <value>ツールストアへの接続エラー：{0}</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_overwrite_or_install_in_parallel_" xml:space="preserve">
-    <value>上書きしますか、それとも並行インストールしますか？</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_overwrite_with_the_older_version__0__or_install_in_parallel_" xml:space="preserve">
-    <value>古いバージョン{0}で上書きしますか、それとも並行インストールしますか？</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_reinstall_or_install_in_parallel_" xml:space="preserve">
-    <value>再インストールしますか、それとも並行インストールしますか？</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_upgrade_to__0__or_install_in_parallel_" xml:space="preserve">
-    <value>{0}にアップグレードしますか、それとも並行インストールしますか？</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_The_tool__0__is_already_installed_" xml:space="preserve">
-    <value>ツール{0}は既にインストールされています。</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_The_tool__0__is_currently_installed_" xml:space="preserve">
-    <value>ツール{0}は現在インストールされています。</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_This_installation_would_modify_the_report_titled__0_" xml:space="preserve">
-    <value>このインストールは{0}というタイトルのレポートを変更します</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_This_is_an_older_installation_v_0__of_the_tool__1_" xml:space="preserve">
-    <value>これはツール{1}の古いインストールv{0}です。</value>
-  </data>
-  <data name="ConfigureToolsDlg_PopulateMacroDropdown_File_path_to_a_temporary_report" xml:space="preserve">
-    <value>一時レポートへのファイルパス</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Do_you_want_to_continue_" xml:space="preserve">
-    <value>続行しますか？</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Error_deleting_the_directory_of_the_existing_tool__Please_close_anything_using_that_directory_and_try_the_overwriting_import_again_later" xml:space="preserve">
-    <value>既存ツールのディレクトリの削除エラー。このディレクトリを使用しているプログラムをすべて閉じ、後でもう一度上書きインポートしてください</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Failed_attempting_to_extract_the_tool_from__0_" xml:space="preserve">
-    <value>{0}からのツールの抽出に失敗しました</value>
-  </data>
-  <data name="ConfigureToolsDlg_unpackZipTool_Failed_to_read_file_0_The_tool_described_failed_to_import" xml:space="preserve">
-    <value>ファイル{0}の読み取りに失敗しました。記載のツールのインポートに失敗しました。</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_In_Parallel" xml:space="preserve">
-    <value>並行</value>
-  </data>
-  <data name="ConfigureToolsDlg_unpackZipTool_Invalid_Tool_Description_in_file__0__" xml:space="preserve">
-    <value>ファイル{0}内の無効なツールの説明。</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Overwrite" xml:space="preserve">
-    <value>上書き</value>
-  </data>
-  <data name="ConfigureToolsDlg_unpackZipTool_skipping_that_tool_" xml:space="preserve">
-    <value>タイトルとコマンドが必要です。</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_There_is_a_naming_conflict__You_already_installed_a_tool_from_a_zip_folder_with_the_name__0___Would_you_like_to_overwrite_or_install_in_parallel_" xml:space="preserve">
-    <value>名前の不一致があります。{0}という名前のzipフォルダから既にツールをインストールしています。上書きしますか、それとも並行インストールしますか？</value>
-  </data>
-  <data name="ConfigureToolsDlg_unpackZipTool_Title_and_Command_are_required" xml:space="preserve">
-    <value>そのツールをスキップするには、</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Warning__overwriting_will_delete_the_following_tools_" xml:space="preserve">
-    <value>警告：上書きにより以下のツールが削除されます：</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Warning__overwriting_will_delete_the_tool__0___Do_you_want_to_continue_" xml:space="preserve">
-    <value>警告：上書きによりツール{0}が削除されます。続行しますか？</value>
-  </data>
-  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Copy_Bitmap" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Copy_Bitmap.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="CopyEmfToolStripMenuItem_CopyEmfToolStripMenuItem_Copy_Metafile" xml:space="preserve">
-    <value>メタファイルをコピー</value>
-  </data>
-  <data name="CopyGraphDataToolStripMenuItem_CopyGraphData_Failed_setting_data_to_clipboard" xml:space="preserve">
-    <value>クリップボードへのデータ設定に失敗しました。</value>
-  </data>
-  <data name="CopyGraphDataToolStripMenuItem_CopyGraphDataToolStripMenuItem_Copy_Data" xml:space="preserve">
-    <value>データをコピー</value>
-  </data>
-  <data name="CopyPasteTest_DoTest_Could_not_read_the_pasted_transition_list___Transition_list_must_be_in_separated_columns_and_cannot_contain_blank_lines_" xml:space="preserve">
-    <value>貼り付けられたトランジションリストを読み取ることができませんでした。 トランジションリストは分離された列になければならず、空の列を含むことはできません。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_BrowseDb_The_specified_file_is_not_a_valid_iRT_database_" xml:space="preserve">
-    <value>指定ファイルは有効なiRTデータベースではありません。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_ImportTextFile_Import_Transition_List__iRT_standards_" xml:space="preserve">
-    <value>トランジションリストをインポート（iRT標準）</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_A_calculator_with_that_name_already_exists___Do_you_want_to_replace_it_" xml:space="preserve">
-    <value>その名前のカルキュレータが既に存在しています。 置き換えますか？</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_Calculator_name_cannot_be_empty" xml:space="preserve">
-    <value>カルキュレータ名は空にできません。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_Error_reading_iRT_standards_transition_list___0_" xml:space="preserve">
-    <value>iRT標準トランジションリストの読み込みエラー：{0}</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_Failed_to_open_the_database_file___0_" xml:space="preserve">
-    <value>データベースファイルを開くのに失敗しました：{0}</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_iRT_database_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
-    <value>iRTデータベース欄には有効なファイルに対するパスが含まれていなければなりません。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_iRT_database_field_must_not_be_empty_" xml:space="preserve">
-    <value>iRTデータベース欄は空にできません。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_Transition_list_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
-    <value>トランジションリスト欄には有効なファイルに対するパスが含まれていなければなりません。</value>
-  </data>
-  <data name="CustomIon_DisplayName_Ion" xml:space="preserve">
-    <value>イオン</value>
-  </data>
-  <data name="CustomMolecule_DisplayName_Molecule" xml:space="preserve">
-    <value>分子</value>
-  </data>
-  <data name="CustomMolecule_Validate_The_mass__0__of_the_custom_molecule_exceeeds_the_maximum_of__1__" xml:space="preserve">
-    <value>カスタム分子の質量{0}は{1}の最大値を上回っています。</value>
-  </data>
-  <data name="CustomMolecule_Validate_The_mass__0__of_the_custom_molecule_is_less_than_the_minimum_of__1__" xml:space="preserve">
-    <value>カスタム分子の質量{0}は{1}の最小値を下回っています。</value>
-  </data>
-  <data name="Cut" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\cut.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Dash" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Dash.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Database_GetJoinColumn_The_type__0__must_have_a_column_of_type__1_" xml:space="preserve">
-    <value>タイプ{0}はタイプ{1}の列を含む必要があります</value>
-  </data>
-  <data name="Database_Join_Cannot_join_tables_of_same_type" xml:space="preserve">
-    <value>同じタイプの表は結合できません。</value>
-  </data>
-  <data name="DatabaseNotConnectedException_DatabaseNotConnectedException_The_database_for_the_calculator__0__could_not_be_opened__Check_that_the_file__1__was_not_moved_or_deleted" xml:space="preserve">
-    <value>カルキュレータ{0}のデータベースが開けませんでした。ファイル{1}が移動または削除されていないことを確認します。</value>
-  </data>
-  <data name="DataboundGridControl_GetClusteredResults_An_error_occured_while_performing_clustering_" xml:space="preserve">
-    <value>クラスタリング実行中にエラーが発生しました。</value>
-  </data>
-  <data name="DataboundGridControl_GetClusteredResults_Unable_to_choose_a_set_of_columns_to_use_for_hierarchical_clustering_" xml:space="preserve">
-    <value>階層クラスタリングに使用する列セットを選択できません。</value>
-  </data>
-  <data name="DataProcessing" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\dataprocessing.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DDASearchControl_SearchProgress_Search_canceled" xml:space="preserve">
-    <value>検索がキャンセルされました。</value>
-  </data>
-  <data name="DDASearchControl_SearchProgress_Search_done" xml:space="preserve">
-    <value>検索が完了しました。</value>
-  </data>
-  <data name="DecoyGeneration_SHUFFLE_SEQUENCE_Shuffle_Sequence" xml:space="preserve">
-    <value>シークエンスのシャッフル</value>
-  </data>
-  <data name="Delete" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\delete.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Demultiplexer_GetDeconvRegionsForMz_TheIsolationSchemeIsInconsistentlySpecified" xml:space="preserve">
-    <value>フルスキャン設定での単離スキームの指定に一貫性がありません。</value>
-  </data>
-  <data name="DetectionHistogramPane_Tooltip_Count" xml:space="preserve">
-    <value>{0}個</value>
-  </data>
-  <data name="DetectionHistogramPane_Tooltip_ReplicateCount" xml:space="preserve">
-    <value>繰り返し測定数</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_AllCount" xml:space="preserve">
-    <value>全数</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_Count" xml:space="preserve">
-    <value>{0}個</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_CumulativeCount" xml:space="preserve">
-    <value>累積数</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_QMedian" xml:space="preserve">
-    <value>Q値の中央値の-log10</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_Replicate" xml:space="preserve">
-    <value>繰り返し測定</value>
-  </data>
-  <data name="DigestHelper_Digest_Digesting__0__proteome_with__1__" xml:space="preserve">
-    <value>{1}による{0}プロテオームの消化中</value>
-  </data>
-  <data name="DigestSettings_Validate_maximum_missed_cleavages" xml:space="preserve">
-    <value>最大ミス開裂数</value>
-  </data>
-  <data name="DigestSettings_ValidateIntRange_The_value__1__for__0__must_be_between__2__and__3__" xml:space="preserve">
-    <value>{0}に対する値{1}は、{2}と{3}の間でなければなりません。</value>
-  </data>
-  <data name="directoryicon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\directoryicon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DisplayEquation_N_A" xml:space="preserve">
-    <value>該当なし</value>
-  </data>
-  <data name="DocumentAnnotations_AnnotationsNotSupported_The_element___0___cannot_have_annotations_" xml:space="preserve">
-    <value>要素「{0}」は注釈を持つことができません。</value>
-  </data>
-  <data name="DocumentGridViewContext_Delete_Are_you_sure_you_want_to_delete_the__0____1___" xml:space="preserve">
-    <value>本当に{0}「{1}」を削除してもよろしいですか？</value>
-    <comment>Example: Are you sure you want to delete the protein 'ALDH'?</comment>
-  </data>
-  <data name="DocumentGridViewContext_Delete_Are_you_sure_you_want_to_delete_these__0___1__" xml:space="preserve">
-    <value>本当にこれら{0}個の{1}を削除してもよろしいですか？</value>
-    <comment>Example: Are you sure you want to delete these 27 proteins?</comment>
-  </data>
-  <data name="down_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\down-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DriftTimePredictor_Validate_Resolving_power_must_be_greater_than_0_" xml:space="preserve">
-    <value>分解能は0より大きくなければなりません。</value>
-  </data>
-  <data name="DriftTimeWindowWidthCalculator_Validate_Fixed window_width_must_be_non_negative_" xml:space="preserve">
-    <value>固定ウィンドウ幅は、正である必要があります。</value>
-  </data>
-  <data name="DriftTimeWindowWidthCalculator_Validate_Peak_width_must_be_non_negative_" xml:space="preserve">
-    <value>ピーク幅は負の値にはできません。</value>
-  </data>
-  <data name="DropImage" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\dropimage.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DsvFileReader_ReadLine_Line__0__has__1__fields_when__2__expected_" xml:space="preserve">
-    <value>{2}が期待されている場合、{0}行目には{1}欄があります。</value>
-  </data>
-  <data name="Edit_Redo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\edit_redo.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Edit_Undo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\edit_undo.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Edit_Undo_Multiple" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Edit_Undo_Multiple.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="EditCoVDlg_btnOk_Click_Maximum_compensation_voltage_cannot_be_less_than_minimum_compensation_volatage_" xml:space="preserve">
-    <value>最大補償電圧は、最小補償電圧未満であってはなりません。</value>
-  </data>
-  <data name="EditCustomMoleculeDlg_OkDialog_A_precursor_with_that_adduct_and_label_type_already_exists_" xml:space="preserve">
-    <value>その付加イオンと標識タイプを持つプリカーサーイオンは既に存在します。</value>
-  </data>
-  <data name="EditCustomMoleculeDlg_OkDialog_Custom_molecules_must_have_a_mass_greater_than_or_equal_to__0__" xml:space="preserve">
-    <value>カスタム分子は、{0}以上の質量でなければなりません。</value>
-  </data>
-  <data name="EditCustomMoleculeDlg_OkDialog_Custom_molecules_must_have_a_mass_less_than_or_equal_to__0__" xml:space="preserve">
-    <value>カスタム分子は、{0}以下の質量でなければなりません。</value>
-  </data>
-  <data name="EditCustomMoleculeDlg_OkDialog_Please_specify_the_ion_mobility_units_" xml:space="preserve">
-    <value>イオン移動度単位を指定してください。</value>
-  </data>
-  <data name="EditEnzymeDlg_OnClosing_The_enzyme__0__already_exists" xml:space="preserve">
-    <value>酵素「{0}」が既に存在しています。</value>
-  </data>
-  <data name="EditEnzymeDlg_ValidateAATextBox__0__must_contain_at_least_one_amino_acid" xml:space="preserve">
-    <value>{0}には1つ以上のアミノ酸が含まれて射なければなりません。</value>
-  </data>
-  <data name="EditEnzymeDlg_ValidateAATextBox_The_character__0__is_not_a_valid_amino_acid" xml:space="preserve">
-    <value>文字「{0}」は有効なアミノ酸ではありません。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_EditIonMobilityLibraryDlg_Adduct" xml:space="preserve">
-    <value>付加物</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_OkDialog_Do_you_want_to_change_it_" xml:space="preserve">
-    <value>変更しますか？</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_OkDialog_Please_choose_a_file_for_the_ion_mobility_library" xml:space="preserve">
-    <value>イオン移動度ライブラリのファイルを選択してください。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_OkDialog_Please_use_a_full_path_to_a_file_for_the_ion_mobility_library_" xml:space="preserve">
-    <value>イオン移動度ライブラリのファイルに対し完全パスを使用してください。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_UpdateNumPeptides__0__Peptide" xml:space="preserve">
-    <value>{0}ペプチド</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_UpdateNumPeptides__0__Peptides" xml:space="preserve">
-    <value>{0}個のペプチド</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateCell_A_value_is_required_" xml:space="preserve">
-    <value>値が必要です。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateCell_The_entry__0__is_not_valid_" xml:space="preserve">
-    <value>エントリ{0}が有効ではありません。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_On_line__0___1_" xml:space="preserve">
-    <value>{0}{1}行</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_charge__Charges_must_be_integer_values_between_1_and__1__" xml:space="preserve">
-    <value>値{0}は有効な電荷ではありません。電荷は1から{1}の整数である必要があります。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_intercept_" xml:space="preserve">
-    <value>値{0}は有効な切片ではありません。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_slope_" xml:space="preserve">
-    <value>値{0}は有効な勾配ではありません。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateResolvingPower_Resolving_power_must_be_greater_than_0_" xml:space="preserve">
-    <value>分解能は0より大きくなければなりません。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_The_following_ions_have_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
-    <value>次のイオンに複数のイオン移動度値があります。Skylineは複数の配座異性体をサポートしているため、これは意図的である可能性があります。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_The_ion__0__has_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
-    <value>イオン{0}に複数のイオン移動度値があります。Skylineは複数の配座異性体をサポートしているため、これは意図的である可能性があります。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_This_list_contains__0__ions_with_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
-    <value>このリストには複数のイオン移動度値を持つイオンが{0}個含まれています。Skylineは複数の配座異性体をサポートしているため、これは意図的である可能性があります。</value>
-  </data>
-  <data name="EditIrtCalcDlg_btnBrowseDb_Click_Open_iRT_Database" xml:space="preserve">
-    <value>iRTデータベースを開く</value>
-  </data>
-  <data name="EditIrtCalcDlg_btnCreateDb_Click_Create_iRT_Database" xml:space="preserve">
-    <value>iRTデータベースを作成</value>
-  </data>
-  <data name="EditIrtCalcDlg_comboStandards_SelectedIndexChanged_The_list_of_standard_peptides_must_contain_only_recognized_iRT_C18_standards_to_switch_to_a_predefined_set_of_iRT_C18_standards_" xml:space="preserve">
-    <value>標準ペプチドのリストには認識されたiRT-C18標準のみを含め、事前定義済みのiRT-C18標準セットに切り替えなければなりません。</value>
-  </data>
-  <data name="EditIrtCalcDlg_CreateDatabase_The_file__0__could_not_be_created" xml:space="preserve">
-    <value>ファイル{0}が作成できませんでした。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_comboMargins_SelectedIndexChanged_Margin" xml:space="preserve">
-    <value>マージン</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_comboMargins_SelectedIndexChanged_Start_margin" xml:space="preserve">
-    <value>マージンを開始</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_ImportRangesFromFiles_Failed_reading_isolation_scheme_" xml:space="preserve">
-    <value>単離スキームの読み出しに失敗しました。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_Specify__0__for_isolation_window" xml:space="preserve">
-    <value>単離ウィンドウに対し{0}を指定します。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_Specify_Start_and_End_values_for_at_least_one_isolation_window" xml:space="preserve">
-    <value>1つ以上の単離ウィンドウに開始値と終値を指定します。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_The_isolation_scheme_named__0__already_exists" xml:space="preserve">
-    <value>「{0}」という名前の単離スキームが既に存在しています。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_The_selected_target_is_not_unique" xml:space="preserve">
-    <value>選択したターゲットは一意ではありません。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_There_are_gaps_in_a_single_cycle_of_your_extraction_windows__Do_you_want_to_continue_" xml:space="preserve">
-    <value>抽出ウィンドウの単一サイクルにギャップがあります。本当に続行しますか？</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_ReadIsolationRanges_Missing_isolation_range_for_the_isolation_target__0__m_z_in_the_file__1_" xml:space="preserve">
-    <value>ファイル{1}における単離ターゲット{0}m/zの欠損単離範囲</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_ReadIsolationRanges_No_repeating_isolation_scheme_found_in__0_" xml:space="preserve">
-    <value>{0}に反復単離スキームがありません</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_UpdateIsolationWidths_Isolation_width" xml:space="preserve">
-    <value>単離幅(&amp;W)：</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_UpdateIsolationWidths_Isolation_widths" xml:space="preserve">
-    <value>単離幅(&amp;W)：</value>
-  </data>
-  <data name="EditLibraryDlg_OkDialog_The_file__0__is_not_a_supported_spectral_library_file_format" xml:space="preserve">
-    <value>ファイル{0}はサポートされているスペクトルライブラリファイル形式ではありません。</value>
-  </data>
-  <data name="EditLink" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\EditLink.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="EditLinkedPeptideDlg_TryMakeLinkedPeptide_The_crosslinker___0___cannot_attach_to_the_amino_acid___1___" xml:space="preserve">
-    <value>クロスリンカー「{0}」は、アミノ酸「{1}」には結合できません。</value>
-  </data>
-  <data name="EditLinkedPeptidesDlg_OkDialog_Some_crosslinked_peptides_are_not_connected_" xml:space="preserve">
-    <value>クロスリンクされているペプチドの一部が結合していません。</value>
-  </data>
-  <data name="EditMeasuredIonDlg_OkDialog_Reporter_ion_masses_must_be_greater_than_or_equal_to__0__" xml:space="preserve">
-    <value>レポーターイオン質量は{0}以上でなければなりません。</value>
-  </data>
-  <data name="EditOptimizationLibraryDlg_UpdateValueHeader_Collision_Energy" xml:space="preserve">
-    <value>衝突エネルギー</value>
-  </data>
-  <data name="EditOptimizationLibraryDlg_UpdateValueHeader_Declustering_Potential" xml:space="preserve">
-    <value>デクラスタリングポテンシャル</value>
-  </data>
-  <data name="EditPeakScoringModelDlg_btnTrainModel_Click_Cannot_train_model_without_either_decoys_or_second_best_peaks_included_" xml:space="preserve">
-    <value>デコイか2番目に良いピークなしではトレインモデルができません。</value>
-  </data>
-  <data name="EditPeakScoringModelDlg_OkDialog_The_peak_scoring_model__0__already_exists" xml:space="preserve">
-    <value>ピークスコアモデル{0}は既に存在しています</value>
-  </data>
-  <data name="EditPeakScoringModelDlg_SelectedModelItem_Invalid_Model_Selection" xml:space="preserve">
-    <value>無効なモデル選択。</value>
-  </data>
-  <data name="EditPeakScoringModelDlg_TrainModel_Calculating_score_contributions" xml:space="preserve">
-    <value>スコア貢献度を計算中</value>
-  </data>
-  <data name="EditRemoteAccountDlg_TestSettings_Error_connecting_to_server__" xml:space="preserve">
-    <value>サーバーの接続エラー：</value>
-  </data>
-  <data name="EditServerDlg_OkDialog_The_server__0__already_exists_" xml:space="preserve">
-    <value>サーバー「{0}」が既に存在しています。</value>
-  </data>
-  <data name="EditServerDlg_OkDialog_The_text__0__is_not_a_valid_server_name_" xml:space="preserve">
-    <value>テキスト「{0}」は有効なサーバー名ではありません。</value>
-  </data>
-  <data name="EmptyList" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\EmptyList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_could_not_find_EncyclopeDia" xml:space="preserve">
-    <value>EncyclopeDIAを見つけられませんでした</value>
-  </data>
-  <data name="EncyclopeDiaHelpers_GenerateLibrary_Combining_chromatogram_libraries" xml:space="preserve">
-    <value>クロマトグラムライブラリの統合</value>
-  </data>
-  <data name="EncyclopeDiaHelpers_GenerateLibrary_Combining_quantification_libraries" xml:space="preserve">
-    <value>定量化ライブラリの統合</value>
-  </data>
-  <data name="EncyclopeDiaHelpers_GenerateLibrary_Running_command___0___1_" xml:space="preserve">
-    <value>コマンドの実行：{0} {1}</value>
-  </data>
-  <data name="EncyclopeDiaSearchDlg_Browse_for_Narrow_Window_Results_Files" xml:space="preserve">
-    <value>狭いウィンドウ結果ファイルを参照</value>
-  </data>
-  <data name="EncyclopeDiaSearchDlg_Browse_For_Wide_Window_Results_Files" xml:space="preserve">
-    <value>広いウィンドウ結果ファイルを参照</value>
-  </data>
-  <data name="Error___0_" xml:space="preserve">
-    <value>エラー：{0}</value>
-  </data>
-  <data name="Expand" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\plus.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="ExportChromatogramDlg_OkDialog_At_least_one_chromatogram_type_must_be_selected" xml:space="preserve">
-    <value>1つ以上のクロマトグラムタイプを選択しなければなりません。</value>
-  </data>
-  <data name="ExportChromatogramDlg_OkDialog_At_least_one_file_must_be_selected" xml:space="preserve">
-    <value>1つ以上のファイルを選択しなければなりません</value>
-  </data>
-  <data name="ExportMethodDlg_btnBrowseTemplate_Click__0__Method" xml:space="preserve">
-    <value>{0}メソッド</value>
-    <comment>Instrument type name Method</comment>
-  </data>
-  <data name="ExportMethodDlg_btnBrowseTemplate_Click_Method_Template" xml:space="preserve">
-    <value>メソッドテンプレート</value>
-  </data>
-  <data name="ExportMethodDlg_comboTargetType_SelectedIndexChanged_Scheduled_methods_are_not_yet_supported_for_DIA_acquisition" xml:space="preserve">
-    <value>スケジュールメソッドはデータ非依存取得に対し、まだサポートされていません。</value>
-  </data>
-  <data name="ExportMethodDlg_comboTargetType_SelectedIndexChanged_To_export_a_scheduled_list_you_must_first_choose_a_retention_time_predictor_in_Peptide_Settings_Prediction_or_import_results_for_all_peptides_in_the_document" xml:space="preserve">
-    <value>スケジュールメソッドをエクスポートするには、まず [ペプチド設定/予測] で保持時間予測を選択するか、ドキュメント内のすべてのペプチドに対する結果をインポートする必要があります。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_Compensation_Voltage_" xml:space="preserve">
-    <value>補償電圧：</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_Compensation_voltage_optimization_should_be_run_on_one_transition_per_peptide__and_the_best_transition_cannot_be_determined_for_the_following_precursors_" xml:space="preserve">
-    <value>補償電圧最適化をプリカーサーごとに1つのトランジション上で実行してください。以下のプリカーサーについては最良のトランジションを判定できませんでした：</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_Export_of_DIA_method_is_not_supported_for__0__" xml:space="preserve">
-    <value>DIAメソッドのエクスポートは{0}ではサポートされていません。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_The_DIA_isolation_list_must_have_prespecified_windows_" xml:space="preserve">
-    <value>DIA分離リストではウィンドウの事前指定が必須です。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_The_precursor_mass_analyzer_type_is_not_set_to__0__in_Transition_Settings_under_the_Full_Scan_tab" xml:space="preserve">
-    <value>トランジション設定（フルスキャンタブ下）で、プリカーサー質量アナライザータイプが{0}に設定されていません。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_You_are_missing_fine_tune_optimized_compensation_voltages_" xml:space="preserve">
-    <value>最適補償電圧が微調整されていません。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_You_are_missing_fine_tune_optimized_compensation_voltages_for_the_following_" xml:space="preserve">
-    <value>以下の最適補償電圧が微調整されていません：</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_You_have_only_rough_tune_optimized_compensation_voltages_" xml:space="preserve">
-    <value>最適補償電圧は粗調整しかされていません。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_Your_document_does_not_contain_compensation_voltage_results__but_compensation_voltage_is_set_under_transition_settings_" xml:space="preserve">
-    <value>ドキュメントに補償電圧は含まれていませんが、補償電圧はトランジション設定に沿って設定されています。</value>
-  </data>
-  <data name="ExportMethodDlg_ValidateSettings_Cannot_export_fine_tune_transition_list__The_following_precursors_are_missing_medium_tune_results_" xml:space="preserve">
-    <value>微調整トランジションリストはエクスポートできません。以下のプリカーサーの標準調整結果がありません：</value>
-  </data>
-  <data name="ExportMethodDlg_ValidateSettings_Cannot_export_medium_tune_transition_list__The_following_precursors_are_missing_rough_tune_results_" xml:space="preserve">
-    <value>標準調整トランジションリストはエクスポートできません。以下のプリカーサーの粗調整結果がありません：</value>
-  </data>
   <data name="ExportMethodDlg_VerifySchedulingAllowed_The__0__instrument_lacks_support_for_direct_method_export_for_triggered_acquisition_" xml:space="preserve">
     <value>{0}装置は、トリガーされた取得に対する直接メソッドエクスポートをサポートしていません。</value>
-  </data>
-  <data name="ExportMethodDlg_VerifySchedulingAllowed_The_current_document_contains_peptides_without_enough_information_to_rank_transitions_for_triggered_acquisition_" xml:space="preserve">
-    <value>現在のドキュメントには、トリガーされた取得のトランジションをランクするのに十分な情報のないペプチドが含まれています。</value>
-  </data>
-  <data name="ExportMethodDlg_VerifySchedulingAllowed_Triggered_acquistion_requires_a_spectral_library_or_imported_results_in_order_to_rank_transitions_" xml:space="preserve">
-    <value>トランジションをランクするために、トリガーされた取得には、スペクトルライブラリまたはインポートされた結果が必要です。</value>
-  </data>
-  <data name="ExportMethodDlg_VerifySchedulingAllowed_You_must_export_a__0__transition_list_and_manually_import_it_into_a_method_file_using_vendor_software_" xml:space="preserve">
-    <value>{0}トランジションリストをエクスポートし、ベンダーソフトウェアを使用して手動でメソッドファイルにインポートする必要があります。</value>
-  </data>
-  <data name="ExportReportDlg_GetDatabase_Analyzing_document" xml:space="preserve">
-    <value>ドキュメントの分析中...</value>
-  </data>
-  <data name="ExportReportDlg_GetDatabase_Generating_Report_Data" xml:space="preserve">
-    <value>レポートデータの生成中</value>
-  </data>
-  <data name="ExportReportDlg_GetExceptionDisplayMessage_The_field__0__does_not_exist_in_this_document" xml:space="preserve">
-    <value>このドキュメントにはフィールド{0}がありません。</value>
-  </data>
-  <data name="ExportReportDlg_OkDialog_Export_Report" xml:space="preserve">
-    <value>レポートをエクスポート</value>
-  </data>
-  <data name="ExportReportDlg_ShowPreview_An_unexpected_error_occurred_attempting_to_display_the_report___0___" xml:space="preserve">
-    <value>レポート「{0}」を表示しようとした際に予期しないエラーが発生しました。</value>
-  </data>
-  <data name="ExportReportDlg_ShowShare_Report_Definitions" xml:space="preserve">
-    <value>定義をレポート</value>
-  </data>
-  <data name="ExternalTool" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ExternalTool.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="File" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\file.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FileStreamManager_Commit_Could_not_replace_file_" xml:space="preserve">
-    <value>ファイルを置換できませんでした</value>
-  </data>
-  <data name="Filter" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Filter.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Find" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\find.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FindNext" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\findnext.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Folder" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\folder.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Fragment" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Fragment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FragmentDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\FragmentDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FragmentLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\fragmentlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FragmentLibDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\FragmentLibDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FullScanAcquisitionExtension_LOCALIZED_VALUES_DIA" xml:space="preserve">
-    <value>DIA</value>
-  </data>
-  <data name="FullScanAcquisitionExtension_LOCALIZED_VALUES_Targeted" xml:space="preserve">
-    <value>ターゲット</value>
-  </data>
-  <data name="FullScanAcquisitionMethod_DDA_DDA" xml:space="preserve">
-    <value>DDA</value>
-  </data>
-  <data name="GenerateDecoys" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\GenerateDecoys.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="GenerateDecoysDlg_GenerateDecoysDlg_All" xml:space="preserve">
-    <value>すべて</value>
-  </data>
-  <data name="GenerateDecoysError_No_peptide_precursor_models_for_decoys_were_found_" xml:space="preserve">
-    <value>デコイのペプチドプリカーサーモデルは見つかりませんでした。</value>
-  </data>
-  <data name="GenericState_AppendErrorAndUri_URL___0_" xml:space="preserve">
-    <value>URL：{0}</value>
-  </data>
-  <data name="GraphChromatogram_DisplayOptimizationTotals_No_optimization_data_available" xml:space="preserve">
-    <value>最適化データがありません。</value>
-  </data>
-  <data name="GraphData_AddRegressionLabel_window" xml:space="preserve">
-    <value>ウィンドウ</value>
-    <comment>In RTLinearRegressionGraphPane</comment>
-  </data>
-  <data name="GraphData_GraphResiduals_Time_from_Regression" xml:space="preserve">
-    <value>回帰からの時間</value>
-  </data>
-  <data name="GraphFullScan_CreateGraph__0_____1_F2__min_" xml:space="preserve">
-    <value>{0}（{1:F2} 分）</value>
-    <comment>"min" stands for "minutes"</comment>
-  </data>
-  <data name="GraphFullScan_CreateGraph_CE_" xml:space="preserve">
-    <value>NCE：</value>
-  </data>
-  <data name="GraphFullScan_CreateGraph_IM__0_" xml:space="preserve">
-    <value>イオン移動度={0}</value>
-    <comment>"IM" stands for "Ion Mobility" - used for displaying ion mobility in raw scan view</comment>
-  </data>
-  <data name="GraphFullScan_CreateGraph_IM_Scan_Range_" xml:space="preserve">
-    <value>IMスキャン範囲：</value>
-  </data>
-  <data name="GraphFullScan_CreateGraph_Scan_Number_" xml:space="preserve">
-    <value>スキャン番号：</value>
-  </data>
-  <data name="GraphFullScan_CreateIonMobilityHeatmap_Quadrupole_Scan_Range__m_z_" xml:space="preserve">
-    <value>四重極スキャン範囲(m/z)</value>
-  </data>
-  <data name="GraphSpectrum_MassErrorFormat_ppm" xml:space="preserve">
-    <value>{0}{1} ppm</value>
-  </data>
-  <data name="GraphSpectrum_UpdateUI_Multiple_charge_states_with_library_spectra" xml:space="preserve">
-    <value>ライブラリスペクトルを伴う多重荷電状態</value>
-  </data>
-  <data name="GraphSummary_UpdateToolbar_All" xml:space="preserve">
-    <value>すべて</value>
-  </data>
-  <data name="GreenCheck" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\GreenCheck.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_End" xml:space="preserve">
-    <value>終了</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_End_margin" xml:space="preserve">
-    <value>マージンを終了</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_none" xml:space="preserve">
-    <value>なし</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_Start" xml:space="preserve">
-    <value>開始</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_Start_margin" xml:space="preserve">
-    <value>マージンを開始</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_Target" xml:space="preserve">
-    <value>ターゲット</value>
-  </data>
-  <data name="GridViewDriver_GetValue_An_invalid_number__0__was_specified_for__1__2__" xml:space="preserve">
-    <value>{1} {2}に対して無効な数値（「{0}」）が指定されました。</value>
-  </data>
-  <data name="GridViewDriver_GridView_DataError__0__must_be_a_valid_number" xml:space="preserve">
-    <value>{0}は有効な数値でなければなりません。</value>
-  </data>
-  <data name="GridViewDriver_ValidateRow_On_line__0__1__" xml:space="preserve">
-    <value>{0}行、{1}</value>
-    <comment>Line refers to line of document</comment>
-  </data>
-  <data name="GroupByItem_ToString_Replicates" xml:space="preserve">
-    <value>繰り返し測定</value>
-  </data>
-  <data name="HeatMapGraph_RefreshData_Heat_Map" xml:space="preserve">
-    <value>ヒートマップ</value>
-  </data>
-  <data name="Helpers_AssumeValue_Nullable_was_expected_to_have_a_value" xml:space="preserve">
-    <value>Nullableは値を持つと予測されていました。</value>
-  </data>
-  <data name="HomeIcon1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\HomeIcon.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="HtmlFragment_ClipBoardText_From_Clipboard" xml:space="preserve">
-    <value>クリップボードから</value>
-  </data>
-  <data name="Icojam-Blueberry-Basic-Arrow-left" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="IIrtRegression_DisplayEquation_iRT" xml:space="preserve">
-    <value>iRT</value>
-  </data>
-  <data name="IIrtRegression_DisplayEquation_Measured_RT" xml:space="preserve">
-    <value>測定されたRT</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_A_maximum_of_one_decoy_per_target_may_be_generated_when_using_reversed_decoys_" xml:space="preserve">
-    <value>リバースデコイを使用する際、ターゲット毎に最大1個のデコイを生成できます。</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Change_digestion_settings" xml:space="preserve">
-    <value>消化設定を変更</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Change_settings" xml:space="preserve">
-    <value>設定を変更</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Change_settings_to_add_precursors" xml:space="preserve">
-    <value>プリカーサーを追加するよう変更を設定</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Importing_the_FASTA_did_not_create_any_target_proteins_" xml:space="preserve">
-    <value>FASTAをインポートしても、ターゲットタンパク質は作成されませんでした。</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Please_enter_a_valid_number_of_decoys_per_target_greater_than_0_" xml:space="preserve">
-    <value>0を上回るターゲット毎にデコイの有効な数を入力してください。</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_The_document_does_not_contain_any_peptides_" xml:space="preserve">
-    <value>ドキュメントにペプチドが含まれていません。</value>
-  </data>
-  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Only_BiblioSpec_libraries_contain_enough_ion_mobility_information_to_support_this_operation_" xml:space="preserve">
-    <value>BiblioSpecライブラリのみが、この操作をサポートするイオン移動度情報を十分に含んでいます。</value>
-  </data>
-  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_choose_a_non_redundant_library_" xml:space="preserve">
-    <value>非冗長ライブラリを選択してください。</value>
-  </data>
-  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_specify_a_path_to_an_existing_spectral_library" xml:space="preserve">
-    <value>既存のスペクトルライブラリにパスを指定してください。</value>
-  </data>
-  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_specify_a_path_to_an_existing_spectral_library_" xml:space="preserve">
-    <value>既存のスペクトルライブラリにパスを指定してください。</value>
-  </data>
-  <data name="ImportPeptideSearchDlg_ImportPeptideSearchDlg_MS_MS_full_scan_settings_were_configured__please_verify_or_change_your_current_full_scan_settings_" xml:space="preserve">
-    <value>MS/MSフルスキャン設定が構成されました。現在のフルスキャン設定を検証または変更してください。</value>
-  </data>
-  <data name="ImportPeptideSearchDlg_NextPage_Please_check_your_peptide_search_pipeline_or_contact_Skyline_support_to_ensure_retention_times_appear_in_your_spectral_libraries_" xml:space="preserve">
-    <value>ペプチド検索パイプラインを確認するか、Skylineサポートに連絡して保持時間がスペクトルライブラリに表示されるようにしてください。</value>
-  </data>
-  <data name="ImportPeptideSearchDlg_NextPage_The_document_specific_spectral_library_does_not_have_valid_retention_times_" xml:space="preserve">
-    <value>ドキュメントの特定のスペクトルライブラリには有効な保持時間がありません。</value>
-  </data>
-  <data name="ImportPeptideSearchManager_LoadBackground_The_current_peak_scoring_model_is_incompatible_with_one_or_more_peptides_in_the_document_" xml:space="preserve">
-    <value>現在のピークスコアモデルは、ドキュメント内の1つ以上のペプチドと互換性がありません。</value>
-  </data>
-  <data name="ImportResultsControl_FindDataFiles_An_error_occurred_attempting_to_find_missing_result_files_in__0__" xml:space="preserve">
-    <value>{0}で欠損している結果ファイルを検索しようとした際にエラーが発生しました。</value>
-  </data>
-  <data name="ImportResultsControl_FindDataFiles_Searching_for_missing_result_files_in__0__" xml:space="preserve">
-    <value>{0}で欠損している結果ファイルの検索中。</value>
-  </data>
-  <data name="ImportResultsControl_FindResultsFiles_An_error_occurred_attempting_to_find_results_files_" xml:space="preserve">
-    <value>結果ファイルを見つけようとした際にエラーが発生しました。</value>
-  </data>
-  <data name="ImportResultsControl_FindResultsFiles_Searching_for_matching_results_files_in__0__" xml:space="preserve">
-    <value>{0}内で一致する結果ファイルの検索中。</value>
-  </data>
-  <data name="ImportResultsControl_FindResultsFiles_Searching_for_Results_Files" xml:space="preserve">
-    <value>結果ファイルの検索中</value>
-  </data>
-  <data name="ImportResultsDlg_DefaultNewName_Default_Name" xml:space="preserve">
-    <value>クロマトグラム</value>
-    <comment>Default replicate name</comment>
-  </data>
-  <data name="ImportResultsDlg_GetDataSourcePathsFile_No_results_files_chosen" xml:space="preserve">
-    <value>結果ファイルが選択されていません。</value>
-  </data>
-  <data name="ImportSkyrHelper_ResolveImportConflicts_Resolving_conflicts_by_overwriting_" xml:space="preserve">
-    <value>上書きして競合を解決中。</value>
-  </data>
-  <data name="ImportSkyrHelper_ResolveImportConflicts_Resolving_conflicts_by_skipping_" xml:space="preserve">
-    <value>スキップして競合を解決中。</value>
   </data>
   <data name="ImportSkyrHelper_ResolveImportConflicts_Use_command" xml:space="preserve">
     <value>エラー： 競合を解決する方法を指定してください。コマンド--report-conflict-resolution=&amp;lt; overwrite | skip &gt;を使用します。</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_AssociateProteins_These_filters_cannot_be_applied_as_they_would_result_in_an_empty_transition_list." xml:space="preserve">
-    <value>これらのフィルターは、空のトランジションリストとなるため、適用できません。</value>
+  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_Python__0__and_the_following_packages__Select_packages_to_install_and_then_click_Install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>このツールにはPython{0}と以下のパッケージが必要です。インストールするパッケージを選択し、インストールをクリックしてインストールプロセスを開始します。</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Explicit_Declustering_Potential" xml:space="preserve">
-    <value>明示的デクラスタリングポテンシャル</value>
+  <data name="SkypDownloadException_GetMessage_Would_you_like_to_add__0__as_a_Panorama_server_in_Skyline_" xml:space="preserve">
+    <value>SkylineのPanoramaサーバーとして{0}を追加しますか？</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_List_Name" xml:space="preserve">
-    <value>分子リスト名</value>
+  <data name="FragmentLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\fragmentlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_Name" xml:space="preserve">
-    <value>分子名</value>
+  <data name="ReportSpecList_Title_Edit_Reports" xml:space="preserve">
+    <value>レポートを編集</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Reassigning_the_Protein_Name_column_will_prevent_the_peptides_from_being_associated_with_proteins_from_the_background_proteome." xml:space="preserve">
-    <value>タンパク質名列を再割り当てすると、ペプチドがバックグラウンドプロテオームからのタンパク質と関連しなくなります。</value>
+  <data name="ImportPeptideSearchDlg_NextPage_The_document_specific_spectral_library_does_not_have_valid_retention_times_" xml:space="preserve">
+    <value>ドキュメントの特定のスペクトルライブラリには有効な保持時間がありません。</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_headerList_Molecular_Formula" xml:space="preserve">
-    <value>分子式</value>
+  <data name="CommandLine_ConnectLibrarySpecs_Warning__Could_not_find_the_spectral_library__0_" xml:space="preserve">
+    <value>警告： スペクトルライブラリ{0}が見つかりませんでした</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Decoy" xml:space="preserve">
-    <value>デコイ</value>
+  <data name="CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_document__using___1___instead_" xml:space="preserve">
+    <value>繰り返し測定「{0}」は既にドキュメントに存在します。代わりに「{1}」を使用します。</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Fragment_Name" xml:space="preserve">
-    <value>フラグメント名</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column" xml:space="preserve">
-    <value>列を無視</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Label_Type" xml:space="preserve">
-    <value>標識タイプ</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence" xml:space="preserve">
-    <value>ペプチド修飾シークエンス</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_Charge" xml:space="preserve">
-    <value>プリカーサー電荷</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z" xml:space="preserve">
-    <value>プリカーサーm/z</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z" xml:space="preserve">
-    <value>プロダクトm/z</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Protein_Name" xml:space="preserve">
-    <value>タンパク質名</value>
-  </data>
-  <data name="ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_" xml:space="preserve">
-    <value>以下の値がないため、トランジションリストをインポートできません。</value>
-  </data>
-  <data name="IncompleteStandardException_IncompleteStandardException_The_calculator__0__requires_all_of_its_standard_peptides_in_order_to_determine_a_regression" xml:space="preserve">
-    <value>カルキュレータ{0}には、回帰を決定するためにすべての標準ペプチドが必要です。</value>
-  </data>
-  <data name="InstrumentInfoUtil_ReadInstrumentConfig_Unexpected_line_in_instrument_config__0__" xml:space="preserve">
-    <value>機器設定における予期しない行：{0}</value>
-  </data>
-  <data name="IonMobilityDb_GetIonMobilityDb_Please_provide_a_path_to_an_existing_ion_mobility_library_" xml:space="preserve">
-    <value>既存のイオン移動度ライブラリへのパスを提供してください。</value>
-  </data>
-  <data name="IonMobilityDb_GetIonMobilityDb_The_file__0__is_not_a_valid_ion_mobility_library_file_" xml:space="preserve">
-    <value>ファイル{0}は有効なイオン移動度ライブラリファイルではありません。</value>
-  </data>
-  <data name="IonMobilityDb_GetIonMobilityDb_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
-    <value>イオン移動度ライブラリファイル{0}を見つけることができませんでした。作成するための十分な権限がないようです。</value>
-  </data>
-  <data name="IonMobilityFilter_IonMobilityUnitsString_Drift_Time__ms_" xml:space="preserve">
-    <value>ドリフト時間(ms)</value>
-  </data>
-  <data name="IonMobilityFinder_ProcessMSLevel_Failed_using_results_to_populate_ion_mobility_library_" xml:space="preserve">
-    <value>結果を使用してイオン移動度ライブラリに入力できませんでした。</value>
-  </data>
-  <data name="IonMobilityLibraryList_AcceptList_will_be_deleted_because_the_libraries_they_depend_on_have_changed__Do_you_want_to_continue_" xml:space="preserve">
-    <value>依存するライブラリが変更されたので削除されます。続行しますか？</value>
-  </data>
-  <data name="IonMobilityPredictor_Validate_Ion_mobility_predictors_using_an_ion_mobility_library_must_include_per_charge_regression_values_" xml:space="preserve">
-    <value>イオン移動ライブラリを使用するイオン移動度予測には電荷毎の回帰値を含まなければなりません。</value>
-  </data>
-  <data name="IonMobilityTest_TestGetIonMobilityDBErrorHandling_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
-    <value>イオン移動度ライブラリファイル{0}を見つけることができませんでした。作成するための十分な権限がないようです。</value>
-  </data>
-  <data name="Ions_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_1.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_2.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_A" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_A.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_B" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_B.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_C" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_C.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_fragments" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_fragments.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_X" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_X.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_Y" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_Y.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_Z" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_Z.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="IrtDb_GetIrtDb_The_file__0__could_not_be_opened" xml:space="preserve">
-    <value>ファイル{0}が開けませんでした。</value>
-  </data>
-  <data name="IrtDb_MakeDocumentXml_iRT_standards" xml:space="preserve">
-    <value>iRT標準</value>
-  </data>
-  <data name="IrtStandard_DocumentStream_No_document_to_import" xml:space="preserve">
-    <value>インポートするドキュメントがありません</value>
-  </data>
-  <data name="IsolationScheme_DoValidate_Special_handling_applies_only_to_prespecified_isolation_windows" xml:space="preserve">
-    <value>特殊処理は、事前指定の単離ウィンドウのみに適用されます</value>
-  </data>
-  <data name="IsolationScheme_DoValidate_Unexpected_name___0___for__1__isolation_scheme" xml:space="preserve">
-    <value>{1}単離スキームに対する予期しない名前「{0}」</value>
-  </data>
-  <data name="IsolationSchemeList_GetDefaults_SWATH__15_m_z_" xml:space="preserve">
-    <value>SWATH (15 m/z)</value>
-  </data>
-  <data name="IsolationSchemeList_GetDefaults_SWATH__25_m_z_" xml:space="preserve">
-    <value>SWATH (25 m/z)</value>
-  </data>
-  <data name="IsolationSchemeList_GetDefaults_SWATH__VW_100_" xml:space="preserve">
-    <value>SWATH (VW 100)</value>
-  </data>
-  <data name="IsolationSchemeList_GetDefaults_SWATH__VW_64_" xml:space="preserve">
-    <value>SWATH (VW 64)</value>
-  </data>
-  <data name="IsolationWindow_DoValidate_Isolation_window_End_must_be_between__0__and__1__" xml:space="preserve">
-    <value>単離ウィンドウの終了は{0}と{1}の間でなければなりません。</value>
-  </data>
-  <data name="IsolationWindow_DoValidate_Isolation_window_margin_must_be_non_negative" xml:space="preserve">
-    <value>単離ウィンドウのマージンは負の値にはできません。</value>
-  </data>
-  <data name="IsolationWindow_DoValidate_Isolation_window_margins_cover_the_entire_isolation_window_at_the_extremes_of_the_instrument_range" xml:space="preserve">
-    <value>単離ウィンドウのマージンは、装置範囲の極限で単離ウィンドウ全体に及びます。</value>
-  </data>
-  <data name="IsolationWindow_DoValidate_Isolation_window_Start_must_be_between__0__and__1__" xml:space="preserve">
-    <value>単離ウィンドウの開始は{0}と{1}の間でなければなりません。</value>
-  </data>
-  <data name="IsotopeDistInfo_IsotopeDistInfo_Minimum_abundance__0__too_high" xml:space="preserve">
-    <value>最小存在度{0}が高すぎます</value>
-  </data>
-  <data name="KdeAlignerFactory_ToString_KDE_Aligner" xml:space="preserve">
-    <value>KDEアライナー</value>
-  </data>
-  <data name="Keep" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\keep.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LabelTypeComboDriver_LoadList_none" xml:space="preserve">
-    <value>なし</value>
-  </data>
-  <data name="LabKey" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LabKey.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LibraryBuildNotificationHandler_AddIrts__0__distinct_CiRT_peptides_were_found__How_many_would_you_like_to_use_as_iRT_standards_" xml:space="preserve">
-    <value>{0}個の異なるCiRTペプチドが見つかりました。何個をiRT標準として使用しますか？</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddProcessedIrts_A_single_run_does_not_have_high_enough_correlation_to_the_existing_iRT_values_to_allow_retention_time_conversion" xml:space="preserve">
-    <value>1回の実行では、既存のiRT値への相関度は保持時間を変換できるほど高くなりません。</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddProcessedIrts_Correlation_to_the_existing_iRT_values_are_not_high_enough_to_allow_retention_time_conversion" xml:space="preserve">
-    <value>既存のiRT値への相関度が保持時間を変換できるほど高くありません。</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddProcessedIrts_None_of__0__runs_were_found_with_high_enough_correlation_to_the_existing_iRT_values_to_allow_retention_time_conversion" xml:space="preserve">
-    <value>{0}回の実行は、いずれも保持時間を変換できるほど既存のiRT値への相関度が高くありませんでした。</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddToLibrary_Do_you_want_to_recalibrate_the_iRT_standard_values_relative_to_the_peptides_being_added_" xml:space="preserve">
-    <value>追加されているペプチドに対してiRT標準値を再校正しますか？</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddToLibrary_This_can_improve_retention_time_alignment_under_stable_chromatographic_conditions_" xml:space="preserve">
-    <value>安定したクロマトグラフ条件では、これによって保持時間のアライメントが改善することがあります。</value>
-  </data>
-  <data name="LibraryGridViewDriver_ValidateMz_Product_m_zs_must_be_greater_than_zero_" xml:space="preserve">
-    <value>プロダクトm/zは0より大きくなければなりません。</value>
-  </data>
-  <data name="LibraryManager_LoadBackground_Updating_library_settings_for__0_" xml:space="preserve">
-    <value>{0}のライブラリ設定を更新中</value>
-  </data>
-  <data name="Loader_Load_Loading_results_for__0__" xml:space="preserve">
-    <value>{0}の結果を読み込み中</value>
-  </data>
-  <data name="LoadingTooSlowlyException_LoadingTooSlowlyException_Data_import_expected_to_consume__0__minutes_with_maximum_of__1__mintues" xml:space="preserve">
-    <value>データのインポートには{0}分（最大{1}分）かかることが予測されます</value>
-  </data>
-  <data name="LocateFileDlg_LocateFileDlg_Below_is_the_saved_value_for_the_path_to_the_executable" xml:space="preserve">
-    <value>以下は、実行可能なファイルに対するパスの保存値です。</value>
+  <data name="ValidatingIonMobilityPeptide_ValidateCollisionalCrossSection_Measured_collisional_cross_section_values_must_be_valid_decimal_numbers_greater_than_zero_" xml:space="preserve">
+    <value>測定衝突断面積値は0より大きな有効な十進数でなければなりません。</value>
   </data>
   <data name="LocateFileDlg_LocateFileDlg_If_you_have_it_installed_please_provide_the_path_below" xml:space="preserve">
     <value>インストールされている場合は、以下のパスを提供してください。</value>
   </data>
-  <data name="LocateFileDlg_LocateFileDlg_Otherwise__please_cancel_and_install__0__version__1__first" xml:space="preserve">
-    <value>それ以外の場合は、キャンセルして{0}バージョン{1}を先にインストールしてください</value>
+  <data name="BuildLibraryDlg_OkWizardPage_Finish" xml:space="preserve">
+    <value>完了</value>
   </data>
-  <data name="LocateFileDlg_LocateFileDlg_Please_verify_and_update_if_incorrect" xml:space="preserve">
-    <value>確認し、間違っている場合にはアップデートしてください。</value>
+  <data name="WizardPeptideIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardPeptideIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="LocateFileDlg_LocateFileDlg_then_run_the_tool_again" xml:space="preserve">
-    <value>その後、ツールをもう一度実行します。</value>
+  <data name="Dash" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Dash.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="LocateFileDlg_LocateFileDlg_This_tool_requires_0_version_1" xml:space="preserve">
-    <value>このツールには{0}バージョン{1}が必要です。</value>
+  <data name="PeptideToMoleculeText_Proteins" xml:space="preserve">
+    <value>タンパク質</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 proteins" to read "2 molecule lists" when non-peptide documents are in use</comment>
   </data>
-  <data name="LocateFileDlg_PathPasses_You_have_not_provided_a_valid_path_" xml:space="preserve">
-    <value>有効なパスが提供されていません。</value>
+  <data name="PcaPlot_RefreshData_PCA_Plot" xml:space="preserve">
+    <value>PCAプロット</value>
   </data>
-  <data name="LowessAlignerFactory_ToString_LOWESS_Aligner" xml:space="preserve">
-    <value>LOWESSアライナー</value>
-  </data>
-  <data name="magnifier_zoom_in" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\magnifier_zoom_in.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MassErrorReplicateGraphPane_UpdateGraph_Select_a_peptide_to_see_the_mass_error_graph" xml:space="preserve">
-    <value>質量誤差グラフを表示するペプチドを選択</value>
-  </data>
-  <data name="MassListImporter_AddRow_Invalid_iRT_value_at_precusor_m_z__0__for_peptide__1_" xml:space="preserve">
-    <value>ペプチド{1}に対するプリカーサーm/z{0}での無効なiRT値。</value>
-  </data>
-  <data name="MassListImporter_AddRow_Invalid_library_intensity_at_precursor__0__for_peptide__1_" xml:space="preserve">
-    <value>ペプチド{1}に対するプリカーサー{0}での無効なライブラリ強度。</value>
-  </data>
-  <data name="MassListImporter_Import_Empty_transition_list" xml:space="preserve">
-    <value>空のトランジションリスト。</value>
-  </data>
-  <data name="MassListImporter_Import_Failed_to_find_peptide_column" xml:space="preserve">
-    <value>ペプチド列の検索に失敗しました。</value>
-  </data>
-  <data name="MassListRowReader_CalcPrecursorExplanations_" xml:space="preserve">
-    <value>プリカーサーm/z{0}が最も近い可能性のある値{1}（誤差={2}）、ペプチド{3}と一致しません。</value>
-  </data>
-  <data name="MassListRowReader_CalcPrecursorExplanations_Check_the_Instrument_tab_in_the_Transition_Settings" xml:space="preserve">
-    <value>トランジション設定の装置タブを確認します。</value>
-  </data>
-  <data name="MassListRowReader_CalcTransitionExplanations_Product_m_z_value__0__in_peptide__1__has_no_matching_product_ion" xml:space="preserve">
-    <value>ペプチド{1}のプロダクトm/z値{0}には一致するプロダクトイオンがありません。</value>
-  </data>
-  <data name="MassListRowReader_CalcTransitionExplanations_The_product_m_z__0__is_out_of_range_for_the_instrument_settings__in_the_peptide_sequence__1_" xml:space="preserve">
-    <value>プロダクトm/z{0}がペプチドシークエンス{1}における装置設定の範囲外です。</value>
-  </data>
-  <data name="MassListRowReader_NextRow_Invalid_peptide_sequence__0__found" xml:space="preserve">
-    <value>無効なペプチドシークエンス{0}が見つかりました</value>
-  </data>
-  <data name="MatchModificationsControl_AddCheckedModifications_Add_checked_modifications" xml:space="preserve">
-    <value>選択した修飾を追加</value>
-  </data>
-  <data name="MatchModificationsControl_AddModification_Add__0__modification__1_" xml:space="preserve">
-    <value>{0}修飾{1}を追加</value>
-  </data>
-  <data name="MeasuredCollisionalCrossSection_Validate_Charge_state_values_must_be_greater_than_0_" xml:space="preserve">
-    <value>電荷状態値は0より大きくなければなりません。</value>
-  </data>
-  <data name="MeasuredCollisionalCrossSection_Validate_Collisional_cross_section_values_must_be_greater_than_0_" xml:space="preserve">
-    <value>衝突断面積値は0より大きくなければなりません。</value>
-  </data>
-  <data name="MeasuredDriftTimeTable_ValidateMeasuredDriftTimeCellValues_On_line__0___1_" xml:space="preserve">
-    <value>{0}{1}行</value>
-  </data>
-  <data name="MeasuredPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry" xml:space="preserve">
-    <value>各エントリには修飾ペプチドシークエンスが必要です。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateAdductListTextBox__0__must_contain_a_comma_separated_list_of_adducts_or_integers_describing_charge_states_with_absolute_value_from__1__to__2__" xml:space="preserve">
-    <value>{0}は、{1}～{2}の絶対値で荷電状態を表記する付加イオンまたは整数値のカンマ区切りのリストを含む必要があります。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_be_greater_than_or_equal_to__1__" xml:space="preserve">
-    <value>{0}は{1}以上でなければなりません。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_be_less_than_or_equal_to__1__" xml:space="preserve">
-    <value>{0}は{1}以下でなければなりません。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_contain_a_decimal_value" xml:space="preserve">
-    <value>{0}には十進数が含まれなければなりません。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty" xml:space="preserve">
-    <value>{0}は空にできません。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateNumberTextBox__0__must_contain_an_integer" xml:space="preserve">
-    <value>{0}は整数を含まなければなりません。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateSignedNumberTextBox_Value__0__must_be_between__1__and__2__or__3__and__4__" xml:space="preserve">
-    <value>値{0}は、{1}と{2}または{3}と{4}の間でなければなりません。</value>
-  </data>
-  <data name="MissingFileDlg_ValidateFilePath_You_must_choose_a_file_with_the___0___filename_extension_" xml:space="preserve">
-    <value>ファイル拡張子が「{0}」のファイルを選択してください。</value>
-  </data>
-  <data name="ModeUIAwareFormHelper_EnableNeededButtonsForModeUI___Would_you_like_to_create_a_new_empty_document_" xml:space="preserve">
-    <value>  新しい空のドキュメントを作成しますか？</value>
-  </data>
-  <data name="Molecule" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Molecule.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeIrt" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\moleculeirt.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeIrtLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\moleculeirtlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\moleculelib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeList" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\MoleculeList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeStandard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\MoleculeStandard.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeStandardLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\MoleculeStandardLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\MoleculeUI.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MProphetPeakScoringModel_CalcLinearScore_Attempted_to_score_a_peak_with__0__features_using_a_model_with__1__trained_scores_" xml:space="preserve">
-    <value>{1}個のトレーニングされたスコアのあるモデルを使用して{0}個の機能を持つピークをスコアしようとしています。</value>
-  </data>
-  <data name="MProphetPeakScoringModel_CreateTransitionGroups_MProphetScoringModel_was_given_a_peak_with__0__features__but_it_has__1__peak_feature_calculators" xml:space="preserve">
-    <value>MProphetScoringModeには{0}個の機能を持つピークが与えられましたが、ピーク機能カルキュレータが{1}個あります</value>
-  </data>
-  <data name="MProphetResultsHandler_Q_VALUE_ANNOTATION_Q_Value" xml:space="preserve">
-    <value>Q値</value>
-  </data>
-  <data name="MQuestReferenceShapeCalc_MQuestReferenceShapeCalc_mProphet_weighted_reference" xml:space="preserve">
-    <value>mProphetの加重基準</value>
-  </data>
-  <data name="MSAmandaLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LogoAmanda_32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MsconvertDdaConverter_Run_Re_using_existing_converted__0__file_for__1__" xml:space="preserve">
-    <value>{1}に既存の変換された{0}を再利用しています。</value>
-  </data>
-  <data name="MultiFileAsynchronousDownloadClient_DownloadFileAsync_Downloading__0" xml:space="preserve">
-    <value>{0}のダウンロード中</value>
-  </data>
-  <data name="MultiFileAsynchronousDownloadClient_DownloadFileAsyncWithBroker_Download_canceled_" xml:space="preserve">
-    <value>ダウンロードがキャンセルされました。</value>
-  </data>
-  <data name="MzMatchException_suggestion" xml:space="preserve">
-    <value>ペプチド設定の修飾タブ、予測タブのm/zタイプ、またはトランジション設定の装置タブのm/z一致許容誤差を確認します。</value>
-  </data>
-  <data name="NewDocument" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\newdocument.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeakBoundaryImporter_Import_Line__0__field_count__1__differs_from_the_first_line__which_has__2_" xml:space="preserve">
+    <value>{0}行のフィールド数{1}が先頭行の{2}と異なります</value>
   </data>
   <data name="NistLibraryBase_CreateCache_" xml:space="preserve">
     <value>インポートされたライブラリには、1つまたは複数{0}のペアに対する複数エントリが含まれています。
@@ -1999,1753 +179,881 @@ Skylineにインポートする前に必要に応じてライブラリをフィ�
 
 以下は、次のエントリから構成された{0}個のペアです： {1}</value>
   </data>
-  <data name="NoCentroidedDataException_NoCentroidedDataException_No_centroided_data_available_for_file___0_____Adjust_your_Full_Scan_settings_" xml:space="preserve">
-    <value>ファイル"{0}"に利用可能なセントロイド化データはありません。 フルスキャン設定を調整。</value>
-  </data>
-  <data name="NoFullScanFilteringException_NoFullScanFilteringException_The_file__0__does_not_contain_SRM_MRM_chromatograms__To_extract_chromatograms_from_its_spectra__go_to_Settings___Transition_Settings___Full_Scan_and_choose_options_appropriate_to_the_acquisition_method_used_" xml:space="preserve">
-    <value>ファイル{0}にはSRM/MRMクロマトグラムが含まれていません。スペクトルからクロマトグラムを抽出するには、[設定] &gt; [トランジションの設定] &gt; [フルスキャン]にアクセスし、使用されている取得メソッドに適切なオプションを選択します。</value>
-    <comment>replaces NoFullScanFilteringException_NoFullScanFilteringException_To_extract_chromatograms_from__0__full_scan_settings_must_be_enabled_</comment>
-  </data>
-  <data name="NoPeak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\nopeak.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Note" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\note.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="OK" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_0_for_a_single_entry_list" xml:space="preserve">
-    <value>単一入力エントリリストに対するインデックス{0}は0でなければなりません。</value>
-  </data>
-  <data name="Open" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\open.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="OpenDataSourceDialog_EnsureRemoteAccount_No_remote_accounts_have_been_specified__If_you_have_an_existing_Unifi_account_you_can_enter_your_login_information_now_" xml:space="preserve">
-    <value>リモートアカウントが指定されていません。既存のUnifiアカウントをお持ちの場合、今すぐログイン情報を入力できます。</value>
-  </data>
-  <data name="OpenDataSourceDialog_lookInComboBox_SelectionChangeCommitted_My_Network_Place" xml:space="preserve">
-    <value>マイネットワークプレース</value>
-  </data>
-  <data name="OpenDataSourceDialog_Open_Error" xml:space="preserve">
-    <value>エラー</value>
-  </data>
-  <data name="OpenDataSourceDialog_OpenDataSourceDialog_My_Recent_Documents" xml:space="preserve">
-    <value>最近開いたドキュメント</value>
-  </data>
-  <data name="OpenDataSourceDialog_sourcePathTextBox_KeyUp_Some_source_paths_are_invalid" xml:space="preserve">
-    <value>一部のソースパスが無効です</value>
-  </data>
-  <data name="OpenFolder" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\openfolder.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="OptimizationDb_ConvertFromOldFormat_Failed_to_convert__0__optimizations_to_new_format_" xml:space="preserve">
-    <value>{0}を新しい形式に最適化する変換に失敗しました。</value>
-  </data>
-  <data name="OverlapDemultiplexer_attempt_to_insert_slice_of_deconvolution_matrix_failed_out_of_range" xml:space="preserve">
-    <value>範囲外エラーにより、デコンボリューションマトリックスのスライスの挿入に失敗しました。</value>
-  </data>
-  <data name="OverlapDemultiplexer_attempt_to_take_slice_of_deconvolution_matrix_failed_out_of_range" xml:space="preserve">
-    <value>範囲外エラーにより、デコンボリューションマトリックスのスライスの取り出しに失敗しました。</value>
-  </data>
-  <data name="OverlapDemultiplexer_RowStart_Number_of_regions__0__in_overlap_demultiplexer_approximation_must_be_less_than_number_of_scans__1__" xml:space="preserve">
-    <value>重複デマルチプレクサ―近似値の領域数{0}は、スキャン数{1}未満でなければなりません。</value>
-  </data>
-  <data name="OverlapDemultiplexer_the_isolation_window_overlap_scheme_does_not_cover_all_isolation_windows" xml:space="preserve">
-    <value>overlapiIsolationウィンドウスキームに欠損している隣接単離ウィンドウがいくつかあります。</value>
-  </data>
-  <data name="Panorama" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Panorama.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PanoramaHelper_ValidateServer_Exception_" xml:space="preserve">
-    <value>エラー：パノラマサーバー情報を確認しようとして不明なエラーが発生しました。
-{0}</value>
-  </data>
-  <data name="PanoramaPublish" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\panoramapublish.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
-    <value>ユーザーを認証できませんでした。サーバーから受信した応答：{0} {1}</value>
-  </data>
-  <data name="PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
-    <value>サーバーは有効なJSON応答を返しませんでした。{0}はPanoramaサーバーではありません。</value>
-  </data>
-  <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
-    <value>サーバーからの予期しないJSON応答：{0}</value>
-  </data>
-  <data name="ParsimonySettings_Validate_The_value__0__for__1__is_not_valid__it_must_be_greater_than_or_equal_to__2__" xml:space="preserve">
-    <value>{1}の値{0}が無効です： {2}に等しいかそれ以上でなければなりません。</value>
-  </data>
-  <data name="Paste" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\paste.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PasteDlg_AddFasta__0__is_not_a_capital_letter_that_corresponds_to_an_amino_acid" xml:space="preserve">
-    <value>「{0}」はアミノ酸に対応する大文字ではありません。</value>
-  </data>
-  <data name="PasteDlg_AddFasta_An_unexpected_error_occurred" xml:space="preserve">
-    <value>予期しないエラーが発生しました：</value>
-  </data>
-  <data name="PasteDlg_AddFasta_An_unexpected_error_occurred__0__1__" xml:space="preserve">
-    <value>予期しないエラーが発生しました：{0} ({1})</value>
-    <comment>Message (Error Type)</comment>
-  </data>
-  <data name="PasteDlg_AddFasta_There_is_no_name_for_this_protein" xml:space="preserve">
-    <value>このタンパク質には名前がありません</value>
-  </data>
-  <data name="PasteDlg_AddFasta_This_must_start_with" xml:space="preserve">
-    <value>これは「&gt;」から始まる必要があります</value>
-  </data>
-  <data name="PasteDlg_AddTransitionList_The_precursor_m_z_must_be_a_number_" xml:space="preserve">
-    <value>プリカーサーm/zは数字でなければなりません。</value>
-  </data>
-  <data name="PasteDlg_AddTransitionList_The_product_m_z_must_be_a_number_" xml:space="preserve">
-    <value>プロダクトm/zは数字でなければなりません。</value>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_" xml:space="preserve">
-    <value>このウィンドウの一番簡単な使用方法は、Excel（またはデータがCSV形式の場合テキストエディタ）からコピーしグリッドに貼り付けることです。
- 
-Skylineでの列の順序は、列のヘッダーを左右にドラッグすることで調整できます。
- 
-ほとんどのペプチドトランジションリストは、「ファイル|インポート|トランジションリスト...」メニューアイテムでインポートでき、[ターゲット]ウィンドウに直接貼り付けることもできます。</value>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_2_" xml:space="preserve">
-    <value>分子のイオン式に関するメモ：
-
-お使いのトランジションリストの形式で分子式と付加イオンの表記を単一の列にまとめている場合（例：「C8H10N4O2[M+Na]」）、[イオン式]の列を使用し、[付加イオン]の列は無視してください。お使いのトランジションリストで分子式と付加イオンの表記を別々の列に記載している場合、[イオン式]の列に分子式を、付加イオンの説明に[付加イオン]の列を使用してください。</value>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_SmallMol_" xml:space="preserve">
-    <value>このウィンドウの一番簡単な使用方法は、Excel（またはデータがCSV形式の場合テキストエディタ）からコピーしグリッドに貼り付けることです。
-
-Skylineでの列の順序は、列のヘッダーを左右にドラッグすることで調整できます。分子の場合、[列...]ボタンで有効にする列を選択することもできます。
-
-ほとんどのペプチドトランジションリストは、「ファイル|インポート|トランジションリスト...」メニューアイテムでインポートでき、[ターゲット]ウィンドウに直接貼り付けることもできます。また列ヘッダーにこれらの名前が使われている場合、分子トランジションリストでもこれが実施できます： </value>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_Supported_values_for__0__are___1_" xml:space="preserve">
-    <value>{0}のサポートされる値には次があります：{1}</value>
-    <comment>{1} is a comma seprated list of supported ion mobility units</comment>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_Transition_List_Help" xml:space="preserve">
-    <value>トランジションリストのヘルプ</value>
-  </data>
-  <data name="PasteDlg_CheckSequence_There_is_no_sequence_for_this_protein" xml:space="preserve">
-    <value>このタンパク質にはシークエンスがありません</value>
-  </data>
-  <data name="PasteDlg_Description_Insert_transition_list" xml:space="preserve">
-    <value>トランジションリストを挿入</value>
-  </data>
-  <data name="PasteDlg_GetMoleculePeptideGroup_Molecule_List__0_" xml:space="preserve">
-    <value>分子リスト{0}</value>
-  </data>
-  <data name="PasteDlg_GetMoleculeTransition_Product_m_z__0__isn_t_close_enough_to_the_nearest_possible_m_z__1___delta_2___" xml:space="preserve">
-    <value>プロダクトm/z{0}が、最も近い可能性のあるm/z{1} (delta{2}) に十分近いものではありません。</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_charge_value__0_" xml:space="preserve">
-    <value>無効な電荷値{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_collision_energy_value__0_" xml:space="preserve">
-    <value>無効な衝突エネルギー値{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_compensation_voltage__0_" xml:space="preserve">
-    <value>無効な補償電圧{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_cone_voltage_value__0_" xml:space="preserve">
-    <value>無効なコーン電圧値{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_declustering_potential__0_" xml:space="preserve">
-    <value>無効なデクラスタリングポテンシャル{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_m_z_value__0_" xml:space="preserve">
-    <value>無効なm/z値{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_retention_time_value__0_" xml:space="preserve">
-    <value>無効な保持時間値{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_retention_time_window_value__0_" xml:space="preserve">
-    <value>無効な保持時間ウィンドウ値{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_S_Lens_value__0_" xml:space="preserve">
-    <value>無効なS-レンズ値{0}</value>
-  </data>
-  <data name="PasteDlg_ShowNoErrors_No_errors" xml:space="preserve">
-    <value>エラーなし</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Collision_Cross_Section__sq_A_" xml:space="preserve">
-    <value>衝突断面積(sq A)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Compensation_Voltage" xml:space="preserve">
-    <value>補償電圧</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Cone_Voltage" xml:space="preserve">
-    <value>コーン電圧</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Decoy" xml:space="preserve">
-    <value>デコイ</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Collision_Cross_Section__sq_A_" xml:space="preserve">
-    <value>明示的な衝突断面積（Aの2乗）</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Collision_Energy" xml:space="preserve">
-    <value>明示的衝突エネルギー</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Compensation_Voltage" xml:space="preserve">
-    <value>明示的補償電圧</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility" xml:space="preserve">
-    <value>指定されたイオン移動度</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility__1_K0_" xml:space="preserve">
-    <value>指定されたイオン移動度(1/K0)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility__msec_" xml:space="preserve">
-    <value>指定されたイオン移動度(msec)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility_High_Energy_Offset" xml:space="preserve">
-    <value>指定されたイオン移動度の高エネルギーオフセット</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility_Units" xml:space="preserve">
-    <value>指定されたイオン移動度の単位</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Retention_Time" xml:space="preserve">
-    <value>明示的保持時間</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Retention_Time_Window" xml:space="preserve">
-    <value>明示的保持時間ウィンドウ</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Fragment_Name" xml:space="preserve">
-    <value>フラグメント名</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility" xml:space="preserve">
-    <value>イオン移動度</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility__1_K0_" xml:space="preserve">
-    <value>イオン移動度(1/K0)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility__msec_" xml:space="preserve">
-    <value>イオン移動度(msec)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility_High_Energy_Offset" xml:space="preserve">
-    <value>イオン移動度高エネルギーオフセット</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility_Units" xml:space="preserve">
-    <value>イオン移動度の単位</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_iRT" xml:space="preserve">
-    <value>iRT</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Label_Type" xml:space="preserve">
-    <value>標識タイプ</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Library_Intensity" xml:space="preserve">
-    <value>ライブラリ強度</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Note" xml:space="preserve">
-    <value>メモ</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Peptide" xml:space="preserve">
-    <value>ペプチド</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Possible_loss_of_data_could_occur_if_you_switch_to__0___Do_you_want_to_continue_" xml:space="preserve">
-    <value>{0}に切り替えた場合、データのロスが生じる可能性があります。続行しますか？</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Precursor_Adduct" xml:space="preserve">
-    <value>プリカーサー付加物</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Precursor_Name" xml:space="preserve">
-    <value>プリカーサー名</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Adduct" xml:space="preserve">
-    <value>プロダクトの付加物</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Charge" xml:space="preserve">
-    <value>プロダクト電荷</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Formula" xml:space="preserve">
-    <value>プロダクトイオン式</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Name" xml:space="preserve">
-    <value>プロダクト名</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Neutral_Loss" xml:space="preserve">
-    <value>プロダクトニュートラルロス</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Protein_description" xml:space="preserve">
-    <value>タンパク質の説明</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Protein_name" xml:space="preserve">
-    <value>タンパク質名</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Retention_Time" xml:space="preserve">
-    <value>保持時間</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Retention_Time_Window" xml:space="preserve">
-    <value>保持時間ウィンドウ</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_S_Lens" xml:space="preserve">
-    <value>S-レンズ</value>
-  </data>
-  <data name="PcaPlot_RefreshData_PCA_Plot" xml:space="preserve">
-    <value>PCAプロット</value>
-  </data>
-  <data name="Peak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peak.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeakBlank" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peakblank.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeakBoundaryImporter_DetermineCorrectSeparator_The_first_line_does_not_contain_any_of_the_possible_separators_comma__tab_or_space_" xml:space="preserve">
-    <value>先頭行に使用可能な分離記号カンマ、タブ、空白がいずれも含まれていません。</value>
-  </data>
-  <data name="PeakBoundaryImporter_DetermineCorrectSeparator_The_first_line_does_not_contain_any_of_the_possible_separators_semicolon__tab_or_space_" xml:space="preserve">
-    <value>先頭行に使用可能な分離記号セミコロン、タブ、空白がいずれも含まれていません。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Failed_to_find_the_necessary_headers__0__in_the_first_line" xml:space="preserve">
-    <value>先頭行に必要なヘッダー{0}の検索に失敗しました</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Failed_to_read_the_first_line_of_the_file" xml:space="preserve">
-    <value>ファイルの先頭行の読み取りに失敗しました</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Line__0__field_count__1__differs_from_the_first_line__which_has__2_" xml:space="preserve">
-    <value>{0}行のフィールド数{1}が先頭行の{2}と異なります</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Missing_end_time_on_line__0_" xml:space="preserve">
-    <value>{0}行目の欠損している終了時間</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Missing_start_time_on_line__0_" xml:space="preserve">
-    <value>{0}行目の欠損している開始時間</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Sample__0__on_line__1__does_not_match_the_file__2__" xml:space="preserve">
-    <value>{1}行目の試料{0}がファイル{2}に一致しません。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_decoy_value__0__on_line__1__is_invalid__must_be_0_or_1_" xml:space="preserve">
-    <value>{1}行目のデコイ値{0}が無効です：0か1でなければなりません。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_charge_state_" xml:space="preserve">
-    <value>{1}行目の値「{0}」は有効な荷電状態ではありません。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_end_time_" xml:space="preserve">
-    <value>{1}行目の値「{0}」は有効な終了時間ではありません。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_start_time_" xml:space="preserve">
-    <value>{1}行目の値「{0}」は有効な開始時間ではありません。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_time_" xml:space="preserve">
-    <value>{1}行目の値「{0}」は有効な時間ではありません。</value>
-  </data>
-  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_Continue_peak_boundary_import_ignoring_this_file_" xml:space="preserve">
-    <value>このファイルを無視してピーク境界のインポートを続行しますか？</value>
-  </data>
-  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_Continue_peak_boundary_import_ignoring_this_peptide_" xml:space="preserve">
-    <value>このペプチドを無視してピーク境界のインポートを続行しますか？</value>
-  </data>
-  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_The_following_file_name_in_the_peak_boundaries_file_was_not_recognized_" xml:space="preserve">
-    <value>ピーク境界ファイル内の以下のファイル名が認識されませんでした：</value>
-  </data>
-  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_" xml:space="preserve">
-    <value>ピーク境界ファイル内の以下のペプチドが認識されませんでした：</value>
-  </data>
-  <data name="PeakBoundsMatch_PeakBoundsMatch_Unable_to_read_a_score_annotation_for_peptide__0__of_file__1_" xml:space="preserve">
-    <value>ファイル{1}のペプチド{0}のスコア注釈を読み取ることができません</value>
-  </data>
-  <data name="PeakBoundsMatch_QValue_Unable_to_read_q_value_annotation_for_peptide__0__of_file__1_" xml:space="preserve">
-    <value>ファイル{0}のペプチドに対するq値の注釈を読み取ることができません{1}</value>
-  </data>
-  <data name="PeakCalculatorGridViewDriver_ValidateRow_On_line__0____1_" xml:space="preserve">
-    <value>{0}行、{1}</value>
-  </data>
-  <data name="PeakCalculatorWeight_Validate___0___is_not_a_known_name_for_a_peak_feature_calculator" xml:space="preserve">
-    <value>「{0}」はピーク機能カルキュレータとして知られている名前ではありません</value>
-  </data>
-  <data name="Peptide" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptide.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Peptide_ExplicitRetentionTimeWindow_Explicit_retention_time_window_requires_an_explicit_retention_time_value_" xml:space="preserve">
-    <value>明示的保持時間ウィンドウには、明示的保持時間値が必要です。</value>
-  </data>
-  <data name="Peptide_GetDeleteConfirmation_Are_you_sure_you_want_to_delete_these__0__peptides_" xml:space="preserve">
-    <value>本当にこれら{0}個のペプチドを削除してもよろしいですか？</value>
-    <comment>Example: Are you sure you want to delete these 47 peptides?</comment>
-  </data>
   <data name="Peptide_ThrowIfNotSmallMolecule_Direct_editing_of_this_value_is_only_supported_for_small_molecules_" xml:space="preserve">
     <value>この値の直接編集は非プロテオミクス分子に対してのみサポートされています。</value>
-  </data>
-  <data name="Peptide_ToString__missed__5__" xml:space="preserve">
-    <value>（ミス{5}）</value>
-  </data>
-  <data name="PeptideDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidedecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideDecoyLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidedecoylib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideGroupBuilder_AppendTransition_Failed_to_explain_all_transitions_for_0__m_z__1__with_a_single_set_of_modifications" xml:space="preserve">
-    <value>修飾の単一セットを持つ{0}m/z{1}のすべてのトランジションの説明に失敗しました</value>
-  </data>
-  <data name="PeptideGroupBuilder_FinalizeTransitionGroups_Two_transitions_of_the_same_precursor___0___m_z__1_____have_different_iRT_values___2__and__3___iRT_values_must_be_assigned_consistently_in_an_imported_transition_list_" xml:space="preserve">
-    <value>同一プリカーサーの2個のトランジション{0} (m/z{1}) には異なるiRT値、{2}、{3}があります。iRT値はインポートされたトランジションリスト内では一貫して割り当てられなければなりません。</value>
-  </data>
-  <data name="PeptideGroupDocNode_ChangeSettings_The_current_document_settings_would_cause_the_number_of_targeted_transitions_to_exceed__0_n0___The_document_settings_must_be_more_restrictive_or_add_fewer_proteins_" xml:space="preserve">
-    <value>現在のドキュメント設定により、ターゲットトランジションの数が{0:n0}を超過する原因となります。ドキュメント設定をさらに制限するか、追加するタンパク質を減らさなければなりません。</value>
-  </data>
-  <data name="PeptideGroupTreeNode_ProteinModalDisplayText__name___0__" xml:space="preserve">
-    <value>&lt;名前：{0}&gt;</value>
-  </data>
-  <data name="PeptideGroupTreeNode_RenderTip_Name" xml:space="preserve">
-    <value>名前</value>
-  </data>
-  <data name="PeptideIrt" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptideirt.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideIrtLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptideirtlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidelib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideList" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\PeptideList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideQc" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptideqc.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideQcLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptideqclib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideSettingsUI_comboPeakScoringModel_SelectedIndexChanged_The_document_must_have_imported_results_in_order_to_train_a_model_" xml:space="preserve">
-    <value>トレインモデルには、ドキュメントにインポートされた結果がなければなりません。</value>
-  </data>
-  <data name="PeptideSettingsUI_ComboPeakScoringModelSelected_Unrecognized_Model" xml:space="preserve">
-    <value>認識されていないモデル</value>
   </data>
   <data name="PeptideSettingsUI_ShowBuildLibraryDlg_Finishing_up_building_library" xml:space="preserve">
     <value>ライブラリ構築の終了中</value>
   </data>
-  <data name="PeptideSettingsUI_ValidateNewSettings_Choose_at_least_one_internal_standard_type" xml:space="preserve">
-    <value>内部標準タイプを1つ以上選択してください。</value>
-  </data>
-  <data name="PeptidesPerProteinDlg_UpdateRemaining_Calculating___" xml:space="preserve">
-    <value>計算中...</value>
-  </data>
-  <data name="PeptideStandard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidestandard.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideStandardLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidestandardlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideTipProvider_RenderTip_CCS" xml:space="preserve">
-    <value>CCS</value>
-    <comment>compact form of Collision Cross Section</comment>
-  </data>
-  <data name="PeptideTipProvider_RenderTip_Ion_Mobility" xml:space="preserve">
-    <value>イオン移動度</value>
-  </data>
-  <data name="PeptideTipProvider_RenderTip_Precursor_m_z" xml:space="preserve">
-    <value>プリカーサーm/z</value>
-  </data>
-  <data name="PeptideToMoleculeText_Ion_adducts" xml:space="preserve">
-    <value>付加イオン</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "Ion charges" to read "Ion adducts" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Ion_charges" xml:space="preserve">
-    <value>イオン電荷</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "Ion charges" to read "Ion adducts" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Modified_Peptide_Sequence" xml:space="preserve">
-    <value>修飾ペプチドシークエンス</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a modifed peptide sequence" to read "select a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Modified_Sequence" xml:space="preserve">
-    <value>修飾シークエンス</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a modifed sequence" to read "select a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Molecule" xml:space="preserve">
-    <value>分子</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a peptide" to read "choose a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Molecule_List" xml:space="preserve">
-    <value>分子リスト</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a protein" to read "choose a molecule list" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Molecule_Lists" xml:space="preserve">
-    <value>分子リスト</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like  "2 proteins" to read "2 molecule lists" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Molecules" xml:space="preserve">
-    <value>分子</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 peptides" to read "2 molecules" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Peptide" xml:space="preserve">
-    <value>ペプチド</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a peptide" to read "choose a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Peptide_List" xml:space="preserve">
-    <value>ペプチドのリスト</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a peptide list" to read "select a molecule list" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Peptide_Sequence" xml:space="preserve">
-    <value>ペプチドシークエンス</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a peptide sequence" to read "select a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Peptides" xml:space="preserve">
-    <value>ペプチド</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 peptides" to read "2 molecules" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Protein" xml:space="preserve">
-    <value>タンパク質</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a protein" to read "choose a molecule list" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Proteins" xml:space="preserve">
-    <value>タンパク質</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 proteins" to read "2 molecule lists" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PersistedViews_GetDefaults_Molecule_Quantification" xml:space="preserve">
-    <value>分子定量化</value>
-  </data>
-  <data name="PersistedViews_GetDefaults_Molecule_Ratio_Results" xml:space="preserve">
-    <value>分子比率の結果</value>
-  </data>
-  <data name="Pivoter_QualifyColumnInfo_AreaRatio" xml:space="preserve">
-    <value>AreaRatio</value>
-  </data>
-  <data name="Pivoter_QualifyColumnInfo_AreaRatioTo" xml:space="preserve">
-    <value>AreaRatioTo</value>
-  </data>
-  <data name="Pivoter_QualifyColumnInfo_TotalAreaRatio" xml:space="preserve">
-    <value>TotalAreaRatio</value>
-  </data>
-  <data name="Pivoter_QualifyColumnInfo_TotalAreaRatioTo" xml:space="preserve">
-    <value>TotalAreaRatioTo</value>
-  </data>
-  <data name="PivotReportDlg_OkDialog_A_report_must_have_at_least_one_column" xml:space="preserve">
-    <value>レポートには1列以上必要です。</value>
-  </data>
-  <data name="PivotReportDlg_ShowPreview_A_report_must_have_at_least_one_column_" xml:space="preserve">
-    <value>レポートには1列以上必要です。</value>
-  </data>
-  <data name="PopupBtn" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\popupbtn.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Print" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\print.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Properties_Button" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Properties.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="prosit_logo_dark_blue" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\prosit_logo_dark_blue.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
   <data name="Protein" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Protein.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="ProteinDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ProteinDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Adduct" xml:space="preserve">
+    <value>プロダクトの付加物</value>
   </data>
-  <data name="ProteinUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ProteinUI.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_Q_value_entered" xml:space="preserve">
+    <value>入力されたQ値が無効です</value>
   </data>
-  <data name="ProteoWizard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ProteoWizard.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PublishDocumentDlg_btnBrowse_Click_Shared_Files" xml:space="preserve">
-    <value>共有ファイル</value>
-  </data>
-  <data name="PublishDocumentDlg_OkDialog_Please_select_a_folder" xml:space="preserve">
-    <value>フォルダを選択してください</value>
-  </data>
-  <data name="PublishDocumentDlg_OkDialog_Please_select_a_Skyline_Shared_file_to_upload" xml:space="preserve">
-    <value>アップロードするSkyline共有ファイルを選択してください。</value>
-  </data>
-  <data name="PublishDocumentDlg_OkDialog_Selected_file_is_not_a_Skyline_Shared_file" xml:space="preserve">
-    <value>選択したファイルはSkyline共有ファイルではありません。</value>
-  </data>
-  <data name="PublishDocumentDlg_ServerSupportsSkydVersion_" xml:space="preserve">
-    <value>選択したサーバーはskydファイル形式のバージョン{0}をサポートしていません。
-サーバーをアップグレードするには、Panoramaサーバー管理者に問い合わせてください。</value>
-  </data>
-  <data name="PublishDocumentDlg_UploadSharedZipFile_Click_here_to_view_the_error_details_" xml:space="preserve">
-    <value>エラーの詳細を表示するにはここをクリックします。</value>
-  </data>
-  <data name="PublishDocumentDlg_UploadSharedZipFile_You_do_not_have_permission_to_upload_to_the_given_folder" xml:space="preserve">
-    <value>指定したフォルダにアップロードする権限がありません。</value>
-  </data>
-  <data name="PythonInstaller_DownloadPackages_Failed_to_download_the_following_packages_" xml:space="preserve">
-    <value>以下のパッケージのダウンロードに失敗しました：</value>
-  </data>
-  <data name="PythonInstaller_DownloadPip_Download_failed__Check_your_network_connection_or_contact_Skyline_developers_" xml:space="preserve">
-    <value>ダウンロードに失敗しました。ネットワーク接続をチェックするか、Skyline開発者に連絡します。</value>
-  </data>
-  <data name="PythonInstaller_DownloadPython_Check_your_network_connection_or_contact_the_tool_provider_for_installation_support_" xml:space="preserve">
-    <value>ネットワーク接続を確認するか、ツールプロバイダに問い合わせてインストールのサポートを依頼します。</value>
-  </data>
-  <data name="PythonInstaller_DownloadPython_Download_failed_" xml:space="preserve">
-    <value>ダウンロードに失敗しました。</value>
-  </data>
-  <data name="PythonInstaller_GetPackages_Package_installation_completed_" xml:space="preserve">
-    <value>パッケージのインストールが完了しました。</value>
-  </data>
-  <data name="PythonInstaller_GetPython_Python_installation_completed_" xml:space="preserve">
-    <value>Pythonのインストールが完了しました。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Package_installation_failed__Error_log_output_in_immediate_window_" xml:space="preserve">
-    <value>パッケージのインストールに失敗しました。即時ウィンドウ内のログ出力エラー。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Package_Installation_was_not_completed__Canceling_tool_installation_" xml:space="preserve">
-    <value>パッケージのインストールが完了しませんでした。ツールのインストールのキャンセル中。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Pip_installation_complete_" xml:space="preserve">
-    <value>Pipのインストールが完了しました。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Python_package_installation_cannot_continue__Canceling_tool_installation_" xml:space="preserve">
-    <value>Pythonパッケージのインストールを続行できません。ツールのインストールのキャンセル中。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Skyline_uses_the_Python_tool_setuptools_and_the_Python_package_manager_Pip_to_install_packages_from_source__Click_install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>Skylineは、PythonツールsetuptoolsとPythonパッケージマネージャPipを使用し、ソースからパッケージをインストールします。インストールをクリックしてインストールプロセスを開始します。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Unknown_error_installing_packages_" xml:space="preserve">
-    <value>パッケージのインストール中の不明なエラー。</value>
-  </data>
-  <data name="PythonInstaller_InstallPip_Pip_installation_failed__Error_log_output_in_immediate_window__" xml:space="preserve">
-    <value>Pipのインストールに失敗しました。即時ウィンドウ内のログ出力エラー。</value>
-  </data>
-  <data name="PythonInstaller_InstallPip_Unknown_error_installing_pip_" xml:space="preserve">
-    <value>Pipのインストール中の不明なエラー。</value>
+  <data name="SkylineWindow_ImportMassList_There_is_an_existing_library_with_the_same_name__0__as_the_document_library_to_be_created___Overwrite_this_library_or_skip_import_of_library_intensities_" xml:space="preserve">
+    <value>ドキュメントライブラリとして作成される同じ名前{0}の既存のライブラリが存在しています。 このライブラリを上書きしますか、それともライブラリ強度のインポートをスキップしますか？</value>
   </data>
   <data name="PythonInstaller_InstallPython_Python_installation_failed__Canceling_tool_installation_" xml:space="preserve">
     <value>Pythonのインストールに失敗しました。ツールのインストールのキャンセル中。</value>
   </data>
-  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_Python__0___Click_install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>このツールにはPython{0}が必要です。インストールをクリックしてインストールプロセスを開始します。</value>
+  <data name="ModeUIAwareFormHelper_EnableNeededButtonsForModeUI___Would_you_like_to_create_a_new_empty_document_" xml:space="preserve">
+    <value>  新しい空のドキュメントを作成しますか？</value>
   </data>
-  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_Python__0__and_the_following_packages__Select_packages_to_install_and_then_click_Install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>このツールにはPython{0}と以下のパッケージが必要です。インストールするパッケージを選択し、インストールをクリックしてインストールプロセスを開始します。</value>
+  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_choose_a_non_redundant_library_" xml:space="preserve">
+    <value>非冗長ライブラリを選択してください。</value>
   </data>
-  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_the_following_Python_packages__Select_packages_to_install_and_then_click_Install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>このツールには以下のPythonパッケージが必要です。インストールするパッケージを選択し、インストールをクリックしてインストールプロセスを開始します。</value>
+  <data name="LibraryManager_LoadBackground_Updating_library_settings_for__0_" xml:space="preserve">
+    <value>{0}のライブラリ設定を更新中</value>
   </data>
-  <data name="RatioToSurrogate_ToString_Ratio_to_surrogate__0____1__" xml:space="preserve">
-    <value>サロゲート{0}に対する比率({1})</value>
+  <data name="CommandLine_OpenSkyFile_File__0__opened_" xml:space="preserve">
+    <value>ファイル{0}が開きました。</value>
   </data>
-  <data name="RCalcIrt_RequireUsable_Unexpected_use_of_iRT_calculator_before_successful_initialization" xml:space="preserve">
-    <value>初期化成功前の予期せぬiRTカルキュレータの使用。</value>
+  <data name="PythonInstaller_InstallPip_Unknown_error_installing_pip_" xml:space="preserve">
+    <value>Pipのインストール中の不明なエラー。</value>
   </data>
-  <data name="RedX" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RedX.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RedXTransparentBackground" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RedXTransparentBackground.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RefineDlg_NormalizationMethod_Total_ion_current" xml:space="preserve">
-    <value>総イオン電流</value>
-  </data>
-  <data name="RefineDlg_RefineDlg_Precursors" xml:space="preserve">
-    <value>プリカーサー</value>
-  </data>
-  <data name="RefineDlg_RefineDlg_Products" xml:space="preserve">
-    <value>プロダクト</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_Do_you_want_to_continue" xml:space="preserve">
-    <value>続行しますか？</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_None_of_the_specified_peptides_are_in_the_document" xml:space="preserve">
-    <value>指定されたペプチドはどれもドキュメント内にありません。</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_Of_the_specified__0__peptides__1__are_not_in_the_document_Do_you_want_to_continue" xml:space="preserve">
-    <value>指定された{0}ペプチド{1}はどれもドキュメント内にありません。続行しますか？</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_following_peptides_are_not_in_the_document" xml:space="preserve">
-    <value>以下のペプチドはドキュメント内にありません：</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_following_sequences_are_not_valid_peptides" xml:space="preserve">
-    <value>以下のシークエンスは有効なペプチドではありません：</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_peptide___0___is_not_in_the_document" xml:space="preserve">
-    <value>ペプチド「{0}」はドキュメント内にありません。</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_peptide__0__is_not_in_the_document_Do_you_want_to_continue" xml:space="preserve">
-    <value>ペプチド「{0}」はドキュメント内にありません。続行しますか？</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_sequence__0__is_not_a_valid_peptide" xml:space="preserve">
-    <value>シークエンス「{0}」は有効なペプチドではありません。</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_Do_you_want_to_continue" xml:space="preserve">
-    <value>続行しますか？</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_None_of_the_specified_proteins_are_in_the_document_" xml:space="preserve">
-    <value>指定されたタンパク質はどれもドキュメント内にありません。</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_Of_the_specified__0__proteins__1__are_not_in_the_document__Do_you_want_to_continue_" xml:space="preserve">
-    <value>指定された{0}タンパク質{1}はどれもドキュメント内にありません。続行しますか？</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_The_following_proteins_are_not_in_the_document_" xml:space="preserve">
-    <value>以下のタンパク質はドキュメント内にありません：</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_The_protein___0___is_not_in_the_document__Do_you_want_to_continue_" xml:space="preserve">
-    <value>タンパク質'{0}'はドキュメント内にありません。続行しますか？</value>
-  </data>
-  <data name="RefinementSettings_Refine_The_document_must_contain_at_least_2_replicates_to_refine_based_on_consistency_" xml:space="preserve">
-    <value>一貫性に基づいて最適化するには、ドキュメントに少なくとも2つの繰り返し測定を含める必要があります。</value>
-  </data>
-  <data name="Regression_intercept" xml:space="preserve">
-    <value>切片</value>
-  </data>
-  <data name="Regression_slope" xml:space="preserve">
-    <value>勾配</value>
-  </data>
-  <data name="RegressionFit_BILINEAR_Bilinear" xml:space="preserve">
-    <value>双線形</value>
-  </data>
-  <data name="RegressionOption_All_Fixed_points__linear_" xml:space="preserve">
-    <value>固定点（線形）</value>
-  </data>
-  <data name="RegressionOption_All_Fixed_points__logarithmic_" xml:space="preserve">
-    <value>固定点（対数）</value>
-  </data>
-  <data name="ReintegrateDlg_OkDialog_Failed_attempting_to_reintegrate_peaks_" xml:space="preserve">
-    <value>ピークを再積分できませんでした。</value>
-  </data>
-  <data name="ReintegrateDlg_OkDialog_Reintegrating" xml:space="preserve">
-    <value>再積分中</value>
-  </data>
-  <data name="ReintegrateDlg_OkDialog_The_current_peak_scoring_model_is_incompatible_with_one_or_more_peptides_in_the_document___Please_train_a_new_model_" xml:space="preserve">
-    <value>現在のピークスコアモデルは、ドキュメント内の1つ以上のペプチドと互換性がありません。新しいモデルをトレーニングしてください。</value>
-  </data>
-  <data name="RemoteSession_FetchContents_There_was_an_error_communicating_with_the_server__" xml:space="preserve">
-    <value>サーバーとの通信にエラーが発生しました：</value>
-  </data>
-  <data name="RemovePeptides_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from__1__peptides_" xml:space="preserve">
-    <value>{1}個のペプチドからこれら{0}個のピークを本当に削除してもよろしいですか？</value>
-  </data>
-  <data name="RemovePrecursors_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from_one_precursor_" xml:space="preserve">
-    <value>1個のプリカーサーからこれら{0}個のピークを本当に削除してもよろしいですか？</value>
-  </data>
-  <data name="RenameProteinsDlg_OkDialog__0__is_not_a_current_protein" xml:space="preserve">
-    <value>{0}は現在のタンパク質ではありません</value>
-  </data>
-  <data name="RenameProteinsDlg_OkDialog_Cannot_rename__0__more_than_once__Please_remove_either__1__or__2__" xml:space="preserve">
-    <value>{0}の名前を1回以上変更することはできません。{1}または{2}を削除してください</value>
-  </data>
-  <data name="RenameProteinsDlg_OkDialog_Edit_name__0__" xml:space="preserve">
-    <value>名前{0}を編集</value>
-  </data>
-  <data name="RenameProteinsDlg_UseFastaFile_The_document_contains_a_naming_conflict_The_name__0__is_currently_used_by_multiple_protein_sequences" xml:space="preserve">
-    <value>ドキュメントに名前の不一致があります。名前{0}は、現在複数のタンパク質シークエンスで使用されています。</value>
-  </data>
-  <data name="Replicate" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Replicate.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="ReportErrorDlg_ReportErrorDlg_Close" xml:space="preserve">
-    <value>閉じる</value>
-  </data>
-  <data name="ReportSpec_ReportToCsvString_Exporting__0__report" xml:space="preserve">
-    <value>{0}レポートのエクスポート中</value>
+  <data name="CommandLine_ImportSkyr_Success__Imported_Reports_from__0_" xml:space="preserve">
+    <value>成功しました！ {0}からインポートされたレポート</value>
   </data>
   <data name="ReportSpecList_EditItem_An_unexpected_error_occurred_while_analyzing_the_current_document" xml:space="preserve">
     <value>現在のドキュメントを分析中に予期しないエラーが発生しました。</value>
   </data>
-  <data name="ReportSpecList_GetDefaults_Molecule_Peak_Boundaries" xml:space="preserve">
-    <value>分子ピーク境界</value>
+  <data name="ValueUnexpectedException_ValueUnexpectedException_The_argument__0__should_not_have_a_value_specified" xml:space="preserve">
+    <value>引数{0}は指定された値を持つことはできません</value>
   </data>
-  <data name="ReportSpecList_GetDefaults_Peak_Boundaries" xml:space="preserve">
-    <value>ピーク境界</value>
-  </data>
-  <data name="ReportSpecList_GetDefaults_Peptide_Ratio_Results" xml:space="preserve">
-    <value>ペプチド比率結果</value>
-  </data>
-  <data name="ReportSpecList_GetDefaults_Peptide_RT_Results" xml:space="preserve">
-    <value>ペプチドRT結果</value>
-  </data>
-  <data name="ReportSpecList_GetDefaults_Transition_Results" xml:space="preserve">
-    <value>トランジション結果</value>
-  </data>
-  <data name="ReportSpecList_Label_Report" xml:space="preserve">
-    <value>レポート(&amp;R)：</value>
-  </data>
-  <data name="ReportSpecList_Title_Edit_Reports" xml:space="preserve">
-    <value>レポートを編集</value>
-  </data>
-  <data name="Resources.ReportSpecList_GetDefaults_Peptide_Quantification" xml:space="preserve">
-    <value>ペプチド定量化</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Acquired_Time" xml:space="preserve">
-    <value>取得時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Area" xml:space="preserve">
-    <value>面積</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Area_Ratio" xml:space="preserve">
-    <value>面積比</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Average_Mass_Error_PPM" xml:space="preserve">
-    <value>平均質量誤差PPM</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Background" xml:space="preserve">
-    <value>バックグラウンド</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Best_Retention_Time" xml:space="preserve">
-    <value>最良保持時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_CellEndEdit_Edit_note" xml:space="preserve">
-    <value>メモを編集</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Count_Truncated" xml:space="preserve">
-    <value>切断数</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_End_Time" xml:space="preserve">
-    <value>終了時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_File_Name" xml:space="preserve">
-    <value>ファイル名</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Fwhm" xml:space="preserve">
-    <value>Fwhm</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Height" xml:space="preserve">
-    <value>高さ</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Identified" xml:space="preserve">
-    <value>同定済み</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Isotope_Dot_Product" xml:space="preserve">
-    <value>同位体内積</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Library_Dot_Product" xml:space="preserve">
-    <value>ライブラリ内積</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Mass_Error_PPM" xml:space="preserve">
-    <value>質量誤差PPM</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Max_End_Time" xml:space="preserve">
-    <value>最大終了時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Max_Fwhm" xml:space="preserve">
-    <value>最大Fwhm</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Max_Height" xml:space="preserve">
-    <value>最大高さ</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Min_Start_Time" xml:space="preserve">
-    <value>最小開始時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Modified_Time" xml:space="preserve">
-    <value>修飾時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Opt_Collision_Energy" xml:space="preserve">
-    <value>最適衝突エネルギー</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Opt_Compensation_Voltage" xml:space="preserve">
-    <value>最適補償電圧</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Opt_Declustering_Potential" xml:space="preserve">
-    <value>最適デクラスタリングポテンシャル</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Opt_Step" xml:space="preserve">
-    <value>最適ステップ</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Peak_Rank" xml:space="preserve">
-    <value>ピークのランク</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Peptide_Peak_Found_Ratio" xml:space="preserve">
-    <value>ペプチドピーク検出率</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Peptide_Retention_Time" xml:space="preserve">
-    <value>ペプチド保持時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Precursor_Peak_Found_Ratio" xml:space="preserve">
-    <value>プリカーサーピーク検出率</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Precursor_Replicate_Note" xml:space="preserve">
-    <value>プリカーサー繰り返し測定メモ</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Ratio_Dot_Product" xml:space="preserve">
-    <value>比率内積</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Ratio_to_Global_Standards" xml:space="preserve">
-    <value>グローバル標準に対する比率</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Ratio_To_Standard" xml:space="preserve">
-    <value>標準に対する比率</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Ratio_To_Standard_Dot_Product" xml:space="preserve">
-    <value>標準内積に対する比率</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Replicate_Name" xml:space="preserve">
-    <value>繰り返し測定名</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Retention_Time" xml:space="preserve">
-    <value>保持時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Sample_Name" xml:space="preserve">
-    <value>試料名</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Start_Time" xml:space="preserve">
-    <value>開始時間</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Total_Area" xml:space="preserve">
-    <value>総面積</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Total_Area_Ratio" xml:space="preserve">
-    <value>総面積比</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Total_Background" xml:space="preserve">
-    <value>総バックグラウンド</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Transition_Replicate_Note" xml:space="preserve">
-    <value>トランジション繰り返し測定メモ</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Truncated" xml:space="preserve">
-    <value>切断</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_User_Set" xml:space="preserve">
-    <value>ユーザーセット</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_User_Set_Total" xml:space="preserve">
-    <value>ユーザーセットの合計</value>
-  </data>
-  <data name="RetentionTimeRegression_RecalcRegression_Recalculating_regression" xml:space="preserve">
-    <value>回帰を再計算中</value>
-  </data>
-  <data name="RInstaller_DownloadPackages_Check_your_network_connection_or_contact_the_tool_provider_for_installation_support_" xml:space="preserve">
-    <value>ネットワーク接続を確認するか、ツールプロバイダに問い合わせてインストールのサポートを依頼します。</value>
-  </data>
-  <data name="RInstaller_DownloadR_Download_failed_" xml:space="preserve">
-    <value>ダウンロードに失敗しました。</value>
-  </data>
-  <data name="RInstaller_GetPackages_Downloading_packages" xml:space="preserve">
-    <value>パッケージのダウンロード中</value>
-  </data>
-  <data name="RInstaller_GetPackages_Package_installation_complete_" xml:space="preserve">
-    <value>パッケージのインストールが完了しました。</value>
-  </data>
-  <data name="RInstaller_GetR_R_installation_complete_" xml:space="preserve">
-    <value>Rのインストールが完了しました。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Download_Canceled" xml:space="preserve">
-    <value>ダウンロードがキャンセルされました</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Error__No_internet_connection_" xml:space="preserve">
-    <value>エラー： インターネット接続がありません。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Error__Package_installation_did_not_complete__Output_logged_to_the_Immediate_Window_" xml:space="preserve">
-    <value>エラー： パッケージのインストールが完了しませんでした。出力が即時ウィンドウに記録されました。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Error_Installing_Packages" xml:space="preserve">
-    <value>パッケージのインストールエラー</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Installing_R_packages_requires_an_internet_connection__Please_check_your_connection_and_try_again" xml:space="preserve">
-    <value>Rパッケージのインストールには、インターネット接続が必要です。インターネット接続を確認してからもう一度お試しください</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Output_logged_to_the_Immediate_Window_" xml:space="preserve">
-    <value>出力が即時ウィンドウに記録されました。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Package_installation_failed__Error_log_output_in_immediate_window_" xml:space="preserve">
-    <value>パッケージのインストールに失敗しました。即時ウィンドウ内のログ出力エラー。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_The_following_packages_failed_to_install_" xml:space="preserve">
-    <value>以下のパッケージをインストールできませんでした：</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Unknown_Error_installing_packages__Output_logged_to_the_Immediate_Window_" xml:space="preserve">
-    <value>パッケージのインストール中の不明なエラー。出力が即時ウィンドウに記録されました。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Unknown_error_installing_packages__Tool_Installation_Failed_" xml:space="preserve">
-    <value>パッケージのインストール中の不明なエラー。ツールのインストールに失敗しました。</value>
-  </data>
-  <data name="RInstaller_InstallR_R_installation_was_not_completed__Cancelling_tool_installation_" xml:space="preserve">
-    <value>Rのインストールが完了しませんでした。ツールのインストールのキャンセル中。</value>
-  </data>
-  <data name="RInstaller_RInstaller_Load_This_tool_requires_the_use_of_R__0___Click_Install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>このツールにはR{0}の使用が必要です。インストールをクリックしてインストールプロセスを開始します。</value>
-  </data>
-  <data name="RInstaller_RInstaller_Load_This_tool_requires_the_use_of_R__0__and_the_following_packages_" xml:space="preserve">
-    <value>このツールではR{0}と以下のパッケージを使用する必要があります。</value>
-  </data>
-  <data name="RInstaller_RInstaller_Load_This_Tool_requires_the_use_of_the_following_R_Packages_" xml:space="preserve">
-    <value>このツールでは以下のRパッケージを使用する必要があります。</value>
-  </data>
-  <data name="RTDetails_gridStatistics_KeyDown_Failed_setting_data_to_clipboard" xml:space="preserve">
-    <value>クリップボードへのデータ設定に失敗しました。</value>
-  </data>
-  <data name="RTLinearRegressionGraphPane_RTLinearRegressionGraphPane_Measured_Time" xml:space="preserve">
-    <value>測定時間</value>
-  </data>
-  <data name="RTLinearRegressionGraphPane_UpdateGraph_Calculating___" xml:space="preserve">
-    <value>計算中...</value>
-  </data>
-  <data name="Save" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\save.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SavitzkyGolaySmoother_WindowSize_SavitzkyGolaySmoother__Invalid_window_size___0____argument_must_be_positive_and_odd" xml:space="preserve">
-    <value>SavitzkyGolaySmoother： 無効なウィンドウサイズ ({0})：引数は正の奇数でなければなりません</value>
-  </data>
-  <data name="ScanProvider_GetScans_The_scan_ID__0__was_not_found_in_the_file__1__" xml:space="preserve">
-    <value>ファイル{1}内にスキャンID{0}が見つかりませんでした。</value>
-  </data>
-  <data name="SequenceMassCalc_ParseModMass_The_expression__0__is_not_a_valid_chemical_formula" xml:space="preserve">
-    <value>式「{0}」は有効な化学式ではありません。</value>
-  </data>
-  <data name="SerializableSettingsList_ImportFile_Failure_loading__0__" xml:space="preserve">
-    <value>{0}の読み込みに失敗しました。</value>
-  </data>
-  <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
-    <value>サーバー{0}に接続できません。</value>
-  </data>
-  <data name="SettingsList_ELEMENT_NONE_None" xml:space="preserve">
-    <value>なし</value>
-  </data>
-  <data name="SettingsListComboDriver_Add" xml:space="preserve">
-    <value>&lt;追加...&gt;</value>
-  </data>
-  <data name="SettingsListComboDriver_Edit_current" xml:space="preserve">
-    <value>&lt;現在の設定を編集...&gt;</value>
-  </data>
-  <data name="SettingsListComboDriver_Edit_list" xml:space="preserve">
-    <value>&lt;リストを編集...&gt;</value>
-  </data>
-  <data name="SettingsUIUtil_DoPasteText_Incorrect_number_of_columns__0__found_on_line__1__" xml:space="preserve">
-    <value>{1}行に間違った列数 ({0}) が見つかりました。</value>
-  </data>
-  <data name="ShareListDlg_ImportFile_Failure_loading__0__" xml:space="preserve">
-    <value>{0}の読み込みに失敗しました。</value>
-  </data>
-  <data name="ShareListDlg_OkDialog_An_error_occurred" xml:space="preserve">
-    <value>エラーが発生しました：</value>
-  </data>
-  <data name="ShareTypeDlg_OkDialog_Including_data_folders_is_not_supported_by_the_currently_selected_version_" xml:space="preserve">
-    <value>データフォルダの含有は、現在選択されているバージョンでは対応していません。</value>
-  </data>
-  <data name="ShareTypeDlg_ShareTypeDlg_Current_saved_file___0__" xml:space="preserve">
-    <value>現在保存されているファイル({0})</value>
-  </data>
-  <data name="ShimadzuMethodExporter_ExportMethod_Error_copying_template_file__0__to_destination__1__" xml:space="preserve">
-    <value>テンプレートファイル{0}の移動先{1}へのコピーのエラー。</value>
-  </data>
-  <data name="ShimadzuMethodExporter_ExportMethod_Unexpected_response__0__from_Shimadzu_method_writer_" xml:space="preserve">
-    <value>Shimadzuメソッドライターからの予期しない反応{0}。</value>
-  </data>
-  <data name="SkippedReportErrorDlg_btnOK_Click_No_Email" xml:space="preserve">
-    <value>エラーについてさらに質問がある場合、連絡を差し上げる電子メールアドレスを入力してください。
- ご希望により、匿名でもレポートできます。</value>
-  </data>
-  <data name="Skyline" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\skyline.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Skyline_Daily" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\skyline_daily.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Skyline_peptides" xml:space="preserve">
-    <value>ペプチド</value>
-  </data>
-  <data name="Skyline_protein" xml:space="preserve">
-    <value>タンパク質</value>
-  </data>
-  <data name="Skyline_Release" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Skyline_Release.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Skyline_Release1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Skyline_Release.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SkylineData" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\SkylineData.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SkylineDataSchema_VerifyDocumentCurrent_The_document_was_modified_in_the_middle_of_the_operation_" xml:space="preserve">
-    <value>ドキュメントが操作の途中で変更されました。</value>
-  </data>
-  <data name="SkylineDoc" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\skylinedoc.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SkylineImg" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\skyline.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SkylineStartup_SaveFileDlg_Please_save_a_new_file_to_work_with_" xml:space="preserve">
-    <value>作業を行う新しいファイルを保存してください。</value>
-  </data>
-  <data name="SkylineStartup_SkylineStartup_Blank_Document" xml:space="preserve">
-    <value>空のドキュメント</value>
-  </data>
-  <data name="SkylineStartup_SkylineStartup_Import_Peptide_List" xml:space="preserve">
-    <value>ペプチドリストをインポート</value>
-  </data>
-  <data name="SkylineStartup_SkylineStartup_Import_Transition_List" xml:space="preserve">
-    <value>トランジションリストをインポート</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Molecules" xml:space="preserve">
-    <value>分子</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Peptides" xml:space="preserve">
-    <value>ペプチド</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
-    <value>プリカーサー</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Proteins" xml:space="preserve">
-    <value>タンパク質</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Replicates" xml:space="preserve">
-    <value>繰り返し測定</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Transitions" xml:space="preserve">
+  <data name="ColumnSet_GetTransitionsTable_Transition" xml:space="preserve">
     <value>トランジション</value>
   </data>
-  <data name="SkylineViewContext_GetTransitionListReportSpec_Peptide_Transition_List" xml:space="preserve">
-    <value>ペプチドトランジションリスト</value>
+  <data name="EditIsolationSchemeDlg_OkDialog_The_isolation_scheme_named__0__already_exists" xml:space="preserve">
+    <value>「{0}」という名前の単離スキームが既に存在しています。</value>
   </data>
-  <data name="SkylineViewContext_GetTransitionListReportSpec_Small_Molecule_Transition_List" xml:space="preserve">
-    <value>低分子トランジションリスト</value>
+  <data name="ComparePeakPickingDlg_SaveData_Save_Model_Comparison_Data" xml:space="preserve">
+    <value>モデル比較データを保存</value>
+  </data>
+  <data name="AssociateProteinsDlg_ApplyChanges_Associated_proteins" xml:space="preserve">
+    <value>関連付けられたタンパク質</value>
+  </data>
+  <data name="PythonInstaller_DownloadPip_Download_failed__Check_your_network_connection_or_contact_Skyline_developers_" xml:space="preserve">
+    <value>ダウンロードに失敗しました。ネットワーク接続をチェックするか、Skyline開発者に連絡します。</value>
   </data>
   <data name="SkylineWindow_AddGroupComparison_Add_Fold_Change" xml:space="preserve">
     <value>倍率変化を追加</value>
   </data>
-  <data name="SkylineWindow_AddIrtPeptides_Imported_peptide__0__with_iRT_library_value_is_already_being_used_as_an_iRT_standard_" xml:space="preserve">
-    <value>iRTライブラリ値を持つインポートされたペプチド{0}は既にiRT標準で使用されています。</value>
+  <data name="CommandLine_SetLibrary_Error__Cannot_set_library_name_without_path_" xml:space="preserve">
+    <value>エラー： パスなしでライブラリ名を設定することはできません。</value>
   </data>
-  <data name="SkylineWindow_AddMolecule_The_precursor_m_z_for_this_molecule_is_out_of_range_for_your_instrument_settings_" xml:space="preserve">
-    <value>この分子のプリカーサーm/zが装置設定の範囲外です。</value>
-  </data>
-  <data name="SkylineWindow_AlignTimesToFileFormat" xml:space="preserve">
-    <value>{0}に時間をアラインする</value>
-  </data>
-  <data name="SkylineWindow_CheckRetentionTimeFilter_NoPredictionAlgorithm" xml:space="preserve">
-    <value>トランジション設定フルスキャン保持時間フィルタは予測保持時間を使用するように設定されていますが、予測アルゴリズムが指定されていません。
-修正するにはペプチド設定の予測タブに移動します。</value>
+  <data name="PasteDlg_UpdateMoleculeType_Fragment_Name" xml:space="preserve">
+    <value>フラグメント名</value>
   </data>
   <data name="SkylineWindow_CompleteProgressUI_Ran_Out_Of_Memory" xml:space="preserve">
     <value>
 
 {0}のメモリがなくなりました。</value>
   </data>
-  <data name="SkylineWindow_CompleteProgressUI_version_issue" xml:space="preserve">
-    <value>
-
-{0}の64-bitバージョンをインストールすることにより、この問題を回避することができる場合があります。</value>
+  <data name="WebPanoramaPublishClient_ImportDataOnServer_Error_importing_Skyline_file_on_Panorama_server__0_" xml:space="preserve">
+    <value>Panoramaサーバー{0}でSkylineファイルのインポート中のエラー</value>
   </data>
-  <data name="SkylineWindow_expandAllMenuItem_DropDownOpening__Lists" xml:space="preserve">
-    <value>リスト(&amp;L)</value>
+  <data name="ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_" xml:space="preserve">
+    <value>以下の値がないため、トランジションリストをインポートできません。</value>
   </data>
-  <data name="SkylineWindow_expandAllMenuItem_DropDownOpening__Molecules" xml:space="preserve">
-    <value>分子(&amp;M)</value>
-  </data>
-  <data name="SkylineWindow_exportIsolationListMenuItem_Click_There_is_no_isolation_list_data_to_export" xml:space="preserve">
-    <value>エクスポートする単離リストデータがありません。</value>
-  </data>
-  <data name="SkylineWindow_HandleStandardsChanged_An_error_occurred_while_attempting_to_load_the_iRT_database__0___iRT_standards_cannot_be_automatically_added_to_the_document_" xml:space="preserve">
-    <value>iRTデータベース{0}を読み込もうとしている間にエラーが発生しました。iRT標準は、自動的にドキュメントに追加できません。</value>
-  </data>
-  <data name="SkylineWindow_ImportFasta_Unexpected_document_change_during_operation" xml:space="preserve">
-    <value>操作中の予期しないドキュメントの変更。</value>
-  </data>
-  <data name="SkylineWindow_ImportFastaFile_Failed_reading_the_file__0__1__" xml:space="preserve">
-    <value>ファイル{0}の読み取りに失敗しました。{1}</value>
-  </data>
-  <data name="SkylineWindow_ImportFastaFile_Import_FASTA" xml:space="preserve">
-    <value>FASTAをインポート</value>
-  </data>
-  <data name="SkylineWindow_ImportFiles_Importing__0__" xml:space="preserve">
-    <value>{0}のインポート中</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_Do_you_want_to_use_the_document_settings_to_automanage_these_new_transitions" xml:space="preserve">
-    <value>自動選択を有効にし、ドキュメント設定を使用してこの新しいトランジションを管理しますか？
-
-自動選択を有効にする：{0}プリカーサーおよび{1}断片のトランジションが現在のドキュメントに追加されます。
-
-自動選択を無効にする：{2}プリカーサーおよび{3}断片のトランジションが現在のドキュメントに追加されます。
-
-無効化を選択した場合、「最適化 &gt; 詳細」メニュー項目で後から自動選択を有効にできます。</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_Failed_reading_the_file___Peptide__0__matches_an_existing_iRT_standard_peptide_" xml:space="preserve">
-    <value>ファイルの読み取りに失敗しました。 ペプチド{0}が既存のiRT標準ペプチドで一致しました。</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_Keep_the_existing_iRT_value_or_overwrite_with_the_imported_value_" xml:space="preserve">
-    <value>既存のiRT値を保持しますか、それともインポートされた値を上書きしますか？</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_The_iRT_calculator_already_contains__0__of_the_imported_peptides_" xml:space="preserve">
-    <value>iRTカルキュレータは既にインポートされたペプチドの{0}に含まれています。</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_library_values___Add_these_iRT_values_to_the_iRT_calculator_" xml:space="preserve">
-    <value>トランジションリストにはiRTライブラリ値が含まれていないようです。 これらのiRT値をiRTカルキュレータに追加しますか？</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_values__but_the_document_does_not_have_an_iRT_calculator___Create_a_new_calculator_and_add_these_iRT_values_" xml:space="preserve">
-    <value>トランジションリストにはiRT値が含まれていないようですが、ドキュメントにはiRTカルキュレータがありません。 新しいカルキュレータを作成し、これらのiRT値を追加しますか？</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_spectral_library_intensities___Create_a_document_library_from_these_intensities_" xml:space="preserve">
-    <value>トランジションリストにはスペクトルライブラリ強度が含まれていないようです。 これらの強度からドキュメントライブラリを作成しますか？</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_There_is_an_existing_library_with_the_same_name__0__as_the_document_library_to_be_created___Overwrite_this_library_or_skip_import_of_library_intensities_" xml:space="preserve">
-    <value>ドキュメントライブラリとして作成される同じ名前{0}の既存のライブラリが存在しています。 このライブラリを上書きしますか、それともライブラリ強度のインポートをスキップしますか？</value>
-  </data>
-  <data name="SkylineWindow_importMassListMenuItem_Click_Data_columns_not_found_in_first_line" xml:space="preserve">
-    <value>先頭行にデータ列が見つかりません。</value>
-  </data>
-  <data name="SkylineWindow_importMassListMenuItem_Click_Transition_List" xml:space="preserve">
-    <value>トランジションリスト</value>
-  </data>
-  <data name="SkylineWindow_ImportResults__0__decoys_do_not_have_a_matching_target" xml:space="preserve">
-    <value>{0}個のデコイが一致するターゲットを含んでいません</value>
-  </data>
-  <data name="SkylineWindow_ImportResults__0__decoys_do_not_have_the_same_number_of_transitions_as_their_matching_targets" xml:space="preserve">
-    <value>{0}個のデコイが、一致するターゲットと同じ数のトランジションを含んでいません</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_1_decoy_does_not_have_a_matching_target" xml:space="preserve">
-    <value>1個のデコイが一致するターゲットを含んでいません</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_1_decoy_does_not_have_the_same_number_of_transitions_as_its_matching_target" xml:space="preserve">
-    <value>1個のデコイが、一致するターゲットと同じ数のトランジションを含んでいません</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_A_maximum_of__0__may_be_missing_and_or_outliers_for_a_successful_import_" xml:space="preserve">
-    <value>最大{0}個の欠損や異常値があっても、インポートできます。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_Add_missing_iRT_standard_peptides_to_your_document_or_change_the_retention_time_predictor_" xml:space="preserve">
-    <value>欠損iRT標準ペプチドをドキュメントに追加するか、保持時間予測を変更します。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_None_may_be_missing_or_outliers_for_a_successful_import_" xml:space="preserve">
-    <value>欠損や異常値があると、インポートできません。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_The_document_contains__0__of_these_iRT_standard_peptides_" xml:space="preserve">
-    <value>ドキュメントには、このiRT標準ペプチドが{0}個含まれています。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_The_document_contains_decoys_that_do_not_match_the_targets__Out_of__0__decoys_" xml:space="preserve">
-    <value>ドキュメントにターゲットと一致しないデコイが含まれています。{0}個のデコイのうち：</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_The_document_does_not_contain_any_of_these_iRT_standard_peptides_" xml:space="preserve">
-    <value>ドキュメントには、このiRT標準ペプチドが全く含まれていません。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_The_document_only_contains__0__of_these_iRT_standard_peptides_" xml:space="preserve">
-    <value>ドキュメントには、このiRT標準ペプチドが{0}個しかありません。</value>
-  </data>
-  <data name="SkylineWindow_OpenSharedFile_Extracting_Files" xml:space="preserve">
-    <value>ファイルの抽出中</value>
-  </data>
-  <data name="SkylineWindow_OpenSharedFile_Failure_extracting_Skyline_document_from_zip_file__0__" xml:space="preserve">
-    <value>zipファイル{0}からのSkylineドキュメントの抽出に失敗しました。</value>
-  </data>
-  <data name="SkylineWindow_Paste_Could_not_perform_transition_list_paste___0_" xml:space="preserve">
-    <value>トランジションリストの貼り付けの実行ができませんでした：{0}</value>
-  </data>
-  <data name="SkylineWindow_Paste_Paste" xml:space="preserve">
-    <value>貼り付け</value>
-  </data>
-  <data name="SkylineWindow_Publish_Error_retrieving_server_information__0__" xml:space="preserve">
-    <value>サーバー情報の取得エラー：{0}</value>
-  </data>
-  <data name="SkylineWindow_Publish_Retrieving_server_information" xml:space="preserve">
-    <value>サーバー情報の取得中。</value>
-  </data>
-  <data name="SkylineWindow_Publish_There_are_no_Panorama_servers_to_publish_to_Please_add_a_server_under_Tools" xml:space="preserve">
-    <value>公開先にPanoramaサーバーがありません。ツールの下にサーバーを追加してください。</value>
-  </data>
-  <data name="SkylineWindow_publishToolStripMenuItem_Click_Skyline_Shared_Documents" xml:space="preserve">
-    <value>Skyline共有ドキュメント</value>
-  </data>
-  <data name="SkylineWindow_SaveDocument_Saving___" xml:space="preserve">
-    <value>保存中...</value>
-  </data>
-  <data name="SkylineWindow_SaveDocumentAs_Skyline_Documents" xml:space="preserve">
-    <value>Skylineドキュメント</value>
-  </data>
-  <data name="SkylineWindow_shareDocumentMenuItem_Click_The_document_must_be_saved_before_it_can_be_shared" xml:space="preserve">
-    <value>共有する前に、ドキュメントを保存しなければなりません。</value>
-  </data>
-  <data name="SkylineWindow_ShowCalculatorScoreFormat" xml:space="preserve">
-    <value>{0}スコアを表示</value>
-  </data>
-  <data name="SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_imported_results_" xml:space="preserve">
-    <value>ドキュメントには、インポート結果が必要です。</value>
-  </data>
-  <data name="SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_targets_for_which_to_export_chromatograms_" xml:space="preserve">
-    <value>ドキュメントには、クロマトグラムをエクスポートするターゲットが含まれている必要があります。</value>
-  </data>
-  <data name="SkylineWindow_ShowExportSpectralLibraryDialog_The_document_must_contain_at_least_one_peptide_precursor_to_export_a_spectral_library_" xml:space="preserve">
-    <value>スペクトルライブラリをエクスポートするには、ドキュメントに1つ以上のペプチドプリカーサーが含まれている必要があります。</value>
-  </data>
-  <data name="SkylineWindow_ShowExportSpectralLibraryDialog_The_document_must_contain_results_to_export_a_spectral_library_" xml:space="preserve">
-    <value>スペクトルライブラリをエクスポートするには、ドキュメントに結果が含まれている必要があります。</value>
-  </data>
-  <data name="SkylineWindow_ShowProgressErrorUI_Do_you_want_to_continue_" xml:space="preserve">
-    <value>続行しますか？</value>
-  </data>
-  <data name="SkylineWindow_ShowProgressErrorUI_Retry" xml:space="preserve">
-    <value>再試行</value>
-  </data>
-  <data name="SkylineWindow_ShowProgressErrorUI_Skip" xml:space="preserve">
-    <value>スキップ</value>
-  </data>
-  <data name="SkylineWindow_ShowPublishDlg_Press_Register_to_register_for_a_project_on_PanoramaWeb_" xml:space="preserve">
-    <value>登録を押してPanoramaWebにプロジェクトを登録します。</value>
-  </data>
-  <data name="SkylineWindow_ShowReintegrateDialog_Reintegration_of_results_requires_a_trained_peak_scoring_model_" xml:space="preserve">
-    <value>結果の再積分には、トレーニングされたピークスコアモデルが必要です。</value>
-  </data>
-  <data name="SkylineWindow_ShowReintegrateDialog_The_document_must_have_imported_results_" xml:space="preserve">
-    <value>ドキュメントには、インポート結果が必要です。</value>
-  </data>
-  <data name="SkylineWindow_ShowReintegrateDialog_The_document_must_have_targets_in_order_to_reintegrate_chromatograms_" xml:space="preserve">
-    <value>ドキュメントには、クロマトグラムを再積分するターゲットが含まれている必要があります。</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_Credentials_saved_in_Skyline_for_the_Panorama_server__0__are_for_the_user__1___This_user_does_not_have_permissions_to_download_the_file__The_skyp_file_was_downloaded_by__2__" xml:space="preserve">
-    <value>Skylineに保存されているPanoramaサーバー{0}の認証情報は、ユーザー{1}のものです。このユーザーにはファイルをダウンロードする権限がありません。skypファイルは{2}によってダウンロードされました。</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_Credentials_saved_in_Skyline_for_the_Panorama_server__0__are_invalid_" xml:space="preserve">
-    <value>Skylineに保存されているPanoramaサーバー{0}の認証情報は無効です。</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_The_skyp_file_was_downloaded_by_the_user__0___Credentials_saved_in_Skyline_for_this_server_are_for_the_user__1__" xml:space="preserve">
-    <value>ユーザー{0}がskypファイルをダウンロードしました。Skylineに保存されているこのサーバーの認証情報は、ユーザー{1}のものです。</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_Would_you_like_to_add__0__as_a_Panorama_server_in_Skyline_" xml:space="preserve">
-    <value>SkylineのPanoramaサーバーとして{0}を追加しますか？</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_Would_you_like_to_update_the_credentials_" xml:space="preserve">
-    <value>認証情報を更新しますか？</value>
-  </data>
-  <data name="SkypFile_GetSkyFileUrl__0__is_not_a_valid_URL_on_a_Panorama_server_" xml:space="preserve">
-    <value>{0}はPanoramaサーバーの有効なURLではありません。</value>
-  </data>
-  <data name="SkypFile_GetSkyFileUrl_Expected_the_URL_of_a_shared_Skyline_document_archive_file___0____Found_filename__1__instead_in_the_URL__2__" xml:space="preserve">
-    <value>共有しているSkylineドキュメントアーカイブファイル({0})のURLを待っていましたが、URL{2}の代わりにファイル名{1}が見つかりました。</value>
-  </data>
-  <data name="SkypFile_GetSkyFileUrl_File_does_not_contain_the_URL_of_a_shared_Skyline_archive_file___0___on_a_Panorama_server_" xml:space="preserve">
-    <value>PanoramaサーバーにあるSkyline共有アーカイブファイル({0})のURLがファイルに含まれていません。</value>
-  </data>
-  <data name="SkypSupport_Download_You_do_not_have_permissions_to_download_this_file_from__0__" xml:space="preserve">
-    <value>{0}からこのファイルをダウンロードする権限がありません。</value>
-  </data>
-  <data name="SkypSupport_Open_Path_to_skyp_file_cannot_be_empty_" xml:space="preserve">
-    <value>skypファイルへのパスは空欄にできません。</value>
-  </data>
-  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Formula" xml:space="preserve">
-    <value>分子式</value>
-  </data>
-  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_InChIKey" xml:space="preserve">
-    <value>InChIKey</value>
-  </data>
-  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Name" xml:space="preserve">
-    <value>名前</value>
-  </data>
-  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_OtherIDs" xml:space="preserve">
-    <value>OtherIDs</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_GetMoleculeTransitionGroup_Inconsistent_molecule_description" xml:space="preserve">
-    <value>分子の説明が一貫していません</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_Precursor_mz_does_not_agree_with_calculated_value_" xml:space="preserve">
-    <value>プリカーサーm/z {0}は、イオン式と荷電状態 (デルタ = {2}, トランジション設定 | 装置 | メソッド許容誤差 m/z = {3}) から計算されているため、値{1}を受け入れません)。表のm/z値を修正するか、または空白にしておけばSkylineが自動的に計算します。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ProcessNeutralLoss_Cannot_use_product_neutral_loss_chemical_formula_without_a_precursor_chemical_formula" xml:space="preserve">
-    <value>プリカーサー化学式のないプロダクトニュートラルロス化学式は使用できません</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ProcessNeutralLoss_Precursor_molecular_formula__0__does_not_contain_sufficient_atoms_to_be_used_with_neutral_loss__1_" xml:space="preserve">
-    <value>プリカーサ―分子式{0}にニュートラルロス{1}で使用する十分な原子が含まれていません</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_Product_mz_does_not_agree_with_calculated_value_" xml:space="preserve">
-    <value>プロダクトm/z {0}は、イオン式と荷電状態 (デルタ = {2}, トランジション設定 | 装置 | メソッド許容誤差 m/z = {3}) から計算されているため、値{1}を受け入れません)。表のm/z値を修正するか、または空白にしておけばSkylineが自動的に計算します。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_CAS_registry_number_" xml:space="preserve">
-    <value>{0}は有効なCAS登録番号ではありません。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_HMDB_identifier_" xml:space="preserve">
-    <value>{0}は有効なHMDB識別子ではありません。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_InChI_identifier_" xml:space="preserve">
-    <value>{0}は有効なInChI識別子ではありません。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_InChiKey_" xml:space="preserve">
-    <value>{0}は有効なInChiKeyではありません。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Adduct__0__charge__1__does_not_agree_with_declared_charge__2_" xml:space="preserve">
-    <value>付加物の{0}電荷{1}が、宣言済みの電荷{2}と一致しません</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Cannot_derive_charge_from_adduct_description___0____Use_the_corresponding_Charge_column_to_set_this_explicitly__or_change_the_adduct_description_as_needed_" xml:space="preserve">
-    <value>付加イオンの表記「{0}」から電荷を計算できません。これを明確に設定するには対応する電荷列を使用するか、必要に応じて付加イオンの表記を変更します。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Formula_already_contains_an_adduct_description__and_it_does_not_match_" xml:space="preserve">
-    <value>式には既に付加物の説明が含まれており、一致しません。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_collisional_cross_section_value__0_" xml:space="preserve">
-    <value>無効な衝突断面積値{0}</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_high_energy_offset_value__0_" xml:space="preserve">
-    <value>イオン移動度の高エネルギーオフセット値{0}が無効です</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_units_value__0___accepted_values_are__1__" xml:space="preserve">
-    <value>イオン移動度の単位値{0}が無効です（受け入れられる値は{1}です）</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_value__0_" xml:space="preserve">
-    <value>イオン移動度値{0}が無効です</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Ion_mobility_units_not_specified" xml:space="preserve">
-    <value>イオン移動度の単位が指定されていません</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Multiple_ion_mobility_declarations" xml:space="preserve">
-    <value>複数のイオン移動度が宣言されています</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Precursor_formula_and_m_z_value_do_not_agree_for_any_charge_state_" xml:space="preserve">
-    <value>プリカーサー式とm/zはいかなる荷電状態も受け入れません。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Precursor_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
-    <value>プリカーサーは次のうちいずれか2つに対して値を必要とします：  式、m/z、荷電。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_formula_and_m_z_value_do_not_agree_for_any_charge_state_" xml:space="preserve">
-    <value>プロダクト式とm/zはいかなる荷電状態も受け入れません。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
-    <value>プロダクトは次のうちいずれか2つに対して値を必要とします：  式、m/z、荷電。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_SmallMoleculeTransitionListReader_" xml:space="preserve">
-    <value>分子列ヘッダーを読み取り中のエラー。次を認識しません：
- {0}
- サポートされる値に次が含まれます：
- {1}</value>
-  </data>
-  <data name="SpecialHandlingType_Validate_None" xml:space="preserve">
-    <value>なし</value>
-  </data>
-  <data name="SpectraGridForm_AddSpectrumFilters__0__spectrum_filters_will_be_added_to_the_document_" xml:space="preserve">
-    <value>{0}個のスペクトルフィルタがドキュメントに追加されます。</value>
-  </data>
-  <data name="SpectrumClassFilter_GetAbbreviatedText_OR" xml:space="preserve">
-    <value>OR</value>
-    <comment>"OR" is the logical operator</comment>
-  </data>
-  <data name="SpectrumClassFilter_MakePredicate_No_spectrum_column__0_" xml:space="preserve">
-    <value>スペクトル列{0}がありません</value>
-  </data>
-  <data name="SpectrumFilter_FindFilterPairs_Two_isolation_windows_contain_targets_which_match_the_isolation_target__0__" xml:space="preserve">
-    <value>2つの単離ウィンドウには、単離ターゲット{0}に一致するターゲットが含まれます。</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Data_files" xml:space="preserve">
-    <value>データファイル</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_ID" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Matched_spectra" xml:space="preserve">
-    <value>一致したスペクトル</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Revision" xml:space="preserve">
-    <value>リビジョン</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Unique_peptides" xml:space="preserve">
-    <value>ユニークペプチド：{0}</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Version" xml:space="preserve">
-    <value>バージョン</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Version__0__" xml:space="preserve">
-    <value>バージョン：{0}</value>
-  </data>
-  <data name="SrmDocument_GetPeptideGroupId_molecules" xml:space="preserve">
-    <value>分子</value>
-  </data>
-  <data name="SrmDocument_ReadLabelType_The_isotope_modification_type__0__does_not_exist_in_the_document_settings" xml:space="preserve">
-    <value>同位体修飾タイプ{0}がドキュメント設定に存在していません。</value>
-  </data>
-  <data name="SrmDocument_ReadTransitionXml_All_transitions_of_decoy_precursors_must_have_a_decoy_mass_shift" xml:space="preserve">
-    <value>デコイプリカーサーのすべてのトランジションには、デコイ質量シフトが必要です。</value>
-  </data>
-  <data name="SrmDocumentSharing_FindSharedSkylineFile_The_zip_file_is_not_a_shared_file" xml:space="preserve">
-    <value>zipファイルは共有ファイルではありません。</value>
-  </data>
-  <data name="SrmDocumentSharing_SrmDocumentSharing_ExtractProgress_Extracting__0__" xml:space="preserve">
-    <value>{0}の抽出中</value>
-  </data>
-  <data name="SrmSettingsList_DEFAULT_3_ions" xml:space="preserve">
-    <value>3個のイオン</value>
-  </data>
-  <data name="SrmSettingsList_DEFAULT_m_z_precursor" xml:space="preserve">
-    <value>m/z &gt;プリカーサー</value>
-  </data>
-  <data name="StartPage_Tutorial_Zip_Files" xml:space="preserve">
-    <value>ZIPファイル</value>
-  </data>
-  <data name="String1" xml:space="preserve">
-    <value>foo</value>
-  </data>
-  <data name="TestNamedPipeProcessRunner_RunProcess_Error_running_process" xml:space="preserve">
-    <value>プロセス実行エラー</value>
-  </data>
-  <data name="TestSkylineProcessRunner_RunProcess_The_operation_was_canceled_by_the_user_" xml:space="preserve">
-    <value>ユーザーによって操作がキャンセルされました。</value>
-  </data>
-  <data name="TestToolStoreClient_GetToolZipFile_Error_downloading_tool" xml:space="preserve">
-    <value>ツールのダウンロードエラー</value>
-  </data>
-  <data name="TextUtil_DeterminDsvSeparator_Unable_to_determine_format_of_delimiter_separated_value_file" xml:space="preserve">
-    <value>値が区切り文字で分けられたファイルの形式を判定できません</value>
-  </data>
-  <data name="ToolDescription_CallArgsCollector_Error_loading_report_from_the_temporary_file__0_" xml:space="preserve">
-    <value>一時ファイル{0}からのレポート読み込みエラー</value>
-  </data>
-  <data name="ToolDescription_RunExecutableBackground_Error_running_the_installed_tool__0___It_seems_to_have_an_error_in_one_of_its_files__Please_reinstall_the_tool_and_try_again" xml:space="preserve">
-    <value>インストールされたツール{0}の実行エラー。ファイルの1つにエラーがあるようです。ツールを再インストールしてからもう一度お試しください</value>
-  </data>
-  <data name="ToolDescription_RunExecutableBackground_Error_running_the_installed_tool_0_It_seems_to_be_missing_a_file__Please_reinstall_the_tool_and_try_again_" xml:space="preserve">
-    <value>インストールされたツール{0}の実行エラー。ファイルが欠損しているようです。ツールを再インストールしてからもう一度お試しください。</value>
-  </data>
-  <data name="ToolDescription_RunExecutableBackground_The_tool__0__had_an_error__it_returned_the_message_" xml:space="preserve">
-    <value>ツール{0}でエラーがあり、次のメッセージが返されました：</value>
-  </data>
-  <data name="ToolDescription_RunTool_File_not_found_" xml:space="preserve">
-    <value>ファイルが見つかりません。</value>
-  </data>
-  <data name="ToolDescription_RunTool_Please_check_the_command_location_is_correct_for_this_tool_" xml:space="preserve">
-    <value>このツールに対してコマンドの場所が正しいか確認してください。</value>
-  </data>
-  <data name="ToolDescription_RunTool_Please_check_the_External_Tools_Store_on_the_Skyline_web_site_for_the_most_recent_version_of_the_QuaSAR_external_tool_" xml:space="preserve">
-    <value>Skylineのウェブサイトの外部ツールストアでQuaSAR外部ツールの最新バージョンを確認してください。</value>
-  </data>
-  <data name="ToolDescription_RunTool_Support_for_the_GenePattern_version_of_QuaSAR_has_been_discontinued_" xml:space="preserve">
-    <value>QuaSARのGenePatternバージョンのサポートは終了しています。</value>
-  </data>
-  <data name="ToolDescription_VerifyAnnotations_Please_enable_these_annotations_and_fill_in_the_appropriate_data_in_order_to_use_the_tool_" xml:space="preserve">
-    <value>このツールを使用するには、これらの注釈を有効にして適切なデータを入力してください。</value>
-  </data>
-  <data name="ToolDescription_VerifyAnnotations_Please_re_install_the_tool_and_try_again_" xml:space="preserve">
-    <value>ツールを再インストールしてからもう一度お試しください。</value>
-  </data>
-  <data name="ToolDescription_VerifyAnnotations_This_tool_requires_the_use_of_the_following_annotations_which_are_missing_or_improperly_formatted" xml:space="preserve">
-    <value>このツールでは、欠損している、または正しい形式でない以下の注釈を使用する必要があります</value>
-  </data>
-  <data name="ToolDescription_VerifyAnnotations_This_tool_requires_the_use_of_the_following_annotations_which_are_not_enabled_for_this_document" xml:space="preserve">
-    <value>このツールでは、このドキュメントに対し有効でない以下の注釈を使用する必要があります</value>
-  </data>
-  <data name="ToolInstaller_UnpackZipTool_Error__The__0__does_not_contain_a_valid__1__attribute_" xml:space="preserve">
-    <value>エラー： {0}には有効な{1}属性が含まれていません。</value>
-  </data>
-  <data name="ToolInstaller_UnpackZipTool_The_selected_zip_file_is_not_a_valid_installable_tool_" xml:space="preserve">
-    <value>選択したzipファイルは有効なインストール可能なツールではありません。</value>
-  </data>
-  <data name="ToolMacros__listArguments_Collected_Arguments" xml:space="preserve">
-    <value>収集された引数</value>
-  </data>
-  <data name="ToolMacros__listArguments_Input_Report_Temp_Path" xml:space="preserve">
-    <value>レポートの一時パスを入力</value>
-  </data>
-  <data name="ToolMacros__listArguments_This_tool_requires_a_Document_Path_to_run" xml:space="preserve">
-    <value>このツールを実行するにはドキュメントパスが必要です</value>
-  </data>
-  <data name="ToolMacros__listArguments_Tool_Directory" xml:space="preserve">
-    <value>ツールディレクトリ</value>
-  </data>
-  <data name="ToolService_InsertSmallMoleculeTransitionList_Insert_Small_Molecule_Transition_List" xml:space="preserve">
-    <value>分子トランジションリストを挿入</value>
-  </data>
-  <data name="ToolUpdateAvailable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ToolUpdateAvailable.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="ToolUpdatesDlg_btnUpdate_Click_Please_select_at_least_one_tool_to_update_" xml:space="preserve">
-    <value>アップデートするツールを1つ以上選択してください。</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayDownloadSummary_Failed_to_download_updates_for_the_following_packages" xml:space="preserve">
-    <value>以下のパッケージのアップデートのダウンロードに失敗しました</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayInstallSummary_Failed_to_update_the_following_tool" xml:space="preserve">
-    <value>以下のツールのアップデートに失敗しました</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayInstallSummary_Failed_to_update_the_following_tools" xml:space="preserve">
-    <value>以下のツールのアップデートに失敗しました</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayInstallSummary_Successfully_updated_the_following_tool" xml:space="preserve">
-    <value>以下のツールが正常にアップデートされました</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayInstallSummary_Successfully_updated_the_following_tools" xml:space="preserve">
-    <value>以下のツールが正常にアップデートされました</value>
-  </data>
-  <data name="ToolUpdatesDlg_DownloadTools_Downloading_updates_for__0_" xml:space="preserve">
-    <value>{0}のアップデートのダウンロード中</value>
-  </data>
-  <data name="ToolUpdatesDlg_InstallUpdates_User_cancelled_installation" xml:space="preserve">
-    <value>ユーザーがインストールをキャンセルしました</value>
-  </data>
-  <data name="Transition_Validate_Precursor_and_product_ion_polarity_do_not_agree_" xml:space="preserve">
-    <value>プリカーサーとプロダクトイオンの極性が一致しません。</value>
+  <data name="ImportResultsDlg_GetDataSourcePathsFile_No_results_files_chosen" xml:space="preserve">
+    <value>結果ファイルが選択されていません。</value>
   </data>
   <data name="Transition_Validate_Precursor_charge__0__must_be_non_zero_and_between__1__and__2__" xml:space="preserve">
     <value>プリカーサー電荷{0}は、ゼロであってはならず、{1}と{2}の間でなければなりません。</value>
   </data>
-  <data name="Transition_Validate_Product_ion_charge__0__must_be_non_zero_and_between__1__and__2__" xml:space="preserve">
-    <value>プロダクト電荷{0}は、ゼロであってはならず、{1}と{2}の間でなければなりません。</value>
+  <data name="SkylineWindow_ImportResults_The_document_contains_decoys_that_do_not_match_the_targets__Out_of__0__decoys_" xml:space="preserve">
+    <value>ドキュメントにターゲットと一致しないデコイが含まれています。{0}個のデコイのうち：</value>
   </data>
-  <data name="TransitionFilter_FragmentEndFinders_3_ions" xml:space="preserve">
-    <value>3個のイオン</value>
+  <data name="ResultsGrid_ResultsGrid_User_Set" xml:space="preserve">
+    <value>ユーザーセット</value>
   </data>
-  <data name="TransitionFilter_FragmentEndFinders_4_ions" xml:space="preserve">
-    <value>4個のイオン</value>
+  <data name="PeptideTipProvider_RenderTip_Ion_Mobility" xml:space="preserve">
+    <value>イオン移動度</value>
   </data>
-  <data name="TransitionFilter_FragmentEndFinders_last_ion" xml:space="preserve">
-    <value>最後のイオン</value>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Version" xml:space="preserve">
+    <value>バージョン</value>
   </data>
-  <data name="TransitionFilter_FragmentEndFinders_last_ion_minus_1" xml:space="preserve">
-    <value>最後のイオン - 1</value>
+  <data name="warning" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\warning.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="TransitionFilter_FragmentStartFinders_ion_1" xml:space="preserve">
-    <value>イオン1</value>
+  <data name="ImportResultsControl_FindDataFiles_Searching_for_missing_result_files_in__0__" xml:space="preserve">
+    <value>{0}で欠損している結果ファイルの検索中。</value>
   </data>
-  <data name="TransitionFilter_FragmentStartFinders_ion_3" xml:space="preserve">
-    <value>イオン3</value>
+  <data name="CommandLine_CreateIrtDatabase_Use_the__0__argument_to_specify_a_file_to_create_" xml:space="preserve">
+    <value>作成するファイルを指定するために{0}引数を使用します。</value>
   </data>
-  <data name="TransitionFullScan_DoValidate_An_isolation_window_width_value_is_not_allowed_in__0___mode" xml:space="preserve">
-    <value>単離ウィンドウ幅値は、{0}モードでは許可されていません。</value>
+  <data name="Pivoter_QualifyColumnInfo_TotalAreaRatio" xml:space="preserve">
+    <value>TotalAreaRatio</value>
   </data>
-  <data name="TransitionFullScan_DoValidate_An_isolation_window_width_value_is_required_in_DIA_mode" xml:space="preserve">
-    <value>DIAモードでは単離ウィンドウ幅値が必要です。</value>
+  <data name="PythonInstaller_InstallPackages_Pip_installation_complete_" xml:space="preserve">
+    <value>Pipのインストールが完了しました。</value>
   </data>
-  <data name="TransitionFullScan_ValidateRes_Mass_accuracy_must_be_between__0__and__1__for_centroided_data_" xml:space="preserve">
-    <value>セントロイド化データの質量精度は{0}と{1}の間でなければなりません。</value>
+  <data name="EditLibraryDlg_OkDialog_The_file__0__is_not_a_supported_spectral_library_file_format" xml:space="preserve">
+    <value>ファイル{0}はサポートされているスペクトルライブラリファイル形式ではありません。</value>
   </data>
-  <data name="TransitionGroup" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\transitiongroup.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="SkylineWindow_ShowReintegrateDialog_The_document_must_have_imported_results_" xml:space="preserve">
+    <value>ドキュメントには、インポート結果が必要です。</value>
   </data>
-  <data name="TransitionGroupDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\transitiongroupdecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_Name" xml:space="preserve">
+    <value>分子名</value>
   </data>
-  <data name="TransitionGroupLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\transitiongrouplib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="RefineDlg_RefineDlg_Precursors" xml:space="preserve">
+    <value>プリカーサー</value>
   </data>
-  <data name="TransitionGroupLibDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TransitionGroupLibDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="Pivoter_QualifyColumnInfo_AreaRatio" xml:space="preserve">
+    <value>AreaRatio</value>
   </data>
-  <data name="TransitionGroupTreeNode_GetResultsText_total_ratio__0__" xml:space="preserve">
-    <value>総比率{0}</value>
+  <data name="CreateIrtCalculatorDlg_OkDialog_iRT_database_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
+    <value>iRTデータベース欄には有効なファイルに対するパスが含まれていなければなりません。</value>
   </data>
-  <data name="TransitionInfo_ReadTransitionLosses_Invalid_loss_index__0__for_modification__1__" xml:space="preserve">
-    <value>修飾{1}のロスインデックス{0}が無効です</value>
+  <data name="LoadingTooSlowlyException_LoadingTooSlowlyException_Data_import_expected_to_consume__0__minutes_with_maximum_of__1__mintues" xml:space="preserve">
+    <value>データのインポートには{0}分（最大{1}分）かかることが予測されます</value>
   </data>
-  <data name="TransitionInfo_ReadTransitionLosses_No_modification_named__0__was_found_in_this_document" xml:space="preserve">
-    <value>このドキュメントでは{0}という名前の修飾が見つかりませんでした。</value>
+  <data name="EditMeasuredIonDlg_OkDialog_Reporter_ion_masses_must_be_greater_than_or_equal_to__0__" xml:space="preserve">
+    <value>レポーターイオン質量は{0}以上でなければなりません。</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_Target" xml:space="preserve">
+    <value>ターゲット</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Transition_Replicate_Note" xml:space="preserve">
+    <value>トランジション繰り返し測定メモ</value>
+  </data>
+  <data name="RInstaller_InstallR_R_installation_was_not_completed__Cancelling_tool_installation_" xml:space="preserve">
+    <value>Rのインストールが完了しませんでした。ツールのインストールのキャンセル中。</value>
   </data>
   <data name="TransitionInfo_ReadXmlAttributes_The_reporter_ion__0__was_not_found_in_the_transition_filter_settings_" xml:space="preserve">
     <value>トランジションフィルタ設定でレポーターイオン{0}が見つかりませんでした。</value>
   </data>
-  <data name="TransitionLibraries_DoValidate_Library_ion_count_value__0__must_not_be_less_than_min_ion_count_value__1__" xml:space="preserve">
-    <value>ライブラリのイオン数値{0}は、最小イオン数値{1}未満であってはなりません。</value>
+  <data name="DigestSettings_ValidateIntRange_The_value__1__for__0__must_be_between__2__and__3__" xml:space="preserve">
+    <value>{0}に対する値{1}は、{2}と{3}の間でなければなりません。</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_An_isolation_scheme_is_required_to_match_multiple_precursors" xml:space="preserve">
-    <value>複数のプリカーサーを一致させるには単離スキームが必要です。</value>
+  <data name="BiblioSpecLiteLibrary_Load_Invalid_precursor_charge__0__found__File_may_be_corrupted" xml:space="preserve">
+    <value>無効なプリカーサー電荷{0}が見つかりました。ファイルが破損している可能性があります。</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_Cannot_use_DIA_window_for_precursor_exclusion_when_isolation_scheme_does_not_contain_prespecified_windows___Please_select_an_isolation_scheme_with_prespecified_windows_" xml:space="preserve">
-    <value>単離スキームに事前指定されたウィンドウが含まれていない場合、プリカーサー排除にはDIAウィンドウを使用することはできません。 事前指定されたウィンドウ付きの単離スキームを選択してください。</value>
+  <data name="PasteDlg_btnTransitionListHelp_Click_2_" xml:space="preserve">
+    <value>分子のイオン式に関するメモ：
+
+お使いのトランジションリストの形式で分子式と付加イオンの表記を単一の列にまとめている場合（例：「C8H10N4O2[M+Na]」）、[イオン式]の列を使用し、[付加イオン]の列は無視してください。お使いのトランジションリストで分子式と付加イオンの表記を別々の列に記載している場合、[イオン式]の列に分子式を、付加イオンの説明に[付加イオン]の列を使用してください。</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_Cannot_use_DIA_window_for_precusor_exclusion_when__All_Ions__is_selected_as_the_isolation_scheme___To_use_the_DIA_window_for_precusor_exclusion__change_the_isolation_scheme_in_the_Full_Scan_settings_" xml:space="preserve">
-    <value>単離スキームとして「すべてのイオン」が選択されている場合、プリカーサー排除にはDIAウィンドウを使用することはできません。 プリカーサー排除にDIAウィンドウを使用するには、フルスキャン設定で単離スキームを変更します。</value>
+  <data name="CommandLine_Run_Error__Failed_importing_the_file__0____1_" xml:space="preserve">
+    <value>エラー： ファイル{0}のインポートに失敗しました。{1}</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_Ion_types_must_contain_a_comma_separated_list_of_ion_types_a_b_c_x_y_z_and_p_for_precursor" xml:space="preserve">
-    <value>イオンタイプには、イオンタイプa、b、c、x、y、z、p（プリカーサー用）のカンマ区切りリストを含む必要があります。</value>
+  <data name="FileStreamManager_Commit_Could_not_replace_file_" xml:space="preserve">
+    <value>ファイルを置換できませんでした</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_Isotope_enrichment_settings_are_required_for_MS1_filtering_on_high_resolution_mass_spectrometers" xml:space="preserve">
-    <value>高分解能質量分析計でのMS1フィルタリングには、同位体濃縮設定が必要です。</value>
+  <data name="SrmDocumentSharing_SrmDocumentSharing_ExtractProgress_Extracting__0__" xml:space="preserve">
+    <value>{0}の抽出中</value>
   </data>
-  <data name="TransitionTreeNode_GetLabel_rank__0__" xml:space="preserve">
-    <value>ランク{0}</value>
+  <data name="LibraryGridViewDriver_AddProcessedIrts_None_of__0__runs_were_found_with_high_enough_correlation_to_the_existing_iRT_values_to_allow_retention_time_conversion" xml:space="preserve">
+    <value>{0}回の実行は、いずれも保持時間を変換できるほど既存のiRT値への相関度が高くありませんでした。</value>
   </data>
-  <data name="TransitionTreeNode_GetResultsText__0__" xml:space="preserve">
-    <value>[{0}]</value>
-    <comment>Rank for transition node</comment>
+  <data name="PeptideToMoleculeText_Peptides" xml:space="preserve">
+    <value>ペプチド</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 peptides" to read "2 molecules" when non-peptide documents are in use</comment>
   </data>
-  <data name="TransitionTreeNode_GetResultsText__0__ratio__1__" xml:space="preserve">
-    <value>{0}（比率{1}）</value>
-    <comment>(0) transition amino acids, (1) transition fragment ion</comment>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Peptides" xml:space="preserve">
+    <value>ペプチド</value>
   </data>
-  <data name="TransitionTreeNode_RenderTip_Charge" xml:space="preserve">
-    <value>電荷</value>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_Start" xml:space="preserve">
+    <value>開始</value>
   </data>
-  <data name="UIModeMixed" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\UIModeMixed.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="RefineListDlg_OkDialog_The_peptide___0___is_not_in_the_document" xml:space="preserve">
+    <value>ペプチド「{0}」はドキュメント内にありません。</value>
   </data>
-  <data name="UIModeProteomic" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\UIModeProteomic.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="TransitionFilter_FragmentEndFinders_last_ion_minus_1" xml:space="preserve">
+    <value>最後のイオン - 1</value>
   </data>
-  <data name="UIModeSmallMolecules" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\UIModeSmallMolecules.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeakBoundaryImporter_Import_The_decoy_value__0__on_line__1__is_invalid__must_be_0_or_1_" xml:space="preserve">
+    <value>{1}行目のデコイ値{0}が無効です：0か1でなければなりません。</value>
+  </data>
+  <data name="PeptideStandardLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidestandardlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Protein_Name" xml:space="preserve">
+    <value>タンパク質名</value>
+  </data>
+  <data name="ReportSpec_ReportToCsvString_Exporting__0__report" xml:space="preserve">
+    <value>{0}レポートのエクスポート中</value>
+  </data>
+  <data name="Collapse" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\minus.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ChromatogramCache_LoadStructs_The_SKYD_file_format__0__is_not_supported_by_Skyline__1__" xml:space="preserve">
+    <value>SKYDファイル形式{0}はSkyline{1}ではサポートされていません。</value>
+  </data>
+  <data name="XHunterLibrary_Load_Invalid_precursor_charge_found_File_may_be_corrupted" xml:space="preserve">
+    <value>無効なプリカーサー電荷が見つかりました。ファイルが破損している可能性があります。</value>
   </data>
   <data name="UniquePeptidesDlg_LaunchPeptideProteinsQuery_" xml:space="preserve">
     <value>{0}
 （遺伝子：{1}）</value>
   </data>
-  <data name="UniquePeptidesDlg_OnShown_The_background_proteome__0__has_not_yet_finished_being_digested_with__1__" xml:space="preserve">
-    <value>バックグラウンドプロテオーム{0}はまだ{1}による消化を完了していません。</value>
+  <data name="SerializableSettingsList_ImportFile_Failure_loading__0__" xml:space="preserve">
+    <value>{0}の読み込みに失敗しました。</value>
   </data>
-  <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_gene_information__this_selection_may_be_suspect_" xml:space="preserve">
-    <value>いくつかのバックグラウンドプロテオームのタンパク質には遺伝子の情報がないので、この選択肢は疑わしい可能性があります。</value>
+  <data name="AreaReplicateGraphPane_UpdateGraph_Peak_Area" xml:space="preserve">
+    <value>ピーク面積</value>
   </data>
-  <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_species_information__this_selection_may_be_suspect_" xml:space="preserve">
-    <value>いくつかのバックグラウンドプロテオームのタンパク質には種の情報がないので、この選択肢は疑わしい可能性があります。</value>
+  <data name="ColorSchemeList_GetDefaults_Distinct" xml:space="preserve">
+    <value>クリア</value>
   </data>
-  <data name="UnpackZipToolHelper_UnpackZipTool_The_tool___0___requires_report_type_titled___1___and_it_is_not_provided__Import_canceled_" xml:space="preserve">
-    <value>ツール「{0}」には「{1}」というタイトルのレポートタイプが必要ですが、提供されていません。インポートがキャンセルされました。</value>
+  <data name="CommandLineTest_ConsoleAddFastaTest_Error" xml:space="preserve">
+    <value>エラー</value>
   </data>
-  <data name="up_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\up-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="SkylineWindow_importMassListMenuItem_Click_Data_columns_not_found_in_first_line" xml:space="preserve">
+    <value>先頭行にデータ列が見つかりません。</value>
   </data>
-  <data name="UpgradeManager_updateCheck_Complete_Failed_attempting_to_check_for_an_upgrade_" xml:space="preserve">
-    <value>アップグレードの確認に失敗しました。</value>
+  <data name="SrmDocument_GetPeptideGroupId_molecules" xml:space="preserve">
+    <value>分子</value>
   </data>
-  <data name="UpgradeManager_updateCheck_Complete_Failed_attempting_to_upgrade_" xml:space="preserve">
-    <value>アップグレードに失敗しました。</value>
+  <data name="PersistedViews_GetDefaults_Molecule_Ratio_Results" xml:space="preserve">
+    <value>分子比率の結果</value>
   </data>
-  <data name="UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
-    <value>サーバー{0}でのユーザー認証情報の認証中にエラーがありました。</value>
+  <data name="PeptideQcLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptideqclib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="UtilDB_Uncompress_Failure_uncompressing_data" xml:space="preserve">
-    <value>データの解凍に失敗。</value>
+  <data name="GenerateDecoys" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\GenerateDecoys.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateAdduct_A_valid_adduct_description__e_g____M_H____must_be_provided_" xml:space="preserve">
-    <value>有効な付加イオンの表記（例：「[M+H]」）を入力する必要があります。</value>
-  </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateCollisionalCrossSection_Measured_collisional_cross_section_values_must_be_valid_decimal_numbers_greater_than_zero_" xml:space="preserve">
-    <value>測定衝突断面積値は0より大きな有効な十進数でなければなりません。</value>
-  </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateHighEnergyIonMobilityOffset_High_energy_ion_mobility_offsets_should_be_empty__or_express_an_offset_value_for_ion_mobility_in_high_collision_energy_scans_which_may_add_velocity_to_ions_" xml:space="preserve">
-    <value>高エネルギーイオン移動度オフセットは空白か、またはイオンを加速する可能性のある高衝突エネルギースキャンにおけるイオン移動度のオフセット値を表現する必要があります。</value>
-  </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry_" xml:space="preserve">
-    <value>各エントリには修飾ペプチドシークエンスが必要です。</value>
-  </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateSequence_The_sequence__0__is_not_a_valid_modified_peptide_sequence_" xml:space="preserve">
-    <value>シークエンス{0}は有効な修飾ペプチドシークエンスではありません。</value>
-  </data>
-  <data name="ValueInvalidChargeListException_ValueInvalidChargeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_integers_" xml:space="preserve">
-    <value>値「{0}」は、整数のカンマ区切りリストを必要とする引数{1}に対して有効ではありません。</value>
-  </data>
-  <data name="ValueInvalidDateException_ValueInvalidDateException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_date_time_value_" xml:space="preserve">
-    <value>値「{0}」は、日時の値を必要とする引数{1}に対して有効ではありません。</value>
-  </data>
-  <data name="ValueInvalidDoubleException_ValueInvalidDoubleException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_decimal_number_" xml:space="preserve">
-    <value>値「{0}」は、十進数を必要とする引数{1}に対して有効ではありません。</value>
-  </data>
-  <data name="ValueInvalidIntException_ValueInvalidIntException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_integer_" xml:space="preserve">
-    <value>値「{0}」は、整数を必要とする引数{1}に対して有効ではありません。</value>
-  </data>
-  <data name="ValueInvalidIonTypeListException_ValueInvalidIonTypeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_fragment_ion_types__a__b__c__x__y__z__p__" xml:space="preserve">
-    <value>値「{0}」は、フラグメントイオンタイプ（a、b、c、x、y、z、p）のカンマ区切りリストを必要とする引数{1}に対して有効ではありません。</value>
+  <data name="MassListImporter_AddRow_Invalid_library_intensity_at_precursor__0__for_peptide__1_" xml:space="preserve">
+    <value>ペプチド{1}に対するプリカーサー{0}での無効なライブラリ強度。</value>
   </data>
   <data name="ValueInvalidMzToleranceException_ValueInvalidMzToleranceException_The_value__0__is_not_valid_for_the_argument__1__which_requires_a_value_and_a_unit__For_example___2__" xml:space="preserve">
     <value>値{0}は引数{1}に有効ではありません。値と単位が必要です。例：{2}</value>
   </data>
-  <data name="ValueInvalidNumberListException_ValueInvalidNumberListException_The_value__0__is_not_valid_for_the_argument__1__which_requires_a_list_of_decimal_numbers_" xml:space="preserve">
-    <value>値{0}は、十進数のリストを必要とする引数{1}に対して無効です。</value>
+  <data name="EditIsolationSchemeDlg_comboMargins_SelectedIndexChanged_Margin" xml:space="preserve">
+    <value>マージン</value>
   </data>
-  <data name="ValueInvalidPathException_ValueInvalidPathException_The_value___0___is_not_valid_for_the_argument__1__failed_attempting_to_convert_it_to_a_full_file_path_" xml:space="preserve">
-    <value>値「{0}」は、フルファイルパスへの変換試行に失敗した引数{1}に対して有効ではありません。</value>
+  <data name="SkylineWindow_ShowReintegrateDialog_The_document_must_have_targets_in_order_to_reintegrate_chromatograms_" xml:space="preserve">
+    <value>ドキュメントには、クロマトグラムを再積分するターゲットが含まれている必要があります。</value>
   </data>
-  <data name="ValueMissingException_ValueMissingException_" xml:space="preserve">
-    <value>引数{0}には値が必要であり、--name=value形式で指定する必要があります</value>
+  <data name="WandProhibit" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\WandProhibit.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_expandAllMenuItem_DropDownOpening__Lists" xml:space="preserve">
+    <value>リスト(&amp;L)</value>
+  </data>
+  <data name="ExportReportDlg_OkDialog_Export_Report" xml:space="preserve">
+    <value>レポートをエクスポート</value>
+  </data>
+  <data name="AddZipToolHelper_InstallProgram_Error__Package_installation_not_handled_in_SkylineRunner___If_you_have_already_handled_package_installation_use_the___tool_ignore_required_packages_flag" xml:space="preserve">
+    <value>エラー： SkylineRunner内で処理されないパッケージインストール。 既にパッケージインストールが処理されている場合、--tool-ignore-required-packagesフラグを使用します</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Version__0__" xml:space="preserve">
+    <value>バージョン：{0}</value>
+  </data>
+  <data name="ToolMacros__listArguments_Tool_Directory" xml:space="preserve">
+    <value>ツールディレクトリ</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_The_document_only_contains__0__of_these_iRT_standard_peptides_" xml:space="preserve">
+    <value>ドキュメントには、このiRT標準ペプチドが{0}個しかありません。</value>
+  </data>
+  <data name="SkypDownloadException_GetMessage_The_skyp_file_was_downloaded_by_the_user__0___Credentials_saved_in_Skyline_for_this_server_are_for_the_user__1__" xml:space="preserve">
+    <value>ユーザー{0}がskypファイルをダウンロードしました。Skylineに保存されているこのサーバーの認証情報は、ユーザー{1}のものです。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Neutral_Loss" xml:space="preserve">
+    <value>プロダクトニュートラルロス</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Acquired_Time" xml:space="preserve">
+    <value>取得時間</value>
+  </data>
+  <data name="BuildBackgroundProteomeDlg_AddFastaFile_The_added_file_included__0__repeated_protein_sequences__Their_names_were_added_as_aliases_to_ensure_the_protein_list_contains_only_one_copy_of_each_sequence_" xml:space="preserve">
+    <value>追加されたファイルには、{0}個の反復タンパク質シークエンスが含まれていました。タンパク質リストに各シークエンスのコピーが1つしか含まれないようにするために、これらの名前はエイリアスとして追加されました。</value>
+  </data>
+  <data name="ChooseSchedulingReplicatesDlg_btnOk_Click_Choose_retention_time_filter_replicates" xml:space="preserve">
+    <value>保持時間フィルタ繰り返し測定を選択</value>
+  </data>
+  <data name="CommandLine_ProcessDocument_Error_saving_file" xml:space="preserve">
+    <value>エラー：ファイルの保存</value>
+  </data>
+  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_specify_a_path_to_an_existing_spectral_library" xml:space="preserve">
+    <value>既存のスペクトルライブラリにパスを指定してください。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Error__Regular_expression___0___does_not_have_any_groups___String" xml:space="preserve">
+    <value>エラー： 正規表現「{0}」にはグループがありません。 1つのグループが必要です。ファイルの一部、または正規表現内の最初のグループに一致するサブディレクトリ名が繰り返し測定名として使用されます。</value>
+  </data>
+  <data name="AsyncChromatogramsGraph_Render__0___sample__1_" xml:space="preserve">
+    <value>{0}、試料{1}</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Warning___line__0___column__1____2_" xml:space="preserve">
+    <value>警告：（行{0}、列{1}）{2}</value>
+  </data>
+  <data name="Transition_Validate_Product_ion_charge__0__must_be_non_zero_and_between__1__and__2__" xml:space="preserve">
+    <value>プロダクト電荷{0}は、ゼロであってはならず、{1}と{2}の間でなければなりません。</value>
+  </data>
+  <data name="DefineAnnotationDlg_OkDialog_There_is_already_an_annotation_defined_named__0__" xml:space="preserve">
+    <value>「{0}」という名前の注釈が既に定義されています。</value>
+  </data>
+  <data name="NistLibraryBase_Load_Loading__0__library" xml:space="preserve">
+    <value>{0}ライブラリの読み込み中</value>
+  </data>
+  <data name="SummaryReplicateGraphPane_SummaryReplicateGraphPane_Replicate" xml:space="preserve">
+    <value>繰り返し測定</value>
+  </data>
+  <data name="ExportMethodDlg_ExportMethodDlg_Export_Isolation_List" xml:space="preserve">
+    <value>単離リストをエクスポート</value>
+  </data>
+  <data name="FastaSequence_ComparePeptides_Peptides_in_different_FASTA_sequences_may_not_be_compared" xml:space="preserve">
+    <value>異なるFASTAシークエンス内のペプチドは比較できません。</value>
+  </data>
+  <data name="EditLibraryDlg_GetLibraryPath_Legacy_Libraries" xml:space="preserve">
+    <value>レガシーライブラリ</value>
+  </data>
+  <data name="CompareElement_CompareElement__Compare____" xml:space="preserve">
+    <value>&lt;比較...&gt;</value>
+  </data>
+  <data name="OverlapDemultiplexer_attempt_to_take_slice_of_deconvolution_matrix_failed_out_of_range" xml:space="preserve">
+    <value>範囲外エラーにより、デコンボリューションマトリックスのスライスの取り出しに失敗しました。</value>
+  </data>
+  <data name="UIModeProteomic" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UIModeProteomic.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_SetLibrary_Error__The_library_you_are_trying_to_add_conflicts_with_a_library_already_in_the_file_" xml:space="preserve">
+    <value>エラー： 追加しようとしているライブラリはファイル内に既にあるライブラリと競合しています。</value>
+  </data>
+  <data name="CommandLine_ImportResultsFile_Warning__Failed_importing_the_results_file__0____Ignoring___" xml:space="preserve">
+    <value>警告： 結果ファイル{0}のインポートに失敗しました。 無視...</value>
+  </data>
+  <data name="TestToolStoreClient_GetToolZipFile_Error_downloading_tool" xml:space="preserve">
+    <value>ツールのダウンロードエラー</value>
+  </data>
+  <data name="IonMobilityFinder_ProcessMSLevel_Failed_using_results_to_populate_ion_mobility_library_" xml:space="preserve">
+    <value>結果を使用してイオン移動度ライブラリに入力できませんでした。</value>
+  </data>
+  <data name="Find" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\find.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ExportMethodDlg_VerifySchedulingAllowed_Triggered_acquistion_requires_a_spectral_library_or_imported_results_in_order_to_rank_transitions_" xml:space="preserve">
+    <value>トランジションをランクするために、トリガーされた取得には、スペクトルライブラリまたはインポートされた結果が必要です。</value>
+  </data>
+  <data name="Loader_Load_Loading_results_for__0__" xml:space="preserve">
+    <value>{0}の結果を読み込み中</value>
+  </data>
+  <data name="PeptideGroupBuilder_AppendTransition_Failed_to_explain_all_transitions_for_0__m_z__1__with_a_single_set_of_modifications" xml:space="preserve">
+    <value>修飾の単一セットを持つ{0}m/z{1}のすべてのトランジションの説明に失敗しました</value>
+  </data>
+  <data name="AbstractSpectrumGraphItem_GetLabel_rank__0__" xml:space="preserve">
+    <value>ランク{0}</value>
+  </data>
+  <data name="RegressionOption_All_Fixed_points__linear_" xml:space="preserve">
+    <value>固定点（線形）</value>
+  </data>
+  <data name="CommandLine_NewSkyFile_FileAlreadyExists" xml:space="preserve">
+    <value>ファイル「{0}」は既に存在します。--overwriteを追加して、Skylineに上書きを許可します。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_You_have_only_rough_tune_optimized_compensation_voltages_" xml:space="preserve">
+    <value>最適補償電圧は粗調整しかされていません。</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Error_Installing_Packages" xml:space="preserve">
+    <value>パッケージのインストールエラー</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_Warning__the_annotation__0__is_being_overwritten" xml:space="preserve">
+    <value>警告：注釈{0}は上書きされています</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Transitions" xml:space="preserve">
+    <value>トランジション</value>
+  </data>
+  <data name="Skyline_Release1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Skyline_Release.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="IonMobilityDb_GetIonMobilityDb_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
+    <value>イオン移動度ライブラリファイル{0}を見つけることができませんでした。作成するための十分な権限がないようです。</value>
+  </data>
+  <data name="CommandLine_SaveFile_Error__The_file_could_not_be_saved_to__0____Check_that_the_directory_exists_and_is_not_read_only_" xml:space="preserve">
+    <value>エラー： ファイルを{0}に保存できませんでした。 ディレクトリが存在し、読み取り専用でないことを確認します。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_File_path_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
+    <value>ファイルパスには有効なファイルに対するパスが含まれていなければなりません。</value>
+  </data>
+  <data name="CommandLine_AddDecoys_Decoys_discarded" xml:space="preserve">
+    <value>デコイが破棄されました</value>
+  </data>
+  <data name="ExportChromatogramDlg_OkDialog_At_least_one_file_must_be_selected" xml:space="preserve">
+    <value>1つ以上のファイルを選択しなければなりません</value>
+  </data>
+  <data name="CalculateIsolationSchemeDlg_OkDialog_Window_width_not_even" xml:space="preserve">
+    <value>奇数の番号が付いたウィンドウの幅は、最適化されたウィンドウの配置が選択された際、重複した逆多重化ではサポートされません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CopyinFile_A_file_named_0_already_exists_that_isn_t_identical_to_the_one_for_tool__1" xml:space="preserve">
+    <value>ツール{1}に対するファイルとは同一でない{0}という名前のファイルが既に存在しています</value>
+  </data>
+  <data name="PeptideList" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\PeptideList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="DDASearchControl_SearchProgress_Search_done" xml:space="preserve">
+    <value>検索が完了しました。</value>
+  </data>
+  <data name="CommandLine_ImportResults_Error__No_files_left_to_import_" xml:space="preserve">
+    <value>エラー：インポートするファイルが残っていません。</value>
+  </data>
+  <data name="PasteDlg_AddTransitionList_The_precursor_m_z_must_be_a_number_" xml:space="preserve">
+    <value>プリカーサーm/zは数字でなければなりません。</value>
+  </data>
+  <data name="SkylineImg" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\skyline.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MatchModificationsControl_AddCheckedModifications_Add_checked_modifications" xml:space="preserve">
+    <value>選択した修飾を追加</value>
+  </data>
+  <data name="OpenFolder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\openfolder.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ProteoWizard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ProteoWizard.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_The_following_file_name_in_the_peak_boundaries_file_was_not_recognized_" xml:space="preserve">
+    <value>ピーク境界ファイル内の以下のファイル名が認識されませんでした：</value>
+  </data>
+  <data name="PanoramaHelper_ValidateServer_Exception_" xml:space="preserve">
+    <value>エラー：パノラマサーバー情報を確認しようとして不明なエラーが発生しました。
+{0}</value>
+  </data>
+  <data name="EditEnzymeDlg_ValidateAATextBox_The_character__0__is_not_a_valid_amino_acid" xml:space="preserve">
+    <value>文字「{0}」は有効なアミノ酸ではありません。</value>
+  </data>
+  <data name="DriftTimeWindowWidthCalculator_Validate_Fixed window_width_must_be_non_negative_" xml:space="preserve">
+    <value>固定ウィンドウ幅は、正である必要があります。</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_OkDialog_The_selected_target_is_not_unique" xml:space="preserve">
+    <value>選択したターゲットは一意ではありません。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Collision_Energy" xml:space="preserve">
+    <value>明示的衝突エネルギー</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_CellEndEdit_Edit_note" xml:space="preserve">
+    <value>メモを編集</value>
+  </data>
+  <data name="AreaReplicateGraphPane_InitFromData_Expected" xml:space="preserve">
+    <value>期待値</value>
+    <comment>expected value</comment>
+  </data>
+  <data name="IsolationScheme_DoValidate_Special_handling_applies_only_to_prespecified_isolation_windows" xml:space="preserve">
+    <value>特殊処理は、事前指定の単離ウィンドウのみに適用されます</value>
+  </data>
+  <data name="CommandLine_ImportTool_Error__Please_import_the_report_format_for__0____Use_the___report_add_parameter_to_add_the_missing_custom_report_" xml:space="preserve">
+    <value>エラー： {0}のレポート形式をインポートしてください。 欠損しているカスタムレポートを追加するには、--report-addパラメータを使用します。</value>
+  </data>
+  <data name="MassErrorReplicateGraphPane_UpdateGraph_Select_a_peptide_to_see_the_mass_error_graph" xml:space="preserve">
+    <value>質量誤差グラフを表示するペプチドを選択</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_S_Lens" xml:space="preserve">
+    <value>S-レンズ</value>
+  </data>
+  <data name="PeptideTipProvider_RenderTip_CCS" xml:space="preserve">
+    <value>CCS</value>
+    <comment>compact form of Collision Cross Section</comment>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Identified" xml:space="preserve">
+    <value>同定済み</value>
+  </data>
+  <data name="RInstaller_DownloadPackages_Check_your_network_connection_or_contact_the_tool_provider_for_installation_support_" xml:space="preserve">
+    <value>ネットワーク接続を確認するか、ツールプロバイダに問い合わせてインストールのサポートを依頼します。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_charge__Charges_must_be_integer_values_between_1_and__1__" xml:space="preserve">
+    <value>値{0}は有効な電荷ではありません。電荷は1から{1}の整数である必要があります。</value>
+  </data>
+  <data name="SkylineWindow_OpenSharedFile_Failure_extracting_Skyline_document_from_zip_file__0__" xml:space="preserve">
+    <value>zipファイル{0}からのSkylineドキュメントの抽出に失敗しました。</value>
+  </data>
+  <data name="MassListImporter_Import_Empty_transition_list" xml:space="preserve">
+    <value>空のトランジションリスト。</value>
+  </data>
+  <data name="Properties_Button" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Properties.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TestNamedPipeProcessRunner_RunProcess_Error_running_process" xml:space="preserve">
+    <value>プロセス実行エラー</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_be_greater_than_or_equal_to__1__" xml:space="preserve">
+    <value>{0}は{1}以上でなければなりません。</value>
+  </data>
+  <data name="ChromCacheBuilder_BuildNextFileInner_The_file__0__does_not_exist" xml:space="preserve">
+    <value>ファイル{0}は存在しません。</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwrite_Error__There_is_a_conflicting_tool" xml:space="preserve">
+    <value>エラー： 競合するツールがあります。</value>
+  </data>
+  <data name="ExportChromatogramDlg_OkDialog_At_least_one_chromatogram_type_must_be_selected" xml:space="preserve">
+    <value>1つ以上のクロマトグラムタイプを選択しなければなりません。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Precursor_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
+    <value>プリカーサーは次のうちいずれか2つに対して値を必要とします：  式、m/z、荷電。</value>
+  </data>
+  <data name="PasteDlg_CheckSequence_There_is_no_sequence_for_this_protein" xml:space="preserve">
+    <value>このタンパク質にはシークエンスがありません</value>
+  </data>
+  <data name="MultiFileAsynchronousDownloadClient_DownloadFileAsyncWithBroker_Download_canceled_" xml:space="preserve">
+    <value>ダウンロードがキャンセルされました。</value>
+  </data>
+  <data name="ToolUpdatesDlg_DisplayInstallSummary_Failed_to_update_the_following_tools" xml:space="preserve">
+    <value>以下のツールのアップデートに失敗しました</value>
   </data>
   <data name="ValueOutOfRangeDoubleException_ValueOutOfRangeException_The_value___0___for_the_argument__1__must_be_between__2__and__3__" xml:space="preserve">
     <value>引数{1}に対する値{0}は、{2}～{3}まででなければなりません。</value>
   </data>
-  <data name="ValueUnexpectedException_ValueUnexpectedException_The_argument__0__should_not_have_a_value_specified" xml:space="preserve">
-    <value>引数{0}は指定された値を持つことはできません</value>
+  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_The_ion__0__has_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
+    <value>イオン{0}に複数のイオン移動度値があります。Skylineは複数の配座異性体をサポートしているため、これは意図的である可能性があります。</value>
   </data>
-  <data name="VendorIssueHelper_ConvertWiffToMzxml_Please_install_Analyst__or_run_this_import_on_a_computure_with_Analyst_installed" xml:space="preserve">
-    <value>Analystをインストールするか、Analystがインストールされているコンピュータでこのインポートを実行してください</value>
+  <data name="ValueInvalidIonTypeListException_ValueInvalidIonTypeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_fragment_ion_types__a__b__c__x__y__z__p__" xml:space="preserve">
+    <value>値「{0}」は、フラグメントイオンタイプ（a、b、c、x、y、z、p）のカンマ区切りリストを必要とする引数{1}に対して有効ではありません。</value>
   </data>
-  <data name="VendorIssueHelper_ConvertWiffToMzxml_The_file__0__cannot_be_imported_by_the_AB_SCIEX_WiffFileDataReader_library_in_a_reasonable_time_frame_1_F02_min" xml:space="preserve">
-    <value>ファイル{0}を妥当な時間内（{1:F02}分）にAB SCIEX WiffFileDataReaderライブラリにインポートできません。</value>
+  <data name="add_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\add-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="FragmentLibDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\FragmentLibDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="WizardPeptideSearchPRM" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardPeptideSearchPRM.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="AddIrtCalculatorDlg_OkDialog_The_file__0__is_not_an_iRT_database" xml:space="preserve">
+    <value>ファイル{0}はiRTデータベースではありません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_GetTitle__New_Tool_0__" xml:space="preserve">
+    <value>[新しいツール{0}]</value>
+  </data>
+  <data name="DDASearchControl_SearchProgress_Search_canceled" xml:space="preserve">
+    <value>検索がキャンセルされました。</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_The_following_proteins_are_not_in_the_document_" xml:space="preserve">
+    <value>以下のタンパク質はドキュメント内にありません：</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_OkDialog_Please_choose_a_file_for_the_ion_mobility_library" xml:space="preserve">
+    <value>イオン移動度ライブラリのファイルを選択してください。</value>
+  </data>
+  <data name="EditLinkedPeptidesDlg_OkDialog_Some_crosslinked_peptides_are_not_connected_" xml:space="preserve">
+    <value>クロスリンクされているペプチドの一部が結合していません。</value>
+  </data>
+  <data name="CommandLine_ExportReport_Error__The_report__0__does_not_exist__If_it_has_spaces_in_its_name__use__double_quotes__around_the_entire_list_of_command_parameters_" xml:space="preserve">
+    <value>エラー： レポート{0}が存在していません。名前に空白がある場合、コマンドパラメータのリスト全体に「二重引用符」を使用します。</value>
+  </data>
+  <data name="PersistedViews_GetDefaults_Molecule_Quantification" xml:space="preserve">
+    <value>分子定量化</value>
+  </data>
+  <data name="CommandLine_OpenSkyFile_Error__There_was_an_error_opening_the_file__0_" xml:space="preserve">
+    <value>エラー： ファイル{0}を開く際にエラーがありました</value>
+  </data>
+  <data name="RInstaller_RInstaller_Load_This_Tool_requires_the_use_of_the_following_R_Packages_" xml:space="preserve">
+    <value>このツールでは以下のRパッケージを使用する必要があります。</value>
+  </data>
+  <data name="GenerateDecoysError_No_peptide_precursor_models_for_decoys_were_found_" xml:space="preserve">
+    <value>デコイのペプチドプリカーサーモデルは見つかりませんでした。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Max_End_Time" xml:space="preserve">
+    <value>最大終了時間</value>
+  </data>
+  <data name="ReintegrateDlg_OkDialog_The_current_peak_scoring_model_is_incompatible_with_one_or_more_peptides_in_the_document___Please_train_a_new_model_" xml:space="preserve">
+    <value>現在のピークスコアモデルは、ドキュメント内の1つ以上のペプチドと互換性がありません。新しいモデルをトレーニングしてください。</value>
+  </data>
+  <data name="RatioToSurrogate_ToString_Ratio_to_surrogate__0____1__" xml:space="preserve">
+    <value>サロゲート{0}に対する比率({1})</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Peak_Boundaries" xml:space="preserve">
+    <value>ピーク境界</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value>foo</value>
+  </data>
+  <data name="CalibrateIrtDlg_TryGetLine_The_standard_must_have_two_fixed_points" xml:space="preserve">
+    <value>標準は2つの固定点を持つ必要があります。</value>
+  </data>
+  <data name="PeptideGroupDocNode_ChangeSettings_The_current_document_settings_would_cause_the_number_of_targeted_transitions_to_exceed__0_n0___The_document_settings_must_be_more_restrictive_or_add_fewer_proteins_" xml:space="preserve">
+    <value>現在のドキュメント設定により、ターゲットトランジションの数が{0:n0}を超過する原因となります。ドキュメント設定をさらに制限するか、追加するタンパク質を減らさなければなりません。</value>
+  </data>
+  <data name="CommandLine_ApplySampleNameRegex_File___0___does_not_have_a_sample__Cannot_apply_sample_name_pattern__Ignoring_" xml:space="preserve">
+    <value>ファイル「{0}」に試料が含まれていません。試料名のパターンを適用できません。無視します。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_UpdateNumPeptides__0__Peptide" xml:space="preserve">
+    <value>{0}ペプチド</value>
+  </data>
+  <data name="ValueInvalidIntException_ValueInvalidIntException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_integer_" xml:space="preserve">
+    <value>値「{0}」は、整数を必要とする引数{1}に対して有効ではありません。</value>
+  </data>
+  <data name="Edit_Undo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\edit_undo.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Peptide_ToString__missed__5__" xml:space="preserve">
+    <value>（ミス{5}）</value>
+  </data>
+  <data name="PythonInstaller_DownloadPackages_Failed_to_download_the_following_packages_" xml:space="preserve">
+    <value>以下のパッケージのダウンロードに失敗しました：</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_ReadIsolationRanges_No_repeating_isolation_scheme_found_in__0_" xml:space="preserve">
+    <value>{0}に反復単離スキームがありません</value>
+  </data>
+  <data name="SkypDownloadException_GetMessage_Credentials_saved_in_Skyline_for_the_Panorama_server__0__are_invalid_" xml:space="preserve">
+    <value>Skylineに保存されているPanoramaサーバー{0}の認証情報は無効です。</value>
+  </data>
+  <data name="CommandLine_ApplyFileAndSampleNameRegex_Error__No_files_match_the_sample_name_pattern___0___" xml:space="preserve">
+    <value>エラー：サンプル名パターン「{0}」に一致するファイルがありません。</value>
+  </data>
+  <data name="XmlElementHelper_Deserialize_Deserialize" xml:space="preserve">
+    <value>直列化解除</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_A_maximum_of_one_decoy_per_target_may_be_generated_when_using_reversed_decoys_" xml:space="preserve">
+    <value>リバースデコイを使用する際、ターゲット毎に最大1個のデコイを生成できます。</value>
+  </data>
+  <data name="Print" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\print.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Unique_peptides" xml:space="preserve">
+    <value>ユニークペプチド：{0}</value>
+  </data>
+  <data name="ImportSkyrHelper_ResolveImportConflicts_Resolving_conflicts_by_skipping_" xml:space="preserve">
+    <value>スキップして競合を解決中。</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
+    <value>プリカーサー</value>
+  </data>
+  <data name="ViewLibraryDlg_EnsureBackgroundProteome_The_background_proteome_must_be_digested_in_order_to_associate_proteins" xml:space="preserve">
+    <value>バックグラウンドプロテオームをタンパク質に関連付けるためには、消化する必要があります。</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_m_z_value__0_" xml:space="preserve">
+    <value>無効なm/z値{0}</value>
+  </data>
+  <data name="CommandLine_ApplyFileNameRegex_File_name___0___does_not_match_the_pattern___1____Ignoring__2_" xml:space="preserve">
+    <value>ファイル名「{0}」がパターン「{1}」と一致しません。 {2}を無視します</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility__msec_" xml:space="preserve">
+    <value>指定されたイオン移動度(msec)</value>
+  </data>
+  <data name="CustomMolecule_Validate_The_mass__0__of_the_custom_molecule_exceeeds_the_maximum_of__1__" xml:space="preserve">
+    <value>カスタム分子の質量{0}は{1}の最大値を上回っています。</value>
+  </data>
+  <data name="LabKey" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LabKey.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="HardklorLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\hardklor_logo.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MProphetPeakScoringModel_CreateTransitionGroups_MProphetScoringModel_was_given_a_peak_with__0__features__but_it_has__1__peak_feature_calculators" xml:space="preserve">
+    <value>MProphetScoringModeには{0}個の機能を持つピークが与えられましたが、ピーク機能カルキュレータが{1}個あります</value>
+  </data>
+  <data name="SkylineWindow_GetDownloadName__0___1__" xml:space="preserve">
+    <value>{0}({1})</value>
+  </data>
+  <data name="AlertDlg_GetDefaultButtonText__Ignore" xml:space="preserve">
+    <value>無視(&amp;I)</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Change_settings" xml:space="preserve">
+    <value>設定を変更</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_The_text__0__is_not_a_valid_peptide_sequence_on_line__1__" xml:space="preserve">
+    <value>{1}行目のテキスト{0}は有効なペプチドシークエンスではありません。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Precursor_Replicate_Note" xml:space="preserve">
+    <value>プリカーサー繰り返し測定メモ</value>
+  </data>
+  <data name="SkylineStartup_SaveFileDlg_Please_save_a_new_file_to_work_with_" xml:space="preserve">
+    <value>作業を行う新しいファイルを保存してください。</value>
+  </data>
+  <data name="PasteDlg_AddFasta__0__is_not_a_capital_letter_that_corresponds_to_an_amino_acid" xml:space="preserve">
+    <value>「{0}」はアミノ酸に対応する大文字ではありません。</value>
+  </data>
+  <data name="PasteDlg_AddFasta_There_is_no_name_for_this_protein" xml:space="preserve">
+    <value>このタンパク質には名前がありません</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_CAS_registry_number_" xml:space="preserve">
+    <value>{0}は有効なCAS登録番号ではありません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CopyinFile_Missing_the_file_0_Tool_1_Import_Failed" xml:space="preserve">
+    <value>ファイル{0}がありません。ツール ({1}) のインポートに失敗しました</value>
+  </data>
+  <data name="ImportResultsControl_FindDataFiles_An_error_occurred_attempting_to_find_missing_result_files_in__0__" xml:space="preserve">
+    <value>{0}で欠損している結果ファイルを検索しようとした際にエラーが発生しました。</value>
+  </data>
+  <data name="DisplayEquation_N_A" xml:space="preserve">
+    <value>該当なし</value>
+  </data>
+  <data name="CommandLine_CreateScoringModel_Creating_scoring_model__0_" xml:space="preserve">
+    <value>スコアモデル{0}を作成中</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence" xml:space="preserve">
+    <value>ペプチド修飾シークエンス</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Peptide" xml:space="preserve">
+    <value>ペプチド</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Ratio_Dot_Product" xml:space="preserve">
+    <value>比率内積</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_The_document_contains__0__of_these_iRT_standard_peptides_" xml:space="preserve">
+    <value>ドキュメントには、このiRT標準ペプチドが{0}個含まれています。</value>
+  </data>
+  <data name="ChromatogramCache_LoadStructs_Please_check_for_a_newer_release_" xml:space="preserve">
+    <value>さらに新しいリリースを確認してください。</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_btnTrainModel_Click_Cannot_train_model_without_either_decoys_or_second_best_peaks_included_" xml:space="preserve">
+    <value>デコイか2番目に良いピークなしではトレインモデルができません。</value>
+  </data>
+  <data name="ComparePeakBoundaries_ComputeMatches_Documents_have_different_number_of_transition_groups___0__vs__1__" xml:space="preserve">
+    <value>ドキュメントにはトランジショングループである{0}対{1}の異なる番号があります。</value>
+  </data>
+  <data name="AddIrtCalculatorDlg_OkDialog_Please_choose_the_iRT_calculator_you_would_like_to_add" xml:space="preserve">
+    <value>追加するiRTカルキュレータを選択してください。</value>
+  </data>
+  <data name="ToolInstaller_UnpackZipTool_Error__The__0__does_not_contain_a_valid__1__attribute_" xml:space="preserve">
+    <value>エラー： {0}には有効な{1}属性が含まれていません。</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_The_following_peptides_are_not_in_the_document" xml:space="preserve">
+    <value>以下のペプチドはドキュメント内にありません：</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Protein_description" xml:space="preserve">
+    <value>タンパク質の説明</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_InChI_identifier_" xml:space="preserve">
+    <value>{0}は有効なInChI識別子ではありません。</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_CumulativeCount" xml:space="preserve">
+    <value>累積数</value>
+  </data>
+  <data name="OpenDataSourceDialog_Open_Error" xml:space="preserve">
+    <value>エラー</value>
+  </data>
+  <data name="ValueInvalidDateException_ValueInvalidDateException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_date_time_value_" xml:space="preserve">
+    <value>値「{0}」は、日時の値を必要とする引数{1}に対して有効ではありません。</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Revision" xml:space="preserve">
+    <value>リビジョン</value>
+  </data>
+  <data name="ViewLibraryDlg_MatchModifications__0__Would_you_like_to_use_the_Unimod_definitions_for__1__modifications_The_document_will_not_change_until_peptides_with_these_modifications_are_added" xml:space="preserve">
+    <value>{0}{1}修飾にUnimod定義を使用しますか？ これらの修飾を持つペプチドが追加されるまでドキュメントは変更されません。</value>
+  </data>
+  <data name="TransitionGroup" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\transitiongroup.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_Count" xml:space="preserve">
+    <value>{0}個</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_Isotope_enrichment_settings_are_required_for_MS1_filtering_on_high_resolution_mass_spectrometers" xml:space="preserve">
+    <value>高分解能質量分析計でのMS1フィルタリングには、同位体濃縮設定が必要です。</value>
+  </data>
+  <data name="PeptideDecoyLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidedecoylib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_NewSkyFile_Deleting_existing_file___0__" xml:space="preserve">
+    <value>既存のファイル「{0}」を削除</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Cone_Voltage" xml:space="preserve">
+    <value>コーン電圧</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility_Units" xml:space="preserve">
+    <value>イオン移動度の単位</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Cannot_derive_charge_from_adduct_description___0____Use_the_corresponding_Charge_column_to_set_this_explicitly__or_change_the_adduct_description_as_needed_" xml:space="preserve">
+    <value>付加イオンの表記「{0}」から電荷を計算できません。これを明確に設定するには対応する電荷列を使用するか、必要に応じて付加イオンの表記を変更します。</value>
+  </data>
+  <data name="SkypFile_GetSkyFileUrl_File_does_not_contain_the_URL_of_a_shared_Skyline_archive_file___0___on_a_Panorama_server_" xml:space="preserve">
+    <value>PanoramaサーバーにあるSkyline共有アーカイブファイル({0})のURLがファイルに含まれていません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_In_Parallel" xml:space="preserve">
+    <value>並行</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Change_settings_to_add_precursors" xml:space="preserve">
+    <value>プリカーサーを追加するよう変更を設定</value>
+  </data>
+  <data name="Ions_A" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_A.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ChromatogramLibrary_LoadLibraryFromDatabase_Reading_precursors_from__0_" xml:space="preserve">
+    <value>{0}からプリカーサーを読み取り中</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_The_following_sequences_are_not_valid_peptides" xml:space="preserve">
+    <value>以下のシークエンスは有効なペプチドではありません：</value>
+  </data>
+  <data name="ImportPeptideSearchDlg_NextPage_Please_check_your_peptide_search_pipeline_or_contact_Skyline_support_to_ensure_retention_times_appear_in_your_spectral_libraries_" xml:space="preserve">
+    <value>ペプチド検索パイプラインを確認するか、Skylineサポートに連絡して保持時間がスペクトルライブラリに表示されるようにしてください。</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_ImportTextFile_Import_Transition_List__iRT_standards_" xml:space="preserve">
+    <value>トランジションリストをインポート（iRT標準）</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Opt_Collision_Energy" xml:space="preserve">
+    <value>最適衝突エネルギー</value>
+  </data>
+  <data name="SkylineWindow_SaveDocumentAs_Skyline_Documents" xml:space="preserve">
+    <value>Skylineドキュメント</value>
+  </data>
+  <data name="PasteDlg_AddTransitionList_The_product_m_z_must_be_a_number_" xml:space="preserve">
+    <value>プロダクトm/zは数字でなければなりません。</value>
+  </data>
+  <data name="Molecule" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Molecule.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="TransitionTreeNode_RenderTip_Charge" xml:space="preserve">
+    <value>電荷</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Best_Retention_Time" xml:space="preserve">
+    <value>最良保持時間</value>
   </data>
   <data name="VendorIssueHelper_ConvertWiffToMzxml_To_work_around_this_issue_requires_Analyst_to_be_installed_on_the_computer_running__0__" xml:space="preserve">
     <value>問題の回避方法は、{0}を実行中のコンピュータにAnalystをインストールする必要があります。</value>
   </data>
-  <data name="VendorIssueHelper_CreateTempFileSubstitute_Convert_to_mzXML_work_around_for__0__" xml:space="preserve">
-    <value>{0}のmzXMLへの変換の回避方法</value>
+  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_This_list_contains__0__ions_with_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
+    <value>このリストには複数のイオン移動度値を持つイオンが{0}個含まれています。Skylineは複数の配座異性体をサポートしているため、これは意図的である可能性があります。</value>
   </data>
-  <data name="VendorIssueHelper_CreateTempFileSubstitute_Local_copy_work_around_for__0__" xml:space="preserve">
-    <value>{0}のローカルコピー回避方法</value>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility__1_K0_" xml:space="preserve">
+    <value>指定されたイオン移動度(1/K0)</value>
+  </data>
+  <data name="ConfigureToolsDlg_unpackZipTool_skipping_that_tool_" xml:space="preserve">
+    <value>タイトルとコマンドが必要です。</value>
+  </data>
+  <data name="TransitionFilter_FragmentEndFinders_last_ion" xml:space="preserve">
+    <value>最後のイオン</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_ImportRangesFromFiles_Failed_reading_isolation_scheme_" xml:space="preserve">
+    <value>単離スキームの読み出しに失敗しました。</value>
+  </data>
+  <data name="RedX" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RedX.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Peptide" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptide.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_values__but_the_document_does_not_have_an_iRT_calculator___Create_a_new_calculator_and_add_these_iRT_values_" xml:space="preserve">
+    <value>トランジションリストにはiRT値が含まれていないようですが、ドキュメントにはiRTカルキュレータがありません。 新しいカルキュレータを作成し、これらのiRT値を追加しますか？</value>
+  </data>
+  <data name="MeasuredCollisionalCrossSection_Validate_Charge_state_values_must_be_greater_than_0_" xml:space="preserve">
+    <value>電荷状態値は0より大きくなければなりません。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_File_path_cannot_be_empty_" xml:space="preserve">
+    <value>ファイルパスは空にできません。</value>
+  </data>
+  <data name="LocateFileDlg_PathPasses_You_have_not_provided_a_valid_path_" xml:space="preserve">
+    <value>有効なパスが提供されていません。</value>
+  </data>
+  <data name="CommandLine_AddDecoys_Error__Attempting_to_add_decoys_to_document_with_decoys_" xml:space="preserve">
+    <value>エラー：デコイを有するドキュメントにデコイを追加しようとしています。</value>
+  </data>
+  <data name="EditIrtCalcDlg_btnBrowseDb_Click_Open_iRT_Database" xml:space="preserve">
+    <value>iRTデータベースを開く</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_TrainModel_Calculating_score_contributions" xml:space="preserve">
+    <value>スコア貢献度を計算中</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_conflicting_annotations__Keeping_existing_" xml:space="preserve">
+    <value>競合する注釈があります。既存の保持中。</value>
+  </data>
+  <data name="SkylineWindow_Paste_Could_not_perform_transition_list_paste___0_" xml:space="preserve">
+    <value>トランジションリストの貼り付けの実行ができませんでした：{0}</value>
+  </data>
+  <data name="ToolDescription_VerifyAnnotations_Please_enable_these_annotations_and_fill_in_the_appropriate_data_in_order_to_use_the_tool_" xml:space="preserve">
+    <value>このツールを使用するには、これらの注釈を有効にして適切なデータを入力してください。</value>
+  </data>
+  <data name="Database_Join_Cannot_join_tables_of_same_type" xml:space="preserve">
+    <value>同じタイプの表は結合できません。</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_none" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="PublishDocumentDlg_UploadSharedZipFile_Click_here_to_view_the_error_details_" xml:space="preserve">
+    <value>エラーの詳細を表示するにはここをクリックします。</value>
   </data>
   <data name="VendorIssueHelper_ShowLibraryMissingExternalSpectrumFileError" xml:space="preserve">
     <value>MaxQuant入力ファイル「{0}」のスペクトルファイルを検索中に、サポートされているファイル拡張子（{3}）を持つ以下のベース名を見つけられませんでした。
@@ -3758,6 +1066,904 @@ Skylineでの列の順序は、列のヘッダーを左右にドラッグする�
 
 オリジナルファイルがない場合は、入力ファイルから埋め込みスペクトルを使用してライブラリを構築できますが、MaxQuant埋め込みスペクトル内のフラグメントイオンは、荷電状態がデコンボリュートされており、1価のフラグメントイオンしか含まれず、これは質量分析計が測定する強度を表すものではない可能性があります。</value>
   </data>
+  <data name="ReportSpecList_GetDefaults_Molecule_Peak_Boundaries" xml:space="preserve">
+    <value>分子ピーク境界</value>
+  </data>
+  <data name="EditCoVDlg_btnOk_Click_Maximum_compensation_voltage_cannot_be_less_than_minimum_compensation_volatage_" xml:space="preserve">
+    <value>最大補償電圧は、最小補償電圧未満であってはなりません。</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_OkDialog_There_are_gaps_in_a_single_cycle_of_your_extraction_windows__Do_you_want_to_continue_" xml:space="preserve">
+    <value>抽出ウィンドウの単一サイクルにギャップがあります。本当に続行しますか？</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_iRT" xml:space="preserve">
+    <value>iRT</value>
+  </data>
+  <data name="CommandLine_CheckReplicateFiles_Error__Replicate__0__in_the_document_has_an_unexpected_file__1__" xml:space="preserve">
+    <value>エラー： ドキュメント内の繰り返し測定{0}には予測しないファイル{1}があります。</value>
+  </data>
+  <data name="MoleculeStandardLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\MoleculeStandardLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ProcessNeutralLoss_Precursor_molecular_formula__0__does_not_contain_sufficient_atoms_to_be_used_with_neutral_loss__1_" xml:space="preserve">
+    <value>プリカーサ―分子式{0}にニュートラルロス{1}で使用する十分な原子が含まれていません</value>
+  </data>
+  <data name="ToolDescription_RunTool_File_not_found_" xml:space="preserve">
+    <value>ファイルが見つかりません。</value>
+  </data>
+  <data name="TransitionFilter_FragmentEndFinders_4_ions" xml:space="preserve">
+    <value>4個のイオン</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Formula" xml:space="preserve">
+    <value>分子式</value>
+  </data>
+  <data name="MSAmandaLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LogoAmanda_32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="OpenDataSourceDialog_lookInComboBox_SelectionChangeCommitted_My_Network_Place" xml:space="preserve">
+    <value>マイネットワークプレース</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_time_" xml:space="preserve">
+    <value>{1}行目の値「{0}」は有効な時間ではありません。</value>
+  </data>
+  <data name="DecoyGeneration_SHUFFLE_SEQUENCE_Shuffle_Sequence" xml:space="preserve">
+    <value>シークエンスのシャッフル</value>
+  </data>
+  <data name="ToolDescription_RunExecutableBackground_Error_running_the_installed_tool__0___It_seems_to_have_an_error_in_one_of_its_files__Please_reinstall_the_tool_and_try_again" xml:space="preserve">
+    <value>インストールされたツール{0}の実行エラー。ファイルの1つにエラーがあるようです。ツールを再インストールしてからもう一度お試しください</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Replicates" xml:space="preserve">
+    <value>繰り返し測定</value>
+  </data>
+  <data name="ChromatogramDataProvider_GetChromatogram_This_import_appears_to_be_taking_longer_than_expected__If_importing_from_a_network_drive__consider_canceling_this_import__copying_to_local_disk_and_retrying_" xml:space="preserve">
+    <value>このインポートは予測より長くかかっています。ネットワークドライブからインポート中である場合、このインポートをキャンセルしてローカルディスクをコピーし再試行することを検討してください。</value>
+  </data>
+  <data name="EmptyList" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\EmptyList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Error__To_create_the_iRT_database___0___for_this_assay_library__you_must_specify_the_iRT_standards_using_either_of_the_arguments__1__or__2_" xml:space="preserve">
+    <value>エラー：このアッセイライブラリのiRTデータベース「{0}」を作成するには、引数{1}または{2}のいずれかを用いてiRT標準を指定する必要があります。</value>
+  </data>
+  <data name="Copy_Bitmap" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Copy_Bitmap.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportToolsFromZip_Installed_tool__0_" xml:space="preserve">
+    <value>ツール{0}がインストールされました</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Importing__0__iRT_values_into_the_iRT_calculator__1_" xml:space="preserve">
+    <value>{0}個のiRT値をiRTカルキュレータ{1}にインポート中</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_upgrade_to__0__or_install_in_parallel_" xml:space="preserve">
+    <value>{0}にアップグレードしますか、それとも並行インストールしますか？</value>
+  </data>
+  <data name="AllIonsStatusButton" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\AllIonsStatusButton.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidedecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_The_imported_file_does_not_contain_any_peak_boundaries_for__0__transition_group___file_pairs___These_chromatograms_will_be_treated_as_if_no_boundary_was_selected_" xml:space="preserve">
+    <value>インポートされたファイルには{0}トランジショングループ/ファイルペアに対するピーク境界が含まれていません。 境界が選択されていない場合、これらのクロマトグラムが処理されます。</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__The_current_document_contains_peptides_without_enough_information_to_rank_transitions_for_triggered_acquisition_" xml:space="preserve">
+    <value>エラー： 現在のドキュメントには、トリガーされた取得のトランジションをランクするのに十分な情報のないペプチドが含まれています。</value>
+  </data>
+  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_Continue_peak_boundary_import_ignoring_this_peptide_" xml:space="preserve">
+    <value>このペプチドを無視してピーク境界のインポートを続行しますか？</value>
+  </data>
+  <data name="BuildLibraryDlg_btnPrevious_Click__Next__" xml:space="preserve">
+    <value>次へ(&amp;N) &gt;</value>
+  </data>
+  <data name="ExportReportDlg_ShowPreview_An_unexpected_error_occurred_attempting_to_display_the_report___0___" xml:space="preserve">
+    <value>レポート「{0}」を表示しようとした際に予期しないエラーが発生しました。</value>
+  </data>
+  <data name="DropImage" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\dropimage.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Collision_Cross_Section__sq_A_" xml:space="preserve">
+    <value>衝突断面積(sq A)</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Cannot_read_high_energy_ion_mobility_offset_value___0___on_line__1__" xml:space="preserve">
+    <value>{1}行目の高エネルギーイオン移動度オフセット値「{0}」が読み取れません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Warning__overwriting_will_delete_the_tool__0___Do_you_want_to_continue_" xml:space="preserve">
+    <value>警告：上書きによりツール{0}が削除されます。続行しますか？</value>
+  </data>
+  <data name="SrmSettingsList_DEFAULT_m_z_precursor" xml:space="preserve">
+    <value>m/z &gt;プリカーサー</value>
+  </data>
+  <data name="EditCustomMoleculeDlg_OkDialog_Custom_molecules_must_have_a_mass_less_than_or_equal_to__0__" xml:space="preserve">
+    <value>カスタム分子は、{0}以下の質量でなければなりません。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Retention_Time" xml:space="preserve">
+    <value>保持時間</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Peptide_Retention_Time" xml:space="preserve">
+    <value>ペプチド保持時間</value>
+  </data>
+  <data name="ChromCacheBuilder_BuildCache_This_document_contains_only_negative_ion_mode_transitions__and_the_imported_file_contains_only_positive_ion_mode_data_so_nothing_can_be_loaded_" xml:space="preserve">
+    <value>このドキュメントには陰イオンモードのトランジションのみが含まれ、インポート済みのファイルには陽イオンモードのデータのみが含まれているので、他のものが読み込めないようになっています。</value>
+  </data>
+  <data name="Note" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\note.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Failed_attempting_to_extract_the_tool_from__0_" xml:space="preserve">
+    <value>{0}からのツールの抽出に失敗しました</value>
+  </data>
+  <data name="NoPeak" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\nopeak.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Peptide_RT_Results" xml:space="preserve">
+    <value>ペプチドRT結果</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Molecule_RT_Results" xml:space="preserve">
+    <value>Molecule RT Results</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Molecule_Transition_Results" xml:space="preserve">
+    <value>Molecule Transition Results</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty" xml:space="preserve">
+    <value>{0}は空にできません。</value>
+  </data>
+  <data name="AnnotationDef_AnnotationTarget_Precursors" xml:space="preserve">
+    <value>プリカーサー</value>
+  </data>
+  <data name="ViewLibraryDlg_CheckLibraryInSettings_The_library__0__is_not_currently_added_to_your_document" xml:space="preserve">
+    <value>ライブラリ{0}は現在ドキュメントに追加されていません。</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_charge_value__0_" xml:space="preserve">
+    <value>無効な電荷値{0}</value>
+  </data>
+  <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_0_for_a_single_entry_list" xml:space="preserve">
+    <value>単一入力エントリリストに対するインデックス{0}は0でなければなりません。</value>
+  </data>
+  <data name="SrmDocument_ReadTransitionXml_All_transitions_of_decoy_precursors_must_have_a_decoy_mass_shift" xml:space="preserve">
+    <value>デコイプリカーサーのすべてのトランジションには、デコイ質量シフトが必要です。</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_None_of_the_specified_peptides_are_in_the_document" xml:space="preserve">
+    <value>指定されたペプチドはどれもドキュメント内にありません。</value>
+  </data>
+  <data name="PasteDlg_ShowNoErrors_No_errors" xml:space="preserve">
+    <value>エラーなし</value>
+  </data>
+  <data name="CalibrationCurveFitter_GetCalibrationCurve_Unable_to_calculate_the_calibration_curve_for_the_because_there_are_different_Precursor_Concentrations_specified_for_the_label__0__" xml:space="preserve">
+    <value>標識{0}に異なるプリカーサー濃度が指定されているため、校正曲線を計算できません。</value>
+  </data>
+  <data name="GridViewDriver_ValidateRow_On_line__0__1__" xml:space="preserve">
+    <value>{0}行、{1}</value>
+    <comment>Line refers to line of document</comment>
+  </data>
+  <data name="EditIrtCalcDlg_btnCreateDb_Click_Create_iRT_Database" xml:space="preserve">
+    <value>iRTデータベースを作成</value>
+  </data>
+  <data name="directoryicon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\directoryicon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Matched_spectra" xml:space="preserve">
+    <value>一致したスペクトル</value>
+  </data>
+  <data name="PeptidesPerProteinDlg_UpdateRemaining_Calculating___" xml:space="preserve">
+    <value>計算中...</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_Processing_Retention_Times" xml:space="preserve">
+    <value>保持時間を処理しています</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_HMDB_identifier_" xml:space="preserve">
+    <value>{0}は有効なHMDB識別子ではありません。</value>
+  </data>
+  <data name="CustomMolecule_DisplayName_Molecule" xml:space="preserve">
+    <value>分子</value>
+  </data>
+  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_Continue_peak_boundary_import_ignoring_this_file_" xml:space="preserve">
+    <value>このファイルを無視してピーク境界のインポートを続行しますか？</value>
+  </data>
+  <data name="CommandLine_SetLibrary_Error__The_file__0__does_not_exist_" xml:space="preserve">
+    <value>エラー： ファイル{0}は存在しません。</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Data_files" xml:space="preserve">
+    <value>データファイル</value>
+  </data>
+  <data name="SkylineWindow_ShowExportSpectralLibraryDialog_The_document_must_contain_results_to_export_a_spectral_library_" xml:space="preserve">
+    <value>スペクトルライブラリをエクスポートするには、ドキュメントに結果が含まれている必要があります。</value>
+  </data>
+  <data name="BioMassCalc_ApplyAdductToFormula_Failed_parsing_adduct_description___0__" xml:space="preserve">
+    <value>付加物の説明「{0}」の解析に失敗しました</value>
+  </data>
+  <data name="ToolDescription_VerifyAnnotations_This_tool_requires_the_use_of_the_following_annotations_which_are_not_enabled_for_this_document" xml:space="preserve">
+    <value>このツールでは、このドキュメントに対し有効でない以下の注釈を使用する必要があります</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_OkDialog_Specify_Start_and_End_values_for_at_least_one_isolation_window" xml:space="preserve">
+    <value>1つ以上の単離ウィンドウに開始値と終値を指定します。</value>
+  </data>
+  <data name="PivotReportDlg_OkDialog_A_report_must_have_at_least_one_column" xml:space="preserve">
+    <value>レポートには1列以上必要です。</value>
+  </data>
+  <data name="FullScanAcquisitionExtension_LOCALIZED_VALUES_Targeted" xml:space="preserve">
+    <value>ターゲット</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_formula_and_m_z_value_do_not_agree_for_any_charge_state_" xml:space="preserve">
+    <value>プロダクト式とm/zはいかなる荷電状態も受け入れません。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Adduct__0__charge__1__does_not_agree_with_declared_charge__2_" xml:space="preserve">
+    <value>付加物の{0}電荷{1}が、宣言済みの電荷{2}と一致しません</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_You_must_enter_a_valid_title_for_the_tool" xml:space="preserve">
+    <value>ツールの有効なタイトルを入力する必要があります。</value>
+  </data>
+  <data name="SettingsListComboDriver_Edit_list" xml:space="preserve">
+    <value>&lt;リストを編集...&gt;</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Area" xml:space="preserve">
+    <value>面積</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_Product_mz_does_not_agree_with_calculated_value_" xml:space="preserve">
+    <value>プロダクトm/z {0}は、イオン式と荷電状態 (デルタ = {2}, トランジション設定 | 装置 | メソッド許容誤差 m/z = {3}) から計算されているため、値{1}を受け入れません)。表のm/z値を修正するか、または空白にしておけばSkylineが自動的に計算します。</value>
+  </data>
+  <data name="RInstaller_RInstaller_Load_This_tool_requires_the_use_of_R__0___Click_Install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>このツールにはR{0}の使用が必要です。インストールをクリックしてインストールプロセスを開始します。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_if_you_would_like_the_command_to_launch_a_link__make_sure_to_include_http____or_https___" xml:space="preserve">
+    <value>コマンドを使ってリンクを立ち上げる場合、必ずhttp://またはhttps://を含みます</value>
+  </data>
+  <data name="SkylineWindow_ShowProgressErrorUI_Skip" xml:space="preserve">
+    <value>スキップ</value>
+  </data>
+  <data name="SkylineWindow_Publish_There_are_no_Panorama_servers_to_publish_to_Please_add_a_server_under_Tools" xml:space="preserve">
+    <value>公開先にPanoramaサーバーがありません。ツールの下にサーバーを追加してください。</value>
+  </data>
+  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_specify_a_path_to_an_existing_spectral_library_" xml:space="preserve">
+    <value>既存のスペクトルライブラリにパスを指定してください。</value>
+  </data>
+  <data name="GraphSpectrum_UpdateUI_Multiple_charge_states_with_library_spectra" xml:space="preserve">
+    <value>ライブラリスペクトルを伴う多重荷電状態</value>
+  </data>
+  <data name="PeptideIrt" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptideirt.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Opt_Compensation_Voltage" xml:space="preserve">
+    <value>最適補償電圧</value>
+  </data>
+  <data name="ViewLibraryDlg_LoadLibrary_Loading_Library" xml:space="preserve">
+    <value>ライブラリの読み込み中</value>
+  </data>
+  <data name="RefinementSettings_Refine_The_document_must_contain_at_least_2_replicates_to_refine_based_on_consistency_" xml:space="preserve">
+    <value>一貫性に基づいて最適化するには、ドキュメントに少なくとも2つの繰り返し測定を含める必要があります。</value>
+  </data>
+  <data name="PeptideToMoleculeText_Ion_adducts" xml:space="preserve">
+    <value>付加イオン</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "Ion charges" to read "Ion adducts" when non-peptide documents are in use</comment>
+  </data>
+  <data name="CommandLine_ImportTool__0__was_added_to_the_Tools_Menu_" xml:space="preserve">
+    <value>{0}がツールメニューに追加されました。</value>
+  </data>
+  <data name="Close" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Close.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_collisional_cross_section_value__0_" xml:space="preserve">
+    <value>無効な衝突断面積値{0}</value>
+  </data>
+  <data name="CommandLine_CanReadFile_Error__File_does_not_exist___0__" xml:space="preserve">
+    <value>エラー： ファイルが存在していません：{0}。</value>
+  </data>
+  <data name="ShimadzuMethodExporter_ExportMethod_Error_copying_template_file__0__to_destination__1__" xml:space="preserve">
+    <value>テンプレートファイル{0}の移動先{1}へのコピーのエラー。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__A_template_file_is_required_to_export_a_method_" xml:space="preserve">
+    <value>エラー： メソッドをエクスポートするにはテンプレートファイルが必要です。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_SmallMoleculeTransitionListReader_" xml:space="preserve">
+    <value>分子列ヘッダーを読み取り中のエラー。次を認識しません：
+ {0}
+ サポートされる値に次が含まれます：
+ {1}</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_SelectedModelItem_Invalid_Model_Selection" xml:space="preserve">
+    <value>無効なモデル選択。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph_CE_" xml:space="preserve">
+    <value>NCE:</value>
+  </data>
+  <data name="WebPanoramaPublishClient_GetInfoForFolders_Failure_retrieving_folder_information_from__0_" xml:space="preserve">
+    <value>{0}からのフォルダ情報の取得に失敗</value>
+  </data>
+  <data name="ExportMethodDlg_VerifySchedulingAllowed_The_current_document_contains_peptides_without_enough_information_to_rank_transitions_for_triggered_acquisition_" xml:space="preserve">
+    <value>現在のドキュメントには、トリガーされた取得のトランジションをランクするのに十分な情報のないペプチドが含まれています。</value>
+  </data>
+  <data name="ValidatingIonMobilityPeptide_ValidateHighEnergyIonMobilityOffset_High_energy_ion_mobility_offsets_should_be_empty__or_express_an_offset_value_for_ion_mobility_in_high_collision_energy_scans_which_may_add_velocity_to_ions_" xml:space="preserve">
+    <value>高エネルギーイオン移動度オフセットは空白か、またはイオンを加速する可能性のある高衝突エネルギースキャンにおけるイオン移動度のオフセット値を表現する必要があります。</value>
+  </data>
+  <data name="CommandLine_SetLibrary_Error__The_file__0__is_not_a_supported_spectral_library_file_format_" xml:space="preserve">
+    <value>エラー： ファイル{0}はサポートされているスペクトルライブラリファイル形式ではありません。</value>
+  </data>
+  <data name="IsolationWindow_DoValidate_Isolation_window_margin_must_be_non_negative" xml:space="preserve">
+    <value>単離ウィンドウのマージンは負の値にはできません。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
+    <value>プロダクトは次のうちいずれか2つに対して値を必要とします：  式、m/z、荷電。</value>
+  </data>
+  <data name="Delete" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\delete.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportTool_Warning__skipping_tool__0__due_to_a_name_conflict_" xml:space="preserve">
+    <value>警告：名前が競合したためツール{0}をスキップ中。</value>
+  </data>
+  <data name="RInstaller_RInstaller_Load_This_tool_requires_the_use_of_R__0__and_the_following_packages_" xml:space="preserve">
+    <value>このツールではR{0}と以下のパッケージを使用する必要があります。</value>
+  </data>
+  <data name="LibraryGridViewDriver_AddToLibrary_Do_you_want_to_recalibrate_the_iRT_standard_values_relative_to_the_peptides_being_added_" xml:space="preserve">
+    <value>追加されているペプチドに対してiRT標準値を再校正しますか？</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateCell_The_entry__0__is_not_valid_" xml:space="preserve">
+    <value>エントリ{0}が有効ではありません。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_OkDialog_Please_use_a_full_path_to_a_file_for_the_ion_mobility_library_" xml:space="preserve">
+    <value>イオン移動度ライブラリのファイルに対し完全パスを使用してください。</value>
+  </data>
+  <data name="SkylineWindow_ShowReintegrateDialog_Reintegration_of_results_requires_a_trained_peak_scoring_model_" xml:space="preserve">
+    <value>結果の再積分には、トレーニングされたピークスコアモデルが必要です。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_The_pasted_text_must_at_a_minimum_contain_columns_for_peptide_and_adduct__along_with_collisional_cross_section_and_or_ion_mobility_" xml:space="preserve">
+    <value>貼り付けられるテキストには、最低でもペプチドと付加物の他、衝突断面積やイオン移動度の列が含まれている必要があります。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__triggered_acquistion_requires_a_spectral_library_or_imported_results_in_order_to_rank_transitions_" xml:space="preserve">
+    <value>エラー：トランジションをランクするために、トリガーされた取得には、スペクトルライブラリまたはインポートされた結果が必要です。</value>
+  </data>
+  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_maximum_log_10_area_entered" xml:space="preserve">
+    <value>入力された最大Log10面積は無効です</value>
+  </data>
+  <data name="MatchModificationsControl_AddModification_Add__0__modification__1_" xml:space="preserve">
+    <value>{0}修飾{1}を追加</value>
+  </data>
+  <data name="RetentionTimeRegression_RecalcRegression_Recalculating_regression" xml:space="preserve">
+    <value>回帰を再計算中</value>
+  </data>
+  <data name="Helpers_AssumeValue_Nullable_was_expected_to_have_a_value" xml:space="preserve">
+    <value>Nullableは値を持つと予測されていました。</value>
+  </data>
+  <data name="ExportMethodDlg_btnBrowseTemplate_Click__0__Method" xml:space="preserve">
+    <value>{0}メソッド</value>
+    <comment>Instrument type name Method</comment>
+  </data>
+  <data name="CommandLine_ImportTool_Error__the_provided_command_for_the_tool__0__is_not_of_a_supported_type___Supported_Types_are___1_" xml:space="preserve">
+    <value>エラー：ツール{0}に提供されたコマンドはサポートされているタイプではありません。 サポートされているタイプ：{1}</value>
+  </data>
+  <data name="SkylineStartup_SkylineStartup_Blank_Document" xml:space="preserve">
+    <value>空のドキュメント</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Please_enter_a_valid_number_of_decoys_per_target_greater_than_0_" xml:space="preserve">
+    <value>0を上回るターゲット毎にデコイの有効な数を入力してください。</value>
+  </data>
+  <data name="UpgradeManager_updateCheck_Complete_Failed_attempting_to_upgrade_" xml:space="preserve">
+    <value>アップグレードに失敗しました。</value>
+  </data>
+  <data name="IsolationWindow_DoValidate_Isolation_window_margins_cover_the_entire_isolation_window_at_the_extremes_of_the_instrument_range" xml:space="preserve">
+    <value>単離ウィンドウのマージンは、装置範囲の極限で単離ウィンドウ全体に及びます。</value>
+  </data>
+  <data name="EditIrtCalcDlg_comboStandards_SelectedIndexChanged_The_list_of_standard_peptides_must_contain_only_recognized_iRT_C18_standards_to_switch_to_a_predefined_set_of_iRT_C18_standards_" xml:space="preserve">
+    <value>標準ペプチドのリストには認識されたiRT-C18標準のみを含め、事前定義済みのiRT-C18標準セットに切り替えなければなりません。</value>
+  </data>
+  <data name="LibraryGridViewDriver_AddProcessedIrts_A_single_run_does_not_have_high_enough_correlation_to_the_existing_iRT_values_to_allow_retention_time_conversion" xml:space="preserve">
+    <value>1回の実行では、既存のiRT値への相関度は保持時間を変換できるほど高くなりません。</value>
+  </data>
+  <data name="PublishDocumentDlg_btnBrowse_Click_Shared_Files" xml:space="preserve">
+    <value>共有ファイル</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_headerList_Molecular_Formula" xml:space="preserve">
+    <value>分子式</value>
+  </data>
+  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_" xml:space="preserve">
+    <value>ピーク境界ファイル内の以下のペプチドが認識されませんでした：</value>
+  </data>
+  <data name="ZedGraphClipboard_CreateCopyMenuItems_Copy" xml:space="preserve">
+    <value>コピー</value>
+  </data>
+  <data name="CommandLine_ExportReport_Error__Failure_attempting_to_save__0__report_to__1__" xml:space="preserve">
+    <value>エラー： {0}レポートの{1}への保存に失敗しました。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_No_list_will_be_exported_" xml:space="preserve">
+    <value>リストはエクスポートされません。</value>
+  </data>
+  <data name="Adduct_ApplyToMolecule_Adduct___0___calls_for_removing_more__1__atoms_than_are_found_in_the_molecule__2_" xml:space="preserve">
+    <value>付加物「{0}」によって、分子{2}で見つかったものよりも多くの{1}の原子を削除する必要があります。</value>
+  </data>
+  <data name="PeptideLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidelib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Failed_to_read_the_first_line_of_the_file" xml:space="preserve">
+    <value>ファイルの先頭行の読み取りに失敗しました</value>
+  </data>
+  <data name="ToolUpdatesDlg_DisplayDownloadSummary_Failed_to_download_updates_for_the_following_packages" xml:space="preserve">
+    <value>以下のパッケージのアップデートのダウンロードに失敗しました</value>
+  </data>
+  <data name="DigestSettings_Validate_maximum_missed_cleavages" xml:space="preserve">
+    <value>最大ミス開裂数</value>
+  </data>
+  <data name="RTDetails_gridStatistics_KeyDown_Failed_setting_data_to_clipboard" xml:space="preserve">
+    <value>クリップボードへのデータ設定に失敗しました。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Method__0__exported_successfully_" xml:space="preserve">
+    <value>メソッド{0}が正常にエクスポートされました。</value>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Package_installation_failed__Error_log_output_in_immediate_window_" xml:space="preserve">
+    <value>パッケージのインストールに失敗しました。即時ウィンドウ内のログ出力エラー。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Could_not_parse_adduct_description___0___on_line__1_" xml:space="preserve">
+    <value>{1}行目の付加物の説明「{0}」を解析できませんでした</value>
+  </data>
+  <data name="ToolUpdatesDlg_DownloadTools_Downloading_updates_for__0_" xml:space="preserve">
+    <value>{0}のアップデートのダウンロード中</value>
+  </data>
+  <data name="ShareListDlg_OkDialog_An_error_occurred" xml:space="preserve">
+    <value>エラーが発生しました：</value>
+  </data>
+  <data name="CommandLineTest_ConsolePathCoverage_successfully_" xml:space="preserve">
+    <value>正常。</value>
+    <comment>Context: something finished "successfully".</comment>
+  </data>
+  <data name="UIModeSmallMolecules" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UIModeSmallMolecules.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="UpgradeManager_updateCheck_Complete_Failed_attempting_to_check_for_an_upgrade_" xml:space="preserve">
+    <value>アップグレードの確認に失敗しました。</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Protein" xml:space="preserve">
+    <value>タンパク質</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column" xml:space="preserve">
+    <value>列を無視</value>
+  </data>
+  <data name="ShareTypeDlg_ShareTypeDlg_Current_saved_file___0__" xml:space="preserve">
+    <value>現在保存されているファイル({0})</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Ratio_To_Standard" xml:space="preserve">
+    <value>標準に対する比率</value>
+  </data>
+  <data name="CommandLine_OpenSkyFile_Error__The_Skyline_file__0__does_not_exist_" xml:space="preserve">
+    <value>エラー： Skylineファイル{0}は存在しません。</value>
+  </data>
+  <data name="SkylineWindow_ShowProgressErrorUI_Retry" xml:space="preserve">
+    <value>再試行</value>
+  </data>
+  <data name="Ions_Y" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_Y.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_contain_a_decimal_value" xml:space="preserve">
+    <value>{0}には十進数が含まれなければなりません。</value>
+  </data>
+  <data name="ExportMethodDlg_comboTargetType_SelectedIndexChanged_To_export_a_scheduled_list_you_must_first_choose_a_retention_time_predictor_in_Peptide_Settings_Prediction_or_import_results_for_all_peptides_in_the_document" xml:space="preserve">
+    <value>スケジュールメソッドをエクスポートするには、まず [ペプチド設定/予測] で保持時間予測を選択するか、ドキュメント内のすべてのペプチドに対する結果をインポートする必要があります。</value>
+  </data>
+  <data name="AnnotationDef_AnnotationTarget_Proteins" xml:space="preserve">
+    <value>タンパク質</value>
+  </data>
+  <data name="PeakBoundsMatch_QValue_Unable_to_read_q_value_annotation_for_peptide__0__of_file__1_" xml:space="preserve">
+    <value>ファイル{0}のペプチドに対するq値の注釈を読み取ることができません{1}</value>
+  </data>
+  <data name="ValueInvalidChargeListException_ValueInvalidChargeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_integers_" xml:space="preserve">
+    <value>値「{0}」は、整数のカンマ区切りリストを必要とする引数{1}に対して有効ではありません。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph_Scan_Number_" xml:space="preserve">
+    <value>スキャン番号：</value>
+  </data>
+  <data name="SkylineWindow_ImportResults__0__decoys_do_not_have_the_same_number_of_transitions_as_their_matching_targets" xml:space="preserve">
+    <value>{0}個のデコイが、一致するターゲットと同じ数のトランジションを含んでいません</value>
+  </data>
+  <data name="OpenDataSourceDialog_EnsureRemoteAccount_No_remote_accounts_have_been_specified__If_you_have_an_existing_Unifi_account_you_can_enter_your_login_information_now_" xml:space="preserve">
+    <value>リモートアカウントが指定されていません。既存のUnifiアカウントをお持ちの場合、今すぐログイン情報を入力できます。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateResolvingPower_Resolving_power_must_be_greater_than_0_" xml:space="preserve">
+    <value>分解能は0より大きくなければなりません。</value>
+  </data>
+  <data name="PopupBtn" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\popupbtn.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_Below_is_the_saved_value_for_the_path_to_the_executable" xml:space="preserve">
+    <value>以下は、実行可能なファイルに対するパスの保存値です。</value>
+  </data>
+  <data name="ReintegrateDlg_OkDialog_Reintegrating" xml:space="preserve">
+    <value>再積分中</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Average_Mass_Error_PPM" xml:space="preserve">
+    <value>平均質量誤差PPM</value>
+  </data>
+  <data name="PythonInstaller_DownloadPython_Check_your_network_connection_or_contact_the_tool_provider_for_installation_support_" xml:space="preserve">
+    <value>ネットワーク接続を確認するか、ツールプロバイダに問い合わせてインストールのサポートを依頼します。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_EditIonMobilityLibraryDlg_Adduct" xml:space="preserve">
+    <value>付加物</value>
+  </data>
+  <data name="TransitionFullScan_DoValidate_An_isolation_window_width_value_is_required_in_DIA_mode" xml:space="preserve">
+    <value>DIAモードでは単離ウィンドウ幅値が必要です。</value>
+  </data>
+  <data name="DigestHelper_Digest_Digesting__0__proteome_with__1__" xml:space="preserve">
+    <value>{1}による{0}プロテオームの消化中</value>
+  </data>
+  <data name="IonMobilityPredictor_Validate_Ion_mobility_predictors_using_an_ion_mobility_library_must_include_per_charge_regression_values_" xml:space="preserve">
+    <value>イオン移動ライブラリを使用するイオン移動度予測には電荷毎の回帰値を含まなければなりません。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility__1_K0_" xml:space="preserve">
+    <value>イオン移動度(1/K0)</value>
+  </data>
+  <data name="ImportResultsControl_FindResultsFiles_An_error_occurred_attempting_to_find_results_files_" xml:space="preserve">
+    <value>結果ファイルを見つけようとした際にエラーが発生しました。</value>
+  </data>
+  <data name="UIModeMixed" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UIModeMixed.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TransitionFullScan_DoValidate_An_isolation_window_width_value_is_not_allowed_in__0___mode" xml:space="preserve">
+    <value>単離ウィンドウ幅値は、{0}モードでは許可されていません。</value>
+  </data>
+  <data name="MoleculeIrtLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\moleculeirtlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Precursor_Adduct" xml:space="preserve">
+    <value>プリカーサー付加物</value>
+  </data>
+  <data name="WizardImportPeptide" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardImportPeptide.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_Model_must_be_trained_before_it_can_be_used_for_peak_boundary_comparison_" xml:space="preserve">
+    <value>ピーク境界比較に使用する前にモデルがトレーニングされている必要があります。</value>
+  </data>
+  <data name="CommandLine_ImportTool_The_tool_was_not_imported___" xml:space="preserve">
+    <value>ツールがインポートされませんでした...</value>
+  </data>
+  <data name="SkylineDoc" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\skylinedoc.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="GraphData_AddRegressionLabel_window" xml:space="preserve">
+    <value>ウィンドウ</value>
+    <comment>In RTLinearRegressionGraphPane</comment>
+  </data>
+  <data name="ImportPeptideSearchDlg_ImportPeptideSearchDlg_MS_MS_full_scan_settings_were_configured__please_verify_or_change_your_current_full_scan_settings_" xml:space="preserve">
+    <value>MS/MSフルスキャン設定が構成されました。現在のフルスキャン設定を検証または変更してください。</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Warning__overwriting_will_delete_the_following_tools_" xml:space="preserve">
+    <value>警告：上書きにより以下のツールが削除されます：</value>
+  </data>
+  <data name="ViewLibraryDlg_MatchModifications_This_library_appears_to_contain_the_following_modifications" xml:space="preserve">
+    <value>このライブラリには以下の修飾が含まれているようです。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_You_are_missing_fine_tune_optimized_compensation_voltages_" xml:space="preserve">
+    <value>最適補償電圧が微調整されていません。</value>
+  </data>
+  <data name="ComparePeakBoundaries_GenerateComparison_Missing_q_value_for_peptide__0__of_file__1_" xml:space="preserve">
+    <value>ファイル{1}のペプチド{0}に対する欠損したq値</value>
+  </data>
+  <data name="SkypSupport_Open_Path_to_skyp_file_cannot_be_empty_" xml:space="preserve">
+    <value>skypファイルへのパスは空欄にできません。</value>
+  </data>
+  <data name="ExternalTool" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ExternalTool.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideStandard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidestandard.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditCustomMoleculeDlg_OkDialog_Please_specify_the_ion_mobility_units_" xml:space="preserve">
+    <value>イオン移動度単位を指定してください。</value>
+  </data>
+  <data name="ValueInvalidDoubleException_ValueInvalidDoubleException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_decimal_number_" xml:space="preserve">
+    <value>値「{0}」は、十進数を必要とする引数{1}に対して有効ではありません。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_GetMoleculeTransitionGroup_Inconsistent_molecule_description" xml:space="preserve">
+    <value>分子の説明が一貫していません</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Download_Canceled" xml:space="preserve">
+    <value>ダウンロードがキャンセルされました</value>
+  </data>
+  <data name="AlertDlg_GetDefaultButtonText_OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_Start_margin" xml:space="preserve">
+    <value>マージンを開始</value>
+  </data>
+  <data name="IsolationSchemeList_GetDefaults_SWATH__VW_64_" xml:space="preserve">
+    <value>SWATH (VW 64)</value>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Python_package_installation_cannot_continue__Canceling_tool_installation_" xml:space="preserve">
+    <value>Pythonパッケージのインストールを続行できません。ツールのインストールのキャンセル中。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Warning__Invalid_optimization_parameter___0____Use__ce____dp___or__none__" xml:space="preserve">
+    <value>警告： 無効な最適化パラメータ ({0})。「ce」、「dp」、「なし」を使用。</value>
+  </data>
+  <data name="ToolDescription_RunExecutableBackground_The_tool__0__had_an_error__it_returned_the_message_" xml:space="preserve">
+    <value>ツール{0}でエラーがあり、次のメッセージが返されました：</value>
+  </data>
+  <data name="RTLinearRegressionGraphPane_RTLinearRegressionGraphPane_Measured_Time" xml:space="preserve">
+    <value>測定時間</value>
+  </data>
+  <data name="Cut" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\cut.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ToolMacros__listArguments_Collected_Arguments" xml:space="preserve">
+    <value>収集された引数</value>
+  </data>
+  <data name="IsolationWindow_DoValidate_Isolation_window_Start_must_be_between__0__and__1__" xml:space="preserve">
+    <value>単離ウィンドウの開始は{0}と{1}の間でなければなりません。</value>
+  </data>
+  <data name="ToolDescription_RunExecutableBackground_Error_running_the_installed_tool_0_It_seems_to_be_missing_a_file__Please_reinstall_the_tool_and_try_again_" xml:space="preserve">
+    <value>インストールされたツール{0}の実行エラー。ファイルが欠損しているようです。ツールを再インストールしてからもう一度お試しください。</value>
+  </data>
+  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_minimum_log_10_area_entered" xml:space="preserve">
+    <value>入力された最小Log10面積は無効です</value>
+  </data>
+  <data name="SkylineWindow_AlignTimesToFileFormat" xml:space="preserve">
+    <value>{0}に時間をアラインする</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_Of_the_specified__0__peptides__1__are_not_in_the_document_Do_you_want_to_continue" xml:space="preserve">
+    <value>指定された{0}ペプチド{1}はどれもドキュメント内にありません。続行しますか？</value>
+  </data>
+  <data name="CommandLine_ExportReport_Error__The_report__0__could_not_be_saved_to__1____Check_to_make_sure_it_is_not_read_only_" xml:space="preserve">
+    <value>エラー： レポート{0}を{1}に保存できませんでした。 読み取り専用でないことを確認します。</value>
+  </data>
+  <data name="AlertDlg_GetDefaultButtonText_Cancel" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="IsolationWindow_DoValidate_Isolation_window_End_must_be_between__0__and__1__" xml:space="preserve">
+    <value>単離ウィンドウの終了は{0}と{1}の間でなければなりません。</value>
+  </data>
+  <data name="ToolMacros__listArguments_Input_Report_Temp_Path" xml:space="preserve">
+    <value>レポートの一時パスを入力</value>
+  </data>
+  <data name="CommandLine_ExportReport_Report__0__exported_successfully_" xml:space="preserve">
+    <value>レポート{0}が正常にエクスポートされました。</value>
+  </data>
+  <data name="BlibDb_CreateLibraryFromSpectra_Creating_spectral_library_for_imported_transition_list" xml:space="preserve">
+    <value>インポート済みトランジションリストのスペクトルライブラリを作成中</value>
+  </data>
+  <data name="ImportResultsControl_FindResultsFiles_Searching_for_Results_Files" xml:space="preserve">
+    <value>結果ファイルの検索中</value>
+  </data>
+  <data name="WizardImportProteins" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardImportProteins.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ToolInstaller_UnpackZipTool_The_selected_zip_file_is_not_a_valid_installable_tool_" xml:space="preserve">
+    <value>選択したzipファイルは有効なインストール可能なツールではありません。</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Error__There_is_an_existing_library_with_the_same_name__0__as_the_document_library_to_be_created_" xml:space="preserve">
+    <value>エラー：作成しようとするドキュメントライブラリと同じ名前{0}の既存ライブラリがあります。</value>
+  </data>
+  <data name="AnnotatedSpectum" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\AnnotatedSpectum.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ValueInvalidNumberListException_ValueInvalidNumberListException_The_value__0__is_not_valid_for_the_argument__1__which_requires_a_list_of_decimal_numbers_" xml:space="preserve">
+    <value>値{0}は、十進数のリストを必要とする引数{1}に対して無効です。</value>
+  </data>
+  <data name="BookmarkEnumerator_Current_No_such_chrominfo__0__" xml:space="preserve">
+    <value>以下のchrominfoがありません：{0}</value>
+  </data>
+  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
+    <value>エラー：</value>
+  </data>
+  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_Python__0___Click_install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>このツールにはPython{0}が必要です。インストールをクリックしてインストールプロセスを開始します。</value>
+  </data>
+  <data name="ChromatogramCache_WriteStructs_Failure_writing_cache___Specified__0__peaks_exceed_total_peak_count__1_" xml:space="preserve">
+    <value>キャッシュの書き込み失敗。指定した{0}個のピークがピーク総数{1}を超えています</value>
+  </data>
+  <data name="File" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\file.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_expandAllMenuItem_DropDownOpening__Molecules" xml:space="preserve">
+    <value>分子(&amp;M)</value>
+  </data>
+  <data name="GridViewDriver_GridView_DataError__0__must_be_a_valid_number" xml:space="preserve">
+    <value>{0}は有効な数値でなければなりません。</value>
+  </data>
+  <data name="SrmDocumentSharing_FindSharedSkylineFile_The_zip_file_is_not_a_shared_file" xml:space="preserve">
+    <value>zipファイルは共有ファイルではありません。</value>
+  </data>
+  <data name="Calculator" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Calculator.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="WizardPeptideSearchDIA" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardPeptideSearchDIA.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditRemoteAccountDlg_TestSettings_Error_connecting_to_server__" xml:space="preserve">
+    <value>サーバーの接続エラー：</value>
+  </data>
+  <data name="MeasuredPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry" xml:space="preserve">
+    <value>各エントリには修飾ペプチドシークエンスが必要です。</value>
+  </data>
+  <data name="ConfigureToolsDlg_unpackZipTool_Invalid_Tool_Description_in_file__0__" xml:space="preserve">
+    <value>ファイル{0}内の無効なツールの説明。</value>
+  </data>
+  <data name="MassListRowReader_CalcTransitionExplanations_Product_m_z_value__0__in_peptide__1__has_no_matching_product_ion" xml:space="preserve">
+    <value>ペプチド{1}のプロダクトm/z値{0}には一致するプロダクトイオンがありません。</value>
+  </data>
+  <data name="SettingsUIUtil_DoPasteText_Incorrect_number_of_columns__0__found_on_line__1__" xml:space="preserve">
+    <value>{1}行に間違った列数 ({0}) が見つかりました。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_high_energy_offset_value__0_" xml:space="preserve">
+    <value>イオン移動度の高エネルギーオフセット値{0}が無効です</value>
+  </data>
+  <data name="Replicate" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Replicate.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportTool_" xml:space="preserve">
+    <value>エラー： {0}というタイトルのツールが既に存在しています。--tool-conflict-resolution=&amp;lt; overwrite | skip &gt;を使用してください。{0}というタイトルのツールは追加されませんでした。</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Warning__The_document_is_missing_iRT_standards" xml:space="preserve">
+    <value>警告：ドキュメントにiRT標準がありません</value>
+  </data>
+  <data name="SpecialHandlingType_Validate_None" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="CopyGraphDataToolStripMenuItem_CopyGraphData_Failed_setting_data_to_clipboard" xml:space="preserve">
+    <value>クリップボードへのデータ設定に失敗しました。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_End_Time" xml:space="preserve">
+    <value>終了時間</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_iRT_database_field_must_not_be_empty_" xml:space="preserve">
+    <value>iRTデータベース欄は空にできません。</value>
+  </data>
+  <data name="PasteDlg_btnTransitionListHelp_Click_Supported_values_for__0__are___1_" xml:space="preserve">
+    <value>{0}のサポートされる値には次があります：{1}</value>
+    <comment>{1} is a comma seprated list of supported ion mobility units</comment>
+  </data>
+  <data name="WizardBlankDocument" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardBlankDocument-ja.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_List_Name" xml:space="preserve">
+    <value>分子リスト名</value>
+  </data>
+  <data name="ParsimonySettings_Validate_The_value__0__for__1__is_not_valid__it_must_be_greater_than_or_equal_to__2__" xml:space="preserve">
+    <value>{1}の値{0}が無効です： {2}に等しいかそれ以上でなければなりません。</value>
+  </data>
+  <data name="CommandLine_ImportResultsFile_Error__Failed_importing_the_results_file__0__" xml:space="preserve">
+    <value>エラー： 結果ファイル{0}のインポートに失敗しました。</value>
+  </data>
+  <data name="OverlapDemultiplexer_RowStart_Number_of_regions__0__in_overlap_demultiplexer_approximation_must_be_less_than_number_of_scans__1__" xml:space="preserve">
+    <value>重複デマルチプレクサ―近似値の領域数{0}は、スキャン数{1}未満でなければなりません。</value>
+  </data>
+  <data name="OverlapDemultiplexer_attempt_to_insert_slice_of_deconvolution_matrix_failed_out_of_range" xml:space="preserve">
+    <value>範囲外エラーにより、デコンボリューションマトリックスのスライスの挿入に失敗しました。</value>
+  </data>
+  <data name="PublishDocumentDlg_UploadSharedZipFile_You_do_not_have_permission_to_upload_to_the_given_folder" xml:space="preserve">
+    <value>指定したフォルダにアップロードする権限がありません。</value>
+  </data>
+  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_maximum_frequency_entered" xml:space="preserve">
+    <value>入力された最大頻度が無効です</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_collision_energy_value__0_" xml:space="preserve">
+    <value>無効な衝突エネルギー値{0}</value>
+  </data>
+  <data name="VendorIssueHelper_ConvertWiffToMzxml_The_file__0__cannot_be_imported_by_the_AB_SCIEX_WiffFileDataReader_library_in_a_reasonable_time_frame_1_F02_min" xml:space="preserve">
+    <value>ファイル{0}を妥当な時間内（{1:F02}分）にAB SCIEX WiffFileDataReaderライブラリにインポートできません。</value>
+  </data>
+  <data name="AnnotationHelper_GetReplicateIndicices_True" xml:space="preserve">
+    <value>True</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Max_Height" xml:space="preserve">
+    <value>最大高さ</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_declustering_potential__0_" xml:space="preserve">
+    <value>無効なデクラスタリングポテンシャル{0}</value>
+  </data>
+  <data name="ExportReportDlg_GetDatabase_Generating_Report_Data" xml:space="preserve">
+    <value>レポートデータの生成中</value>
+  </data>
+  <data name="OptimizationDb_ConvertFromOldFormat_Failed_to_convert__0__optimizations_to_new_format_" xml:space="preserve">
+    <value>{0}を新しい形式に最適化する変換に失敗しました。</value>
+  </data>
+  <data name="TransitionGroupLibDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TransitionGroupLibDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ConnectLibrarySpecs_Error__Could_not_find_the_spectral_library__0__for_this_document_" xml:space="preserve">
+    <value>エラー： このドキュメントのスペクトルライブラリ{0}が見つかりませんでした。</value>
+  </data>
+  <data name="WizardPeptideSearchDDA" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardPeptideSearch.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_Publish_Retrieving_server_information" xml:space="preserve">
+    <value>サーバー情報の取得中。</value>
+  </data>
+  <data name="SkippedReportErrorDlg_btnOK_Click_No_Email" xml:space="preserve">
+    <value>エラーについてさらに質問がある場合、連絡を差し上げる電子メールアドレスを入力してください。
+ ご希望により、匿名でもレポートできます。</value>
+  </data>
+  <data name="ExportMethodDlg_ValidateSettings_Cannot_export_medium_tune_transition_list__The_following_precursors_are_missing_rough_tune_results_" xml:space="preserve">
+    <value>標準調整トランジションリストはエクスポートできません。以下のプリカーサーの粗調整結果がありません：</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_Cannot_use_DIA_window_for_precusor_exclusion_when__All_Ions__is_selected_as_the_isolation_scheme___To_use_the_DIA_window_for_precusor_exclusion__change_the_isolation_scheme_in_the_Full_Scan_settings_" xml:space="preserve">
+    <value>単離スキームとして「すべてのイオン」が選択されている場合、プリカーサー排除にはDIAウィンドウを使用することはできません。 プリカーサー排除にDIAウィンドウを使用するには、フルスキャン設定で単離スキームを変更します。</value>
+  </data>
+  <data name="magnifier_zoom_in" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\magnifier_zoom_in.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="BiblioSpecLiteLibrary_Load_Failed_loading_library__0__" xml:space="preserve">
+    <value>ライブラリ「{0}」の読み込みに失敗しました。</value>
+  </data>
+  <data name="DsvFileReader_ReadLine_Line__0__has__1__fields_when__2__expected_" xml:space="preserve">
+    <value>{2}が期待されている場合、{0}行目には{1}欄があります。</value>
+  </data>
+  <data name="RenameProteinsDlg_OkDialog_Cannot_rename__0__more_than_once__Please_remove_either__1__or__2__" xml:space="preserve">
+    <value>{0}の名前を1回以上変更することはできません。{1}または{2}を削除してください</value>
+  </data>
+  <data name="ValidatingIonMobilityPeptide_ValidateAdduct_A_valid_adduct_description__e_g____M_H____must_be_provided_" xml:space="preserve">
+    <value>有効な付加イオンの表記（例：「[M+H]」）を入力する必要があります。</value>
+  </data>
+  <data name="TransitionFilter_FragmentEndFinders_3_ions" xml:space="preserve">
+    <value>3個のイオン</value>
+  </data>
+  <data name="up_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\up-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ProteinUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ProteinUI.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Regression_slope" xml:space="preserve">
+    <value>勾配</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Adding__0__spectra_to_the_library__1_" xml:space="preserve">
+    <value>{0}個のスペクトルをライブラリ{1}に追加中</value>
+  </data>
+  <data name="SkylineWindow_shareDocumentMenuItem_Click_The_document_must_be_saved_before_it_can_be_shared" xml:space="preserve">
+    <value>共有する前に、ドキュメントを保存しなければなりません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_The_command_for__0__must_be_of_a_supported_type" xml:space="preserve">
+    <value>{0}に対するコマンドはサポートされたタイプでなければなりません。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Ratio_to_Global_Standards" xml:space="preserve">
+    <value>グローバル標準に対する比率</value>
+  </data>
+  <data name="ChromCacheBuilder_WriteLoop_Existing_write_threads___0_" xml:space="preserve">
+    <value>既存の書き込みスレッド：{0}</value>
+  </data>
+  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Only_BiblioSpec_libraries_contain_enough_ion_mobility_information_to_support_this_operation_" xml:space="preserve">
+    <value>BiblioSpecライブラリのみが、この操作をサポートするイオン移動度情報を十分に含んでいます。</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_A_calculator_with_that_name_already_exists___Do_you_want_to_replace_it_" xml:space="preserve">
+    <value>その名前のカルキュレータが既に存在しています。 置き換えますか？</value>
+  </data>
+  <data name="AnnotationDef_AnnotationTarget_Peptides" xml:space="preserve">
+    <value>ペプチド</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_Otherwise__please_cancel_and_install__0__version__1__first" xml:space="preserve">
+    <value>それ以外の場合は、キャンセルして{0}バージョン{1}を先にインストールしてください</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Error____0___is_not_a_valid_value_for__1___It_must_be_one_of_the_following___2_" xml:space="preserve">
+    <value>エラー：「{0}」は{1}の有効な値ではありません。次のいずれかでなければなりません：{2}</value>
+  </data>
+  <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_species_information__this_selection_may_be_suspect_" xml:space="preserve">
+    <value>いくつかのバックグラウンドプロテオームのタンパク質には種の情報がないので、この選択肢は疑わしい可能性があります。</value>
+  </data>
+  <data name="PythonInstaller_InstallPip_Pip_installation_failed__Error_log_output_in_immediate_window__" xml:space="preserve">
+    <value>Pipのインストールに失敗しました。即時ウィンドウ内のログ出力エラー。</value>
+  </data>
+  <data name="ChromCacheJoiner_FinishRead_Unexpected_end_of_file_in__0__" xml:space="preserve">
+    <value>{0}での予期しないファイルの終了。</value>
+  </data>
+  <data name="AddIrtCalculatorDlgOkDialogThe_file__0__does_not_exist" xml:space="preserve">
+    <value>ファイル{0}は存在しません。</value>
+  </data>
+  <data name="PythonInstaller_GetPython_Python_installation_completed_" xml:space="preserve">
+    <value>Pythonのインストールが完了しました。</value>
+  </data>
+  <data name="Resources.ReportSpecList_GetDefaults_Peptide_Quantification" xml:space="preserve">
+    <value>ペプチド定量化</value>
+  </data>
+  <data name="PeakCalculatorGridViewDriver_ValidateRow_On_line__0____1_" xml:space="preserve">
+    <value>{0}行、{1}</value>
+  </data>
+  <data name="MoleculeIrt" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\moleculeirt.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_An_isolation_scheme_is_required_to_match_multiple_precursors" xml:space="preserve">
+    <value>複数のプリカーサーを一致させるには単離スキームが必要です。</value>
+  </data>
+  <data name="BuildLibraryDlg_ValidateBuilder_The_lab_authority_name__0__is_not_valid_This_should_look_like_an_internet_server_address_e_g_mylab_myu_edu_and_be_unlikely_to_be_used_by_any_other_lab_but_need_not_refer_to_an_actual_server" xml:space="preserve">
+    <value>研究室管轄者名{0}が有効ではありません。これはインターネットサーバーアドレス（mylab.myu.eduなど）のようなもので、他の研究室で使用される可能性は低いものの、実際のサーバーアドレスである必要はありません。</value>
+  </data>
+  <data name="EditServerDlg_OkDialog_The_text__0__is_not_a_valid_server_name_" xml:space="preserve">
+    <value>テキスト「{0}」は有効なサーバー名ではありません。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_charge_state_" xml:space="preserve">
+    <value>{1}行目の値「{0}」は有効な荷電状態ではありません。</value>
+  </data>
   <data name="VendorIssueHelper_ShowLibraryMissingExternalSpectrumFilesError" xml:space="preserve">
     <value>MaxQuant入力ファイル「{0}」のスペクトルファイルを検索中に、サポートされているファイル拡張子（{3}）を持つ以下のベース名を見つけられませんでした。
 
@@ -3769,93 +1975,2013 @@ Skylineでの列の順序は、列のヘッダーを左右にドラッグする�
 
 オリジナルファイルがない場合は、入力ファイルから埋め込みスペクトルを使用してライブラリを構築できますが、MaxQuant埋め込みスペクトル内のフラグメントイオンは、荷電状態がデコンボリュートされており、1価のフラグメントイオンしか含まれず、これは質量分析計が測定する強度を表すものではない可能性があります。</value>
   </data>
-  <data name="ViewLibraryDlg_CheckLibraryInSettings_The_library__0__is_not_currently_added_to_your_document" xml:space="preserve">
-    <value>ライブラリ{0}は現在ドキュメントに追加されていません。</value>
+  <data name="SkylineWindow_ImportResults_A_maximum_of__0__may_be_missing_and_or_outliers_for_a_successful_import_" xml:space="preserve">
+    <value>最大{0}個の欠損や異常値があっても、インポートできます。</value>
   </data>
-  <data name="ViewLibraryDlg_EnsureBackgroundProteome_The_background_proteome_must_be_digested_in_order_to_associate_proteins" xml:space="preserve">
-    <value>バックグラウンドプロテオームをタンパク質に関連付けるためには、消化する必要があります。</value>
+  <data name="ScanProvider_GetScans_The_scan_ID__0__was_not_found_in_the_file__1__" xml:space="preserve">
+    <value>ファイル{1}内にスキャンID{0}が見つかりませんでした。</value>
   </data>
-  <data name="ViewLibraryDlg_LoadLibrary_An_error_occurred_attempting_to_import_the__0__library" xml:space="preserve">
-    <value>{0}ライブラリをインポートしようとした際にエラーが発生しました。</value>
+  <data name="CommandLine_ImportTransitionList_Importing_transiton_list__0____" xml:space="preserve">
+    <value>トランジションリスト{0}をインポート中...</value>
   </data>
-  <data name="ViewLibraryDlg_LoadLibrary_Loading_Library" xml:space="preserve">
-    <value>ライブラリの読み込み中</value>
+  <data name="PeptideToMoleculeText_Protein" xml:space="preserve">
+    <value>タンパク質</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a protein" to read "choose a molecule list" when non-peptide documents are in use</comment>
   </data>
-  <data name="ViewLibraryDlg_MatchModifications__0__Would_you_like_to_use_the_Unimod_definitions_for__1__modifications_The_document_will_not_change_until_peptides_with_these_modifications_are_added" xml:space="preserve">
-    <value>{0}{1}修飾にUnimod定義を使用しますか？ これらの修飾を持つペプチドが追加されるまでドキュメントは変更されません。</value>
+  <data name="RInstaller_InstallPackages_Installing_R_packages_requires_an_internet_connection__Please_check_your_connection_and_try_again" xml:space="preserve">
+    <value>Rパッケージのインストールには、インターネット接続が必要です。インターネット接続を確認してからもう一度お試しください</value>
   </data>
-  <data name="ViewLibraryDlg_MatchModifications_the_matching" xml:space="preserve">
-    <value>一致</value>
-    <comment>In the sentence 'Would you like to use the Unimod definition for the matching modification?</comment>
+  <data name="TransitionGroupDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\transitiongroupdecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="IonMobilityLibraryList_AcceptList_will_be_deleted_because_the_libraries_they_depend_on_have_changed__Do_you_want_to_continue_" xml:space="preserve">
+    <value>依存するライブラリが変更されたので削除されます。続行しますか？</value>
+  </data>
+  <data name="ConfigureToolsDlg_PopulateMacroDropdown_File_path_to_a_temporary_report" xml:space="preserve">
+    <value>一時レポートへのファイルパス</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Retention_Time" xml:space="preserve">
+    <value>保持時間</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_units_value__0___accepted_values_are__1__" xml:space="preserve">
+    <value>イオン移動度の単位値{0}が無効です（受け入れられる値は{1}です）</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_Do_you_want_to_continue" xml:space="preserve">
+    <value>続行しますか？</value>
+  </data>
+  <data name="AllChromatogramsGraph_btnCancelFile_Click_Cancel_file" xml:space="preserve">
+    <value>ファイルをキャンセル</value>
+  </data>
+  <data name="RenameProteinsDlg_OkDialog_Edit_name__0__" xml:space="preserve">
+    <value>名前{0}を編集</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_Your_document_does_not_contain_compensation_voltage_results__but_compensation_voltage_is_set_under_transition_settings_" xml:space="preserve">
+    <value>ドキュメントに補償電圧は含まれていませんが、補償電圧はトランジション設定に沿って設定されています。</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_The_document_does_not_contain_any_peptides_" xml:space="preserve">
+    <value>ドキュメントにペプチドが含まれていません。</value>
+  </data>
+  <data name="MassListRowReader_CalcPrecursorExplanations_Check_the_Instrument_tab_in_the_Transition_Settings" xml:space="preserve">
+    <value>トランジション設定の装置タブを確認します。</value>
+  </data>
+  <data name="PeptideGroupTreeNode_RenderTip_Name" xml:space="preserve">
+    <value>名前</value>
+  </data>
+  <data name="PeptideGroupBuilder_FinalizeTransitionGroups_Two_transitions_of_the_same_precursor___0___m_z__1_____have_different_iRT_values___2__and__3___iRT_values_must_be_assigned_consistently_in_an_imported_transition_list_" xml:space="preserve">
+    <value>同一プリカーサーの2個のトランジション{0} (m/z{1}) には異なるiRT値、{2}、{3}があります。iRT値はインポートされたトランジションリスト内では一貫して割り当てられなければなりません。</value>
+  </data>
+  <data name="SkylineWindow_AddIrtPeptides_Imported_peptide__0__with_iRT_library_value_is_already_being_used_as_an_iRT_standard_" xml:space="preserve">
+    <value>iRTライブラリ値を持つインポートされたペプチド{0}は既にiRT標準で使用されています。</value>
+  </data>
+  <data name="CommandLine_AssociateProteins_a_FASTA_file_must_be_imported_before_associating_proteins" xml:space="preserve">
+    <value>エラー：タンパク質を関連付けする前に、FASTAファイルをインポートする必要があります</value>
+  </data>
+  <data name="RenameProteinsDlg_OkDialog__0__is_not_a_current_protein" xml:space="preserve">
+    <value>{0}は現在のタンパク質ではありません</value>
+  </data>
+  <data name="PublishDocumentDlg_OkDialog_Selected_file_is_not_a_Skyline_Shared_file" xml:space="preserve">
+    <value>選択したファイルはSkyline共有ファイルではありません。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_start_time_" xml:space="preserve">
+    <value>{1}行目の値「{0}」は有効な開始時間ではありません。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Precursor_Name" xml:space="preserve">
+    <value>プリカーサー名</value>
+  </data>
+  <data name="ToolUpdatesDlg_InstallUpdates_User_cancelled_installation" xml:space="preserve">
+    <value>ユーザーがインストールをキャンセルしました</value>
+  </data>
+  <data name="ColumnSet_GetColumnInfos_Unexpected_report_type" xml:space="preserve">
+    <value>予期しないレポートタイプ</value>
+  </data>
+  <data name="ExportMethodDlg_comboTargetType_SelectedIndexChanged_Scheduled_methods_are_not_yet_supported_for_DIA_acquisition" xml:space="preserve">
+    <value>スケジュールメソッドはデータ非依存取得に対し、まだサポートされていません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_unpackZipTool_Title_and_Command_are_required" xml:space="preserve">
+    <value>そのツールをスキップするには、</value>
+  </data>
+  <data name="Paste" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\paste.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Proteins" xml:space="preserve">
+    <value>タンパク質</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_Keep_the_existing_iRT_value_or_overwrite_with_the_imported_value_" xml:space="preserve">
+    <value>既存のiRT値を保持しますか、それともインポートされた値を上書きしますか？</value>
+  </data>
+  <data name="ExportMethodDlg_ValidateSettings_Cannot_export_fine_tune_transition_list__The_following_precursors_are_missing_medium_tune_results_" xml:space="preserve">
+    <value>微調整トランジションリストはエクスポートできません。以下のプリカーサーの標準調整結果がありません：</value>
+  </data>
+  <data name="Keep" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\keep.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_The_command_cannot_be_blank__please_enter_a_valid_command_for__0_" xml:space="preserve">
+    <value>コマンドは空にできません。{0}に対する有効なコマンドを入力してください</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_Export_of_DIA_method_is_not_supported_for__0__" xml:space="preserve">
+    <value>DIAメソッドのエクスポートは{0}ではサポートされていません。</value>
+  </data>
+  <data name="GenerateDecoysDlg_GenerateDecoysDlg_All" xml:space="preserve">
+    <value>すべて</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__The_template_file__0__does_not_exist_" xml:space="preserve">
+    <value>エラー： テンプレートファイル{0}がありません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_Supported_Types___1_" xml:space="preserve">
+    <value>サポートされているタイプ：{1}</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Error__No_internet_connection_" xml:space="preserve">
+    <value>エラー： インターネット接続がありません。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility_Units" xml:space="preserve">
+    <value>指定されたイオン移動度の単位</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_conflicting_annotations__Overwriting_" xml:space="preserve">
+    <value>競合する注釈があります。上書き中。</value>
+  </data>
+  <data name="MoleculeUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\MoleculeUI.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideToMoleculeText_Ion_charges" xml:space="preserve">
+    <value>イオン電荷</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "Ion charges" to read "Ion adducts" when non-peptide documents are in use</comment>
+  </data>
+  <data name="ToolDescription_VerifyAnnotations_This_tool_requires_the_use_of_the_following_annotations_which_are_missing_or_improperly_formatted" xml:space="preserve">
+    <value>このツールでは、欠損している、または正しい形式でない以下の注釈を使用する必要があります</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_Do_you_want_to_use_the_document_settings_to_automanage_these_new_transitions" xml:space="preserve">
+    <value>自動選択を有効にし、ドキュメント設定を使用してこの新しいトランジションを管理しますか？
+
+自動選択を有効にする：{0}プリカーサーおよび{1}フラグメントのトランジションが現在のドキュメントに追加されます。
+
+自動選択を無効にする：{2}プリカーサーおよび{3}フラグメントのトランジションが現在のドキュメントに追加されます。
+
+無効化を選択した場合、「最適化 &gt; 詳細」メニュー項目で後から自動選択を有効にできます。</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_retention_time_window_value__0_" xml:space="preserve">
+    <value>無効な保持時間ウィンドウ値{0}</value>
+  </data>
+  <data name="PeptideSettingsUI_ValidateNewSettings_Choose_at_least_one_internal_standard_type" xml:space="preserve">
+    <value>内部標準タイプを1つ以上選択してください。</value>
+  </data>
+  <data name="ReintegrateDlg_OkDialog_Failed_attempting_to_reintegrate_peaks_" xml:space="preserve">
+    <value>ピークを再積分できませんでした。</value>
+  </data>
+  <data name="PanoramaPublish" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\panoramapublish.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TransitionFullScan_ValidateRes_Mass_accuracy_must_be_between__0__and__1__for_centroided_data_" xml:space="preserve">
+    <value>セントロイド化データの質量精度は{0}と{1}の間でなければなりません。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_end_time_" xml:space="preserve">
+    <value>{1}行目の値「{0}」は有効な終了時間ではありません。</value>
+  </data>
+  <data name="ToolUpdateAvailable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ToolUpdateAvailable.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MassListRowReader_CalcTransitionExplanations_The_product_m_z__0__is_out_of_range_for_the_instrument_settings__in_the_peptide_sequence__1_" xml:space="preserve">
+    <value>プロダクトm/z{0}がペプチドシークエンス{1}における装置設定の範囲外です。</value>
+  </data>
+  <data name="PeptideIrtLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptideirtlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ExportReportDlg_GetExceptionDisplayMessage_The_field__0__does_not_exist_in_this_document" xml:space="preserve">
+    <value>このドキュメントにはフィールド{0}がありません。</value>
+  </data>
+  <data name="MassListRowReader_CalcPrecursorExplanations_" xml:space="preserve">
+    <value>プリカーサーm/z{0}が最も近い可能性のある値{1}（誤差={2}）、ペプチド{3}と一致しません。</value>
+  </data>
+  <data name="PeakBoundaryImporter_DetermineCorrectSeparator_The_first_line_does_not_contain_any_of_the_possible_separators_comma__tab_or_space_" xml:space="preserve">
+    <value>先頭行に使用可能な分離記号カンマ、タブ、空白がいずれも含まれていません。</value>
+  </data>
+  <data name="DataboundGridControl_GetClusteredResults_An_error_occured_while_performing_clustering_" xml:space="preserve">
+    <value>クラスタリング実行中にエラーが発生しました。</value>
+  </data>
+  <data name="PeakBoundaryImporter_DetermineCorrectSeparator_The_first_line_does_not_contain_any_of_the_possible_separators_semicolon__tab_or_space_" xml:space="preserve">
+    <value>先頭行に使用可能な分離記号セミコロン、タブ、空白がいずれも含まれていません。</value>
+  </data>
+  <data name="Columns_Columns_Duplicate_column___0__" xml:space="preserve">
+    <value>列「{0}」が重複しています</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_OkDialog_Specify__0__for_isolation_window" xml:space="preserve">
+    <value>単離ウィンドウに対し{0}を指定します。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_DoRowValidating_The_sequence__0__is_already_present_in_the_list_" xml:space="preserve">
+    <value>シークエンス{0}が既にリストに存在しています。</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Peptides" xml:space="preserve">
+    <value>ペプチド</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="MProphetPeakScoringModel_CalcLinearScore_Attempted_to_score_a_peak_with__0__features_using_a_model_with__1__trained_scores_" xml:space="preserve">
+    <value>{1}個のトレーニングされたスコアのあるモデルを使用して{0}個の機能を持つピークをスコアしようとしています。</value>
+  </data>
+  <data name="PasteDlg_btnTransitionListHelp_Click_SmallMol_" xml:space="preserve">
+    <value>このウィンドウの一番簡単な使用方法は、Excel（またはデータがCSV形式の場合テキストエディタ）からコピーしグリッドに貼り付けることです。
+
+Skylineでの列の順序は、列のヘッダーを左右にドラッグすることで調整できます。分子の場合、[列...]ボタンで有効にする列を選択することもできます。
+
+ほとんどのペプチドトランジションリストは、「ファイル|インポート|トランジションリスト...」メニューアイテムでインポートでき、[ターゲット]ウィンドウに直接貼り付けることもできます。また列ヘッダーにこれらの名前が使われている場合、分子トランジションリストでもこれが実施できます： </value>
+  </data>
+  <data name="NewDocument" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\newdocument.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_Charge" xml:space="preserve">
+    <value>プリカーサー電荷</value>
+  </data>
+  <data name="IrtDb_GetIrtDb_The_file__0__could_not_be_opened" xml:space="preserve">
+    <value>ファイル{0}が開けませんでした。</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_Warning__the_annotation__0__may_not_be_what_your_tool_requires_" xml:space="preserve">
+    <value>警告：注釈{0}は、ツールに必要な注釈でない可能性があります。</value>
+  </data>
+  <data name="TransitionTreeNode_GetResultsText__0__" xml:space="preserve">
+    <value>[{0}]</value>
+    <comment>Rank for transition node</comment>
+  </data>
+  <data name="CopyPasteTest_DoTest_Could_not_read_the_pasted_transition_list___Transition_list_must_be_in_separated_columns_and_cannot_contain_blank_lines_" xml:space="preserve">
+    <value>貼り付けられたトランジションリストを読み取ることができませんでした。 トランジションリストは分離された列になければならず、空の列を含むことはできません。</value>
+  </data>
+  <data name="UnpackZipToolHelper_UnpackZipTool_The_tool___0___requires_report_type_titled___1___and_it_is_not_provided__Import_canceled_" xml:space="preserve">
+    <value>ツール「{0}」には「{1}」というタイトルのレポートタイプが必要ですが、提供されていません。インポートがキャンセルされました。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Error__Use___in_to_specify_a_Skyline_document_to_open_" xml:space="preserve">
+    <value>エラー： 開くSkylineドキュメントを指定するために--inを使用します。</value>
+  </data>
+  <data name="DocumentGridViewContext_Delete_Are_you_sure_you_want_to_delete_the__0____1___" xml:space="preserve">
+    <value>本当に{0}「{1}」を削除してもよろしいですか？</value>
+    <comment>Example: Are you sure you want to delete the protein 'ALDH'?</comment>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Package_Installation_was_not_completed__Canceling_tool_installation_" xml:space="preserve">
+    <value>パッケージのインストールが完了しませんでした。ツールのインストールのキャンセル中。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_adduct_description_on_line__0_" xml:space="preserve">
+    <value>{0}行目に付加物の説明がありません</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_then_run_the_tool_again" xml:space="preserve">
+    <value>その後、ツールをもう一度実行します。</value>
+  </data>
+  <data name="IonMobilityDb_GetIonMobilityDb_The_file__0__is_not_a_valid_ion_mobility_library_file_" xml:space="preserve">
+    <value>ファイル{0}は有効なイオン移動度ライブラリファイルではありません。</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Peptide" xml:space="preserve">
+    <value>ペプチド</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Opt_Step" xml:space="preserve">
+    <value>最適ステップ</value>
+  </data>
+  <data name="HomeIcon1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\HomeIcon.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassToolInternal__ToolDir__is_not_a_valid_macro_for_a_tool_that_was_not_installed_and_therefore_does_not_have_a_Tool_Directory_" xml:space="preserve">
+    <value>インストールされていないためにツールディレクトリのないツールに対し、$(ToolDir) は有効なマクロではありません。</value>
+  </data>
+  <data name="MultiFileAsynchronousDownloadClient_DownloadFileAsync_Downloading__0" xml:space="preserve">
+    <value>{0}のダウンロード中</value>
+  </data>
+  <data name="CopyGraphDataToolStripMenuItem_CopyGraphDataToolStripMenuItem_Copy_Data" xml:space="preserve">
+    <value>データをコピー</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_The_peptide__0__is_not_in_the_document_Do_you_want_to_continue" xml:space="preserve">
+    <value>ペプチド「{0}」はドキュメント内にありません。続行しますか？</value>
+  </data>
+  <data name="TransitionLibraries_DoValidate_Library_ion_count_value__0__must_not_be_less_than_min_ion_count_value__1__" xml:space="preserve">
+    <value>ライブラリのイオン数値{0}は、最小イオン数値{1}未満であってはなりません。</value>
+  </data>
+  <data name="ReportErrorDlg_ReportErrorDlg_Close" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="Expand" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\plus.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_The_current_file_or_model_has_no_q_values_or_scores_to_analyze___Either_q_values_or_scores_are_necessary_to_compare_peak_picking_tools_" xml:space="preserve">
+    <value>現在のファイルまたはモデルには分析するためのq値かスコアがありません。 ピーク選択ツールを比較するためにq値またはスコアのどちらかが必要です。</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_None_may_be_missing_or_outliers_for_a_successful_import_" xml:space="preserve">
+    <value>欠損や異常値があると、インポートできません。</value>
+  </data>
+  <data name="DocumentGridViewContext_Delete_Are_you_sure_you_want_to_delete_these__0___1__" xml:space="preserve">
+    <value>本当にこれら{0}個の{1}を削除してもよろしいですか？</value>
+    <comment>Example: Are you sure you want to delete these 27 proteins?</comment>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z" xml:space="preserve">
+    <value>プリカーサーm/z</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_List__0__exported_successfully_" xml:space="preserve">
+    <value>リスト{0}が正常にエクスポートされました。</value>
+  </data>
+  <data name="CustomIon_DisplayName_Ion" xml:space="preserve">
+    <value>イオン</value>
+  </data>
+  <data name="BiblioSpecLiteLibrary_ReadRedundantSpectrum_Spectrum_peaks__0__excede_the_maximum_allowed__1__" xml:space="preserve">
+    <value>スペクトルピーク{0}が最大許容値{1}を超えています。</value>
+  </data>
+  <data name="ConfigureToolsDlg_Cancel_Do_you_wish_to_Save_changes_" xml:space="preserve">
+    <value>変更を保存しますか？</value>
+  </data>
+  <data name="FragmentDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\FragmentDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RenameProteinsDlg_UseFastaFile_The_document_contains_a_naming_conflict_The_name__0__is_currently_used_by_multiple_protein_sequences" xml:space="preserve">
+    <value>ドキュメントに名前の不一致があります。名前{0}は、現在複数のタンパク質シークエンスで使用されています。</value>
+  </data>
+  <data name="RefineDlg_NormalizationMethod_Total_ion_current" xml:space="preserve">
+    <value>総イオン電流</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Decoy" xml:space="preserve">
+    <value>デコイ</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Truncated" xml:space="preserve">
+    <value>切断</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Warning__The_export_strategy__0__is_not_valid__It_must_be_one_of_the_following___string" xml:space="preserve">
+    <value>警告： エクスポート方法{0}が有効ではありません。以下の中の1つでなければなりません：「単一」、「タンパク質」、「バケット」。単一にデフォルト中。</value>
+  </data>
+  <data name="SequenceMassCalc_ParseModMass_The_expression__0__is_not_a_valid_chemical_formula" xml:space="preserve">
+    <value>式「{0}」は有効な化学式ではありません。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Height" xml:space="preserve">
+    <value>高さ</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Label_Type" xml:space="preserve">
+    <value>標識タイプ</value>
+  </data>
+  <data name="GreenCheck" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\GreenCheck.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_be_less_than_or_equal_to__1__" xml:space="preserve">
+    <value>{0}は{1}以下でなければなりません。</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_Do_you_want_to_continue" xml:space="preserve">
+    <value>続行しますか？</value>
+  </data>
+  <data name="MassListImporter_AddRow_Invalid_iRT_value_at_precusor_m_z__0__for_peptide__1_" xml:space="preserve">
+    <value>ペプチド{1}に対するプリカーサーm/z{0}での無効なiRT値。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_There_is_already_an_imported_file_with_the_current_name___Please_choose_another_name" xml:space="preserve">
+    <value>現在の名前を持つインポートされたファイルが既にあります。 別の名前を選択してください</value>
+  </data>
+  <data name="ShimadzuMethodExporter_ExportMethod_Unexpected_response__0__from_Shimadzu_method_writer_" xml:space="preserve">
+    <value>Shimadzuメソッドライターからの予期しない反応{0}。</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Transition_Results" xml:space="preserve">
+    <value>トランジション結果</value>
   </data>
   <data name="ViewLibraryDlg_MatchModifications_these" xml:space="preserve">
     <value>これら</value>
     <comment>In the sentence 'Would you like to use the Unimod definitions for these modifications?'</comment>
   </data>
-  <data name="ViewLibraryDlg_MatchModifications_This_library_appears_to_contain_the_following_modifications" xml:space="preserve">
-    <value>このライブラリには以下の修飾が含まれているようです。</value>
+  <data name="ChromatogramExporter_Export_Corrupted_chromatogram_data_at_charge__0__state_of_peptide__1_" xml:space="preserve">
+    <value>ペプチド{1}の荷電{0}状態での破損したクロマトグラムデータ</value>
   </data>
-  <data name="Wand" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Wand.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_The_tool__0__is_already_installed_" xml:space="preserve">
+    <value>ツール{0}は既にインストールされています。</value>
   </data>
-  <data name="WandProhibit" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\WandProhibit.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeptideToMoleculeText_Modified_Peptide_Sequence" xml:space="preserve">
+    <value>修飾ペプチドシークエンス</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a modifed peptide sequence" to read "select a molecule" when non-peptide documents are in use</comment>
   </data>
-  <data name="warning" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\warning.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="BrukerTimsTofMethodExporter_ExportMethod_Error_copying_template_file_" xml:space="preserve">
+    <value>テンプレートファイルをコピーできませんでした。</value>
   </data>
-  <data name="WebPanoramaPublishClient_GetInfoForFolders_Failure_retrieving_folder_information_from__0_" xml:space="preserve">
-    <value>{0}からのフォルダ情報の取得に失敗</value>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Compensation_Voltage" xml:space="preserve">
+    <value>明示的補償電圧</value>
   </data>
-  <data name="WebPanoramaPublishClient_ImportDataOnServer_Error_importing_Skyline_file_on_Panorama_server__0_" xml:space="preserve">
-    <value>Panoramaサーバー{0}でSkylineファイルのインポート中のエラー</value>
+  <data name="CommandLine_ApplyFileAndSampleNameRegex_Error__No_files_match_the_file_name_pattern___0___" xml:space="preserve">
+    <value>エラー：ファイル名パターン「{0}」に一致するファイルがありません。</value>
   </data>
-  <data name="WizardBlankDocument" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardBlankDocument-ja.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="GroupByItem_ToString_Replicates" xml:space="preserve">
+    <value>繰り返し測定</value>
   </data>
-  <data name="WizardFasta" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardFasta.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="Edit_Undo_Multiple" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Edit_Undo_Multiple.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="WizardImportPeptide" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardImportPeptide.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="EditCustomMoleculeDlg_OkDialog_Custom_molecules_must_have_a_mass_greater_than_or_equal_to__0__" xml:space="preserve">
+    <value>カスタム分子は、{0}以上の質量でなければなりません。</value>
   </data>
-  <data name="WizardImportProteins" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardImportProteins.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeptideToMoleculeText_Peptide" xml:space="preserve">
+    <value>ペプチド</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a peptide" to read "choose a molecule" when non-peptide documents are in use</comment>
   </data>
-  <data name="WizardImportTransition" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardImportTransition.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="AddZipToolHelper_ShouldOverwrite_Overwriting_tool___0_" xml:space="preserve">
+    <value>上書きツール：{0}</value>
   </data>
-  <data name="WizardMoleculeIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardMoleculeIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeptideSettingsUI_comboPeakScoringModel_SelectedIndexChanged_The_document_must_have_imported_results_in_order_to_train_a_model_" xml:space="preserve">
+    <value>トレインモデルには、ドキュメントにインポートされた結果がなければなりません。</value>
   </data>
-  <data name="WizardPeptideIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardPeptideIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="EditLinkedPeptideDlg_TryMakeLinkedPeptide_The_crosslinker___0___cannot_attach_to_the_amino_acid___1___" xml:space="preserve">
+    <value>クロスリンカー「{0}」は、アミノ酸「{1}」には結合できません。</value>
   </data>
-  <data name="WizardPeptideSearchDDA" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardPeptideSearch.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="EditIonMobilityLibraryDlg_OkDialog_Do_you_want_to_change_it_" xml:space="preserve">
+    <value>変更しますか？</value>
   </data>
-  <data name="WizardPeptideSearchDIA" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardPeptideSearchDIA.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="RInstaller_DownloadR_Download_failed_" xml:space="preserve">
+    <value>ダウンロードに失敗しました。</value>
   </data>
-  <data name="WizardPeptideSearchPRM" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardPeptideSearchPRM.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="CommandLine_AssociateProteins_Failed_to_associate_proteins" xml:space="preserve">
+    <value>タンパク質の関連付けに失敗しました</value>
   </data>
-  <data name="WizardTransitionIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardTransitionIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_CV_cutoff_entered" xml:space="preserve">
+    <value>入力されたCVカットオフが無効です</value>
   </data>
-  <data name="XHunterLibrary_Load_Invalid_precursor_charge_found_File_may_be_corrupted" xml:space="preserve">
-    <value>無効なプリカーサー電荷が見つかりました。ファイルが破損している可能性があります。</value>
+  <data name="ToolUpdatesDlg_DisplayInstallSummary_Successfully_updated_the_following_tool" xml:space="preserve">
+    <value>以下のツールが正常にアップデートされました</value>
   </data>
-  <data name="XmlElementHelper_Deserialize_Deserialize" xml:space="preserve">
-    <value>直列化解除</value>
+  <data name="SkylineWindow_SaveDocument_Saving___" xml:space="preserve">
+    <value>保存中...</value>
   </data>
-  <data name="XmlUtil_GetAttribute_The_value__0__is_not_valid_for_the_attribute__1__" xml:space="preserve">
-    <value>値「{0}」は属性{1}に対して有効ではありません。</value>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Fragment_Name" xml:space="preserve">
+    <value>フラグメント名</value>
+  </data>
+  <data name="PythonInstaller_DownloadPython_Download_failed_" xml:space="preserve">
+    <value>ダウンロードに失敗しました。</value>
+  </data>
+  <data name="CommandLine_ImportTool_Error__to_import_a_tool_it_must_have_a_name_and_a_command___Use___tool_add_to_specify_a_name_and_use___tool_command_to_specify_a_command___The_tool_was_not_imported___" xml:space="preserve">
+    <value>エラー：ツールをインポートするには、名前とコマンドがなければなりません。 名前を指定するには--tool-addを使用し、コマンドを指定するには--tool-commandを使用します。 ツールがインポートされませんでした...</value>
+  </data>
+  <data name="PeptideToMoleculeText_Peptide_Sequence" xml:space="preserve">
+    <value>ペプチドシークエンス</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a peptide sequence" to read "select a molecule" when non-peptide documents are in use</comment>
   </data>
   <data name="XmlUtil_GetInvalidDataMessage_The_file_contains_an_error_on_line__0__at_column__1__" xml:space="preserve">
     <value>ファイルの{1}行{0}列にエラーが含まれています。</value>
   </data>
-  <data name="ZedGraphClipboard_CreateCopyMenuItems_Copy" xml:space="preserve">
-    <value>コピー</value>
+  <data name="PeptideToMoleculeText_Modified_Sequence" xml:space="preserve">
+    <value>修飾シークエンス</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a modifed sequence" to read "select a molecule" when non-peptide documents are in use</comment>
+  </data>
+  <data name="AssociateProteinsDlg_UseFastaFile_An_error_occurred_during_protein_association_" xml:space="preserve">
+    <value>タンパク質の関連付け中にエラーが発生しました。</value>
+  </data>
+  <data name="ViewLibraryDlg_MatchModifications_the_matching" xml:space="preserve">
+    <value>一致</value>
+    <comment>In the sentence 'Would you like to use the Unimod definition for the matching modification?</comment>
+  </data>
+  <data name="DriftTimeWindowWidthCalculator_Validate_Peak_width_must_be_non_negative_" xml:space="preserve">
+    <value>ピーク幅は負の値にはできません。</value>
+  </data>
+  <data name="ProteinDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ProteinDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="BiblioSpecLiteLibrary_ReadSpectrum_Unexpected_SQLite_failure_reading__0__" xml:space="preserve">
+    <value>{0}読み込み中の予期せぬSQLiteの不具合。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_InChiKey_" xml:space="preserve">
+    <value>{0}は有効なInChiKeyではありません。</value>
+  </data>
+  <data name="Demultiplexer_GetDeconvRegionsForMz_TheIsolationSchemeIsInconsistentlySpecified" xml:space="preserve">
+    <value>フルスキャン設定での単離スキームの指定に一貫性がありません。</value>
+  </data>
+  <data name="SkylineWindow_OpenSharedFile_Extracting_Files" xml:space="preserve">
+    <value>ファイルの抽出中</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_No_method_will_be_exported_" xml:space="preserve">
+    <value>メソッドはエクスポートされません。</value>
+  </data>
+  <data name="UniquePeptidesDlg_OnShown_The_background_proteome__0__has_not_yet_finished_being_digested_with__1__" xml:space="preserve">
+    <value>バックグラウンドプロテオーム{0}はまだ{1}による消化を完了していません。</value>
+  </data>
+  <data name="CommandLine_ImportSearch_Creating_spectral_library_from_files_" xml:space="preserve">
+    <value>以下のファイルからのスペクトルライブラリを作成中：</value>
+  </data>
+  <data name="AddIrtCalculatorDlg_OkDialog_Please_specify_a_path_to_an_existing_iRT_database" xml:space="preserve">
+    <value>既存のiRTデータベースのパスを指定してください。</value>
+  </data>
+  <data name="SkylineWindow_Paste_Paste" xml:space="preserve">
+    <value>貼り付け</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Unknown_Error_installing_packages__Output_logged_to_the_Immediate_Window_" xml:space="preserve">
+    <value>パッケージのインストール中の不明なエラー。出力が即時ウィンドウに記録されました。</value>
+  </data>
+  <data name="AlignmentForm_UpdateGraph_Time_from__0__" xml:space="preserve">
+    <value>{0}からの時間</value>
+  </data>
+  <data name="CommandLine_ImportSearch_Adding__0__modifications_" xml:space="preserve">
+    <value>{0}修飾を追加中。</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_overwrite_with_the_older_version__0__or_install_in_parallel_" xml:space="preserve">
+    <value>古いバージョン{0}で上書きしますか、それとも並行インストールしますか？</value>
+  </data>
+  <data name="EditLink" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\EditLink.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Peptide_GetDeleteConfirmation_Are_you_sure_you_want_to_delete_these__0__peptides_" xml:space="preserve">
+    <value>本当にこれら{0}個のペプチドを削除してもよろしいですか？</value>
+    <comment>Example: Are you sure you want to delete these 47 peptides?</comment>
+  </data>
+  <data name="CommandLine_ApplyNamingPattern_Error__Duplicate_replicate_name___0___after_applying_regular_expression_" xml:space="preserve">
+    <value>エラー： 正規表現の適用後に繰り返し測定名'{0}'が重複しています。</value>
+  </data>
+  <data name="SkylineViewContext_GetTransitionListReportSpec_Peptide_Transition_List" xml:space="preserve">
+    <value>ペプチドトランジションリスト</value>
+  </data>
+  <data name="Database_GetJoinColumn_The_type__0__must_have_a_column_of_type__1_" xml:space="preserve">
+    <value>タイプ{0}はタイプ{1}の列を含む必要があります</value>
+  </data>
+  <data name="IonMobilityDb_GetIonMobilityDb_Please_provide_a_path_to_an_existing_ion_mobility_library_" xml:space="preserve">
+    <value>既存のイオン移動度ライブラリへのパスを提供してください。</value>
+  </data>
+  <data name="SkypFile_GetSkyFileUrl__0__is_not_a_valid_URL_on_a_Panorama_server_" xml:space="preserve">
+    <value>{0}はPanoramaサーバーの有効なURLではありません。</value>
+  </data>
+  <data name="ToolDescription_RunTool_Support_for_the_GenePattern_version_of_QuaSAR_has_been_discontinued_" xml:space="preserve">
+    <value>QuaSARのGenePatternバージョンのサポートは終了しています。</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_spectral_library_intensities___Create_a_document_library_from_these_intensities_" xml:space="preserve">
+    <value>トランジションリストにはスペクトルライブラリ強度が含まれていないようです。 これらの強度からドキュメントライブラリを作成しますか？</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_End_margin" xml:space="preserve">
+    <value>マージンを終了</value>
+  </data>
+  <data name="SkylineWindow_ImportFiles_Importing__0__" xml:space="preserve">
+    <value>{0}のインポート中</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Decoy" xml:space="preserve">
+    <value>デコイ</value>
+  </data>
+  <data name="BuildLibraryDlg_ValidateBuilder_The_library_identifier__0__is_not_valid_Identifiers_start_with_a_letter_number_or_underscore_and_contain_only_letters_numbers_underscores_and_dashes" xml:space="preserve">
+    <value>ライブラリ識別子{0}が有効ではありません。識別子は英数字またはアンダースコアから始まり、英数字、アンダースコア、ダッシュのみを含みます。</value>
+    <comment>Letters restricted to English alphabet</comment>
+  </data>
+  <data name="SkylineData" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\SkylineData.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ExportReportDlg_ShowShare_Report_Definitions" xml:space="preserve">
+    <value>定義をレポート</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Explicit_Declustering_Potential" xml:space="preserve">
+    <value>明示的デクラスタリングポテンシャル</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Library_Dot_Product" xml:space="preserve">
+    <value>ライブラリ内積</value>
+  </data>
+  <data name="ValidatingIonMobilityPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry_" xml:space="preserve">
+    <value>各エントリには修飾ペプチドシークエンスが必要です。</value>
+  </data>
+  <data name="RefineDlg_RefineDlg_Products" xml:space="preserve">
+    <value>プロダクト</value>
+  </data>
+  <data name="ConfigureToolsDlg_GetZipFromWeb_Error_connecting_to_the_Tool_Store___0_" xml:space="preserve">
+    <value>ツールストアへの接続エラー：{0}</value>
+  </data>
+  <data name="PeptideToMoleculeText_Molecule_Lists" xml:space="preserve">
+    <value>分子リスト</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like  "2 proteins" to read "2 molecule lists" when non-peptide documents are in use</comment>
+  </data>
+  <data name="CommandLine_ExportReport_" xml:space="preserve">
+    <value>エラー： レポートを指定した場合、--report-file=path/to/file.csvパラメータを指定しなければなりません。</value>
+  </data>
+  <data name="MassListImporter_Import_Failed_to_find_peptide_column" xml:space="preserve">
+    <value>ペプチド列の検索に失敗しました。</value>
+  </data>
+  <data name="SkypDownloadException_GetMessage_Would_you_like_to_update_the_credentials_" xml:space="preserve">
+    <value>認証情報を更新しますか？</value>
+  </data>
+  <data name="CommandLine_ImportResultsFile_Results_added_from__0__to_replicate__1__" xml:space="preserve">
+    <value>結果が{0}から繰り返し測定{1}に追加されました。</value>
+  </data>
+  <data name="LibraryGridViewDriver_AddProcessedIrts_Correlation_to_the_existing_iRT_values_are_not_high_enough_to_allow_retention_time_conversion" xml:space="preserve">
+    <value>既存のiRT値への相関度が保持時間を変換できるほど高くありません。</value>
+  </data>
+  <data name="ChromLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Name" xml:space="preserve">
+    <value>名前</value>
+  </data>
+  <data name="MassListRowReader_NextRow_Invalid_peptide_sequence__0__found" xml:space="preserve">
+    <value>無効なペプチドシークエンス{0}が見つかりました</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Finishing_up_import" xml:space="preserve">
+    <value>インポートの終了中</value>
+  </data>
+  <data name="BookmarkEnumerator_Current_No_such_node__0__" xml:space="preserve">
+    <value>以下のノードがありません：{0}</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Retention_Time_Window" xml:space="preserve">
+    <value>明示的保持時間ウィンドウ</value>
+  </data>
+  <data name="BuildBackgroundProteomeDlg_RefreshStatus_The_proteome_has_already_been_digested" xml:space="preserve">
+    <value>プロテオームはすでに消化されています。</value>
+  </data>
+  <data name="PublishDocumentDlg_OkDialog_Please_select_a_folder" xml:space="preserve">
+    <value>フォルダを選択してください</value>
+  </data>
+  <data name="ValueMissingException_ValueMissingException_" xml:space="preserve">
+    <value>引数{0}には値が必要であり、--name=value形式で指定する必要があります</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_comboMargins_SelectedIndexChanged_Start_margin" xml:space="preserve">
+    <value>マージンを開始</value>
+  </data>
+  <data name="AllChromatogramsGraph_UpdateStatus_Joining_chromatograms___" xml:space="preserve">
+    <value>クロマトグラムの結合中...</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Molecules" xml:space="preserve">
+    <value>分子</value>
+  </data>
+  <data name="GraphData_GraphResiduals_Time_from_Regression" xml:space="preserve">
+    <value>回帰からの時間</value>
+  </data>
+  <data name="BiblioSpecLiteBuilder_AmbiguousMatches_The_library_built_successfully__Spectra_matching_the_following_peptides_had_multiple_ambiguous_peptide_matches_and_were_excluded_" xml:space="preserve">
+    <value>ライブラリが正常に構築されました。 以下のペプチドに一致するスペクトルにペプチドのあいまい一致が複数あり、これらのスペクトルは除外されました：</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_Please_verify_and_update_if_incorrect" xml:space="preserve">
+    <value>確認し、間違っている場合にはアップデートしてください。</value>
+  </data>
+  <data name="DataboundGridControl_GetClusteredResults_Unable_to_choose_a_set_of_columns_to_use_for_hierarchical_clustering_" xml:space="preserve">
+    <value>階層クラスタリングに使用する列セットを選択できません。</value>
+  </data>
+  <data name="Edit_Redo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\edit_redo.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideGroupTreeNode_ProteinModalDisplayText__name___0__" xml:space="preserve">
+    <value>&lt;名前：{0}&gt;</value>
+  </data>
+  <data name="MQuestReferenceShapeCalc_MQuestReferenceShapeCalc_mProphet_weighted_reference" xml:space="preserve">
+    <value>mProphetの加重基準</value>
+  </data>
+  <data name="SkylineDataSchema_VerifyDocumentCurrent_The_document_was_modified_in_the_middle_of_the_operation_" xml:space="preserve">
+    <value>ドキュメントが操作の途中で変更されました。</value>
+  </data>
+  <data name="Comment" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\comment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportFasta_Importing_FASTA_file__0____" xml:space="preserve">
+    <value>FASTAファイル{0}のインポート中...</value>
+  </data>
+  <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_gene_information__this_selection_may_be_suspect_" xml:space="preserve">
+    <value>いくつかのバックグラウンドプロテオームのタンパク質には遺伝子の情報がないので、この選択肢は疑わしい可能性があります。</value>
+  </data>
+  <data name="OpenDataSourceDialog_OpenDataSourceDialog_My_Recent_Documents" xml:space="preserve">
+    <value>最近開いたドキュメント</value>
+  </data>
+  <data name="AlignmentForm_UpdateGraph_Outliers" xml:space="preserve">
+    <value>異常値</value>
+  </data>
+  <data name="RTLinearRegressionGraphPane_UpdateGraph_Calculating___" xml:space="preserve">
+    <value>計算中...</value>
+  </data>
+  <data name="SkylineWindow_ImportFasta_Unexpected_document_change_during_operation" xml:space="preserve">
+    <value>操作中の予期しないドキュメントの変更。</value>
+  </data>
+  <data name="MProphetResultsHandler_Q_VALUE_ANNOTATION_Q_Value" xml:space="preserve">
+    <value>Q値</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__the_specified_instrument__0__is_not_compatible_with_scheduled_methods_" xml:space="preserve">
+    <value>エラー：指定された装置{0}にはスケジュールメソッドとの互換性がありません。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Warning__Invalid_max_transitions_per_injection_parameter___0___" xml:space="preserve">
+    <value>警告： インジェクションパラメータ毎の無効な最大トランジション ({0})。</value>
+  </data>
+  <data name="SkypDownloadException_GetMessage_Credentials_saved_in_Skyline_for_the_Panorama_server__0__are_for_the_user__1___This_user_does_not_have_permissions_to_download_the_file__The_skyp_file_was_downloaded_by__2__" xml:space="preserve">
+    <value>Skylineに保存されているPanoramaサーバー{0}の認証情報は、ユーザー{1}のものです。このユーザーにはファイルをダウンロードする権限がありません。skypファイルは{2}によってダウンロードされました。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_ion_mobility_value_on_line__0__" xml:space="preserve">
+    <value>{0}行目にイオン移動度値がありません。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Peak_Rank" xml:space="preserve">
+    <value>ピークのランク</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_UpdateIsolationWidths_Isolation_widths" xml:space="preserve">
+    <value>単離幅(&amp;W)：</value>
+  </data>
+  <data name="SkylineWindow_ImportResults__0__decoys_do_not_have_a_matching_target" xml:space="preserve">
+    <value>{0}個のデコイが一致するターゲットを含んでいません</value>
+  </data>
+  <data name="GraphSpectrum_MassErrorFormat_ppm" xml:space="preserve">
+    <value>{0}{1} ppm</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_retention_time_value__0_" xml:space="preserve">
+    <value>無効な保持時間値{0}</value>
+  </data>
+  <data name="TransitionGroupLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\transitiongrouplib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RegressionFit_BILINEAR_Bilinear" xml:space="preserve">
+    <value>双線形</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Do_you_want_to_continue_" xml:space="preserve">
+    <value>続行しますか？</value>
+  </data>
+  <data name="Ions_C" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_C.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeakCalculatorWeight_Validate___0___is_not_a_known_name_for_a_peak_feature_calculator" xml:space="preserve">
+    <value>「{0}」はピーク機能カルキュレータとして知られている名前ではありません</value>
+  </data>
+  <data name="EditEnzymeDlg_ValidateAATextBox__0__must_contain_at_least_one_amino_acid" xml:space="preserve">
+    <value>{0}には1つ以上のアミノ酸が含まれて射なければなりません。</value>
+  </data>
+  <data name="CommandLine_RefineDocument_Refining_document___" xml:space="preserve">
+    <value>ドキュメントの最適化中...</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_File_Name" xml:space="preserve">
+    <value>ファイル名</value>
+  </data>
+  <data name="AbstractModificationMatcherFoundMatches__0__equals__1__" xml:space="preserve">
+    <value>{0} = {1}</value>
+  </data>
+  <data name="CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_does_not_exist__Please_verify_the_file_location_and_try_again_" xml:space="preserve">
+    <value>エラー：--tool-add-zipコマンドで指定されたファイルが存在していません。ファイルの場所を確認してからもう一度お試しください。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Failed_to_find_the_necessary_headers__0__in_the_first_line" xml:space="preserve">
+    <value>先頭行に必要なヘッダー{0}の検索に失敗しました</value>
+  </data>
+  <data name="AssociateProteinsDlg_UseFastaFile_There_was_an_error_reading_from_the_file_" xml:space="preserve">
+    <value>ファイルから読み込み中にエラーが発生しました。</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_Error_reading_iRT_standards_transition_list___0_" xml:space="preserve">
+    <value>iRT標準トランジションリストの読み込みエラー：{0}</value>
+  </data>
+  <data name="IsolationSchemeList_GetDefaults_SWATH__VW_100_" xml:space="preserve">
+    <value>SWATH (VW 100)</value>
+  </data>
+  <data name="EditEnzymeDlg_OnClosing_The_enzyme__0__already_exists" xml:space="preserve">
+    <value>酵素「{0}」が既に存在しています。</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_reinstall_or_install_in_parallel_" xml:space="preserve">
+    <value>再インストールしますか、それとも並行インストールしますか？</value>
+  </data>
+  <data name="Error___0_" xml:space="preserve">
+    <value>エラー：{0}</value>
+  </data>
+  <data name="ColumnSet_GetColumnInfos_Unable_to_find_table_for__0_" xml:space="preserve">
+    <value>{0}の表が見つかりません</value>
+  </data>
+  <data name="ImportSkyrHelper_ResolveImportConflicts_Resolving_conflicts_by_overwriting_" xml:space="preserve">
+    <value>上書きして競合を解決中。</value>
+  </data>
+  <data name="LibraryGridViewDriver_AddToLibrary_This_can_improve_retention_time_alignment_under_stable_chromatographic_conditions_" xml:space="preserve">
+    <value>安定したクロマトグラフ条件では、これによって保持時間のアライメントが改善することがあります。</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Peptide_Ratio_Results" xml:space="preserve">
+    <value>ペプチド比率結果</value>
+  </data>
+  <data name="AnnotationHelper_GetReplicateIndicices_False" xml:space="preserve">
+    <value>False</value>
+  </data>
+  <data name="ConfigureToolsDlg_unpackZipTool_Failed_to_read_file_0_The_tool_described_failed_to_import" xml:space="preserve">
+    <value>ファイル{0}の読み取りに失敗しました。記載のツールのインポートに失敗しました。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_intercept_" xml:space="preserve">
+    <value>値{0}は有効な切片ではありません。</value>
+  </data>
+  <data name="SkylineViewContext_GetTransitionListReportSpec_Small_Molecule_Transition_List" xml:space="preserve">
+    <value>低分子トランジションリスト</value>
+  </data>
+  <data name="Skyline" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\skyline.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ReportSpecList_Label_Report" xml:space="preserve">
+    <value>レポート(&amp;R)：</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Fwhm" xml:space="preserve">
+    <value>Fwhm</value>
+  </data>
+  <data name="IrtStandard_DocumentStream_No_document_to_import" xml:space="preserve">
+    <value>インポートするドキュメントがありません</value>
+  </data>
+  <data name="PeakBlank" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peakblank.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ValueInvalidPathException_ValueInvalidPathException_The_value___0___is_not_valid_for_the_argument__1__failed_attempting_to_convert_it_to_a_full_file_path_" xml:space="preserve">
+    <value>値「{0}」は、フルファイルパスへの変換試行に失敗した引数{1}に対して有効ではありません。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_peptide_sequence_on_line__0__" xml:space="preserve">
+    <value>{0}行目の欠損しているペプチドシークエンス。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility_High_Energy_Offset" xml:space="preserve">
+    <value>イオン移動度高エネルギーオフセット</value>
+  </data>
+  <data name="CommandArgs_ParseRegexArgument_Error__Regular_expression___0___for__1__cannot_be_parsed_" xml:space="preserve">
+    <value>エラー：{1}の正規表現「{0}」が解析できません。</value>
+  </data>
+  <data name="ComparePeakPickingDlg_SaveGraph_Either_the_ROC_or_Q_q_plot_tab_must_be_selected_to_save_a_graph_" xml:space="preserve">
+    <value>グラフを保存するには、ROCまたはQ-qプロットタブのどちらかを選択しなければなりません。</value>
+  </data>
+  <data name="PasteDlg_btnTransitionListHelp_Click_Transition_List_Help" xml:space="preserve">
+    <value>トランジションリストのヘルプ</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateNumberTextBox__0__must_contain_an_integer" xml:space="preserve">
+    <value>{0}は整数を含まなければなりません。</value>
+  </data>
+  <data name="RInstaller_InstallPackages_The_following_packages_failed_to_install_" xml:space="preserve">
+    <value>以下のパッケージをインストールできませんでした：</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_The_document_does_not_contain_any_of_these_iRT_standard_peptides_" xml:space="preserve">
+    <value>ドキュメントには、このiRT標準ペプチドが全く含まれていません。</value>
+  </data>
+  <data name="Ions_X" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_X.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="XmlUtil_GetAttribute_The_value__0__is_not_valid_for_the_attribute__1__" xml:space="preserve">
+    <value>値「{0}」は属性{1}に対して有効ではありません。</value>
+  </data>
+  <data name="MsconvertDdaConverter_Run_Re_using_existing_converted__0__file_for__1__" xml:space="preserve">
+    <value>{1}に既存の変換された{0}を再利用しています。</value>
+  </data>
+  <data name="SettingsListComboDriver_Add" xml:space="preserve">
+    <value>&lt;追加...&gt;</value>
+  </data>
+  <data name="PublishDocumentDlg_OkDialog_Please_select_a_Skyline_Shared_file_to_upload" xml:space="preserve">
+    <value>アップロードするSkyline共有ファイルを選択してください。</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_annotations_with_conflicting_names__Please_use_the___tool_zip_overwrite_annotations_command_" xml:space="preserve">
+    <value>競合名のある注釈があります。--tool-zip-overwrite-annotationsコマンドを使用してください。</value>
+  </data>
+  <data name="RedXTransparentBackground" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RedXTransparentBackground.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="BioMassCalc_SynchMasses_Fixing_isotope_abundance_masses_requires_a_monoisotopic_mass_calculator" xml:space="preserve">
+    <value>同位体存在質量の確定には、モノアイソトピック質量カルキュレータが必要です</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Total_Background" xml:space="preserve">
+    <value>総バックグラウンド</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Missing_end_time_on_line__0_" xml:space="preserve">
+    <value>{0}行目の欠損している終了時間</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Label_Type" xml:space="preserve">
+    <value>標識タイプ</value>
+  </data>
+  <data name="CalculateIsolationSchemeDlg_OkDialog_Start_value_must_be_less_than_End_value" xml:space="preserve">
+    <value>開始値は終値より小さい値でなければなりません。</value>
+  </data>
+  <data name="EditServerDlg_OkDialog_The_server__0__already_exists_" xml:space="preserve">
+    <value>サーバー「{0}」が既に存在しています。</value>
+  </data>
+  <data name="EditIrtCalcDlg_CreateDatabase_The_file__0__could_not_be_created" xml:space="preserve">
+    <value>ファイル{0}が作成できませんでした。</value>
+  </data>
+  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_the_following_Python_packages__Select_packages_to_install_and_then_click_Install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>このツールには以下のPythonパッケージが必要です。インストールするパッケージを選択し、インストールをクリックしてインストールプロセスを開始します。</value>
+  </data>
+  <data name="NoCentroidedDataException_NoCentroidedDataException_No_centroided_data_available_for_file___0_____Adjust_your_Full_Scan_settings_" xml:space="preserve">
+    <value>ファイル"{0}"に利用可能なセントロイド化データはありません。 フルスキャン設定を調整。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Mass_Error_PPM" xml:space="preserve">
+    <value>質量誤差PPM</value>
+  </data>
+  <data name="ImportResultsDlg_DefaultNewName_Default_Name" xml:space="preserve">
+    <value>クロマトグラム</value>
+    <comment>Default replicate name</comment>
+  </data>
+  <data name="CommandLine_SaveFile_File__0__saved_" xml:space="preserve">
+    <value>ファイル{0}が保存されました。</value>
+  </data>
+  <data name="RemoteSession_FetchContents_There_was_an_error_communicating_with_the_server__" xml:space="preserve">
+    <value>サーバーとの通信にエラーが発生しました：</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Change_digestion_settings" xml:space="preserve">
+    <value>消化設定を変更</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_InChIKey" xml:space="preserve">
+    <value>InChIKey</value>
+  </data>
+  <data name="FindNext" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\findnext.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="NoFullScanFilteringException_NoFullScanFilteringException_The_file__0__does_not_contain_SRM_MRM_chromatograms__To_extract_chromatograms_from_its_spectra__go_to_Settings___Transition_Settings___Full_Scan_and_choose_options_appropriate_to_the_acquisition_method_used_" xml:space="preserve">
+    <value>ファイル{0}にはSRM/MRMクロマトグラムが含まれていません。スペクトルからクロマトグラムを抽出するには、[設定] &gt; [トランジションの設定] &gt; [フルスキャン]にアクセスし、使用されている取得メソッドに適切なオプションを選択します。</value>
+    <comment>replaces NoFullScanFilteringException_NoFullScanFilteringException_To_extract_chromatograms_from__0__full_scan_settings_must_be_enabled_</comment>
+  </data>
+  <data name="CommandLine_ImportDataFilesWithAppend_Error__The_replicate__0__already_exists_in_the_given_document_and_the___import_append_option_is_not_specified___The_replicate_will_not_be_added_to_the_document_" xml:space="preserve">
+    <value>エラー：指定のドキュメントには繰り返し測定{0}がすでに存在し、--import-appendオプションが指定されていません。この繰り返し測定はドキュメントに追加されません。</value>
+  </data>
+  <data name="DataProcessing" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\dataprocessing.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="GraphSummary_UpdateToolbar_All" xml:space="preserve">
+    <value>すべて</value>
+  </data>
+  <data name="SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_targets_for_which_to_export_chromatograms_" xml:space="preserve">
+    <value>ドキュメントには、クロマトグラムをエクスポートするターゲットが含まれている必要があります。</value>
+  </data>
+  <data name="MoleculeList" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\MoleculeList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_End" xml:space="preserve">
+    <value>終了</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Overwrite" xml:space="preserve">
+    <value>上書き</value>
+  </data>
+  <data name="ExportMethodDlg_btnBrowseTemplate_Click_Method_Template" xml:space="preserve">
+    <value>メソッドテンプレート</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z" xml:space="preserve">
+    <value>プロダクトm/z</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Start_Time" xml:space="preserve">
+    <value>開始時間</value>
+  </data>
+  <data name="AssociateProteinsDlg_UseBackgroundProteome_No_background_proteome_defined" xml:space="preserve">
+    <value>バックグラウンドプロテオームは定義されていません。詳細は[ペプチド設定]の[消化]タブを参照してください。</value>
+    <comment>If background proteome is set to "None" and user attempts to "Use background proteome" when associating proteins</comment>
+  </data>
+  <data name="WizardFasta" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardFasta.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_UpdateIsolationWidths_Isolation_width" xml:space="preserve">
+    <value>単離幅(&amp;W)：</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Unknown_error_installing_packages__Tool_Installation_Failed_" xml:space="preserve">
+    <value>パッケージのインストール中の不明なエラー。ツールのインストールに失敗しました。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility__msec_" xml:space="preserve">
+    <value>イオン移動度(msec)</value>
+  </data>
+  <data name="LabelTypeComboDriver_LoadList_none" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg_Press_Register_to_register_for_a_project_on_PanoramaWeb_" xml:space="preserve">
+    <value>登録を押してPanoramaWebにプロジェクトを登録します。</value>
+  </data>
+  <data name="PeptideToMoleculeText_Molecule_List" xml:space="preserve">
+    <value>分子リスト</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a protein" to read "choose a molecule list" when non-peptide documents are in use</comment>
+  </data>
+  <data name="LowessAlignerFactory_ToString_LOWESS_Aligner" xml:space="preserve">
+    <value>LOWESSアライナー</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ProcessNeutralLoss_Cannot_use_product_neutral_loss_chemical_formula_without_a_precursor_chemical_formula" xml:space="preserve">
+    <value>プリカーサー化学式のないプロダクトニュートラルロス化学式は使用できません</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_QMedian" xml:space="preserve">
+    <value>Q値の中央値の-log10</value>
+  </data>
+  <data name="SkylineWindow_ImportFastaFile_Import_FASTA" xml:space="preserve">
+    <value>FASTAをインポート</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Transitions" xml:space="preserve">
+    <value>トランジション</value>
+  </data>
+  <data name="ValidatingIonMobilityPeptide_ValidateSequence_The_sequence__0__is_not_a_valid_modified_peptide_sequence_" xml:space="preserve">
+    <value>シークエンス{0}は有効な修飾ペプチドシークエンスではありません。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Sample_Name" xml:space="preserve">
+    <value>試料名</value>
+  </data>
+  <data name="TextUtil_DeterminDsvSeparator_Unable_to_determine_format_of_delimiter_separated_value_file" xml:space="preserve">
+    <value>値が区切り文字で分けられたファイルの形式を判定できません</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_collisional_cross_section_value_on_line__0__" xml:space="preserve">
+    <value>{0}行目の欠損している衝突断面積。</value>
+  </data>
+  <data name="Skyline_protein" xml:space="preserve">
+    <value>タンパク質</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Defaulting_to_standard_" xml:space="preserve">
+    <value>標準にデフォルト中。</value>
+  </data>
+  <data name="VendorIssueHelper_ConvertWiffToMzxml_Please_install_Analyst__or_run_this_import_on_a_computure_with_Analyst_installed" xml:space="preserve">
+    <value>Analystをインストールするか、Analystがインストールされているコンピュータでこのインポートを実行してください</value>
+  </data>
+  <data name="ConfigureToolsDlg_CopyinFile_Not_importing_this_tool" xml:space="preserve">
+    <value>このツールのインポート中ではありません...</value>
+  </data>
+  <data name="Columns_Columns_Unrecognized_column___0__" xml:space="preserve">
+    <value>列「{0}」が認識できません</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_OkDialog_The_peak_scoring_model__0__already_exists" xml:space="preserve">
+    <value>ピークスコアモデル{0}は既に存在しています</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Precursor_Peak_Found_Ratio" xml:space="preserve">
+    <value>プリカーサーピーク検出率</value>
+  </data>
+  <data name="SkylineWindow_CompleteProgressUI_version_issue" xml:space="preserve">
+    <value>
+
+{0}の64-bitバージョンをインストールすることにより、この問題を回避することができる場合があります。</value>
+  </data>
+  <data name="StartPage_Tutorial_Zip_Files" xml:space="preserve">
+    <value>ZIPファイル</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_Failed_to_open_the_database_file___0_" xml:space="preserve">
+    <value>データベースファイルを開くのに失敗しました：{0}</value>
+  </data>
+  <data name="DocumentAnnotations_AnnotationsNotSupported_The_element___0___cannot_have_annotations_" xml:space="preserve">
+    <value>要素「{0}」は注釈を持つことができません。</value>
+  </data>
+  <data name="LibraryBuildNotificationHandler_AddIrts__0__distinct_CiRT_peptides_were_found__How_many_would_you_like_to_use_as_iRT_standards_" xml:space="preserve">
+    <value>{0}個の異なるCiRTペプチドが見つかりました。何個をiRT標準として使用しますか？</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Reassigning_the_Protein_Name_column_will_prevent_the_peptides_from_being_associated_with_proteins_from_the_background_proteome." xml:space="preserve">
+    <value>タンパク質名列を再割り当てすると、ペプチドがバックグラウンドプロテオームからのタンパク質と関連しなくなります。</value>
+  </data>
+  <data name="Save" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\save.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Skyline_peptides" xml:space="preserve">
+    <value>ペプチド</value>
+  </data>
+  <data name="IsolationSchemeList_GetDefaults_SWATH__15_m_z_" xml:space="preserve">
+    <value>SWATH (15 m/z)</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_The_iRT_calculator_already_contains__0__of_the_imported_peptides_" xml:space="preserve">
+    <value>iRTカルキュレータは既にインポートされたペプチドの{0}に含まれています。</value>
+  </data>
+  <data name="ToolUpdatesDlg_btnUpdate_Click_Please_select_at_least_one_tool_to_update_" xml:space="preserve">
+    <value>アップデートするツールを1つ以上選択してください。</value>
+  </data>
+  <data name="BioMassCalc_ApplyAdductToFormula_Unknown_symbol___0___in_adduct_description___1__" xml:space="preserve">
+    <value>付加物の説明「{1}」にある記号「{0}」は未知です</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_1_decoy_does_not_have_the_same_number_of_transitions_as_its_matching_target" xml:space="preserve">
+    <value>1個のデコイが、一致するターゲットと同じ数のトランジションを含んでいません</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_The_sequence__0__is_not_a_valid_peptide" xml:space="preserve">
+    <value>シークエンス「{0}」は有効なペプチドではありません。</value>
+  </data>
+  <data name="SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_imported_results_" xml:space="preserve">
+    <value>ドキュメントには、インポート結果が必要です。</value>
+  </data>
+  <data name="TransitionTreeNode_GetResultsText__0__ratio__1__" xml:space="preserve">
+    <value>{0}（比率{1}）</value>
+    <comment>(0) transition amino acids, (1) transition fragment ion</comment>
+  </data>
+  <data name="PublishDocumentDlg_ServerSupportsSkydVersion_" xml:space="preserve">
+    <value>選択したサーバーはskydファイル形式のバージョン{0}をサポートしていません。
+サーバーをアップグレードするには、Panoramaサーバー管理者に問い合わせてください。</value>
+  </data>
+  <data name="PivotReportDlg_ShowPreview_A_report_must_have_at_least_one_column_" xml:space="preserve">
+    <value>レポートには1列以上必要です。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_It_must_be_a_number__Defaulting_to__0__" xml:space="preserve">
+    <value>数値でなければなりません。{0}にデフォルト中。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassToolInternal_" xml:space="preserve">
+    <value>インストールされていないためにツールディレクトリのないツールに対し、$(ToolDir) は有効なマクロではありません。</value>
+  </data>
+  <data name="ImportResultsControl_FindResultsFiles_Searching_for_matching_results_files_in__0__" xml:space="preserve">
+    <value>{0}内で一致する結果ファイルの検索中。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Protein_name" xml:space="preserve">
+    <value>タンパク質名</value>
+  </data>
+  <data name="CommandLine_LogNewEntries_Document_unchanged" xml:space="preserve">
+    <value>ドキュメントは変更されていません</value>
+  </data>
+  <data name="TransitionGroupTreeNode_GetResultsText_total_ratio__0__" xml:space="preserve">
+    <value>総比率{0}</value>
+  </data>
+  <data name="ToolDescription_RunTool_Please_check_the_External_Tools_Store_on_the_Skyline_web_site_for_the_most_recent_version_of_the_QuaSAR_external_tool_" xml:space="preserve">
+    <value>Skylineのウェブサイトの外部ツールストアでQuaSAR外部ツールの最新バージョンを確認してください。</value>
+  </data>
+  <data name="CommandLineTest_ConsoleAddFastaTest_Warning" xml:space="preserve">
+    <value>警告</value>
+  </data>
+  <data name="SrmDocument_ReadLabelType_The_isotope_modification_type__0__does_not_exist_in_the_document_settings" xml:space="preserve">
+    <value>同位体修飾タイプ{0}がドキュメント設定に存在していません。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Possible_loss_of_data_could_occur_if_you_switch_to__0___Do_you_want_to_continue_" xml:space="preserve">
+    <value>{0}に切り替えた場合、データのロスが生じる可能性があります。続行しますか？</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_The_precursor_mass_analyzer_type_is_not_set_to__0__in_Transition_Settings_under_the_Full_Scan_tab" xml:space="preserve">
+    <value>トランジション設定（フルスキャンタブ下）で、プリカーサー質量アナライザータイプが{0}に設定されていません。</value>
+  </data>
+  <data name="Blank" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\blank.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SettingsListComboDriver_Edit_current" xml:space="preserve">
+    <value>&lt;現在の設定を編集...&gt;</value>
+  </data>
+  <data name="WizardTransitionIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardTransitionIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideQc" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptideqc.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditOptimizationLibraryDlg_UpdateValueHeader_Collision_Energy" xml:space="preserve">
+    <value>衝突エネルギー</value>
+  </data>
+  <data name="CommandLine_ImportSearchInternal_Error___0__must_be_set_when_using_CiRT_peptides_" xml:space="preserve">
+    <value>エラー：CiRTペプチドを使用する際は、{0}を設定する必要があります。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_Compensation_voltage_optimization_should_be_run_on_one_transition_per_peptide__and_the_best_transition_cannot_be_determined_for_the_following_precursors_" xml:space="preserve">
+    <value>補償電圧最適化をプリカーサーごとに1つのトランジション上で実行してください。以下のプリカーサーについては最良のトランジションを判定できませんでした：</value>
+  </data>
+  <data name="SkylineWindow_ImportFastaFile_Failed_reading_the_file__0__1__" xml:space="preserve">
+    <value>ファイル{0}の読み取りに失敗しました。{1}</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_cone_voltage_value__0_" xml:space="preserve">
+    <value>無効なコーン電圧値{0}</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Precursor" xml:space="preserve">
+    <value>プリカーサー</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Opt_Declustering_Potential" xml:space="preserve">
+    <value>最適デクラスタリングポテンシャル</value>
+  </data>
+  <data name="ChooseAnnotationsDlg_OkDialog_Change_Annotation_Settings" xml:space="preserve">
+    <value>注釈設定を変更</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_Replicate" xml:space="preserve">
+    <value>繰り返し測定</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Precursors" xml:space="preserve">
+    <value>プリカーサー</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Importing_the_FASTA_did_not_create_any_target_proteins_" xml:space="preserve">
+    <value>FASTAをインポートしても、ターゲットタンパク質は作成されませんでした。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateCell_A_value_is_required_" xml:space="preserve">
+    <value>値が必要です。</value>
+  </data>
+  <data name="IonMobilityFilter_IonMobilityUnitsString_Drift_Time__ms_" xml:space="preserve">
+    <value>ドリフト時間(ms)</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_Compensation_Voltage_" xml:space="preserve">
+    <value>補償電圧：</value>
+  </data>
+  <data name="PeptideToMoleculeText_Molecules" xml:space="preserve">
+    <value>分子</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 peptides" to read "2 molecules" when non-peptide documents are in use</comment>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_Comparison_name_cannot_be_empty_" xml:space="preserve">
+    <value>比較名は空にできません。</value>
+  </data>
+  <data name="ComparePeakPickingDlg_SaveGraph_Save_Model_Comparison_Graph" xml:space="preserve">
+    <value>モデル比較グラフを保存</value>
+  </data>
+  <data name="RCalcIrt_RequireUsable_Unexpected_use_of_iRT_calculator_before_successful_initialization" xml:space="preserve">
+    <value>初期化成功前の予期せぬiRTカルキュレータの使用。</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_None_of_the_specified_proteins_are_in_the_document_" xml:space="preserve">
+    <value>指定されたタンパク質はどれもドキュメント内にありません。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_The_following_ions_have_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
+    <value>次のイオンに複数のイオン移動度値があります。Skylineは複数の配座異性体をサポートしているため、これは意図的である可能性があります。</value>
+  </data>
+  <data name="WizardMoleculeIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardMoleculeIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TransitionInfo_ReadTransitionLosses_No_modification_named__0__was_found_in_this_document" xml:space="preserve">
+    <value>このドキュメントでは{0}という名前の修飾が見つかりませんでした。</value>
+  </data>
+  <data name="IsotopeDistInfo_IsotopeDistInfo_Minimum_abundance__0__too_high" xml:space="preserve">
+    <value>最小存在度{0}が高すぎます</value>
+  </data>
+  <data name="MoleculeStandard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\MoleculeStandard.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Modified_Time" xml:space="preserve">
+    <value>修飾時間</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Warning__The_iRT_calculator_already_contains__0__with_the_value__1___Ignoring__2_" xml:space="preserve">
+    <value>警告：iRTカルキュレータには値{1}を含む{0}が既にあります。 {2}を無視します</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility" xml:space="preserve">
+    <value>イオン移動度</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Error___line__0___column__1____2_" xml:space="preserve">
+    <value>エラー：（行{0}、列{1}）{2}</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_S_Lens_value__0_" xml:space="preserve">
+    <value>無効なS-レンズ値{0}</value>
+  </data>
+  <data name="CommandLine_OpenSkyFile_Opening_file___" xml:space="preserve">
+    <value>ファイルを開いています...</value>
+  </data>
+  <data name="PasteDlg_AddFasta_An_unexpected_error_occurred" xml:space="preserve">
+    <value>予期しないエラーが発生しました：</value>
+  </data>
+  <data name="AreaReplicateGraphPane_UpdateGraph_Peak_Area_Ratio_To__0_" xml:space="preserve">
+    <value>{0}に対するピーク面積比</value>
+  </data>
+  <data name="RemovePrecursors_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from_one_precursor_" xml:space="preserve">
+    <value>1個のプリカーサーからこれら{0}個のピークを本当に削除してもよろしいですか？</value>
+  </data>
+  <data name="Skyline_Daily" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\skyline_daily.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LibraryGridViewDriver_ValidateMz_Product_m_zs_must_be_greater_than_zero_" xml:space="preserve">
+    <value>プロダクトm/zは0より大きくなければなりません。</value>
+  </data>
+  <data name="VendorIssueHelper_CreateTempFileSubstitute_Convert_to_mzXML_work_around_for__0__" xml:space="preserve">
+    <value>{0}のmzXMLへの変換の回避方法</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Missing_start_time_on_line__0_" xml:space="preserve">
+    <value>{0}行目の欠損している開始時間</value>
+  </data>
+  <data name="CachedLibrary_WarnInvalidEntries_" xml:space="preserve">
+    <value>ライブラリ「{0}」に無効なエントリが見つかりました。
+{2}個のペプチドまたは分子のうち、{3}を含む{1}個が無効でした。 </value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Library_Intensity" xml:space="preserve">
+    <value>ライブラリ強度</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Error_deleting_the_directory_of_the_existing_tool__Please_close_anything_using_that_directory_and_try_the_overwriting_import_again_later" xml:space="preserve">
+    <value>既存ツールのディレクトリの削除エラー。このディレクトリを使用しているプログラムをすべて閉じ、後でもう一度上書きインポートしてください</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_AllCount" xml:space="preserve">
+    <value>全数</value>
+  </data>
+  <data name="SkypSupport_Download_You_do_not_have_permissions_to_download_this_file_from__0__" xml:space="preserve">
+    <value>{0}からこのファイルをダウンロードする権限がありません。</value>
+  </data>
+  <data name="SettingsList_ELEMENT_NONE_None" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="PasteDlg_GetMoleculePeptideGroup_Molecule_List__0_" xml:space="preserve">
+    <value>分子リスト{0}</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_OtherIDs" xml:space="preserve">
+    <value>OtherIDs</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Retention_Time_Window" xml:space="preserve">
+    <value>保持時間ウィンドウ</value>
+  </data>
+  <data name="Transition_Validate_Precursor_and_product_ion_polarity_do_not_agree_" xml:space="preserve">
+    <value>プリカーサーとプロダクトイオンの極性が一致しません。</value>
+  </data>
+  <data name="MissingFileDlg_ValidateFilePath_You_must_choose_a_file_with_the___0___filename_extension_" xml:space="preserve">
+    <value>ファイル拡張子が「{0}」のファイルを選択してください。</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_This_installation_would_modify_the_report_titled__0_" xml:space="preserve">
+    <value>このインストールは{0}というタイトルのレポートを変更します</value>
+  </data>
+  <data name="Peak" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peak.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Regression_intercept" xml:space="preserve">
+    <value>切片</value>
+  </data>
+  <data name="ComparePeakBoundaries_ComputeMatches_Number_of_results_in_transition_group__0__does_not_match_between_the_two_documents" xml:space="preserve">
+    <value>トランジショングループ{0}内の結果数が2つのドキュメント間で一致しません</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Ion_mobility_units_not_specified" xml:space="preserve">
+    <value>イオン移動度の単位が指定されていません</value>
+  </data>
+  <data name="SkylineWindow_ShowExportSpectralLibraryDialog_The_document_must_contain_at_least_one_peptide_precursor_to_export_a_spectral_library_" xml:space="preserve">
+    <value>スペクトルライブラリをエクスポートするには、ドキュメントに1つ以上のペプチドプリカーサーが含まれている必要があります。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Count_Truncated" xml:space="preserve">
+    <value>切断数</value>
+  </data>
+  <data name="CommandLine_RemoveImportedFiles__0______1___Note__The_file_has_already_been_imported__Ignoring___" xml:space="preserve">
+    <value>{0} -&gt; {1} メモ： ファイルは既にインポートされています。無視...</value>
+  </data>
+  <data name="IIrtRegression_DisplayEquation_Measured_RT" xml:space="preserve">
+    <value>測定されたRT</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateAdductListTextBox__0__must_contain_a_comma_separated_list_of_adducts_or_integers_describing_charge_states_with_absolute_value_from__1__to__2__" xml:space="preserve">
+    <value>{0}は、{1}～{2}の絶対値で荷電状態を表記する付加イオンまたは整数値のカンマ区切りのリストを含む必要があります。</value>
+  </data>
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Peptide_Peak_Found_Ratio" xml:space="preserve">
+    <value>ペプチドピーク検出率</value>
+  </data>
+  <data name="SkylineWindow_exportIsolationListMenuItem_Click_There_is_no_isolation_list_data_to_export" xml:space="preserve">
+    <value>エクスポートする単離リストデータがありません。</value>
+  </data>
+  <data name="MzMatchException_suggestion" xml:space="preserve">
+    <value>ペプチド設定の修飾タブ、予測タブのm/zタイプ、またはトランジション設定の装置タブのm/z一致許容誤差を確認します。</value>
+  </data>
+  <data name="SkylineWindow_Publish_Error_retrieving_server_information__0__" xml:space="preserve">
+    <value>サーバー情報の取得エラー：{0}</value>
+  </data>
+  <data name="Filter" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Filter.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SpectrumFilter_FindFilterPairs_Two_isolation_windows_contain_targets_which_match_the_isolation_target__0__" xml:space="preserve">
+    <value>2つの単離ウィンドウには、単離ターゲット{0}に一致するターゲットが含まれます。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Note" xml:space="preserve">
+    <value>メモ</value>
+  </data>
+  <data name="BuildBackgroundProteomeDlg_RefreshStatus_Click_the_Add_File_button_to_add_a_FASTA_file_and_create_a_new_proteome_file" xml:space="preserve">
+    <value>「ファイルを追加」ボタンをクリックしてFASTAファイルを追加し、新しいプロテオームファイルを作成します。</value>
+  </data>
+  <data name="Skyline_Release" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Skyline_Release.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateSignedNumberTextBox_Value__0__must_be_between__1__and__2__or__3__and__4__" xml:space="preserve">
+    <value>値{0}は、{1}と{2}または{3}と{4}の間でなければなりません。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph_IM_Scan_Range_" xml:space="preserve">
+    <value>IMスキャン範囲：</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_slope_" xml:space="preserve">
+    <value>値{0}は有効な勾配ではありません。</value>
+  </data>
+  <data name="AnnotationDef_AnnotationTarget_Transitions" xml:space="preserve">
+    <value>トランジション</value>
+  </data>
+  <data name="OpenDataSourceDialog_sourcePathTextBox_KeyUp_Some_source_paths_are_invalid" xml:space="preserve">
+    <value>一部のソースパスが無効です</value>
+  </data>
+  <data name="RInstaller_GetPackages_Downloading_packages" xml:space="preserve">
+    <value>パッケージのダウンロード中</value>
+  </data>
+  <data name="SrmSettingsList_DEFAULT_3_ions" xml:space="preserve">
+    <value>3個のイオン</value>
+  </data>
+  <data name="CommandArgs_WarnArgRequirment_Warning__Use_of_the_argument__0__requires_the_argument__1_" xml:space="preserve">
+    <value>警告：引数{0}を使用するには引数{1}が必要です</value>
+  </data>
+  <data name="IncompleteStandardException_IncompleteStandardException_The_calculator__0__requires_all_of_its_standard_peptides_in_order_to_determine_a_regression" xml:space="preserve">
+    <value>カルキュレータ{0}には、回帰を決定するためにすべての標準ペプチドが必要です。</value>
+  </data>
+  <data name="PeptideToMoleculeText_Peptide_List" xml:space="preserve">
+    <value>ペプチドのリスト</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a peptide list" to read "select a molecule list" when non-peptide documents are in use</comment>
+  </data>
+  <data name="DriftTimePredictor_Validate_Resolving_power_must_be_greater_than_0_" xml:space="preserve">
+    <value>分解能は0より大きくなければなりません。</value>
+  </data>
+  <data name="Pivoter_QualifyColumnInfo_TotalAreaRatioTo" xml:space="preserve">
+    <value>TotalAreaRatioTo</value>
+  </data>
+  <data name="PeptideToMoleculeText_Molecule" xml:space="preserve">
+    <value>分子</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a peptide" to read "choose a molecule" when non-peptide documents are in use</comment>
+  </data>
+  <data name="RInstaller_InstallPackages_Output_logged_to_the_Immediate_Window_" xml:space="preserve">
+    <value>出力が即時ウィンドウに記録されました。</value>
+  </data>
+  <data name="Pivoter_QualifyColumnInfo_AreaRatioTo" xml:space="preserve">
+    <value>AreaRatioTo</value>
+  </data>
+  <data name="SkylineWindow_ShowProgressErrorUI_Do_you_want_to_continue_" xml:space="preserve">
+    <value>続行しますか？</value>
+  </data>
+  <data name="ToolService_InsertSmallMoleculeTransitionList_Insert_Small_Molecule_Transition_List" xml:space="preserve">
+    <value>分子トランジションリストを挿入</value>
+  </data>
+  <data name="CommandLine_AddDecoys_Error_The_number_of_peptides" xml:space="preserve">
+    <value>エラー：ペプチド{0}の数は、デコイ{1}のペプチドプリカーサーモデルの数より少なくなければなりません。でなければ、{2}={3}のデコイ生成法を使用してください。</value>
+  </data>
+  <data name="SkypFile_GetSkyFileUrl_Expected_the_URL_of_a_shared_Skyline_document_archive_file___0____Found_filename__1__instead_in_the_URL__2__" xml:space="preserve">
+    <value>共有しているSkylineドキュメントアーカイブファイル({0})のURLを待っていましたが、URL{2}の代わりにファイル名{1}が見つかりました。</value>
+  </data>
+  <data name="AbstractSpectrumGraphItem_AddAnnotations_" xml:space="preserve">
+    <value>スコア = {0:F06}</value>
+  </data>
+  <data name="SkylineStartup_SkylineStartup_Import_Peptide_List" xml:space="preserve">
+    <value>ペプチドリストをインポート</value>
+  </data>
+  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
+    <value>エラー：ドキュメントをPanormaにアップロードするため必要な以下の引数に値を指定してください：
+{0}</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_You_are_missing_fine_tune_optimized_compensation_voltages_for_the_following_" xml:space="preserve">
+    <value>以下の最適補償電圧が微調整されていません：</value>
+  </data>
+  <data name="CommandLine_ImportTool_Warning__the_tool__0__was_overwritten" xml:space="preserve">
+    <value>警告：ツール{0}は上書きされました</value>
+  </data>
+  <data name="IonMobilityTest_TestGetIonMobilityDBErrorHandling_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
+    <value>イオン移動度ライブラリファイル{0}を見つけることができませんでした。作成するための十分な権限がないようです。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility_High_Energy_Offset" xml:space="preserve">
+    <value>指定されたイオン移動度の高エネルギーオフセット</value>
+  </data>
+  <data name="OverlapDemultiplexer_the_isolation_window_overlap_scheme_does_not_cover_all_isolation_windows" xml:space="preserve">
+    <value>overlapiIsolationウィンドウスキームに欠損している隣接単離ウィンドウがいくつかあります。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Ratio_To_Standard_Dot_Product" xml:space="preserve">
+    <value>標準内積に対する比率</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_This_tool_requires_0_version_1" xml:space="preserve">
+    <value>このツールには{0}バージョン{1}が必要です。</value>
+  </data>
+  <data name="MeasuredCollisionalCrossSection_Validate_Collisional_cross_section_values_must_be_greater_than_0_" xml:space="preserve">
+    <value>衝突断面積値は0より大きくなければなりません。</value>
+  </data>
+  <data name="AlertDlg_GetDefaultButtonText__Abort" xml:space="preserve">
+    <value>中断(&amp;A)</value>
+  </data>
+  <data name="RInstaller_GetR_R_installation_complete_" xml:space="preserve">
+    <value>Rのインストールが完了しました。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_Error_applying_imported_peak_boundaries___0_" xml:space="preserve">
+    <value>インポートされたピーク境界の適用エラー：{0}</value>
+  </data>
+  <data name="GridViewDriver_GetValue_An_invalid_number__0__was_specified_for__1__2__" xml:space="preserve">
+    <value>{1} {2}に対して無効な数値（「{0}」）が指定されました。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Multiple_ion_mobility_declarations" xml:space="preserve">
+    <value>複数のイオン移動度が宣言されています</value>
+  </data>
+  <data name="TransitionFilter_FragmentStartFinders_ion_3" xml:space="preserve">
+    <value>イオン3</value>
+  </data>
+  <data name="ToolDescription_CallArgsCollector_Error_loading_report_from_the_temporary_file__0_" xml:space="preserve">
+    <value>一時ファイル{0}からのレポート読み込みエラー</value>
+  </data>
+  <data name="GraphChromatogram_DisplayOptimizationTotals_No_optimization_data_available" xml:space="preserve">
+    <value>最適化データがありません。</value>
+  </data>
+  <data name="SkylineStartup_SkylineStartup_Import_Transition_List" xml:space="preserve">
+    <value>トランジションリストをインポート</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Charge" xml:space="preserve">
+    <value>プロダクト電荷</value>
+  </data>
+  <data name="CalibrationGridViewDriver_CiRT_option_name" xml:space="preserve">
+    <value>CiRT（検出）</value>
+  </data>
+  <data name="RInstaller_GetPackages_Package_installation_complete_" xml:space="preserve">
+    <value>パッケージのインストールが完了しました。</value>
+  </data>
+  <data name="ToolDescription_VerifyAnnotations_Please_re_install_the_tool_and_try_again_" xml:space="preserve">
+    <value>ツールを再インストールしてからもう一度お試しください。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_The_selected_model_is_already_included_in_the_list_of_comparisons__Please_choose_another_model_" xml:space="preserve">
+    <value>選択モデルは既に比較リストに含まれています。別のモデルを選択してください。</value>
+  </data>
+  <data name="Open" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\open.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="InstrumentInfoUtil_ReadInstrumentConfig_Unexpected_line_in_instrument_config__0__" xml:space="preserve">
+    <value>機器設定における予期しない行：{0}</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Defaulting_to_none_" xml:space="preserve">
+    <value>なしにデフォルト中。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Precursor_formula_and_m_z_value_do_not_agree_for_any_charge_state_" xml:space="preserve">
+    <value>プリカーサー式とm/zはいかなる荷電状態も受け入れません。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Error__Attempting_to_exclude_an_unknown_feature_name___0____Try_one_of_the_following_" xml:space="preserve">
+    <value>エラー：不明なフィーチャー名「{0}」を除外しようとしています。次のいずれかを試してみてください。</value>
+  </data>
+  <data name="WizardImportTransition" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardImportTransition.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RemovePeptides_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from__1__peptides_" xml:space="preserve">
+    <value>{1}個のペプチドからこれら{0}個のピークを本当に削除してもよろしいですか？</value>
+  </data>
+  <data name="VendorIssueHelper_CreateTempFileSubstitute_Local_copy_work_around_for__0__" xml:space="preserve">
+    <value>{0}のローカルコピー回避方法</value>
+  </data>
+  <data name="Panorama" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Panorama.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Retention_Time" xml:space="preserve">
+    <value>明示的保持時間</value>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Unknown_error_installing_packages_" xml:space="preserve">
+    <value>パッケージのインストール中の不明なエラー。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_The_DIA_isolation_list_must_have_prespecified_windows_" xml:space="preserve">
+    <value>DIA分離リストではウィンドウの事前指定が必須です。</value>
+  </data>
+  <data name="Ions_fragments" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_fragments.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_library_values___Add_these_iRT_values_to_the_iRT_calculator_" xml:space="preserve">
+    <value>トランジションリストにはiRTライブラリ値が含まれていないようです。 これらのiRT値をiRTカルキュレータに追加しますか？</value>
+  </data>
+  <data name="AllChromatogramsGraph_UpdateStatus__0__of__1__files" xml:space="preserve">
+    <value>ファイル{1}個中{0}個</value>
+  </data>
+  <data name="ImportPeptideSearchManager_LoadBackground_The_current_peak_scoring_model_is_incompatible_with_one_or_more_peptides_in_the_document_" xml:space="preserve">
+    <value>現在のピークスコアモデルは、ドキュメント内の1つ以上のペプチドと互換性がありません。</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Error__The_name__0__specified_with__1__was_not_found_in_the_imported_assay_library_" xml:space="preserve">
+    <value>エラー：{1}で指定された名前{0}が、インポート済みのアッセイライブラリに見つかりませんでした。</value>
+  </data>
+  <data name="AreaChartPropertyDlg_ValidateDotpDecimal__0__must_contain_a_decimal_value" xml:space="preserve">
+    <value>{0}には十進数が含まれなければなりません。</value>
+  </data>
+  <data name="IsolationSchemeList_GetDefaults_SWATH__25_m_z_" xml:space="preserve">
+    <value>SWATH (25 m/z)</value>
+  </data>
+  <data name="AlignmentForm_UpdateGraph_Peptides_Refined" xml:space="preserve">
+    <value>ペプチドの精製</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_An_error_occurred_while_processing_retention_times_" xml:space="preserve">
+    <value>保持時間の処理中にエラーが発生しました。</value>
+  </data>
+  <data name="SkylineWindow_AddMolecule_The_precursor_m_z_for_this_molecule_is_out_of_range_for_your_instrument_settings_" xml:space="preserve">
+    <value>この分子のプリカーサーm/zが装置設定の範囲外です。</value>
+  </data>
+  <data name="BioMassCalc_CalculateMass_The_expression__0__is_not_a_valid_chemical_formula" xml:space="preserve">
+    <value>式「{0}」は有効な化学式ではありません。</value>
+  </data>
+  <data name="ViewLibraryDlg_LoadLibrary_An_error_occurred_attempting_to_import_the__0__library" xml:space="preserve">
+    <value>{0}ライブラリをインポートしようとした際にエラーが発生しました。</value>
+  </data>
+  <data name="PeptideTipProvider_RenderTip_Precursor_m_z" xml:space="preserve">
+    <value>プリカーサーm/z</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Isotope_Dot_Product" xml:space="preserve">
+    <value>同位体内積</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_Add_missing_iRT_standard_peptides_to_your_document_or_change_the_retention_time_predictor_" xml:space="preserve">
+    <value>欠損iRT標準ペプチドをドキュメントに追加するか、保持時間予測を変更します。</value>
+  </data>
+  <data name="CommandLine_ImportTool_Error__If__0__is_and_argument_the_tool_must_have_a_Report_Title__Use_the___tool_report_parameter_to_specify_a_report_" xml:space="preserve">
+    <value>エラー： {0}があり、かつ引数の場合、ツールにはレポートタイトルが必要です。レポートを指定するには、--tool-reportパラメータを使用します。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__to_export_a_scheduled_method__you_must_first_choose_a_retention_time_predictor_in_Peptide_Settings___Prediction__or_import_results_for_all_peptides_in_the_document_" xml:space="preserve">
+    <value>エラー：スケジュールメソッドをエクスポートするには、まず [ペプチド設定/予測] で保持時間予測を選択するか、ドキュメント内のすべてのペプチドに対する結果をインポートする必要があります。</value>
+  </data>
+  <data name="DetectionHistogramPane_Tooltip_ReplicateCount" xml:space="preserve">
+    <value>繰り返し測定数</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_On_line__0___1_" xml:space="preserve">
+    <value>{0}{1}行</value>
+  </data>
+  <data name="CustomMolecule_Validate_The_mass__0__of_the_custom_molecule_is_less_than_the_minimum_of__1__" xml:space="preserve">
+    <value>カスタム分子の質量{0}は{1}の最小値を下回っています。</value>
+  </data>
+  <data name="TransitionFilter_FragmentStartFinders_ion_1" xml:space="preserve">
+    <value>イオン1</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_value__0_" xml:space="preserve">
+    <value>イオン移動度値{0}が無効です</value>
+  </data>
+  <data name="KdeAlignerFactory_ToString_KDE_Aligner" xml:space="preserve">
+    <value>KDEアライナー</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Compensation_Voltage" xml:space="preserve">
+    <value>補償電圧</value>
+  </data>
+  <data name="TestSkylineProcessRunner_RunProcess_The_operation_was_canceled_by_the_user_" xml:space="preserve">
+    <value>ユーザーによって操作がキャンセルされました。</value>
+  </data>
+  <data name="MeasuredDriftTimeTable_ValidateMeasuredDriftTimeCellValues_On_line__0___1_" xml:space="preserve">
+    <value>{0}{1}行</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Formula" xml:space="preserve">
+    <value>プロダクトイオン式</value>
+  </data>
+  <data name="PasteDlg_btnTransitionListHelp_Click_" xml:space="preserve">
+    <value>このウィンドウの一番簡単な使用方法は、Excel（またはデータがCSV形式の場合テキストエディタ）からコピーしグリッドに貼り付けることです。
+ 
+Skylineでの列の順序は、列のヘッダーを左右にドラッグすることで調整できます。
+ 
+ほとんどのペプチドトランジションリストは、「ファイル|インポート|トランジションリスト...」メニューアイテムでインポートでき、[ターゲット]ウィンドウに直接貼り付けることもできます。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Total_Area_Ratio" xml:space="preserve">
+    <value>総面積比</value>
+  </data>
+  <data name="PasteDlg_Description_Insert_transition_list" xml:space="preserve">
+    <value>トランジションリストを挿入</value>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Skyline_uses_the_Python_tool_setuptools_and_the_Python_package_manager_Pip_to_install_packages_from_source__Click_install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>Skylineは、PythonツールsetuptoolsとPythonパッケージマネージャPipを使用し、ソースからパッケージをインストールします。インストールをクリックしてインストールプロセスを開始します。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow__0__is_not_a_valid_charge__Precursor_charges_must_be_integers_with_absolute_value_between_1_and__1__" xml:space="preserve">
+    <value>{0}は有効な電荷ではありません。プリカーサー電荷は1から{1}の絶対値を持つ整数である必要があります。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Formula_already_contains_an_adduct_description__and_it_does_not_match_" xml:space="preserve">
+    <value>式には既に付加物の説明が含まれており、一致しません。</value>
+  </data>
+  <data name="PasteDlg_GetMoleculeTransition_Product_m_z__0__isn_t_close_enough_to_the_nearest_possible_m_z__1___delta_2___" xml:space="preserve">
+    <value>プロダクトm/z{0}が、最も近い可能性のあるm/z{1} (delta{2}) に十分近いものではありません。</value>
+  </data>
+  <data name="AddIrtPeptidesDlg_AddIrtPeptidesDlg_Success" xml:space="preserve">
+    <value>成功</value>
+  </data>
+  <data name="PeptideSettingsUI_ComboPeakScoringModelSelected_Unrecognized_Model" xml:space="preserve">
+    <value>認識されていないモデル</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_The_tool__0__is_currently_installed_" xml:space="preserve">
+    <value>ツール{0}は現在インストールされています。</value>
+  </data>
+  <data name="DetectionHistogramPane_Tooltip_Count" xml:space="preserve">
+    <value>{0}個</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool__The_command_for__0__may_not_exist_in_that_location__Would_you_like_to_edit_it__" xml:space="preserve">
+    <value>{0}のコマンドがその場所に存在しない可能性があります。編集しますか？</value>
+  </data>
+  <data name="GraphFullScan_CreateIonMobilityHeatmap_Quadrupole_Scan_Range__m_z_" xml:space="preserve">
+    <value>四重極スキャン範囲(m/z)</value>
+  </data>
+  <data name="BiblioSpecLiteLibrary_CreateCache_No_spectra_were_found_in_the_library__0__" xml:space="preserve">
+    <value>ライブラリ{0}でスペクトルが見つかりませんでした</value>
+  </data>
+  <data name="Ions_Z" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_Z.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditOptimizationLibraryDlg_UpdateValueHeader_Declustering_Potential" xml:space="preserve">
+    <value>デクラスタリングポテンシャル</value>
+  </data>
+  <data name="HtmlFragment_ClipBoardText_From_Clipboard" xml:space="preserve">
+    <value>クリップボードから</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_The_selected_file_or_model_does_not_assign_peak_boundaries_to_any_chromatograms_in_the_document___Please_select_a_different_model_or_file_" xml:space="preserve">
+    <value>選択ファイルまたはモデルはドキュメント内のクロマトグラムに対するピーク境界を割り当てていません。 別のモデルまたはファイルを選択してください。</value>
+  </data>
+  <data name="CopyEmfToolStripMenuItem_CopyEmfToolStripMenuItem_Copy_Metafile" xml:space="preserve">
+    <value>メタファイルをコピー</value>
+  </data>
+  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_maximum_CV_entered" xml:space="preserve">
+    <value>入力された最大CVが無効です</value>
+  </data>
+  <data name="CommandLine_CreateIrtDatabase_Error__Importing_an_assay_library_to_a_document_without_an_iRT_calculator_cannot_create__0___because_it_exists_" xml:space="preserve">
+    <value>エラー： iRTカルキュレーターなしでドキュメントをアッセイライブラリにインポートすると、{0}が既に存在するためにこれを作成できません。</value>
+  </data>
+  <data name="Ions_B" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_B.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="down_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\down-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Wand" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Wand.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="UtilDB_Uncompress_Failure_uncompressing_data" xml:space="preserve">
+    <value>データの解凍に失敗。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph_IM__0_" xml:space="preserve">
+    <value>イオン移動度={0}</value>
+    <comment>"IM" stands for "Ion Mobility" - used for displaying ion mobility in raw scan view</comment>
+  </data>
+  <data name="IrtDb_MakeDocumentXml_iRT_standards" xml:space="preserve">
+    <value>iRT標準</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Total_Area" xml:space="preserve">
+    <value>総面積</value>
+  </data>
+  <data name="ShareListDlg_ImportFile_Failure_loading__0__" xml:space="preserve">
+    <value>{0}の読み込みに失敗しました。</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_Transition_list_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
+    <value>トランジションリスト欄には有効なファイルに対するパスが含まれていなければなりません。</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_This_is_an_older_installation_v_0__of_the_tool__1_" xml:space="preserve">
+    <value>これはツール{1}の古いインストールv{0}です。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Max_Fwhm" xml:space="preserve">
+    <value>最大Fwhm</value>
+  </data>
+  <data name="CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_is_not_a__zip_file__Please_specify_a_valid__zip_file_" xml:space="preserve">
+    <value>エラー：--tool-add-zipコマンドで指定されたファイルは.zipファイルではありません。有効な.zipファイルを指定してください。</value>
+  </data>
+  <data name="PasteDlg_AddFasta_An_unexpected_error_occurred__0__1__" xml:space="preserve">
+    <value>予期しないエラーが発生しました：{0} ({1})</value>
+    <comment>Message (Error Type)</comment>
+  </data>
+  <data name="PythonInstaller_GetPackages_Package_installation_completed_" xml:space="preserve">
+    <value>パッケージのインストールが完了しました。</value>
+  </data>
+  <data name="CommandLine_ExportReport_Exporting_report__0____" xml:space="preserve">
+    <value>レポート{0}のエクスポート中...</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_There_is_a_naming_conflict__You_already_installed_a_tool_from_a_zip_folder_with_the_name__0___Would_you_like_to_overwrite_or_install_in_parallel_" xml:space="preserve">
+    <value>名前の不一致があります。{0}という名前のzipフォルダから既にツールをインストールしています。上書きしますか、それとも並行インストールしますか？</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Area_Ratio" xml:space="preserve">
+    <value>面積比</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_Cannot_use_DIA_window_for_precursor_exclusion_when_isolation_scheme_does_not_contain_prespecified_windows___Please_select_an_isolation_scheme_with_prespecified_windows_" xml:space="preserve">
+    <value>単離スキームに事前指定されたウィンドウが含まれていない場合、プリカーサー排除にはDIAウィンドウを使用することはできません。 事前指定されたウィンドウ付きの単離スキームを選択してください。</value>
+  </data>
+  <data name="MoleculeLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\moleculelib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Replicate_Name" xml:space="preserve">
+    <value>繰り返し測定名</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_Of_the_specified__0__proteins__1__are_not_in_the_document__Do_you_want_to_continue_" xml:space="preserve">
+    <value>指定された{0}タンパク質{1}はどれもドキュメント内にありません。続行しますか？</value>
+  </data>
+  <data name="DdaSearch_Search_failed__0" xml:space="preserve">
+    <value>検索に失敗しました：{0}</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_The_protein___0___is_not_in_the_document__Do_you_want_to_continue_" xml:space="preserve">
+    <value>タンパク質'{0}'はドキュメント内にありません。続行しますか？</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility" xml:space="preserve">
+    <value>指定されたイオン移動度</value>
+  </data>
+  <data name="TransitionInfo_ReadTransitionLosses_Invalid_loss_index__0__for_modification__1__" xml:space="preserve">
+    <value>修飾{1}のロスインデックス{0}が無効です</value>
+  </data>
+  <data name="AddZipToolHelper_FindProgramPath_A_tool_requires_Program__0__Version__1__and_it_is_not_specified_with_the___tool_program_macro_and___tool_program_path_commands__Tool_Installation_Canceled_" xml:space="preserve">
+    <value>ツールにはプログラムが必要です：{0} バージョン：{1}、--tool-program-macro、--tool-program-pathコマンドを使用して指定されていません。ツールのインストールがキャンセルされました。</value>
+  </data>
+  <data name="PeakBoundsMatch_PeakBoundsMatch_Unable_to_read_a_score_annotation_for_peptide__0__of_file__1_" xml:space="preserve">
+    <value>ファイル{1}のペプチド{0}のスコア注釈を読み取ることができません</value>
+  </data>
+  <data name="EditCustomMoleculeDlg_OkDialog_A_precursor_with_that_adduct_and_label_type_already_exists_" xml:space="preserve">
+    <value>その付加イオンと標識タイプを持つプリカーサーイオンは既に存在します。</value>
+  </data>
+  <data name="SkylineWindow_ShowCalculatorScoreFormat" xml:space="preserve">
+    <value>{0}スコアを表示</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Error__Package_installation_did_not_complete__Output_logged_to_the_Immediate_Window_" xml:space="preserve">
+    <value>エラー： パッケージのインストールが完了しませんでした。出力が即時ウィンドウに記録されました。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_UpdateNumPeptides__0__Peptides" xml:space="preserve">
+    <value>{0}個のペプチド</value>
+  </data>
+  <data name="ToolMacros__listArguments_This_tool_requires_a_Document_Path_to_run" xml:space="preserve">
+    <value>このツールを実行するにはドキュメントパスが必要です</value>
+  </data>
+  <data name="SavitzkyGolaySmoother_WindowSize_SavitzkyGolaySmoother__Invalid_window_size___0____argument_must_be_positive_and_odd" xml:space="preserve">
+    <value>SavitzkyGolaySmoother： 無効なウィンドウサイズ ({0})：引数は正の奇数でなければなりません</value>
+  </data>
+  <data name="CommandLine_ShowLibraryMissingExternalSpectraError_Description" xml:space="preserve">
+    <value>引数 --import-search-prefer-embedded-spectraを使用し、ライブラリビルドを強制して埋め込みスペクトルを使用するか、上記にリストしたディレクトリの1つにオリジナルのスペクトルファイルを入れて再実行します。</value>
+  </data>
+  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
+    <value>エラー：ドキュメントをPanoramaにアップロードするため必要な以下の引数に値を指定してください：
+{0}</value>
+  </data>
+  <data name="IIrtRegression_DisplayEquation_iRT" xml:space="preserve">
+    <value>iRT</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_BrowseDb_The_specified_file_is_not_a_valid_iRT_database_" xml:space="preserve">
+    <value>指定ファイルは有効なiRTデータベースではありません。</value>
+  </data>
+  <data name="ComparePeakPickingDlg_ComparePeakPickingDlg_Fraction_of_Manual_ID_s" xml:space="preserve">
+    <value>手動IDの割合</value>
+  </data>
+  <data name="HeatMapGraph_RefreshData_Heat_Map" xml:space="preserve">
+    <value>ヒートマップ</value>
+  </data>
+  <data name="FullScanAcquisitionMethod_DDA_DDA" xml:space="preserve">
+    <value>DDA</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_Failed_reading_the_file___Peptide__0__matches_an_existing_iRT_standard_peptide_" xml:space="preserve">
+    <value>ファイルの読み取りに失敗しました。 ペプチド{0}が既存のiRT標準ペプチドで一致しました。</value>
+  </data>
+  <data name="Fragment" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Fragment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Min_Start_Time" xml:space="preserve">
+    <value>最小開始時間</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwrite__in_the_file__0_" xml:space="preserve">
+    <value> なおかつ競合するツールがあります{0}</value>
+  </data>
+  <data name="ChromCacheBuilder_BuildCache_This_document_contains_only_positive_ion_mode_transitions__and_the_imported_file_contains_only_negative_ion_mode_data_so_nothing_can_be_loaded___Negative_ion_mode_transitions_need_to_have_negative_charge_values_" xml:space="preserve">
+    <value>このドキュメントには陽イオンモードのトランジションのみが含まれ、インポート済みのファイルには陰イオンモードのデータのみが含まれているので、他のものが読み込めないようになっています。  陰イオンモードのトランジションには、負電荷の値が必要です。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph__0_____1_F2__min_" xml:space="preserve">
+    <value>{0}（{1:F2} 分）</value>
+    <comment>"min" stands for "minutes"</comment>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_User_Set_Total" xml:space="preserve">
+    <value>ユーザーセットの合計</value>
+  </data>
+  <data name="ToolUpdatesDlg_DisplayInstallSummary_Successfully_updated_the_following_tools" xml:space="preserve">
+    <value>以下のツールが正常にアップデートされました</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Package_installation_failed__Error_log_output_in_immediate_window_" xml:space="preserve">
+    <value>パッケージのインストールに失敗しました。即時ウィンドウ内のログ出力エラー。</value>
+  </data>
+  <data name="TransitionTreeNode_GetLabel_rank__0__" xml:space="preserve">
+    <value>ランク{0}</value>
+  </data>
+  <data name="CalculateIsolationSchemeDlg_OkDialog_Window_width_must_be_less_than_or_equal_to_the_isolation_range" xml:space="preserve">
+    <value>ウィンドウ幅は単離範囲以下でなければなりません。</value>
+  </data>
+  <data name="Ions_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_1.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_CheckRetentionTimeFilter_NoPredictionAlgorithm" xml:space="preserve">
+    <value>トランジション設定フルスキャン保持時間フィルタは予測保持時間を使用するように設定されていますが、予測アルゴリズムが指定されていません。
+修正するにはペプチド設定の予測タブに移動します。</value>
+  </data>
+  <data name="ExportReportDlg_GetDatabase_Analyzing_document" xml:space="preserve">
+    <value>ドキュメントの分析中...</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_Calculator_name_cannot_be_empty" xml:space="preserve">
+    <value>カルキュレータ名は空にできません。</value>
+  </data>
+  <data name="SkylineWindow_publishToolStripMenuItem_Click_Skyline_Shared_Documents" xml:space="preserve">
+    <value>Skyline共有ドキュメント</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Warning__The_method_type__0__is_invalid__It_must_be_one_of_the_following___standard____scheduled__or__triggered__" xml:space="preserve">
+    <value>警告： メソッドタイプ{0}が無効です。以下の中の1つでなければなりません：「標準」、「スケジュール」、「トリガー」。</value>
+  </data>
+  <data name="ToolUpdatesDlg_DisplayInstallSummary_Failed_to_update_the_following_tool" xml:space="preserve">
+    <value>以下のツールのアップデートに失敗しました</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_overwrite_or_install_in_parallel_" xml:space="preserve">
+    <value>上書きしますか、それとも並行インストールしますか？</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_Ion_types_must_contain_a_comma_separated_list_of_ion_types_a_b_c_x_y_z_and_p_for_precursor" xml:space="preserve">
+    <value>イオンタイプには、イオンタイプa、b、c、x、y、z、p（プリカーサー用）のカンマ区切りリストを含む必要があります。</value>
+  </data>
+  <data name="IsolationScheme_DoValidate_Unexpected_name___0___for__1__isolation_scheme" xml:space="preserve">
+    <value>{1}単離スキームに対する予期しない名前「{0}」</value>
+  </data>
+  <data name="GenericState_AppendErrorAndUri_URL___0_" xml:space="preserve">
+    <value>URL：{0}</value>
+  </data>
+  <data name="SkylineWindow_importMassListMenuItem_Click_Transition_List" xml:space="preserve">
+    <value>トランジションリスト</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Name" xml:space="preserve">
+    <value>プロダクト名</value>
+  </data>
+  <data name="CommandLine_AddDecoys_Added__0__decoy_peptides_using___1___method" xml:space="preserve">
+    <value>「{1}」メソッドを使用して{0}個のデコイペプチドを追加しました</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_1_decoy_does_not_have_a_matching_target" xml:space="preserve">
+    <value>1個のデコイが一致するターゲットを含んでいません</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Collision_Cross_Section__sq_A_" xml:space="preserve">
+    <value>明示的な衝突断面積（Aの2乗）</value>
+  </data>
+  <data name="Folder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\folder.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ExportMethodDlg_VerifySchedulingAllowed_You_must_export_a__0__transition_list_and_manually_import_it_into_a_method_file_using_vendor_software_" xml:space="preserve">
+    <value>{0}トランジションリストをエクスポートし、ベンダーソフトウェアを使用して手動でメソッドファイルにインポートする必要があります。</value>
+  </data>
+  <data name="ShareTypeDlg_OkDialog_Including_data_folders_is_not_supported_by_the_currently_selected_version_" xml:space="preserve">
+    <value>データフォルダの含有は、現在選択されているバージョンでは対応していません。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_Precursor_mz_does_not_agree_with_calculated_value_" xml:space="preserve">
+    <value>プリカーサーm/z {0}は、イオン式と荷電状態 (デルタ = {2}, トランジション設定 | 装置 | メソッド許容誤差 m/z = {3}) から計算されているため、値{1}を受け入れません)。表のm/z値を修正するか、または空白にしておけばSkylineが自動的に計算します。</value>
+  </data>
+  <data name="Peptide_ExplicitRetentionTimeWindow_Explicit_retention_time_window_requires_an_explicit_retention_time_value_" xml:space="preserve">
+    <value>明示的保持時間ウィンドウには、明示的保持時間値が必要です。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Sample__0__on_line__1__does_not_match_the_file__2__" xml:space="preserve">
+    <value>{1}行目の試料{0}がファイル{2}に一致しません。</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_compensation_voltage__0_" xml:space="preserve">
+    <value>無効な補償電圧{0}</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_AssociateProteins_These_filters_cannot_be_applied_as_they_would_result_in_an_empty_transition_list." xml:space="preserve">
+    <value>これらのフィルターは、空のトランジションリストとなるため、適用できません。</value>
+  </data>
+  <data name="ToolDescription_RunTool_Please_check_the_command_location_is_correct_for_this_tool_" xml:space="preserve">
+    <value>このツールに対してコマンドの場所が正しいか確認してください。</value>
+  </data>
+  <data name="SkylineWindow_HandleStandardsChanged_An_error_occurred_while_attempting_to_load_the_iRT_database__0___iRT_standards_cannot_be_automatically_added_to_the_document_" xml:space="preserve">
+    <value>iRTデータベース{0}を読み込もうとしている間にエラーが発生しました。iRT標準は、自動的にドキュメントに追加できません。</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_ReadIsolationRanges_Missing_isolation_range_for_the_isolation_target__0__m_z_in_the_file__1_" xml:space="preserve">
+    <value>ファイル{1}における単離ターゲット{0}m/zの欠損単離範囲</value>
+  </data>
+  <data name="DatabaseNotConnectedException_DatabaseNotConnectedException_The_database_for_the_calculator__0__could_not_be_opened__Check_that_the_file__1__was_not_moved_or_deleted" xml:space="preserve">
+    <value>カルキュレータ{0}のデータベースが開けませんでした。ファイル{1}が移動または削除されていないことを確認します。</value>
+  </data>
+  <data name="RegressionOption_All_Fixed_points__logarithmic_" xml:space="preserve">
+    <value>固定点（対数）</value>
+  </data>
+  <data name="FullScanAcquisitionExtension_LOCALIZED_VALUES_DIA" xml:space="preserve">
+    <value>DIA</value>
+  </data>
+  <data name="Ions_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_2.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Background" xml:space="preserve">
+    <value>バックグラウンド</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwrite_Please_specify__overwrite__or__parallel__with_the___tool_zip_conflict_resolution_command_" xml:space="preserve">
+    <value>--tool-zip-conflict-resolutionコマンドとともに「上書き」または「並列」を指定してください。</value>
+  </data>
+  <data name="PasteDlg_AddFasta_This_must_start_with" xml:space="preserve">
+    <value>これは「&gt;」から始まる必要があります</value>
+  </data>
+  <data name="PanoramaDownload" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\PanoramaDownload.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
+    <value>ユーザーを認証できませんでした。サーバーから受信した応答：{0} {1}</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
+    <value>サーバーからの予期しないJSON応答：{0}</value>
+  </data>
+  <data name="UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
+    <value>サーバー{0}でのユーザー認証情報の認証中にエラーがありました。</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
+    <value>サーバーは有効なJSON応答を返しませんでした。{0}はPanoramaサーバーではありません。</value>
+  </data>
+  <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
+    <value>サーバー{0}に接続できません。</value>
+  </data>
+  <data name="SpectrumClassFilter_MakePredicate_No_spectrum_column__0_" xml:space="preserve">
+    <value>スペクトル列{0}がありません</value>
+  </data>
+  <data name="SpectraGridForm_AddSpectrumFilters__0__spectrum_filters_will_be_added_to_the_document_" xml:space="preserve">
+    <value>{0}個のスペクトルフィルタがドキュメントに追加されます。</value>
+  </data>
+  <data name="EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_could_not_find_EncyclopeDia" xml:space="preserve">
+    <value>could not find EncyclopeDIA</value>
+  </data>
+  <data name="EncyclopeDiaHelpers_GenerateLibrary_Combining_quantification_libraries" xml:space="preserve">
+    <value>定量化ライブラリの統合</value>
+  </data>
+  <data name="EncyclopeDiaHelpers_GenerateLibrary_Combining_chromatogram_libraries" xml:space="preserve">
+    <value>クロマトグラムライブラリの統合</value>
+  </data>
+  <data name="EncyclopeDiaSearchDlg_Browse_for_Narrow_Window_Results_Files" xml:space="preserve">
+    <value>狭いウィンドウ結果ファイルを参照</value>
+  </data>
+  <data name="EncyclopeDiaSearchDlg_Browse_For_Wide_Window_Results_Files" xml:space="preserve">
+    <value>広いウィンドウ結果ファイルを参照</value>
+  </data>
+  <data name="SpectrumClassFilter_GetAbbreviatedText_OR" xml:space="preserve">
+    <value>OR</value>
+    <comment>"OR" is the logical operator</comment>
+  </data>
+  <data name="EncyclopeDiaHelpers_GenerateLibrary_Running_command___0___1_" xml:space="preserve">
+    <value>コマンドの実行：{0} {1}</value>
+  </data>
+  <data name="SkylineWindow_DownloadPanoramaFile_File_does_not_exist__It_may_have_been_deleted_on_the_server_" xml:space="preserve">
+    <value>File does not exist. It may have been deleted on the server.</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg_There_are_no_Panorama_servers_with_a_user_account__To_upload_documents_to_a_server_a_user_account_is_required_" xml:space="preserve">
+    <value>There are no Panorama servers with a user account. To upload documents to a server a user account is required.</value>
+  </data>
+  <data name="ProteinAssociation_CreateDocTree_Unmapped_Peptides" xml:space="preserve">
+    <value>Unmapped Peptides</value>
+  </data>
+  <data name="CommandLine_ExportSpecLib_Spectral_library_file__0__exported_successfully_" xml:space="preserve">
+    <value>Spectral library file {0} exported successfully.</value>
+  </data>
+  <data name="CommandLine_ExportSpecLib_Error__The_document_must_contain_at_least_one_precursor_to_export_a_spectral_library_" xml:space="preserve">
+    <value>Error: The document must contain at least one precursor to export a spectral library.</value>
+  </data>
+  <data name="CommandLine_ExportSpecLib_Error__The_document_must_contain_results_to_export_a_spectral_library_" xml:space="preserve">
+    <value>Error: The document must contain results to export a spectral library.</value>
+  </data>
+  <data name="CommandLine_ExportMProphetFeatures_mProphet_features_file__0__exported_successfully_" xml:space="preserve">
+    <value>mProphet features file {0} exported successfully.</value>
+  </data>
+  <data name="CommandLine_ExportMProphetFeatures_Error__The_document_must_contain_targets_for_which_to_export_mProphet_features_" xml:space="preserve">
+    <value>Error: The document must contain targets for which to export mProphet features.</value>
+  </data>
+  <data name="CommandLine_ExportMProphetFeatures_Error__The_document_must_contain_results_to_export_mProphet_features_" xml:space="preserve">
+    <value>Error: The document must contain results to export mProphet features.</value>
+  </data>
+  <data name="CommandArgs_ParseAnnotationTypes_Error__Attempting_to_exclude_an_unknown_annotation_type__0___Try_one_of_the_following_" xml:space="preserve">
+    <value>Error: Attempting to exclude an unknown annotation type '{0}'. Try one of the following:</value>
+  </data>
+  <data name="CommandLine_AddAnnotations_Annotations_successfully_defined_from_file__0__" xml:space="preserve">
+    <value>Annotations successfully defined from file {0}.</value>
+  </data>
+  <data name="Extensions_CustomToString_Protein_Expression" xml:space="preserve">
+    <value>Protein Expression</value>
+  </data>
+  <data name="CommandLine_ExportAnnotations_Annotations_file__0__exported_successfully_" xml:space="preserve">
+    <value>Annotations file {0} exported successfully.</value>
+  </data>
+  <data name="CommandLine_AddAnnotations_Error__Unable_to_read_annotations_from_file__0__" xml:space="preserve">
+    <value>Error: Unable to read annotations from file {0}.</value>
+  </data>
+  <data name="CommandArgs_ParseAnnotationTypes_Error__Attempting_to_specify_an_unknown_annotation_type___0____Try_one_of_the_following_" xml:space="preserve">
+    <value>Error: Attempting to specify an unknown annotation type '{0}'. Try one of the following:</value>
+  </data>
+  <data name="CommandArgs_ParseAnnotationTarget_Error__Attempting_to_specify_an_unknown_annotation_target___0____Try_one_of_the_following_" xml:space="preserve">
+    <value>Error: Attempting to specify an unknown annotation target '{0}'. Try one of the following:</value>
+  </data>
+  <data name="CommandLine_SetAnnotations_Warning__Skipping_annotation___0___due_to_a_name_conflict_" xml:space="preserve">
+    <value>Warning: Skipping annotation '{0}' due to a name conflict with an existing annotation.</value>
+  </data>
+  <data name="CommandLine_SetAnnotations_Warning__The_annotation___0___was_overwritten_" xml:space="preserve">
+    <value>Warning: Overwriting existing annotation '{0}' due to a name conflict.</value>
+  </data>
+  <data name="CommandLine_AddAnnotationsFromArguments_Error__Cannot_add_a__0__type_annotation_without_providing_a_list_values_of_through__1__" xml:space="preserve">
+    <value>Error: Cannot add a {0} type annotation without providing a list of values through {1}.</value>
+  </data>
+  <data name="CommandLine_AddAnnotationFromEnvironment_Error__Cannot_add_new_annotation___0___without_providing_at_least_one_target_through__1__" xml:space="preserve">
+    <value>Error: Cannot add new annotation '{0}' without providing at least one target through {1}.</value>
+  </data>
+  <data name="CommandLine_ExportAnnotations_Try_one_of_the_following_" xml:space="preserve">
+    <value>Try one of the following:</value>
+  </data>
+  <data name="CommandLine_ExportAnnotations_Error__The_document_must_contain_annotations_in_order_to_export_annotations_" xml:space="preserve">
+    <value>Error: The document must contain annotations in order to export annotations.</value>
+  </data>
+  <data name="CommandLine_SetPeptideDigestSettings_Error__Could_not_find_background_proteome_file__0_" xml:space="preserve">
+    <value>Error: Could not find background proteome file {0}</value>
+  </data>
+  <data name="PeptideMod_SetTerminus_A_peptide_modification_must_be_added_before_giving_it_a_terminal_or_amino_acid_specificity_" xml:space="preserve">
+    <value>A peptide modification must be added before giving it a terminal or amino acid specificity.</value>
+  </data>
+  <data name="koina_logo_fdf731d5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\koina-logo.fdf731d5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportPeptideList_Importing_peptide_list__0__from_file__1____" xml:space="preserve">
+    <value>Importing peptide list {0} from file {1}...</value>
+  </data>
+  <data name="CommandLine_ImportPeptideList_Importing_peptide_lists_from_file__0____" xml:space="preserve">
+    <value>Importing peptide lists from file {0}...</value>
+  </data>
+  <data name="CommandLine_ImportPeptideList_Warning__peptide_list_file_contains_lines_with_____Ignoring_provided_list_name_" xml:space="preserve">
+    <value>Warning: peptide list file contains lines with &gt;&gt;. Ignoring provided list name.</value>
+  </data>
+  <data name="CommandLine_AssociateProteins_Associating_peptides_with_proteins_from_FASTA_file__0_" xml:space="preserve">
+    <value>Associating peptides with proteins from FASTA file {0}</value>
+  </data>
+  <data name="BuildLibraryDlg_ValidateBuilder_Add_peptide_precursors_to_the_document_to_build_a_library_from_Koina_predictions_" xml:space="preserve">
+    <value>Add peptide precursors to the document to build a library from Koina predictions.</value>
+  </data>
+  <data name="CommandLine_ImportPeptideList_Using_the_Unimod_definitions_for_the_following_modifications_" xml:space="preserve">
+    <value>Using the Unimod definitions for the following modifications:</value>
+  </data>
+  <data name="PeptideMod_SetVariable_A_peptide_modification_must_be_added_before_assigning_its_variable_status_" xml:space="preserve">
+    <value>A peptide modification must be added before assigning its variable status.</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -118,1877 +118,57 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="AbstractModificationMatcherFoundMatches__0__equals__1__" xml:space="preserve">
-    <value>{0} = {1}</value>
-  </data>
-  <data name="AbstractSpectrumGraphItem_AddAnnotations_" xml:space="preserve">
-    <value>得分= {0:F06}</value>
-  </data>
-  <data name="AbstractSpectrumGraphItem_GetLabel_rank__0__" xml:space="preserve">
-    <value>排名 {0}</value>
-  </data>
-  <data name="add_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\add-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="AddIrtCalculatorDlg_OkDialog_Please_choose_the_iRT_calculator_you_would_like_to_add" xml:space="preserve">
-    <value>请选择您想要添加的 iRT 计算器。</value>
-  </data>
-  <data name="AddIrtCalculatorDlg_OkDialog_Please_specify_a_path_to_an_existing_iRT_database" xml:space="preserve">
-    <value>请为现有的 iRT 数据库指明路径。</value>
-  </data>
-  <data name="AddIrtCalculatorDlg_OkDialog_The_file__0__is_not_an_iRT_database" xml:space="preserve">
-    <value>文件{0}不是 iRT 数据库。</value>
-  </data>
-  <data name="AddIrtCalculatorDlgOkDialogThe_file__0__does_not_exist" xml:space="preserve">
-    <value>文件{0}不存在。</value>
-  </data>
-  <data name="AddIrtPeptidesDlg_AddIrtPeptidesDlg_Success" xml:space="preserve">
-    <value>成功</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_Comparison_name_cannot_be_empty_" xml:space="preserve">
-    <value>比较名称不得为空。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_Error_applying_imported_peak_boundaries___0_" xml:space="preserve">
-    <value>应用导入的峰值边界出错：{0}</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_File_path_cannot_be_empty_" xml:space="preserve">
-    <value>文件路径不能为空。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_File_path_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
-    <value>文件路径字段必须包括至有效文件的路径。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_Model_must_be_trained_before_it_can_be_used_for_peak_boundary_comparison_" xml:space="preserve">
-    <value>模型在用于峰值边界比较前必须被训练。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_The_current_file_or_model_has_no_q_values_or_scores_to_analyze___Either_q_values_or_scores_are_necessary_to_compare_peak_picking_tools_" xml:space="preserve">
-    <value>当前文件或模型没有需要分析的 q 值或得分。 q 值或得分都不是比较峰值拣选工具所必需的。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_The_imported_file_does_not_contain_any_peak_boundaries_for__0__transition_group___file_pairs___These_chromatograms_will_be_treated_as_if_no_boundary_was_selected_" xml:space="preserve">
-    <value>导入的文件不含任何针对{0}离子对群组/文件对的峰值边界。 这些色谱图将得到仿佛未选定任何边界一样的处理。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_The_selected_file_or_model_does_not_assign_peak_boundaries_to_any_chromatograms_in_the_document___Please_select_a_different_model_or_file_" xml:space="preserve">
-    <value>选定的文件或模型不向文档中的色谱图分配任何峰值边界。 请选择一个不同的模型或文件。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_The_selected_model_is_already_included_in_the_list_of_comparisons__Please_choose_another_model_" xml:space="preserve">
-    <value>选定的模型已经包含于比较列表中。请选择另一个模型。</value>
-  </data>
-  <data name="AddPeakCompareDlg_OkDialog_There_is_already_an_imported_file_with_the_current_name___Please_choose_another_name" xml:space="preserve">
-    <value>已经存在拥有当前名称的导入文件。 请选择另一个名称</value>
-  </data>
-  <data name="Adduct_ApplyToMolecule_Adduct___0___calls_for_removing_more__1__atoms_than_are_found_in_the_molecule__2_" xml:space="preserve">
-    <value>加合物“{0}”需要删除比在分子 {2} 中发现的更多 {1} 原子</value>
-  </data>
-  <data name="AddZipToolHelper_FindProgramPath_A_tool_requires_Program__0__Version__1__and_it_is_not_specified_with_the___tool_program_macro_and___tool_program_path_commands__Tool_Installation_Canceled_" xml:space="preserve">
-    <value>工具需要程序：{0} 版本：{1}并且其未借助“--工具-程序-宏”和“--工具-程序-路径”命令指定。工具安装取消。</value>
-  </data>
-  <data name="AddZipToolHelper_InstallProgram_Error__Package_installation_not_handled_in_SkylineRunner___If_you_have_already_handled_package_installation_use_the___tool_ignore_required_packages_flag" xml:space="preserve">
-    <value>错误：软件包安装未在 SkylineRunner 中处理。 如果您已经处理软件安装包，请使用“--工具-忽视-必需-软件包”标记。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwrite__in_the_file__0_" xml:space="preserve">
-    <value> 在文件{0}中</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwrite_Error__There_is_a_conflicting_tool" xml:space="preserve">
-    <value>错误：存在一个冲突工具</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwrite_Overwriting_tool___0_" xml:space="preserve">
-    <value>覆盖工具：{0}</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwrite_Please_specify__overwrite__or__parallel__with_the___tool_zip_conflict_resolution_command_" xml:space="preserve">
-    <value>请使用“--工具-zip-冲突-分辨率”命令指定“覆盖”或“并行”。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_annotations_with_conflicting_names__Please_use_the___tool_zip_overwrite_annotations_command_" xml:space="preserve">
-    <value>带有冲突名称的注释。请使用“--工具-zip-覆盖-注释”命令。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_conflicting_annotations__Keeping_existing_" xml:space="preserve">
-    <value>存在冲突注释。保持存在。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_conflicting_annotations__Overwriting_" xml:space="preserve">
-    <value>存在冲突注释。覆盖。</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_Warning__the_annotation__0__is_being_overwritten" xml:space="preserve">
-    <value>警告：注释{0}正在被覆盖</value>
-  </data>
-  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_Warning__the_annotation__0__may_not_be_what_your_tool_requires_" xml:space="preserve">
-    <value>警告：注释{0}可能不是您的工具所需的。</value>
-  </data>
-  <data name="AlertDlg_GetDefaultButtonText__Abort" xml:space="preserve">
-    <value>中止(&amp;A)</value>
-  </data>
-  <data name="AlertDlg_GetDefaultButtonText__Ignore" xml:space="preserve">
-    <value>忽略(&amp;I)</value>
-  </data>
-  <data name="AlertDlg_GetDefaultButtonText_Cancel" xml:space="preserve">
-    <value>取消</value>
-  </data>
-  <data name="AlertDlg_GetDefaultButtonText_OK" xml:space="preserve">
-    <value>确定</value>
-  </data>
-  <data name="AlertDlg_TruncateMessage_Message_truncated__Press_Ctrl_C_to_copy_entire_message_to_the_clipboard_" xml:space="preserve">
-    <value>消息已被截短。按 Ctrl+C 将完整消息复制到剪贴板。</value>
-  </data>
-  <data name="AlignmentForm_UpdateGraph_Outliers" xml:space="preserve">
-    <value>异常值</value>
-  </data>
-  <data name="AlignmentForm_UpdateGraph_Peptides_Refined" xml:space="preserve">
-    <value>肽段调整</value>
-  </data>
-  <data name="AlignmentForm_UpdateGraph_Time_from__0__" xml:space="preserve">
-    <value>从 {0} 开始的时间</value>
-  </data>
-  <data name="AllChromatogramsGraph_btnCancelFile_Click_Cancel_file" xml:space="preserve">
-    <value>取消文件</value>
-  </data>
-  <data name="AllChromatogramsGraph_UpdateStatus__0__of__1__files" xml:space="preserve">
-    <value>{1} 个文件中的 {0} 个</value>
-  </data>
-  <data name="AllChromatogramsGraph_UpdateStatus_Joining_chromatograms___" xml:space="preserve">
-    <value>加入色谱图…</value>
-  </data>
-  <data name="AllIonsStatusButton" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\AllIonsStatusButton.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="AnnotatedSpectum" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\AnnotatedSpectum.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="AnnotationDef_AnnotationTarget_Peptides" xml:space="preserve">
-    <value>肽段</value>
-  </data>
-  <data name="AnnotationDef_AnnotationTarget_Precursors" xml:space="preserve">
-    <value>母离子</value>
-  </data>
-  <data name="AnnotationDef_AnnotationTarget_Proteins" xml:space="preserve">
-    <value>蛋白质</value>
-  </data>
-  <data name="AnnotationDef_AnnotationTarget_Transitions" xml:space="preserve">
-    <value>离子对</value>
-  </data>
-  <data name="AnnotationHelper_GetReplicateIndicices_False" xml:space="preserve">
-    <value>假</value>
-  </data>
-  <data name="AnnotationHelper_GetReplicateIndicices_True" xml:space="preserve">
-    <value>真</value>
-  </data>
-  <data name="AreaChartPropertyDlg_ValidateDotpDecimal__0__must_contain_a_decimal_value" xml:space="preserve">
-    <value>{0} 必须包含十进制值。</value>
-  </data>
-  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_CV_cutoff_entered" xml:space="preserve">
-    <value>输入的 CV 截止值无效</value>
-  </data>
-  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_maximum_CV_entered" xml:space="preserve">
-    <value>输入的最大 CV 无效</value>
-  </data>
-  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_maximum_frequency_entered" xml:space="preserve">
-    <value>输入的最大频率无效</value>
-  </data>
-  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_maximum_log_10_area_entered" xml:space="preserve">
-    <value>输入的最大 log10 面积无效</value>
-  </data>
-  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_minimum_log_10_area_entered" xml:space="preserve">
-    <value>输入的最小 log10 面积无效</value>
-  </data>
-  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_Q_value_entered" xml:space="preserve">
-    <value>输入的 Q 值无效</value>
-  </data>
-  <data name="AreaReplicateGraphPane_InitFromData_Expected" xml:space="preserve">
-    <value>预期的</value>
-    <comment>expected value</comment>
-  </data>
-  <data name="AreaReplicateGraphPane_UpdateGraph_Peak_Area" xml:space="preserve">
-    <value>峰面积</value>
-  </data>
-  <data name="AreaReplicateGraphPane_UpdateGraph_Peak_Area_Ratio_To__0_" xml:space="preserve">
-    <value>相对于 {0} 的峰面积比率</value>
-  </data>
-  <data name="AssociateProteinsDlg_ApplyChanges_Associated_proteins" xml:space="preserve">
-    <value>关联的蛋白质</value>
-  </data>
-  <data name="AssociateProteinsDlg_UseBackgroundProteome_No_background_proteome_defined" xml:space="preserve">
-    <value>未定义任何背景蛋白质组，请参阅“肽段设置”中的“酶解”选项卡以了解更多信息。</value>
-    <comment>If background proteome is set to "None" and user attempts to "Use background proteome" when associating proteins</comment>
-  </data>
-  <data name="AssociateProteinsDlg_UseFastaFile_An_error_occurred_during_protein_association_" xml:space="preserve">
-    <value>关联蛋白质时出错。</value>
-  </data>
-  <data name="AssociateProteinsDlg_UseFastaFile_There_was_an_error_reading_from_the_file_" xml:space="preserve">
-    <value>从文件读取时发生错误。</value>
-  </data>
-  <data name="AsyncChromatogramsGraph_Render__0___sample__1_" xml:space="preserve">
-    <value>{0}，样品 {1}</value>
-  </data>
-  <data name="BiblioSpecLiteBuilder_AmbiguousMatches_The_library_built_successfully__Spectra_matching_the_following_peptides_had_multiple_ambiguous_peptide_matches_and_were_excluded_" xml:space="preserve">
-    <value>成功建立库。与以下肽段匹配的谱图曾经有多个模糊肽段匹配，已经被排除：</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_CreateCache_No_spectra_were_found_in_the_library__0__" xml:space="preserve">
-    <value>库{0}中未发现谱图</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_Load_Failed_loading_library__0__" xml:space="preserve">
-    <value>加载库“{0}”失败。</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_Load_Invalid_precursor_charge__0__found__File_may_be_corrupted" xml:space="preserve">
-    <value>发现无效的母离子电荷{0}。文件可能已损坏。</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_ReadRedundantSpectrum_Spectrum_peaks__0__excede_the_maximum_allowed__1__" xml:space="preserve">
-    <value>谱图峰{0}超出容许的最大{1}。</value>
-  </data>
-  <data name="BiblioSpecLiteLibrary_ReadSpectrum_Unexpected_SQLite_failure_reading__0__" xml:space="preserve">
-    <value>意外的 SQLite 读出{0}失败。</value>
-  </data>
-  <data name="BioMassCalc_ApplyAdductToFormula_Failed_parsing_adduct_description___0__" xml:space="preserve">
-    <value>解析加合物描述“{0}”失败</value>
-  </data>
-  <data name="BioMassCalc_ApplyAdductToFormula_Unknown_symbol___0___in_adduct_description___1__" xml:space="preserve">
-    <value>加合物描述“{1}”中有未知符号“{0}”</value>
-  </data>
-  <data name="BioMassCalc_CalculateMass_The_expression__0__is_not_a_valid_chemical_formula" xml:space="preserve">
-    <value>表达式“{0}”不是有效的化学式。</value>
-  </data>
-  <data name="BioMassCalc_SynchMasses_Fixing_isotope_abundance_masses_requires_a_monoisotopic_mass_calculator" xml:space="preserve">
-    <value>固定同位素丰度质量需要一个单一同位素质量计算器</value>
-  </data>
-  <data name="Blank" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\blank.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="BlibDb_CreateLibraryFromSpectra_Creating_spectral_library_for_imported_transition_list" xml:space="preserve">
-    <value>正在针对导入的离子对列表创建谱图库</value>
-  </data>
-  <data name="BookmarkEnumerator_Current_No_such_chrominfo__0__" xml:space="preserve">
-    <value>无此类色谱图信息：{0}</value>
-  </data>
-  <data name="BookmarkEnumerator_Current_No_such_node__0__" xml:space="preserve">
-    <value>无此类节点：{0}</value>
-  </data>
-  <data name="BrukerTimsTofMethodExporter_ExportMethod_Error_copying_template_file_" xml:space="preserve">
-    <value>复制模板文件时出错。</value>
-  </data>
-  <data name="BuildBackgroundProteomeDlg_AddFastaFile_The_added_file_included__0__repeated_protein_sequences__Their_names_were_added_as_aliases_to_ensure_the_protein_list_contains_only_one_copy_of_each_sequence_" xml:space="preserve">
-    <value>添加的文件包含 {0} 个重复的蛋白质序列。它们的名称作为别名添加，以确保蛋白质列表只包含每个序列的一个副本。</value>
-  </data>
-  <data name="BuildBackgroundProteomeDlg_RefreshStatus_Click_the_Add_File_button_to_add_a_FASTA_file_and_create_a_new_proteome_file" xml:space="preserve">
-    <value>单击“添加文件”按钮来添加一个 FASTA 文件，并且创建一个新的蛋白质组文件。</value>
-  </data>
-  <data name="BuildBackgroundProteomeDlg_RefreshStatus_The_proteome_has_already_been_digested" xml:space="preserve">
-    <value>蛋白质组已经被酶解。</value>
-  </data>
-  <data name="BuildLibraryDlg_btnPrevious_Click__Next__" xml:space="preserve">
-    <value>下一步(&amp;N) &gt;</value>
-  </data>
-  <data name="BuildLibraryDlg_OkWizardPage_Finish" xml:space="preserve">
-    <value>完成</value>
-  </data>
-  <data name="BuildLibraryDlg_ValidateBuilder_The_lab_authority_name__0__is_not_valid_This_should_look_like_an_internet_server_address_e_g_mylab_myu_edu_and_be_unlikely_to_be_used_by_any_other_lab_but_need_not_refer_to_an_actual_server" xml:space="preserve">
-    <value>实验室机构名称{0}无效。它应该形如互联网服务器地址（例如，mylab.myu.edu），并且不可能被任何其他实验室使用，但无需参考实际的服务器。</value>
-  </data>
-  <data name="BuildLibraryDlg_ValidateBuilder_The_library_identifier__0__is_not_valid_Identifiers_start_with_a_letter_number_or_underscore_and_contain_only_letters_numbers_underscores_and_dashes" xml:space="preserve">
-    <value>库标识符{0}无效。标识符以字母、数字或下划线开始，并且仅包含字母、数字、下划线和破折号。</value>
-    <comment>Letters restricted to English alphabet</comment>
-  </data>
-  <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_An_error_occurred_while_processing_retention_times_" xml:space="preserve">
-    <value>处理保留时间时出错。</value>
-  </data>
-  <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_Processing_Retention_Times" xml:space="preserve">
-    <value>正在处理保留时间</value>
-  </data>
-  <data name="CachedLibrary_WarnInvalidEntries_" xml:space="preserve">
-    <value>在库 '{0}' 中找到无效的条目。
-{2} 个肽段或分子中的 {1} 个无效，包括:：{3}</value>
-  </data>
-  <data name="CalculateIsolationSchemeDlg_OkDialog_Start_value_must_be_less_than_End_value" xml:space="preserve">
-    <value>起始值必须小于最终值。</value>
-  </data>
-  <data name="CalculateIsolationSchemeDlg_OkDialog_Window_width_must_be_less_than_or_equal_to_the_isolation_range" xml:space="preserve">
-    <value>窗口宽度必须小于或等于分离范围。</value>
-  </data>
-  <data name="CalculateIsolationSchemeDlg_OkDialog_Window_width_not_even" xml:space="preserve">
-    <value>奇数窗口宽度不受所选优化窗口放置重叠分解支持。</value>
-  </data>
-  <data name="Calculator" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Calculator.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="CalibrateIrtDlg_TryGetLine_The_standard_must_have_two_fixed_points" xml:space="preserve">
-    <value>标准必须拥有两个固定点。</value>
-  </data>
-  <data name="CalibrationCurveFitter_GetCalibrationCurve_Unable_to_calculate_the_calibration_curve_for_the_because_there_are_different_Precursor_Concentrations_specified_for_the_label__0__" xml:space="preserve">
-    <value>无法计算校准曲线，因为为标记 {0} 指定了不同的母离子浓度。</value>
-  </data>
-  <data name="CalibrationGridViewDriver_CiRT_option_name" xml:space="preserve">
-    <value>CiRT （已发现）</value>
-  </data>
-  <data name="ChooseAnnotationsDlg_OkDialog_Change_Annotation_Settings" xml:space="preserve">
-    <value>更改注释设置</value>
-  </data>
-  <data name="ChooseSchedulingReplicatesDlg_btnOk_Click_Choose_retention_time_filter_replicates" xml:space="preserve">
-    <value>选择保留时间过滤器重复测定</value>
-  </data>
-  <data name="ChromatogramCache_LoadStructs_Please_check_for_a_newer_release_" xml:space="preserve">
-    <value>请查看更新的版本。</value>
-  </data>
-  <data name="ChromatogramCache_LoadStructs_The_SKYD_file_format__0__is_not_supported_by_Skyline__1__" xml:space="preserve">
-    <value>Skyline {1}不支持 SKYD 文件格式{0}。</value>
-  </data>
-  <data name="ChromatogramCache_WriteStructs_Failure_writing_cache___Specified__0__peaks_exceed_total_peak_count__1_" xml:space="preserve">
-    <value>写入缓存失败。特定的{0}峰超出总峰计数 {1}</value>
-  </data>
-  <data name="ChromatogramDataProvider_GetChromatogram_This_import_appears_to_be_taking_longer_than_expected__If_importing_from_a_network_drive__consider_canceling_this_import__copying_to_local_disk_and_retrying_" xml:space="preserve">
-    <value>此次导入好像比预期的时间长。如果是从网络驱动器导入，请考虑取消这次导入，复制到本地磁盘，再重试。</value>
-  </data>
-  <data name="ChromatogramExporter_Export_Corrupted_chromatogram_data_at_charge__0__state_of_peptide__1_" xml:space="preserve">
-    <value>肽段{1}在电荷{0}态下的损坏色谱图数据</value>
-  </data>
-  <data name="ChromatogramLibrary_LoadLibraryFromDatabase_Reading_precursors_from__0_" xml:space="preserve">
-    <value>从{0}读取母离子</value>
-  </data>
-  <data name="ChromCacheBuilder_BuildCache_This_document_contains_only_negative_ion_mode_transitions__and_the_imported_file_contains_only_positive_ion_mode_data_so_nothing_can_be_loaded_" xml:space="preserve">
-    <value>本文档仅包含负离子模式离子对，而导入的文件仅包含正离子模式数据，因此，没有任何内容可加载。</value>
-  </data>
-  <data name="ChromCacheBuilder_BuildCache_This_document_contains_only_positive_ion_mode_transitions__and_the_imported_file_contains_only_negative_ion_mode_data_so_nothing_can_be_loaded___Negative_ion_mode_transitions_need_to_have_negative_charge_values_" xml:space="preserve">
-    <value>本文档仅包含正离子模式离子对，而导入的文件仅包含负离子模式数据，因此，没有任何内容可加载。 负离子模式离子对需要有负电荷值。</value>
-  </data>
-  <data name="ChromCacheBuilder_BuildNextFileInner_The_file__0__does_not_exist" xml:space="preserve">
-    <value>文件{0}不存在。</value>
-  </data>
-  <data name="ChromCacheBuilder_WriteLoop_Existing_write_threads___0_" xml:space="preserve">
-    <value>现有的线程写入：{0}</value>
-  </data>
-  <data name="ChromCacheJoiner_FinishRead_Unexpected_end_of_file_in__0__" xml:space="preserve">
-    <value>在{0}中的非正常文件结束。</value>
-  </data>
-  <data name="ChromLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Close" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Close.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Collapse" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\minus.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_DoRowValidating_The_sequence__0__is_already_present_in_the_list_" xml:space="preserve">
-    <value>序列 {0} 已经存在于列表中。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow__0__is_not_a_valid_charge__Precursor_charges_must_be_integers_with_absolute_value_between_1_and__1__" xml:space="preserve">
-    <value>{0} 不是有效电荷。母离子电荷必须为绝对值介于 1 和 {1} 之间的整数。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Cannot_read_high_energy_ion_mobility_offset_value___0___on_line__1__" xml:space="preserve">
-    <value>无法读取第 {1} 行的高能离子迁移偏置值“{0}”。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Could_not_parse_adduct_description___0___on_line__1_" xml:space="preserve">
-    <value>无法解析第 {1} 行的加合物描述“{0}”</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_adduct_description_on_line__0_" xml:space="preserve">
-    <value>第 {0} 行缺少加合物描述</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_collisional_cross_section_value_on_line__0__" xml:space="preserve">
-    <value>第 {0} 行上缺失碰撞横截面值。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_ion_mobility_value_on_line__0__" xml:space="preserve">
-    <value>第 {0} 行缺少离子迁移值。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_peptide_sequence_on_line__0__" xml:space="preserve">
-    <value>第 {0} 行缺少肽段序列</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_The_pasted_text_must_at_a_minimum_contain_columns_for_peptide_and_adduct__along_with_collisional_cross_section_and_or_ion_mobility_" xml:space="preserve">
-    <value>粘贴的文本至少必须包含用于肽段和加合物的列，以及包含碰撞横截面和/或离子迁移。</value>
-  </data>
-  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_The_text__0__is_not_a_valid_peptide_sequence_on_line__1__" xml:space="preserve">
-    <value>第 {1} 行上的文本{0}不是有效的肽段序列。</value>
-  </data>
-  <data name="ColorSchemeList_GetDefaults_Distinct" xml:space="preserve">
-    <value>明显不同的</value>
-  </data>
-  <data name="Columns_Columns_Duplicate_column___0__" xml:space="preserve">
-    <value>重复列“{0}”</value>
-  </data>
-  <data name="Columns_Columns_Unrecognized_column___0__" xml:space="preserve">
-    <value>未识别列“{0}”</value>
-  </data>
-  <data name="ColumnSet_GetColumnInfos_Unable_to_find_table_for__0_" xml:space="preserve">
-    <value>无法找到针对{0}的表格</value>
-  </data>
-  <data name="ColumnSet_GetColumnInfos_Unexpected_report_type" xml:space="preserve">
-    <value>意外的报告类型</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Peptide" xml:space="preserve">
-    <value>肽段</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Peptides" xml:space="preserve">
-    <value>肽段</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Precursor" xml:space="preserve">
-    <value>母离子</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Precursors" xml:space="preserve">
-    <value>母离子</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Protein" xml:space="preserve">
-    <value>蛋白质</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Transition" xml:space="preserve">
-    <value>离子对</value>
-  </data>
-  <data name="ColumnSet_GetTransitionsTable_Transitions" xml:space="preserve">
-    <value>离子对</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
-    <value>错误：请为向 Panorma 上传文档时需要的以下参数指定一个值：
-{0}</value>
-  </data>
-  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
-    <value>错误：请为向 Panorma 上传文档时需要的以下参数指定一个值：
-{0}</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Defaulting_to_none_" xml:space="preserve">
-    <value>默认设置为无。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Defaulting_to_standard_" xml:space="preserve">
-    <value>默认设置为标准。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Error____0___is_not_a_valid_value_for__1___It_must_be_one_of_the_following___2_" xml:space="preserve">
-    <value>错误：“{0}”不是 {1} 的有效值。必须是以下一种：{2}</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Error__Attempting_to_exclude_an_unknown_feature_name___0____Try_one_of_the_following_" xml:space="preserve">
-    <value>错误：尝试排除未知的特征名称“{0}”。尝试以下一种：</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Error__Regular_expression___0___does_not_have_any_groups___String" xml:space="preserve">
-    <value>错误：正则表达式'{0}'没有任何群组。 必需拥有一个群组。与正则表达式中第一群组匹配的部分文件或子目录名称用作重复测定名称。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Error__Use___in_to_specify_a_Skyline_document_to_open_" xml:space="preserve">
-    <value>错误：使用“--在内”来指定要打开的 Skyline 文档。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_It_must_be_a_number__Defaulting_to__0__" xml:space="preserve">
-    <value>它必须是一个数字。默认设置为{0}。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Warning__Invalid_max_transitions_per_injection_parameter___0___" xml:space="preserve">
-    <value>警告：无效的每次进样参数最大离子对数目({0})。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Warning__Invalid_optimization_parameter___0____Use__ce____dp___or__none__" xml:space="preserve">
-    <value>警告：无效的最优化参数({0})。使用“ce”、“dp”或“无”。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Warning__The_export_strategy__0__is_not_valid__It_must_be_one_of_the_following___string" xml:space="preserve">
-    <value>警告：导出策略{0}无效。它必须是下列内容之一：“单一”、“蛋白质”或“存储桶”。默认设置为单一。</value>
-  </data>
-  <data name="CommandArgs_ParseArgsInternal_Warning__The_method_type__0__is_invalid__It_must_be_one_of_the_following___standard____scheduled__or__triggered__" xml:space="preserve">
-    <value>警告：方法类型{0}无效。它必须是下列内容之一：“标准”、“预定”或“触发”。</value>
-  </data>
-  <data name="CommandArgs_ParseRegexArgument_Error__Regular_expression___0___for__1__cannot_be_parsed_" xml:space="preserve">
-    <value>错误：{1} 的正则表达式“{0}”无法解析。</value>
-  </data>
-  <data name="CommandArgs_WarnArgRequirment_Warning__Use_of_the_argument__0__requires_the_argument__1_" xml:space="preserve">
-    <value>警告：使用参数 {0} 需要参数 {1}</value>
-  </data>
-  <data name="CommandLine_AddDecoys_Added__0__decoy_peptides_using___1___method" xml:space="preserve">
-    <value>已经使用“{1}”方法添加了 {0} 个诱饵肽段</value>
-  </data>
-  <data name="CommandLine_AddDecoys_Decoys_discarded" xml:space="preserve">
-    <value>已丢弃诱饵</value>
-  </data>
-  <data name="CommandLine_AddDecoys_Error__Attempting_to_add_decoys_to_document_with_decoys_" xml:space="preserve">
-    <value>错误：正在尝试对有诱饵的文档添加诱饵。</value>
-  </data>
-  <data name="CommandLine_AddDecoys_Error_The_number_of_peptides" xml:space="preserve">
-    <value>错误：肽段数目 {0} 必须小于针对诱饵 {1} 的肽段母离子模型数目，或使用 {2}={3} 诱饵生成方法。</value>
-  </data>
-  <data name="CommandLine_ApplyFileAndSampleNameRegex_Error__No_files_match_the_file_name_pattern___0___" xml:space="preserve">
-    <value>错误：没有与文件名模式 '{0}' 相匹配的文件。</value>
-  </data>
-  <data name="CommandLine_ApplyFileAndSampleNameRegex_Error__No_files_match_the_sample_name_pattern___0___" xml:space="preserve">
-    <value>错误：没有与示例名称模式 '{0}' 相匹配的文件。</value>
-  </data>
-  <data name="CommandLine_ApplyFileNameRegex_File_name___0___does_not_match_the_pattern___1____Ignoring__2_" xml:space="preserve">
-    <value>文件名“{0}”不符合模式“{1}”。忽视{2}</value>
-  </data>
-  <data name="CommandLine_ApplyNamingPattern_Error__Duplicate_replicate_name___0___after_applying_regular_expression_" xml:space="preserve">
-    <value>错误：应用正则表达式后重复测定名称“{0}”重复。</value>
-  </data>
-  <data name="CommandLine_ApplySampleNameRegex_File___0___does_not_have_a_sample__Cannot_apply_sample_name_pattern__Ignoring_" xml:space="preserve">
-    <value>文件“{0}” 无样品。无法应用样品名称模式。忽视。</value>
-  </data>
-  <data name="CommandLine_AssociateProteins_a_FASTA_file_must_be_imported_before_associating_proteins" xml:space="preserve">
-    <value>错误：必须先导入 FASTA 文件，然后才能关联蛋白质</value>
-  </data>
-  <data name="CommandLine_AssociateProteins_Failed_to_associate_proteins" xml:space="preserve">
-    <value>未能关联蛋白质</value>
-  </data>
-  <data name="CommandLine_CanReadFile_Error__File_does_not_exist___0__" xml:space="preserve">
-    <value>错误：文件不存在：{0}。</value>
-  </data>
-  <data name="CommandLine_CheckReplicateFiles_Error__Replicate__0__in_the_document_has_an_unexpected_file__1__" xml:space="preserve">
-    <value>错误：文档中的重复测定{0}具有意外文件{1}。</value>
-  </data>
-  <data name="CommandLine_ConnectLibrarySpecs_Error__Could_not_find_the_spectral_library__0__for_this_document_" xml:space="preserve">
-    <value>错误：无法针对此文档找到谱图库{0}。</value>
-  </data>
-  <data name="CommandLine_ConnectLibrarySpecs_Warning__Could_not_find_the_spectral_library__0_" xml:space="preserve">
-    <value>警告：无法找到谱图库{0}</value>
-  </data>
-  <data name="CommandLine_CreateIrtDatabase_Error__Importing_an_assay_library_to_a_document_without_an_iRT_calculator_cannot_create__0___because_it_exists_" xml:space="preserve">
-    <value>错误：导入分析库到没有 iRT 计算器的文档无法创建{0}，因为它已经存在。</value>
-  </data>
-  <data name="CommandLine_CreateIrtDatabase_Use_the__0__argument_to_specify_a_file_to_create_" xml:space="preserve">
-    <value>使用{0}参数指定要创建的文件。</value>
-  </data>
-  <data name="CommandLine_CreateScoringModel_Creating_scoring_model__0_" xml:space="preserve">
-    <value>正在创建得分模型{0}</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__A_template_file_is_required_to_export_a_method_" xml:space="preserve">
-    <value>错误：需要模板文件来导出方法。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__The_current_document_contains_peptides_without_enough_information_to_rank_transitions_for_triggered_acquisition_" xml:space="preserve">
-    <value>错误：当前文档包含的肽段不具有足够信息，无法对离子对进行排名以触发采集。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__the_specified_instrument__0__is_not_compatible_with_scheduled_methods_" xml:space="preserve">
-    <value>错误：指定的仪器{0}和预定方法不兼容。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__The_template_file__0__does_not_exist_" xml:space="preserve">
-    <value>错误：模板文件{0}不存在。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__to_export_a_scheduled_method__you_must_first_choose_a_retention_time_predictor_in_Peptide_Settings___Prediction__or_import_results_for_all_peptides_in_the_document_" xml:space="preserve">
-    <value>错误：如要导出预定方法，您必须首先在肽段设置/预测中选择一个保留时间预测器，或者在文档中导入针对所有肽段的结果。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Error__triggered_acquistion_requires_a_spectral_library_or_imported_results_in_order_to_rank_transitions_" xml:space="preserve">
-    <value>错误：触发采集需要一个谱图库或导入结果，以排名离子对。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_List__0__exported_successfully_" xml:space="preserve">
-    <value>列表{0}已成功导出。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_Method__0__exported_successfully_" xml:space="preserve">
-    <value>方法{0}已成功导出。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_No_list_will_be_exported_" xml:space="preserve">
-    <value>无列表将被导出。</value>
-  </data>
-  <data name="CommandLine_ExportInstrumentFile_No_method_will_be_exported_" xml:space="preserve">
-    <value>无方法将被导出。</value>
-  </data>
-  <data name="CommandLine_ExportReport_" xml:space="preserve">
-    <value>错误：如果您指定一个报告，则必须指定--report-file=path/to/file.csv 参数。</value>
-  </data>
-  <data name="CommandLine_ExportReport_Error__Failure_attempting_to_save__0__report_to__1__" xml:space="preserve">
-    <value>错误：尝试将{0}报告保存至{1}失败。</value>
-  </data>
-  <data name="CommandLine_ExportReport_Error__The_report__0__could_not_be_saved_to__1____Check_to_make_sure_it_is_not_read_only_" xml:space="preserve">
-    <value>错误：报告{0}无法保存至{1}。 查看以确保报告不是只读格式。</value>
-  </data>
-  <data name="CommandLine_ExportReport_Error__The_report__0__does_not_exist__If_it_has_spaces_in_its_name__use__double_quotes__around_the_entire_list_of_command_parameters_" xml:space="preserve">
-    <value>错误：报告{0}不存在。如果名称中存在空格，请在整个命令参数列表周围使用“双引号”。</value>
-  </data>
-  <data name="CommandLine_ExportReport_Exporting_report__0____" xml:space="preserve">
-    <value>报告{0}导出中...</value>
-  </data>
-  <data name="CommandLine_ExportReport_Report__0__exported_successfully_" xml:space="preserve">
-    <value>报告{0}已成功导出。</value>
-  </data>
-  <data name="CommandLine_ImportDataFilesWithAppend_Error__The_replicate__0__already_exists_in_the_given_document_and_the___import_append_option_is_not_specified___The_replicate_will_not_be_added_to_the_document_" xml:space="preserve">
-    <value>错误：指定的文档中已存在重复测定 {0}，并且未指定 --import-append 选项。该重复测定不会添加到文档中。</value>
-  </data>
-  <data name="CommandLine_ImportFasta_Importing_FASTA_file__0____" xml:space="preserve">
-    <value>FASTA 文件{0}导入中...</value>
-  </data>
-  <data name="CommandLine_ImportResults_Error__No_files_left_to_import_" xml:space="preserve">
-    <value>错误：没有可供导入的文件。</value>
-  </data>
-  <data name="CommandLine_ImportResultsFile_Error__Failed_importing_the_results_file__0__" xml:space="preserve">
-    <value>错误：导入结果文件{0}失败。</value>
-  </data>
-  <data name="CommandLine_ImportResultsFile_Results_added_from__0__to_replicate__1__" xml:space="preserve">
-    <value>从{0}向重复测定{1}中添加结果。</value>
-  </data>
-  <data name="CommandLine_ImportResultsFile_Warning__Failed_importing_the_results_file__0____Ignoring___" xml:space="preserve">
-    <value>警告：导入结果文件{0}失败。 忽视...</value>
-  </data>
-  <data name="CommandLine_ImportSearch_Adding__0__modifications_" xml:space="preserve">
-    <value>添加 {0} 个修饰。</value>
-  </data>
-  <data name="CommandLine_ImportSearch_Creating_spectral_library_from_files_" xml:space="preserve">
-    <value>正在通过以下文件创建谱图库：</value>
-  </data>
-  <data name="CommandLine_ImportSearchInternal_Error___0__must_be_set_when_using_CiRT_peptides_" xml:space="preserve">
-    <value>错误：使用 CiRT 肽段时必须设置 {0}。</value>
-  </data>
-  <data name="CommandLine_ImportSkyr_Success__Imported_Reports_from__0_" xml:space="preserve">
-    <value>成功！从{0}中导入报告</value>
-  </data>
-  <data name="CommandLine_ImportTool_" xml:space="preserve">
-    <value>错误：标题为{0}的工具已经存在。请使用“--工具-冲突-分辨率=&amp;lt; 覆盖 | 跳过 &gt;”。标题为{0}的工具未添加。</value>
-  </data>
-  <data name="CommandLine_ImportTool__0__was_added_to_the_Tools_Menu_" xml:space="preserve">
-    <value>{0}添加至“工具菜单”。</value>
-  </data>
-  <data name="CommandLine_ImportTool_Error__If__0__is_and_argument_the_tool_must_have_a_Report_Title__Use_the___tool_report_parameter_to_specify_a_report_" xml:space="preserve">
-    <value>错误：如果 {0} 是参数，则工具必须具有报告标题。使用“--工具-报告”参数来指定报告。</value>
-  </data>
-  <data name="CommandLine_ImportTool_Error__Please_import_the_report_format_for__0____Use_the___report_add_parameter_to_add_the_missing_custom_report_" xml:space="preserve">
-    <value>错误：请针对{0}导入报告格式。 使用“--报告-添加”参数来添加丢失的自定义报告。</value>
-  </data>
-  <data name="CommandLine_ImportTool_Error__the_provided_command_for_the_tool__0__is_not_of_a_supported_type___Supported_Types_are___1_" xml:space="preserve">
-    <value>错误：提供给工具{0}命令不属于被支持的类型。 支持类型是：{1}</value>
-  </data>
-  <data name="CommandLine_ImportTool_Error__to_import_a_tool_it_must_have_a_name_and_a_command___Use___tool_add_to_specify_a_name_and_use___tool_command_to_specify_a_command___The_tool_was_not_imported___" xml:space="preserve">
-    <value>错误：如要导入工具，则必须含有名称和命令。 使用“--工具-添加”来指定一个名称，并且使用“--工具-命令”来指定一个命令。 工具未导入...</value>
-  </data>
-  <data name="CommandLine_ImportTool_The_tool_was_not_imported___" xml:space="preserve">
-    <value>工具未导入...</value>
-  </data>
-  <data name="CommandLine_ImportTool_Warning__skipping_tool__0__due_to_a_name_conflict_" xml:space="preserve">
-    <value>警告：因命名冲突跳过工具{0}。</value>
-  </data>
-  <data name="CommandLine_ImportTool_Warning__the_tool__0__was_overwritten" xml:space="preserve">
-    <value>警告：工具{0}已被覆盖</value>
-  </data>
-  <data name="CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_does_not_exist__Please_verify_the_file_location_and_try_again_" xml:space="preserve">
-    <value>错误：以“--工具-添加-zip”命令指定的文件不存在。请验证文件位置并重试。</value>
-  </data>
-  <data name="CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_is_not_a__zip_file__Please_specify_a_valid__zip_file_" xml:space="preserve">
-    <value>错误：以“--工具-添加-zip”命令指定的文件不是 .zip 文件。请指定有效的 .zip 文件。</value>
-  </data>
-  <data name="CommandLine_ImportToolsFromZip_Installed_tool__0_" xml:space="preserve">
-    <value>已安装的工具{0}</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Adding__0__spectra_to_the_library__1_" xml:space="preserve">
-    <value>正在添加 {0} 谱图到库 {1}</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Error___line__0___column__1____2_" xml:space="preserve">
-    <value>错误：（行 {0}，列 {1}） {2}</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Error__The_name__0__specified_with__1__was_not_found_in_the_imported_assay_library_" xml:space="preserve">
-    <value>错误：在导入的分析库中未找到以{1}指定的名称{0}。</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Error__There_is_an_existing_library_with_the_same_name__0__as_the_document_library_to_be_created_" xml:space="preserve">
-    <value>错误：存在与将要创建的文档库相同名称{0}的现有库。</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Error__To_create_the_iRT_database___0___for_this_assay_library__you_must_specify_the_iRT_standards_using_either_of_the_arguments__1__or__2_" xml:space="preserve">
-    <value>错误：要为此分析库创建 iRT 数据库“{0}”，您必须使用参数 {1} 或 {2} 指定 iRT 标准</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Finishing_up_import" xml:space="preserve">
-    <value>完成导入</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Importing__0__iRT_values_into_the_iRT_calculator__1_" xml:space="preserve">
-    <value>将{0} iRT 值导入到 iRT 计算器{1}</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Importing_transiton_list__0____" xml:space="preserve">
-    <value>正在导入离子对列表{0}...</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Warning___line__0___column__1____2_" xml:space="preserve">
-    <value>警告：（行 {0}，列 {1}） {2}</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Warning__The_document_is_missing_iRT_standards" xml:space="preserve">
-    <value>警告：文档中缺失 iRT 标准</value>
-  </data>
-  <data name="CommandLine_ImportTransitionList_Warning__The_iRT_calculator_already_contains__0__with_the_value__1___Ignoring__2_" xml:space="preserve">
-    <value>警告：iRT 计算器已经含有有{1}值的{0}。忽视{2}</value>
-  </data>
-  <data name="CommandLine_LogNewEntries_Document_unchanged" xml:space="preserve">
-    <value>文档未更改</value>
-  </data>
-  <data name="CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_document__using___1___instead_" xml:space="preserve">
-    <value>本文档中已经存在重复测定”{0}“，使用”{1}“代替。</value>
-  </data>
-  <data name="CommandLine_NewSkyFile_Deleting_existing_file___0__" xml:space="preserve">
-    <value>正在删除现有文件“{0}”</value>
-  </data>
-  <data name="CommandLine_NewSkyFile_FileAlreadyExists" xml:space="preserve">
-    <value>文件“{0}”已存在；添加 --overwrite 将允许 Skyline 覆盖。</value>
-  </data>
-  <data name="CommandLine_OpenSkyFile_Error__The_Skyline_file__0__does_not_exist_" xml:space="preserve">
-    <value>错误：Skyline 文件{0}不存在。</value>
-  </data>
-  <data name="CommandLine_OpenSkyFile_Error__There_was_an_error_opening_the_file__0_" xml:space="preserve">
-    <value>错误：打开文件{0}出现错误</value>
-  </data>
-  <data name="CommandLine_OpenSkyFile_File__0__opened_" xml:space="preserve">
-    <value>文件{0}已打开。</value>
-  </data>
-  <data name="CommandLine_OpenSkyFile_Opening_file___" xml:space="preserve">
-    <value>文件打开中...</value>
-  </data>
-  <data name="CommandLine_ProcessDocument_Error_saving_file" xml:space="preserve">
-    <value>错误：保存文件时出错</value>
-  </data>
-  <data name="CommandLine_RefineDocument_Refining_document___" xml:space="preserve">
-    <value>正在细化文档...</value>
-  </data>
-  <data name="CommandLine_RemoveImportedFiles__0______1___Note__The_file_has_already_been_imported__Ignoring___" xml:space="preserve">
-    <value>{0} -&gt; {1} 注释：文件已导入。忽视...</value>
-  </data>
-  <data name="CommandLine_Run_Error__Failed_importing_the_file__0____1_" xml:space="preserve">
-    <value>错误：导入文件失败{0}。{1}</value>
-  </data>
-  <data name="CommandLine_SaveFile_Error__The_file_could_not_be_saved_to__0____Check_that_the_directory_exists_and_is_not_read_only_" xml:space="preserve">
-    <value>错误：文件无法保存至{0}。 查看目录存在并且不是只读格式。</value>
-  </data>
-  <data name="CommandLine_SaveFile_File__0__saved_" xml:space="preserve">
-    <value>文件{0}已保存。</value>
-  </data>
-  <data name="CommandLine_SetLibrary_Error__Cannot_set_library_name_without_path_" xml:space="preserve">
-    <value>错误：无法在没有路径的情况下设定库名称。</value>
-  </data>
-  <data name="CommandLine_SetLibrary_Error__The_file__0__does_not_exist_" xml:space="preserve">
-    <value>错误：文件{0}不存在。</value>
-  </data>
-  <data name="CommandLine_SetLibrary_Error__The_file__0__is_not_a_supported_spectral_library_file_format_" xml:space="preserve">
-    <value>错误：文件{0}不是支持的谱图库文件格式。</value>
-  </data>
-  <data name="CommandLine_SetLibrary_Error__The_library_you_are_trying_to_add_conflicts_with_a_library_already_in_the_file_" xml:space="preserve">
-    <value>错误：您试图添加的库与文件中已经存在的库发生冲突。</value>
-  </data>
-  <data name="CommandLine_ShowLibraryMissingExternalSpectraError_Description" xml:space="preserve">
-    <value>使用参数 --import-search-prefer-embedded-spectra 强制建库以使用嵌入的谱图，或将原始谱图文件放在上面列出的其中一个目录并重新运行。</value>
-  </data>
-  <data name="CommandLineTest_ConsoleAddFastaTest_Error" xml:space="preserve">
-    <value>错误</value>
-  </data>
-  <data name="CommandLineTest_ConsoleAddFastaTest_Warning" xml:space="preserve">
-    <value>警告</value>
-  </data>
-  <data name="CommandLineTest_ConsolePathCoverage_successfully_" xml:space="preserve">
-    <value>成功。</value>
-    <comment>Context: something finished "successfully".</comment>
-  </data>
-  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
-    <value>错误：</value>
-  </data>
-  <data name="Comment" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\comment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="CompareElement_CompareElement__Compare____" xml:space="preserve">
-    <value>&lt;比较…&gt;</value>
-  </data>
-  <data name="ComparePeakBoundaries_ComputeMatches_Documents_have_different_number_of_transition_groups___0__vs__1__" xml:space="preserve">
-    <value>文档具有不同的离子对群组数目，{0} 对比 {1}。</value>
-  </data>
-  <data name="ComparePeakBoundaries_ComputeMatches_Number_of_results_in_transition_group__0__does_not_match_between_the_two_documents" xml:space="preserve">
-    <value>离子对群组{0}中的结果数目在两个文档之间不匹配</value>
-  </data>
-  <data name="ComparePeakBoundaries_GenerateComparison_Missing_q_value_for_peptide__0__of_file__1_" xml:space="preserve">
-    <value>缺失针对文件{1}中肽段{0}的 q 值</value>
-  </data>
-  <data name="ComparePeakPickingDlg_ComparePeakPickingDlg_Fraction_of_Manual_ID_s" xml:space="preserve">
-    <value>手动 ID 的部分</value>
-  </data>
-  <data name="ComparePeakPickingDlg_SaveData_Save_Model_Comparison_Data" xml:space="preserve">
-    <value>保存模型比较数据</value>
-  </data>
-  <data name="ComparePeakPickingDlg_SaveGraph_Either_the_ROC_or_Q_q_plot_tab_must_be_selected_to_save_a_graph_" xml:space="preserve">
-    <value>ROC 或 Q-q 图标签必须被选择，以保存图形。</value>
-  </data>
-  <data name="ComparePeakPickingDlg_SaveGraph_Save_Model_Comparison_Graph" xml:space="preserve">
-    <value>保存模型比较图</value>
-  </data>
-  <data name="ConfigureToolsDlg_Cancel_Do_you_wish_to_Save_changes_" xml:space="preserve">
-    <value>您是否想要保存更改？</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool__The_command_for__0__may_not_exist_in_that_location__Would_you_like_to_edit_it__" xml:space="preserve">
-    <value>针对{0}的命令可能不存在于那个位置。您是否想要编辑它？</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_if_you_would_like_the_command_to_launch_a_link__make_sure_to_include_http____or_https___" xml:space="preserve">
-    <value>如果您想要此命令来启动一个链接，请确保包含 http:// 或 https://</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_Supported_Types___1_" xml:space="preserve">
-    <value>支持类型：{1}</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_The_command_cannot_be_blank__please_enter_a_valid_command_for__0_" xml:space="preserve">
-    <value>命令不得为空。请针对{0}输入一个有效的命令</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_The_command_for__0__must_be_of_a_supported_type" xml:space="preserve">
-    <value>针对{0}的命令必须是支持的类型。</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassTool_You_must_enter_a_valid_title_for_the_tool" xml:space="preserve">
-    <value>您必须针对工具输入一个有效的标题。</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassToolInternal_" xml:space="preserve">
-    <value>$(ToolDir) 不是针对未安装之工具的有效宏，因此没有工具目录。</value>
-  </data>
-  <data name="ConfigureToolsDlg_CheckPassToolInternal__ToolDir__is_not_a_valid_macro_for_a_tool_that_was_not_installed_and_therefore_does_not_have_a_Tool_Directory_" xml:space="preserve">
-    <value>$(ToolDir) 不是针对未安装之工具的有效宏，因此没有工具目录。</value>
-  </data>
-  <data name="ConfigureToolsDlg_CopyinFile_A_file_named_0_already_exists_that_isn_t_identical_to_the_one_for_tool__1" xml:space="preserve">
-    <value>名为{0}的文件已经存在，它与针对工具{1}的文件不同</value>
-  </data>
-  <data name="ConfigureToolsDlg_CopyinFile_Missing_the_file_0_Tool_1_Import_Failed" xml:space="preserve">
-    <value>缺少文件{0}。工具({1})导入失败</value>
-  </data>
-  <data name="ConfigureToolsDlg_CopyinFile_Not_importing_this_tool" xml:space="preserve">
-    <value>未导入此工具…</value>
-  </data>
-  <data name="ConfigureToolsDlg_GetTitle__New_Tool_0__" xml:space="preserve">
-    <value>[新工具{0}]</value>
-  </data>
-  <data name="ConfigureToolsDlg_GetZipFromWeb_Error_connecting_to_the_Tool_Store___0_" xml:space="preserve">
-    <value>连接至工具商店出错：{0}</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_overwrite_or_install_in_parallel_" xml:space="preserve">
-    <value>您是否想要覆盖或并行安装？</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_overwrite_with_the_older_version__0__or_install_in_parallel_" xml:space="preserve">
-    <value>您想要使用较早版本 {0} 覆盖还是并行安装？</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_reinstall_or_install_in_parallel_" xml:space="preserve">
-    <value>您是否想要重新安装或并行安装？</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_upgrade_to__0__or_install_in_parallel_" xml:space="preserve">
-    <value>您是否想要升级至{0}或并行安装？</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_The_tool__0__is_already_installed_" xml:space="preserve">
-    <value>工具{0}已安装。</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_The_tool__0__is_currently_installed_" xml:space="preserve">
-    <value>工具{0}当前已安装。</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_This_installation_would_modify_the_report_titled__0_" xml:space="preserve">
-    <value>此安装将修饰标题为{0}的报告</value>
-  </data>
-  <data name="ConfigureToolsDlg_OverwriteOrInParallel_This_is_an_older_installation_v_0__of_the_tool__1_" xml:space="preserve">
-    <value>这是工具{1}的较早安装版本 {0}</value>
-  </data>
-  <data name="ConfigureToolsDlg_PopulateMacroDropdown_File_path_to_a_temporary_report" xml:space="preserve">
-    <value>通向临时报告的文件路径</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Do_you_want_to_continue_" xml:space="preserve">
-    <value>您是否想要继续？</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Error_deleting_the_directory_of_the_existing_tool__Please_close_anything_using_that_directory_and_try_the_overwriting_import_again_later" xml:space="preserve">
-    <value>删除现有工具目录出错。请关闭使用该目录的所有内容并且稍候再次尝试覆盖导入</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Failed_attempting_to_extract_the_tool_from__0_" xml:space="preserve">
-    <value>尝试从{0}提取工具失败</value>
-  </data>
-  <data name="ConfigureToolsDlg_unpackZipTool_Failed_to_read_file_0_The_tool_described_failed_to_import" xml:space="preserve">
-    <value>读取文件{0}失败。描述的工具导入失败。</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_In_Parallel" xml:space="preserve">
-    <value>并行</value>
-  </data>
-  <data name="ConfigureToolsDlg_unpackZipTool_Invalid_Tool_Description_in_file__0__" xml:space="preserve">
-    <value>文件{0}中的无效工具描述。</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Overwrite" xml:space="preserve">
-    <value>覆盖</value>
-  </data>
-  <data name="ConfigureToolsDlg_unpackZipTool_skipping_that_tool_" xml:space="preserve">
-    <value>跳过该工具。</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_There_is_a_naming_conflict__You_already_installed_a_tool_from_a_zip_folder_with_the_name__0___Would_you_like_to_overwrite_or_install_in_parallel_" xml:space="preserve">
-    <value>出现命名冲突。您已经从压缩文件夹内使用名称{0}安装一个工具。您是否想要覆盖或并行安装？</value>
-  </data>
-  <data name="ConfigureToolsDlg_unpackZipTool_Title_and_Command_are_required" xml:space="preserve">
-    <value>需要标题和命令</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Warning__overwriting_will_delete_the_following_tools_" xml:space="preserve">
-    <value>警告，覆盖将删除下列工具：</value>
-  </data>
-  <data name="ConfigureToolsDlg_UnpackZipTool_Warning__overwriting_will_delete_the_tool__0___Do_you_want_to_continue_" xml:space="preserve">
-    <value>警告，覆盖将删除工具{0}。您是否想要继续？</value>
-  </data>
-  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Copy_Bitmap" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Copy_Bitmap.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="CopyEmfToolStripMenuItem_CopyEmfToolStripMenuItem_Copy_Metafile" xml:space="preserve">
-    <value>复制图元文件</value>
-  </data>
-  <data name="CopyGraphDataToolStripMenuItem_CopyGraphData_Failed_setting_data_to_clipboard" xml:space="preserve">
-    <value>向剪切板设定数据失败。</value>
-  </data>
-  <data name="CopyGraphDataToolStripMenuItem_CopyGraphDataToolStripMenuItem_Copy_Data" xml:space="preserve">
-    <value>复制数据</value>
-  </data>
-  <data name="CopyPasteTest_DoTest_Could_not_read_the_pasted_transition_list___Transition_list_must_be_in_separated_columns_and_cannot_contain_blank_lines_" xml:space="preserve">
-    <value>无法读取粘贴的离子对。 离子对必须在单独列中并且不能包含空行。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_BrowseDb_The_specified_file_is_not_a_valid_iRT_database_" xml:space="preserve">
-    <value>指定文件不是有效的 iRT 数据库。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_ImportTextFile_Import_Transition_List__iRT_standards_" xml:space="preserve">
-    <value>导入离子对列表（iRT 标准）</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_A_calculator_with_that_name_already_exists___Do_you_want_to_replace_it_" xml:space="preserve">
-    <value>具有该名称的计算器已经存在。 您是否想要替换它？</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_Calculator_name_cannot_be_empty" xml:space="preserve">
-    <value>计算器名称不得为空。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_Error_reading_iRT_standards_transition_list___0_" xml:space="preserve">
-    <value>阅读 iRT 标准离子对列表出现错误：{0}</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_Failed_to_open_the_database_file___0_" xml:space="preserve">
-    <value>打开数据库文件失败：{0}</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_iRT_database_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
-    <value>iRT 数据库字段必须包括至有效文件的路径。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_iRT_database_field_must_not_be_empty_" xml:space="preserve">
-    <value>iRT 数据库字段不得为空。</value>
-  </data>
-  <data name="CreateIrtCalculatorDlg_OkDialog_Transition_list_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
-    <value>离子对列表字段必须包含至有效文件的路径。</value>
-  </data>
-  <data name="CustomIon_DisplayName_Ion" xml:space="preserve">
-    <value>离子</value>
-  </data>
-  <data name="CustomMolecule_DisplayName_Molecule" xml:space="preserve">
-    <value>分子</value>
-  </data>
-  <data name="CustomMolecule_Validate_The_mass__0__of_the_custom_molecule_exceeeds_the_maximum_of__1__" xml:space="preserve">
-    <value>自定义分子质量 {0} 超过 {1} 最大值。</value>
-  </data>
-  <data name="CustomMolecule_Validate_The_mass__0__of_the_custom_molecule_is_less_than_the_minimum_of__1__" xml:space="preserve">
-    <value>自定义分子质量 {0} 小于 {1} 最小值。</value>
-  </data>
-  <data name="Cut" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\cut.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Dash" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Dash.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Database_GetJoinColumn_The_type__0__must_have_a_column_of_type__1_" xml:space="preserve">
-    <value>类型{0}必须具备一列类型{1}</value>
-  </data>
-  <data name="Database_Join_Cannot_join_tables_of_same_type" xml:space="preserve">
-    <value>无法结合同类的表格。</value>
-  </data>
-  <data name="DatabaseNotConnectedException_DatabaseNotConnectedException_The_database_for_the_calculator__0__could_not_be_opened__Check_that_the_file__1__was_not_moved_or_deleted" xml:space="preserve">
-    <value>针对计算器{0}的数据库无法被打开。检查文件{1}未被移动或删除。</value>
-  </data>
-  <data name="DataboundGridControl_GetClusteredResults_An_error_occured_while_performing_clustering_" xml:space="preserve">
-    <value>执行去簇时出错。</value>
-  </data>
-  <data name="DataboundGridControl_GetClusteredResults_Unable_to_choose_a_set_of_columns_to_use_for_hierarchical_clustering_" xml:space="preserve">
-    <value>无法选择一组用于层次去簇的列。</value>
-  </data>
-  <data name="DataProcessing" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\dataprocessing.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DDASearchControl_SearchProgress_Search_canceled" xml:space="preserve">
-    <value>搜索取消。</value>
-  </data>
-  <data name="DDASearchControl_SearchProgress_Search_done" xml:space="preserve">
-    <value>搜索完成。</value>
-  </data>
-  <data name="DecoyGeneration_SHUFFLE_SEQUENCE_Shuffle_Sequence" xml:space="preserve">
-    <value>随机序列</value>
-  </data>
-  <data name="Delete" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\delete.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Demultiplexer_GetDeconvRegionsForMz_TheIsolationSchemeIsInconsistentlySpecified" xml:space="preserve">
-    <value>全扫描设置中的分离方案方案说明不一致。</value>
-  </data>
-  <data name="DetectionHistogramPane_Tooltip_Count" xml:space="preserve">
-    <value>{0} 计数</value>
-  </data>
-  <data name="DetectionHistogramPane_Tooltip_ReplicateCount" xml:space="preserve">
-    <value>重复测定计数</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_AllCount" xml:space="preserve">
-    <value>所有计数</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_Count" xml:space="preserve">
-    <value>{0} 计数</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_CumulativeCount" xml:space="preserve">
-    <value>累积计数</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_QMedian" xml:space="preserve">
-    <value>Q 值中位数的 -log10</value>
-  </data>
-  <data name="DetectionPlotPane_Tooltip_Replicate" xml:space="preserve">
-    <value>重复测定</value>
-  </data>
-  <data name="DigestHelper_Digest_Digesting__0__proteome_with__1__" xml:space="preserve">
-    <value>借助{1}消化 {0} 个蛋白质组</value>
-  </data>
-  <data name="DigestSettings_Validate_maximum_missed_cleavages" xml:space="preserve">
-    <value>最大遗漏的酶解位点数</value>
-  </data>
-  <data name="DigestSettings_ValidateIntRange_The_value__1__for__0__must_be_between__2__and__3__" xml:space="preserve">
-    <value>针对{0}的值 {1} 必须在 {2} 和 {3} 之间。</value>
-  </data>
-  <data name="directoryicon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\directoryicon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DisplayEquation_N_A" xml:space="preserve">
-    <value>不适用</value>
-  </data>
-  <data name="DocumentAnnotations_AnnotationsNotSupported_The_element___0___cannot_have_annotations_" xml:space="preserve">
-    <value>元素“{0}”不能有注释。</value>
-  </data>
-  <data name="DocumentGridViewContext_Delete_Are_you_sure_you_want_to_delete_the__0____1___" xml:space="preserve">
-    <value>您是否确定想要删除 {0}“{1}”？</value>
-    <comment>Example: Are you sure you want to delete the protein 'ALDH'?</comment>
-  </data>
-  <data name="DocumentGridViewContext_Delete_Are_you_sure_you_want_to_delete_these__0___1__" xml:space="preserve">
-    <value>您是否确定想要删除这些 {0} {1}？</value>
-    <comment>Example: Are you sure you want to delete these 27 proteins?</comment>
-  </data>
-  <data name="down_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\down-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DriftTimePredictor_Validate_Resolving_power_must_be_greater_than_0_" xml:space="preserve">
-    <value>分辨力必须大于 0。</value>
-  </data>
-  <data name="DriftTimeWindowWidthCalculator_Validate_Fixed window_width_must_be_non_negative_" xml:space="preserve">
-    <value>固定窗口宽度必须为非负数。</value>
-  </data>
-  <data name="DriftTimeWindowWidthCalculator_Validate_Peak_width_must_be_non_negative_" xml:space="preserve">
-    <value>峰宽度不得为负数。</value>
-  </data>
-  <data name="DropImage" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\dropimage.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="DsvFileReader_ReadLine_Line__0__has__1__fields_when__2__expected_" xml:space="preserve">
-    <value>行 {0} 应有{2}个字段，但仅发现 {1} 个。</value>
-  </data>
-  <data name="Edit_Redo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\edit_redo.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Edit_Undo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\edit_undo.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Edit_Undo_Multiple" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Edit_Undo_Multiple.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="EditCoVDlg_btnOk_Click_Maximum_compensation_voltage_cannot_be_less_than_minimum_compensation_volatage_" xml:space="preserve">
-    <value>最大补偿电压不能小于最小补偿电压。</value>
-  </data>
-  <data name="EditCustomMoleculeDlg_OkDialog_A_precursor_with_that_adduct_and_label_type_already_exists_" xml:space="preserve">
-    <value>已存在带该加合物和标记类型的母离子。</value>
-  </data>
-  <data name="EditCustomMoleculeDlg_OkDialog_Custom_molecules_must_have_a_mass_greater_than_or_equal_to__0__" xml:space="preserve">
-    <value>自定义分子必须拥有比更大的质量或与{0}相等的质量。</value>
-  </data>
-  <data name="EditCustomMoleculeDlg_OkDialog_Custom_molecules_must_have_a_mass_less_than_or_equal_to__0__" xml:space="preserve">
-    <value>自定义分子必须拥有比更小的质量或与{0}相等的质量。</value>
-  </data>
-  <data name="EditCustomMoleculeDlg_OkDialog_Please_specify_the_ion_mobility_units_" xml:space="preserve">
-    <value>请指定离子迁移率单位。</value>
-  </data>
-  <data name="EditEnzymeDlg_OnClosing_The_enzyme__0__already_exists" xml:space="preserve">
-    <value>酶“{0}”已经存在。</value>
-  </data>
-  <data name="EditEnzymeDlg_ValidateAATextBox__0__must_contain_at_least_one_amino_acid" xml:space="preserve">
-    <value>{0}必须至少包含一个氨基酸。</value>
-  </data>
-  <data name="EditEnzymeDlg_ValidateAATextBox_The_character__0__is_not_a_valid_amino_acid" xml:space="preserve">
-    <value>字符“{0}”不是有效的氨基酸。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_EditIonMobilityLibraryDlg_Adduct" xml:space="preserve">
-    <value>加合物</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_OkDialog_Do_you_want_to_change_it_" xml:space="preserve">
-    <value>是否要更改？</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_OkDialog_Please_choose_a_file_for_the_ion_mobility_library" xml:space="preserve">
-    <value>请为离子迁移库选择一个文件。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_OkDialog_Please_use_a_full_path_to_a_file_for_the_ion_mobility_library_" xml:space="preserve">
-    <value>请为离子迁移库使用一个到文件的完整路径。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_UpdateNumPeptides__0__Peptide" xml:space="preserve">
-    <value>{0} 个肽段</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_UpdateNumPeptides__0__Peptides" xml:space="preserve">
-    <value>{0} 个肽段</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateCell_A_value_is_required_" xml:space="preserve">
-    <value>值必填。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateCell_The_entry__0__is_not_valid_" xml:space="preserve">
-    <value>条目 {0} 无效。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_On_line__0___1_" xml:space="preserve">
-    <value>在第 {0} {1} 行上</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_charge__Charges_must_be_integer_values_between_1_and__1__" xml:space="preserve">
-    <value>值 {0} 不是有效电荷。电荷必须是介于 1 和 {1} 之间的整数。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_intercept_" xml:space="preserve">
-    <value>值 {0} 不是有效的截距。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_slope_" xml:space="preserve">
-    <value>值 {0} 不是有效的斜率。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateResolvingPower_Resolving_power_must_be_greater_than_0_" xml:space="preserve">
-    <value>分辨力必须大于 0。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_The_following_ions_have_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
-    <value>以下离子有多个离子迁移值。Skyline 支持多个构象异构体，因此这可能是有意为之。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_The_ion__0__has_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
-    <value>离子 {0} 有多个离子迁移值。Skyline 支持多个构象异构体，因此这可能是有意为之。</value>
-  </data>
-  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_This_list_contains__0__ions_with_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
-    <value>该列表包含 {0} 个离子，且这些离子具有多个离子迁移值。Skyline 支持多个构象异构体，因此这可能是有意为之。</value>
-  </data>
-  <data name="EditIrtCalcDlg_btnBrowseDb_Click_Open_iRT_Database" xml:space="preserve">
-    <value>打开 iRT 数据库</value>
-  </data>
-  <data name="EditIrtCalcDlg_btnCreateDb_Click_Create_iRT_Database" xml:space="preserve">
-    <value>创建 iRT 数据库</value>
-  </data>
-  <data name="EditIrtCalcDlg_comboStandards_SelectedIndexChanged_The_list_of_standard_peptides_must_contain_only_recognized_iRT_C18_standards_to_switch_to_a_predefined_set_of_iRT_C18_standards_" xml:space="preserve">
-    <value>标准肽段列表必须仅包含被认可的 iRT-C18 标准，才能转换到预定义的 iRT-C18 标准集。</value>
-  </data>
-  <data name="EditIrtCalcDlg_CreateDatabase_The_file__0__could_not_be_created" xml:space="preserve">
-    <value>文件{0}无法被创建。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_comboMargins_SelectedIndexChanged_Margin" xml:space="preserve">
-    <value>边距</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_comboMargins_SelectedIndexChanged_Start_margin" xml:space="preserve">
-    <value>起始边距</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_ImportRangesFromFiles_Failed_reading_isolation_scheme_" xml:space="preserve">
-    <value>读取分离方案失败。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_Specify__0__for_isolation_window" xml:space="preserve">
-    <value>针对分离窗口指定{0}。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_Specify_Start_and_End_values_for_at_least_one_isolation_window" xml:space="preserve">
-    <value>针对至少一个分离窗口指定起始和最终值。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_The_isolation_scheme_named__0__already_exists" xml:space="preserve">
-    <value>名为“{0}”的分离方案已经存在。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_The_selected_target_is_not_unique" xml:space="preserve">
-    <value>选定目标并不是独一无二的。</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_OkDialog_There_are_gaps_in_a_single_cycle_of_your_extraction_windows__Do_you_want_to_continue_" xml:space="preserve">
-    <value>在您提取窗口的单一周期内存在间隙。您确定想要继续？</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_ReadIsolationRanges_Missing_isolation_range_for_the_isolation_target__0__m_z_in_the_file__1_" xml:space="preserve">
-    <value>缺失文件 {1} 内的分离目标 {0} 质荷比的分离范围</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_ReadIsolationRanges_No_repeating_isolation_scheme_found_in__0_" xml:space="preserve">
-    <value>未在 {0} 内找到重复的分离方案</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_UpdateIsolationWidths_Isolation_width" xml:space="preserve">
-    <value>分离宽度(&amp;W)：</value>
-  </data>
-  <data name="EditIsolationSchemeDlg_UpdateIsolationWidths_Isolation_widths" xml:space="preserve">
-    <value>分离宽度(&amp;W)：</value>
-  </data>
-  <data name="EditLibraryDlg_OkDialog_The_file__0__is_not_a_supported_spectral_library_file_format" xml:space="preserve">
-    <value>文件{0}不是支持的谱图库文件格式。</value>
-  </data>
-  <data name="EditLink" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\EditLink.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="EditLinkedPeptideDlg_TryMakeLinkedPeptide_The_crosslinker___0___cannot_attach_to_the_amino_acid___1___" xml:space="preserve">
-    <value>交联剂 '{0}' 无法附加到氨基酸 '{1}'。</value>
-  </data>
-  <data name="EditLinkedPeptidesDlg_OkDialog_Some_crosslinked_peptides_are_not_connected_" xml:space="preserve">
-    <value>有些交联肽段未连接。</value>
-  </data>
-  <data name="EditMeasuredIonDlg_OkDialog_Reporter_ion_masses_must_be_greater_than_or_equal_to__0__" xml:space="preserve">
-    <value>报告离子质量必须大于或等于 {0}。</value>
-  </data>
-  <data name="EditOptimizationLibraryDlg_UpdateValueHeader_Collision_Energy" xml:space="preserve">
-    <value>碰撞能量</value>
-  </data>
-  <data name="EditOptimizationLibraryDlg_UpdateValueHeader_Declustering_Potential" xml:space="preserve">
-    <value>去簇电压</value>
-  </data>
-  <data name="EditPeakScoringModelDlg_btnTrainModel_Click_Cannot_train_model_without_either_decoys_or_second_best_peaks_included_" xml:space="preserve">
-    <value>无法在不包含诱饵或次优峰值的情况下训练模型。</value>
-  </data>
-  <data name="EditPeakScoringModelDlg_OkDialog_The_peak_scoring_model__0__already_exists" xml:space="preserve">
-    <value>峰排名模型{0}已经存在</value>
-  </data>
-  <data name="EditPeakScoringModelDlg_SelectedModelItem_Invalid_Model_Selection" xml:space="preserve">
-    <value>无效的模型选择。</value>
-  </data>
-  <data name="EditPeakScoringModelDlg_TrainModel_Calculating_score_contributions" xml:space="preserve">
-    <value>正在计算得分贡献</value>
-  </data>
-  <data name="EditRemoteAccountDlg_TestSettings_Error_connecting_to_server__" xml:space="preserve">
-    <value>连接服务器出错：</value>
-  </data>
-  <data name="EditServerDlg_OkDialog_The_server__0__already_exists_" xml:space="preserve">
-    <value>服务器“{0}”已经存在。</value>
-  </data>
-  <data name="EditServerDlg_OkDialog_The_text__0__is_not_a_valid_server_name_" xml:space="preserve">
-    <value>文本“{0}”不是有效的服务器名称。</value>
-  </data>
-  <data name="EmptyList" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\EmptyList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_could_not_find_EncyclopeDia" xml:space="preserve">
-    <value>找不到 EncyclopeDIA</value>
-  </data>
-  <data name="EncyclopeDiaHelpers_GenerateLibrary_Combining_chromatogram_libraries" xml:space="preserve">
-    <value>正在组合谱图库</value>
-  </data>
-  <data name="EncyclopeDiaHelpers_GenerateLibrary_Combining_quantification_libraries" xml:space="preserve">
-    <value>正在组合定量库</value>
-  </data>
-  <data name="EncyclopeDiaHelpers_GenerateLibrary_Running_command___0___1_" xml:space="preserve">
-    <value>正在运行命令:{0} {1}</value>
-  </data>
-  <data name="EncyclopeDiaSearchDlg_Browse_for_Narrow_Window_Results_Files" xml:space="preserve">
-    <value>浏览窄窗口结果文件</value>
-  </data>
-  <data name="EncyclopeDiaSearchDlg_Browse_For_Wide_Window_Results_Files" xml:space="preserve">
-    <value>浏览宽窗口结果文件</value>
-  </data>
-  <data name="Error___0_" xml:space="preserve">
-    <value>错误：{0}</value>
-  </data>
-  <data name="Expand" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\plus.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="ExportChromatogramDlg_OkDialog_At_least_one_chromatogram_type_must_be_selected" xml:space="preserve">
-    <value>必须至少选定一个色谱图类型。</value>
-  </data>
-  <data name="ExportChromatogramDlg_OkDialog_At_least_one_file_must_be_selected" xml:space="preserve">
-    <value>必须至少选定一个文件</value>
-  </data>
-  <data name="ExportMethodDlg_btnBrowseTemplate_Click__0__Method" xml:space="preserve">
-    <value>{0}方法</value>
-    <comment>Instrument type name Method</comment>
-  </data>
-  <data name="ExportMethodDlg_btnBrowseTemplate_Click_Method_Template" xml:space="preserve">
-    <value>方法模板</value>
-  </data>
-  <data name="ExportMethodDlg_comboTargetType_SelectedIndexChanged_Scheduled_methods_are_not_yet_supported_for_DIA_acquisition" xml:space="preserve">
-    <value>非数据依赖 (DIA) 采集不支持预定方法。</value>
-  </data>
-  <data name="ExportMethodDlg_comboTargetType_SelectedIndexChanged_To_export_a_scheduled_list_you_must_first_choose_a_retention_time_predictor_in_Peptide_Settings_Prediction_or_import_results_for_all_peptides_in_the_document" xml:space="preserve">
-    <value>如要导出预定方法，您必须首先在肽段设置/预测中选择一个保留时间预测器，或者在文档中导入针对所有肽段的结果。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_Compensation_Voltage_" xml:space="preserve">
-    <value>补偿电压：</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_Compensation_voltage_optimization_should_be_run_on_one_transition_per_peptide__and_the_best_transition_cannot_be_determined_for_the_following_precursors_" xml:space="preserve">
-    <value>应对每个母离子的一个离子对运行补偿电压最优化。无法确定以下母离子的最佳离子对：</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_Export_of_DIA_method_is_not_supported_for__0__" xml:space="preserve">
-    <value>DIA 导出方法针对{0}未获得支持。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_The_DIA_isolation_list_must_have_prespecified_windows_" xml:space="preserve">
-    <value>DIA 分离列表一定有预先设定的窗口。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_The_precursor_mass_analyzer_type_is_not_set_to__0__in_Transition_Settings_under_the_Full_Scan_tab" xml:space="preserve">
-    <value>母离子质量分析器类型在“离子对设置”（在“全扫描”标签下）中未设定为{0}。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_You_are_missing_fine_tune_optimized_compensation_voltages_" xml:space="preserve">
-    <value>您缺失了精细调谐最优补偿电压。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_You_are_missing_fine_tune_optimized_compensation_voltages_for_the_following_" xml:space="preserve">
-    <value>您缺失了对于以下的精细调谐最优补偿电压：</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_You_have_only_rough_tune_optimized_compensation_voltages_" xml:space="preserve">
-    <value>您只有粗略调谐最优补偿电压。</value>
-  </data>
-  <data name="ExportMethodDlg_OkDialog_Your_document_does_not_contain_compensation_voltage_results__but_compensation_voltage_is_set_under_transition_settings_" xml:space="preserve">
-    <value>您的文档不含有补偿电压结果，但补偿电压已在离子对设置中设置。</value>
-  </data>
-  <data name="ExportMethodDlg_ValidateSettings_Cannot_export_fine_tune_transition_list__The_following_precursors_are_missing_medium_tune_results_" xml:space="preserve">
-    <value>无法导出精细调谐离子对列表。以下母离子缺失中等调谐结果：</value>
-  </data>
-  <data name="ExportMethodDlg_ValidateSettings_Cannot_export_medium_tune_transition_list__The_following_precursors_are_missing_rough_tune_results_" xml:space="preserve">
-    <value>无法导出中等调谐离子对列表。以下母离子缺失粗略调谐结果：</value>
-  </data>
   <data name="ExportMethodDlg_VerifySchedulingAllowed_The__0__instrument_lacks_support_for_direct_method_export_for_triggered_acquisition_" xml:space="preserve">
     <value>{0}仪器缺少对触发采集的直接方法导出的支持。</value>
-  </data>
-  <data name="ExportMethodDlg_VerifySchedulingAllowed_The_current_document_contains_peptides_without_enough_information_to_rank_transitions_for_triggered_acquisition_" xml:space="preserve">
-    <value>当前文档包含的肽段不具有足够信息，无法对离子对进行排名以触发采集。</value>
-  </data>
-  <data name="ExportMethodDlg_VerifySchedulingAllowed_Triggered_acquistion_requires_a_spectral_library_or_imported_results_in_order_to_rank_transitions_" xml:space="preserve">
-    <value>触发采集需要一个谱图库或导入结果，以排名离子对。</value>
-  </data>
-  <data name="ExportMethodDlg_VerifySchedulingAllowed_You_must_export_a__0__transition_list_and_manually_import_it_into_a_method_file_using_vendor_software_" xml:space="preserve">
-    <value>您必须导出一个{0}离子对列表并使用供应商软件来将其手动导入方法文件。</value>
-  </data>
-  <data name="ExportReportDlg_GetDatabase_Analyzing_document" xml:space="preserve">
-    <value>文档分析中…</value>
-  </data>
-  <data name="ExportReportDlg_GetDatabase_Generating_Report_Data" xml:space="preserve">
-    <value>生成报告数据</value>
-  </data>
-  <data name="ExportReportDlg_GetExceptionDisplayMessage_The_field__0__does_not_exist_in_this_document" xml:space="preserve">
-    <value>字段{0}不存在于本文档中。</value>
-  </data>
-  <data name="ExportReportDlg_OkDialog_Export_Report" xml:space="preserve">
-    <value>导出报告</value>
-  </data>
-  <data name="ExportReportDlg_ShowPreview_An_unexpected_error_occurred_attempting_to_display_the_report___0___" xml:space="preserve">
-    <value>尝试显示报告“{0}”时出现意外错误。</value>
-  </data>
-  <data name="ExportReportDlg_ShowShare_Report_Definitions" xml:space="preserve">
-    <value>报告定义</value>
-  </data>
-  <data name="ExternalTool" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ExternalTool.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="File" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\file.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FileStreamManager_Commit_Could_not_replace_file_" xml:space="preserve">
-    <value>无法替换文件 </value>
-  </data>
-  <data name="Filter" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Filter.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Find" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\find.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FindNext" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\findnext.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Folder" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\folder.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Fragment" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Fragment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FragmentDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\FragmentDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FragmentLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\fragmentlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FragmentLibDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\FragmentLibDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="FullScanAcquisitionExtension_LOCALIZED_VALUES_DIA" xml:space="preserve">
-    <value>DIA</value>
-  </data>
-  <data name="FullScanAcquisitionExtension_LOCALIZED_VALUES_Targeted" xml:space="preserve">
-    <value>定向的</value>
-  </data>
-  <data name="FullScanAcquisitionMethod_DDA_DDA" xml:space="preserve">
-    <value>DDA</value>
-  </data>
-  <data name="GenerateDecoys" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\GenerateDecoys.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="GenerateDecoysDlg_GenerateDecoysDlg_All" xml:space="preserve">
-    <value>全部</value>
-  </data>
-  <data name="GenerateDecoysError_No_peptide_precursor_models_for_decoys_were_found_" xml:space="preserve">
-    <value>未找到针对诱饵的肽段母离子模型。</value>
-  </data>
-  <data name="GenericState_AppendErrorAndUri_URL___0_" xml:space="preserve">
-    <value>URL: {0}</value>
-  </data>
-  <data name="GraphChromatogram_DisplayOptimizationTotals_No_optimization_data_available" xml:space="preserve">
-    <value>无可用的最优化数据。</value>
-  </data>
-  <data name="GraphData_AddRegressionLabel_window" xml:space="preserve">
-    <value>窗口</value>
-    <comment>In RTLinearRegressionGraphPane</comment>
-  </data>
-  <data name="GraphData_GraphResiduals_Time_from_Regression" xml:space="preserve">
-    <value>回归的时间</value>
-  </data>
-  <data name="GraphFullScan_CreateGraph__0_____1_F2__min_" xml:space="preserve">
-    <value>{0}（{1:F2} 分钟）</value>
-    <comment>"min" stands for "minutes"</comment>
-  </data>
-  <data name="GraphFullScan_CreateGraph_CE_" xml:space="preserve">
-    <value>NCE：</value>
-  </data>
-  <data name="GraphFullScan_CreateGraph_IM__0_" xml:space="preserve">
-    <value>IM={0}</value>
-    <comment>"IM" stands for "Ion Mobility" - used for displaying ion mobility in raw scan view</comment>
-  </data>
-  <data name="GraphFullScan_CreateGraph_IM_Scan_Range_" xml:space="preserve">
-    <value>IM Scan 范围：</value>
-  </data>
-  <data name="GraphFullScan_CreateGraph_Scan_Number_" xml:space="preserve">
-    <value>扫描编号：</value>
-  </data>
-  <data name="GraphFullScan_CreateIonMobilityHeatmap_Quadrupole_Scan_Range__m_z_" xml:space="preserve">
-    <value>四极杆扫描范围 (质荷比)</value>
-  </data>
-  <data name="GraphSpectrum_MassErrorFormat_ppm" xml:space="preserve">
-    <value>{0}{1} ppm</value>
-  </data>
-  <data name="GraphSpectrum_UpdateUI_Multiple_charge_states_with_library_spectra" xml:space="preserve">
-    <value>带有库谱图的多个电荷态</value>
-  </data>
-  <data name="GraphSummary_UpdateToolbar_All" xml:space="preserve">
-    <value>全部</value>
-  </data>
-  <data name="GreenCheck" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\GreenCheck.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_End" xml:space="preserve">
-    <value>结束</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_End_margin" xml:space="preserve">
-    <value>终止边距</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_none" xml:space="preserve">
-    <value>无</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_Start" xml:space="preserve">
-    <value>开始</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_Start_margin" xml:space="preserve">
-    <value>起始边距</value>
-  </data>
-  <data name="GridColumnsExtension_getDefaultLanguageValues_Target" xml:space="preserve">
-    <value>目标</value>
-  </data>
-  <data name="GridViewDriver_GetValue_An_invalid_number__0__was_specified_for__1__2__" xml:space="preserve">
-    <value>无效数字（“{0}”）针对{1} {2}指定。</value>
-  </data>
-  <data name="GridViewDriver_GridView_DataError__0__must_be_a_valid_number" xml:space="preserve">
-    <value>{0} 必须是有效的数字。</value>
-  </data>
-  <data name="GridViewDriver_ValidateRow_On_line__0__1__" xml:space="preserve">
-    <value>在第{0}, {1}行 上</value>
-    <comment>Line refers to line of document</comment>
-  </data>
-  <data name="GroupByItem_ToString_Replicates" xml:space="preserve">
-    <value>重复测定</value>
-  </data>
-  <data name="HeatMapGraph_RefreshData_Heat_Map" xml:space="preserve">
-    <value>热图</value>
-  </data>
-  <data name="Helpers_AssumeValue_Nullable_was_expected_to_have_a_value" xml:space="preserve">
-    <value>可空预计拥有一个数值。</value>
-  </data>
-  <data name="HomeIcon1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\HomeIcon.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="HtmlFragment_ClipBoardText_From_Clipboard" xml:space="preserve">
-    <value>从剪切板</value>
-  </data>
-  <data name="Icojam-Blueberry-Basic-Arrow-left" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="IIrtRegression_DisplayEquation_iRT" xml:space="preserve">
-    <value>iRT</value>
-  </data>
-  <data name="IIrtRegression_DisplayEquation_Measured_RT" xml:space="preserve">
-    <value>测量的 RT</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_A_maximum_of_one_decoy_per_target_may_be_generated_when_using_reversed_decoys_" xml:space="preserve">
-    <value>在使用反向诱饵时，每个目标最多只能生成一个诱饵。</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Change_digestion_settings" xml:space="preserve">
-    <value>更改酶解设置</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Change_settings" xml:space="preserve">
-    <value>更改设置</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Change_settings_to_add_precursors" xml:space="preserve">
-    <value>更改设置以添加母离子</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Importing_the_FASTA_did_not_create_any_target_proteins_" xml:space="preserve">
-    <value>导入 FASTA 未生成任何目标蛋白质。</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_Please_enter_a_valid_number_of_decoys_per_target_greater_than_0_" xml:space="preserve">
-    <value>请为每个目标输入一个有效的大于 0 的诱饵数字。</value>
-  </data>
-  <data name="ImportFastaControl_ImportFasta_The_document_does_not_contain_any_peptides_" xml:space="preserve">
-    <value>文档不包含任何肽段。</value>
-  </data>
-  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Only_BiblioSpec_libraries_contain_enough_ion_mobility_information_to_support_this_operation_" xml:space="preserve">
-    <value>只有 BiblioSpec 库包含支持该操作的足够离子迁移信息。</value>
-  </data>
-  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_choose_a_non_redundant_library_" xml:space="preserve">
-    <value>请选择一个非冗余库。</value>
-  </data>
-  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_specify_a_path_to_an_existing_spectral_library" xml:space="preserve">
-    <value>请指定一个对应到现有谱图库的路径。</value>
-  </data>
-  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_specify_a_path_to_an_existing_spectral_library_" xml:space="preserve">
-    <value>请指定一个对应到现有谱图库的路径。</value>
-  </data>
-  <data name="ImportPeptideSearchDlg_ImportPeptideSearchDlg_MS_MS_full_scan_settings_were_configured__please_verify_or_change_your_current_full_scan_settings_" xml:space="preserve">
-    <value>MS/MS 全扫描设置已被配置，请验证或更改您当前的全扫描设置。</value>
-  </data>
-  <data name="ImportPeptideSearchDlg_NextPage_Please_check_your_peptide_search_pipeline_or_contact_Skyline_support_to_ensure_retention_times_appear_in_your_spectral_libraries_" xml:space="preserve">
-    <value>请查看您的肽段搜索管道或联络 Skyline 支持，以确保保留时间出现在您的谱图库中。</value>
-  </data>
-  <data name="ImportPeptideSearchDlg_NextPage_The_document_specific_spectral_library_does_not_have_valid_retention_times_" xml:space="preserve">
-    <value>特定于文件的谱图库没有有效的保留时间。</value>
-  </data>
-  <data name="ImportPeptideSearchManager_LoadBackground_The_current_peak_scoring_model_is_incompatible_with_one_or_more_peptides_in_the_document_" xml:space="preserve">
-    <value>当前的峰得分模型与文档中的一个或多个肽段不兼容。</value>
-  </data>
-  <data name="ImportResultsControl_FindDataFiles_An_error_occurred_attempting_to_find_missing_result_files_in__0__" xml:space="preserve">
-    <value>尝试在{0}中查找缺失结果文件时发生错误。</value>
-  </data>
-  <data name="ImportResultsControl_FindDataFiles_Searching_for_missing_result_files_in__0__" xml:space="preserve">
-    <value>在{0}中搜索缺失结果文件。</value>
-  </data>
-  <data name="ImportResultsControl_FindResultsFiles_An_error_occurred_attempting_to_find_results_files_" xml:space="preserve">
-    <value>尝试查找结果文件时出错。</value>
-  </data>
-  <data name="ImportResultsControl_FindResultsFiles_Searching_for_matching_results_files_in__0__" xml:space="preserve">
-    <value>在{0}中搜索匹配结果文件。</value>
-  </data>
-  <data name="ImportResultsControl_FindResultsFiles_Searching_for_Results_Files" xml:space="preserve">
-    <value>搜索结果文件</value>
-  </data>
-  <data name="ImportResultsDlg_DefaultNewName_Default_Name" xml:space="preserve">
-    <value>色谱图</value>
-    <comment>Default replicate name</comment>
-  </data>
-  <data name="ImportResultsDlg_GetDataSourcePathsFile_No_results_files_chosen" xml:space="preserve">
-    <value>未选择任何结果文件。</value>
-  </data>
-  <data name="ImportSkyrHelper_ResolveImportConflicts_Resolving_conflicts_by_overwriting_" xml:space="preserve">
-    <value>通过覆盖来解决冲突。</value>
-  </data>
-  <data name="ImportSkyrHelper_ResolveImportConflicts_Resolving_conflicts_by_skipping_" xml:space="preserve">
-    <value>通过跳过来解决冲突。</value>
   </data>
   <data name="ImportSkyrHelper_ResolveImportConflicts_Use_command" xml:space="preserve">
     <value>错误：请指定一种方法来解决冲突。使用命令“--报告-冲突-分辨率=&amp;lt; 覆盖 | 跳过 &gt;”。</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_AssociateProteins_These_filters_cannot_be_applied_as_they_would_result_in_an_empty_transition_list." xml:space="preserve">
-    <value>不能应用这些过滤器，因为它们会导致出现空的离子对列表。</value>
+  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_Python__0__and_the_following_packages__Select_packages_to_install_and_then_click_Install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>本工具需要 Python{0}和下列软件包。选择将要安装的软件包，然后单击“安装”以开始安装过程。</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Explicit_Declustering_Potential" xml:space="preserve">
-    <value>明确的去簇电压</value>
+  <data name="SkypDownloadException_GetMessage_Would_you_like_to_add__0__as_a_Panorama_server_in_Skyline_" xml:space="preserve">
+    <value>您想在 Skyline 中添加 {0} 作为 Panorama 服务器吗?</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_List_Name" xml:space="preserve">
-    <value>分子列表名称</value>
+  <data name="FragmentLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\fragmentlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_Name" xml:space="preserve">
-    <value>分子名称</value>
+  <data name="ReportSpecList_Title_Edit_Reports" xml:space="preserve">
+    <value>编辑报告</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Reassigning_the_Protein_Name_column_will_prevent_the_peptides_from_being_associated_with_proteins_from_the_background_proteome." xml:space="preserve">
-    <value>重新分配蛋白质名称列将防止肽段与背景蛋白质组中的蛋白质相关联。</value>
+  <data name="ImportPeptideSearchDlg_NextPage_The_document_specific_spectral_library_does_not_have_valid_retention_times_" xml:space="preserve">
+    <value>特定于文件的谱图库没有有效的保留时间。</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_headerList_Molecular_Formula" xml:space="preserve">
-    <value>分子式</value>
+  <data name="CommandLine_ConnectLibrarySpecs_Warning__Could_not_find_the_spectral_library__0_" xml:space="preserve">
+    <value>警告：无法找到谱图库{0}</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Decoy" xml:space="preserve">
-    <value>诱饵</value>
+  <data name="CommandLine_MakeReplicateNamesUnique_Replicate___0___already_exists_in_the_document__using___1___instead_" xml:space="preserve">
+    <value>本文档中已经存在重复测定”{0}“，使用”{1}“代替。</value>
   </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Fragment_Name" xml:space="preserve">
-    <value>片段名称</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column" xml:space="preserve">
-    <value>忽略列</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Label_Type" xml:space="preserve">
-    <value>标记类型</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence" xml:space="preserve">
-    <value>肽段修饰序列</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_Charge" xml:space="preserve">
-    <value>母离子电荷</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z" xml:space="preserve">
-    <value>母离子质荷比</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z" xml:space="preserve">
-    <value>子离子质荷比</value>
-  </data>
-  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Protein_Name" xml:space="preserve">
-    <value>蛋白质名称</value>
-  </data>
-  <data name="ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_" xml:space="preserve">
-    <value>无法导入此离子对列表，因为它未为以下对象提供值：</value>
-  </data>
-  <data name="IncompleteStandardException_IncompleteStandardException_The_calculator__0__requires_all_of_its_standard_peptides_in_order_to_determine_a_regression" xml:space="preserve">
-    <value>计算器{0}需要所有标准肽段以确定回归。</value>
-  </data>
-  <data name="InstrumentInfoUtil_ReadInstrumentConfig_Unexpected_line_in_instrument_config__0__" xml:space="preserve">
-    <value>仪器配置中的意外行：{0}</value>
-  </data>
-  <data name="IonMobilityDb_GetIonMobilityDb_Please_provide_a_path_to_an_existing_ion_mobility_library_" xml:space="preserve">
-    <value>请为现有的离子迁移库提供一个路径。</value>
-  </data>
-  <data name="IonMobilityDb_GetIonMobilityDb_The_file__0__is_not_a_valid_ion_mobility_library_file_" xml:space="preserve">
-    <value>文件{0}不是有效的离子迁移库文件。</value>
-  </data>
-  <data name="IonMobilityDb_GetIonMobilityDb_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
-    <value>离子迁移库文件{0}无法找到。可能您没有足够的权限来创建它？</value>
-  </data>
-  <data name="IonMobilityFilter_IonMobilityUnitsString_Drift_Time__ms_" xml:space="preserve">
-    <value>漂移时间 （毫秒）</value>
-  </data>
-  <data name="IonMobilityFinder_ProcessMSLevel_Failed_using_results_to_populate_ion_mobility_library_" xml:space="preserve">
-    <value>使用结果填充离子迁移库失败：</value>
-  </data>
-  <data name="IonMobilityLibraryList_AcceptList_will_be_deleted_because_the_libraries_they_depend_on_have_changed__Do_you_want_to_continue_" xml:space="preserve">
-    <value>将被删除，因为其依靠的库已发生改变。您是否想要继续？</value>
-  </data>
-  <data name="IonMobilityPredictor_Validate_Ion_mobility_predictors_using_an_ion_mobility_library_must_include_per_charge_regression_values_" xml:space="preserve">
-    <value>使用离子迁移库的离子迁移预测器必须包含基于每个电荷的回归值。</value>
-  </data>
-  <data name="IonMobilityTest_TestGetIonMobilityDBErrorHandling_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
-    <value>离子迁移库文件{0}无法找到。可能您没有足够的权限来创建它？</value>
-  </data>
-  <data name="Ions_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_1.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_2.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_A" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_A.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_B" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_B.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_C" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_C.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_fragments" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_fragments.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_X" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_X.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_Y" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_Y.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Ions_Z" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Ions_Z.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="IrtDb_GetIrtDb_The_file__0__could_not_be_opened" xml:space="preserve">
-    <value>文件{0}无法被打开。</value>
-  </data>
-  <data name="IrtDb_MakeDocumentXml_iRT_standards" xml:space="preserve">
-    <value>iRT 标准</value>
-  </data>
-  <data name="IrtStandard_DocumentStream_No_document_to_import" xml:space="preserve">
-    <value>没有要导入的文档</value>
-  </data>
-  <data name="IsolationScheme_DoValidate_Special_handling_applies_only_to_prespecified_isolation_windows" xml:space="preserve">
-    <value>特别处理仅适用于预先设定的分离窗口</value>
-  </data>
-  <data name="IsolationScheme_DoValidate_Unexpected_name___0___for__1__isolation_scheme" xml:space="preserve">
-    <value>针对{1}分离方案的意外名称“{0}”</value>
-  </data>
-  <data name="IsolationSchemeList_GetDefaults_SWATH__15_m_z_" xml:space="preserve">
-    <value>SWATH（15 质荷比）</value>
-  </data>
-  <data name="IsolationSchemeList_GetDefaults_SWATH__25_m_z_" xml:space="preserve">
-    <value>SWATH（25 质荷比）</value>
-  </data>
-  <data name="IsolationSchemeList_GetDefaults_SWATH__VW_100_" xml:space="preserve">
-    <value>SWATH (VW 100)</value>
-  </data>
-  <data name="IsolationSchemeList_GetDefaults_SWATH__VW_64_" xml:space="preserve">
-    <value>SWATH (VW 64)</value>
-  </data>
-  <data name="IsolationWindow_DoValidate_Isolation_window_End_must_be_between__0__and__1__" xml:space="preserve">
-    <value>分离窗口“结束”必须在{0}和{1}之间。</value>
-  </data>
-  <data name="IsolationWindow_DoValidate_Isolation_window_margin_must_be_non_negative" xml:space="preserve">
-    <value>分离窗口边距必须是非负数。</value>
-  </data>
-  <data name="IsolationWindow_DoValidate_Isolation_window_margins_cover_the_entire_isolation_window_at_the_extremes_of_the_instrument_range" xml:space="preserve">
-    <value>分离窗口边距在仪器范围的极端覆盖整个分离窗口。</value>
-  </data>
-  <data name="IsolationWindow_DoValidate_Isolation_window_Start_must_be_between__0__and__1__" xml:space="preserve">
-    <value>分离窗口“起始”必须在{0}和{1}之间。</value>
-  </data>
-  <data name="IsotopeDistInfo_IsotopeDistInfo_Minimum_abundance__0__too_high" xml:space="preserve">
-    <value>最小丰度值 {0} 太高</value>
-  </data>
-  <data name="KdeAlignerFactory_ToString_KDE_Aligner" xml:space="preserve">
-    <value>核密度估计校准器</value>
-  </data>
-  <data name="Keep" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\keep.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LabelTypeComboDriver_LoadList_none" xml:space="preserve">
-    <value>无</value>
-  </data>
-  <data name="LabKey" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LabKey.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="LibraryBuildNotificationHandler_AddIrts__0__distinct_CiRT_peptides_were_found__How_many_would_you_like_to_use_as_iRT_standards_" xml:space="preserve">
-    <value>发现 {0} 明显不同的 CiRT 肽段。您想要使用多少作为 iRT 标准？</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddProcessedIrts_A_single_run_does_not_have_high_enough_correlation_to_the_existing_iRT_values_to_allow_retention_time_conversion" xml:space="preserve">
-    <value>单一运行对现有 iRT 值的相关度不够高，无法实现保留时间转换。</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddProcessedIrts_Correlation_to_the_existing_iRT_values_are_not_high_enough_to_allow_retention_time_conversion" xml:space="preserve">
-    <value>对现有 iRT 值的相关度不够高，无法实现保留时间转换。</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddProcessedIrts_None_of__0__runs_were_found_with_high_enough_correlation_to_the_existing_iRT_values_to_allow_retention_time_conversion" xml:space="preserve">
-    <value>所有{0}个运行对现有 iRT 值的相关性都不够高，无法实现保留时间转换。</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddToLibrary_Do_you_want_to_recalibrate_the_iRT_standard_values_relative_to_the_peptides_being_added_" xml:space="preserve">
-    <value>您想要重新校准与添加的肽段有关的 iRT 标准值吗？</value>
-  </data>
-  <data name="LibraryGridViewDriver_AddToLibrary_This_can_improve_retention_time_alignment_under_stable_chromatographic_conditions_" xml:space="preserve">
-    <value>这样可以在稳定的色谱条件下改善保留时间校准。</value>
-  </data>
-  <data name="LibraryGridViewDriver_ValidateMz_Product_m_zs_must_be_greater_than_zero_" xml:space="preserve">
-    <value>子离子质荷比必须大于零。</value>
-  </data>
-  <data name="LibraryManager_LoadBackground_Updating_library_settings_for__0_" xml:space="preserve">
-    <value>正在更新{0}的库设置</value>
-  </data>
-  <data name="Loader_Load_Loading_results_for__0__" xml:space="preserve">
-    <value>针对{0}加载结果</value>
-  </data>
-  <data name="LoadingTooSlowlyException_LoadingTooSlowlyException_Data_import_expected_to_consume__0__minutes_with_maximum_of__1__mintues" xml:space="preserve">
-    <value>导入的数据预计消耗 {0} 分钟，最多 {1} 分钟</value>
-  </data>
-  <data name="LocateFileDlg_LocateFileDlg_Below_is_the_saved_value_for_the_path_to_the_executable" xml:space="preserve">
-    <value>下方是路径向可执行的保存值。</value>
+  <data name="ValidatingIonMobilityPeptide_ValidateCollisionalCrossSection_Measured_collisional_cross_section_values_must_be_valid_decimal_numbers_greater_than_zero_" xml:space="preserve">
+    <value>测量的碰撞横截面值必须是大于零的有效十进制数。</value>
   </data>
   <data name="LocateFileDlg_LocateFileDlg_If_you_have_it_installed_please_provide_the_path_below" xml:space="preserve">
     <value>如果您已安装，请于下方提供路径。</value>
   </data>
-  <data name="LocateFileDlg_LocateFileDlg_Otherwise__please_cancel_and_install__0__version__1__first" xml:space="preserve">
-    <value>否则，请首先取消并安装{0}版本{1}</value>
+  <data name="BuildLibraryDlg_OkWizardPage_Finish" xml:space="preserve">
+    <value>完成</value>
   </data>
-  <data name="LocateFileDlg_LocateFileDlg_Please_verify_and_update_if_incorrect" xml:space="preserve">
-    <value>如果不正确，请验证并更新。</value>
+  <data name="WizardPeptideIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardPeptideIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="LocateFileDlg_LocateFileDlg_then_run_the_tool_again" xml:space="preserve">
-    <value>然后再次运行工具。</value>
+  <data name="Dash" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Dash.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="LocateFileDlg_LocateFileDlg_This_tool_requires_0_version_1" xml:space="preserve">
-    <value>本工具需要{0}版本{1}。</value>
+  <data name="PeptideToMoleculeText_Proteins" xml:space="preserve">
+    <value>蛋白质</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 proteins" to read "2 molecule lists" when non-peptide documents are in use</comment>
   </data>
-  <data name="LocateFileDlg_PathPasses_You_have_not_provided_a_valid_path_" xml:space="preserve">
-    <value>您还未提供有效的路径。</value>
+  <data name="PcaPlot_RefreshData_PCA_Plot" xml:space="preserve">
+    <value>PCA 图</value>
   </data>
-  <data name="LowessAlignerFactory_ToString_LOWESS_Aligner" xml:space="preserve">
-    <value>局部加权回归散点平滑法校准器</value>
-  </data>
-  <data name="magnifier_zoom_in" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\magnifier_zoom_in.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MassErrorReplicateGraphPane_UpdateGraph_Select_a_peptide_to_see_the_mass_error_graph" xml:space="preserve">
-    <value>选择一个肽段，以查看质量误差图</value>
-  </data>
-  <data name="MassListImporter_AddRow_Invalid_iRT_value_at_precusor_m_z__0__for_peptide__1_" xml:space="preserve">
-    <value>肽段{1}在母离子质荷比 {0} 上的无效 iRT 值。</value>
-  </data>
-  <data name="MassListImporter_AddRow_Invalid_library_intensity_at_precursor__0__for_peptide__1_" xml:space="preserve">
-    <value>肽段{1}在母离子{0}上的无效库强度。</value>
-  </data>
-  <data name="MassListImporter_Import_Empty_transition_list" xml:space="preserve">
-    <value>空离子对列表。</value>
-  </data>
-  <data name="MassListImporter_Import_Failed_to_find_peptide_column" xml:space="preserve">
-    <value>未能发现肽段列。</value>
-  </data>
-  <data name="MassListRowReader_CalcPrecursorExplanations_" xml:space="preserve">
-    <value>母离子质荷比 {0} 不匹配最接近的可能值 {1}（增量= {2}），肽段{3}。</value>
-  </data>
-  <data name="MassListRowReader_CalcPrecursorExplanations_Check_the_Instrument_tab_in_the_Transition_Settings" xml:space="preserve">
-    <value>在“离子对设置”中核选“仪器”标签。</value>
-  </data>
-  <data name="MassListRowReader_CalcTransitionExplanations_Product_m_z_value__0__in_peptide__1__has_no_matching_product_ion" xml:space="preserve">
-    <value>肽段{1}中的子离子质荷比值 {0} 无匹配的子离子。</value>
-  </data>
-  <data name="MassListRowReader_CalcTransitionExplanations_The_product_m_z__0__is_out_of_range_for_the_instrument_settings__in_the_peptide_sequence__1_" xml:space="preserve">
-    <value>在肽段序列{1}中，子离子质荷比 {0} 超出仪器设置范围。</value>
-  </data>
-  <data name="MassListRowReader_NextRow_Invalid_peptide_sequence__0__found" xml:space="preserve">
-    <value>发现无效的肽段序列{0}</value>
-  </data>
-  <data name="MatchModificationsControl_AddCheckedModifications_Add_checked_modifications" xml:space="preserve">
-    <value>添加选中的修饰</value>
-  </data>
-  <data name="MatchModificationsControl_AddModification_Add__0__modification__1_" xml:space="preserve">
-    <value>添加{0}修饰{1}</value>
-  </data>
-  <data name="MeasuredCollisionalCrossSection_Validate_Charge_state_values_must_be_greater_than_0_" xml:space="preserve">
-    <value>电荷态值必须大于 0。</value>
-  </data>
-  <data name="MeasuredCollisionalCrossSection_Validate_Collisional_cross_section_values_must_be_greater_than_0_" xml:space="preserve">
-    <value>碰撞横截面值必须大于 0。</value>
-  </data>
-  <data name="MeasuredDriftTimeTable_ValidateMeasuredDriftTimeCellValues_On_line__0___1_" xml:space="preserve">
-    <value>在第{0} {1}行 上</value>
-  </data>
-  <data name="MeasuredPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry" xml:space="preserve">
-    <value>每个条目都需要修饰肽段序列。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateAdductListTextBox__0__must_contain_a_comma_separated_list_of_adducts_or_integers_describing_charge_states_with_absolute_value_from__1__to__2__" xml:space="preserve">
-    <value>{0} 必须包含加合物或整数的逗号分隔列表，描述绝对值从 {1} 到 {2} 的电荷态。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_be_greater_than_or_equal_to__1__" xml:space="preserve">
-    <value>{0}必须大于或等于 {1}。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_be_less_than_or_equal_to__1__" xml:space="preserve">
-    <value>{0}必须小于或等于 {1}。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_contain_a_decimal_value" xml:space="preserve">
-    <value>{0}必须包含一个十进位值。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty" xml:space="preserve">
-    <value>{0}不能为空。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateNumberTextBox__0__must_contain_an_integer" xml:space="preserve">
-    <value>{0} 必须包含一个整数。</value>
-  </data>
-  <data name="MessageBoxHelper_ValidateSignedNumberTextBox_Value__0__must_be_between__1__and__2__or__3__and__4__" xml:space="preserve">
-    <value>值 {0} 必须在 {1} 和 {2} 或 {3} 和 {4} 之间。</value>
-  </data>
-  <data name="MissingFileDlg_ValidateFilePath_You_must_choose_a_file_with_the___0___filename_extension_" xml:space="preserve">
-    <value>您必须选择扩展名为 '{0}' 的文件。</value>
-  </data>
-  <data name="ModeUIAwareFormHelper_EnableNeededButtonsForModeUI___Would_you_like_to_create_a_new_empty_document_" xml:space="preserve">
-    <value>  您是否想要创建一个新的空文档？</value>
-  </data>
-  <data name="Molecule" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Molecule.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeIrt" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\moleculeirt.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeIrtLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\moleculeirtlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\moleculelib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeList" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\MoleculeList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeStandard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\MoleculeStandard.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeStandardLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\MoleculeStandardLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MoleculeUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\MoleculeUI.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MProphetPeakScoringModel_CalcLinearScore_Attempted_to_score_a_peak_with__0__features_using_a_model_with__1__trained_scores_" xml:space="preserve">
-    <value>尝试使用具有{1}训练得分的模型以计分带有{0}特性的峰。</value>
-  </data>
-  <data name="MProphetPeakScoringModel_CreateTransitionGroups_MProphetScoringModel_was_given_a_peak_with__0__features__but_it_has__1__peak_feature_calculators" xml:space="preserve">
-    <value>MProphetScoringModel 被赋予带有{0}特征的峰，但它拥有 {1} 个峰特征计算器</value>
-  </data>
-  <data name="MProphetResultsHandler_Q_VALUE_ANNOTATION_Q_Value" xml:space="preserve">
-    <value>Q 值</value>
-  </data>
-  <data name="MQuestReferenceShapeCalc_MQuestReferenceShapeCalc_mProphet_weighted_reference" xml:space="preserve">
-    <value>mProphet 权重参考</value>
-  </data>
-  <data name="MSAmandaLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\LogoAmanda_32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="MsconvertDdaConverter_Run_Re_using_existing_converted__0__file_for__1__" xml:space="preserve">
-    <value>为 {1} 重新使用转换过的现有 {0} 文件。</value>
-  </data>
-  <data name="MultiFileAsynchronousDownloadClient_DownloadFileAsync_Downloading__0" xml:space="preserve">
-    <value>下载{0}</value>
-  </data>
-  <data name="MultiFileAsynchronousDownloadClient_DownloadFileAsyncWithBroker_Download_canceled_" xml:space="preserve">
-    <value>下载取消。</value>
-  </data>
-  <data name="MzMatchException_suggestion" xml:space="preserve">
-    <value>检查“肽段设置”中的“修饰”标签、“预测”标签上的质荷比类型，或者“离子对设置”中的“仪器”标签上的质荷比匹配耐受性。</value>
-  </data>
-  <data name="NewDocument" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\newdocument.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeakBoundaryImporter_Import_Line__0__field_count__1__differs_from_the_first_line__which_has__2_" xml:space="preserve">
+    <value>第{0}行字段计数 {1} 与第一行计数{2}不同</value>
   </data>
   <data name="NistLibraryBase_CreateCache_" xml:space="preserve">
     <value>导入的库包含一个或多个 {0} 对的条目。
@@ -2002,1753 +182,881 @@
 以下是含多个条目的 {0} 对：
 {1}</value>
   </data>
-  <data name="NoCentroidedDataException_NoCentroidedDataException_No_centroided_data_available_for_file___0_____Adjust_your_Full_Scan_settings_" xml:space="preserve">
-    <value>文件“{0}”没有可用的质心数据。 调整您的全扫描设置。</value>
-  </data>
-  <data name="NoFullScanFilteringException_NoFullScanFilteringException_The_file__0__does_not_contain_SRM_MRM_chromatograms__To_extract_chromatograms_from_its_spectra__go_to_Settings___Transition_Settings___Full_Scan_and_choose_options_appropriate_to_the_acquisition_method_used_" xml:space="preserve">
-    <value>文件 {0} 不包含 SRM/MRM 色谱图。要从其谱图中提取色谱图，请转至“设置&gt;离子对设置&gt;全扫描”，然后选择适合所用采集方法的选项。</value>
-    <comment>replaces NoFullScanFilteringException_NoFullScanFilteringException_To_extract_chromatograms_from__0__full_scan_settings_must_be_enabled_</comment>
-  </data>
-  <data name="NoPeak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\nopeak.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Note" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\note.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="OK" xml:space="preserve">
-    <value>确定</value>
-  </data>
-  <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_0_for_a_single_entry_list" xml:space="preserve">
-    <value>指数 {0} 针对单一条目列表必须是 0。</value>
-  </data>
-  <data name="Open" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\open.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="OpenDataSourceDialog_EnsureRemoteAccount_No_remote_accounts_have_been_specified__If_you_have_an_existing_Unifi_account_you_can_enter_your_login_information_now_" xml:space="preserve">
-    <value>未指定远程账户。如果您有现有的 Unifi 账户，那么您可以现在输入您的登录信息。</value>
-  </data>
-  <data name="OpenDataSourceDialog_lookInComboBox_SelectionChangeCommitted_My_Network_Place" xml:space="preserve">
-    <value>我的网络位置</value>
-  </data>
-  <data name="OpenDataSourceDialog_Open_Error" xml:space="preserve">
-    <value>错误</value>
-  </data>
-  <data name="OpenDataSourceDialog_OpenDataSourceDialog_My_Recent_Documents" xml:space="preserve">
-    <value>我的最近文档</value>
-  </data>
-  <data name="OpenDataSourceDialog_sourcePathTextBox_KeyUp_Some_source_paths_are_invalid" xml:space="preserve">
-    <value>部分源路径无效</value>
-  </data>
-  <data name="OpenFolder" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\openfolder.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="OptimizationDb_ConvertFromOldFormat_Failed_to_convert__0__optimizations_to_new_format_" xml:space="preserve">
-    <value>转换{0}优化至新格式失败。</value>
-  </data>
-  <data name="OverlapDemultiplexer_attempt_to_insert_slice_of_deconvolution_matrix_failed_out_of_range" xml:space="preserve">
-    <value>因范围外误差而尝试插入去卷积片段基质失败。</value>
-  </data>
-  <data name="OverlapDemultiplexer_attempt_to_take_slice_of_deconvolution_matrix_failed_out_of_range" xml:space="preserve">
-    <value>因范围外误差而尝试获取去卷积片段基质失败。</value>
-  </data>
-  <data name="OverlapDemultiplexer_RowStart_Number_of_regions__0__in_overlap_demultiplexer_approximation_must_be_less_than_number_of_scans__1__" xml:space="preserve">
-    <value>重叠多路输出选择器近似值中的区域数目 {0} 必须小于扫描数目 {1}。</value>
-  </data>
-  <data name="OverlapDemultiplexer_the_isolation_window_overlap_scheme_does_not_cover_all_isolation_windows" xml:space="preserve">
-    <value>重叠分离窗口方案缺少部分连续的分离窗口。</value>
-  </data>
-  <data name="Panorama" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Panorama.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PanoramaHelper_ValidateServer_Exception_" xml:space="preserve">
-    <value>错误：尝试验证 Panorama 服务器信息时发生未知错误。
-{0}</value>
-  </data>
-  <data name="PanoramaPublish" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\panoramapublish.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
-    <value>无法验证用户身份。从服务器收到的响应:{0} {1}</value>
-  </data>
-  <data name="PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
-    <value>服务器未返回有效的 JSON 响应。{0} 并非 Panorama  服务器。</value>
-  </data>
-  <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
-    <value>服务器 {0} 的响应异常</value>
-  </data>
-  <data name="ParsimonySettings_Validate_The_value__0__for__1__is_not_valid__it_must_be_greater_than_or_equal_to__2__" xml:space="preserve">
-    <value>{1} 的 {0} 值无效：必须大于或等于 {2}。</value>
-  </data>
-  <data name="Paste" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\paste.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PasteDlg_AddFasta__0__is_not_a_capital_letter_that_corresponds_to_an_amino_acid" xml:space="preserve">
-    <value>“{0}”不是对应氨基酸的大写字母。</value>
-  </data>
-  <data name="PasteDlg_AddFasta_An_unexpected_error_occurred" xml:space="preserve">
-    <value>发生意外错误：</value>
-  </data>
-  <data name="PasteDlg_AddFasta_An_unexpected_error_occurred__0__1__" xml:space="preserve">
-    <value>发生意外错误：{0} ({1})</value>
-    <comment>Message (Error Type)</comment>
-  </data>
-  <data name="PasteDlg_AddFasta_There_is_no_name_for_this_protein" xml:space="preserve">
-    <value>此蛋白质没有名称</value>
-  </data>
-  <data name="PasteDlg_AddFasta_This_must_start_with" xml:space="preserve">
-    <value>它必须以“&gt;”开始</value>
-  </data>
-  <data name="PasteDlg_AddTransitionList_The_precursor_m_z_must_be_a_number_" xml:space="preserve">
-    <value>母离子质荷比必须是数字。</value>
-  </data>
-  <data name="PasteDlg_AddTransitionList_The_product_m_z_must_be_a_number_" xml:space="preserve">
-    <value>子离子质荷比必须是数字。</value>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_" xml:space="preserve">
-    <value>使用此窗口最简易的方法是从 Excel（或如果数据是 CSV 格式，则使用任何文本编辑器）复制并将其粘贴到网格。
-    
-请注意，您可以在 Skyline 中通过向左或右拖动列标题调整列顺序。
-
-大多数肽段离子对列表可以用“文件|导入|离子对列表...”菜单项目导入或甚至直接粘贴到“目标”窗口。</value>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_2_" xml:space="preserve">
-    <value>关于分子离子公式的注释：
-
-如果您的离子对列表格式将公式和加合物汇总在单一列（例如“C8H10N4O2[M+Na]”）中，那么使用“离子公式”列，而丢弃“加合物”列。 如果您的离子对列表将中和公式和加合物放置在不同的列中，那么对中和公式使用“离子公式”，而对加合物使用“加合物”列。</value>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_SmallMol_" xml:space="preserve">
-    <value>使用此窗口最简易的方法是从 Excel（或如果数据是 CSV 格式，则使用任何文本编辑器）复制并将其粘贴到网格。
-    
-请注意，您可以在 Skyline 中通过向左或右拖动列标题调整列顺序。 对于分子，您还可以使用“列...”按钮选择要启用的列。
-
-大多数肽段离子对列表可以用“文件|导入|离子对列表...”菜单项目导入或甚至直接粘贴到“目标”窗口。如果它们使用这些名称作为列标题，您也可以使用分子离子对列表执行此操作：</value>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_Supported_values_for__0__are___1_" xml:space="preserve">
-    <value>{0} 所支持的值是：{1}</value>
-    <comment>{1} is a comma seprated list of supported ion mobility units</comment>
-  </data>
-  <data name="PasteDlg_btnTransitionListHelp_Click_Transition_List_Help" xml:space="preserve">
-    <value>离子对列表帮助</value>
-  </data>
-  <data name="PasteDlg_CheckSequence_There_is_no_sequence_for_this_protein" xml:space="preserve">
-    <value>无此蛋白质序列</value>
-  </data>
-  <data name="PasteDlg_Description_Insert_transition_list" xml:space="preserve">
-    <value>插入离子对列表</value>
-  </data>
-  <data name="PasteDlg_GetMoleculePeptideGroup_Molecule_List__0_" xml:space="preserve">
-    <value>分子列表 {0}</value>
-  </data>
-  <data name="PasteDlg_GetMoleculeTransition_Product_m_z__0__isn_t_close_enough_to_the_nearest_possible_m_z__1___delta_2___" xml:space="preserve">
-    <value>子离子质荷比{0}与最相近的可能质荷比{1}（增量{2}）不够相近。</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_charge_value__0_" xml:space="preserve">
-    <value>无效电荷值{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_collision_energy_value__0_" xml:space="preserve">
-    <value>无效碰撞能量值{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_compensation_voltage__0_" xml:space="preserve">
-    <value>无效补偿电压 {0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_cone_voltage_value__0_" xml:space="preserve">
-    <value>无效的锥孔电压值 {0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_declustering_potential__0_" xml:space="preserve">
-    <value>无效去簇电压 {0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_m_z_value__0_" xml:space="preserve">
-    <value>无效质荷比值{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_retention_time_value__0_" xml:space="preserve">
-    <value>无效保留时间值{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_retention_time_window_value__0_" xml:space="preserve">
-    <value>无效保留时间窗口值{0}</value>
-  </data>
-  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_S_Lens_value__0_" xml:space="preserve">
-    <value>无效的 S-Lens 值 {0}</value>
-  </data>
-  <data name="PasteDlg_ShowNoErrors_No_errors" xml:space="preserve">
-    <value>无错误</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Collision_Cross_Section__sq_A_" xml:space="preserve">
-    <value>碰撞横截面(sq A)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Compensation_Voltage" xml:space="preserve">
-    <value>补偿电压</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Cone_Voltage" xml:space="preserve">
-    <value>锥孔电压</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Decoy" xml:space="preserve">
-    <value>诱饵</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Collision_Cross_Section__sq_A_" xml:space="preserve">
-    <value>明确碰撞横截面 (sq A)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Collision_Energy" xml:space="preserve">
-    <value>明确碰撞能量</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Compensation_Voltage" xml:space="preserve">
-    <value>明确的补偿电压</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility" xml:space="preserve">
-    <value>明示离子迁移</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility__1_K0_" xml:space="preserve">
-    <value>明确离子迁移 (1/K0)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility__msec_" xml:space="preserve">
-    <value>明确离子迁移 (ms)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility_High_Energy_Offset" xml:space="preserve">
-    <value>明示离子迁移高能偏置</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility_Units" xml:space="preserve">
-    <value>明示离子迁移单位</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Retention_Time" xml:space="preserve">
-    <value>明确保留时间</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Explicit_Retention_Time_Window" xml:space="preserve">
-    <value>明确保留时间窗口</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Fragment_Name" xml:space="preserve">
-    <value>片段名称</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility" xml:space="preserve">
-    <value>离子迁移</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility__1_K0_" xml:space="preserve">
-    <value>离子迁移 (1/K0)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility__msec_" xml:space="preserve">
-    <value>离子迁移(ms)</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility_High_Energy_Offset" xml:space="preserve">
-    <value>离子迁移高能偏置</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility_Units" xml:space="preserve">
-    <value>离子迁移单位</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_iRT" xml:space="preserve">
-    <value>iRT</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Label_Type" xml:space="preserve">
-    <value>标记类型</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Library_Intensity" xml:space="preserve">
-    <value>库强度</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Note" xml:space="preserve">
-    <value>注释</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Peptide" xml:space="preserve">
-    <value>肽段</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Possible_loss_of_data_could_occur_if_you_switch_to__0___Do_you_want_to_continue_" xml:space="preserve">
-    <value>如果您切换到{0}，可能发生数据的可能性丢失。您是否想要继续？</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Precursor_Adduct" xml:space="preserve">
-    <value>母离子加合物</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Precursor_Name" xml:space="preserve">
-    <value>母离子名称</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Adduct" xml:space="preserve">
-    <value>子离子加合物</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Charge" xml:space="preserve">
-    <value>子离子电荷</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Formula" xml:space="preserve">
-    <value>子离子公式</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Name" xml:space="preserve">
-    <value>子离子名称</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Product_Neutral_Loss" xml:space="preserve">
-    <value>子离子中性丢失</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Protein_description" xml:space="preserve">
-    <value>蛋白质描述</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Protein_name" xml:space="preserve">
-    <value>蛋白质名称</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Retention_Time" xml:space="preserve">
-    <value>保留时间</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_Retention_Time_Window" xml:space="preserve">
-    <value>保留时间窗口</value>
-  </data>
-  <data name="PasteDlg_UpdateMoleculeType_S_Lens" xml:space="preserve">
-    <value>S-Lens</value>
-  </data>
-  <data name="PcaPlot_RefreshData_PCA_Plot" xml:space="preserve">
-    <value>PCA 图</value>
-  </data>
-  <data name="Peak" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peak.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeakBlank" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peakblank.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeakBoundaryImporter_DetermineCorrectSeparator_The_first_line_does_not_contain_any_of_the_possible_separators_comma__tab_or_space_" xml:space="preserve">
-    <value>第一行不包含任何可能的分隔符：逗号、标记或空格。</value>
-  </data>
-  <data name="PeakBoundaryImporter_DetermineCorrectSeparator_The_first_line_does_not_contain_any_of_the_possible_separators_semicolon__tab_or_space_" xml:space="preserve">
-    <value>第一行不包含任何可能的分隔符：分号、标记或空格。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Failed_to_find_the_necessary_headers__0__in_the_first_line" xml:space="preserve">
-    <value>未能在第一行发现必要的标题{0}</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Failed_to_read_the_first_line_of_the_file" xml:space="preserve">
-    <value>读取文件第一行失败</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Line__0__field_count__1__differs_from_the_first_line__which_has__2_" xml:space="preserve">
-    <value>第{0}行字段计数 {1} 与第一行计数{2}不同</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Missing_end_time_on_line__0_" xml:space="preserve">
-    <value>第 {0} 行缺失终止时间</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Missing_start_time_on_line__0_" xml:space="preserve">
-    <value>第 {0} 行缺失起始时间</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_Sample__0__on_line__1__does_not_match_the_file__2__" xml:space="preserve">
-    <value>第 {1} 行上的样品{0}不匹配文件{2}。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_decoy_value__0__on_line__1__is_invalid__must_be_0_or_1_" xml:space="preserve">
-    <value>第 {1} 行上的诱饵值 {0} 无效：必须是 0 或 1。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_charge_state_" xml:space="preserve">
-    <value>第 {1} 行上的值“{0}”不是有效的电荷价态。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_end_time_" xml:space="preserve">
-    <value>第 {1} 行上的值“{0}”不是有效的结束时间。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_start_time_" xml:space="preserve">
-    <value>第 {1} 行上的值“{0}”不是有效的起始时间。</value>
-  </data>
-  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_time_" xml:space="preserve">
-    <value>第 {1} 行上的值“{0}”不是有效的时间。</value>
-  </data>
-  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_Continue_peak_boundary_import_ignoring_this_file_" xml:space="preserve">
-    <value>忽视该文件,继续峰边界导入？</value>
-  </data>
-  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_Continue_peak_boundary_import_ignoring_this_peptide_" xml:space="preserve">
-    <value>忽视该肽段,继续峰边界导入？</value>
-  </data>
-  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_The_following_file_name_in_the_peak_boundaries_file_was_not_recognized_" xml:space="preserve">
-    <value>峰边界文件中的下列文件名称没有被识别：</value>
-  </data>
-  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_" xml:space="preserve">
-    <value>峰边界文件中的下列肽段没有被识别：</value>
-  </data>
-  <data name="PeakBoundsMatch_PeakBoundsMatch_Unable_to_read_a_score_annotation_for_peptide__0__of_file__1_" xml:space="preserve">
-    <value>无法针对文件 {1} 的肽段 {0} 读取得分注释</value>
-  </data>
-  <data name="PeakBoundsMatch_QValue_Unable_to_read_q_value_annotation_for_peptide__0__of_file__1_" xml:space="preserve">
-    <value>无法针对文件{1}的肽段{0}读取 q 值注释</value>
-  </data>
-  <data name="PeakCalculatorGridViewDriver_ValidateRow_On_line__0____1_" xml:space="preserve">
-    <value>在第{0}, {1}行 上</value>
-  </data>
-  <data name="PeakCalculatorWeight_Validate___0___is_not_a_known_name_for_a_peak_feature_calculator" xml:space="preserve">
-    <value>“{0}”不是针对峰特性计算器的已知名称</value>
-  </data>
-  <data name="Peptide" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptide.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Peptide_ExplicitRetentionTimeWindow_Explicit_retention_time_window_requires_an_explicit_retention_time_value_" xml:space="preserve">
-    <value>明确保留时间窗口需要明确保留时间值。</value>
-  </data>
-  <data name="Peptide_GetDeleteConfirmation_Are_you_sure_you_want_to_delete_these__0__peptides_" xml:space="preserve">
-    <value>您是否确定想要删除这些{0}肽段？</value>
-    <comment>Example: Are you sure you want to delete these 47 peptides?</comment>
-  </data>
   <data name="Peptide_ThrowIfNotSmallMolecule_Direct_editing_of_this_value_is_only_supported_for_small_molecules_" xml:space="preserve">
     <value>仅支持对非蛋白质组学分子直接编辑该值。</value>
-  </data>
-  <data name="Peptide_ToString__missed__5__" xml:space="preserve">
-    <value>（缺少{5}）</value>
-  </data>
-  <data name="PeptideDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidedecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideDecoyLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidedecoylib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideGroupBuilder_AppendTransition_Failed_to_explain_all_transitions_for_0__m_z__1__with_a_single_set_of_modifications" xml:space="preserve">
-    <value>未能借助单一修饰集解释针对{0}质荷比 {1} 的所有离子对</value>
-  </data>
-  <data name="PeptideGroupBuilder_FinalizeTransitionGroups_Two_transitions_of_the_same_precursor___0___m_z__1_____have_different_iRT_values___2__and__3___iRT_values_must_be_assigned_consistently_in_an_imported_transition_list_" xml:space="preserve">
-    <value>来自同一母离子的两个离子对{0}（质荷比 {1}）具有不同的 iRT 值 {2} 和 {3}。iRT值必须在导入的离子对列表中分配一致。</value>
-  </data>
-  <data name="PeptideGroupDocNode_ChangeSettings_The_current_document_settings_would_cause_the_number_of_targeted_transitions_to_exceed__0_n0___The_document_settings_must_be_more_restrictive_or_add_fewer_proteins_" xml:space="preserve">
-    <value>当前文档设置可能会导致目标离子对数量超过{0:n0}。文档设置必须更具限制性或添加较少的蛋白质。</value>
-  </data>
-  <data name="PeptideGroupTreeNode_ProteinModalDisplayText__name___0__" xml:space="preserve">
-    <value>&lt;名称：{0}&gt;</value>
-  </data>
-  <data name="PeptideGroupTreeNode_RenderTip_Name" xml:space="preserve">
-    <value>名称</value>
-  </data>
-  <data name="PeptideIrt" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptideirt.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideIrtLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptideirtlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidelib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideList" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\PeptideList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideQc" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptideqc.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideQcLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptideqclib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideSettingsUI_comboPeakScoringModel_SelectedIndexChanged_The_document_must_have_imported_results_in_order_to_train_a_model_" xml:space="preserve">
-    <value>文档必须具备导入的结果，以训练模型。</value>
-  </data>
-  <data name="PeptideSettingsUI_ComboPeakScoringModelSelected_Unrecognized_Model" xml:space="preserve">
-    <value>未识别的模型</value>
   </data>
   <data name="PeptideSettingsUI_ShowBuildLibraryDlg_Finishing_up_building_library" xml:space="preserve">
     <value>正在完成建立库。</value>
   </data>
-  <data name="PeptideSettingsUI_ValidateNewSettings_Choose_at_least_one_internal_standard_type" xml:space="preserve">
-    <value>至少选择一个内部标准类型。</value>
-  </data>
-  <data name="PeptidesPerProteinDlg_UpdateRemaining_Calculating___" xml:space="preserve">
-    <value>正在计算...</value>
-  </data>
-  <data name="PeptideStandard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidestandard.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideStandardLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\peptidestandardlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PeptideTipProvider_RenderTip_CCS" xml:space="preserve">
-    <value>CCS</value>
-    <comment>compact form of Collision Cross Section</comment>
-  </data>
-  <data name="PeptideTipProvider_RenderTip_Ion_Mobility" xml:space="preserve">
-    <value>离子迁移</value>
-  </data>
-  <data name="PeptideTipProvider_RenderTip_Precursor_m_z" xml:space="preserve">
-    <value>母离子质荷比</value>
-  </data>
-  <data name="PeptideToMoleculeText_Ion_adducts" xml:space="preserve">
-    <value>离子加合物</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "Ion charges" to read "Ion adducts" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Ion_charges" xml:space="preserve">
-    <value>离子电荷</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "Ion charges" to read "Ion adducts" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Modified_Peptide_Sequence" xml:space="preserve">
-    <value>修改的肽段序列</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a modifed peptide sequence" to read "select a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Modified_Sequence" xml:space="preserve">
-    <value>修改序列</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a modifed sequence" to read "select a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Molecule" xml:space="preserve">
-    <value>分子</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a peptide" to read "choose a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Molecule_List" xml:space="preserve">
-    <value>分子列表</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a protein" to read "choose a molecule list" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Molecule_Lists" xml:space="preserve">
-    <value>分子列表</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like  "2 proteins" to read "2 molecule lists" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Molecules" xml:space="preserve">
-    <value>分子</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 peptides" to read "2 molecules" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Peptide" xml:space="preserve">
-    <value>肽段</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a peptide" to read "choose a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Peptide_List" xml:space="preserve">
-    <value>肽段列表</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a peptide list" to read "select a molecule list" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Peptide_Sequence" xml:space="preserve">
-    <value>肽段序列</value>
-    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a peptide sequence" to read "select a molecule" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Peptides" xml:space="preserve">
-    <value>肽段</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 peptides" to read "2 molecules" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Protein" xml:space="preserve">
-    <value>蛋白质</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a protein" to read "choose a molecule list" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PeptideToMoleculeText_Proteins" xml:space="preserve">
-    <value>蛋白质</value>
-    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 proteins" to read "2 molecule lists" when non-peptide documents are in use</comment>
-  </data>
-  <data name="PersistedViews_GetDefaults_Molecule_Quantification" xml:space="preserve">
-    <value>分子定量</value>
-  </data>
-  <data name="PersistedViews_GetDefaults_Molecule_Ratio_Results" xml:space="preserve">
-    <value>分子比率结果</value>
-  </data>
-  <data name="Pivoter_QualifyColumnInfo_AreaRatio" xml:space="preserve">
-    <value>面积比率</value>
-  </data>
-  <data name="Pivoter_QualifyColumnInfo_AreaRatioTo" xml:space="preserve">
-    <value>面积比率</value>
-  </data>
-  <data name="Pivoter_QualifyColumnInfo_TotalAreaRatio" xml:space="preserve">
-    <value>总面积比率</value>
-  </data>
-  <data name="Pivoter_QualifyColumnInfo_TotalAreaRatioTo" xml:space="preserve">
-    <value>总面积比率</value>
-  </data>
-  <data name="PivotReportDlg_OkDialog_A_report_must_have_at_least_one_column" xml:space="preserve">
-    <value>报告必须至少具备一列。</value>
-  </data>
-  <data name="PivotReportDlg_ShowPreview_A_report_must_have_at_least_one_column_" xml:space="preserve">
-    <value>报告必须至少具备一列。</value>
-  </data>
-  <data name="PopupBtn" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\popupbtn.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Print" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\print.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Properties_Button" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Properties.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="prosit_logo_dark_blue" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\prosit_logo_dark_blue.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
   <data name="Protein" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Protein.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="ProteinDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ProteinDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Adduct" xml:space="preserve">
+    <value>子离子加合物</value>
   </data>
-  <data name="ProteinUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ProteinUI.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_Q_value_entered" xml:space="preserve">
+    <value>输入的 Q 值无效</value>
   </data>
-  <data name="ProteoWizard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ProteoWizard.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="PublishDocumentDlg_btnBrowse_Click_Shared_Files" xml:space="preserve">
-    <value>共享文件</value>
-  </data>
-  <data name="PublishDocumentDlg_OkDialog_Please_select_a_folder" xml:space="preserve">
-    <value>请选择一个文件夹</value>
-  </data>
-  <data name="PublishDocumentDlg_OkDialog_Please_select_a_Skyline_Shared_file_to_upload" xml:space="preserve">
-    <value>请选择一个 Skyline 共享文件上传。</value>
-  </data>
-  <data name="PublishDocumentDlg_OkDialog_Selected_file_is_not_a_Skyline_Shared_file" xml:space="preserve">
-    <value>选定的文件不是 Skyline 共享文件。</value>
-  </data>
-  <data name="PublishDocumentDlg_ServerSupportsSkydVersion_" xml:space="preserve">
-    <value>选择的服务器不支持 skyd 文件格式版本{0}。
-请联系 Panorama 服务器管理员以升级服务器。</value>
-  </data>
-  <data name="PublishDocumentDlg_UploadSharedZipFile_Click_here_to_view_the_error_details_" xml:space="preserve">
-    <value>单击此处，以查看错误详情。</value>
-  </data>
-  <data name="PublishDocumentDlg_UploadSharedZipFile_You_do_not_have_permission_to_upload_to_the_given_folder" xml:space="preserve">
-    <value>您没有权限上传特定的文件夹。</value>
-  </data>
-  <data name="PythonInstaller_DownloadPackages_Failed_to_download_the_following_packages_" xml:space="preserve">
-    <value>未能下载下列软件包：</value>
-  </data>
-  <data name="PythonInstaller_DownloadPip_Download_failed__Check_your_network_connection_or_contact_Skyline_developers_" xml:space="preserve">
-    <value>下载失败。检查您的网络连接或联络 Skyline 开发者。</value>
-  </data>
-  <data name="PythonInstaller_DownloadPython_Check_your_network_connection_or_contact_the_tool_provider_for_installation_support_" xml:space="preserve">
-    <value>检查您的网络连接或联络工具提供商以获得安装支持。</value>
-  </data>
-  <data name="PythonInstaller_DownloadPython_Download_failed_" xml:space="preserve">
-    <value>下载失败。</value>
-  </data>
-  <data name="PythonInstaller_GetPackages_Package_installation_completed_" xml:space="preserve">
-    <value>软件包安装已完成。</value>
-  </data>
-  <data name="PythonInstaller_GetPython_Python_installation_completed_" xml:space="preserve">
-    <value>Python 安装已完成。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Package_installation_failed__Error_log_output_in_immediate_window_" xml:space="preserve">
-    <value>软件包安装失败。在即时窗口中记录输出失败。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Package_Installation_was_not_completed__Canceling_tool_installation_" xml:space="preserve">
-    <value>软件包安装未完成。取消工具安装。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Pip_installation_complete_" xml:space="preserve">
-    <value>Pip 安装完成。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Python_package_installation_cannot_continue__Canceling_tool_installation_" xml:space="preserve">
-    <value>Python 软件包安装无法继续。取消工具安装。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Skyline_uses_the_Python_tool_setuptools_and_the_Python_package_manager_Pip_to_install_packages_from_source__Click_install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>Skyline 使用 Python 工具设置工具以及 Python 软件包管理器 Pip 从源安装软件包。单击“安装”以开始安装流程。</value>
-  </data>
-  <data name="PythonInstaller_InstallPackages_Unknown_error_installing_packages_" xml:space="preserve">
-    <value>安装软件包的未知错误。</value>
-  </data>
-  <data name="PythonInstaller_InstallPip_Pip_installation_failed__Error_log_output_in_immediate_window__" xml:space="preserve">
-    <value>Pip 安装失败。在即时窗口中记录输出失败。</value>
-  </data>
-  <data name="PythonInstaller_InstallPip_Unknown_error_installing_pip_" xml:space="preserve">
-    <value>安装 pip 的未知错误。</value>
+  <data name="SkylineWindow_ImportMassList_There_is_an_existing_library_with_the_same_name__0__as_the_document_library_to_be_created___Overwrite_this_library_or_skip_import_of_library_intensities_" xml:space="preserve">
+    <value>存在与将要创建的文档库相同名称{0}的现有库。 覆盖此库还是跳过库强度的导入？</value>
   </data>
   <data name="PythonInstaller_InstallPython_Python_installation_failed__Canceling_tool_installation_" xml:space="preserve">
     <value>Python 安装失败。取消工具安装。</value>
   </data>
-  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_Python__0___Click_install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>本工具需要 Python{0}。单击“安装”以开始安装流程。</value>
+  <data name="ModeUIAwareFormHelper_EnableNeededButtonsForModeUI___Would_you_like_to_create_a_new_empty_document_" xml:space="preserve">
+    <value>  您是否想要创建一个新的空文档？</value>
   </data>
-  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_Python__0__and_the_following_packages__Select_packages_to_install_and_then_click_Install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>本工具需要 Python{0}和下列软件包。选择将要安装的软件包，然后单击“安装”以开始安装过程。</value>
+  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_choose_a_non_redundant_library_" xml:space="preserve">
+    <value>请选择一个非冗余库。</value>
   </data>
-  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_the_following_Python_packages__Select_packages_to_install_and_then_click_Install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>本工具需要下列 Python 软件包。选择将要安装的软件包，然后单击“安装”以开始安装过程。</value>
+  <data name="LibraryManager_LoadBackground_Updating_library_settings_for__0_" xml:space="preserve">
+    <value>正在更新{0}的库设置</value>
   </data>
-  <data name="RatioToSurrogate_ToString_Ratio_to_surrogate__0____1__" xml:space="preserve">
-    <value>与替代的比例 {0} ({1})</value>
+  <data name="CommandLine_OpenSkyFile_File__0__opened_" xml:space="preserve">
+    <value>文件{0}已打开。</value>
   </data>
-  <data name="RCalcIrt_RequireUsable_Unexpected_use_of_iRT_calculator_before_successful_initialization" xml:space="preserve">
-    <value>初始化成功前对 iRT 计算器的意外使用。</value>
+  <data name="PythonInstaller_InstallPip_Unknown_error_installing_pip_" xml:space="preserve">
+    <value>安装 pip 的未知错误。</value>
   </data>
-  <data name="RedX" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RedX.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RedXTransparentBackground" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\RedXTransparentBackground.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="RefineDlg_NormalizationMethod_Total_ion_current" xml:space="preserve">
-    <value>总离子电流</value>
-  </data>
-  <data name="RefineDlg_RefineDlg_Precursors" xml:space="preserve">
-    <value>母离子</value>
-  </data>
-  <data name="RefineDlg_RefineDlg_Products" xml:space="preserve">
-    <value>子离子</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_Do_you_want_to_continue" xml:space="preserve">
-    <value>您是否想要继续？</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_None_of_the_specified_peptides_are_in_the_document" xml:space="preserve">
-    <value>所有指定的肽段都不在文档中。</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_Of_the_specified__0__peptides__1__are_not_in_the_document_Do_you_want_to_continue" xml:space="preserve">
-    <value>指定的 {0} 个肽段{1}不存在于文档中。您是否想要继续？</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_following_peptides_are_not_in_the_document" xml:space="preserve">
-    <value>下列肽段不在文档中：</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_following_sequences_are_not_valid_peptides" xml:space="preserve">
-    <value>下列序列不是有效的肽段：</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_peptide___0___is_not_in_the_document" xml:space="preserve">
-    <value>肽段“{0}”不存在于文档中。</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_peptide__0__is_not_in_the_document_Do_you_want_to_continue" xml:space="preserve">
-    <value>肽段“{0}”不存在于文档中。您是否想要继续？</value>
-  </data>
-  <data name="RefineListDlg_OkDialog_The_sequence__0__is_not_a_valid_peptide" xml:space="preserve">
-    <value>序列“{0}”并不是有效的肽段。</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_Do_you_want_to_continue" xml:space="preserve">
-    <value>您是否想要继续？</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_None_of_the_specified_proteins_are_in_the_document_" xml:space="preserve">
-    <value>没有任何指定蛋白质在文档中。</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_Of_the_specified__0__proteins__1__are_not_in_the_document__Do_you_want_to_continue_" xml:space="preserve">
-    <value>指定的 {0} 个蛋白质{1}不存在于文档中。您是否想要继续？</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_The_following_proteins_are_not_in_the_document_" xml:space="preserve">
-    <value>下列蛋白质不在文档中：</value>
-  </data>
-  <data name="RefineListDlgProtein_OkDialog_The_protein___0___is_not_in_the_document__Do_you_want_to_continue_" xml:space="preserve">
-    <value>蛋白质“{0}”不存在于文档中。您是否想要继续？</value>
-  </data>
-  <data name="RefinementSettings_Refine_The_document_must_contain_at_least_2_replicates_to_refine_based_on_consistency_" xml:space="preserve">
-    <value>该文档必须包括至少 2 个重复测定，以便根据一致性进行调整。</value>
-  </data>
-  <data name="Regression_intercept" xml:space="preserve">
-    <value>截距</value>
-  </data>
-  <data name="Regression_slope" xml:space="preserve">
-    <value>斜率</value>
-  </data>
-  <data name="RegressionFit_BILINEAR_Bilinear" xml:space="preserve">
-    <value>双线性</value>
-  </data>
-  <data name="RegressionOption_All_Fixed_points__linear_" xml:space="preserve">
-    <value>固定点（线性）</value>
-  </data>
-  <data name="RegressionOption_All_Fixed_points__logarithmic_" xml:space="preserve">
-    <value>固定点（对数）</value>
-  </data>
-  <data name="ReintegrateDlg_OkDialog_Failed_attempting_to_reintegrate_peaks_" xml:space="preserve">
-    <value>尝试重新合并峰失败。</value>
-  </data>
-  <data name="ReintegrateDlg_OkDialog_Reintegrating" xml:space="preserve">
-    <value>重新合并</value>
-  </data>
-  <data name="ReintegrateDlg_OkDialog_The_current_peak_scoring_model_is_incompatible_with_one_or_more_peptides_in_the_document___Please_train_a_new_model_" xml:space="preserve">
-    <value>当前的峰得分模型与文档中的一个或多个肽段不兼容。请训练一个新模型。</value>
-  </data>
-  <data name="RemoteSession_FetchContents_There_was_an_error_communicating_with_the_server__" xml:space="preserve">
-    <value>与服务器通讯出现错误：</value>
-  </data>
-  <data name="RemovePeptides_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from__1__peptides_" xml:space="preserve">
-    <value>您是否确定想要从 {1} 个肽段中删除这 {0} 个峰？</value>
-  </data>
-  <data name="RemovePrecursors_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from_one_precursor_" xml:space="preserve">
-    <value>您是否确定想要从一个母离子中删除这 {0} 个峰？</value>
-  </data>
-  <data name="RenameProteinsDlg_OkDialog__0__is_not_a_current_protein" xml:space="preserve">
-    <value>{0}不是当前的蛋白质</value>
-  </data>
-  <data name="RenameProteinsDlg_OkDialog_Cannot_rename__0__more_than_once__Please_remove_either__1__or__2__" xml:space="preserve">
-    <value>无法多次重新命名{0}。请删除{1}或{2}</value>
-  </data>
-  <data name="RenameProteinsDlg_OkDialog_Edit_name__0__" xml:space="preserve">
-    <value>编辑名称{0}</value>
-  </data>
-  <data name="RenameProteinsDlg_UseFastaFile_The_document_contains_a_naming_conflict_The_name__0__is_currently_used_by_multiple_protein_sequences" xml:space="preserve">
-    <value>文档包含一个命名冲突。名称{0}当前被多个蛋白质序列使用。</value>
-  </data>
-  <data name="Replicate" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Replicate.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="ReportErrorDlg_ReportErrorDlg_Close" xml:space="preserve">
-    <value>关闭</value>
-  </data>
-  <data name="ReportSpec_ReportToCsvString_Exporting__0__report" xml:space="preserve">
-    <value>导出{0}报告</value>
+  <data name="CommandLine_ImportSkyr_Success__Imported_Reports_from__0_" xml:space="preserve">
+    <value>成功！从{0}中导入报告</value>
   </data>
   <data name="ReportSpecList_EditItem_An_unexpected_error_occurred_while_analyzing_the_current_document" xml:space="preserve">
     <value>分析当前文档过程中出现意外错误。</value>
   </data>
-  <data name="ReportSpecList_GetDefaults_Molecule_Peak_Boundaries" xml:space="preserve">
-    <value>分子峰边界</value>
+  <data name="ValueUnexpectedException_ValueUnexpectedException_The_argument__0__should_not_have_a_value_specified" xml:space="preserve">
+    <value>参数 {0} 不应该具有指定的值</value>
   </data>
-  <data name="ReportSpecList_GetDefaults_Peak_Boundaries" xml:space="preserve">
-    <value>峰边界</value>
-  </data>
-  <data name="ReportSpecList_GetDefaults_Peptide_Ratio_Results" xml:space="preserve">
-    <value>肽段比率结果</value>
-  </data>
-  <data name="ReportSpecList_GetDefaults_Peptide_RT_Results" xml:space="preserve">
-    <value>肽段RT 结果</value>
-  </data>
-  <data name="ReportSpecList_GetDefaults_Transition_Results" xml:space="preserve">
-    <value>离子对结果（多个）</value>
-  </data>
-  <data name="ReportSpecList_Label_Report" xml:space="preserve">
-    <value>报告(&amp;R)：</value>
-  </data>
-  <data name="ReportSpecList_Title_Edit_Reports" xml:space="preserve">
-    <value>编辑报告</value>
-  </data>
-  <data name="Resources.ReportSpecList_GetDefaults_Peptide_Quantification" xml:space="preserve">
-    <value>肽段定量</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Acquired_Time" xml:space="preserve">
-    <value>采集时间</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Area" xml:space="preserve">
-    <value>面积</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Area_Ratio" xml:space="preserve">
-    <value>面积比</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Average_Mass_Error_PPM" xml:space="preserve">
-    <value>平均质量误差 PPM</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Background" xml:space="preserve">
-    <value>背景</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Best_Retention_Time" xml:space="preserve">
-    <value>最佳保留时间</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_CellEndEdit_Edit_note" xml:space="preserve">
-    <value>编辑注释</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Count_Truncated" xml:space="preserve">
-    <value>截尾计数</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_End_Time" xml:space="preserve">
-    <value>结束时间</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_File_Name" xml:space="preserve">
-    <value>文件名称</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Fwhm" xml:space="preserve">
-    <value>半峰宽</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Height" xml:space="preserve">
-    <value>高度</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Identified" xml:space="preserve">
-    <value>已确认的</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Isotope_Dot_Product" xml:space="preserve">
-    <value>同位素点积值</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Library_Dot_Product" xml:space="preserve">
-    <value>库点积</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Mass_Error_PPM" xml:space="preserve">
-    <value>质量误差 PPM</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Max_End_Time" xml:space="preserve">
-    <value>结束时间最大值</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Max_Fwhm" xml:space="preserve">
-    <value>半峰宽最大值</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Max_Height" xml:space="preserve">
-    <value>高度最大值</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Min_Start_Time" xml:space="preserve">
-    <value>启动时间最小值</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Modified_Time" xml:space="preserve">
-    <value>修饰时间</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Opt_Collision_Energy" xml:space="preserve">
-    <value>最优碰撞能量</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Opt_Compensation_Voltage" xml:space="preserve">
-    <value>最优补偿电压</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Opt_Declustering_Potential" xml:space="preserve">
-    <value>最优去簇电压</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Opt_Step" xml:space="preserve">
-    <value>最优步骤</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Peak_Rank" xml:space="preserve">
-    <value>峰排名</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Peptide_Peak_Found_Ratio" xml:space="preserve">
-    <value>肽段峰值检出比</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Peptide_Retention_Time" xml:space="preserve">
-    <value>肽段保留时间</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Precursor_Peak_Found_Ratio" xml:space="preserve">
-    <value>母离子峰值检出比</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Precursor_Replicate_Note" xml:space="preserve">
-    <value>母离子重复测定注释</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Ratio_Dot_Product" xml:space="preserve">
-    <value>比率点积</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Ratio_to_Global_Standards" xml:space="preserve">
-    <value>相对于总体标准品比率</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Ratio_To_Standard" xml:space="preserve">
-    <value>相对于标准品比率</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Ratio_To_Standard_Dot_Product" xml:space="preserve">
-    <value>相对于标准品比率点积</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Replicate_Name" xml:space="preserve">
-    <value>重复测定名称</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Retention_Time" xml:space="preserve">
-    <value>保留时间</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Sample_Name" xml:space="preserve">
-    <value>样品名称</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Start_Time" xml:space="preserve">
-    <value>启动时间</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Total_Area" xml:space="preserve">
-    <value>总面积</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Total_Area_Ratio" xml:space="preserve">
-    <value>总面积比</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Total_Background" xml:space="preserve">
-    <value>总体背景</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Transition_Replicate_Note" xml:space="preserve">
-    <value>离子对重复测定注释</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_Truncated" xml:space="preserve">
-    <value>截短的</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_User_Set" xml:space="preserve">
-    <value>用户设定</value>
-  </data>
-  <data name="ResultsGrid_ResultsGrid_User_Set_Total" xml:space="preserve">
-    <value>用户设定总数</value>
-  </data>
-  <data name="RetentionTimeRegression_RecalcRegression_Recalculating_regression" xml:space="preserve">
-    <value>重新计算回归</value>
-  </data>
-  <data name="RInstaller_DownloadPackages_Check_your_network_connection_or_contact_the_tool_provider_for_installation_support_" xml:space="preserve">
-    <value>检查您的网络连接或联络工具提供商以获得安装支持。</value>
-  </data>
-  <data name="RInstaller_DownloadR_Download_failed_" xml:space="preserve">
-    <value>下载失败。</value>
-  </data>
-  <data name="RInstaller_GetPackages_Downloading_packages" xml:space="preserve">
-    <value>下载软件包</value>
-  </data>
-  <data name="RInstaller_GetPackages_Package_installation_complete_" xml:space="preserve">
-    <value>软件包安装完成。</value>
-  </data>
-  <data name="RInstaller_GetR_R_installation_complete_" xml:space="preserve">
-    <value>R 安装完成。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Download_Canceled" xml:space="preserve">
-    <value>下载取消</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Error__No_internet_connection_" xml:space="preserve">
-    <value>错误：无网络连接。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Error__Package_installation_did_not_complete__Output_logged_to_the_Immediate_Window_" xml:space="preserve">
-    <value>错误：软件包安装未完成。输出录入即时窗口。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Error_Installing_Packages" xml:space="preserve">
-    <value>安装包出错</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Installing_R_packages_requires_an_internet_connection__Please_check_your_connection_and_try_again" xml:space="preserve">
-    <value>安装 R 软件包需要网络连接。请检查您的连接并重试</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Output_logged_to_the_Immediate_Window_" xml:space="preserve">
-    <value>输出录入即时窗口。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Package_installation_failed__Error_log_output_in_immediate_window_" xml:space="preserve">
-    <value>软件包安装失败。在即时窗口中记录输出失败。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_The_following_packages_failed_to_install_" xml:space="preserve">
-    <value>下列软件包安装失败：</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Unknown_Error_installing_packages__Output_logged_to_the_Immediate_Window_" xml:space="preserve">
-    <value>安装软件包的未知错误。输出录入即时窗口。</value>
-  </data>
-  <data name="RInstaller_InstallPackages_Unknown_error_installing_packages__Tool_Installation_Failed_" xml:space="preserve">
-    <value>安装软件包的未知错误。工具安装失败。</value>
-  </data>
-  <data name="RInstaller_InstallR_R_installation_was_not_completed__Cancelling_tool_installation_" xml:space="preserve">
-    <value>R 安装未完成。取消工具安装。</value>
-  </data>
-  <data name="RInstaller_RInstaller_Load_This_tool_requires_the_use_of_R__0___Click_Install_to_begin_the_installation_process_" xml:space="preserve">
-    <value>本工具需要使用 R{0}。单击“安装”以开始安装流程。</value>
-  </data>
-  <data name="RInstaller_RInstaller_Load_This_tool_requires_the_use_of_R__0__and_the_following_packages_" xml:space="preserve">
-    <value>此工具要求使用 R{0}和下列软件包。</value>
-  </data>
-  <data name="RInstaller_RInstaller_Load_This_Tool_requires_the_use_of_the_following_R_Packages_" xml:space="preserve">
-    <value>此工具要求使用下列 R 软件包。</value>
-  </data>
-  <data name="RTDetails_gridStatistics_KeyDown_Failed_setting_data_to_clipboard" xml:space="preserve">
-    <value>向剪切板设定数据失败。</value>
-  </data>
-  <data name="RTLinearRegressionGraphPane_RTLinearRegressionGraphPane_Measured_Time" xml:space="preserve">
-    <value>测量时间</value>
-  </data>
-  <data name="RTLinearRegressionGraphPane_UpdateGraph_Calculating___" xml:space="preserve">
-    <value>正在计算...</value>
-  </data>
-  <data name="Save" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\save.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SavitzkyGolaySmoother_WindowSize_SavitzkyGolaySmoother__Invalid_window_size___0____argument_must_be_positive_and_odd" xml:space="preserve">
-    <value>SavitzkyGolay 滤波器：无效的窗口大小 ({0}) ：参数必须是正奇数</value>
-  </data>
-  <data name="ScanProvider_GetScans_The_scan_ID__0__was_not_found_in_the_file__1__" xml:space="preserve">
-    <value>未能在文件{1}中找到扫描ID{0}。</value>
-  </data>
-  <data name="SequenceMassCalc_ParseModMass_The_expression__0__is_not_a_valid_chemical_formula" xml:space="preserve">
-    <value>表达式“{0}”不是有效的化学式。</value>
-  </data>
-  <data name="SerializableSettingsList_ImportFile_Failure_loading__0__" xml:space="preserve">
-    <value>加载{0}失败。</value>
-  </data>
-  <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
-    <value>无法连接到服务器 {0}。</value>
-  </data>
-  <data name="SettingsList_ELEMENT_NONE_None" xml:space="preserve">
-    <value>无</value>
-  </data>
-  <data name="SettingsListComboDriver_Add" xml:space="preserve">
-    <value>&lt;添加…&gt;</value>
-  </data>
-  <data name="SettingsListComboDriver_Edit_current" xml:space="preserve">
-    <value>&lt;编辑当前…&gt;</value>
-  </data>
-  <data name="SettingsListComboDriver_Edit_list" xml:space="preserve">
-    <value>&lt;编辑列表…&gt;</value>
-  </data>
-  <data name="SettingsUIUtil_DoPasteText_Incorrect_number_of_columns__0__found_on_line__1__" xml:space="preserve">
-    <value>在第 {1} 行发现列数目{0}不正确。</value>
-  </data>
-  <data name="ShareListDlg_ImportFile_Failure_loading__0__" xml:space="preserve">
-    <value>加载{0}失败。</value>
-  </data>
-  <data name="ShareListDlg_OkDialog_An_error_occurred" xml:space="preserve">
-    <value>发生错误：</value>
-  </data>
-  <data name="ShareTypeDlg_OkDialog_Including_data_folders_is_not_supported_by_the_currently_selected_version_" xml:space="preserve">
-    <value>当前所选版本不支持包含数据文件夹。</value>
-  </data>
-  <data name="ShareTypeDlg_ShareTypeDlg_Current_saved_file___0__" xml:space="preserve">
-    <value>当前保存的文件 ({0})</value>
-  </data>
-  <data name="ShimadzuMethodExporter_ExportMethod_Error_copying_template_file__0__to_destination__1__" xml:space="preserve">
-    <value>在将模板文件{0}复制到目标{1}时出现错误。</value>
-  </data>
-  <data name="ShimadzuMethodExporter_ExportMethod_Unexpected_response__0__from_Shimadzu_method_writer_" xml:space="preserve">
-    <value>来自 Shimadzu 方法写入器的非预期响应 {0}。</value>
-  </data>
-  <data name="SkippedReportErrorDlg_btnOK_Click_No_Email" xml:space="preserve">
-    <value>请提供电子邮件地址以便我们对该错误有任何其他问题时联系您。 
-如果您愿意，您可以选择匿名报告。</value>
-  </data>
-  <data name="Skyline" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\skyline.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Skyline_Daily" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\skyline_daily.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Skyline_peptides" xml:space="preserve">
-    <value>肽段</value>
-  </data>
-  <data name="Skyline_protein" xml:space="preserve">
-    <value>蛋白质</value>
-  </data>
-  <data name="Skyline_Release" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Skyline_Release.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="Skyline_Release1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Skyline_Release.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SkylineData" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\SkylineData.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SkylineDataSchema_VerifyDocumentCurrent_The_document_was_modified_in_the_middle_of_the_operation_" xml:space="preserve">
-    <value>该文档在操作过程中进行了修改。</value>
-  </data>
-  <data name="SkylineDoc" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\skylinedoc.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SkylineImg" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\skyline.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="SkylineStartup_SaveFileDlg_Please_save_a_new_file_to_work_with_" xml:space="preserve">
-    <value>请保存将要处理的新文件。</value>
-  </data>
-  <data name="SkylineStartup_SkylineStartup_Blank_Document" xml:space="preserve">
-    <value>空白文档</value>
-  </data>
-  <data name="SkylineStartup_SkylineStartup_Import_Peptide_List" xml:space="preserve">
-    <value>导入肽段列表</value>
-  </data>
-  <data name="SkylineStartup_SkylineStartup_Import_Transition_List" xml:space="preserve">
-    <value>导入离子对列表</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Molecules" xml:space="preserve">
-    <value>分子</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Peptides" xml:space="preserve">
-    <value>肽段</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
-    <value>母离子</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Proteins" xml:space="preserve">
-    <value>蛋白质</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Replicates" xml:space="preserve">
-    <value>重复测定</value>
-  </data>
-  <data name="SkylineViewContext_GetDocumentGridRowSources_Transitions" xml:space="preserve">
+  <data name="ColumnSet_GetTransitionsTable_Transition" xml:space="preserve">
     <value>离子对</value>
   </data>
-  <data name="SkylineViewContext_GetTransitionListReportSpec_Peptide_Transition_List" xml:space="preserve">
-    <value>肽段离子对列表</value>
+  <data name="EditIsolationSchemeDlg_OkDialog_The_isolation_scheme_named__0__already_exists" xml:space="preserve">
+    <value>名为“{0}”的分离方案已经存在。</value>
   </data>
-  <data name="SkylineViewContext_GetTransitionListReportSpec_Small_Molecule_Transition_List" xml:space="preserve">
-    <value>小分子离子对列表</value>
+  <data name="ComparePeakPickingDlg_SaveData_Save_Model_Comparison_Data" xml:space="preserve">
+    <value>保存模型比较数据</value>
+  </data>
+  <data name="AssociateProteinsDlg_ApplyChanges_Associated_proteins" xml:space="preserve">
+    <value>关联的蛋白质</value>
+  </data>
+  <data name="PythonInstaller_DownloadPip_Download_failed__Check_your_network_connection_or_contact_Skyline_developers_" xml:space="preserve">
+    <value>下载失败。检查您的网络连接或联络 Skyline 开发者。</value>
   </data>
   <data name="SkylineWindow_AddGroupComparison_Add_Fold_Change" xml:space="preserve">
     <value>添加倍数变化</value>
   </data>
-  <data name="SkylineWindow_AddIrtPeptides_Imported_peptide__0__with_iRT_library_value_is_already_being_used_as_an_iRT_standard_" xml:space="preserve">
-    <value>具有 iRT 库值的导入肽段{0}已经用作 iRT 标准。</value>
+  <data name="CommandLine_SetLibrary_Error__Cannot_set_library_name_without_path_" xml:space="preserve">
+    <value>错误：无法在没有路径的情况下设定库名称。</value>
   </data>
-  <data name="SkylineWindow_AddMolecule_The_precursor_m_z_for_this_molecule_is_out_of_range_for_your_instrument_settings_" xml:space="preserve">
-    <value>分子的母离子质荷比超出您的仪器设置范围。</value>
-  </data>
-  <data name="SkylineWindow_AlignTimesToFileFormat" xml:space="preserve">
-    <value>将时间校准至 {0}</value>
-  </data>
-  <data name="SkylineWindow_CheckRetentionTimeFilter_NoPredictionAlgorithm" xml:space="preserve">
-    <value>离子对设置全扫描保留时间过滤器的设定旨在使用预测的保留时间，但还未指定任何预测算法。
-前往“肽段设置预测”标签以修复。</value>
+  <data name="PasteDlg_UpdateMoleculeType_Fragment_Name" xml:space="preserve">
+    <value>片段名称</value>
   </data>
   <data name="SkylineWindow_CompleteProgressUI_Ran_Out_Of_Memory" xml:space="preserve">
     <value>
 
 {0}内存溢出。</value>
   </data>
-  <data name="SkylineWindow_CompleteProgressUI_version_issue" xml:space="preserve">
-    <value>
-
-您可以通过安装 64-位版本的{0}来避免此问题的出现。</value>
+  <data name="WebPanoramaPublishClient_ImportDataOnServer_Error_importing_Skyline_file_on_Panorama_server__0_" xml:space="preserve">
+    <value>在 Panorama 服务器{0}上导入 Skyline 文件出错</value>
   </data>
-  <data name="SkylineWindow_expandAllMenuItem_DropDownOpening__Lists" xml:space="preserve">
-    <value>列表(&amp;L)</value>
+  <data name="ImportTransitionListErrorDlg_ImportTransitionListErrorDlg_This_transition_list_cannot_be_imported_as_it_does_not_provide_values_for_" xml:space="preserve">
+    <value>无法导入此离子对列表，因为它未为以下对象提供值：</value>
   </data>
-  <data name="SkylineWindow_expandAllMenuItem_DropDownOpening__Molecules" xml:space="preserve">
-    <value>分子(&amp;M)</value>
-  </data>
-  <data name="SkylineWindow_exportIsolationListMenuItem_Click_There_is_no_isolation_list_data_to_export" xml:space="preserve">
-    <value>没有需要导出的采集列表。</value>
-  </data>
-  <data name="SkylineWindow_HandleStandardsChanged_An_error_occurred_while_attempting_to_load_the_iRT_database__0___iRT_standards_cannot_be_automatically_added_to_the_document_" xml:space="preserve">
-    <value>尝试加载 iRT 数据库 {0} 时出错。iRT 标准无法自动添加到文档中。 </value>
-  </data>
-  <data name="SkylineWindow_ImportFasta_Unexpected_document_change_during_operation" xml:space="preserve">
-    <value>操作过程中的意外文档修改。</value>
-  </data>
-  <data name="SkylineWindow_ImportFastaFile_Failed_reading_the_file__0__1__" xml:space="preserve">
-    <value>读取文件{0}失败。{1}</value>
-  </data>
-  <data name="SkylineWindow_ImportFastaFile_Import_FASTA" xml:space="preserve">
-    <value>导入 FASTA</value>
-  </data>
-  <data name="SkylineWindow_ImportFiles_Importing__0__" xml:space="preserve">
-    <value>导入{0}</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_Do_you_want_to_use_the_document_settings_to_automanage_these_new_transitions" xml:space="preserve">
-    <value>您想要启用自动选择，并使用文档设置来管理这些新离子对吗?
-
-启用自动选择: {0} 个母离子和 {1} 个碎片离子对将添加到当前文档。
-
-禁用自动选择: {2} 个母离子和 {3} 个碎片离子对将添加到当前文档。
-
-如果选择“禁用”，则可以稍后使用“细化 &gt; 高级”菜单项启用自动选择。</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_Failed_reading_the_file___Peptide__0__matches_an_existing_iRT_standard_peptide_" xml:space="preserve">
-    <value>读取文件失败。 肽段{0}匹配现有的 iRT 标准肽段。</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_Keep_the_existing_iRT_value_or_overwrite_with_the_imported_value_" xml:space="preserve">
-    <value>保留现有 iRT 值或使用导入值覆盖？</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_The_iRT_calculator_already_contains__0__of_the_imported_peptides_" xml:space="preserve">
-    <value>iRT 计算器已经包含导入肽段中的 {0} 个。</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_library_values___Add_these_iRT_values_to_the_iRT_calculator_" xml:space="preserve">
-    <value>离子对列表似乎包含 iRT 库值。 将这些 iRT 值添加到 iRT 计算器？</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_values__but_the_document_does_not_have_an_iRT_calculator___Create_a_new_calculator_and_add_these_iRT_values_" xml:space="preserve">
-    <value>离子对列表中似乎包含 iRT 值，但文档中并没有 iRT 计算器。 创建新的计算器并添加这些 iRT 值？</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_spectral_library_intensities___Create_a_document_library_from_these_intensities_" xml:space="preserve">
-    <value>离子对列表中似乎包含谱图库强度。 从这些强度中创建文档库？</value>
-  </data>
-  <data name="SkylineWindow_ImportMassList_There_is_an_existing_library_with_the_same_name__0__as_the_document_library_to_be_created___Overwrite_this_library_or_skip_import_of_library_intensities_" xml:space="preserve">
-    <value>存在与将要创建的文档库相同名称{0}的现有库。 覆盖此库还是跳过库强度的导入？</value>
-  </data>
-  <data name="SkylineWindow_importMassListMenuItem_Click_Data_columns_not_found_in_first_line" xml:space="preserve">
-    <value>第一行中未发现数据列。</value>
-  </data>
-  <data name="SkylineWindow_importMassListMenuItem_Click_Transition_List" xml:space="preserve">
-    <value>离子对列表</value>
-  </data>
-  <data name="SkylineWindow_ImportResults__0__decoys_do_not_have_a_matching_target" xml:space="preserve">
-    <value>{0} 个诱饵没有匹配的目标</value>
-  </data>
-  <data name="SkylineWindow_ImportResults__0__decoys_do_not_have_the_same_number_of_transitions_as_their_matching_targets" xml:space="preserve">
-    <value>{0} 个诱饵没有与其匹配目标相同的离子对数目。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_1_decoy_does_not_have_a_matching_target" xml:space="preserve">
-    <value>1 个诱饵没有匹配的目标</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_1_decoy_does_not_have_the_same_number_of_transitions_as_its_matching_target" xml:space="preserve">
-    <value>1 个诱饵没有与其匹配目标相同的离子对数目。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_A_maximum_of__0__may_be_missing_and_or_outliers_for_a_successful_import_" xml:space="preserve">
-    <value>可能缺失最多 {0} 个，或者是成功导入的异常值。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_Add_missing_iRT_standard_peptides_to_your_document_or_change_the_retention_time_predictor_" xml:space="preserve">
-    <value>将缺失的 iRT 标准肽段添加到您的文档，或者更改保留时间预测器。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_None_may_be_missing_or_outliers_for_a_successful_import_" xml:space="preserve">
-    <value>可能无缺失，或者无成功导入的异常值。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_The_document_contains__0__of_these_iRT_standard_peptides_" xml:space="preserve">
-    <value>文档包括这些 iRT 标准肽段中的 {0} 个。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_The_document_contains_decoys_that_do_not_match_the_targets__Out_of__0__decoys_" xml:space="preserve">
-    <value>文档内包含与目标不匹配的诱饵。{0} 个诱饵中：</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_The_document_does_not_contain_any_of_these_iRT_standard_peptides_" xml:space="preserve">
-    <value>文档不包括任何这些 iRT 标准肽段。</value>
-  </data>
-  <data name="SkylineWindow_ImportResults_The_document_only_contains__0__of_these_iRT_standard_peptides_" xml:space="preserve">
-    <value>文档仅包括这些 iRT 标准肽段中的 {0} 个。</value>
-  </data>
-  <data name="SkylineWindow_OpenSharedFile_Extracting_Files" xml:space="preserve">
-    <value>提取文件</value>
-  </data>
-  <data name="SkylineWindow_OpenSharedFile_Failure_extracting_Skyline_document_from_zip_file__0__" xml:space="preserve">
-    <value>从压缩文件{0}中提取 Skyline 文档失败。</value>
-  </data>
-  <data name="SkylineWindow_Paste_Could_not_perform_transition_list_paste___0_" xml:space="preserve">
-    <value>无法执行离子对列表粘贴：{0}</value>
-  </data>
-  <data name="SkylineWindow_Paste_Paste" xml:space="preserve">
-    <value>粘贴</value>
-  </data>
-  <data name="SkylineWindow_Publish_Error_retrieving_server_information__0__" xml:space="preserve">
-    <value>检索服务器信息出错：{0}</value>
-  </data>
-  <data name="SkylineWindow_Publish_Retrieving_server_information" xml:space="preserve">
-    <value>正在获取服务器信息。</value>
-  </data>
-  <data name="SkylineWindow_Publish_There_are_no_Panorama_servers_to_publish_to_Please_add_a_server_under_Tools" xml:space="preserve">
-    <value>没有可以发布到 Panorama 的服务器。请在“工具”下添加一个服务器。</value>
-  </data>
-  <data name="SkylineWindow_publishToolStripMenuItem_Click_Skyline_Shared_Documents" xml:space="preserve">
-    <value>Skyline 共享文档</value>
-  </data>
-  <data name="SkylineWindow_SaveDocument_Saving___" xml:space="preserve">
-    <value>保存...</value>
-  </data>
-  <data name="SkylineWindow_SaveDocumentAs_Skyline_Documents" xml:space="preserve">
-    <value>Skyline 文档</value>
-  </data>
-  <data name="SkylineWindow_shareDocumentMenuItem_Click_The_document_must_be_saved_before_it_can_be_shared" xml:space="preserve">
-    <value>文档必须在共享前被保存。</value>
-  </data>
-  <data name="SkylineWindow_ShowCalculatorScoreFormat" xml:space="preserve">
-    <value>显示 {0} 得分</value>
-  </data>
-  <data name="SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_imported_results_" xml:space="preserve">
-    <value>文档必须具有导入的结果。</value>
-  </data>
-  <data name="SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_targets_for_which_to_export_chromatograms_" xml:space="preserve">
-    <value>文档必须包含针对其导出色谱图的目标。</value>
-  </data>
-  <data name="SkylineWindow_ShowExportSpectralLibraryDialog_The_document_must_contain_at_least_one_peptide_precursor_to_export_a_spectral_library_" xml:space="preserve">
-    <value>文档必须至少包含一个肽段母离子才能导出谱图库。</value>
-  </data>
-  <data name="SkylineWindow_ShowExportSpectralLibraryDialog_The_document_must_contain_results_to_export_a_spectral_library_" xml:space="preserve">
-    <value>文档必须包含结果才能导出谱图库。</value>
-  </data>
-  <data name="SkylineWindow_ShowProgressErrorUI_Do_you_want_to_continue_" xml:space="preserve">
-    <value>您是否想要继续？</value>
-  </data>
-  <data name="SkylineWindow_ShowProgressErrorUI_Retry" xml:space="preserve">
-    <value>重试</value>
-  </data>
-  <data name="SkylineWindow_ShowProgressErrorUI_Skip" xml:space="preserve">
-    <value>跳过</value>
-  </data>
-  <data name="SkylineWindow_ShowPublishDlg_Press_Register_to_register_for_a_project_on_PanoramaWeb_" xml:space="preserve">
-    <value>按下“注册”，以在 PanoramaWeb 上注册一个项目。</value>
-  </data>
-  <data name="SkylineWindow_ShowReintegrateDialog_Reintegration_of_results_requires_a_trained_peak_scoring_model_" xml:space="preserve">
-    <value>重新合并结果需要训练过的峰排名模型。</value>
-  </data>
-  <data name="SkylineWindow_ShowReintegrateDialog_The_document_must_have_imported_results_" xml:space="preserve">
-    <value>文档必须具有导入的结果。</value>
-  </data>
-  <data name="SkylineWindow_ShowReintegrateDialog_The_document_must_have_targets_in_order_to_reintegrate_chromatograms_" xml:space="preserve">
-    <value>文档必须具有目标，以重新合并色谱图。</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_Credentials_saved_in_Skyline_for_the_Panorama_server__0__are_for_the_user__1___This_user_does_not_have_permissions_to_download_the_file__The_skyp_file_was_downloaded_by__2__" xml:space="preserve">
-    <value>Skyline 中保存的 Panorama 服务器 {0} 的凭据适用于用户 {1}。该用户不具备下载该文件的权限。该 skyp 文件由 {2} 下载。</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_Credentials_saved_in_Skyline_for_the_Panorama_server__0__are_invalid_" xml:space="preserve">
-    <value>Skyline 中保存的 Panorama 服务器 {0} 的凭据无效。</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_The_skyp_file_was_downloaded_by_the_user__0___Credentials_saved_in_Skyline_for_this_server_are_for_the_user__1__" xml:space="preserve">
-    <value>该 skyp 文件由用户 {0} 下载。Skyline 中保存的此服务器的凭据适用于用户 {1}。</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_Would_you_like_to_add__0__as_a_Panorama_server_in_Skyline_" xml:space="preserve">
-    <value>您想在 Skyline 中添加 {0} 作为 Panorama 服务器吗?</value>
-  </data>
-  <data name="SkypDownloadException_GetMessage_Would_you_like_to_update_the_credentials_" xml:space="preserve">
-    <value>您想更新凭据吗?</value>
-  </data>
-  <data name="SkypFile_GetSkyFileUrl__0__is_not_a_valid_URL_on_a_Panorama_server_" xml:space="preserve">
-    <value>{0} 非 Panorama 服务器上有效的 URL。</value>
-  </data>
-  <data name="SkypFile_GetSkyFileUrl_Expected_the_URL_of_a_shared_Skyline_document_archive_file___0____Found_filename__1__instead_in_the_URL__2__" xml:space="preserve">
-    <value>应提供共享的 Skyline 文档存档文件 ({0}) 的 URL。但在 URL {2} 中找到的文件名为 {1}。</value>
-  </data>
-  <data name="SkypFile_GetSkyFileUrl_File_does_not_contain_the_URL_of_a_shared_Skyline_archive_file___0___on_a_Panorama_server_" xml:space="preserve">
-    <value>文件不包括 Panorama 服务器上共享 Skyline 存档文档 ({0}) 的 URL。</value>
-  </data>
-  <data name="SkypSupport_Download_You_do_not_have_permissions_to_download_this_file_from__0__" xml:space="preserve">
-    <value>您无从 {0} 下载此文件的权限。</value>
-  </data>
-  <data name="SkypSupport_Open_Path_to_skyp_file_cannot_be_empty_" xml:space="preserve">
-    <value>skyp 文件的路径不能为空。</value>
-  </data>
-  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Formula" xml:space="preserve">
-    <value>公式</value>
-  </data>
-  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_InChIKey" xml:space="preserve">
-    <value>InChIKey</value>
-  </data>
-  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Name" xml:space="preserve">
-    <value>名称</value>
-  </data>
-  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_OtherIDs" xml:space="preserve">
-    <value>其他 ID</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_GetMoleculeTransitionGroup_Inconsistent_molecule_description" xml:space="preserve">
-    <value>不一致的分子描述</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_Precursor_mz_does_not_agree_with_calculated_value_" xml:space="preserve">
-    <value>母离子质荷比 {0} 与根据离子公式和电荷状态计算得出的值 {1} 不一致（增量 = {2},离子对设置 | 仪器 | 方法匹配耐受性质荷比 = {3}）。纠正表中的质荷比值，或留空来让Skyline 为您进行计算。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ProcessNeutralLoss_Cannot_use_product_neutral_loss_chemical_formula_without_a_precursor_chemical_formula" xml:space="preserve">
-    <value>没有母离子化学式，不能使用子离子中性丢失化学式</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ProcessNeutralLoss_Precursor_molecular_formula__0__does_not_contain_sufficient_atoms_to_be_used_with_neutral_loss__1_" xml:space="preserve">
-    <value>母离子分子式 {0} 包含的原子不足以用于中性丢失 {1}</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_Product_mz_does_not_agree_with_calculated_value_" xml:space="preserve">
-    <value>子离子质荷比 {0} 与根据离子公式和电荷状态计算得出的值 {1} 不一致（增量 = {2},离子对设置 | 仪器 | 方法匹配耐受性质荷比 = {3}）。纠正表中的质荷比值，或留空来让Skyline 为您进行计算。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_CAS_registry_number_" xml:space="preserve">
-    <value>{0}不是有效的CAS注册号。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_HMDB_identifier_" xml:space="preserve">
-    <value>{0}不是有效的HMDB标识符。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_InChI_identifier_" xml:space="preserve">
-    <value>{0}不是有效的InChI标识符。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_InChiKey_" xml:space="preserve">
-    <value>{0}不是有效的InChiKey。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Adduct__0__charge__1__does_not_agree_with_declared_charge__2_" xml:space="preserve">
-    <value>加合物 {0} 电荷 {1} 与声明电荷 {2} 不匹配</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Cannot_derive_charge_from_adduct_description___0____Use_the_corresponding_Charge_column_to_set_this_explicitly__or_change_the_adduct_description_as_needed_" xml:space="preserve">
-    <value>无法从加合物描述“{0}”中取得电荷。使用相应的电荷列明示设置，或根据需要更改加合物描述。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Formula_already_contains_an_adduct_description__and_it_does_not_match_" xml:space="preserve">
-    <value>公式已经包含加合物描述，但是它不匹配。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_collisional_cross_section_value__0_" xml:space="preserve">
-    <value>无效的碰撞横截面值 {0}</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_high_energy_offset_value__0_" xml:space="preserve">
-    <value>无效的离子迁移高能偏置值 {0}</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_units_value__0___accepted_values_are__1__" xml:space="preserve">
-    <value>无效的离子迁移单位值 {0}（允许值是 {1}）</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_value__0_" xml:space="preserve">
-    <value>无效的离子迁移值 {0}</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Ion_mobility_units_not_specified" xml:space="preserve">
-    <value>未指定离子迁移单位</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Multiple_ion_mobility_declarations" xml:space="preserve">
-    <value>多个离子迁移声明</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Precursor_formula_and_m_z_value_do_not_agree_for_any_charge_state_" xml:space="preserve">
-    <value>母离子公式和质荷比值在任何电荷状态下都不一致。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Precursor_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
-    <value>母离子需要以下任意两项的值：公式、质荷比或电荷。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_formula_and_m_z_value_do_not_agree_for_any_charge_state_" xml:space="preserve">
-    <value>子离子公式和质荷比值在任何电荷状态下都不一致。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
-    <value>子离子需要以下任意两项的值：公式、质荷比或电荷。</value>
-  </data>
-  <data name="SmallMoleculeTransitionListReader_SmallMoleculeTransitionListReader_" xml:space="preserve">
-    <value>读取分子列标题时出错，无法识别：
-{0}
-支持的值包含：
-{1}</value>
-  </data>
-  <data name="SpecialHandlingType_Validate_None" xml:space="preserve">
-    <value>无</value>
-  </data>
-  <data name="SpectraGridForm_AddSpectrumFilters__0__spectrum_filters_will_be_added_to_the_document_" xml:space="preserve">
-    <value>{0}个谱图过滤器将添加到该文档。</value>
-  </data>
-  <data name="SpectrumClassFilter_GetAbbreviatedText_OR" xml:space="preserve">
-    <value>OR</value>
-    <comment>"OR" is the logical operator</comment>
-  </data>
-  <data name="SpectrumClassFilter_MakePredicate_No_spectrum_column__0_" xml:space="preserve">
-    <value>无谱图列 {0}</value>
-  </data>
-  <data name="SpectrumFilter_FindFilterPairs_Two_isolation_windows_contain_targets_which_match_the_isolation_target__0__" xml:space="preserve">
-    <value>两个分离窗口包含匹配分离目标{0}的目标。</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Data_files" xml:space="preserve">
-    <value>数据文件</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_ID" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Matched_spectra" xml:space="preserve">
-    <value>匹配的谱图</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Revision" xml:space="preserve">
-    <value>修订</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Unique_peptides" xml:space="preserve">
-    <value>序列特异的肽段：{0}</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Version" xml:space="preserve">
-    <value>版本</value>
-  </data>
-  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Version__0__" xml:space="preserve">
-    <value>版本：{0}</value>
-  </data>
-  <data name="SrmDocument_GetPeptideGroupId_molecules" xml:space="preserve">
-    <value>分子</value>
-  </data>
-  <data name="SrmDocument_ReadLabelType_The_isotope_modification_type__0__does_not_exist_in_the_document_settings" xml:space="preserve">
-    <value>同位素修饰类型{0}不存在于文档设置中。</value>
-  </data>
-  <data name="SrmDocument_ReadTransitionXml_All_transitions_of_decoy_precursors_must_have_a_decoy_mass_shift" xml:space="preserve">
-    <value>诱饵母离子的所有离子对必须具有诱饵质量偏移。</value>
-  </data>
-  <data name="SrmDocumentSharing_FindSharedSkylineFile_The_zip_file_is_not_a_shared_file" xml:space="preserve">
-    <value>压缩文件不是共享文件。</value>
-  </data>
-  <data name="SrmDocumentSharing_SrmDocumentSharing_ExtractProgress_Extracting__0__" xml:space="preserve">
-    <value>提取{0}</value>
-  </data>
-  <data name="SrmSettingsList_DEFAULT_3_ions" xml:space="preserve">
-    <value>3 个离子</value>
-  </data>
-  <data name="SrmSettingsList_DEFAULT_m_z_precursor" xml:space="preserve">
-    <value>质荷比 &gt; 母离子</value>
-  </data>
-  <data name="StartPage_Tutorial_Zip_Files" xml:space="preserve">
-    <value>压缩文件</value>
-  </data>
-  <data name="String1" xml:space="preserve">
-    <value>foo</value>
-  </data>
-  <data name="TestNamedPipeProcessRunner_RunProcess_Error_running_process" xml:space="preserve">
-    <value>运行过程出错</value>
-  </data>
-  <data name="TestSkylineProcessRunner_RunProcess_The_operation_was_canceled_by_the_user_" xml:space="preserve">
-    <value>操作已由用户取消。</value>
-  </data>
-  <data name="TestToolStoreClient_GetToolZipFile_Error_downloading_tool" xml:space="preserve">
-    <value>下载工具出错</value>
-  </data>
-  <data name="TextUtil_DeterminDsvSeparator_Unable_to_determine_format_of_delimiter_separated_value_file" xml:space="preserve">
-    <value>无法确定分隔符分隔的值文件的格式</value>
-  </data>
-  <data name="ToolDescription_CallArgsCollector_Error_loading_report_from_the_temporary_file__0_" xml:space="preserve">
-    <value>从临时文件{0}加载报告出错</value>
-  </data>
-  <data name="ToolDescription_RunExecutableBackground_Error_running_the_installed_tool__0___It_seems_to_have_an_error_in_one_of_its_files__Please_reinstall_the_tool_and_try_again" xml:space="preserve">
-    <value>运行安装工具{0}出错。文件之一可能出错。请重新安装工具并重试</value>
-  </data>
-  <data name="ToolDescription_RunExecutableBackground_Error_running_the_installed_tool_0_It_seems_to_be_missing_a_file__Please_reinstall_the_tool_and_try_again_" xml:space="preserve">
-    <value>运行安装工具{0}出错。这看起来缺少一个文件。请重新安装工具并重试。</value>
-  </data>
-  <data name="ToolDescription_RunExecutableBackground_The_tool__0__had_an_error__it_returned_the_message_" xml:space="preserve">
-    <value>工具{0}出错，它返回消息：</value>
-  </data>
-  <data name="ToolDescription_RunTool_File_not_found_" xml:space="preserve">
-    <value>未发现文件。</value>
-  </data>
-  <data name="ToolDescription_RunTool_Please_check_the_command_location_is_correct_for_this_tool_" xml:space="preserve">
-    <value>请查看命令位置针对此工具是正确的。</value>
-  </data>
-  <data name="ToolDescription_RunTool_Please_check_the_External_Tools_Store_on_the_Skyline_web_site_for_the_most_recent_version_of_the_QuaSAR_external_tool_" xml:space="preserve">
-    <value>请针对 QuaSAR 外部工具的最新版本于 Skyline 网站查看外部工具商店。</value>
-  </data>
-  <data name="ToolDescription_RunTool_Support_for_the_GenePattern_version_of_QuaSAR_has_been_discontinued_" xml:space="preserve">
-    <value>QuaSAR 之 GenePattern 版本支持已中断。</value>
-  </data>
-  <data name="ToolDescription_VerifyAnnotations_Please_enable_these_annotations_and_fill_in_the_appropriate_data_in_order_to_use_the_tool_" xml:space="preserve">
-    <value>请启用这些注释并填入适当的数据，以使用工具。</value>
-  </data>
-  <data name="ToolDescription_VerifyAnnotations_Please_re_install_the_tool_and_try_again_" xml:space="preserve">
-    <value>请重新安装工具并重试。</value>
-  </data>
-  <data name="ToolDescription_VerifyAnnotations_This_tool_requires_the_use_of_the_following_annotations_which_are_missing_or_improperly_formatted" xml:space="preserve">
-    <value>本工具需要使用已丢失或不当格式化的下列注释</value>
-  </data>
-  <data name="ToolDescription_VerifyAnnotations_This_tool_requires_the_use_of_the_following_annotations_which_are_not_enabled_for_this_document" xml:space="preserve">
-    <value>本工具需要使用未针对此文档启用的下列注释</value>
-  </data>
-  <data name="ToolInstaller_UnpackZipTool_Error__The__0__does_not_contain_a_valid__1__attribute_" xml:space="preserve">
-    <value>错误：{0}不包含有效的{1}属性。</value>
-  </data>
-  <data name="ToolInstaller_UnpackZipTool_The_selected_zip_file_is_not_a_valid_installable_tool_" xml:space="preserve">
-    <value>选定的压缩文件不是有效的可安装工具。</value>
-  </data>
-  <data name="ToolMacros__listArguments_Collected_Arguments" xml:space="preserve">
-    <value>采集的参数</value>
-  </data>
-  <data name="ToolMacros__listArguments_Input_Report_Temp_Path" xml:space="preserve">
-    <value>输入报告临时路径</value>
-  </data>
-  <data name="ToolMacros__listArguments_This_tool_requires_a_Document_Path_to_run" xml:space="preserve">
-    <value>本工具需要运行一个文档路径</value>
-  </data>
-  <data name="ToolMacros__listArguments_Tool_Directory" xml:space="preserve">
-    <value>工具目录</value>
-  </data>
-  <data name="ToolService_InsertSmallMoleculeTransitionList_Insert_Small_Molecule_Transition_List" xml:space="preserve">
-    <value>插入分子离子对列表</value>
-  </data>
-  <data name="ToolUpdateAvailable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\ToolUpdateAvailable.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="ToolUpdatesDlg_btnUpdate_Click_Please_select_at_least_one_tool_to_update_" xml:space="preserve">
-    <value>请至少选择一个工具以更新。</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayDownloadSummary_Failed_to_download_updates_for_the_following_packages" xml:space="preserve">
-    <value>未能下载下列软件包的更新</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayInstallSummary_Failed_to_update_the_following_tool" xml:space="preserve">
-    <value>更新下列工具失败</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayInstallSummary_Failed_to_update_the_following_tools" xml:space="preserve">
-    <value>更新下列工具失败</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayInstallSummary_Successfully_updated_the_following_tool" xml:space="preserve">
-    <value>成功更新下列工具</value>
-  </data>
-  <data name="ToolUpdatesDlg_DisplayInstallSummary_Successfully_updated_the_following_tools" xml:space="preserve">
-    <value>成功更新下列工具</value>
-  </data>
-  <data name="ToolUpdatesDlg_DownloadTools_Downloading_updates_for__0_" xml:space="preserve">
-    <value>下载{0}的更新</value>
-  </data>
-  <data name="ToolUpdatesDlg_InstallUpdates_User_cancelled_installation" xml:space="preserve">
-    <value>用户取消安装</value>
-  </data>
-  <data name="Transition_Validate_Precursor_and_product_ion_polarity_do_not_agree_" xml:space="preserve">
-    <value>母离子和子离子极性不匹配。</value>
+  <data name="ImportResultsDlg_GetDataSourcePathsFile_No_results_files_chosen" xml:space="preserve">
+    <value>未选择任何结果文件。</value>
   </data>
   <data name="Transition_Validate_Precursor_charge__0__must_be_non_zero_and_between__1__and__2__" xml:space="preserve">
     <value>母离子电荷{0}必须非零且在{1}和{2}之间。</value>
   </data>
-  <data name="Transition_Validate_Product_ion_charge__0__must_be_non_zero_and_between__1__and__2__" xml:space="preserve">
-    <value>子离子电荷{0}必须非零且在{1}和{2}之间。</value>
+  <data name="SkylineWindow_ImportResults_The_document_contains_decoys_that_do_not_match_the_targets__Out_of__0__decoys_" xml:space="preserve">
+    <value>文档内包含与目标不匹配的诱饵。{0} 个诱饵中：</value>
   </data>
-  <data name="TransitionFilter_FragmentEndFinders_3_ions" xml:space="preserve">
-    <value>3 个离子</value>
+  <data name="ResultsGrid_ResultsGrid_User_Set" xml:space="preserve">
+    <value>用户设定</value>
   </data>
-  <data name="TransitionFilter_FragmentEndFinders_4_ions" xml:space="preserve">
-    <value>4 个离子</value>
+  <data name="PeptideTipProvider_RenderTip_Ion_Mobility" xml:space="preserve">
+    <value>离子迁移</value>
   </data>
-  <data name="TransitionFilter_FragmentEndFinders_last_ion" xml:space="preserve">
-    <value>最后一个离子</value>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Version" xml:space="preserve">
+    <value>版本</value>
   </data>
-  <data name="TransitionFilter_FragmentEndFinders_last_ion_minus_1" xml:space="preserve">
-    <value>最后一个离子 - 1</value>
+  <data name="warning" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\warning.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="TransitionFilter_FragmentStartFinders_ion_1" xml:space="preserve">
-    <value>离子 1</value>
+  <data name="ImportResultsControl_FindDataFiles_Searching_for_missing_result_files_in__0__" xml:space="preserve">
+    <value>在{0}中搜索缺失结果文件。</value>
   </data>
-  <data name="TransitionFilter_FragmentStartFinders_ion_3" xml:space="preserve">
-    <value>离子 3</value>
+  <data name="CommandLine_CreateIrtDatabase_Use_the__0__argument_to_specify_a_file_to_create_" xml:space="preserve">
+    <value>使用{0}参数指定要创建的文件。</value>
   </data>
-  <data name="TransitionFullScan_DoValidate_An_isolation_window_width_value_is_not_allowed_in__0___mode" xml:space="preserve">
-    <value>{0} 模式下不允许使用分离窗口宽度值。</value>
+  <data name="Pivoter_QualifyColumnInfo_TotalAreaRatio" xml:space="preserve">
+    <value>总面积比率</value>
   </data>
-  <data name="TransitionFullScan_DoValidate_An_isolation_window_width_value_is_required_in_DIA_mode" xml:space="preserve">
-    <value>DIA 模式需要分离窗口宽度值。</value>
+  <data name="PythonInstaller_InstallPackages_Pip_installation_complete_" xml:space="preserve">
+    <value>Pip 安装完成。</value>
   </data>
-  <data name="TransitionFullScan_ValidateRes_Mass_accuracy_must_be_between__0__and__1__for_centroided_data_" xml:space="preserve">
-    <value>针对质心数据质量准确性必须在 {0} 和 {1} 之间。</value>
+  <data name="EditLibraryDlg_OkDialog_The_file__0__is_not_a_supported_spectral_library_file_format" xml:space="preserve">
+    <value>文件{0}不是支持的谱图库文件格式。</value>
   </data>
-  <data name="TransitionGroup" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\transitiongroup.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="SkylineWindow_ShowReintegrateDialog_The_document_must_have_imported_results_" xml:space="preserve">
+    <value>文档必须具有导入的结果。</value>
   </data>
-  <data name="TransitionGroupDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\transitiongroupdecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_Name" xml:space="preserve">
+    <value>分子名称</value>
   </data>
-  <data name="TransitionGroupLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\transitiongrouplib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="RefineDlg_RefineDlg_Precursors" xml:space="preserve">
+    <value>母离子</value>
   </data>
-  <data name="TransitionGroupLibDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\TransitionGroupLibDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="Pivoter_QualifyColumnInfo_AreaRatio" xml:space="preserve">
+    <value>面积比率</value>
   </data>
-  <data name="TransitionGroupTreeNode_GetResultsText_total_ratio__0__" xml:space="preserve">
-    <value>总比率 {0}</value>
+  <data name="CreateIrtCalculatorDlg_OkDialog_iRT_database_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
+    <value>iRT 数据库字段必须包括至有效文件的路径。</value>
   </data>
-  <data name="TransitionInfo_ReadTransitionLosses_Invalid_loss_index__0__for_modification__1__" xml:space="preserve">
-    <value>针对修饰{1}的无效丢失指数 {0}</value>
+  <data name="LoadingTooSlowlyException_LoadingTooSlowlyException_Data_import_expected_to_consume__0__minutes_with_maximum_of__1__mintues" xml:space="preserve">
+    <value>导入的数据预计消耗 {0} 分钟，最多 {1} 分钟</value>
   </data>
-  <data name="TransitionInfo_ReadTransitionLosses_No_modification_named__0__was_found_in_this_document" xml:space="preserve">
-    <value>未在文档中发现名为{0}的修饰。</value>
+  <data name="EditMeasuredIonDlg_OkDialog_Reporter_ion_masses_must_be_greater_than_or_equal_to__0__" xml:space="preserve">
+    <value>报告离子质量必须大于或等于 {0}。</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_Target" xml:space="preserve">
+    <value>目标</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Transition_Replicate_Note" xml:space="preserve">
+    <value>离子对重复测定注释</value>
+  </data>
+  <data name="RInstaller_InstallR_R_installation_was_not_completed__Cancelling_tool_installation_" xml:space="preserve">
+    <value>R 安装未完成。取消工具安装。</value>
   </data>
   <data name="TransitionInfo_ReadXmlAttributes_The_reporter_ion__0__was_not_found_in_the_transition_filter_settings_" xml:space="preserve">
     <value>未在离子对过滤器设置中发现报告离子 {0}。</value>
   </data>
-  <data name="TransitionLibraries_DoValidate_Library_ion_count_value__0__must_not_be_less_than_min_ion_count_value__1__" xml:space="preserve">
-    <value>库离子计数值 {0} 不得少于最小离子计数值 {1}。</value>
+  <data name="DigestSettings_ValidateIntRange_The_value__1__for__0__must_be_between__2__and__3__" xml:space="preserve">
+    <value>针对{0}的值 {1} 必须在 {2} 和 {3} 之间。</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_An_isolation_scheme_is_required_to_match_multiple_precursors" xml:space="preserve">
-    <value>分离方案要求匹配多个母离子。</value>
+  <data name="BiblioSpecLiteLibrary_Load_Invalid_precursor_charge__0__found__File_may_be_corrupted" xml:space="preserve">
+    <value>发现无效的母离子电荷{0}。文件可能已损坏。</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_Cannot_use_DIA_window_for_precursor_exclusion_when_isolation_scheme_does_not_contain_prespecified_windows___Please_select_an_isolation_scheme_with_prespecified_windows_" xml:space="preserve">
-    <value>当分离方案不包含预先设定的窗口时，无法针对母离子排除使用 DIA 窗口。 请选择一个带有预先设定窗口的分离方案。</value>
+  <data name="PasteDlg_btnTransitionListHelp_Click_2_" xml:space="preserve">
+    <value>关于分子离子公式的注释：
+
+如果您的离子对列表格式将公式和加合物汇总在单一列（例如“C8H10N4O2[M+Na]”）中，那么使用“离子公式”列，而丢弃“加合物”列。 如果您的离子对列表将中和公式和加合物放置在不同的列中，那么对中和公式使用“离子公式”，而对加合物使用“加合物”列。</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_Cannot_use_DIA_window_for_precusor_exclusion_when__All_Ions__is_selected_as_the_isolation_scheme___To_use_the_DIA_window_for_precusor_exclusion__change_the_isolation_scheme_in_the_Full_Scan_settings_" xml:space="preserve">
-    <value>当“所有离子”被选定为分离方案时，无法针对母离子排除使用 DIA 窗口。 如要将 DIA 窗口用于母离子排除，请在“全扫描”设置中更改分离方案。</value>
+  <data name="CommandLine_Run_Error__Failed_importing_the_file__0____1_" xml:space="preserve">
+    <value>错误：导入文件失败{0}。{1}</value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_Ion_types_must_contain_a_comma_separated_list_of_ion_types_a_b_c_x_y_z_and_p_for_precursor" xml:space="preserve">
-    <value>离子类型必须包含以逗号分隔的离子类型 a、b、c、x、y、z 和 p 列表（针对母离子）。</value>
+  <data name="FileStreamManager_Commit_Could_not_replace_file_" xml:space="preserve">
+    <value>无法替换文件 </value>
   </data>
-  <data name="TransitionSettingsUI_OkDialog_Isotope_enrichment_settings_are_required_for_MS1_filtering_on_high_resolution_mass_spectrometers" xml:space="preserve">
-    <value>高分辨率质谱仪上的 MS1 过滤需要同位素富集设置。</value>
+  <data name="SrmDocumentSharing_SrmDocumentSharing_ExtractProgress_Extracting__0__" xml:space="preserve">
+    <value>提取{0}</value>
   </data>
-  <data name="TransitionTreeNode_GetLabel_rank__0__" xml:space="preserve">
-    <value>排名 {0}</value>
+  <data name="LibraryGridViewDriver_AddProcessedIrts_None_of__0__runs_were_found_with_high_enough_correlation_to_the_existing_iRT_values_to_allow_retention_time_conversion" xml:space="preserve">
+    <value>所有{0}个运行对现有 iRT 值的相关性都不够高，无法实现保留时间转换。</value>
   </data>
-  <data name="TransitionTreeNode_GetResultsText__0__" xml:space="preserve">
-    <value>[{0}]</value>
-    <comment>Rank for transition node</comment>
+  <data name="PeptideToMoleculeText_Peptides" xml:space="preserve">
+    <value>肽段</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 peptides" to read "2 molecules" when non-peptide documents are in use</comment>
   </data>
-  <data name="TransitionTreeNode_GetResultsText__0__ratio__1__" xml:space="preserve">
-    <value>{0}（比率 {1}）</value>
-    <comment>(0) transition amino acids, (1) transition fragment ion</comment>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Peptides" xml:space="preserve">
+    <value>肽段</value>
   </data>
-  <data name="TransitionTreeNode_RenderTip_Charge" xml:space="preserve">
-    <value>电荷</value>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_Start" xml:space="preserve">
+    <value>开始</value>
   </data>
-  <data name="UIModeMixed" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\UIModeMixed.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="RefineListDlg_OkDialog_The_peptide___0___is_not_in_the_document" xml:space="preserve">
+    <value>肽段“{0}”不存在于文档中。</value>
   </data>
-  <data name="UIModeProteomic" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\UIModeProteomic.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="TransitionFilter_FragmentEndFinders_last_ion_minus_1" xml:space="preserve">
+    <value>最后一个离子 - 1</value>
   </data>
-  <data name="UIModeSmallMolecules" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\UIModeSmallMolecules.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeakBoundaryImporter_Import_The_decoy_value__0__on_line__1__is_invalid__must_be_0_or_1_" xml:space="preserve">
+    <value>第 {1} 行上的诱饵值 {0} 无效：必须是 0 或 1。</value>
+  </data>
+  <data name="PeptideStandardLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidestandardlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Protein_Name" xml:space="preserve">
+    <value>蛋白质名称</value>
+  </data>
+  <data name="ReportSpec_ReportToCsvString_Exporting__0__report" xml:space="preserve">
+    <value>导出{0}报告</value>
+  </data>
+  <data name="Collapse" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\minus.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ChromatogramCache_LoadStructs_The_SKYD_file_format__0__is_not_supported_by_Skyline__1__" xml:space="preserve">
+    <value>Skyline {1}不支持 SKYD 文件格式{0}。</value>
+  </data>
+  <data name="XHunterLibrary_Load_Invalid_precursor_charge_found_File_may_be_corrupted" xml:space="preserve">
+    <value>发现无效的母离子电荷。文件可能已损坏。</value>
   </data>
   <data name="UniquePeptidesDlg_LaunchPeptideProteinsQuery_" xml:space="preserve">
     <value>{0}
 （基因：{1}）</value>
   </data>
-  <data name="UniquePeptidesDlg_OnShown_The_background_proteome__0__has_not_yet_finished_being_digested_with__1__" xml:space="preserve">
-    <value>背景蛋白质组{0}还未结束与{1}的消化过程。</value>
+  <data name="SerializableSettingsList_ImportFile_Failure_loading__0__" xml:space="preserve">
+    <value>加载{0}失败。</value>
   </data>
-  <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_gene_information__this_selection_may_be_suspect_" xml:space="preserve">
-    <value>一些背景蛋白质组蛋白没有基因信息，此选择可疑。</value>
+  <data name="AreaReplicateGraphPane_UpdateGraph_Peak_Area" xml:space="preserve">
+    <value>峰面积</value>
   </data>
-  <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_species_information__this_selection_may_be_suspect_" xml:space="preserve">
-    <value>一些背景蛋白质组蛋白没有物种信息，此选择可疑。</value>
+  <data name="ColorSchemeList_GetDefaults_Distinct" xml:space="preserve">
+    <value>明显不同的</value>
   </data>
-  <data name="UnpackZipToolHelper_UnpackZipTool_The_tool___0___requires_report_type_titled___1___and_it_is_not_provided__Import_canceled_" xml:space="preserve">
-    <value>工具“{0}”需要标题为“{1}”的报告类型，并且该类型未提供。导入已取消。</value>
+  <data name="CommandLineTest_ConsoleAddFastaTest_Error" xml:space="preserve">
+    <value>错误</value>
   </data>
-  <data name="up_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\up-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="SkylineWindow_importMassListMenuItem_Click_Data_columns_not_found_in_first_line" xml:space="preserve">
+    <value>第一行中未发现数据列。</value>
   </data>
-  <data name="UpgradeManager_updateCheck_Complete_Failed_attempting_to_check_for_an_upgrade_" xml:space="preserve">
-    <value>尝试检查升级失败。</value>
+  <data name="SrmDocument_GetPeptideGroupId_molecules" xml:space="preserve">
+    <value>分子</value>
   </data>
-  <data name="UpgradeManager_updateCheck_Complete_Failed_attempting_to_upgrade_" xml:space="preserve">
-    <value>尝试升级失败。</value>
+  <data name="PersistedViews_GetDefaults_Molecule_Ratio_Results" xml:space="preserve">
+    <value>分子比率结果</value>
   </data>
-  <data name="UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
-    <value>验证服务器 {0} 上的用户凭据时出错。</value>
+  <data name="PeptideQcLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptideqclib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="UtilDB_Uncompress_Failure_uncompressing_data" xml:space="preserve">
-    <value>解压数据失败。</value>
+  <data name="GenerateDecoys" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\GenerateDecoys.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateAdduct_A_valid_adduct_description__e_g____M_H____must_be_provided_" xml:space="preserve">
-    <value>必须提供有效的加合物描述（例如“[M + H]”）。</value>
-  </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateCollisionalCrossSection_Measured_collisional_cross_section_values_must_be_valid_decimal_numbers_greater_than_zero_" xml:space="preserve">
-    <value>测量的碰撞横截面值必须是大于零的有效十进制数。</value>
-  </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateHighEnergyIonMobilityOffset_High_energy_ion_mobility_offsets_should_be_empty__or_express_an_offset_value_for_ion_mobility_in_high_collision_energy_scans_which_may_add_velocity_to_ions_" xml:space="preserve">
-    <value>高能离子迁移偏置应为空，或表示可能增加离子速度的高碰撞能量扫描中离子迁移的偏置值。</value>
-  </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry_" xml:space="preserve">
-    <value>每个条目都需要修饰肽段序列。</value>
-  </data>
-  <data name="ValidatingIonMobilityPeptide_ValidateSequence_The_sequence__0__is_not_a_valid_modified_peptide_sequence_" xml:space="preserve">
-    <value>序列 {0} 不是有效的修饰肽段序列。</value>
-  </data>
-  <data name="ValueInvalidChargeListException_ValueInvalidChargeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_integers_" xml:space="preserve">
-    <value>值“{0}”对于参数 {1} 无效，该参数必须是以逗号分隔的整数列表。</value>
-  </data>
-  <data name="ValueInvalidDateException_ValueInvalidDateException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_date_time_value_" xml:space="preserve">
-    <value>值“{0}”对于必须是日期时间值的参数 {1} 无效。</value>
-  </data>
-  <data name="ValueInvalidDoubleException_ValueInvalidDoubleException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_decimal_number_" xml:space="preserve">
-    <value>值“{0}”对于必须是十进制数的参数 {1} 无效。</value>
-  </data>
-  <data name="ValueInvalidIntException_ValueInvalidIntException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_integer_" xml:space="preserve">
-    <value>值“{0}”对于参数 {1} 无效，该参数必须是整数。</value>
-  </data>
-  <data name="ValueInvalidIonTypeListException_ValueInvalidIonTypeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_fragment_ion_types__a__b__c__x__y__z__p__" xml:space="preserve">
-    <value>值“{0}”对于参数 {1} 无效，该参数必须是以逗号分隔的碎片离子类型列表(a, b, c, x, y, z, p)。</value>
+  <data name="MassListImporter_AddRow_Invalid_library_intensity_at_precursor__0__for_peptide__1_" xml:space="preserve">
+    <value>肽段{1}在母离子{0}上的无效库强度。</value>
   </data>
   <data name="ValueInvalidMzToleranceException_ValueInvalidMzToleranceException_The_value__0__is_not_valid_for_the_argument__1__which_requires_a_value_and_a_unit__For_example___2__" xml:space="preserve">
-    <value>{0} 值对于参数 {1} 无效，该参数需要的是值和单位。例如: {2}。</value>
+    <value>{0} 值对于参数 {1} 无效，该参数需要的是一个值和一个单位。例如: {2}。</value>
   </data>
-  <data name="ValueInvalidNumberListException_ValueInvalidNumberListException_The_value__0__is_not_valid_for_the_argument__1__which_requires_a_list_of_decimal_numbers_" xml:space="preserve">
-    <value>值 {0} 对于必须是十进制数的参数清单 {1} 无效。</value>
+  <data name="EditIsolationSchemeDlg_comboMargins_SelectedIndexChanged_Margin" xml:space="preserve">
+    <value>边距</value>
   </data>
-  <data name="ValueInvalidPathException_ValueInvalidPathException_The_value___0___is_not_valid_for_the_argument__1__failed_attempting_to_convert_it_to_a_full_file_path_" xml:space="preserve">
-    <value>值“{0}”对于参数 {1} 无效，尝试将其转换为完整文件路径失败。</value>
+  <data name="SkylineWindow_ShowReintegrateDialog_The_document_must_have_targets_in_order_to_reintegrate_chromatograms_" xml:space="preserve">
+    <value>文档必须具有目标，以重新合并色谱图。</value>
   </data>
-  <data name="ValueMissingException_ValueMissingException_" xml:space="preserve">
-    <value>参数 {0} 需要数值并且必须在“ --名称=值”的格式中指定</value>
+  <data name="WandProhibit" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\WandProhibit.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_expandAllMenuItem_DropDownOpening__Lists" xml:space="preserve">
+    <value>列表(&amp;L)</value>
+  </data>
+  <data name="ExportReportDlg_OkDialog_Export_Report" xml:space="preserve">
+    <value>导出报告</value>
+  </data>
+  <data name="AddZipToolHelper_InstallProgram_Error__Package_installation_not_handled_in_SkylineRunner___If_you_have_already_handled_package_installation_use_the___tool_ignore_required_packages_flag" xml:space="preserve">
+    <value>错误：软件包安装未在 SkylineRunner 中处理。 如果您已经处理软件安装包，请使用“--工具-忽视-必需-软件包”标记。</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Version__0__" xml:space="preserve">
+    <value>版本：{0}</value>
+  </data>
+  <data name="ToolMacros__listArguments_Tool_Directory" xml:space="preserve">
+    <value>工具目录</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_The_document_only_contains__0__of_these_iRT_standard_peptides_" xml:space="preserve">
+    <value>文档仅包括这些 iRT 标准肽段中的 {0} 个。</value>
+  </data>
+  <data name="SkypDownloadException_GetMessage_The_skyp_file_was_downloaded_by_the_user__0___Credentials_saved_in_Skyline_for_this_server_are_for_the_user__1__" xml:space="preserve">
+    <value>该 skyp 文件由用户 {0} 下载。Skyline 中保存的此服务器凭据仅适用于用户 {1}。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Neutral_Loss" xml:space="preserve">
+    <value>子离子中性丢失</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Acquired_Time" xml:space="preserve">
+    <value>采集时间</value>
+  </data>
+  <data name="BuildBackgroundProteomeDlg_AddFastaFile_The_added_file_included__0__repeated_protein_sequences__Their_names_were_added_as_aliases_to_ensure_the_protein_list_contains_only_one_copy_of_each_sequence_" xml:space="preserve">
+    <value>添加的文件包含 {0} 个重复的蛋白质序列。它们的名称作为别名添加，以确保蛋白质列表只包含每个序列的一个副本。</value>
+  </data>
+  <data name="ChooseSchedulingReplicatesDlg_btnOk_Click_Choose_retention_time_filter_replicates" xml:space="preserve">
+    <value>选择保留时间过滤器重复测定</value>
+  </data>
+  <data name="CommandLine_ProcessDocument_Error_saving_file" xml:space="preserve">
+    <value>错误：保存文件时出错</value>
+  </data>
+  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_specify_a_path_to_an_existing_spectral_library" xml:space="preserve">
+    <value>请指定一个对应到现有谱图库的路径。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Error__Regular_expression___0___does_not_have_any_groups___String" xml:space="preserve">
+    <value>错误：正则表达式'{0}'没有任何群组。 必需拥有一个群组。与正则表达式中第一群组匹配的部分文件或子目录名称用作重复测定名称。</value>
+  </data>
+  <data name="AsyncChromatogramsGraph_Render__0___sample__1_" xml:space="preserve">
+    <value>{0}，样品 {1}</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Warning___line__0___column__1____2_" xml:space="preserve">
+    <value>警告：（行 {0}，列 {1}） {2}</value>
+  </data>
+  <data name="Transition_Validate_Product_ion_charge__0__must_be_non_zero_and_between__1__and__2__" xml:space="preserve">
+    <value>子离子电荷{0}必须非零且在{1}和{2}之间。</value>
+  </data>
+  <data name="DefineAnnotationDlg_OkDialog_There_is_already_an_annotation_defined_named__0__" xml:space="preserve">
+    <value>已经存在名为“{0}”的已定义注释。</value>
+  </data>
+  <data name="NistLibraryBase_Load_Loading__0__library" xml:space="preserve">
+    <value>加载{0}库</value>
+  </data>
+  <data name="SummaryReplicateGraphPane_SummaryReplicateGraphPane_Replicate" xml:space="preserve">
+    <value>重复测定</value>
+  </data>
+  <data name="ExportMethodDlg_ExportMethodDlg_Export_Isolation_List" xml:space="preserve">
+    <value>导出分离列表</value>
+  </data>
+  <data name="FastaSequence_ComparePeptides_Peptides_in_different_FASTA_sequences_may_not_be_compared" xml:space="preserve">
+    <value>FASTA 序列不同的肽段不可比较。</value>
+  </data>
+  <data name="EditLibraryDlg_GetLibraryPath_Legacy_Libraries" xml:space="preserve">
+    <value>遗留库</value>
+  </data>
+  <data name="CompareElement_CompareElement__Compare____" xml:space="preserve">
+    <value>&lt;比较…&gt;</value>
+  </data>
+  <data name="OverlapDemultiplexer_attempt_to_take_slice_of_deconvolution_matrix_failed_out_of_range" xml:space="preserve">
+    <value>因范围外误差而尝试获取去卷积片段基质失败。</value>
+  </data>
+  <data name="UIModeProteomic" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UIModeProteomic.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_SetLibrary_Error__The_library_you_are_trying_to_add_conflicts_with_a_library_already_in_the_file_" xml:space="preserve">
+    <value>错误：您试图添加的库与文件中已经存在的库发生冲突。</value>
+  </data>
+  <data name="CommandLine_ImportResultsFile_Warning__Failed_importing_the_results_file__0____Ignoring___" xml:space="preserve">
+    <value>警告：导入结果文件{0}失败。 忽视...</value>
+  </data>
+  <data name="TestToolStoreClient_GetToolZipFile_Error_downloading_tool" xml:space="preserve">
+    <value>下载工具出错</value>
+  </data>
+  <data name="IonMobilityFinder_ProcessMSLevel_Failed_using_results_to_populate_ion_mobility_library_" xml:space="preserve">
+    <value>使用结果填充离子迁移库失败：</value>
+  </data>
+  <data name="Find" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\find.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ExportMethodDlg_VerifySchedulingAllowed_Triggered_acquistion_requires_a_spectral_library_or_imported_results_in_order_to_rank_transitions_" xml:space="preserve">
+    <value>触发采集需要一个谱图库或导入结果，以排名离子对。</value>
+  </data>
+  <data name="Loader_Load_Loading_results_for__0__" xml:space="preserve">
+    <value>针对{0}加载结果</value>
+  </data>
+  <data name="PeptideGroupBuilder_AppendTransition_Failed_to_explain_all_transitions_for_0__m_z__1__with_a_single_set_of_modifications" xml:space="preserve">
+    <value>未能借助单一修饰集解释针对{0}质荷比 {1} 的所有离子对</value>
+  </data>
+  <data name="AbstractSpectrumGraphItem_GetLabel_rank__0__" xml:space="preserve">
+    <value>排名 {0}</value>
+  </data>
+  <data name="RegressionOption_All_Fixed_points__linear_" xml:space="preserve">
+    <value>固定点（线性）</value>
+  </data>
+  <data name="CommandLine_NewSkyFile_FileAlreadyExists" xml:space="preserve">
+    <value>文件“{0}”已存在；添加 --overwrite 将允许 Skyline 覆盖。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_You_have_only_rough_tune_optimized_compensation_voltages_" xml:space="preserve">
+    <value>您只有粗略调谐最优补偿电压。</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Error_Installing_Packages" xml:space="preserve">
+    <value>安装包出错</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_Warning__the_annotation__0__is_being_overwritten" xml:space="preserve">
+    <value>警告：注释{0}正在被覆盖</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Transitions" xml:space="preserve">
+    <value>离子对</value>
+  </data>
+  <data name="Skyline_Release1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Skyline_Release.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="IonMobilityDb_GetIonMobilityDb_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
+    <value>离子迁移库文件{0}无法找到。可能您没有足够的权限来创建它？</value>
+  </data>
+  <data name="CommandLine_SaveFile_Error__The_file_could_not_be_saved_to__0____Check_that_the_directory_exists_and_is_not_read_only_" xml:space="preserve">
+    <value>错误：文件无法保存至{0}。 查看目录存在并且不是只读格式。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_File_path_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
+    <value>文件路径字段必须包括至有效文件的路径。</value>
+  </data>
+  <data name="CommandLine_AddDecoys_Decoys_discarded" xml:space="preserve">
+    <value>已丢弃诱饵</value>
+  </data>
+  <data name="ExportChromatogramDlg_OkDialog_At_least_one_file_must_be_selected" xml:space="preserve">
+    <value>必须至少选定一个文件</value>
+  </data>
+  <data name="CalculateIsolationSchemeDlg_OkDialog_Window_width_not_even" xml:space="preserve">
+    <value>奇数窗口宽度不受所选优化窗口放置重叠分解支持。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CopyinFile_A_file_named_0_already_exists_that_isn_t_identical_to_the_one_for_tool__1" xml:space="preserve">
+    <value>名为{0}的文件已经存在，它与针对工具{1}的文件不同</value>
+  </data>
+  <data name="PeptideList" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\PeptideList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="DDASearchControl_SearchProgress_Search_done" xml:space="preserve">
+    <value>搜索完成。</value>
+  </data>
+  <data name="CommandLine_ImportResults_Error__No_files_left_to_import_" xml:space="preserve">
+    <value>错误：没有可供导入的文件。</value>
+  </data>
+  <data name="PasteDlg_AddTransitionList_The_precursor_m_z_must_be_a_number_" xml:space="preserve">
+    <value>母离子质荷比必须是数字。</value>
+  </data>
+  <data name="SkylineImg" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\skyline.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MatchModificationsControl_AddCheckedModifications_Add_checked_modifications" xml:space="preserve">
+    <value>添加选中的修饰</value>
+  </data>
+  <data name="OpenFolder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\openfolder.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ProteoWizard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ProteoWizard.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_The_following_file_name_in_the_peak_boundaries_file_was_not_recognized_" xml:space="preserve">
+    <value>峰边界文件中的下列文件名称没有被识别：</value>
+  </data>
+  <data name="PanoramaHelper_ValidateServer_Exception_" xml:space="preserve">
+    <value>错误：尝试验证 Panorama 服务器信息时发生未知错误。
+{0}</value>
+  </data>
+  <data name="EditEnzymeDlg_ValidateAATextBox_The_character__0__is_not_a_valid_amino_acid" xml:space="preserve">
+    <value>字符“{0}”不是有效的氨基酸。</value>
+  </data>
+  <data name="DriftTimeWindowWidthCalculator_Validate_Fixed window_width_must_be_non_negative_" xml:space="preserve">
+    <value>固定窗口宽度必须为非负数。</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_OkDialog_The_selected_target_is_not_unique" xml:space="preserve">
+    <value>选定目标并不是独一无二的。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Collision_Energy" xml:space="preserve">
+    <value>明确碰撞能量</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_CellEndEdit_Edit_note" xml:space="preserve">
+    <value>编辑注释</value>
+  </data>
+  <data name="AreaReplicateGraphPane_InitFromData_Expected" xml:space="preserve">
+    <value>预期的</value>
+    <comment>expected value</comment>
+  </data>
+  <data name="IsolationScheme_DoValidate_Special_handling_applies_only_to_prespecified_isolation_windows" xml:space="preserve">
+    <value>特别处理仅适用于预先设定的分离窗口</value>
+  </data>
+  <data name="CommandLine_ImportTool_Error__Please_import_the_report_format_for__0____Use_the___report_add_parameter_to_add_the_missing_custom_report_" xml:space="preserve">
+    <value>错误：请针对{0}导入报告格式。 使用“--报告-添加”参数来添加丢失的自定义报告。</value>
+  </data>
+  <data name="MassErrorReplicateGraphPane_UpdateGraph_Select_a_peptide_to_see_the_mass_error_graph" xml:space="preserve">
+    <value>选择一个肽段，以查看质量误差图</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_S_Lens" xml:space="preserve">
+    <value>S-Lens</value>
+  </data>
+  <data name="PeptideTipProvider_RenderTip_CCS" xml:space="preserve">
+    <value>CCS</value>
+    <comment>compact form of Collision Cross Section</comment>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Identified" xml:space="preserve">
+    <value>已确认的</value>
+  </data>
+  <data name="RInstaller_DownloadPackages_Check_your_network_connection_or_contact_the_tool_provider_for_installation_support_" xml:space="preserve">
+    <value>检查您的网络连接或联络工具提供商以获得安装支持。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_charge__Charges_must_be_integer_values_between_1_and__1__" xml:space="preserve">
+    <value>值 {0} 不是有效电荷。电荷必须是介于 1 和 {1} 之间的整数。</value>
+  </data>
+  <data name="SkylineWindow_OpenSharedFile_Failure_extracting_Skyline_document_from_zip_file__0__" xml:space="preserve">
+    <value>从压缩文件{0}中提取 Skyline 文档失败。</value>
+  </data>
+  <data name="MassListImporter_Import_Empty_transition_list" xml:space="preserve">
+    <value>空离子对列表。</value>
+  </data>
+  <data name="Properties_Button" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Properties.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TestNamedPipeProcessRunner_RunProcess_Error_running_process" xml:space="preserve">
+    <value>运行过程出错</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_be_greater_than_or_equal_to__1__" xml:space="preserve">
+    <value>{0}必须大于或等于 {1}。</value>
+  </data>
+  <data name="ChromCacheBuilder_BuildNextFileInner_The_file__0__does_not_exist" xml:space="preserve">
+    <value>文件{0}不存在。</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwrite_Error__There_is_a_conflicting_tool" xml:space="preserve">
+    <value>错误：存在一个冲突工具</value>
+  </data>
+  <data name="ExportChromatogramDlg_OkDialog_At_least_one_chromatogram_type_must_be_selected" xml:space="preserve">
+    <value>必须至少选定一个色谱图类型。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Precursor_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
+    <value>母离子需要以下任意两项的值：公式、质荷比或电荷。</value>
+  </data>
+  <data name="PasteDlg_CheckSequence_There_is_no_sequence_for_this_protein" xml:space="preserve">
+    <value>无此蛋白质序列</value>
+  </data>
+  <data name="MultiFileAsynchronousDownloadClient_DownloadFileAsyncWithBroker_Download_canceled_" xml:space="preserve">
+    <value>下载取消。</value>
+  </data>
+  <data name="ToolUpdatesDlg_DisplayInstallSummary_Failed_to_update_the_following_tools" xml:space="preserve">
+    <value>更新下列工具失败</value>
   </data>
   <data name="ValueOutOfRangeDoubleException_ValueOutOfRangeException_The_value___0___for_the_argument__1__must_be_between__2__and__3__" xml:space="preserve">
     <value>参数 {1} 的值“{0}”必须介于 {2} 和 {3} 之间。</value>
   </data>
-  <data name="ValueUnexpectedException_ValueUnexpectedException_The_argument__0__should_not_have_a_value_specified" xml:space="preserve">
-    <value>参数 {0} 不应该具有指定的值</value>
+  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_The_ion__0__has_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
+    <value>离子 {0} 有多个离子迁移值。Skyline 支持多个构象异构体，因此这可能是有意为之。</value>
   </data>
-  <data name="VendorIssueHelper_ConvertWiffToMzxml_Please_install_Analyst__or_run_this_import_on_a_computure_with_Analyst_installed" xml:space="preserve">
-    <value>请安装 Analyst，或者在安装有 Analyst 的电脑上运行此导入</value>
+  <data name="ValueInvalidIonTypeListException_ValueInvalidIonTypeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_fragment_ion_types__a__b__c__x__y__z__p__" xml:space="preserve">
+    <value>值“{0}”对于参数 {1} 无效，该参数必须是以逗号分隔的碎片离子类型列表(a, b, c, x, y, z, p)。</value>
   </data>
-  <data name="VendorIssueHelper_ConvertWiffToMzxml_The_file__0__cannot_be_imported_by_the_AB_SCIEX_WiffFileDataReader_library_in_a_reasonable_time_frame_1_F02_min" xml:space="preserve">
-    <value>文件{0}无法在合理的时间框架（{1:F02} 分钟）内由 AB SCIEX WiffFileDataReader 库导入。</value>
+  <data name="add_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\add-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="FragmentLibDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\FragmentLibDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="WizardPeptideSearchPRM" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardPeptideSearchPRM.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="AddIrtCalculatorDlg_OkDialog_The_file__0__is_not_an_iRT_database" xml:space="preserve">
+    <value>文件{0}不是 iRT 数据库。</value>
+  </data>
+  <data name="ConfigureToolsDlg_GetTitle__New_Tool_0__" xml:space="preserve">
+    <value>[新工具{0}]</value>
+  </data>
+  <data name="DDASearchControl_SearchProgress_Search_canceled" xml:space="preserve">
+    <value>搜索取消。</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_The_following_proteins_are_not_in_the_document_" xml:space="preserve">
+    <value>下列蛋白质不在文档中：</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_OkDialog_Please_choose_a_file_for_the_ion_mobility_library" xml:space="preserve">
+    <value>请为离子迁移库选择一个文件。</value>
+  </data>
+  <data name="EditLinkedPeptidesDlg_OkDialog_Some_crosslinked_peptides_are_not_connected_" xml:space="preserve">
+    <value>有些交联肽段未连接。</value>
+  </data>
+  <data name="CommandLine_ExportReport_Error__The_report__0__does_not_exist__If_it_has_spaces_in_its_name__use__double_quotes__around_the_entire_list_of_command_parameters_" xml:space="preserve">
+    <value>错误：报告{0}不存在。如果名称中存在空格，请在整个命令参数列表周围使用“双引号”。</value>
+  </data>
+  <data name="PersistedViews_GetDefaults_Molecule_Quantification" xml:space="preserve">
+    <value>分子定量</value>
+  </data>
+  <data name="CommandLine_OpenSkyFile_Error__There_was_an_error_opening_the_file__0_" xml:space="preserve">
+    <value>错误：打开文件{0}出现错误</value>
+  </data>
+  <data name="RInstaller_RInstaller_Load_This_Tool_requires_the_use_of_the_following_R_Packages_" xml:space="preserve">
+    <value>此工具要求使用下列 R 软件包。</value>
+  </data>
+  <data name="GenerateDecoysError_No_peptide_precursor_models_for_decoys_were_found_" xml:space="preserve">
+    <value>未找到针对诱饵的肽段母离子模型。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Max_End_Time" xml:space="preserve">
+    <value>结束时间最大值</value>
+  </data>
+  <data name="ReintegrateDlg_OkDialog_The_current_peak_scoring_model_is_incompatible_with_one_or_more_peptides_in_the_document___Please_train_a_new_model_" xml:space="preserve">
+    <value>当前的峰得分模型与文档中的一个或多个肽段不兼容。请训练一个新模型。</value>
+  </data>
+  <data name="RatioToSurrogate_ToString_Ratio_to_surrogate__0____1__" xml:space="preserve">
+    <value>与替代的比例 {0} ({1})</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Peak_Boundaries" xml:space="preserve">
+    <value>峰边界</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value>foo</value>
+  </data>
+  <data name="CalibrateIrtDlg_TryGetLine_The_standard_must_have_two_fixed_points" xml:space="preserve">
+    <value>标准必须拥有两个固定点。</value>
+  </data>
+  <data name="PeptideGroupDocNode_ChangeSettings_The_current_document_settings_would_cause_the_number_of_targeted_transitions_to_exceed__0_n0___The_document_settings_must_be_more_restrictive_or_add_fewer_proteins_" xml:space="preserve">
+    <value>当前文档设置可能会导致目标离子对数量超过{0:n0}。文档设置必须更具限制性或添加较少的蛋白质。</value>
+  </data>
+  <data name="CommandLine_ApplySampleNameRegex_File___0___does_not_have_a_sample__Cannot_apply_sample_name_pattern__Ignoring_" xml:space="preserve">
+    <value>文件“{0}” 无样品。无法应用样品名称模式。忽视。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_UpdateNumPeptides__0__Peptide" xml:space="preserve">
+    <value>{0} 个肽段</value>
+  </data>
+  <data name="ValueInvalidIntException_ValueInvalidIntException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_integer_" xml:space="preserve">
+    <value>值“{0}”对于参数 {1} 无效，该参数必须是整数。</value>
+  </data>
+  <data name="Edit_Undo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\edit_undo.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Peptide_ToString__missed__5__" xml:space="preserve">
+    <value>（缺少{5}）</value>
+  </data>
+  <data name="PythonInstaller_DownloadPackages_Failed_to_download_the_following_packages_" xml:space="preserve">
+    <value>未能下载下列软件包：</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_ReadIsolationRanges_No_repeating_isolation_scheme_found_in__0_" xml:space="preserve">
+    <value>未在 {0} 内找到重复的分离方案</value>
+  </data>
+  <data name="SkypDownloadException_GetMessage_Credentials_saved_in_Skyline_for_the_Panorama_server__0__are_invalid_" xml:space="preserve">
+    <value>Skyline 中保存的 Panorama 服务器 {0} 的凭据无效。</value>
+  </data>
+  <data name="CommandLine_ApplyFileAndSampleNameRegex_Error__No_files_match_the_sample_name_pattern___0___" xml:space="preserve">
+    <value>错误：没有与示例名称模式 '{0}' 相匹配的文件。</value>
+  </data>
+  <data name="XmlElementHelper_Deserialize_Deserialize" xml:space="preserve">
+    <value>反序列化</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_A_maximum_of_one_decoy_per_target_may_be_generated_when_using_reversed_decoys_" xml:space="preserve">
+    <value>在使用反向诱饵时，每个目标最多只能生成一个诱饵。</value>
+  </data>
+  <data name="Print" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\print.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Unique_peptides" xml:space="preserve">
+    <value>序列特异的肽段：{0}</value>
+  </data>
+  <data name="ImportSkyrHelper_ResolveImportConflicts_Resolving_conflicts_by_skipping_" xml:space="preserve">
+    <value>通过跳过来解决冲突。</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Precursors" xml:space="preserve">
+    <value>母离子</value>
+  </data>
+  <data name="ViewLibraryDlg_EnsureBackgroundProteome_The_background_proteome_must_be_digested_in_order_to_associate_proteins" xml:space="preserve">
+    <value>背景蛋白质组必须被消化才能关联蛋白质。</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_m_z_value__0_" xml:space="preserve">
+    <value>无效质荷比值{0}</value>
+  </data>
+  <data name="CommandLine_ApplyFileNameRegex_File_name___0___does_not_match_the_pattern___1____Ignoring__2_" xml:space="preserve">
+    <value>文件名“{0}”不符合模式“{1}”。忽视{2}</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility__msec_" xml:space="preserve">
+    <value>明确离子迁移 (ms)</value>
+  </data>
+  <data name="CustomMolecule_Validate_The_mass__0__of_the_custom_molecule_exceeeds_the_maximum_of__1__" xml:space="preserve">
+    <value>自定义分子质量 {0} 超过 {1} 最大值。</value>
+  </data>
+  <data name="LabKey" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LabKey.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="HardklorLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\hardklor_logo.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MProphetPeakScoringModel_CreateTransitionGroups_MProphetScoringModel_was_given_a_peak_with__0__features__but_it_has__1__peak_feature_calculators" xml:space="preserve">
+    <value>MProphetScoringModel 被赋予带有{0}特征的峰，但它拥有 {1} 个峰特征计算器</value>
+  </data>
+  <data name="SkylineWindow_GetDownloadName__0___1__" xml:space="preserve">
+    <value>{0}({1})</value>
+  </data>
+  <data name="AlertDlg_GetDefaultButtonText__Ignore" xml:space="preserve">
+    <value>忽略(&amp;I)</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Change_settings" xml:space="preserve">
+    <value>更改设置</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_The_text__0__is_not_a_valid_peptide_sequence_on_line__1__" xml:space="preserve">
+    <value>第 {1} 行上的文本{0}不是有效的肽段序列。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Precursor_Replicate_Note" xml:space="preserve">
+    <value>母离子重复测定注释</value>
+  </data>
+  <data name="SkylineStartup_SaveFileDlg_Please_save_a_new_file_to_work_with_" xml:space="preserve">
+    <value>请保存将要处理的新文件。</value>
+  </data>
+  <data name="PasteDlg_AddFasta__0__is_not_a_capital_letter_that_corresponds_to_an_amino_acid" xml:space="preserve">
+    <value>“{0}”不是对应氨基酸的大写字母。</value>
+  </data>
+  <data name="PasteDlg_AddFasta_There_is_no_name_for_this_protein" xml:space="preserve">
+    <value>此蛋白质没有名称</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_CAS_registry_number_" xml:space="preserve">
+    <value>{0}不是有效的CAS注册号。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CopyinFile_Missing_the_file_0_Tool_1_Import_Failed" xml:space="preserve">
+    <value>缺少文件{0}。工具({1})导入失败</value>
+  </data>
+  <data name="ImportResultsControl_FindDataFiles_An_error_occurred_attempting_to_find_missing_result_files_in__0__" xml:space="preserve">
+    <value>尝试在{0}中查找缺失结果文件时发生错误。</value>
+  </data>
+  <data name="DisplayEquation_N_A" xml:space="preserve">
+    <value>不适用</value>
+  </data>
+  <data name="CommandLine_CreateScoringModel_Creating_scoring_model__0_" xml:space="preserve">
+    <value>正在创建得分模型{0}</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Peptide_Modified_Sequence" xml:space="preserve">
+    <value>肽段修饰序列</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Peptide" xml:space="preserve">
+    <value>肽段</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Ratio_Dot_Product" xml:space="preserve">
+    <value>比率点积</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_The_document_contains__0__of_these_iRT_standard_peptides_" xml:space="preserve">
+    <value>文档包括这些 iRT 标准肽段中的 {0} 个。</value>
+  </data>
+  <data name="ChromatogramCache_LoadStructs_Please_check_for_a_newer_release_" xml:space="preserve">
+    <value>请查看更新的版本。</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_btnTrainModel_Click_Cannot_train_model_without_either_decoys_or_second_best_peaks_included_" xml:space="preserve">
+    <value>无法在不包含诱饵或次优峰值的情况下训练模型。</value>
+  </data>
+  <data name="ComparePeakBoundaries_ComputeMatches_Documents_have_different_number_of_transition_groups___0__vs__1__" xml:space="preserve">
+    <value>文档具有不同的离子对群组数目，{0} 对比 {1}。</value>
+  </data>
+  <data name="AddIrtCalculatorDlg_OkDialog_Please_choose_the_iRT_calculator_you_would_like_to_add" xml:space="preserve">
+    <value>请选择您想要添加的 iRT 计算器。</value>
+  </data>
+  <data name="ToolInstaller_UnpackZipTool_Error__The__0__does_not_contain_a_valid__1__attribute_" xml:space="preserve">
+    <value>错误：{0}不包含有效的{1}属性。</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_The_following_peptides_are_not_in_the_document" xml:space="preserve">
+    <value>下列肽段不在文档中：</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Protein_description" xml:space="preserve">
+    <value>蛋白质描述</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_InChI_identifier_" xml:space="preserve">
+    <value>{0}不是有效的InChI标识符。</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_CumulativeCount" xml:space="preserve">
+    <value>累积计数</value>
+  </data>
+  <data name="OpenDataSourceDialog_Open_Error" xml:space="preserve">
+    <value>错误</value>
+  </data>
+  <data name="ValueInvalidDateException_ValueInvalidDateException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_date_time_value_" xml:space="preserve">
+    <value>值“{0}”对于必须是日期时间值的参数 {1} 无效。</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Revision" xml:space="preserve">
+    <value>修订</value>
+  </data>
+  <data name="ViewLibraryDlg_MatchModifications__0__Would_you_like_to_use_the_Unimod_definitions_for__1__modifications_The_document_will_not_change_until_peptides_with_these_modifications_are_added" xml:space="preserve">
+    <value>{0}您是否想要使用针对{1}修饰的 Unimod 定义？文档在具有这些修饰的肽段被添加前不会改变。</value>
+  </data>
+  <data name="TransitionGroup" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\transitiongroup.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_Count" xml:space="preserve">
+    <value>{0} 计数</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_Isotope_enrichment_settings_are_required_for_MS1_filtering_on_high_resolution_mass_spectrometers" xml:space="preserve">
+    <value>高分辨率质谱仪上的 MS1 过滤需要同位素富集设置。</value>
+  </data>
+  <data name="PeptideDecoyLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidedecoylib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_NewSkyFile_Deleting_existing_file___0__" xml:space="preserve">
+    <value>正在删除现有文件“{0}”</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Cone_Voltage" xml:space="preserve">
+    <value>锥孔电压</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility_Units" xml:space="preserve">
+    <value>离子迁移单位</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Cannot_derive_charge_from_adduct_description___0____Use_the_corresponding_Charge_column_to_set_this_explicitly__or_change_the_adduct_description_as_needed_" xml:space="preserve">
+    <value>无法从加合物描述“{0}”中取得电荷。使用相应的电荷列明示设置，或根据需要更改加合物描述。</value>
+  </data>
+  <data name="SkypFile_GetSkyFileUrl_File_does_not_contain_the_URL_of_a_shared_Skyline_archive_file___0___on_a_Panorama_server_" xml:space="preserve">
+    <value>文件不包括 Panorama 服务器上共享 Skyline 存档文档 ({0}) 的 URL。</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_In_Parallel" xml:space="preserve">
+    <value>并行</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Change_settings_to_add_precursors" xml:space="preserve">
+    <value>更改设置以添加母离子</value>
+  </data>
+  <data name="Ions_A" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_A.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ChromatogramLibrary_LoadLibraryFromDatabase_Reading_precursors_from__0_" xml:space="preserve">
+    <value>从{0}读取母离子</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_The_following_sequences_are_not_valid_peptides" xml:space="preserve">
+    <value>下列序列不是有效的肽段：</value>
+  </data>
+  <data name="ImportPeptideSearchDlg_NextPage_Please_check_your_peptide_search_pipeline_or_contact_Skyline_support_to_ensure_retention_times_appear_in_your_spectral_libraries_" xml:space="preserve">
+    <value>请查看您的肽段搜索管道或联络 Skyline 支持，以确保保留时间出现在您的谱图库中。</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_ImportTextFile_Import_Transition_List__iRT_standards_" xml:space="preserve">
+    <value>导入离子对列表（iRT 标准）</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Opt_Collision_Energy" xml:space="preserve">
+    <value>最优碰撞能量</value>
+  </data>
+  <data name="SkylineWindow_SaveDocumentAs_Skyline_Documents" xml:space="preserve">
+    <value>Skyline 文档</value>
+  </data>
+  <data name="PasteDlg_AddTransitionList_The_product_m_z_must_be_a_number_" xml:space="preserve">
+    <value>子离子质荷比必须是数字。</value>
+  </data>
+  <data name="Molecule" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Molecule.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="TransitionTreeNode_RenderTip_Charge" xml:space="preserve">
+    <value>电荷</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Best_Retention_Time" xml:space="preserve">
+    <value>最佳保留时间</value>
   </data>
   <data name="VendorIssueHelper_ConvertWiffToMzxml_To_work_around_this_issue_requires_Analyst_to_be_installed_on_the_computer_running__0__" xml:space="preserve">
     <value>解决这一问题需要在运行{0}的电脑上安装 Analyst。</value>
   </data>
-  <data name="VendorIssueHelper_CreateTempFileSubstitute_Convert_to_mzXML_work_around_for__0__" xml:space="preserve">
-    <value>针对{0}转换成 mzXML 替代方法</value>
+  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_This_list_contains__0__ions_with_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
+    <value>该列表包含 {0} 个离子，且这些离子具有多个离子迁移值。Skyline 支持多个构象异构体，因此这可能是有意为之。</value>
   </data>
-  <data name="VendorIssueHelper_CreateTempFileSubstitute_Local_copy_work_around_for__0__" xml:space="preserve">
-    <value>针对{0}的本地复制应急措施</value>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility__1_K0_" xml:space="preserve">
+    <value>明确离子迁移 (1/K0)</value>
+  </data>
+  <data name="ConfigureToolsDlg_unpackZipTool_skipping_that_tool_" xml:space="preserve">
+    <value>跳过该工具。</value>
+  </data>
+  <data name="TransitionFilter_FragmentEndFinders_last_ion" xml:space="preserve">
+    <value>最后一个离子</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_ImportRangesFromFiles_Failed_reading_isolation_scheme_" xml:space="preserve">
+    <value>读取分离方案失败。</value>
+  </data>
+  <data name="RedX" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RedX.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Peptide" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptide.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_values__but_the_document_does_not_have_an_iRT_calculator___Create_a_new_calculator_and_add_these_iRT_values_" xml:space="preserve">
+    <value>离子对列表中似乎包含 iRT 值，但文档中并没有 iRT 计算器。 创建新的计算器并添加这些 iRT 值？</value>
+  </data>
+  <data name="MeasuredCollisionalCrossSection_Validate_Charge_state_values_must_be_greater_than_0_" xml:space="preserve">
+    <value>电荷态值必须大于 0。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_File_path_cannot_be_empty_" xml:space="preserve">
+    <value>文件路径不能为空。</value>
+  </data>
+  <data name="LocateFileDlg_PathPasses_You_have_not_provided_a_valid_path_" xml:space="preserve">
+    <value>您还未提供有效的路径。</value>
+  </data>
+  <data name="CommandLine_AddDecoys_Error__Attempting_to_add_decoys_to_document_with_decoys_" xml:space="preserve">
+    <value>错误：正在尝试对有诱饵的文档添加诱饵。</value>
+  </data>
+  <data name="EditIrtCalcDlg_btnBrowseDb_Click_Open_iRT_Database" xml:space="preserve">
+    <value>打开 iRT 数据库</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_TrainModel_Calculating_score_contributions" xml:space="preserve">
+    <value>正在计算得分贡献</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_conflicting_annotations__Keeping_existing_" xml:space="preserve">
+    <value>存在冲突注释。保持存在。</value>
+  </data>
+  <data name="SkylineWindow_Paste_Could_not_perform_transition_list_paste___0_" xml:space="preserve">
+    <value>无法执行离子对列表粘贴：{0}</value>
+  </data>
+  <data name="ToolDescription_VerifyAnnotations_Please_enable_these_annotations_and_fill_in_the_appropriate_data_in_order_to_use_the_tool_" xml:space="preserve">
+    <value>请启用这些注释并填入适当的数据，以使用工具。</value>
+  </data>
+  <data name="Database_Join_Cannot_join_tables_of_same_type" xml:space="preserve">
+    <value>无法结合同类的表格。</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_none" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="PublishDocumentDlg_UploadSharedZipFile_Click_here_to_view_the_error_details_" xml:space="preserve">
+    <value>单击此处，以查看错误详情。</value>
   </data>
   <data name="VendorIssueHelper_ShowLibraryMissingExternalSpectrumFileError" xml:space="preserve">
     <value>在为 MaxQuant 输入文件 '{0}' 搜索谱图文件时，找不到以下具有任何支持的文件扩展名 ({3}) 的基本名称：
@@ -3761,6 +1069,904 @@
 
 如果您没有原始文件，可以使用输入文件中的嵌入谱图来建库。但是，MaxQuant 嵌入谱图中的碎片离子的电荷状态为解卷积，并且仅包含单电荷碎片离子，这些碎片离子可能无法代表质谱仪测出的强度。</value>
   </data>
+  <data name="ReportSpecList_GetDefaults_Molecule_Peak_Boundaries" xml:space="preserve">
+    <value>分子峰边界</value>
+  </data>
+  <data name="EditCoVDlg_btnOk_Click_Maximum_compensation_voltage_cannot_be_less_than_minimum_compensation_volatage_" xml:space="preserve">
+    <value>最大补偿电压不能小于最小补偿电压。</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_OkDialog_There_are_gaps_in_a_single_cycle_of_your_extraction_windows__Do_you_want_to_continue_" xml:space="preserve">
+    <value>在您提取窗口的单一周期内存在间隙。您确定想要继续？</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_iRT" xml:space="preserve">
+    <value>iRT</value>
+  </data>
+  <data name="CommandLine_CheckReplicateFiles_Error__Replicate__0__in_the_document_has_an_unexpected_file__1__" xml:space="preserve">
+    <value>错误：文档中的重复测定{0}具有意外文件{1}。</value>
+  </data>
+  <data name="MoleculeStandardLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\MoleculeStandardLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ProcessNeutralLoss_Precursor_molecular_formula__0__does_not_contain_sufficient_atoms_to_be_used_with_neutral_loss__1_" xml:space="preserve">
+    <value>母离子分子式 {0} 包含的原子不足以用于中性丢失 {1}</value>
+  </data>
+  <data name="ToolDescription_RunTool_File_not_found_" xml:space="preserve">
+    <value>未发现文件。</value>
+  </data>
+  <data name="TransitionFilter_FragmentEndFinders_4_ions" xml:space="preserve">
+    <value>4 个离子</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Formula" xml:space="preserve">
+    <value>公式</value>
+  </data>
+  <data name="MSAmandaLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\LogoAmanda_32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="OpenDataSourceDialog_lookInComboBox_SelectionChangeCommitted_My_Network_Place" xml:space="preserve">
+    <value>我的网络位置</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_time_" xml:space="preserve">
+    <value>第 {1} 行上的值“{0}”不是有效的时间。</value>
+  </data>
+  <data name="DecoyGeneration_SHUFFLE_SEQUENCE_Shuffle_Sequence" xml:space="preserve">
+    <value>随机序列</value>
+  </data>
+  <data name="ToolDescription_RunExecutableBackground_Error_running_the_installed_tool__0___It_seems_to_have_an_error_in_one_of_its_files__Please_reinstall_the_tool_and_try_again" xml:space="preserve">
+    <value>运行安装工具{0}出错。文件之一可能出错。请重新安装工具并重试</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Replicates" xml:space="preserve">
+    <value>重复测定</value>
+  </data>
+  <data name="ChromatogramDataProvider_GetChromatogram_This_import_appears_to_be_taking_longer_than_expected__If_importing_from_a_network_drive__consider_canceling_this_import__copying_to_local_disk_and_retrying_" xml:space="preserve">
+    <value>此次导入好像比预期的时间长。如果是从网络驱动器导入，请考虑取消这次导入，复制到本地磁盘，再重试。</value>
+  </data>
+  <data name="EmptyList" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\EmptyList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Error__To_create_the_iRT_database___0___for_this_assay_library__you_must_specify_the_iRT_standards_using_either_of_the_arguments__1__or__2_" xml:space="preserve">
+    <value>错误：要为此分析库创建 iRT 数据库“{0}”，您必须使用参数 {1} 或 {2} 指定 iRT 标准</value>
+  </data>
+  <data name="Copy_Bitmap" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Copy_Bitmap.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportToolsFromZip_Installed_tool__0_" xml:space="preserve">
+    <value>已安装的工具{0}</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Importing__0__iRT_values_into_the_iRT_calculator__1_" xml:space="preserve">
+    <value>将{0} iRT 值导入到 iRT 计算器{1}</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_upgrade_to__0__or_install_in_parallel_" xml:space="preserve">
+    <value>您是否想要升级至{0}或并行安装？</value>
+  </data>
+  <data name="AllIonsStatusButton" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\AllIonsStatusButton.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidedecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_The_imported_file_does_not_contain_any_peak_boundaries_for__0__transition_group___file_pairs___These_chromatograms_will_be_treated_as_if_no_boundary_was_selected_" xml:space="preserve">
+    <value>导入的文件不含任何针对{0}离子对群组/文件对的峰值边界。 这些色谱图将得到仿佛未选定任何边界一样的处理。</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__The_current_document_contains_peptides_without_enough_information_to_rank_transitions_for_triggered_acquisition_" xml:space="preserve">
+    <value>错误：当前文档包含的肽段不具有足够信息，无法对离子对进行排名以触发采集。</value>
+  </data>
+  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_Continue_peak_boundary_import_ignoring_this_peptide_" xml:space="preserve">
+    <value>忽视该肽段,继续峰边界导入？</value>
+  </data>
+  <data name="BuildLibraryDlg_btnPrevious_Click__Next__" xml:space="preserve">
+    <value>下一步(&amp;N) &gt;</value>
+  </data>
+  <data name="ExportReportDlg_ShowPreview_An_unexpected_error_occurred_attempting_to_display_the_report___0___" xml:space="preserve">
+    <value>尝试显示报告“{0}”时出现意外错误。</value>
+  </data>
+  <data name="DropImage" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\dropimage.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Collision_Cross_Section__sq_A_" xml:space="preserve">
+    <value>碰撞横截面(sq A)</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Cannot_read_high_energy_ion_mobility_offset_value___0___on_line__1__" xml:space="preserve">
+    <value>无法读取第 {1} 行的高能离子迁移偏置值“{0}”。</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Warning__overwriting_will_delete_the_tool__0___Do_you_want_to_continue_" xml:space="preserve">
+    <value>警告，覆盖将删除工具{0}。您是否想要继续？</value>
+  </data>
+  <data name="SrmSettingsList_DEFAULT_m_z_precursor" xml:space="preserve">
+    <value>质荷比 &gt; 母离子</value>
+  </data>
+  <data name="EditCustomMoleculeDlg_OkDialog_Custom_molecules_must_have_a_mass_less_than_or_equal_to__0__" xml:space="preserve">
+    <value>自定义分子必须拥有比更小的质量或与{0}相等的质量。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Retention_Time" xml:space="preserve">
+    <value>保留时间</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Peptide_Retention_Time" xml:space="preserve">
+    <value>肽段保留时间</value>
+  </data>
+  <data name="ChromCacheBuilder_BuildCache_This_document_contains_only_negative_ion_mode_transitions__and_the_imported_file_contains_only_positive_ion_mode_data_so_nothing_can_be_loaded_" xml:space="preserve">
+    <value>本文档仅包含负离子模式离子对，而导入的文件仅包含正离子模式数据，因此，没有任何内容可加载。</value>
+  </data>
+  <data name="Note" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\note.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Failed_attempting_to_extract_the_tool_from__0_" xml:space="preserve">
+    <value>尝试从{0}提取工具失败</value>
+  </data>
+  <data name="NoPeak" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\nopeak.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Peptide_RT_Results" xml:space="preserve">
+    <value>肽段RT 结果</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Molecule_RT_Results" xml:space="preserve">
+    <value>Molecule RT Results</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Molecule_Transition_Results" xml:space="preserve">
+    <value>Molecule Transition Results</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty" xml:space="preserve">
+    <value>{0}不能为空。</value>
+  </data>
+  <data name="AnnotationDef_AnnotationTarget_Precursors" xml:space="preserve">
+    <value>母离子</value>
+  </data>
+  <data name="ViewLibraryDlg_CheckLibraryInSettings_The_library__0__is_not_currently_added_to_your_document" xml:space="preserve">
+    <value>库{0}当前并未添加至您的文档。</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_charge_value__0_" xml:space="preserve">
+    <value>无效电荷值{0}</value>
+  </data>
+  <data name="OneOrManyList_ValidateIndex_The_index__0__must_be_0_for_a_single_entry_list" xml:space="preserve">
+    <value>指数 {0} 针对单一条目列表必须是 0。</value>
+  </data>
+  <data name="SrmDocument_ReadTransitionXml_All_transitions_of_decoy_precursors_must_have_a_decoy_mass_shift" xml:space="preserve">
+    <value>诱饵母离子的所有离子对必须具有诱饵质量偏移。</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_None_of_the_specified_peptides_are_in_the_document" xml:space="preserve">
+    <value>所有指定的肽段都不在文档中。</value>
+  </data>
+  <data name="PasteDlg_ShowNoErrors_No_errors" xml:space="preserve">
+    <value>无错误</value>
+  </data>
+  <data name="CalibrationCurveFitter_GetCalibrationCurve_Unable_to_calculate_the_calibration_curve_for_the_because_there_are_different_Precursor_Concentrations_specified_for_the_label__0__" xml:space="preserve">
+    <value>无法计算校准曲线，因为为标记 {0} 指定了不同的母离子浓度。</value>
+  </data>
+  <data name="GridViewDriver_ValidateRow_On_line__0__1__" xml:space="preserve">
+    <value>在第{0}, {1}行 上</value>
+    <comment>Line refers to line of document</comment>
+  </data>
+  <data name="EditIrtCalcDlg_btnCreateDb_Click_Create_iRT_Database" xml:space="preserve">
+    <value>创建 iRT 数据库</value>
+  </data>
+  <data name="directoryicon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\directoryicon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Matched_spectra" xml:space="preserve">
+    <value>匹配的谱图</value>
+  </data>
+  <data name="PeptidesPerProteinDlg_UpdateRemaining_Calculating___" xml:space="preserve">
+    <value>正在计算...</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_Processing_Retention_Times" xml:space="preserve">
+    <value>正在处理保留时间</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_HMDB_identifier_" xml:space="preserve">
+    <value>{0}不是有效的HMDB标识符。</value>
+  </data>
+  <data name="CustomMolecule_DisplayName_Molecule" xml:space="preserve">
+    <value>分子</value>
+  </data>
+  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_Continue_peak_boundary_import_ignoring_this_file_" xml:space="preserve">
+    <value>忽视该文件,继续峰边界导入？</value>
+  </data>
+  <data name="CommandLine_SetLibrary_Error__The_file__0__does_not_exist_" xml:space="preserve">
+    <value>错误：文件{0}不存在。</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_Data_files" xml:space="preserve">
+    <value>数据文件</value>
+  </data>
+  <data name="SkylineWindow_ShowExportSpectralLibraryDialog_The_document_must_contain_results_to_export_a_spectral_library_" xml:space="preserve">
+    <value>文档必须包含结果才能导出谱图库。</value>
+  </data>
+  <data name="BioMassCalc_ApplyAdductToFormula_Failed_parsing_adduct_description___0__" xml:space="preserve">
+    <value>解析加合物描述“{0}”失败</value>
+  </data>
+  <data name="ToolDescription_VerifyAnnotations_This_tool_requires_the_use_of_the_following_annotations_which_are_not_enabled_for_this_document" xml:space="preserve">
+    <value>本工具需要使用未针对此文档启用的下列注释</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_OkDialog_Specify_Start_and_End_values_for_at_least_one_isolation_window" xml:space="preserve">
+    <value>针对至少一个分离窗口指定起始和最终值。</value>
+  </data>
+  <data name="PivotReportDlg_OkDialog_A_report_must_have_at_least_one_column" xml:space="preserve">
+    <value>报告必须至少具备一列。</value>
+  </data>
+  <data name="FullScanAcquisitionExtension_LOCALIZED_VALUES_Targeted" xml:space="preserve">
+    <value>定向的</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_formula_and_m_z_value_do_not_agree_for_any_charge_state_" xml:space="preserve">
+    <value>子离子公式和质荷比值在任何电荷状态下都不一致。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Adduct__0__charge__1__does_not_agree_with_declared_charge__2_" xml:space="preserve">
+    <value>加合物 {0} 电荷 {1} 与声明电荷 {2} 不匹配</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_You_must_enter_a_valid_title_for_the_tool" xml:space="preserve">
+    <value>您必须针对工具输入一个有效的标题。</value>
+  </data>
+  <data name="SettingsListComboDriver_Edit_list" xml:space="preserve">
+    <value>&lt;编辑列表…&gt;</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Area" xml:space="preserve">
+    <value>面积</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_Product_mz_does_not_agree_with_calculated_value_" xml:space="preserve">
+    <value>子离子质荷比 {0} 与根据离子公式和电荷状态计算得出的值 {1} 不一致（增量 = {2},离子对设置 | 仪器 | 方法匹配耐受性质荷比 = {3}）。纠正表中的质荷比值，或留空来让Skyline 为您进行计算。</value>
+  </data>
+  <data name="RInstaller_RInstaller_Load_This_tool_requires_the_use_of_R__0___Click_Install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>本工具需要使用 R{0}。单击“安装”以开始安装流程。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_if_you_would_like_the_command_to_launch_a_link__make_sure_to_include_http____or_https___" xml:space="preserve">
+    <value>如果您想要此命令来启动一个链接，请确保包含 http:// 或 https://</value>
+  </data>
+  <data name="SkylineWindow_ShowProgressErrorUI_Skip" xml:space="preserve">
+    <value>跳过</value>
+  </data>
+  <data name="SkylineWindow_Publish_There_are_no_Panorama_servers_to_publish_to_Please_add_a_server_under_Tools" xml:space="preserve">
+    <value>没有可以发布到 Panorama 的服务器。请在“工具”下添加一个服务器。</value>
+  </data>
+  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Please_specify_a_path_to_an_existing_spectral_library_" xml:space="preserve">
+    <value>请指定一个对应到现有谱图库的路径。</value>
+  </data>
+  <data name="GraphSpectrum_UpdateUI_Multiple_charge_states_with_library_spectra" xml:space="preserve">
+    <value>带有库谱图的多个电荷态</value>
+  </data>
+  <data name="PeptideIrt" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptideirt.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Opt_Compensation_Voltage" xml:space="preserve">
+    <value>最优补偿电压</value>
+  </data>
+  <data name="ViewLibraryDlg_LoadLibrary_Loading_Library" xml:space="preserve">
+    <value>正在加载库</value>
+  </data>
+  <data name="RefinementSettings_Refine_The_document_must_contain_at_least_2_replicates_to_refine_based_on_consistency_" xml:space="preserve">
+    <value>该文档必须包括至少 2 个重复测定，以便根据一致性进行调整。</value>
+  </data>
+  <data name="PeptideToMoleculeText_Ion_adducts" xml:space="preserve">
+    <value>离子加合物</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "Ion charges" to read "Ion adducts" when non-peptide documents are in use</comment>
+  </data>
+  <data name="CommandLine_ImportTool__0__was_added_to_the_Tools_Menu_" xml:space="preserve">
+    <value>{0}添加至“工具菜单”。</value>
+  </data>
+  <data name="Close" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Close.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_collisional_cross_section_value__0_" xml:space="preserve">
+    <value>无效的碰撞横截面值 {0}</value>
+  </data>
+  <data name="CommandLine_CanReadFile_Error__File_does_not_exist___0__" xml:space="preserve">
+    <value>错误：文件不存在：{0}。</value>
+  </data>
+  <data name="ShimadzuMethodExporter_ExportMethod_Error_copying_template_file__0__to_destination__1__" xml:space="preserve">
+    <value>在将模板文件{0}复制到目标{1}时出现错误。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__A_template_file_is_required_to_export_a_method_" xml:space="preserve">
+    <value>错误：需要模板文件来导出方法。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_SmallMoleculeTransitionListReader_" xml:space="preserve">
+    <value>读取分子列标题时出错，无法识别：
+{0}
+支持的值包含：
+{1}</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_SelectedModelItem_Invalid_Model_Selection" xml:space="preserve">
+    <value>无效的模型选择。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph_CE_" xml:space="preserve">
+    <value>NCE:</value>
+  </data>
+  <data name="WebPanoramaPublishClient_GetInfoForFolders_Failure_retrieving_folder_information_from__0_" xml:space="preserve">
+    <value>从{0}检索文件夹信息失败</value>
+  </data>
+  <data name="ExportMethodDlg_VerifySchedulingAllowed_The_current_document_contains_peptides_without_enough_information_to_rank_transitions_for_triggered_acquisition_" xml:space="preserve">
+    <value>当前文档包含的肽段不具有足够信息，无法对离子对进行排名以触发采集。</value>
+  </data>
+  <data name="ValidatingIonMobilityPeptide_ValidateHighEnergyIonMobilityOffset_High_energy_ion_mobility_offsets_should_be_empty__or_express_an_offset_value_for_ion_mobility_in_high_collision_energy_scans_which_may_add_velocity_to_ions_" xml:space="preserve">
+    <value>高能离子迁移偏置应为空，或表示可能增加离子速度的高碰撞能量扫描中离子迁移的偏置值。</value>
+  </data>
+  <data name="CommandLine_SetLibrary_Error__The_file__0__is_not_a_supported_spectral_library_file_format_" xml:space="preserve">
+    <value>错误：文件{0}不是支持的谱图库文件格式。</value>
+  </data>
+  <data name="IsolationWindow_DoValidate_Isolation_window_margin_must_be_non_negative" xml:space="preserve">
+    <value>分离窗口边距必须是非负数。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Product_needs_values_for_any_two_of__Formula__m_z_or_Charge_" xml:space="preserve">
+    <value>子离子需要以下任意两项的值：公式、质荷比或电荷。</value>
+  </data>
+  <data name="Delete" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\delete.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportTool_Warning__skipping_tool__0__due_to_a_name_conflict_" xml:space="preserve">
+    <value>警告：因命名冲突跳过工具{0}。</value>
+  </data>
+  <data name="RInstaller_RInstaller_Load_This_tool_requires_the_use_of_R__0__and_the_following_packages_" xml:space="preserve">
+    <value>此工具要求使用 R{0}和下列软件包。</value>
+  </data>
+  <data name="LibraryGridViewDriver_AddToLibrary_Do_you_want_to_recalibrate_the_iRT_standard_values_relative_to_the_peptides_being_added_" xml:space="preserve">
+    <value>您想要重新校准与添加的肽段有关的 iRT 标准值吗？</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateCell_The_entry__0__is_not_valid_" xml:space="preserve">
+    <value>条目 {0} 无效。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_OkDialog_Please_use_a_full_path_to_a_file_for_the_ion_mobility_library_" xml:space="preserve">
+    <value>请为离子迁移库使用一个到文件的完整路径。</value>
+  </data>
+  <data name="SkylineWindow_ShowReintegrateDialog_Reintegration_of_results_requires_a_trained_peak_scoring_model_" xml:space="preserve">
+    <value>重新合并结果需要训练过的峰排名模型。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_The_pasted_text_must_at_a_minimum_contain_columns_for_peptide_and_adduct__along_with_collisional_cross_section_and_or_ion_mobility_" xml:space="preserve">
+    <value>粘贴的文本至少必须包含用于肽段和加合物的列，以及包含碰撞横截面和/或离子迁移。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__triggered_acquistion_requires_a_spectral_library_or_imported_results_in_order_to_rank_transitions_" xml:space="preserve">
+    <value>错误：触发采集需要一个谱图库或导入结果，以排名离子对。</value>
+  </data>
+  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_maximum_log_10_area_entered" xml:space="preserve">
+    <value>输入的最大 log10 面积无效</value>
+  </data>
+  <data name="MatchModificationsControl_AddModification_Add__0__modification__1_" xml:space="preserve">
+    <value>添加{0}修饰{1}</value>
+  </data>
+  <data name="RetentionTimeRegression_RecalcRegression_Recalculating_regression" xml:space="preserve">
+    <value>重新计算回归</value>
+  </data>
+  <data name="Helpers_AssumeValue_Nullable_was_expected_to_have_a_value" xml:space="preserve">
+    <value>可空预计拥有一个数值。</value>
+  </data>
+  <data name="ExportMethodDlg_btnBrowseTemplate_Click__0__Method" xml:space="preserve">
+    <value>{0}方法</value>
+    <comment>Instrument type name Method</comment>
+  </data>
+  <data name="CommandLine_ImportTool_Error__the_provided_command_for_the_tool__0__is_not_of_a_supported_type___Supported_Types_are___1_" xml:space="preserve">
+    <value>错误：提供给工具{0}命令不属于被支持的类型。 支持类型是：{1}</value>
+  </data>
+  <data name="SkylineStartup_SkylineStartup_Blank_Document" xml:space="preserve">
+    <value>空白文档</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Please_enter_a_valid_number_of_decoys_per_target_greater_than_0_" xml:space="preserve">
+    <value>请为每个目标输入一个有效的大于 0 的诱饵数字。</value>
+  </data>
+  <data name="UpgradeManager_updateCheck_Complete_Failed_attempting_to_upgrade_" xml:space="preserve">
+    <value>尝试升级失败。</value>
+  </data>
+  <data name="IsolationWindow_DoValidate_Isolation_window_margins_cover_the_entire_isolation_window_at_the_extremes_of_the_instrument_range" xml:space="preserve">
+    <value>分离窗口边距在仪器范围的极端覆盖整个分离窗口。</value>
+  </data>
+  <data name="EditIrtCalcDlg_comboStandards_SelectedIndexChanged_The_list_of_standard_peptides_must_contain_only_recognized_iRT_C18_standards_to_switch_to_a_predefined_set_of_iRT_C18_standards_" xml:space="preserve">
+    <value>标准肽段列表必须仅包含被认可的 iRT-C18 标准，才能转换到预定义的 iRT-C18 标准集。</value>
+  </data>
+  <data name="LibraryGridViewDriver_AddProcessedIrts_A_single_run_does_not_have_high_enough_correlation_to_the_existing_iRT_values_to_allow_retention_time_conversion" xml:space="preserve">
+    <value>单一运行对现有 iRT 值的相关度不够高，无法实现保留时间转换。</value>
+  </data>
+  <data name="PublishDocumentDlg_btnBrowse_Click_Shared_Files" xml:space="preserve">
+    <value>共享文件</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_headerList_Molecular_Formula" xml:space="preserve">
+    <value>分子式</value>
+  </data>
+  <data name="PeakBoundaryImporter_UnrecognizedPeptidesCancel_The_following_peptide_in_the_peak_boundaries_file_was_not_recognized_" xml:space="preserve">
+    <value>峰边界文件中的下列肽段没有被识别：</value>
+  </data>
+  <data name="ZedGraphClipboard_CreateCopyMenuItems_Copy" xml:space="preserve">
+    <value>复制</value>
+  </data>
+  <data name="CommandLine_ExportReport_Error__Failure_attempting_to_save__0__report_to__1__" xml:space="preserve">
+    <value>错误：尝试将{0}报告保存至{1}失败。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_No_list_will_be_exported_" xml:space="preserve">
+    <value>无列表将被导出。</value>
+  </data>
+  <data name="Adduct_ApplyToMolecule_Adduct___0___calls_for_removing_more__1__atoms_than_are_found_in_the_molecule__2_" xml:space="preserve">
+    <value>加合物“{0}”需要删除比在分子 {2} 中发现的更多 {1} 原子</value>
+  </data>
+  <data name="PeptideLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidelib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Failed_to_read_the_first_line_of_the_file" xml:space="preserve">
+    <value>读取文件第一行失败</value>
+  </data>
+  <data name="ToolUpdatesDlg_DisplayDownloadSummary_Failed_to_download_updates_for_the_following_packages" xml:space="preserve">
+    <value>未能下载下列软件包的更新</value>
+  </data>
+  <data name="DigestSettings_Validate_maximum_missed_cleavages" xml:space="preserve">
+    <value>最大遗漏的酶解位点数</value>
+  </data>
+  <data name="RTDetails_gridStatistics_KeyDown_Failed_setting_data_to_clipboard" xml:space="preserve">
+    <value>向剪切板设定数据失败。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Method__0__exported_successfully_" xml:space="preserve">
+    <value>方法{0}已成功导出。</value>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Package_installation_failed__Error_log_output_in_immediate_window_" xml:space="preserve">
+    <value>软件包安装失败。在即时窗口中记录输出失败。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Could_not_parse_adduct_description___0___on_line__1_" xml:space="preserve">
+    <value>无法解析第 {1} 行的加合物描述“{0}”</value>
+  </data>
+  <data name="ToolUpdatesDlg_DownloadTools_Downloading_updates_for__0_" xml:space="preserve">
+    <value>下载{0}的更新</value>
+  </data>
+  <data name="ShareListDlg_OkDialog_An_error_occurred" xml:space="preserve">
+    <value>发生错误：</value>
+  </data>
+  <data name="CommandLineTest_ConsolePathCoverage_successfully_" xml:space="preserve">
+    <value>成功。</value>
+    <comment>Context: something finished "successfully".</comment>
+  </data>
+  <data name="UIModeSmallMolecules" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UIModeSmallMolecules.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="UpgradeManager_updateCheck_Complete_Failed_attempting_to_check_for_an_upgrade_" xml:space="preserve">
+    <value>尝试检查升级失败。</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Protein" xml:space="preserve">
+    <value>蛋白质</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Ignore_Column" xml:space="preserve">
+    <value>忽略列</value>
+  </data>
+  <data name="ShareTypeDlg_ShareTypeDlg_Current_saved_file___0__" xml:space="preserve">
+    <value>当前保存的文件 ({0})</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Ratio_To_Standard" xml:space="preserve">
+    <value>相对于标准品比率</value>
+  </data>
+  <data name="CommandLine_OpenSkyFile_Error__The_Skyline_file__0__does_not_exist_" xml:space="preserve">
+    <value>错误：Skyline 文件{0}不存在。</value>
+  </data>
+  <data name="SkylineWindow_ShowProgressErrorUI_Retry" xml:space="preserve">
+    <value>重试</value>
+  </data>
+  <data name="Ions_Y" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_Y.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_contain_a_decimal_value" xml:space="preserve">
+    <value>{0}必须包含一个十进位值。</value>
+  </data>
+  <data name="ExportMethodDlg_comboTargetType_SelectedIndexChanged_To_export_a_scheduled_list_you_must_first_choose_a_retention_time_predictor_in_Peptide_Settings_Prediction_or_import_results_for_all_peptides_in_the_document" xml:space="preserve">
+    <value>如要导出预定方法，您必须首先在肽段设置/预测中选择一个保留时间预测器，或者在文档中导入针对所有肽段的结果。</value>
+  </data>
+  <data name="AnnotationDef_AnnotationTarget_Proteins" xml:space="preserve">
+    <value>蛋白质</value>
+  </data>
+  <data name="PeakBoundsMatch_QValue_Unable_to_read_q_value_annotation_for_peptide__0__of_file__1_" xml:space="preserve">
+    <value>无法针对文件{1}的肽段{0}读取 q 值注释</value>
+  </data>
+  <data name="ValueInvalidChargeListException_ValueInvalidChargeListException_The_value___0___is_not_valid_for_the_argument__1__which_requires_an_comma_separated_list_of_integers_" xml:space="preserve">
+    <value>值“{0}”对于参数 {1} 无效，该参数必须是以逗号分隔的整数列表。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph_Scan_Number_" xml:space="preserve">
+    <value>扫描编号：</value>
+  </data>
+  <data name="SkylineWindow_ImportResults__0__decoys_do_not_have_the_same_number_of_transitions_as_their_matching_targets" xml:space="preserve">
+    <value>{0} 个诱饵没有与其匹配目标相同的离子对数目。</value>
+  </data>
+  <data name="OpenDataSourceDialog_EnsureRemoteAccount_No_remote_accounts_have_been_specified__If_you_have_an_existing_Unifi_account_you_can_enter_your_login_information_now_" xml:space="preserve">
+    <value>未指定远程账户。如果您有现有的 Unifi 账户，那么您可以现在输入您的登录信息。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateResolvingPower_Resolving_power_must_be_greater_than_0_" xml:space="preserve">
+    <value>分辨力必须大于 0。</value>
+  </data>
+  <data name="PopupBtn" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\popupbtn.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_Below_is_the_saved_value_for_the_path_to_the_executable" xml:space="preserve">
+    <value>下方是路径向可执行的保存值。</value>
+  </data>
+  <data name="ReintegrateDlg_OkDialog_Reintegrating" xml:space="preserve">
+    <value>重新合并</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Average_Mass_Error_PPM" xml:space="preserve">
+    <value>平均质量误差 PPM</value>
+  </data>
+  <data name="PythonInstaller_DownloadPython_Check_your_network_connection_or_contact_the_tool_provider_for_installation_support_" xml:space="preserve">
+    <value>检查您的网络连接或联络工具提供商以获得安装支持。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_EditIonMobilityLibraryDlg_Adduct" xml:space="preserve">
+    <value>加合物</value>
+  </data>
+  <data name="TransitionFullScan_DoValidate_An_isolation_window_width_value_is_required_in_DIA_mode" xml:space="preserve">
+    <value>DIA 模式需要分离窗口宽度值。</value>
+  </data>
+  <data name="DigestHelper_Digest_Digesting__0__proteome_with__1__" xml:space="preserve">
+    <value>借助{1}消化 {0} 个蛋白质组</value>
+  </data>
+  <data name="IonMobilityPredictor_Validate_Ion_mobility_predictors_using_an_ion_mobility_library_must_include_per_charge_regression_values_" xml:space="preserve">
+    <value>使用离子迁移库的离子迁移预测器必须包含基于每个电荷的回归值。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility__1_K0_" xml:space="preserve">
+    <value>离子迁移 (1/K0)</value>
+  </data>
+  <data name="ImportResultsControl_FindResultsFiles_An_error_occurred_attempting_to_find_results_files_" xml:space="preserve">
+    <value>尝试查找结果文件时出错。</value>
+  </data>
+  <data name="UIModeMixed" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\UIModeMixed.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TransitionFullScan_DoValidate_An_isolation_window_width_value_is_not_allowed_in__0___mode" xml:space="preserve">
+    <value>{0} 模式下不允许使用分离窗口宽度值。</value>
+  </data>
+  <data name="MoleculeIrtLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\moleculeirtlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Precursor_Adduct" xml:space="preserve">
+    <value>母离子加合物</value>
+  </data>
+  <data name="WizardImportPeptide" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardImportPeptide.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_Model_must_be_trained_before_it_can_be_used_for_peak_boundary_comparison_" xml:space="preserve">
+    <value>模型在用于峰值边界比较前必须被训练。</value>
+  </data>
+  <data name="CommandLine_ImportTool_The_tool_was_not_imported___" xml:space="preserve">
+    <value>工具未导入...</value>
+  </data>
+  <data name="SkylineDoc" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\skylinedoc.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="GraphData_AddRegressionLabel_window" xml:space="preserve">
+    <value>窗口</value>
+    <comment>In RTLinearRegressionGraphPane</comment>
+  </data>
+  <data name="ImportPeptideSearchDlg_ImportPeptideSearchDlg_MS_MS_full_scan_settings_were_configured__please_verify_or_change_your_current_full_scan_settings_" xml:space="preserve">
+    <value>MS/MS 全扫描设置已被配置，请验证或更改您当前的全扫描设置。</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Warning__overwriting_will_delete_the_following_tools_" xml:space="preserve">
+    <value>警告，覆盖将删除下列工具：</value>
+  </data>
+  <data name="ViewLibraryDlg_MatchModifications_This_library_appears_to_contain_the_following_modifications" xml:space="preserve">
+    <value>此库看起来包含下列修饰。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_You_are_missing_fine_tune_optimized_compensation_voltages_" xml:space="preserve">
+    <value>您缺失了精细调谐最优补偿电压。</value>
+  </data>
+  <data name="ComparePeakBoundaries_GenerateComparison_Missing_q_value_for_peptide__0__of_file__1_" xml:space="preserve">
+    <value>缺失针对文件{1}中肽段{0}的 q 值</value>
+  </data>
+  <data name="SkypSupport_Open_Path_to_skyp_file_cannot_be_empty_" xml:space="preserve">
+    <value>skyp 文件的路径不能为空。</value>
+  </data>
+  <data name="ExternalTool" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ExternalTool.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideStandard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptidestandard.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditCustomMoleculeDlg_OkDialog_Please_specify_the_ion_mobility_units_" xml:space="preserve">
+    <value>请指定离子迁移率单位。</value>
+  </data>
+  <data name="ValueInvalidDoubleException_ValueInvalidDoubleException_The_value___0___is_not_valid_for_the_argument__1__which_requires_a_decimal_number_" xml:space="preserve">
+    <value>值“{0}”对于必须是十进制数的参数 {1} 无效。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_GetMoleculeTransitionGroup_Inconsistent_molecule_description" xml:space="preserve">
+    <value>不一致的分子描述</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Download_Canceled" xml:space="preserve">
+    <value>下载取消</value>
+  </data>
+  <data name="AlertDlg_GetDefaultButtonText_OK" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_Start_margin" xml:space="preserve">
+    <value>起始边距</value>
+  </data>
+  <data name="IsolationSchemeList_GetDefaults_SWATH__VW_64_" xml:space="preserve">
+    <value>SWATH (VW 64)</value>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Python_package_installation_cannot_continue__Canceling_tool_installation_" xml:space="preserve">
+    <value>Python 软件包安装无法继续。取消工具安装。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Warning__Invalid_optimization_parameter___0____Use__ce____dp___or__none__" xml:space="preserve">
+    <value>警告：无效的最优化参数({0})。使用“ce”、“dp”或“无”。</value>
+  </data>
+  <data name="ToolDescription_RunExecutableBackground_The_tool__0__had_an_error__it_returned_the_message_" xml:space="preserve">
+    <value>工具{0}出错，它返回消息：</value>
+  </data>
+  <data name="RTLinearRegressionGraphPane_RTLinearRegressionGraphPane_Measured_Time" xml:space="preserve">
+    <value>测量时间</value>
+  </data>
+  <data name="Cut" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\cut.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ToolMacros__listArguments_Collected_Arguments" xml:space="preserve">
+    <value>采集的参数</value>
+  </data>
+  <data name="IsolationWindow_DoValidate_Isolation_window_Start_must_be_between__0__and__1__" xml:space="preserve">
+    <value>分离窗口“起始”必须在{0}和{1}之间。</value>
+  </data>
+  <data name="ToolDescription_RunExecutableBackground_Error_running_the_installed_tool_0_It_seems_to_be_missing_a_file__Please_reinstall_the_tool_and_try_again_" xml:space="preserve">
+    <value>运行安装工具{0}出错。这看起来缺少一个文件。请重新安装工具并重试。</value>
+  </data>
+  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_minimum_log_10_area_entered" xml:space="preserve">
+    <value>输入的最小 log10 面积无效</value>
+  </data>
+  <data name="SkylineWindow_AlignTimesToFileFormat" xml:space="preserve">
+    <value>将时间校准至 {0}</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_Of_the_specified__0__peptides__1__are_not_in_the_document_Do_you_want_to_continue" xml:space="preserve">
+    <value>指定的 {0} 个肽段{1}不存在于文档中。您是否想要继续？</value>
+  </data>
+  <data name="CommandLine_ExportReport_Error__The_report__0__could_not_be_saved_to__1____Check_to_make_sure_it_is_not_read_only_" xml:space="preserve">
+    <value>错误：报告{0}无法保存至{1}。 查看以确保报告不是只读格式。</value>
+  </data>
+  <data name="AlertDlg_GetDefaultButtonText_Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="IsolationWindow_DoValidate_Isolation_window_End_must_be_between__0__and__1__" xml:space="preserve">
+    <value>分离窗口“结束”必须在{0}和{1}之间。</value>
+  </data>
+  <data name="ToolMacros__listArguments_Input_Report_Temp_Path" xml:space="preserve">
+    <value>输入报告临时路径</value>
+  </data>
+  <data name="CommandLine_ExportReport_Report__0__exported_successfully_" xml:space="preserve">
+    <value>报告{0}已成功导出。</value>
+  </data>
+  <data name="BlibDb_CreateLibraryFromSpectra_Creating_spectral_library_for_imported_transition_list" xml:space="preserve">
+    <value>正在针对导入的离子对列表创建谱图库</value>
+  </data>
+  <data name="ImportResultsControl_FindResultsFiles_Searching_for_Results_Files" xml:space="preserve">
+    <value>搜索结果文件</value>
+  </data>
+  <data name="WizardImportProteins" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardImportProteins.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ToolInstaller_UnpackZipTool_The_selected_zip_file_is_not_a_valid_installable_tool_" xml:space="preserve">
+    <value>选定的压缩文件不是有效的可安装工具。</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Error__There_is_an_existing_library_with_the_same_name__0__as_the_document_library_to_be_created_" xml:space="preserve">
+    <value>错误：存在与将要创建的文档库相同名称{0}的现有库。</value>
+  </data>
+  <data name="AnnotatedSpectum" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\AnnotatedSpectum.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ValueInvalidNumberListException_ValueInvalidNumberListException_The_value__0__is_not_valid_for_the_argument__1__which_requires_a_list_of_decimal_numbers_" xml:space="preserve">
+    <value>值 {0} 对于必须是十进制数的参数清单 {1} 无效。</value>
+  </data>
+  <data name="BookmarkEnumerator_Current_No_such_chrominfo__0__" xml:space="preserve">
+    <value>无此类色谱图信息：{0}</value>
+  </data>
+  <data name="CommandStatusWriter_WriteLine_Error_" xml:space="preserve">
+    <value>错误：</value>
+  </data>
+  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_Python__0___Click_install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>本工具需要 Python{0}。单击“安装”以开始安装流程。</value>
+  </data>
+  <data name="ChromatogramCache_WriteStructs_Failure_writing_cache___Specified__0__peaks_exceed_total_peak_count__1_" xml:space="preserve">
+    <value>写入缓存失败。特定的{0}峰超出总峰计数 {1}</value>
+  </data>
+  <data name="File" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\file.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_expandAllMenuItem_DropDownOpening__Molecules" xml:space="preserve">
+    <value>分子(&amp;M)</value>
+  </data>
+  <data name="GridViewDriver_GridView_DataError__0__must_be_a_valid_number" xml:space="preserve">
+    <value>{0} 必须是有效的数字。</value>
+  </data>
+  <data name="SrmDocumentSharing_FindSharedSkylineFile_The_zip_file_is_not_a_shared_file" xml:space="preserve">
+    <value>压缩文件不是共享文件。</value>
+  </data>
+  <data name="Calculator" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Calculator.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="WizardPeptideSearchDIA" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardPeptideSearchDIA.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditRemoteAccountDlg_TestSettings_Error_connecting_to_server__" xml:space="preserve">
+    <value>连接服务器出错：</value>
+  </data>
+  <data name="MeasuredPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry" xml:space="preserve">
+    <value>每个条目都需要修饰肽段序列。</value>
+  </data>
+  <data name="ConfigureToolsDlg_unpackZipTool_Invalid_Tool_Description_in_file__0__" xml:space="preserve">
+    <value>文件{0}中的无效工具描述。</value>
+  </data>
+  <data name="MassListRowReader_CalcTransitionExplanations_Product_m_z_value__0__in_peptide__1__has_no_matching_product_ion" xml:space="preserve">
+    <value>肽段{1}中的子离子质荷比值 {0} 无匹配的子离子。</value>
+  </data>
+  <data name="SettingsUIUtil_DoPasteText_Incorrect_number_of_columns__0__found_on_line__1__" xml:space="preserve">
+    <value>在第 {1} 行发现列数目{0}不正确。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_high_energy_offset_value__0_" xml:space="preserve">
+    <value>无效的离子迁移高能偏置值 {0}</value>
+  </data>
+  <data name="Replicate" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Replicate.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportTool_" xml:space="preserve">
+    <value>错误：标题为{0}的工具已经存在。请使用“--工具-冲突-分辨率=&amp;lt; 覆盖 | 跳过 &gt;”。标题为{0}的工具未添加。</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Warning__The_document_is_missing_iRT_standards" xml:space="preserve">
+    <value>警告：文档中缺失 iRT 标准</value>
+  </data>
+  <data name="SpecialHandlingType_Validate_None" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="CopyGraphDataToolStripMenuItem_CopyGraphData_Failed_setting_data_to_clipboard" xml:space="preserve">
+    <value>向剪切板设定数据失败。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_End_Time" xml:space="preserve">
+    <value>结束时间</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_iRT_database_field_must_not_be_empty_" xml:space="preserve">
+    <value>iRT 数据库字段不得为空。</value>
+  </data>
+  <data name="PasteDlg_btnTransitionListHelp_Click_Supported_values_for__0__are___1_" xml:space="preserve">
+    <value>{0} 所支持的值是：{1}</value>
+    <comment>{1} is a comma seprated list of supported ion mobility units</comment>
+  </data>
+  <data name="WizardBlankDocument" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardBlankDocument-zh-CHS.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Molecule_List_Name" xml:space="preserve">
+    <value>分子列表名称</value>
+  </data>
+  <data name="ParsimonySettings_Validate_The_value__0__for__1__is_not_valid__it_must_be_greater_than_or_equal_to__2__" xml:space="preserve">
+    <value>{1} 的 {0} 值无效：必须大于或等于 {2}。</value>
+  </data>
+  <data name="CommandLine_ImportResultsFile_Error__Failed_importing_the_results_file__0__" xml:space="preserve">
+    <value>错误：导入结果文件{0}失败。</value>
+  </data>
+  <data name="OverlapDemultiplexer_RowStart_Number_of_regions__0__in_overlap_demultiplexer_approximation_must_be_less_than_number_of_scans__1__" xml:space="preserve">
+    <value>重叠多路输出选择器近似值中的区域数目 {0} 必须小于扫描数目 {1}。</value>
+  </data>
+  <data name="OverlapDemultiplexer_attempt_to_insert_slice_of_deconvolution_matrix_failed_out_of_range" xml:space="preserve">
+    <value>因范围外误差而尝试插入去卷积片段基质失败。</value>
+  </data>
+  <data name="PublishDocumentDlg_UploadSharedZipFile_You_do_not_have_permission_to_upload_to_the_given_folder" xml:space="preserve">
+    <value>您没有权限上传特定的文件夹。</value>
+  </data>
+  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_maximum_frequency_entered" xml:space="preserve">
+    <value>输入的最大频率无效</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_collision_energy_value__0_" xml:space="preserve">
+    <value>无效碰撞能量值{0}</value>
+  </data>
+  <data name="VendorIssueHelper_ConvertWiffToMzxml_The_file__0__cannot_be_imported_by_the_AB_SCIEX_WiffFileDataReader_library_in_a_reasonable_time_frame_1_F02_min" xml:space="preserve">
+    <value>文件{0}无法在合理的时间框架（{1:F02} 分钟）内由 AB SCIEX WiffFileDataReader 库导入。</value>
+  </data>
+  <data name="AnnotationHelper_GetReplicateIndicices_True" xml:space="preserve">
+    <value>真</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Max_Height" xml:space="preserve">
+    <value>高度最大值</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_declustering_potential__0_" xml:space="preserve">
+    <value>无效去簇电压 {0}</value>
+  </data>
+  <data name="ExportReportDlg_GetDatabase_Generating_Report_Data" xml:space="preserve">
+    <value>生成报告数据</value>
+  </data>
+  <data name="OptimizationDb_ConvertFromOldFormat_Failed_to_convert__0__optimizations_to_new_format_" xml:space="preserve">
+    <value>转换{0}优化至新格式失败。</value>
+  </data>
+  <data name="TransitionGroupLibDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\TransitionGroupLibDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ConnectLibrarySpecs_Error__Could_not_find_the_spectral_library__0__for_this_document_" xml:space="preserve">
+    <value>错误：无法针对此文档找到谱图库{0}。</value>
+  </data>
+  <data name="WizardPeptideSearchDDA" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardPeptideSearch.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_Publish_Retrieving_server_information" xml:space="preserve">
+    <value>正在获取服务器信息。</value>
+  </data>
+  <data name="SkippedReportErrorDlg_btnOK_Click_No_Email" xml:space="preserve">
+    <value>请提供电子邮件地址以便我们对该错误有任何其他问题时联系您。 
+如果您愿意，您可以选择匿名报告。</value>
+  </data>
+  <data name="ExportMethodDlg_ValidateSettings_Cannot_export_medium_tune_transition_list__The_following_precursors_are_missing_rough_tune_results_" xml:space="preserve">
+    <value>无法导出中等调谐离子对列表。以下母离子缺失粗略调谐结果：</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_Cannot_use_DIA_window_for_precusor_exclusion_when__All_Ions__is_selected_as_the_isolation_scheme___To_use_the_DIA_window_for_precusor_exclusion__change_the_isolation_scheme_in_the_Full_Scan_settings_" xml:space="preserve">
+    <value>当“所有离子”被选定为分离方案时，无法针对母离子排除使用 DIA 窗口。 如要将 DIA 窗口用于母离子排除，请在“全扫描”设置中更改分离方案。</value>
+  </data>
+  <data name="magnifier_zoom_in" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\magnifier_zoom_in.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="BiblioSpecLiteLibrary_Load_Failed_loading_library__0__" xml:space="preserve">
+    <value>加载库“{0}”失败。</value>
+  </data>
+  <data name="DsvFileReader_ReadLine_Line__0__has__1__fields_when__2__expected_" xml:space="preserve">
+    <value>行 {0} 应有{2}个字段，但仅发现 {1} 个。</value>
+  </data>
+  <data name="RenameProteinsDlg_OkDialog_Cannot_rename__0__more_than_once__Please_remove_either__1__or__2__" xml:space="preserve">
+    <value>无法多次重新命名{0}。请删除{1}或{2}</value>
+  </data>
+  <data name="ValidatingIonMobilityPeptide_ValidateAdduct_A_valid_adduct_description__e_g____M_H____must_be_provided_" xml:space="preserve">
+    <value>必须提供有效的加合物描述（例如“[M + H]”）。</value>
+  </data>
+  <data name="TransitionFilter_FragmentEndFinders_3_ions" xml:space="preserve">
+    <value>3 个离子</value>
+  </data>
+  <data name="up_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\up-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ProteinUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ProteinUI.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Regression_slope" xml:space="preserve">
+    <value>斜率</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Adding__0__spectra_to_the_library__1_" xml:space="preserve">
+    <value>正在添加 {0} 谱图到库 {1}</value>
+  </data>
+  <data name="SkylineWindow_shareDocumentMenuItem_Click_The_document_must_be_saved_before_it_can_be_shared" xml:space="preserve">
+    <value>文档必须在共享前被保存。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_The_command_for__0__must_be_of_a_supported_type" xml:space="preserve">
+    <value>针对{0}的命令必须是支持的类型。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Ratio_to_Global_Standards" xml:space="preserve">
+    <value>相对于总体标准品比率</value>
+  </data>
+  <data name="ChromCacheBuilder_WriteLoop_Existing_write_threads___0_" xml:space="preserve">
+    <value>现有的线程写入：{0}</value>
+  </data>
+  <data name="ImportIonMobilityFromSpectralLibrary_ValidateSpectralLibraryPath_Only_BiblioSpec_libraries_contain_enough_ion_mobility_information_to_support_this_operation_" xml:space="preserve">
+    <value>只有 BiblioSpec 库包含支持该操作的足够离子迁移信息。</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_A_calculator_with_that_name_already_exists___Do_you_want_to_replace_it_" xml:space="preserve">
+    <value>具有该名称的计算器已经存在。 您是否想要替换它？</value>
+  </data>
+  <data name="AnnotationDef_AnnotationTarget_Peptides" xml:space="preserve">
+    <value>肽段</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_Otherwise__please_cancel_and_install__0__version__1__first" xml:space="preserve">
+    <value>否则，请首先取消并安装{0}版本{1}</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Error____0___is_not_a_valid_value_for__1___It_must_be_one_of_the_following___2_" xml:space="preserve">
+    <value>错误：“{0}”不是 {1} 的有效值。必须是以下一种：{2}</value>
+  </data>
+  <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_species_information__this_selection_may_be_suspect_" xml:space="preserve">
+    <value>一些背景蛋白质组蛋白没有物种信息，此选择可疑。</value>
+  </data>
+  <data name="PythonInstaller_InstallPip_Pip_installation_failed__Error_log_output_in_immediate_window__" xml:space="preserve">
+    <value>Pip 安装失败。在即时窗口中记录输出失败。</value>
+  </data>
+  <data name="ChromCacheJoiner_FinishRead_Unexpected_end_of_file_in__0__" xml:space="preserve">
+    <value>在{0}中的非正常文件结束。</value>
+  </data>
+  <data name="AddIrtCalculatorDlgOkDialogThe_file__0__does_not_exist" xml:space="preserve">
+    <value>文件{0}不存在。</value>
+  </data>
+  <data name="PythonInstaller_GetPython_Python_installation_completed_" xml:space="preserve">
+    <value>Python 安装已完成。</value>
+  </data>
+  <data name="Resources.ReportSpecList_GetDefaults_Peptide_Quantification" xml:space="preserve">
+    <value>肽段定量</value>
+  </data>
+  <data name="PeakCalculatorGridViewDriver_ValidateRow_On_line__0____1_" xml:space="preserve">
+    <value>在第{0}, {1}行 上</value>
+  </data>
+  <data name="MoleculeIrt" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\moleculeirt.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_An_isolation_scheme_is_required_to_match_multiple_precursors" xml:space="preserve">
+    <value>分离方案要求匹配多个母离子。</value>
+  </data>
+  <data name="BuildLibraryDlg_ValidateBuilder_The_lab_authority_name__0__is_not_valid_This_should_look_like_an_internet_server_address_e_g_mylab_myu_edu_and_be_unlikely_to_be_used_by_any_other_lab_but_need_not_refer_to_an_actual_server" xml:space="preserve">
+    <value>实验室机构名称{0}无效。它应该形如互联网服务器地址（例如，mylab.myu.edu），并且不可能被任何其他实验室使用，但无需参考实际的服务器。</value>
+  </data>
+  <data name="EditServerDlg_OkDialog_The_text__0__is_not_a_valid_server_name_" xml:space="preserve">
+    <value>文本“{0}”不是有效的服务器名称。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_charge_state_" xml:space="preserve">
+    <value>第 {1} 行上的值“{0}”不是有效的电荷价态。</value>
+  </data>
   <data name="VendorIssueHelper_ShowLibraryMissingExternalSpectrumFilesError" xml:space="preserve">
     <value>在为 MaxQuant 输入文件 '{0}' 搜索谱图文件时，找不到以下具有任何支持的文件扩展名 ({3}) 的基本名称：
 
@@ -3772,93 +1978,2013 @@
 
 如果您没有原始文件，可以使用输入文件中的嵌入谱图来建库。但是，MaxQuant 嵌入谱图中的碎片离子的电荷状态为解卷积，并且仅包含单电荷碎片离子，这些碎片离子可能无法代表质谱仪测出的强度。</value>
   </data>
-  <data name="ViewLibraryDlg_CheckLibraryInSettings_The_library__0__is_not_currently_added_to_your_document" xml:space="preserve">
-    <value>库{0}当前并未添加至您的文档。</value>
+  <data name="SkylineWindow_ImportResults_A_maximum_of__0__may_be_missing_and_or_outliers_for_a_successful_import_" xml:space="preserve">
+    <value>可能缺失最多 {0} 个，或者是成功导入的异常值。</value>
   </data>
-  <data name="ViewLibraryDlg_EnsureBackgroundProteome_The_background_proteome_must_be_digested_in_order_to_associate_proteins" xml:space="preserve">
-    <value>背景蛋白质组必须被消化才能关联蛋白质。</value>
+  <data name="ScanProvider_GetScans_The_scan_ID__0__was_not_found_in_the_file__1__" xml:space="preserve">
+    <value>未能在文件{1}中找到扫描ID{0}。</value>
   </data>
-  <data name="ViewLibraryDlg_LoadLibrary_An_error_occurred_attempting_to_import_the__0__library" xml:space="preserve">
-    <value>尝试导入{0}库时出现错误。</value>
+  <data name="CommandLine_ImportTransitionList_Importing_transiton_list__0____" xml:space="preserve">
+    <value>正在导入离子对列表{0}...</value>
   </data>
-  <data name="ViewLibraryDlg_LoadLibrary_Loading_Library" xml:space="preserve">
-    <value>正在加载库</value>
+  <data name="PeptideToMoleculeText_Protein" xml:space="preserve">
+    <value>蛋白质</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a protein" to read "choose a molecule list" when non-peptide documents are in use</comment>
   </data>
-  <data name="ViewLibraryDlg_MatchModifications__0__Would_you_like_to_use_the_Unimod_definitions_for__1__modifications_The_document_will_not_change_until_peptides_with_these_modifications_are_added" xml:space="preserve">
-    <value>{0}您是否想要使用针对{1}修饰的 Unimod 定义？文档在具有这些修饰的肽段被添加前不会改变。</value>
+  <data name="RInstaller_InstallPackages_Installing_R_packages_requires_an_internet_connection__Please_check_your_connection_and_try_again" xml:space="preserve">
+    <value>安装 R 软件包需要网络连接。请检查您的连接并重试</value>
   </data>
-  <data name="ViewLibraryDlg_MatchModifications_the_matching" xml:space="preserve">
-    <value>匹配</value>
-    <comment>In the sentence 'Would you like to use the Unimod definition for the matching modification?</comment>
+  <data name="TransitionGroupDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\transitiongroupdecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="IonMobilityLibraryList_AcceptList_will_be_deleted_because_the_libraries_they_depend_on_have_changed__Do_you_want_to_continue_" xml:space="preserve">
+    <value>将被删除，因为其依靠的库已发生改变。您是否想要继续？</value>
+  </data>
+  <data name="ConfigureToolsDlg_PopulateMacroDropdown_File_path_to_a_temporary_report" xml:space="preserve">
+    <value>通向临时报告的文件路径</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Retention_Time" xml:space="preserve">
+    <value>保留时间</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_units_value__0___accepted_values_are__1__" xml:space="preserve">
+    <value>无效的离子迁移单位值 {0}（允许值是 {1}）</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_Do_you_want_to_continue" xml:space="preserve">
+    <value>您是否想要继续？</value>
+  </data>
+  <data name="AllChromatogramsGraph_btnCancelFile_Click_Cancel_file" xml:space="preserve">
+    <value>取消文件</value>
+  </data>
+  <data name="RenameProteinsDlg_OkDialog_Edit_name__0__" xml:space="preserve">
+    <value>编辑名称{0}</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_Your_document_does_not_contain_compensation_voltage_results__but_compensation_voltage_is_set_under_transition_settings_" xml:space="preserve">
+    <value>您的文档不含有补偿电压结果，但补偿电压已在离子对设置中设置。</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_The_document_does_not_contain_any_peptides_" xml:space="preserve">
+    <value>文档不包含任何肽段。</value>
+  </data>
+  <data name="MassListRowReader_CalcPrecursorExplanations_Check_the_Instrument_tab_in_the_Transition_Settings" xml:space="preserve">
+    <value>在“离子对设置”中核选“仪器”标签。</value>
+  </data>
+  <data name="PeptideGroupTreeNode_RenderTip_Name" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="PeptideGroupBuilder_FinalizeTransitionGroups_Two_transitions_of_the_same_precursor___0___m_z__1_____have_different_iRT_values___2__and__3___iRT_values_must_be_assigned_consistently_in_an_imported_transition_list_" xml:space="preserve">
+    <value>来自同一母离子的两个离子对{0}（质荷比 {1}）具有不同的 iRT 值 {2} 和 {3}。iRT值必须在导入的离子对列表中分配一致。</value>
+  </data>
+  <data name="SkylineWindow_AddIrtPeptides_Imported_peptide__0__with_iRT_library_value_is_already_being_used_as_an_iRT_standard_" xml:space="preserve">
+    <value>具有 iRT 库值的导入肽段{0}已经用作 iRT 标准。</value>
+  </data>
+  <data name="CommandLine_AssociateProteins_a_FASTA_file_must_be_imported_before_associating_proteins" xml:space="preserve">
+    <value>错误：必须先导入 FASTA 文件才能关联蛋白质</value>
+  </data>
+  <data name="RenameProteinsDlg_OkDialog__0__is_not_a_current_protein" xml:space="preserve">
+    <value>{0}不是当前的蛋白质</value>
+  </data>
+  <data name="PublishDocumentDlg_OkDialog_Selected_file_is_not_a_Skyline_Shared_file" xml:space="preserve">
+    <value>选定的文件不是 Skyline 共享文件。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_start_time_" xml:space="preserve">
+    <value>第 {1} 行上的值“{0}”不是有效的起始时间。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Precursor_Name" xml:space="preserve">
+    <value>母离子名称</value>
+  </data>
+  <data name="ToolUpdatesDlg_InstallUpdates_User_cancelled_installation" xml:space="preserve">
+    <value>用户取消安装</value>
+  </data>
+  <data name="ColumnSet_GetColumnInfos_Unexpected_report_type" xml:space="preserve">
+    <value>意外的报告类型</value>
+  </data>
+  <data name="ExportMethodDlg_comboTargetType_SelectedIndexChanged_Scheduled_methods_are_not_yet_supported_for_DIA_acquisition" xml:space="preserve">
+    <value>非数据依赖 (DIA) 采集不支持预定方法。</value>
+  </data>
+  <data name="ConfigureToolsDlg_unpackZipTool_Title_and_Command_are_required" xml:space="preserve">
+    <value>需要标题和命令</value>
+  </data>
+  <data name="Paste" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\paste.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Proteins" xml:space="preserve">
+    <value>蛋白质</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_Keep_the_existing_iRT_value_or_overwrite_with_the_imported_value_" xml:space="preserve">
+    <value>保留现有 iRT 值或使用导入值覆盖？</value>
+  </data>
+  <data name="ExportMethodDlg_ValidateSettings_Cannot_export_fine_tune_transition_list__The_following_precursors_are_missing_medium_tune_results_" xml:space="preserve">
+    <value>无法导出精细调谐离子对列表。以下母离子缺失中等调谐结果：</value>
+  </data>
+  <data name="Keep" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\keep.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_The_command_cannot_be_blank__please_enter_a_valid_command_for__0_" xml:space="preserve">
+    <value>命令不得为空。请针对{0}输入一个有效的命令</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_Export_of_DIA_method_is_not_supported_for__0__" xml:space="preserve">
+    <value>DIA 导出方法针对{0}未获得支持。</value>
+  </data>
+  <data name="GenerateDecoysDlg_GenerateDecoysDlg_All" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__The_template_file__0__does_not_exist_" xml:space="preserve">
+    <value>错误：模板文件{0}不存在。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool_Supported_Types___1_" xml:space="preserve">
+    <value>支持类型：{1}</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Error__No_internet_connection_" xml:space="preserve">
+    <value>错误：无网络连接。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility_Units" xml:space="preserve">
+    <value>明示离子迁移单位</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_conflicting_annotations__Overwriting_" xml:space="preserve">
+    <value>存在冲突注释。覆盖。</value>
+  </data>
+  <data name="MoleculeUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\MoleculeUI.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideToMoleculeText_Ion_charges" xml:space="preserve">
+    <value>离子电荷</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "Ion charges" to read "Ion adducts" when non-peptide documents are in use</comment>
+  </data>
+  <data name="ToolDescription_VerifyAnnotations_This_tool_requires_the_use_of_the_following_annotations_which_are_missing_or_improperly_formatted" xml:space="preserve">
+    <value>本工具需要使用已丢失或不当格式化的下列注释</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_Do_you_want_to_use_the_document_settings_to_automanage_these_new_transitions" xml:space="preserve">
+    <value>您想要启用自动选择，并使用文档设置来管理这些新离子对吗?
+
+启用自动选择: {0} 个母离子和 {1} 个碎片离子对将添加到当前文档。
+
+禁用自动选择: {2} 个母离子和 {3} 个碎片离子对将添加到当前文档。
+
+如果选择“禁用”，则可以稍后使用“细化 &gt; 高级”菜单项来启用自动选择。</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_retention_time_window_value__0_" xml:space="preserve">
+    <value>无效保留时间窗口值{0}</value>
+  </data>
+  <data name="PeptideSettingsUI_ValidateNewSettings_Choose_at_least_one_internal_standard_type" xml:space="preserve">
+    <value>至少选择一个内部标准类型。</value>
+  </data>
+  <data name="ReintegrateDlg_OkDialog_Failed_attempting_to_reintegrate_peaks_" xml:space="preserve">
+    <value>尝试重新合并峰失败。</value>
+  </data>
+  <data name="PanoramaPublish" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\panoramapublish.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TransitionFullScan_ValidateRes_Mass_accuracy_must_be_between__0__and__1__for_centroided_data_" xml:space="preserve">
+    <value>针对质心数据质量准确性必须在 {0} 和 {1} 之间。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_The_value___0___on_line__1__is_not_a_valid_end_time_" xml:space="preserve">
+    <value>第 {1} 行上的值“{0}”不是有效的结束时间。</value>
+  </data>
+  <data name="ToolUpdateAvailable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ToolUpdateAvailable.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MassListRowReader_CalcTransitionExplanations_The_product_m_z__0__is_out_of_range_for_the_instrument_settings__in_the_peptide_sequence__1_" xml:space="preserve">
+    <value>在肽段序列{1}中，子离子质荷比 {0} 超出仪器设置范围。</value>
+  </data>
+  <data name="PeptideIrtLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptideirtlib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ExportReportDlg_GetExceptionDisplayMessage_The_field__0__does_not_exist_in_this_document" xml:space="preserve">
+    <value>字段{0}不存在于本文档中。</value>
+  </data>
+  <data name="MassListRowReader_CalcPrecursorExplanations_" xml:space="preserve">
+    <value>母离子质荷比 {0} 不匹配最接近的可能值 {1}（增量= {2}），肽段{3}。</value>
+  </data>
+  <data name="PeakBoundaryImporter_DetermineCorrectSeparator_The_first_line_does_not_contain_any_of_the_possible_separators_comma__tab_or_space_" xml:space="preserve">
+    <value>第一行不包含任何可能的分隔符：逗号、标记或空格。</value>
+  </data>
+  <data name="DataboundGridControl_GetClusteredResults_An_error_occured_while_performing_clustering_" xml:space="preserve">
+    <value>执行去簇时出错。</value>
+  </data>
+  <data name="PeakBoundaryImporter_DetermineCorrectSeparator_The_first_line_does_not_contain_any_of_the_possible_separators_semicolon__tab_or_space_" xml:space="preserve">
+    <value>第一行不包含任何可能的分隔符：分号、标记或空格。</value>
+  </data>
+  <data name="Columns_Columns_Duplicate_column___0__" xml:space="preserve">
+    <value>重复列“{0}”</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_OkDialog_Specify__0__for_isolation_window" xml:space="preserve">
+    <value>针对分离窗口指定{0}。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_DoRowValidating_The_sequence__0__is_already_present_in_the_list_" xml:space="preserve">
+    <value>序列 {0} 已经存在于列表中。</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Peptides" xml:space="preserve">
+    <value>肽段</value>
+  </data>
+  <data name="SpectrumLibraryInfoDlg_SetDetailsText_ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="MProphetPeakScoringModel_CalcLinearScore_Attempted_to_score_a_peak_with__0__features_using_a_model_with__1__trained_scores_" xml:space="preserve">
+    <value>尝试使用具有{1}训练得分的模型以计分带有{0}特性的峰。</value>
+  </data>
+  <data name="PasteDlg_btnTransitionListHelp_Click_SmallMol_" xml:space="preserve">
+    <value>使用此窗口最简易的方法是从 Excel（或如果数据是 CSV 格式，则使用任何文本编辑器）复制并将其粘贴到网格。
+    
+请注意，您可以在 Skyline 中通过向左或右拖动列标题调整列顺序。 对于分子，您还可以使用“列...”按钮选择要启用的列。
+
+大多数肽段离子对列表可以用“文件|导入|离子对列表...”菜单项目导入或甚至直接粘贴到“目标”窗口。如果它们使用这些名称作为列标题，您也可以使用分子离子对列表执行此操作：</value>
+  </data>
+  <data name="NewDocument" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\newdocument.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_Charge" xml:space="preserve">
+    <value>母离子电荷</value>
+  </data>
+  <data name="IrtDb_GetIrtDb_The_file__0__could_not_be_opened" xml:space="preserve">
+    <value>文件{0}无法被打开。</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_Warning__the_annotation__0__may_not_be_what_your_tool_requires_" xml:space="preserve">
+    <value>警告：注释{0}可能不是您的工具所需的。</value>
+  </data>
+  <data name="TransitionTreeNode_GetResultsText__0__" xml:space="preserve">
+    <value>[{0}]</value>
+    <comment>Rank for transition node</comment>
+  </data>
+  <data name="CopyPasteTest_DoTest_Could_not_read_the_pasted_transition_list___Transition_list_must_be_in_separated_columns_and_cannot_contain_blank_lines_" xml:space="preserve">
+    <value>无法读取粘贴的离子对。 离子对必须在单独列中并且不能包含空行。</value>
+  </data>
+  <data name="UnpackZipToolHelper_UnpackZipTool_The_tool___0___requires_report_type_titled___1___and_it_is_not_provided__Import_canceled_" xml:space="preserve">
+    <value>工具“{0}”需要标题为“{1}”的报告类型，并且该类型未提供。导入已取消。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Error__Use___in_to_specify_a_Skyline_document_to_open_" xml:space="preserve">
+    <value>错误：使用“--在内”来指定要打开的 Skyline 文档。</value>
+  </data>
+  <data name="DocumentGridViewContext_Delete_Are_you_sure_you_want_to_delete_the__0____1___" xml:space="preserve">
+    <value>您是否确定想要删除 {0}“{1}”？</value>
+    <comment>Example: Are you sure you want to delete the protein 'ALDH'?</comment>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Package_Installation_was_not_completed__Canceling_tool_installation_" xml:space="preserve">
+    <value>软件包安装未完成。取消工具安装。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_adduct_description_on_line__0_" xml:space="preserve">
+    <value>第 {0} 行缺少加合物描述</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_then_run_the_tool_again" xml:space="preserve">
+    <value>然后再次运行工具。</value>
+  </data>
+  <data name="IonMobilityDb_GetIonMobilityDb_The_file__0__is_not_a_valid_ion_mobility_library_file_" xml:space="preserve">
+    <value>文件{0}不是有效的离子迁移库文件。</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Peptide" xml:space="preserve">
+    <value>肽段</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Opt_Step" xml:space="preserve">
+    <value>最优步骤</value>
+  </data>
+  <data name="HomeIcon1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\HomeIcon.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassToolInternal__ToolDir__is_not_a_valid_macro_for_a_tool_that_was_not_installed_and_therefore_does_not_have_a_Tool_Directory_" xml:space="preserve">
+    <value>$(ToolDir) 不是针对未安装之工具的有效宏，因此没有工具目录。</value>
+  </data>
+  <data name="MultiFileAsynchronousDownloadClient_DownloadFileAsync_Downloading__0" xml:space="preserve">
+    <value>下载{0}</value>
+  </data>
+  <data name="CopyGraphDataToolStripMenuItem_CopyGraphDataToolStripMenuItem_Copy_Data" xml:space="preserve">
+    <value>复制数据</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_The_peptide__0__is_not_in_the_document_Do_you_want_to_continue" xml:space="preserve">
+    <value>肽段“{0}”不存在于文档中。您是否想要继续？</value>
+  </data>
+  <data name="TransitionLibraries_DoValidate_Library_ion_count_value__0__must_not_be_less_than_min_ion_count_value__1__" xml:space="preserve">
+    <value>库离子计数值 {0} 不得少于最小离子计数值 {1}。</value>
+  </data>
+  <data name="ReportErrorDlg_ReportErrorDlg_Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="Expand" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\plus.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_The_current_file_or_model_has_no_q_values_or_scores_to_analyze___Either_q_values_or_scores_are_necessary_to_compare_peak_picking_tools_" xml:space="preserve">
+    <value>当前文件或模型没有需要分析的 q 值或得分。 q 值或得分都不是比较峰值拣选工具所必需的。</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_None_may_be_missing_or_outliers_for_a_successful_import_" xml:space="preserve">
+    <value>可能无缺失，或者无成功导入的异常值。</value>
+  </data>
+  <data name="DocumentGridViewContext_Delete_Are_you_sure_you_want_to_delete_these__0___1__" xml:space="preserve">
+    <value>您是否确定想要删除这些 {0} {1}？</value>
+    <comment>Example: Are you sure you want to delete these 27 proteins?</comment>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Precursor_m_z" xml:space="preserve">
+    <value>母离子质荷比</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_List__0__exported_successfully_" xml:space="preserve">
+    <value>列表{0}已成功导出。</value>
+  </data>
+  <data name="CustomIon_DisplayName_Ion" xml:space="preserve">
+    <value>离子</value>
+  </data>
+  <data name="BiblioSpecLiteLibrary_ReadRedundantSpectrum_Spectrum_peaks__0__excede_the_maximum_allowed__1__" xml:space="preserve">
+    <value>谱图峰{0}超出容许的最大{1}。</value>
+  </data>
+  <data name="ConfigureToolsDlg_Cancel_Do_you_wish_to_Save_changes_" xml:space="preserve">
+    <value>您是否想要保存更改？</value>
+  </data>
+  <data name="FragmentDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\FragmentDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RenameProteinsDlg_UseFastaFile_The_document_contains_a_naming_conflict_The_name__0__is_currently_used_by_multiple_protein_sequences" xml:space="preserve">
+    <value>文档包含一个命名冲突。名称{0}当前被多个蛋白质序列使用。</value>
+  </data>
+  <data name="RefineDlg_NormalizationMethod_Total_ion_current" xml:space="preserve">
+    <value>总离子电流</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Decoy" xml:space="preserve">
+    <value>诱饵</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Truncated" xml:space="preserve">
+    <value>截短的</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Warning__The_export_strategy__0__is_not_valid__It_must_be_one_of_the_following___string" xml:space="preserve">
+    <value>警告：导出策略{0}无效。它必须是下列内容之一：“单一”、“蛋白质”或“存储桶”。默认设置为单一。</value>
+  </data>
+  <data name="SequenceMassCalc_ParseModMass_The_expression__0__is_not_a_valid_chemical_formula" xml:space="preserve">
+    <value>表达式“{0}”不是有效的化学式。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Height" xml:space="preserve">
+    <value>高度</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Label_Type" xml:space="preserve">
+    <value>标记类型</value>
+  </data>
+  <data name="GreenCheck" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\GreenCheck.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateDecimalTextBox__0__must_be_less_than_or_equal_to__1__" xml:space="preserve">
+    <value>{0}必须小于或等于 {1}。</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_Do_you_want_to_continue" xml:space="preserve">
+    <value>您是否想要继续？</value>
+  </data>
+  <data name="MassListImporter_AddRow_Invalid_iRT_value_at_precusor_m_z__0__for_peptide__1_" xml:space="preserve">
+    <value>肽段{1}在母离子质荷比 {0} 上的无效 iRT 值。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_There_is_already_an_imported_file_with_the_current_name___Please_choose_another_name" xml:space="preserve">
+    <value>已经存在拥有当前名称的导入文件。 请选择另一个名称</value>
+  </data>
+  <data name="ShimadzuMethodExporter_ExportMethod_Unexpected_response__0__from_Shimadzu_method_writer_" xml:space="preserve">
+    <value>来自 Shimadzu 方法写入器的非预期响应 {0}。</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Transition_Results" xml:space="preserve">
+    <value>离子对结果（多个）</value>
   </data>
   <data name="ViewLibraryDlg_MatchModifications_these" xml:space="preserve">
     <value>这些</value>
     <comment>In the sentence 'Would you like to use the Unimod definitions for these modifications?'</comment>
   </data>
-  <data name="ViewLibraryDlg_MatchModifications_This_library_appears_to_contain_the_following_modifications" xml:space="preserve">
-    <value>此库看起来包含下列修饰。</value>
+  <data name="ChromatogramExporter_Export_Corrupted_chromatogram_data_at_charge__0__state_of_peptide__1_" xml:space="preserve">
+    <value>肽段{1}在电荷{0}态下的损坏色谱图数据</value>
   </data>
-  <data name="Wand" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\Wand.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_The_tool__0__is_already_installed_" xml:space="preserve">
+    <value>工具{0}已安装。</value>
   </data>
-  <data name="WandProhibit" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\WandProhibit.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeptideToMoleculeText_Modified_Peptide_Sequence" xml:space="preserve">
+    <value>修改的肽段序列</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a modifed peptide sequence" to read "select a molecule" when non-peptide documents are in use</comment>
   </data>
-  <data name="warning" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\warning.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="BrukerTimsTofMethodExporter_ExportMethod_Error_copying_template_file_" xml:space="preserve">
+    <value>复制模板文件时出错。</value>
   </data>
-  <data name="WebPanoramaPublishClient_GetInfoForFolders_Failure_retrieving_folder_information_from__0_" xml:space="preserve">
-    <value>从{0}检索文件夹信息失败</value>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Compensation_Voltage" xml:space="preserve">
+    <value>明确的补偿电压</value>
   </data>
-  <data name="WebPanoramaPublishClient_ImportDataOnServer_Error_importing_Skyline_file_on_Panorama_server__0_" xml:space="preserve">
-    <value>在 Panorama 服务器{0}上导入 Skyline 文件出错</value>
+  <data name="CommandLine_ApplyFileAndSampleNameRegex_Error__No_files_match_the_file_name_pattern___0___" xml:space="preserve">
+    <value>错误：没有与文件名模式 '{0}' 相匹配的文件。</value>
   </data>
-  <data name="WizardBlankDocument" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardBlankDocument-zh-CHS.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="GroupByItem_ToString_Replicates" xml:space="preserve">
+    <value>重复测定</value>
   </data>
-  <data name="WizardFasta" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardFasta.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="Edit_Undo_Multiple" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Edit_Undo_Multiple.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="WizardImportPeptide" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardImportPeptide.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="EditCustomMoleculeDlg_OkDialog_Custom_molecules_must_have_a_mass_greater_than_or_equal_to__0__" xml:space="preserve">
+    <value>自定义分子必须拥有比更大的质量或与{0}相等的质量。</value>
   </data>
-  <data name="WizardImportProteins" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardImportProteins.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeptideToMoleculeText_Peptide" xml:space="preserve">
+    <value>肽段</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a peptide" to read "choose a molecule" when non-peptide documents are in use</comment>
   </data>
-  <data name="WizardImportTransition" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardImportTransition.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="AddZipToolHelper_ShouldOverwrite_Overwriting_tool___0_" xml:space="preserve">
+    <value>覆盖工具：{0}</value>
   </data>
-  <data name="WizardMoleculeIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardMoleculeIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="PeptideSettingsUI_comboPeakScoringModel_SelectedIndexChanged_The_document_must_have_imported_results_in_order_to_train_a_model_" xml:space="preserve">
+    <value>文档必须具备导入的结果，以训练模型。</value>
   </data>
-  <data name="WizardPeptideIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardPeptideIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="EditLinkedPeptideDlg_TryMakeLinkedPeptide_The_crosslinker___0___cannot_attach_to_the_amino_acid___1___" xml:space="preserve">
+    <value>交联剂 '{0}' 无法附加到氨基酸 '{1}'。</value>
   </data>
-  <data name="WizardPeptideSearchDDA" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardPeptideSearch.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="EditIonMobilityLibraryDlg_OkDialog_Do_you_want_to_change_it_" xml:space="preserve">
+    <value>是否要更改？</value>
   </data>
-  <data name="WizardPeptideSearchDIA" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardPeptideSearchDIA.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="RInstaller_DownloadR_Download_failed_" xml:space="preserve">
+    <value>下载失败。</value>
   </data>
-  <data name="WizardPeptideSearchPRM" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardPeptideSearchPRM.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="CommandLine_AssociateProteins_Failed_to_associate_proteins" xml:space="preserve">
+    <value>未能关联蛋白质</value>
   </data>
-  <data name="WizardTransitionIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\StartPage\WizardTransitionIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  <data name="AreaCvToolbarProperties_btnOk_Click_Invalid_CV_cutoff_entered" xml:space="preserve">
+    <value>输入的 CV 截止值无效</value>
   </data>
-  <data name="XHunterLibrary_Load_Invalid_precursor_charge_found_File_may_be_corrupted" xml:space="preserve">
-    <value>发现无效的母离子电荷。文件可能已损坏。</value>
+  <data name="ToolUpdatesDlg_DisplayInstallSummary_Successfully_updated_the_following_tool" xml:space="preserve">
+    <value>成功更新下列工具</value>
   </data>
-  <data name="XmlElementHelper_Deserialize_Deserialize" xml:space="preserve">
-    <value>反序列化</value>
+  <data name="SkylineWindow_SaveDocument_Saving___" xml:space="preserve">
+    <value>保存...</value>
   </data>
-  <data name="XmlUtil_GetAttribute_The_value__0__is_not_valid_for_the_attribute__1__" xml:space="preserve">
-    <value>值“{0}”不是属性{1}的有效值。</value>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Fragment_Name" xml:space="preserve">
+    <value>片段名称</value>
+  </data>
+  <data name="PythonInstaller_DownloadPython_Download_failed_" xml:space="preserve">
+    <value>下载失败。</value>
+  </data>
+  <data name="CommandLine_ImportTool_Error__to_import_a_tool_it_must_have_a_name_and_a_command___Use___tool_add_to_specify_a_name_and_use___tool_command_to_specify_a_command___The_tool_was_not_imported___" xml:space="preserve">
+    <value>错误：如要导入工具，则必须含有名称和命令。 使用“--工具-添加”来指定一个名称，并且使用“--工具-命令”来指定一个命令。 工具未导入...</value>
+  </data>
+  <data name="PeptideToMoleculeText_Peptide_Sequence" xml:space="preserve">
+    <value>肽段序列</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a peptide sequence" to read "select a molecule" when non-peptide documents are in use</comment>
   </data>
   <data name="XmlUtil_GetInvalidDataMessage_The_file_contains_an_error_on_line__0__at_column__1__" xml:space="preserve">
     <value>文件在第 {1} 列第 {0} 行包含一个错误。</value>
   </data>
-  <data name="ZedGraphClipboard_CreateCopyMenuItems_Copy" xml:space="preserve">
-    <value>复制</value>
+  <data name="PeptideToMoleculeText_Modified_Sequence" xml:space="preserve">
+    <value>修改序列</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a modifed sequence" to read "select a molecule" when non-peptide documents are in use</comment>
+  </data>
+  <data name="AssociateProteinsDlg_UseFastaFile_An_error_occurred_during_protein_association_" xml:space="preserve">
+    <value>关联蛋白质时出错。</value>
+  </data>
+  <data name="ViewLibraryDlg_MatchModifications_the_matching" xml:space="preserve">
+    <value>匹配</value>
+    <comment>In the sentence 'Would you like to use the Unimod definition for the matching modification?</comment>
+  </data>
+  <data name="DriftTimeWindowWidthCalculator_Validate_Peak_width_must_be_non_negative_" xml:space="preserve">
+    <value>峰宽度不得为负数。</value>
+  </data>
+  <data name="ProteinDecoy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ProteinDecoy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="BiblioSpecLiteLibrary_ReadSpectrum_Unexpected_SQLite_failure_reading__0__" xml:space="preserve">
+    <value>意外的 SQLite 读出{0}失败。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadMoleculeIdColumns__0__is_not_a_valid_InChiKey_" xml:space="preserve">
+    <value>{0}不是有效的InChiKey。</value>
+  </data>
+  <data name="Demultiplexer_GetDeconvRegionsForMz_TheIsolationSchemeIsInconsistentlySpecified" xml:space="preserve">
+    <value>全扫描设置中的分离方案方案说明不一致。</value>
+  </data>
+  <data name="SkylineWindow_OpenSharedFile_Extracting_Files" xml:space="preserve">
+    <value>提取文件</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_No_method_will_be_exported_" xml:space="preserve">
+    <value>无方法将被导出。</value>
+  </data>
+  <data name="UniquePeptidesDlg_OnShown_The_background_proteome__0__has_not_yet_finished_being_digested_with__1__" xml:space="preserve">
+    <value>背景蛋白质组{0}还未结束与{1}的消化过程。</value>
+  </data>
+  <data name="CommandLine_ImportSearch_Creating_spectral_library_from_files_" xml:space="preserve">
+    <value>正在通过以下文件创建谱图库：</value>
+  </data>
+  <data name="AddIrtCalculatorDlg_OkDialog_Please_specify_a_path_to_an_existing_iRT_database" xml:space="preserve">
+    <value>请为现有的 iRT 数据库指明路径。</value>
+  </data>
+  <data name="SkylineWindow_Paste_Paste" xml:space="preserve">
+    <value>粘贴</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Unknown_Error_installing_packages__Output_logged_to_the_Immediate_Window_" xml:space="preserve">
+    <value>安装软件包的未知错误。输出录入即时窗口。</value>
+  </data>
+  <data name="AlignmentForm_UpdateGraph_Time_from__0__" xml:space="preserve">
+    <value>从 {0} 开始的时间</value>
+  </data>
+  <data name="CommandLine_ImportSearch_Adding__0__modifications_" xml:space="preserve">
+    <value>添加 {0} 个修饰。</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_overwrite_with_the_older_version__0__or_install_in_parallel_" xml:space="preserve">
+    <value>您想要使用较早版本 {0} 覆盖还是并行安装？</value>
+  </data>
+  <data name="EditLink" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\EditLink.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Peptide_GetDeleteConfirmation_Are_you_sure_you_want_to_delete_these__0__peptides_" xml:space="preserve">
+    <value>您是否确定想要删除这些{0}肽段？</value>
+    <comment>Example: Are you sure you want to delete these 47 peptides?</comment>
+  </data>
+  <data name="CommandLine_ApplyNamingPattern_Error__Duplicate_replicate_name___0___after_applying_regular_expression_" xml:space="preserve">
+    <value>错误：应用正则表达式后重复测定名称“{0}”重复。</value>
+  </data>
+  <data name="SkylineViewContext_GetTransitionListReportSpec_Peptide_Transition_List" xml:space="preserve">
+    <value>肽段离子对列表</value>
+  </data>
+  <data name="Database_GetJoinColumn_The_type__0__must_have_a_column_of_type__1_" xml:space="preserve">
+    <value>类型{0}必须具备一列类型{1}</value>
+  </data>
+  <data name="IonMobilityDb_GetIonMobilityDb_Please_provide_a_path_to_an_existing_ion_mobility_library_" xml:space="preserve">
+    <value>请为现有的离子迁移库提供一个路径。</value>
+  </data>
+  <data name="SkypFile_GetSkyFileUrl__0__is_not_a_valid_URL_on_a_Panorama_server_" xml:space="preserve">
+    <value>{0} 非 Panorama 服务器上有效的 URL。</value>
+  </data>
+  <data name="ToolDescription_RunTool_Support_for_the_GenePattern_version_of_QuaSAR_has_been_discontinued_" xml:space="preserve">
+    <value>QuaSAR 之 GenePattern 版本支持已中断。</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_spectral_library_intensities___Create_a_document_library_from_these_intensities_" xml:space="preserve">
+    <value>离子对列表中似乎包含谱图库强度。 从这些强度中创建文档库？</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_End_margin" xml:space="preserve">
+    <value>终止边距</value>
+  </data>
+  <data name="SkylineWindow_ImportFiles_Importing__0__" xml:space="preserve">
+    <value>导入{0}</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Decoy" xml:space="preserve">
+    <value>诱饵</value>
+  </data>
+  <data name="BuildLibraryDlg_ValidateBuilder_The_library_identifier__0__is_not_valid_Identifiers_start_with_a_letter_number_or_underscore_and_contain_only_letters_numbers_underscores_and_dashes" xml:space="preserve">
+    <value>库标识符{0}无效。标识符以字母、数字或下划线开始，并且仅包含字母、数字、下划线和破折号。</value>
+    <comment>Letters restricted to English alphabet</comment>
+  </data>
+  <data name="SkylineData" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\SkylineData.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ExportReportDlg_ShowShare_Report_Definitions" xml:space="preserve">
+    <value>报告定义</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Explicit_Declustering_Potential" xml:space="preserve">
+    <value>明确的去簇电压</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Library_Dot_Product" xml:space="preserve">
+    <value>库点积</value>
+  </data>
+  <data name="ValidatingIonMobilityPeptide_ValidateSequence_A_modified_peptide_sequence_is_required_for_each_entry_" xml:space="preserve">
+    <value>每个条目都需要修饰肽段序列。</value>
+  </data>
+  <data name="RefineDlg_RefineDlg_Products" xml:space="preserve">
+    <value>子离子</value>
+  </data>
+  <data name="ConfigureToolsDlg_GetZipFromWeb_Error_connecting_to_the_Tool_Store___0_" xml:space="preserve">
+    <value>连接至工具商店出错：{0}</value>
+  </data>
+  <data name="PeptideToMoleculeText_Molecule_Lists" xml:space="preserve">
+    <value>分子列表</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like  "2 proteins" to read "2 molecule lists" when non-peptide documents are in use</comment>
+  </data>
+  <data name="CommandLine_ExportReport_" xml:space="preserve">
+    <value>错误：如果您指定一个报告，则必须指定--report-file=path/to/file.csv 参数。</value>
+  </data>
+  <data name="MassListImporter_Import_Failed_to_find_peptide_column" xml:space="preserve">
+    <value>未能发现肽段列。</value>
+  </data>
+  <data name="SkypDownloadException_GetMessage_Would_you_like_to_update_the_credentials_" xml:space="preserve">
+    <value>您想更新凭据吗?</value>
+  </data>
+  <data name="CommandLine_ImportResultsFile_Results_added_from__0__to_replicate__1__" xml:space="preserve">
+    <value>从{0}向重复测定{1}中添加结果。</value>
+  </data>
+  <data name="LibraryGridViewDriver_AddProcessedIrts_Correlation_to_the_existing_iRT_values_are_not_high_enough_to_allow_retention_time_conversion" xml:space="preserve">
+    <value>对现有 iRT 值的相关度不够高，无法实现保留时间转换。</value>
+  </data>
+  <data name="ChromLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Name" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="MassListRowReader_NextRow_Invalid_peptide_sequence__0__found" xml:space="preserve">
+    <value>发现无效的肽段序列{0}</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Finishing_up_import" xml:space="preserve">
+    <value>完成导入</value>
+  </data>
+  <data name="BookmarkEnumerator_Current_No_such_node__0__" xml:space="preserve">
+    <value>无此类节点：{0}</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Retention_Time_Window" xml:space="preserve">
+    <value>明确保留时间窗口</value>
+  </data>
+  <data name="BuildBackgroundProteomeDlg_RefreshStatus_The_proteome_has_already_been_digested" xml:space="preserve">
+    <value>蛋白质组已经被酶解。</value>
+  </data>
+  <data name="PublishDocumentDlg_OkDialog_Please_select_a_folder" xml:space="preserve">
+    <value>请选择一个文件夹</value>
+  </data>
+  <data name="ValueMissingException_ValueMissingException_" xml:space="preserve">
+    <value>参数 {0} 需要数值并且必须在“ --名称=值”的格式中指定</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_comboMargins_SelectedIndexChanged_Start_margin" xml:space="preserve">
+    <value>起始边距</value>
+  </data>
+  <data name="AllChromatogramsGraph_UpdateStatus_Joining_chromatograms___" xml:space="preserve">
+    <value>加入色谱图…</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Molecules" xml:space="preserve">
+    <value>分子</value>
+  </data>
+  <data name="GraphData_GraphResiduals_Time_from_Regression" xml:space="preserve">
+    <value>回归的时间</value>
+  </data>
+  <data name="BiblioSpecLiteBuilder_AmbiguousMatches_The_library_built_successfully__Spectra_matching_the_following_peptides_had_multiple_ambiguous_peptide_matches_and_were_excluded_" xml:space="preserve">
+    <value>成功建立库。与以下肽段匹配的谱图曾经有多个模糊肽段匹配，已经被排除：</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_Please_verify_and_update_if_incorrect" xml:space="preserve">
+    <value>如果不正确，请验证并更新。</value>
+  </data>
+  <data name="DataboundGridControl_GetClusteredResults_Unable_to_choose_a_set_of_columns_to_use_for_hierarchical_clustering_" xml:space="preserve">
+    <value>无法选择一组用于层次去簇的列。</value>
+  </data>
+  <data name="Edit_Redo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\edit_redo.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideGroupTreeNode_ProteinModalDisplayText__name___0__" xml:space="preserve">
+    <value>&lt;名称：{0}&gt;</value>
+  </data>
+  <data name="MQuestReferenceShapeCalc_MQuestReferenceShapeCalc_mProphet_weighted_reference" xml:space="preserve">
+    <value>mProphet 权重参考</value>
+  </data>
+  <data name="SkylineDataSchema_VerifyDocumentCurrent_The_document_was_modified_in_the_middle_of_the_operation_" xml:space="preserve">
+    <value>该文档在操作过程中进行了修改。</value>
+  </data>
+  <data name="Comment" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\comment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportFasta_Importing_FASTA_file__0____" xml:space="preserve">
+    <value>FASTA 文件{0}导入中...</value>
+  </data>
+  <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_gene_information__this_selection_may_be_suspect_" xml:space="preserve">
+    <value>一些背景蛋白质组蛋白没有基因信息，此选择可疑。</value>
+  </data>
+  <data name="OpenDataSourceDialog_OpenDataSourceDialog_My_Recent_Documents" xml:space="preserve">
+    <value>我的最近文档</value>
+  </data>
+  <data name="AlignmentForm_UpdateGraph_Outliers" xml:space="preserve">
+    <value>异常值</value>
+  </data>
+  <data name="RTLinearRegressionGraphPane_UpdateGraph_Calculating___" xml:space="preserve">
+    <value>正在计算...</value>
+  </data>
+  <data name="SkylineWindow_ImportFasta_Unexpected_document_change_during_operation" xml:space="preserve">
+    <value>操作过程中的意外文档修改。</value>
+  </data>
+  <data name="MProphetResultsHandler_Q_VALUE_ANNOTATION_Q_Value" xml:space="preserve">
+    <value>Q 值</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__the_specified_instrument__0__is_not_compatible_with_scheduled_methods_" xml:space="preserve">
+    <value>错误：指定的仪器{0}和预定方法不兼容。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Warning__Invalid_max_transitions_per_injection_parameter___0___" xml:space="preserve">
+    <value>警告：无效的每次进样参数最大离子对数目({0})。</value>
+  </data>
+  <data name="SkypDownloadException_GetMessage_Credentials_saved_in_Skyline_for_the_Panorama_server__0__are_for_the_user__1___This_user_does_not_have_permissions_to_download_the_file__The_skyp_file_was_downloaded_by__2__" xml:space="preserve">
+    <value>Skyline 中保存的 Panorama 服务器 {0} 的凭据仅适用于用户 {1}。该用户不具备下载该文件的权限。该 skyp 文件由 {2} 下载。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_ion_mobility_value_on_line__0__" xml:space="preserve">
+    <value>第 {0} 行缺少离子迁移值。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Peak_Rank" xml:space="preserve">
+    <value>峰排名</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_UpdateIsolationWidths_Isolation_widths" xml:space="preserve">
+    <value>分离宽度(&amp;W)：</value>
+  </data>
+  <data name="SkylineWindow_ImportResults__0__decoys_do_not_have_a_matching_target" xml:space="preserve">
+    <value>{0} 个诱饵没有匹配的目标</value>
+  </data>
+  <data name="GraphSpectrum_MassErrorFormat_ppm" xml:space="preserve">
+    <value>{0}{1} ppm</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_retention_time_value__0_" xml:space="preserve">
+    <value>无效保留时间值{0}</value>
+  </data>
+  <data name="TransitionGroupLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\transitiongrouplib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RegressionFit_BILINEAR_Bilinear" xml:space="preserve">
+    <value>双线性</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Do_you_want_to_continue_" xml:space="preserve">
+    <value>您是否想要继续？</value>
+  </data>
+  <data name="Ions_C" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_C.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeakCalculatorWeight_Validate___0___is_not_a_known_name_for_a_peak_feature_calculator" xml:space="preserve">
+    <value>“{0}”不是针对峰特性计算器的已知名称</value>
+  </data>
+  <data name="EditEnzymeDlg_ValidateAATextBox__0__must_contain_at_least_one_amino_acid" xml:space="preserve">
+    <value>{0}必须至少包含一个氨基酸。</value>
+  </data>
+  <data name="CommandLine_RefineDocument_Refining_document___" xml:space="preserve">
+    <value>正在细化文档...</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_File_Name" xml:space="preserve">
+    <value>文件名称</value>
+  </data>
+  <data name="AbstractModificationMatcherFoundMatches__0__equals__1__" xml:space="preserve">
+    <value>{0} = {1}</value>
+  </data>
+  <data name="CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_does_not_exist__Please_verify_the_file_location_and_try_again_" xml:space="preserve">
+    <value>错误：以“--工具-添加-zip”命令指定的文件不存在。请验证文件位置并重试。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Failed_to_find_the_necessary_headers__0__in_the_first_line" xml:space="preserve">
+    <value>未能在第一行发现必要的标题{0}</value>
+  </data>
+  <data name="AssociateProteinsDlg_UseFastaFile_There_was_an_error_reading_from_the_file_" xml:space="preserve">
+    <value>从文件读取时发生错误。</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_Error_reading_iRT_standards_transition_list___0_" xml:space="preserve">
+    <value>阅读 iRT 标准离子对列表出现错误：{0}</value>
+  </data>
+  <data name="IsolationSchemeList_GetDefaults_SWATH__VW_100_" xml:space="preserve">
+    <value>SWATH (VW 100)</value>
+  </data>
+  <data name="EditEnzymeDlg_OnClosing_The_enzyme__0__already_exists" xml:space="preserve">
+    <value>酶“{0}”已经存在。</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_reinstall_or_install_in_parallel_" xml:space="preserve">
+    <value>您是否想要重新安装或并行安装？</value>
+  </data>
+  <data name="Error___0_" xml:space="preserve">
+    <value>错误：{0}</value>
+  </data>
+  <data name="ColumnSet_GetColumnInfos_Unable_to_find_table_for__0_" xml:space="preserve">
+    <value>无法找到针对{0}的表格</value>
+  </data>
+  <data name="ImportSkyrHelper_ResolveImportConflicts_Resolving_conflicts_by_overwriting_" xml:space="preserve">
+    <value>通过覆盖来解决冲突。</value>
+  </data>
+  <data name="LibraryGridViewDriver_AddToLibrary_This_can_improve_retention_time_alignment_under_stable_chromatographic_conditions_" xml:space="preserve">
+    <value>这样可以在稳定的色谱条件下改善保留时间校准。</value>
+  </data>
+  <data name="ReportSpecList_GetDefaults_Peptide_Ratio_Results" xml:space="preserve">
+    <value>肽段比率结果</value>
+  </data>
+  <data name="AnnotationHelper_GetReplicateIndicices_False" xml:space="preserve">
+    <value>假</value>
+  </data>
+  <data name="ConfigureToolsDlg_unpackZipTool_Failed_to_read_file_0_The_tool_described_failed_to_import" xml:space="preserve">
+    <value>读取文件{0}失败。描述的工具导入失败。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_intercept_" xml:space="preserve">
+    <value>值 {0} 不是有效的截距。</value>
+  </data>
+  <data name="SkylineViewContext_GetTransitionListReportSpec_Small_Molecule_Transition_List" xml:space="preserve">
+    <value>小分子离子对列表</value>
+  </data>
+  <data name="Skyline" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\skyline.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ReportSpecList_Label_Report" xml:space="preserve">
+    <value>报告(&amp;R)：</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Fwhm" xml:space="preserve">
+    <value>半峰宽</value>
+  </data>
+  <data name="IrtStandard_DocumentStream_No_document_to_import" xml:space="preserve">
+    <value>没有要导入的文档</value>
+  </data>
+  <data name="PeakBlank" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peakblank.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ValueInvalidPathException_ValueInvalidPathException_The_value___0___is_not_valid_for_the_argument__1__failed_attempting_to_convert_it_to_a_full_file_path_" xml:space="preserve">
+    <value>值“{0}”对于参数 {1} 无效，尝试将其转换为完整文件路径失败。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_peptide_sequence_on_line__0__" xml:space="preserve">
+    <value>第 {0} 行缺少肽段序列</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility_High_Energy_Offset" xml:space="preserve">
+    <value>离子迁移高能偏置</value>
+  </data>
+  <data name="CommandArgs_ParseRegexArgument_Error__Regular_expression___0___for__1__cannot_be_parsed_" xml:space="preserve">
+    <value>错误：{1} 的正则表达式“{0}”无法解析。</value>
+  </data>
+  <data name="ComparePeakPickingDlg_SaveGraph_Either_the_ROC_or_Q_q_plot_tab_must_be_selected_to_save_a_graph_" xml:space="preserve">
+    <value>ROC 或 Q-q 图标签必须被选择，以保存图形。</value>
+  </data>
+  <data name="PasteDlg_btnTransitionListHelp_Click_Transition_List_Help" xml:space="preserve">
+    <value>离子对列表帮助</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateNumberTextBox__0__must_contain_an_integer" xml:space="preserve">
+    <value>{0} 必须包含一个整数。</value>
+  </data>
+  <data name="RInstaller_InstallPackages_The_following_packages_failed_to_install_" xml:space="preserve">
+    <value>下列软件包安装失败：</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_The_document_does_not_contain_any_of_these_iRT_standard_peptides_" xml:space="preserve">
+    <value>文档不包括任何这些 iRT 标准肽段。</value>
+  </data>
+  <data name="Ions_X" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_X.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="XmlUtil_GetAttribute_The_value__0__is_not_valid_for_the_attribute__1__" xml:space="preserve">
+    <value>值“{0}”不是属性{1}的有效值。</value>
+  </data>
+  <data name="MsconvertDdaConverter_Run_Re_using_existing_converted__0__file_for__1__" xml:space="preserve">
+    <value>为 {1} 重新使用转换过的现有 {0} 文件。</value>
+  </data>
+  <data name="SettingsListComboDriver_Add" xml:space="preserve">
+    <value>&lt;添加…&gt;</value>
+  </data>
+  <data name="PublishDocumentDlg_OkDialog_Please_select_a_Skyline_Shared_file_to_upload" xml:space="preserve">
+    <value>请选择一个 Skyline 共享文件上传。</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwriteAnnotations_There_are_annotations_with_conflicting_names__Please_use_the___tool_zip_overwrite_annotations_command_" xml:space="preserve">
+    <value>带有冲突名称的注释。请使用“--工具-zip-覆盖-注释”命令。</value>
+  </data>
+  <data name="RedXTransparentBackground" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\RedXTransparentBackground.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="BioMassCalc_SynchMasses_Fixing_isotope_abundance_masses_requires_a_monoisotopic_mass_calculator" xml:space="preserve">
+    <value>固定同位素丰度质量需要一个单一同位素质量计算器</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Total_Background" xml:space="preserve">
+    <value>总体背景</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Missing_end_time_on_line__0_" xml:space="preserve">
+    <value>第 {0} 行缺失终止时间</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Label_Type" xml:space="preserve">
+    <value>标记类型</value>
+  </data>
+  <data name="CalculateIsolationSchemeDlg_OkDialog_Start_value_must_be_less_than_End_value" xml:space="preserve">
+    <value>起始值必须小于最终值。</value>
+  </data>
+  <data name="EditServerDlg_OkDialog_The_server__0__already_exists_" xml:space="preserve">
+    <value>服务器“{0}”已经存在。</value>
+  </data>
+  <data name="EditIrtCalcDlg_CreateDatabase_The_file__0__could_not_be_created" xml:space="preserve">
+    <value>文件{0}无法被创建。</value>
+  </data>
+  <data name="PythonInstaller_PythonInstaller_Load_This_tool_requires_the_following_Python_packages__Select_packages_to_install_and_then_click_Install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>本工具需要下列 Python 软件包。选择将要安装的软件包，然后单击“安装”以开始安装过程。</value>
+  </data>
+  <data name="NoCentroidedDataException_NoCentroidedDataException_No_centroided_data_available_for_file___0_____Adjust_your_Full_Scan_settings_" xml:space="preserve">
+    <value>文件“{0}”没有可用的质心数据。 调整您的全扫描设置。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Mass_Error_PPM" xml:space="preserve">
+    <value>质量误差 PPM</value>
+  </data>
+  <data name="ImportResultsDlg_DefaultNewName_Default_Name" xml:space="preserve">
+    <value>色谱图</value>
+    <comment>Default replicate name</comment>
+  </data>
+  <data name="CommandLine_SaveFile_File__0__saved_" xml:space="preserve">
+    <value>文件{0}已保存。</value>
+  </data>
+  <data name="RemoteSession_FetchContents_There_was_an_error_communicating_with_the_server__" xml:space="preserve">
+    <value>与服务器通讯出现错误：</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Change_digestion_settings" xml:space="preserve">
+    <value>更改酶解设置</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_InChIKey" xml:space="preserve">
+    <value>InChIKey</value>
+  </data>
+  <data name="FindNext" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\findnext.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="NoFullScanFilteringException_NoFullScanFilteringException_The_file__0__does_not_contain_SRM_MRM_chromatograms__To_extract_chromatograms_from_its_spectra__go_to_Settings___Transition_Settings___Full_Scan_and_choose_options_appropriate_to_the_acquisition_method_used_" xml:space="preserve">
+    <value>文件 {0} 不包含 SRM/MRM 色谱图。要从其谱图中提取色谱图，请转至“设置&gt;离子对设置&gt;全扫描”，然后选择适合所用采集方法的选项。</value>
+    <comment>replaces NoFullScanFilteringException_NoFullScanFilteringException_To_extract_chromatograms_from__0__full_scan_settings_must_be_enabled_</comment>
+  </data>
+  <data name="CommandLine_ImportDataFilesWithAppend_Error__The_replicate__0__already_exists_in_the_given_document_and_the___import_append_option_is_not_specified___The_replicate_will_not_be_added_to_the_document_" xml:space="preserve">
+    <value>错误：指定的文档中已存在重复测定 {0}，并且未指定 --import-append 选项。该重复测定不会添加到文档中。</value>
+  </data>
+  <data name="DataProcessing" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\dataprocessing.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="GraphSummary_UpdateToolbar_All" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_targets_for_which_to_export_chromatograms_" xml:space="preserve">
+    <value>文档必须包含针对其导出色谱图的目标。</value>
+  </data>
+  <data name="MoleculeList" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\MoleculeList.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="GridColumnsExtension_getDefaultLanguageValues_End" xml:space="preserve">
+    <value>结束</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Overwrite" xml:space="preserve">
+    <value>覆盖</value>
+  </data>
+  <data name="ExportMethodDlg_btnBrowseTemplate_Click_Method_Template" xml:space="preserve">
+    <value>方法模板</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Product_m_z" xml:space="preserve">
+    <value>子离子质荷比</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Start_Time" xml:space="preserve">
+    <value>启动时间</value>
+  </data>
+  <data name="AssociateProteinsDlg_UseBackgroundProteome_No_background_proteome_defined" xml:space="preserve">
+    <value>未定义任何背景蛋白质组，请参阅“肽段设置”中的“酶解”选项卡以了解更多信息。</value>
+    <comment>If background proteome is set to "None" and user attempts to "Use background proteome" when associating proteins</comment>
+  </data>
+  <data name="WizardFasta" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardFasta.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditIsolationSchemeDlg_UpdateIsolationWidths_Isolation_width" xml:space="preserve">
+    <value>分离宽度(&amp;W)：</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Unknown_error_installing_packages__Tool_Installation_Failed_" xml:space="preserve">
+    <value>安装软件包的未知错误。工具安装失败。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility__msec_" xml:space="preserve">
+    <value>离子迁移(ms)</value>
+  </data>
+  <data name="LabelTypeComboDriver_LoadList_none" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg_Press_Register_to_register_for_a_project_on_PanoramaWeb_" xml:space="preserve">
+    <value>按下“注册”，以在 PanoramaWeb 上注册一个项目。</value>
+  </data>
+  <data name="PeptideToMoleculeText_Molecule_List" xml:space="preserve">
+    <value>分子列表</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a protein" to read "choose a molecule list" when non-peptide documents are in use</comment>
+  </data>
+  <data name="LowessAlignerFactory_ToString_LOWESS_Aligner" xml:space="preserve">
+    <value>局部加权回归散点平滑法校准器</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ProcessNeutralLoss_Cannot_use_product_neutral_loss_chemical_formula_without_a_precursor_chemical_formula" xml:space="preserve">
+    <value>没有母离子化学式，不能使用子离子中性丢失化学式</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_QMedian" xml:space="preserve">
+    <value>Q 值中位数的 -log10</value>
+  </data>
+  <data name="SkylineWindow_ImportFastaFile_Import_FASTA" xml:space="preserve">
+    <value>导入 FASTA</value>
+  </data>
+  <data name="SkylineViewContext_GetDocumentGridRowSources_Transitions" xml:space="preserve">
+    <value>离子对</value>
+  </data>
+  <data name="ValidatingIonMobilityPeptide_ValidateSequence_The_sequence__0__is_not_a_valid_modified_peptide_sequence_" xml:space="preserve">
+    <value>序列 {0} 不是有效的修饰肽段序列。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Sample_Name" xml:space="preserve">
+    <value>样品名称</value>
+  </data>
+  <data name="TextUtil_DeterminDsvSeparator_Unable_to_determine_format_of_delimiter_separated_value_file" xml:space="preserve">
+    <value>无法识别分隔符分隔值文件的格式</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow_Missing_collisional_cross_section_value_on_line__0__" xml:space="preserve">
+    <value>第 {0} 行上缺失碰撞横截面值。</value>
+  </data>
+  <data name="Skyline_protein" xml:space="preserve">
+    <value>蛋白质</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Defaulting_to_standard_" xml:space="preserve">
+    <value>默认设置为标准。</value>
+  </data>
+  <data name="VendorIssueHelper_ConvertWiffToMzxml_Please_install_Analyst__or_run_this_import_on_a_computure_with_Analyst_installed" xml:space="preserve">
+    <value>请安装 Analyst，或者在安装有 Analyst 的电脑上运行此导入</value>
+  </data>
+  <data name="ConfigureToolsDlg_CopyinFile_Not_importing_this_tool" xml:space="preserve">
+    <value>未导入此工具…</value>
+  </data>
+  <data name="Columns_Columns_Unrecognized_column___0__" xml:space="preserve">
+    <value>未识别列“{0}”</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_OkDialog_The_peak_scoring_model__0__already_exists" xml:space="preserve">
+    <value>峰排名模型{0}已经存在</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Precursor_Peak_Found_Ratio" xml:space="preserve">
+    <value>母离子峰值检出比</value>
+  </data>
+  <data name="SkylineWindow_CompleteProgressUI_version_issue" xml:space="preserve">
+    <value>
+
+您可以通过安装 64-位版本的{0}来避免此问题的出现。</value>
+  </data>
+  <data name="StartPage_Tutorial_Zip_Files" xml:space="preserve">
+    <value>压缩文件</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_Failed_to_open_the_database_file___0_" xml:space="preserve">
+    <value>打开数据库文件失败：{0}</value>
+  </data>
+  <data name="DocumentAnnotations_AnnotationsNotSupported_The_element___0___cannot_have_annotations_" xml:space="preserve">
+    <value>元素“{0}”不能有注释。</value>
+  </data>
+  <data name="LibraryBuildNotificationHandler_AddIrts__0__distinct_CiRT_peptides_were_found__How_many_would_you_like_to_use_as_iRT_standards_" xml:space="preserve">
+    <value>发现 {0} 明显不同的 CiRT 肽段。您想要使用多少作为 iRT 标准？</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_ComboChanged_Reassigning_the_Protein_Name_column_will_prevent_the_peptides_from_being_associated_with_proteins_from_the_background_proteome." xml:space="preserve">
+    <value>重新分配蛋白质名称列将防止肽段与背景蛋白质组中的蛋白质相关联。</value>
+  </data>
+  <data name="Save" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\save.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Skyline_peptides" xml:space="preserve">
+    <value>肽段</value>
+  </data>
+  <data name="IsolationSchemeList_GetDefaults_SWATH__15_m_z_" xml:space="preserve">
+    <value>SWATH（15 质荷比）</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_The_iRT_calculator_already_contains__0__of_the_imported_peptides_" xml:space="preserve">
+    <value>iRT 计算器已经包含导入肽段中的 {0} 个。</value>
+  </data>
+  <data name="ToolUpdatesDlg_btnUpdate_Click_Please_select_at_least_one_tool_to_update_" xml:space="preserve">
+    <value>请至少选择一个工具以更新。</value>
+  </data>
+  <data name="BioMassCalc_ApplyAdductToFormula_Unknown_symbol___0___in_adduct_description___1__" xml:space="preserve">
+    <value>加合物描述“{1}”中有未知符号“{0}”</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_1_decoy_does_not_have_the_same_number_of_transitions_as_its_matching_target" xml:space="preserve">
+    <value>1 个诱饵没有与其匹配目标相同的离子对数目。</value>
+  </data>
+  <data name="RefineListDlg_OkDialog_The_sequence__0__is_not_a_valid_peptide" xml:space="preserve">
+    <value>序列“{0}”并不是有效的肽段。</value>
+  </data>
+  <data name="SkylineWindow_ShowChromatogramFeaturesDialog_The_document_must_have_imported_results_" xml:space="preserve">
+    <value>文档必须具有导入的结果。</value>
+  </data>
+  <data name="TransitionTreeNode_GetResultsText__0__ratio__1__" xml:space="preserve">
+    <value>{0}（比率 {1}）</value>
+    <comment>(0) transition amino acids, (1) transition fragment ion</comment>
+  </data>
+  <data name="PublishDocumentDlg_ServerSupportsSkydVersion_" xml:space="preserve">
+    <value>选择的服务器不支持 skyd 文件格式版本{0}。
+请联系 Panorama 服务器管理员以升级服务器。</value>
+  </data>
+  <data name="PivotReportDlg_ShowPreview_A_report_must_have_at_least_one_column_" xml:space="preserve">
+    <value>报告必须至少具备一列。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_It_must_be_a_number__Defaulting_to__0__" xml:space="preserve">
+    <value>它必须是一个数字。默认设置为{0}。</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassToolInternal_" xml:space="preserve">
+    <value>$(ToolDir) 不是针对未安装之工具的有效宏，因此没有工具目录。</value>
+  </data>
+  <data name="ImportResultsControl_FindResultsFiles_Searching_for_matching_results_files_in__0__" xml:space="preserve">
+    <value>在{0}中搜索匹配结果文件。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Protein_name" xml:space="preserve">
+    <value>蛋白质名称</value>
+  </data>
+  <data name="CommandLine_LogNewEntries_Document_unchanged" xml:space="preserve">
+    <value>文档未更改</value>
+  </data>
+  <data name="TransitionGroupTreeNode_GetResultsText_total_ratio__0__" xml:space="preserve">
+    <value>总比率 {0}</value>
+  </data>
+  <data name="ToolDescription_RunTool_Please_check_the_External_Tools_Store_on_the_Skyline_web_site_for_the_most_recent_version_of_the_QuaSAR_external_tool_" xml:space="preserve">
+    <value>请针对 QuaSAR 外部工具的最新版本于 Skyline 网站查看外部工具商店。</value>
+  </data>
+  <data name="CommandLineTest_ConsoleAddFastaTest_Warning" xml:space="preserve">
+    <value>警告</value>
+  </data>
+  <data name="SrmDocument_ReadLabelType_The_isotope_modification_type__0__does_not_exist_in_the_document_settings" xml:space="preserve">
+    <value>同位素修饰类型{0}不存在于文档设置中。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Possible_loss_of_data_could_occur_if_you_switch_to__0___Do_you_want_to_continue_" xml:space="preserve">
+    <value>如果您切换到{0}，可能发生数据的可能性丢失。您是否想要继续？</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_The_precursor_mass_analyzer_type_is_not_set_to__0__in_Transition_Settings_under_the_Full_Scan_tab" xml:space="preserve">
+    <value>母离子质量分析器类型在“离子对设置”（在“全扫描”标签下）中未设定为{0}。</value>
+  </data>
+  <data name="Blank" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\blank.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SettingsListComboDriver_Edit_current" xml:space="preserve">
+    <value>&lt;编辑当前…&gt;</value>
+  </data>
+  <data name="WizardTransitionIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardTransitionIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PeptideQc" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peptideqc.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditOptimizationLibraryDlg_UpdateValueHeader_Collision_Energy" xml:space="preserve">
+    <value>碰撞能量</value>
+  </data>
+  <data name="CommandLine_ImportSearchInternal_Error___0__must_be_set_when_using_CiRT_peptides_" xml:space="preserve">
+    <value>错误：使用 CiRT 肽段时必须设置 {0}。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_Compensation_voltage_optimization_should_be_run_on_one_transition_per_peptide__and_the_best_transition_cannot_be_determined_for_the_following_precursors_" xml:space="preserve">
+    <value>应对每个母离子的一个离子对运行补偿电压最优化。无法确定以下母离子的最佳离子对：</value>
+  </data>
+  <data name="SkylineWindow_ImportFastaFile_Failed_reading_the_file__0__1__" xml:space="preserve">
+    <value>读取文件{0}失败。{1}</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_cone_voltage_value__0_" xml:space="preserve">
+    <value>无效的锥孔电压值 {0}</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Precursor" xml:space="preserve">
+    <value>母离子</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Opt_Declustering_Potential" xml:space="preserve">
+    <value>最优去簇电压</value>
+  </data>
+  <data name="ChooseAnnotationsDlg_OkDialog_Change_Annotation_Settings" xml:space="preserve">
+    <value>更改注释设置</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_Replicate" xml:space="preserve">
+    <value>重复测定</value>
+  </data>
+  <data name="ColumnSet_GetTransitionsTable_Precursors" xml:space="preserve">
+    <value>母离子</value>
+  </data>
+  <data name="ImportFastaControl_ImportFasta_Importing_the_FASTA_did_not_create_any_target_proteins_" xml:space="preserve">
+    <value>导入 FASTA 未生成任何目标蛋白质。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateCell_A_value_is_required_" xml:space="preserve">
+    <value>值必填。</value>
+  </data>
+  <data name="IonMobilityFilter_IonMobilityUnitsString_Drift_Time__ms_" xml:space="preserve">
+    <value>漂移时间 （毫秒）</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_Compensation_Voltage_" xml:space="preserve">
+    <value>补偿电压：</value>
+  </data>
+  <data name="PeptideToMoleculeText_Molecules" xml:space="preserve">
+    <value>分子</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "2 peptides" to read "2 molecules" when non-peptide documents are in use</comment>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_Comparison_name_cannot_be_empty_" xml:space="preserve">
+    <value>比较名称不得为空。</value>
+  </data>
+  <data name="ComparePeakPickingDlg_SaveGraph_Save_Model_Comparison_Graph" xml:space="preserve">
+    <value>保存模型比较图</value>
+  </data>
+  <data name="RCalcIrt_RequireUsable_Unexpected_use_of_iRT_calculator_before_successful_initialization" xml:space="preserve">
+    <value>初始化成功前对 iRT 计算器的意外使用。</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_None_of_the_specified_proteins_are_in_the_document_" xml:space="preserve">
+    <value>没有任何指定蛋白质在文档中。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateUniquePrecursors_The_following_ions_have_multiple_ion_mobility_values__Skyline_supports_multiple_conformers__so_this_may_be_intentional_" xml:space="preserve">
+    <value>以下离子有多个离子迁移值。Skyline 支持多个构象异构体，因此这可能是有意为之。</value>
+  </data>
+  <data name="WizardMoleculeIcon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardMoleculeIcon.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="TransitionInfo_ReadTransitionLosses_No_modification_named__0__was_found_in_this_document" xml:space="preserve">
+    <value>未在文档中发现名为{0}的修饰。</value>
+  </data>
+  <data name="IsotopeDistInfo_IsotopeDistInfo_Minimum_abundance__0__too_high" xml:space="preserve">
+    <value>最小丰度值 {0} 太高</value>
+  </data>
+  <data name="MoleculeStandard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\MoleculeStandard.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Modified_Time" xml:space="preserve">
+    <value>修饰时间</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Warning__The_iRT_calculator_already_contains__0__with_the_value__1___Ignoring__2_" xml:space="preserve">
+    <value>警告：iRT 计算器已经含有有{1}值的{0}。忽视{2}</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Ion_Mobility" xml:space="preserve">
+    <value>离子迁移</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Error___line__0___column__1____2_" xml:space="preserve">
+    <value>错误：（行 {0}，列 {1}） {2}</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_S_Lens_value__0_" xml:space="preserve">
+    <value>无效的 S-Lens 值 {0}</value>
+  </data>
+  <data name="CommandLine_OpenSkyFile_Opening_file___" xml:space="preserve">
+    <value>文件打开中...</value>
+  </data>
+  <data name="PasteDlg_AddFasta_An_unexpected_error_occurred" xml:space="preserve">
+    <value>发生意外错误：</value>
+  </data>
+  <data name="AreaReplicateGraphPane_UpdateGraph_Peak_Area_Ratio_To__0_" xml:space="preserve">
+    <value>相对于 {0} 的峰面积比率</value>
+  </data>
+  <data name="RemovePrecursors_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from_one_precursor_" xml:space="preserve">
+    <value>您是否确定想要从一个母离子中删除这 {0} 个峰？</value>
+  </data>
+  <data name="Skyline_Daily" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\skyline_daily.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="LibraryGridViewDriver_ValidateMz_Product_m_zs_must_be_greater_than_zero_" xml:space="preserve">
+    <value>子离子质荷比必须大于零。</value>
+  </data>
+  <data name="VendorIssueHelper_CreateTempFileSubstitute_Convert_to_mzXML_work_around_for__0__" xml:space="preserve">
+    <value>针对{0}转换成 mzXML 替代方法</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Missing_start_time_on_line__0_" xml:space="preserve">
+    <value>第 {0} 行缺失起始时间</value>
+  </data>
+  <data name="CachedLibrary_WarnInvalidEntries_" xml:space="preserve">
+    <value>在库 '{0}' 中找到无效的条目。
+{2} 个肽段或分子中的 {1} 个无效，包括:：{3}</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Library_Intensity" xml:space="preserve">
+    <value>库强度</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_Error_deleting_the_directory_of_the_existing_tool__Please_close_anything_using_that_directory_and_try_the_overwriting_import_again_later" xml:space="preserve">
+    <value>删除现有工具目录出错。请关闭使用该目录的所有内容并且稍候再次尝试覆盖导入</value>
+  </data>
+  <data name="DetectionPlotPane_Tooltip_AllCount" xml:space="preserve">
+    <value>所有计数</value>
+  </data>
+  <data name="SkypSupport_Download_You_do_not_have_permissions_to_download_this_file_from__0__" xml:space="preserve">
+    <value>您无从 {0} 下载此文件的权限。</value>
+  </data>
+  <data name="SettingsList_ELEMENT_NONE_None" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="PasteDlg_GetMoleculePeptideGroup_Molecule_List__0_" xml:space="preserve">
+    <value>分子列表 {0}</value>
+  </data>
+  <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_OtherIDs" xml:space="preserve">
+    <value>其他 ID</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Retention_Time_Window" xml:space="preserve">
+    <value>保留时间窗口</value>
+  </data>
+  <data name="Transition_Validate_Precursor_and_product_ion_polarity_do_not_agree_" xml:space="preserve">
+    <value>母离子和子离子极性不匹配。</value>
+  </data>
+  <data name="MissingFileDlg_ValidateFilePath_You_must_choose_a_file_with_the___0___filename_extension_" xml:space="preserve">
+    <value>您必须选择扩展名为 '{0}' 的文件。</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_This_installation_would_modify_the_report_titled__0_" xml:space="preserve">
+    <value>此安装将修饰标题为{0}的报告</value>
+  </data>
+  <data name="Peak" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\peak.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Regression_intercept" xml:space="preserve">
+    <value>截距</value>
+  </data>
+  <data name="ComparePeakBoundaries_ComputeMatches_Number_of_results_in_transition_group__0__does_not_match_between_the_two_documents" xml:space="preserve">
+    <value>离子对群组{0}中的结果数目在两个文档之间不匹配</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Ion_mobility_units_not_specified" xml:space="preserve">
+    <value>未指定离子迁移单位</value>
+  </data>
+  <data name="SkylineWindow_ShowExportSpectralLibraryDialog_The_document_must_contain_at_least_one_peptide_precursor_to_export_a_spectral_library_" xml:space="preserve">
+    <value>文档必须至少包含一个肽段母离子才能导出谱图库。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Count_Truncated" xml:space="preserve">
+    <value>截尾计数</value>
+  </data>
+  <data name="CommandLine_RemoveImportedFiles__0______1___Note__The_file_has_already_been_imported__Ignoring___" xml:space="preserve">
+    <value>{0} -&gt; {1} 注释：文件已导入。忽视...</value>
+  </data>
+  <data name="IIrtRegression_DisplayEquation_Measured_RT" xml:space="preserve">
+    <value>测量的 RT</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateAdductListTextBox__0__must_contain_a_comma_separated_list_of_adducts_or_integers_describing_charge_states_with_absolute_value_from__1__to__2__" xml:space="preserve">
+    <value>{0} 必须包含加合物或整数的逗号分隔列表，描述绝对值从 {1} 到 {2} 的电荷态。</value>
+  </data>
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Peptide_Peak_Found_Ratio" xml:space="preserve">
+    <value>肽段峰值检出比</value>
+  </data>
+  <data name="SkylineWindow_exportIsolationListMenuItem_Click_There_is_no_isolation_list_data_to_export" xml:space="preserve">
+    <value>没有需要导出的采集列表。</value>
+  </data>
+  <data name="MzMatchException_suggestion" xml:space="preserve">
+    <value>检查“肽段设置”中的“修饰”标签、“预测”标签上的质荷比类型，或者“离子对设置”中的“仪器”标签上的质荷比匹配耐受性。</value>
+  </data>
+  <data name="SkylineWindow_Publish_Error_retrieving_server_information__0__" xml:space="preserve">
+    <value>检索服务器信息出错：{0}</value>
+  </data>
+  <data name="Filter" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Filter.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SpectrumFilter_FindFilterPairs_Two_isolation_windows_contain_targets_which_match_the_isolation_target__0__" xml:space="preserve">
+    <value>两个分离窗口包含匹配分离目标{0}的目标。</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Note" xml:space="preserve">
+    <value>注释</value>
+  </data>
+  <data name="BuildBackgroundProteomeDlg_RefreshStatus_Click_the_Add_File_button_to_add_a_FASTA_file_and_create_a_new_proteome_file" xml:space="preserve">
+    <value>单击“添加文件”按钮来添加一个 FASTA 文件，并且创建一个新的蛋白质组文件。</value>
+  </data>
+  <data name="Skyline_Release" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Skyline_Release.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="MessageBoxHelper_ValidateSignedNumberTextBox_Value__0__must_be_between__1__and__2__or__3__and__4__" xml:space="preserve">
+    <value>值 {0} 必须在 {1} 和 {2} 或 {3} 和 {4} 之间。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph_IM_Scan_Range_" xml:space="preserve">
+    <value>IM Scan 范围：</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_the_value__0__is_not_a_valid_slope_" xml:space="preserve">
+    <value>值 {0} 不是有效的斜率。</value>
+  </data>
+  <data name="AnnotationDef_AnnotationTarget_Transitions" xml:space="preserve">
+    <value>离子对</value>
+  </data>
+  <data name="OpenDataSourceDialog_sourcePathTextBox_KeyUp_Some_source_paths_are_invalid" xml:space="preserve">
+    <value>部分源路径无效</value>
+  </data>
+  <data name="RInstaller_GetPackages_Downloading_packages" xml:space="preserve">
+    <value>下载软件包</value>
+  </data>
+  <data name="SrmSettingsList_DEFAULT_3_ions" xml:space="preserve">
+    <value>3 个离子</value>
+  </data>
+  <data name="CommandArgs_WarnArgRequirment_Warning__Use_of_the_argument__0__requires_the_argument__1_" xml:space="preserve">
+    <value>警告：使用参数 {0} 需要参数 {1}</value>
+  </data>
+  <data name="IncompleteStandardException_IncompleteStandardException_The_calculator__0__requires_all_of_its_standard_peptides_in_order_to_determine_a_regression" xml:space="preserve">
+    <value>计算器{0}需要所有标准肽段以确定回归。</value>
+  </data>
+  <data name="PeptideToMoleculeText_Peptide_List" xml:space="preserve">
+    <value>肽段列表</value>
+    <comment>&gt;Used in PeptideToMoleculeText.Translate to update strings like "select a peptide list" to read "select a molecule list" when non-peptide documents are in use</comment>
+  </data>
+  <data name="DriftTimePredictor_Validate_Resolving_power_must_be_greater_than_0_" xml:space="preserve">
+    <value>分辨力必须大于 0。</value>
+  </data>
+  <data name="Pivoter_QualifyColumnInfo_TotalAreaRatioTo" xml:space="preserve">
+    <value>总面积比率</value>
+  </data>
+  <data name="PeptideToMoleculeText_Molecule" xml:space="preserve">
+    <value>分子</value>
+    <comment>Used in PeptideToMoleculeText.Translate to update strings like "choose a peptide" to read "choose a molecule" when non-peptide documents are in use</comment>
+  </data>
+  <data name="RInstaller_InstallPackages_Output_logged_to_the_Immediate_Window_" xml:space="preserve">
+    <value>输出录入即时窗口。</value>
+  </data>
+  <data name="Pivoter_QualifyColumnInfo_AreaRatioTo" xml:space="preserve">
+    <value>面积比率</value>
+  </data>
+  <data name="SkylineWindow_ShowProgressErrorUI_Do_you_want_to_continue_" xml:space="preserve">
+    <value>您是否想要继续？</value>
+  </data>
+  <data name="ToolService_InsertSmallMoleculeTransitionList_Insert_Small_Molecule_Transition_List" xml:space="preserve">
+    <value>插入分子离子对列表</value>
+  </data>
+  <data name="CommandLine_AddDecoys_Error_The_number_of_peptides" xml:space="preserve">
+    <value>错误：肽段数目 {0} 必须小于针对诱饵 {1} 的肽段母离子模型数目，或使用 {2}={3} 诱饵生成方法。</value>
+  </data>
+  <data name="SkypFile_GetSkyFileUrl_Expected_the_URL_of_a_shared_Skyline_document_archive_file___0____Found_filename__1__instead_in_the_URL__2__" xml:space="preserve">
+    <value>应有共享 Skyline 存档文件({0})的 URL。但在 URL {2} 中找到的文件名为 {1}。</value>
+  </data>
+  <data name="AbstractSpectrumGraphItem_AddAnnotations_" xml:space="preserve">
+    <value>得分= {0:F06}</value>
+  </data>
+  <data name="SkylineStartup_SkylineStartup_Import_Peptide_List" xml:space="preserve">
+    <value>导入肽段列表</value>
+  </data>
+  <data name="CommandArgs_PanoramaArgsComplete_plural_" xml:space="preserve">
+    <value>错误：请为向 Panorma 上传文档时需要的以下参数指定一个值：
+{0}</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_You_are_missing_fine_tune_optimized_compensation_voltages_for_the_following_" xml:space="preserve">
+    <value>您缺失了对于以下的精细调谐最优补偿电压：</value>
+  </data>
+  <data name="CommandLine_ImportTool_Warning__the_tool__0__was_overwritten" xml:space="preserve">
+    <value>警告：工具{0}已被覆盖</value>
+  </data>
+  <data name="IonMobilityTest_TestGetIonMobilityDBErrorHandling_The_ion_mobility_library_file__0__could_not_be_found__Perhaps_you_did_not_have_sufficient_privileges_to_create_it_" xml:space="preserve">
+    <value>离子迁移库文件{0}无法找到。可能您没有足够的权限来创建它？</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility_High_Energy_Offset" xml:space="preserve">
+    <value>明示离子迁移高能偏置</value>
+  </data>
+  <data name="OverlapDemultiplexer_the_isolation_window_overlap_scheme_does_not_cover_all_isolation_windows" xml:space="preserve">
+    <value>重叠分离窗口方案缺少部分连续的分离窗口。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Ratio_To_Standard_Dot_Product" xml:space="preserve">
+    <value>相对于标准品比率点积</value>
+  </data>
+  <data name="LocateFileDlg_LocateFileDlg_This_tool_requires_0_version_1" xml:space="preserve">
+    <value>本工具需要{0}版本{1}。</value>
+  </data>
+  <data name="MeasuredCollisionalCrossSection_Validate_Collisional_cross_section_values_must_be_greater_than_0_" xml:space="preserve">
+    <value>碰撞横截面值必须大于 0。</value>
+  </data>
+  <data name="AlertDlg_GetDefaultButtonText__Abort" xml:space="preserve">
+    <value>中止(&amp;A)</value>
+  </data>
+  <data name="RInstaller_GetR_R_installation_complete_" xml:space="preserve">
+    <value>R 安装完成。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_Error_applying_imported_peak_boundaries___0_" xml:space="preserve">
+    <value>应用导入的峰值边界出错：{0}</value>
+  </data>
+  <data name="GridViewDriver_GetValue_An_invalid_number__0__was_specified_for__1__2__" xml:space="preserve">
+    <value>无效数字（“{0}”）针对{1} {2}指定。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Multiple_ion_mobility_declarations" xml:space="preserve">
+    <value>多个离子迁移声明</value>
+  </data>
+  <data name="TransitionFilter_FragmentStartFinders_ion_3" xml:space="preserve">
+    <value>离子 3</value>
+  </data>
+  <data name="ToolDescription_CallArgsCollector_Error_loading_report_from_the_temporary_file__0_" xml:space="preserve">
+    <value>从临时文件{0}加载报告出错</value>
+  </data>
+  <data name="GraphChromatogram_DisplayOptimizationTotals_No_optimization_data_available" xml:space="preserve">
+    <value>无可用的最优化数据。</value>
+  </data>
+  <data name="SkylineStartup_SkylineStartup_Import_Transition_List" xml:space="preserve">
+    <value>导入离子对列表</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Charge" xml:space="preserve">
+    <value>子离子电荷</value>
+  </data>
+  <data name="CalibrationGridViewDriver_CiRT_option_name" xml:space="preserve">
+    <value>CiRT （已发现）</value>
+  </data>
+  <data name="RInstaller_GetPackages_Package_installation_complete_" xml:space="preserve">
+    <value>软件包安装完成。</value>
+  </data>
+  <data name="ToolDescription_VerifyAnnotations_Please_re_install_the_tool_and_try_again_" xml:space="preserve">
+    <value>请重新安装工具并重试。</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_The_selected_model_is_already_included_in_the_list_of_comparisons__Please_choose_another_model_" xml:space="preserve">
+    <value>选定的模型已经包含于比较列表中。请选择另一个模型。</value>
+  </data>
+  <data name="Open" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\open.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="InstrumentInfoUtil_ReadInstrumentConfig_Unexpected_line_in_instrument_config__0__" xml:space="preserve">
+    <value>仪器配置中的意外行：{0}</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Defaulting_to_none_" xml:space="preserve">
+    <value>默认设置为无。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Precursor_formula_and_m_z_value_do_not_agree_for_any_charge_state_" xml:space="preserve">
+    <value>母离子公式和质荷比值在任何电荷状态下都不一致。</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Error__Attempting_to_exclude_an_unknown_feature_name___0____Try_one_of_the_following_" xml:space="preserve">
+    <value>错误：尝试排除未知的特征名称“{0}”。尝试以下一种：</value>
+  </data>
+  <data name="WizardImportTransition" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\StartPage\WizardImportTransition.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="RemovePeptides_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from__1__peptides_" xml:space="preserve">
+    <value>您是否确定想要从 {1} 个肽段中删除这 {0} 个峰？</value>
+  </data>
+  <data name="VendorIssueHelper_CreateTempFileSubstitute_Local_copy_work_around_for__0__" xml:space="preserve">
+    <value>针对{0}的本地复制应急措施</value>
+  </data>
+  <data name="Panorama" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Panorama.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Retention_Time" xml:space="preserve">
+    <value>明确保留时间</value>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Unknown_error_installing_packages_" xml:space="preserve">
+    <value>安装软件包的未知错误。</value>
+  </data>
+  <data name="ExportMethodDlg_OkDialog_The_DIA_isolation_list_must_have_prespecified_windows_" xml:space="preserve">
+    <value>DIA 分离列表一定有预先设定的窗口。</value>
+  </data>
+  <data name="Ions_fragments" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_fragments.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_library_values___Add_these_iRT_values_to_the_iRT_calculator_" xml:space="preserve">
+    <value>离子对列表似乎包含 iRT 库值。 将这些 iRT 值添加到 iRT 计算器？</value>
+  </data>
+  <data name="AllChromatogramsGraph_UpdateStatus__0__of__1__files" xml:space="preserve">
+    <value>{1} 个文件中的 {0} 个</value>
+  </data>
+  <data name="ImportPeptideSearchManager_LoadBackground_The_current_peak_scoring_model_is_incompatible_with_one_or_more_peptides_in_the_document_" xml:space="preserve">
+    <value>当前的峰得分模型与文档中的一个或多个肽段不兼容。</value>
+  </data>
+  <data name="CommandLine_ImportTransitionList_Error__The_name__0__specified_with__1__was_not_found_in_the_imported_assay_library_" xml:space="preserve">
+    <value>错误：在导入的分析库中未找到以{1}指定的名称{0}。</value>
+  </data>
+  <data name="AreaChartPropertyDlg_ValidateDotpDecimal__0__must_contain_a_decimal_value" xml:space="preserve">
+    <value>{0} 必须包含十进制值。</value>
+  </data>
+  <data name="IsolationSchemeList_GetDefaults_SWATH__25_m_z_" xml:space="preserve">
+    <value>SWATH（25 质荷比）</value>
+  </data>
+  <data name="AlignmentForm_UpdateGraph_Peptides_Refined" xml:space="preserve">
+    <value>肽段调整</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_An_error_occurred_while_processing_retention_times_" xml:space="preserve">
+    <value>处理保留时间时出错。</value>
+  </data>
+  <data name="SkylineWindow_AddMolecule_The_precursor_m_z_for_this_molecule_is_out_of_range_for_your_instrument_settings_" xml:space="preserve">
+    <value>分子的母离子质荷比超出您的仪器设置范围。</value>
+  </data>
+  <data name="BioMassCalc_CalculateMass_The_expression__0__is_not_a_valid_chemical_formula" xml:space="preserve">
+    <value>表达式“{0}”不是有效的化学式。</value>
+  </data>
+  <data name="ViewLibraryDlg_LoadLibrary_An_error_occurred_attempting_to_import_the__0__library" xml:space="preserve">
+    <value>尝试导入{0}库时出现错误。</value>
+  </data>
+  <data name="PeptideTipProvider_RenderTip_Precursor_m_z" xml:space="preserve">
+    <value>母离子质荷比</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Isotope_Dot_Product" xml:space="preserve">
+    <value>同位素点积值</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_Add_missing_iRT_standard_peptides_to_your_document_or_change_the_retention_time_predictor_" xml:space="preserve">
+    <value>将缺失的 iRT 标准肽段添加到您的文档，或者更改保留时间预测器。</value>
+  </data>
+  <data name="CommandLine_ImportTool_Error__If__0__is_and_argument_the_tool_must_have_a_Report_Title__Use_the___tool_report_parameter_to_specify_a_report_" xml:space="preserve">
+    <value>错误：如果 {0} 是参数，则工具必须具有报告标题。使用“--工具-报告”参数来指定报告。</value>
+  </data>
+  <data name="CommandLine_ExportInstrumentFile_Error__to_export_a_scheduled_method__you_must_first_choose_a_retention_time_predictor_in_Peptide_Settings___Prediction__or_import_results_for_all_peptides_in_the_document_" xml:space="preserve">
+    <value>错误：如要导出预定方法，您必须首先在肽段设置/预测中选择一个保留时间预测器，或者在文档中导入针对所有肽段的结果。</value>
+  </data>
+  <data name="DetectionHistogramPane_Tooltip_ReplicateCount" xml:space="preserve">
+    <value>重复测定计数</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_ValidateRegressionCellValues_On_line__0___1_" xml:space="preserve">
+    <value>在第 {0} {1} 行上</value>
+  </data>
+  <data name="CustomMolecule_Validate_The_mass__0__of_the_custom_molecule_is_less_than_the_minimum_of__1__" xml:space="preserve">
+    <value>自定义分子质量 {0} 小于 {1} 最小值。</value>
+  </data>
+  <data name="TransitionFilter_FragmentStartFinders_ion_1" xml:space="preserve">
+    <value>离子 1</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Invalid_ion_mobility_value__0_" xml:space="preserve">
+    <value>无效的离子迁移值 {0}</value>
+  </data>
+  <data name="KdeAlignerFactory_ToString_KDE_Aligner" xml:space="preserve">
+    <value>核密度估计校准器</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Compensation_Voltage" xml:space="preserve">
+    <value>补偿电压</value>
+  </data>
+  <data name="TestSkylineProcessRunner_RunProcess_The_operation_was_canceled_by_the_user_" xml:space="preserve">
+    <value>操作已由用户取消。</value>
+  </data>
+  <data name="MeasuredDriftTimeTable_ValidateMeasuredDriftTimeCellValues_On_line__0___1_" xml:space="preserve">
+    <value>在第{0} {1}行 上</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Formula" xml:space="preserve">
+    <value>子离子公式</value>
+  </data>
+  <data name="PasteDlg_btnTransitionListHelp_Click_" xml:space="preserve">
+    <value>使用此窗口最简易的方法是从 Excel（或如果数据是 CSV 格式，则使用任何文本编辑器）复制并将其粘贴到网格。
+    
+请注意，您可以在 Skyline 中通过向左或右拖动列标题调整列顺序。
+
+大多数肽段离子对列表可以用“文件|导入|离子对列表...”菜单项目导入或甚至直接粘贴到“目标”窗口。</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Total_Area_Ratio" xml:space="preserve">
+    <value>总面积比</value>
+  </data>
+  <data name="PasteDlg_Description_Insert_transition_list" xml:space="preserve">
+    <value>插入离子对列表</value>
+  </data>
+  <data name="PythonInstaller_InstallPackages_Skyline_uses_the_Python_tool_setuptools_and_the_Python_package_manager_Pip_to_install_packages_from_source__Click_install_to_begin_the_installation_process_" xml:space="preserve">
+    <value>Skyline 使用 Python 工具设置工具以及 Python 软件包管理器 Pip 从源安装软件包。单击“安装”以开始安装流程。</value>
+  </data>
+  <data name="CollisionalCrossSectionGridViewDriverBase_ValidateRow__0__is_not_a_valid_charge__Precursor_charges_must_be_integers_with_absolute_value_between_1_and__1__" xml:space="preserve">
+    <value>{0} 不是有效电荷。母离子电荷必须为绝对值介于 1 和 {1} 之间的整数。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_ReadPrecursorOrProductColumns_Formula_already_contains_an_adduct_description__and_it_does_not_match_" xml:space="preserve">
+    <value>公式已经包含加合物描述，但是它不匹配。</value>
+  </data>
+  <data name="PasteDlg_GetMoleculeTransition_Product_m_z__0__isn_t_close_enough_to_the_nearest_possible_m_z__1___delta_2___" xml:space="preserve">
+    <value>子离子质荷比{0}与最相近的可能质荷比{1}（增量{2}）不够相近。</value>
+  </data>
+  <data name="AddIrtPeptidesDlg_AddIrtPeptidesDlg_Success" xml:space="preserve">
+    <value>成功</value>
+  </data>
+  <data name="PeptideSettingsUI_ComboPeakScoringModelSelected_Unrecognized_Model" xml:space="preserve">
+    <value>未识别的模型</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_The_tool__0__is_currently_installed_" xml:space="preserve">
+    <value>工具{0}当前已安装。</value>
+  </data>
+  <data name="DetectionHistogramPane_Tooltip_Count" xml:space="preserve">
+    <value>{0} 计数</value>
+  </data>
+  <data name="ConfigureToolsDlg_CheckPassTool__The_command_for__0__may_not_exist_in_that_location__Would_you_like_to_edit_it__" xml:space="preserve">
+    <value>针对{0}的命令可能不存在于那个位置。您是否想要编辑它？</value>
+  </data>
+  <data name="GraphFullScan_CreateIonMobilityHeatmap_Quadrupole_Scan_Range__m_z_" xml:space="preserve">
+    <value>四极杆扫描范围 (质荷比)</value>
+  </data>
+  <data name="BiblioSpecLiteLibrary_CreateCache_No_spectra_were_found_in_the_library__0__" xml:space="preserve">
+    <value>库{0}中未发现谱图</value>
+  </data>
+  <data name="Ions_Z" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_Z.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="EditOptimizationLibraryDlg_UpdateValueHeader_Declustering_Potential" xml:space="preserve">
+    <value>去簇电压</value>
+  </data>
+  <data name="HtmlFragment_ClipBoardText_From_Clipboard" xml:space="preserve">
+    <value>从剪切板</value>
+  </data>
+  <data name="AddPeakCompareDlg_OkDialog_The_selected_file_or_model_does_not_assign_peak_boundaries_to_any_chromatograms_in_the_document___Please_select_a_different_model_or_file_" xml:space="preserve">
+    <value>选定的文件或模型不向文档中的色谱图分配任何峰值边界。 请选择一个不同的模型或文件。</value>
+  </data>
+  <data name="CopyEmfToolStripMenuItem_CopyEmfToolStripMenuItem_Copy_Metafile" xml:space="preserve">
+    <value>复制图元文件</value>
+  </data>
+  <data name="AreaCVToolbarProperties_btnOk_Click_Invalid_maximum_CV_entered" xml:space="preserve">
+    <value>输入的最大 CV 无效</value>
+  </data>
+  <data name="CommandLine_CreateIrtDatabase_Error__Importing_an_assay_library_to_a_document_without_an_iRT_calculator_cannot_create__0___because_it_exists_" xml:space="preserve">
+    <value>错误：导入分析库到没有 iRT 计算器的文档无法创建{0}，因为它已经存在。</value>
+  </data>
+  <data name="Ions_B" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_B.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="down_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\down-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Wand" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Wand.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="UtilDB_Uncompress_Failure_uncompressing_data" xml:space="preserve">
+    <value>解压数据失败。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph_IM__0_" xml:space="preserve">
+    <value>IM={0}</value>
+    <comment>"IM" stands for "Ion Mobility" - used for displaying ion mobility in raw scan view</comment>
+  </data>
+  <data name="IrtDb_MakeDocumentXml_iRT_standards" xml:space="preserve">
+    <value>iRT 标准</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Total_Area" xml:space="preserve">
+    <value>总面积</value>
+  </data>
+  <data name="ShareListDlg_ImportFile_Failure_loading__0__" xml:space="preserve">
+    <value>加载{0}失败。</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_Transition_list_field_must_contain_a_path_to_a_valid_file_" xml:space="preserve">
+    <value>离子对列表字段必须包含至有效文件的路径。</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_This_is_an_older_installation_v_0__of_the_tool__1_" xml:space="preserve">
+    <value>这是工具{1}的较早安装版本 {0}</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Max_Fwhm" xml:space="preserve">
+    <value>半峰宽最大值</value>
+  </data>
+  <data name="CommandLine_ImportToolsFromZip_Error__the_file_specified_with_the___tool_add_zip_command_is_not_a__zip_file__Please_specify_a_valid__zip_file_" xml:space="preserve">
+    <value>错误：以“--工具-添加-zip”命令指定的文件不是 .zip 文件。请指定有效的 .zip 文件。</value>
+  </data>
+  <data name="PasteDlg_AddFasta_An_unexpected_error_occurred__0__1__" xml:space="preserve">
+    <value>发生意外错误：{0} ({1})</value>
+    <comment>Message (Error Type)</comment>
+  </data>
+  <data name="PythonInstaller_GetPackages_Package_installation_completed_" xml:space="preserve">
+    <value>软件包安装已完成。</value>
+  </data>
+  <data name="CommandLine_ExportReport_Exporting_report__0____" xml:space="preserve">
+    <value>报告{0}导出中...</value>
+  </data>
+  <data name="ConfigureToolsDlg_UnpackZipTool_There_is_a_naming_conflict__You_already_installed_a_tool_from_a_zip_folder_with_the_name__0___Would_you_like_to_overwrite_or_install_in_parallel_" xml:space="preserve">
+    <value>出现命名冲突。您已经从压缩文件夹内使用名称{0}安装一个工具。您是否想要覆盖或并行安装？</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Area_Ratio" xml:space="preserve">
+    <value>面积比</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_Cannot_use_DIA_window_for_precursor_exclusion_when_isolation_scheme_does_not_contain_prespecified_windows___Please_select_an_isolation_scheme_with_prespecified_windows_" xml:space="preserve">
+    <value>当分离方案不包含预先设定的窗口时，无法针对母离子排除使用 DIA 窗口。 请选择一个带有预先设定窗口的分离方案。</value>
+  </data>
+  <data name="MoleculeLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\moleculelib.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Replicate_Name" xml:space="preserve">
+    <value>重复测定名称</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_Of_the_specified__0__proteins__1__are_not_in_the_document__Do_you_want_to_continue_" xml:space="preserve">
+    <value>指定的 {0} 个蛋白质{1}不存在于文档中。您是否想要继续？</value>
+  </data>
+  <data name="DdaSearch_Search_failed__0" xml:space="preserve">
+    <value>搜索失败：{0}</value>
+  </data>
+  <data name="RefineListDlgProtein_OkDialog_The_protein___0___is_not_in_the_document__Do_you_want_to_continue_" xml:space="preserve">
+    <value>蛋白质“{0}”不存在于文档中。您是否想要继续？</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Ion_Mobility" xml:space="preserve">
+    <value>明示离子迁移</value>
+  </data>
+  <data name="TransitionInfo_ReadTransitionLosses_Invalid_loss_index__0__for_modification__1__" xml:space="preserve">
+    <value>针对修饰{1}的无效丢失指数 {0}</value>
+  </data>
+  <data name="AddZipToolHelper_FindProgramPath_A_tool_requires_Program__0__Version__1__and_it_is_not_specified_with_the___tool_program_macro_and___tool_program_path_commands__Tool_Installation_Canceled_" xml:space="preserve">
+    <value>工具需要程序：{0} 版本：{1}并且其未借助“--工具-程序-宏”和“--工具-程序-路径”命令指定。工具安装取消。</value>
+  </data>
+  <data name="PeakBoundsMatch_PeakBoundsMatch_Unable_to_read_a_score_annotation_for_peptide__0__of_file__1_" xml:space="preserve">
+    <value>无法针对文件 {1} 的肽段 {0} 读取得分注释</value>
+  </data>
+  <data name="EditCustomMoleculeDlg_OkDialog_A_precursor_with_that_adduct_and_label_type_already_exists_" xml:space="preserve">
+    <value>已存在带该加合物和标记类型的母离子。</value>
+  </data>
+  <data name="SkylineWindow_ShowCalculatorScoreFormat" xml:space="preserve">
+    <value>显示 {0} 得分</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Error__Package_installation_did_not_complete__Output_logged_to_the_Immediate_Window_" xml:space="preserve">
+    <value>错误：软件包安装未完成。输出录入即时窗口。</value>
+  </data>
+  <data name="EditIonMobilityLibraryDlg_UpdateNumPeptides__0__Peptides" xml:space="preserve">
+    <value>{0} 个肽段</value>
+  </data>
+  <data name="ToolMacros__listArguments_This_tool_requires_a_Document_Path_to_run" xml:space="preserve">
+    <value>本工具需要运行一个文档路径</value>
+  </data>
+  <data name="SavitzkyGolaySmoother_WindowSize_SavitzkyGolaySmoother__Invalid_window_size___0____argument_must_be_positive_and_odd" xml:space="preserve">
+    <value>SavitzkyGolay 滤波器：无效的窗口大小 ({0}) ：参数必须是正奇数</value>
+  </data>
+  <data name="CommandLine_ShowLibraryMissingExternalSpectraError_Description" xml:space="preserve">
+    <value>使用参数 --import-search-prefer-embedded-spectra 强制建库以使用嵌入的谱图，或将原始谱图文件放在上面列出的其中一个目录并重新运行。</value>
+  </data>
+  <data name="CommandArgs_PanoramaArgsComplete_" xml:space="preserve">
+    <value>错误：请为向 Panorma 上传文档时需要的以下参数指定一个值：
+{0}</value>
+  </data>
+  <data name="IIrtRegression_DisplayEquation_iRT" xml:space="preserve">
+    <value>iRT</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_BrowseDb_The_specified_file_is_not_a_valid_iRT_database_" xml:space="preserve">
+    <value>指定文件不是有效的 iRT 数据库。</value>
+  </data>
+  <data name="ComparePeakPickingDlg_ComparePeakPickingDlg_Fraction_of_Manual_ID_s" xml:space="preserve">
+    <value>手动 ID 的部分</value>
+  </data>
+  <data name="HeatMapGraph_RefreshData_Heat_Map" xml:space="preserve">
+    <value>热图</value>
+  </data>
+  <data name="FullScanAcquisitionMethod_DDA_DDA" xml:space="preserve">
+    <value>DDA</value>
+  </data>
+  <data name="SkylineWindow_ImportMassList_Failed_reading_the_file___Peptide__0__matches_an_existing_iRT_standard_peptide_" xml:space="preserve">
+    <value>读取文件失败。 肽段{0}匹配现有的 iRT 标准肽段。</value>
+  </data>
+  <data name="Fragment" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Fragment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Min_Start_Time" xml:space="preserve">
+    <value>启动时间最小值</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwrite__in_the_file__0_" xml:space="preserve">
+    <value> 在文件{0}中</value>
+  </data>
+  <data name="ChromCacheBuilder_BuildCache_This_document_contains_only_positive_ion_mode_transitions__and_the_imported_file_contains_only_negative_ion_mode_data_so_nothing_can_be_loaded___Negative_ion_mode_transitions_need_to_have_negative_charge_values_" xml:space="preserve">
+    <value>本文档仅包含正离子模式离子对，而导入的文件仅包含负离子模式数据，因此，没有任何内容可加载。 负离子模式离子对需要有负电荷值。</value>
+  </data>
+  <data name="GraphFullScan_CreateGraph__0_____1_F2__min_" xml:space="preserve">
+    <value>{0}（{1:F2} 分钟）</value>
+    <comment>"min" stands for "minutes"</comment>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_User_Set_Total" xml:space="preserve">
+    <value>用户设定总数</value>
+  </data>
+  <data name="ToolUpdatesDlg_DisplayInstallSummary_Successfully_updated_the_following_tools" xml:space="preserve">
+    <value>成功更新下列工具</value>
+  </data>
+  <data name="RInstaller_InstallPackages_Package_installation_failed__Error_log_output_in_immediate_window_" xml:space="preserve">
+    <value>软件包安装失败。在即时窗口中记录输出失败。</value>
+  </data>
+  <data name="TransitionTreeNode_GetLabel_rank__0__" xml:space="preserve">
+    <value>排名 {0}</value>
+  </data>
+  <data name="CalculateIsolationSchemeDlg_OkDialog_Window_width_must_be_less_than_or_equal_to_the_isolation_range" xml:space="preserve">
+    <value>窗口宽度必须小于或等于分离范围。</value>
+  </data>
+  <data name="Ions_1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_1.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="SkylineWindow_CheckRetentionTimeFilter_NoPredictionAlgorithm" xml:space="preserve">
+    <value>离子对设置全扫描保留时间过滤器的设定旨在使用预测的保留时间，但还未指定任何预测算法。
+前往“肽段设置预测”标签以修复。</value>
+  </data>
+  <data name="ExportReportDlg_GetDatabase_Analyzing_document" xml:space="preserve">
+    <value>文档分析中…</value>
+  </data>
+  <data name="CreateIrtCalculatorDlg_OkDialog_Calculator_name_cannot_be_empty" xml:space="preserve">
+    <value>计算器名称不得为空。</value>
+  </data>
+  <data name="SkylineWindow_publishToolStripMenuItem_Click_Skyline_Shared_Documents" xml:space="preserve">
+    <value>Skyline 共享文档</value>
+  </data>
+  <data name="CommandArgs_ParseArgsInternal_Warning__The_method_type__0__is_invalid__It_must_be_one_of_the_following___standard____scheduled__or__triggered__" xml:space="preserve">
+    <value>警告：方法类型{0}无效。它必须是下列内容之一：“标准”、“预定”或“触发”。</value>
+  </data>
+  <data name="ToolUpdatesDlg_DisplayInstallSummary_Failed_to_update_the_following_tool" xml:space="preserve">
+    <value>更新下列工具失败</value>
+  </data>
+  <data name="ConfigureToolsDlg_OverwriteOrInParallel_Do_you_wish_to_overwrite_or_install_in_parallel_" xml:space="preserve">
+    <value>您是否想要覆盖或并行安装？</value>
+  </data>
+  <data name="TransitionSettingsUI_OkDialog_Ion_types_must_contain_a_comma_separated_list_of_ion_types_a_b_c_x_y_z_and_p_for_precursor" xml:space="preserve">
+    <value>离子类型必须包含以逗号分隔的离子类型 a、b、c、x、y、z 和 p 列表（针对母离子）。</value>
+  </data>
+  <data name="IsolationScheme_DoValidate_Unexpected_name___0___for__1__isolation_scheme" xml:space="preserve">
+    <value>针对{1}分离方案的意外名称“{0}”</value>
+  </data>
+  <data name="GenericState_AppendErrorAndUri_URL___0_" xml:space="preserve">
+    <value>URL: {0}</value>
+  </data>
+  <data name="SkylineWindow_importMassListMenuItem_Click_Transition_List" xml:space="preserve">
+    <value>离子对列表</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Product_Name" xml:space="preserve">
+    <value>子离子名称</value>
+  </data>
+  <data name="CommandLine_AddDecoys_Added__0__decoy_peptides_using___1___method" xml:space="preserve">
+    <value>已经使用“{1}”方法添加了 {0} 个诱饵肽段</value>
+  </data>
+  <data name="SkylineWindow_ImportResults_1_decoy_does_not_have_a_matching_target" xml:space="preserve">
+    <value>1 个诱饵没有匹配的目标</value>
+  </data>
+  <data name="PasteDlg_UpdateMoleculeType_Explicit_Collision_Cross_Section__sq_A_" xml:space="preserve">
+    <value>明确碰撞横截面 (sq A)</value>
+  </data>
+  <data name="Folder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\folder.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ExportMethodDlg_VerifySchedulingAllowed_You_must_export_a__0__transition_list_and_manually_import_it_into_a_method_file_using_vendor_software_" xml:space="preserve">
+    <value>您必须导出一个{0}离子对列表并使用供应商软件来将其手动导入方法文件。</value>
+  </data>
+  <data name="ShareTypeDlg_OkDialog_Including_data_folders_is_not_supported_by_the_currently_selected_version_" xml:space="preserve">
+    <value>当前所选版本不支持包含数据的文件夹。</value>
+  </data>
+  <data name="SmallMoleculeTransitionListReader_Precursor_mz_does_not_agree_with_calculated_value_" xml:space="preserve">
+    <value>母离子质荷比 {0} 与根据离子公式和电荷状态计算得出的值 {1} 不一致（增量 = {2},离子对设置 | 仪器 | 方法匹配耐受性质荷比 = {3}）。纠正表中的质荷比值，或留空来让Skyline 为您进行计算。</value>
+  </data>
+  <data name="Peptide_ExplicitRetentionTimeWindow_Explicit_retention_time_window_requires_an_explicit_retention_time_value_" xml:space="preserve">
+    <value>明确保留时间窗口需要明确保留时间值。</value>
+  </data>
+  <data name="PeakBoundaryImporter_Import_Sample__0__on_line__1__does_not_match_the_file__2__" xml:space="preserve">
+    <value>第 {1} 行上的样品{0}不匹配文件{2}。</value>
+  </data>
+  <data name="PasteDlg_ReadPrecursorOrProductColumns_Invalid_compensation_voltage__0_" xml:space="preserve">
+    <value>无效补偿电压 {0}</value>
+  </data>
+  <data name="ImportTransitionListColumnSelectDlg_AssociateProteins_These_filters_cannot_be_applied_as_they_would_result_in_an_empty_transition_list." xml:space="preserve">
+    <value>不能应用这些过滤器，因为它们会导致出现空的离子对列表。</value>
+  </data>
+  <data name="ToolDescription_RunTool_Please_check_the_command_location_is_correct_for_this_tool_" xml:space="preserve">
+    <value>请查看命令位置针对此工具是正确的。</value>
+  </data>
+  <data name="SkylineWindow_HandleStandardsChanged_An_error_occurred_while_attempting_to_load_the_iRT_database__0___iRT_standards_cannot_be_automatically_added_to_the_document_" xml:space="preserve">
+    <value>尝试加载 iRT 数据库 {0} 时出错。iRT 标准无法自动添加到文档中。 </value>
+  </data>
+  <data name="EditIsolationSchemeDlg_ReadIsolationRanges_Missing_isolation_range_for_the_isolation_target__0__m_z_in_the_file__1_" xml:space="preserve">
+    <value>缺失文件 {1} 内的分离目标 {0} 质荷比的分离范围</value>
+  </data>
+  <data name="DatabaseNotConnectedException_DatabaseNotConnectedException_The_database_for_the_calculator__0__could_not_be_opened__Check_that_the_file__1__was_not_moved_or_deleted" xml:space="preserve">
+    <value>针对计算器{0}的数据库无法被打开。检查文件{1}未被移动或删除。</value>
+  </data>
+  <data name="RegressionOption_All_Fixed_points__logarithmic_" xml:space="preserve">
+    <value>固定点（对数）</value>
+  </data>
+  <data name="FullScanAcquisitionExtension_LOCALIZED_VALUES_DIA" xml:space="preserve">
+    <value>DIA</value>
+  </data>
+  <data name="Ions_2" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Ions_2.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="ResultsGrid_ResultsGrid_Background" xml:space="preserve">
+    <value>背景</value>
+  </data>
+  <data name="AddZipToolHelper_ShouldOverwrite_Please_specify__overwrite__or__parallel__with_the___tool_zip_conflict_resolution_command_" xml:space="preserve">
+    <value>请使用“--工具-zip-冲突-分辨率”命令指定“覆盖”或“并行”。</value>
+  </data>
+  <data name="PasteDlg_AddFasta_This_must_start_with" xml:space="preserve">
+    <value>它必须以“&gt;”开始</value>
+  </data>
+  <data name="PanoramaDownload" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\PanoramaDownload.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
+    <value>无法验证用户身份。服务器的反馈:{0} {1}</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
+    <value>服务器 {0} 的JSON响应异常</value>
+  </data>
+  <data name="UserState_getErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
+    <value>验证服务器 {0} 上的用户凭据时出错。</value>
+  </data>
+  <data name="PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
+    <value>服务器未返回有效的 JSON 响应。{0} 并非 Panorama  服务器。</value>
+  </data>
+  <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
+    <value>无法连接到服务器 {0}。</value>
+  </data>
+  <data name="SpectrumClassFilter_MakePredicate_No_spectrum_column__0_" xml:space="preserve">
+    <value>无谱图列 {0}</value>
+  </data>
+  <data name="SpectraGridForm_AddSpectrumFilters__0__spectrum_filters_will_be_added_to_the_document_" xml:space="preserve">
+    <value>{0}个谱图过滤器将添加到该文档。</value>
+  </data>
+  <data name="EncyclopeDiaHelpers_ConvertFastaToKoinaInputCsv_could_not_find_EncyclopeDia" xml:space="preserve">
+    <value>could not find EncyclopeDIA</value>
+  </data>
+  <data name="EncyclopeDiaHelpers_GenerateLibrary_Combining_quantification_libraries" xml:space="preserve">
+    <value>正在组合定量库</value>
+  </data>
+  <data name="EncyclopeDiaHelpers_GenerateLibrary_Combining_chromatogram_libraries" xml:space="preserve">
+    <value>正在组合谱图库</value>
+  </data>
+  <data name="EncyclopeDiaSearchDlg_Browse_for_Narrow_Window_Results_Files" xml:space="preserve">
+    <value>浏览窄窗口结果文件</value>
+  </data>
+  <data name="EncyclopeDiaSearchDlg_Browse_For_Wide_Window_Results_Files" xml:space="preserve">
+    <value>浏览宽窗口结果文件</value>
+  </data>
+  <data name="SpectrumClassFilter_GetAbbreviatedText_OR" xml:space="preserve">
+    <value>OR</value>
+    <comment>"OR" is the logical operator</comment>
+  </data>
+  <data name="EncyclopeDiaHelpers_GenerateLibrary_Running_command___0___1_" xml:space="preserve">
+    <value>正在运行命令:{0} {1}</value>
+  </data>
+  <data name="SkylineWindow_DownloadPanoramaFile_File_does_not_exist__It_may_have_been_deleted_on_the_server_" xml:space="preserve">
+    <value>File does not exist. It may have been deleted on the server.</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg_There_are_no_Panorama_servers_with_a_user_account__To_upload_documents_to_a_server_a_user_account_is_required_" xml:space="preserve">
+    <value>There are no Panorama servers with a user account. To upload documents to a server a user account is required.</value>
+  </data>
+  <data name="ProteinAssociation_CreateDocTree_Unmapped_Peptides" xml:space="preserve">
+    <value>Unmapped Peptides</value>
+  </data>
+  <data name="CommandLine_ExportSpecLib_Spectral_library_file__0__exported_successfully_" xml:space="preserve">
+    <value>Spectral library file {0} exported successfully.</value>
+  </data>
+  <data name="CommandLine_ExportSpecLib_Error__The_document_must_contain_at_least_one_precursor_to_export_a_spectral_library_" xml:space="preserve">
+    <value>Error: The document must contain at least one precursor to export a spectral library.</value>
+  </data>
+  <data name="CommandLine_ExportSpecLib_Error__The_document_must_contain_results_to_export_a_spectral_library_" xml:space="preserve">
+    <value>Error: The document must contain results to export a spectral library.</value>
+  </data>
+  <data name="CommandLine_ExportMProphetFeatures_mProphet_features_file__0__exported_successfully_" xml:space="preserve">
+    <value>mProphet features file {0} exported successfully.</value>
+  </data>
+  <data name="CommandLine_ExportMProphetFeatures_Error__The_document_must_contain_targets_for_which_to_export_mProphet_features_" xml:space="preserve">
+    <value>Error: The document must contain targets for which to export mProphet features.</value>
+  </data>
+  <data name="CommandLine_ExportMProphetFeatures_Error__The_document_must_contain_results_to_export_mProphet_features_" xml:space="preserve">
+    <value>Error: The document must contain results to export mProphet features.</value>
+  </data>
+  <data name="CommandArgs_ParseAnnotationTypes_Error__Attempting_to_exclude_an_unknown_annotation_type__0___Try_one_of_the_following_" xml:space="preserve">
+    <value>Error: Attempting to exclude an unknown annotation type '{0}'. Try one of the following:</value>
+  </data>
+  <data name="CommandLine_AddAnnotations_Annotations_successfully_defined_from_file__0__" xml:space="preserve">
+    <value>Annotations successfully defined from file {0}.</value>
+  </data>
+  <data name="Extensions_CustomToString_Protein_Expression" xml:space="preserve">
+    <value>Protein Expression</value>
+  </data>
+  <data name="CommandLine_ExportAnnotations_Annotations_file__0__exported_successfully_" xml:space="preserve">
+    <value>Annotations file {0} exported successfully.</value>
+  </data>
+  <data name="CommandLine_AddAnnotations_Error__Unable_to_read_annotations_from_file__0__" xml:space="preserve">
+    <value>Error: Unable to read annotations from file {0}.</value>
+  </data>
+  <data name="CommandArgs_ParseAnnotationTypes_Error__Attempting_to_specify_an_unknown_annotation_type___0____Try_one_of_the_following_" xml:space="preserve">
+    <value>Error: Attempting to specify an unknown annotation type '{0}'. Try one of the following:</value>
+  </data>
+  <data name="CommandArgs_ParseAnnotationTarget_Error__Attempting_to_specify_an_unknown_annotation_target___0____Try_one_of_the_following_" xml:space="preserve">
+    <value>Error: Attempting to specify an unknown annotation target '{0}'. Try one of the following:</value>
+  </data>
+  <data name="CommandLine_SetAnnotations_Warning__Skipping_annotation___0___due_to_a_name_conflict_" xml:space="preserve">
+    <value>Warning: Skipping annotation '{0}' due to a name conflict with an existing annotation.</value>
+  </data>
+  <data name="CommandLine_SetAnnotations_Warning__The_annotation___0___was_overwritten_" xml:space="preserve">
+    <value>Warning: Overwriting existing annotation '{0}' due to a name conflict.</value>
+  </data>
+  <data name="CommandLine_AddAnnotationsFromArguments_Error__Cannot_add_a__0__type_annotation_without_providing_a_list_values_of_through__1__" xml:space="preserve">
+    <value>Error: Cannot add a {0} type annotation without providing a list of values through {1}.</value>
+  </data>
+  <data name="CommandLine_AddAnnotationFromEnvironment_Error__Cannot_add_new_annotation___0___without_providing_at_least_one_target_through__1__" xml:space="preserve">
+    <value>Error: Cannot add new annotation '{0}' without providing at least one target through {1}.</value>
+  </data>
+  <data name="CommandLine_ExportAnnotations_Try_one_of_the_following_" xml:space="preserve">
+    <value>Try one of the following:</value>
+  </data>
+  <data name="CommandLine_ExportAnnotations_Error__The_document_must_contain_annotations_in_order_to_export_annotations_" xml:space="preserve">
+    <value>Error: The document must contain annotations in order to export annotations.</value>
+  </data>
+  <data name="CommandLine_SetPeptideDigestSettings_Error__Could_not_find_background_proteome_file__0_" xml:space="preserve">
+    <value>Error: Could not find background proteome file {0}</value>
+  </data>
+  <data name="PeptideMod_SetTerminus_A_peptide_modification_must_be_added_before_giving_it_a_terminal_or_amino_acid_specificity_" xml:space="preserve">
+    <value>A peptide modification must be added before giving it a terminal or amino acid specificity.</value>
+  </data>
+  <data name="koina_logo_fdf731d5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\koina-logo.fdf731d5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="CommandLine_ImportPeptideList_Importing_peptide_list__0__from_file__1____" xml:space="preserve">
+    <value>Importing peptide list {0} from file {1}...</value>
+  </data>
+  <data name="CommandLine_ImportPeptideList_Importing_peptide_lists_from_file__0____" xml:space="preserve">
+    <value>Importing peptide lists from file {0}...</value>
+  </data>
+  <data name="CommandLine_ImportPeptideList_Warning__peptide_list_file_contains_lines_with_____Ignoring_provided_list_name_" xml:space="preserve">
+    <value>Warning: peptide list file contains lines with &gt;&gt;. Ignoring provided list name.</value>
+  </data>
+  <data name="CommandLine_AssociateProteins_Associating_peptides_with_proteins_from_FASTA_file__0_" xml:space="preserve">
+    <value>Associating peptides with proteins from FASTA file {0}</value>
+  </data>
+  <data name="BuildLibraryDlg_ValidateBuilder_Add_peptide_precursors_to_the_document_to_build_a_library_from_Koina_predictions_" xml:space="preserve">
+    <value>Add peptide precursors to the document to build a library from Koina predictions.</value>
+  </data>
+  <data name="CommandLine_ImportPeptideList_Using_the_Unimod_definitions_for_the_following_modifications_" xml:space="preserve">
+    <value>Using the Unimod definitions for the following modifications:</value>
+  </data>
+  <data name="PeptideMod_SetVariable_A_peptide_modification_must_be_added_before_assigning_its_variable_status_" xml:space="preserve">
+    <value>A peptide modification must be added before assigning its variable status.</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.ja.resx
@@ -238,13 +238,13 @@
     <value>15, 69</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
+    <value>66, 13</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>出力先のパス(&amp;O)：</value>
+    <value>&amp;Output path:</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -299,7 +299,7 @@
     <value>12</value>
   </data>
   <data name="iRTPeptidesLabel.Text" xml:space="preserve">
-    <value>iRT標準ペプチド(&amp;I)：</value>
+    <value>i&amp;RT standard peptides:</value>
   </data>
   <data name="&gt;&gt;iRTPeptidesLabel.Name" xml:space="preserve">
     <value>iRTPeptidesLabel</value>
@@ -457,6 +457,9 @@
   <data name="cbIncludeAmbiguousMatches.Text" xml:space="preserve">
     <value>曖昧な一致を含む(&amp;M)</value>
   </data>
+  <data name="cbIncludeAmbiguousMatches.ToolTip" xml:space="preserve">
+    <value>Check to keep spectra that match multiple peptides.</value>
+  </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.Name" xml:space="preserve">
     <value>cbIncludeAmbiguousMatches</value>
   </data>
@@ -485,7 +488,7 @@
     <value>14</value>
   </data>
   <data name="cbKeepRedundant.Text" xml:space="preserve">
-    <value>冗長ライブラリを保持する(&amp;K)</value>
+    <value>K&amp;eep redundant library</value>
   </data>
   <data name="cbKeepRedundant.ToolTip" xml:space="preserve">
     <value>今後、さらにスペクトルを追加する冗長ライブラリのコピーを保持する場合は選択します。</value>
@@ -519,6 +522,9 @@
   </data>
   <data name="cbFilter.Text" xml:space="preserve">
     <value>ドキュメント内のペプチドをフィルタリング(&amp;D)</value>
+  </data>
+  <data name="cbFilter.ToolTip" xml:space="preserve">
+    <value>Check to filter matches for only the peptides in the document.</value>
   </data>
   <data name="&gt;&gt;cbFilter.Name" xml:space="preserve">
     <value>cbFilter</value>
@@ -598,21 +604,6 @@
   <data name="&gt;&gt;panelFilesKoinaProperties.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="koinaInfoSettingsBtn.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="koinaInfoSettingsBtn.Location" type="System.Drawing.Point, System.Drawing">
-    <value>190, 44</value>
-  </data>
-  <data name="koinaInfoSettingsBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
-  </data>
-  <data name="koinaInfoSettingsBtn.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="koinaInfoSettingsBtn.Text" xml:space="preserve">
-    <value>情報/設定</value>
-  </data>
   <data name="&gt;&gt;koinaInfoSettingsBtn.Name" xml:space="preserve">
     <value>koinaInfoSettingsBtn</value>
   </data>
@@ -625,24 +616,6 @@
   <data name="&gt;&gt;koinaInfoSettingsBtn.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="koinaDataSourceRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 42</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 17</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.Text" xml:space="preserve">
-    <value>Pro&amp;sit</value>
-  </data>
   <data name="&gt;&gt;koinaDataSourceRadioButton.Name" xml:space="preserve">
     <value>koinaDataSourceRadioButton</value>
   </data>
@@ -654,21 +627,6 @@
   </data>
   <data name="&gt;&gt;koinaDataSourceRadioButton.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 17</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.Text" xml:space="preserve">
-    <value>ファイル(&amp;F)</value>
   </data>
   <data name="&gt;&gt;dataSourceFilesRadioButton.Name" xml:space="preserve">
     <value>dataSourceFilesRadioButton</value>
@@ -754,20 +712,56 @@
   <data name="&gt;&gt;panelProperties.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="koinaInfoSettingsBtn.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="koinaInfoSettingsBtn.Location" type="System.Drawing.Point, System.Drawing">
+    <value>190, 44</value>
+  </data>
+  <data name="koinaInfoSettingsBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>68, 13</value>
+  </data>
+  <data name="koinaInfoSettingsBtn.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="koinaInfoSettingsBtn.Text" xml:space="preserve">
+    <value>Info/Settings</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 42</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.Text" xml:space="preserve">
+    <value>&amp;Koina</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 17</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.Text" xml:space="preserve">
+    <value>ファイル(&amp;F)</value>
+  </data>
   <data name="panelFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="gridInputFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="gridInputFiles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 38</value>
-  </data>
-  <data name="gridInputFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>428, 336</value>
-  </data>
-  <data name="gridInputFiles.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;gridInputFiles.Name" xml:space="preserve">
     <value>gridInputFiles</value>
@@ -781,21 +775,6 @@
   <data name="&gt;&gt;gridInputFiles.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="btnAddPaths.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnAddPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>445, 96</value>
-  </data>
-  <data name="btnAddPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 23</value>
-  </data>
-  <data name="btnAddPaths.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="btnAddPaths.Text" xml:space="preserve">
-    <value>パスを追加(&amp;H)...</value>
-  </data>
   <data name="&gt;&gt;btnAddPaths.Name" xml:space="preserve">
     <value>btnAddPaths</value>
   </data>
@@ -807,21 +786,6 @@
   </data>
   <data name="&gt;&gt;btnAddPaths.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 19</value>
-  </data>
-  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
-  </data>
-  <data name="label7.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>入力ファイル(&amp;I)：</value>
   </data>
   <data name="&gt;&gt;label7.Name" xml:space="preserve">
     <value>label7</value>
@@ -835,25 +799,6 @@
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="btnAddDirectory.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnAddDirectory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>445, 67</value>
-  </data>
-  <data name="btnAddDirectory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 23</value>
-  </data>
-  <data name="btnAddDirectory.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="btnAddDirectory.Text" xml:space="preserve">
-    <value>ディレクトリを追加(&amp;D)...</value>
-  </data>
-  <data name="btnAddDirectory.ToolTip" xml:space="preserve">
-    <value>ルートディレクトリ下で見つかった容認可能なスペクトルファイルをすべて追加します。
-ライブラリに追加したくないファイルは、チェックボックスをオフにします。</value>
-  </data>
   <data name="&gt;&gt;btnAddDirectory.Name" xml:space="preserve">
     <value>btnAddDirectory</value>
   </data>
@@ -865,24 +810,6 @@
   </data>
   <data name="&gt;&gt;btnAddDirectory.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="btnAddFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnAddFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>445, 38</value>
-  </data>
-  <data name="btnAddFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 23</value>
-  </data>
-  <data name="btnAddFile.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="btnAddFile.Text" xml:space="preserve">
-    <value>ファイルを追加(&amp;F)...</value>
-  </data>
-  <data name="btnAddFile.ToolTip" xml:space="preserve">
-    <value>単一ディレクトリから1つ以上のファイルを追加します。</value>
   </data>
   <data name="&gt;&gt;btnAddFile.Name" xml:space="preserve">
     <value>btnAddFile</value>
@@ -919,6 +846,85 @@
   </data>
   <data name="&gt;&gt;panelFiles.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="gridInputFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="gridInputFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 38</value>
+  </data>
+  <data name="gridInputFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>428, 336</value>
+  </data>
+  <data name="gridInputFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="btnAddPaths.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnAddPaths.Location" type="System.Drawing.Point, System.Drawing">
+    <value>445, 96</value>
+  </data>
+  <data name="btnAddPaths.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 23</value>
+  </data>
+  <data name="btnAddPaths.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="btnAddPaths.Text" xml:space="preserve">
+    <value>パスを追加(&amp;H)...</value>
+  </data>
+  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 19</value>
+  </data>
+  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 13</value>
+  </data>
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label7.Text" xml:space="preserve">
+    <value>入力ファイル(&amp;I)：</value>
+  </data>
+  <data name="btnAddDirectory.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnAddDirectory.Location" type="System.Drawing.Point, System.Drawing">
+    <value>445, 67</value>
+  </data>
+  <data name="btnAddDirectory.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 23</value>
+  </data>
+  <data name="btnAddDirectory.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="btnAddDirectory.Text" xml:space="preserve">
+    <value>ディレクトリを追加(&amp;D)...</value>
+  </data>
+  <data name="btnAddDirectory.ToolTip" xml:space="preserve">
+    <value>ルートディレクトリ下で見つかった容認可能なスペクトルファイルをすべて追加します。
+ライブラリに追加したくないファイルは、チェックボックスをオフにします。</value>
+  </data>
+  <data name="btnAddFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnAddFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>445, 38</value>
+  </data>
+  <data name="btnAddFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 23</value>
+  </data>
+  <data name="btnAddFile.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="btnAddFile.Text" xml:space="preserve">
+    <value>ファイルを追加(&amp;F)...</value>
+  </data>
+  <data name="btnAddFile.ToolTip" xml:space="preserve">
+    <value>単一ディレクトリから1つ以上のファイルを追加します。</value>
   </data>
   <data name="btnPrevious.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.resx
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.resx
@@ -730,18 +730,6 @@ you can append more spectra in the future.</value>
   <data name="koinaInfoSettingsBtn.Text" xml:space="preserve">
     <value>Info/Settings</value>
   </data>
-  <data name="&gt;&gt;koinaInfoSettingsBtn.Name" xml:space="preserve">
-    <value>koinaInfoSettingsBtn</value>
-  </data>
-  <data name="&gt;&gt;koinaInfoSettingsBtn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;koinaInfoSettingsBtn.Parent" xml:space="preserve">
-    <value>dataSourceGroupBox</value>
-  </data>
-  <data name="&gt;&gt;koinaInfoSettingsBtn.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="koinaDataSourceRadioButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -760,18 +748,6 @@ you can append more spectra in the future.</value>
   <data name="koinaDataSourceRadioButton.Text" xml:space="preserve">
     <value>&amp;Koina</value>
   </data>
-  <data name="&gt;&gt;koinaDataSourceRadioButton.Name" xml:space="preserve">
-    <value>koinaDataSourceRadioButton</value>
-  </data>
-  <data name="&gt;&gt;koinaDataSourceRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;koinaDataSourceRadioButton.Parent" xml:space="preserve">
-    <value>dataSourceGroupBox</value>
-  </data>
-  <data name="&gt;&gt;koinaDataSourceRadioButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="dataSourceFilesRadioButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -786,18 +762,6 @@ you can append more spectra in the future.</value>
   </data>
   <data name="dataSourceFilesRadioButton.Text" xml:space="preserve">
     <value>&amp;Files</value>
-  </data>
-  <data name="&gt;&gt;dataSourceFilesRadioButton.Name" xml:space="preserve">
-    <value>dataSourceFilesRadioButton</value>
-  </data>
-  <data name="&gt;&gt;dataSourceFilesRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataSourceFilesRadioButton.Parent" xml:space="preserve">
-    <value>dataSourceGroupBox</value>
-  </data>
-  <data name="&gt;&gt;dataSourceFilesRadioButton.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="panelFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
@@ -898,18 +862,6 @@ you can append more spectra in the future.</value>
   <data name="gridInputFiles.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;gridInputFiles.Name" xml:space="preserve">
-    <value>gridInputFiles</value>
-  </data>
-  <data name="&gt;&gt;gridInputFiles.Type" xml:space="preserve">
-    <value>pwiz.Skyline.FileUI.PeptideSearch.BuildLibraryGridView, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;gridInputFiles.Parent" xml:space="preserve">
-    <value>panelFiles</value>
-  </data>
-  <data name="&gt;&gt;gridInputFiles.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnAddPaths.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
   </data>
@@ -925,18 +877,6 @@ you can append more spectra in the future.</value>
   <data name="btnAddPaths.Text" xml:space="preserve">
     <value>Add Pat&amp;hs...</value>
   </data>
-  <data name="&gt;&gt;btnAddPaths.Name" xml:space="preserve">
-    <value>btnAddPaths</value>
-  </data>
-  <data name="&gt;&gt;btnAddPaths.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAddPaths.Parent" xml:space="preserve">
-    <value>panelFiles</value>
-  </data>
-  <data name="&gt;&gt;btnAddPaths.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -951,18 +891,6 @@ you can append more spectra in the future.</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>&amp;Input Files:</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>panelFiles</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="btnAddDirectory.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -983,18 +911,6 @@ you can append more spectra in the future.</value>
     <value>Add all acceptable spectrum files found below a root directory.
 You can uncheck ones you do not want added to the library.</value>
   </data>
-  <data name="&gt;&gt;btnAddDirectory.Name" xml:space="preserve">
-    <value>btnAddDirectory</value>
-  </data>
-  <data name="&gt;&gt;btnAddDirectory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAddDirectory.Parent" xml:space="preserve">
-    <value>panelFiles</value>
-  </data>
-  <data name="&gt;&gt;btnAddDirectory.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="btnAddFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
   </data>
@@ -1012,18 +928,6 @@ You can uncheck ones you do not want added to the library.</value>
   </data>
   <data name="btnAddFile.ToolTip" xml:space="preserve">
     <value>Add a file or multiple files from a single directory.</value>
-  </data>
-  <data name="&gt;&gt;btnAddFile.Name" xml:space="preserve">
-    <value>btnAddFile</value>
-  </data>
-  <data name="&gt;&gt;btnAddFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAddFile.Parent" xml:space="preserve">
-    <value>panelFiles</value>
-  </data>
-  <data name="&gt;&gt;btnAddFile.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="btnPrevious.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.zh-CHS.resx
@@ -238,13 +238,13 @@
     <value>15, 69</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
+    <value>66, 13</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>输出路径(&amp;O)：</value>
+    <value>&amp;Output path:</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -299,7 +299,7 @@
     <value>12</value>
   </data>
   <data name="iRTPeptidesLabel.Text" xml:space="preserve">
-    <value>iRT 标准肽段(&amp;I)：</value>
+    <value>i&amp;RT standard peptides:</value>
   </data>
   <data name="&gt;&gt;iRTPeptidesLabel.Name" xml:space="preserve">
     <value>iRTPeptidesLabel</value>
@@ -459,6 +459,9 @@
   <data name="cbIncludeAmbiguousMatches.Text" xml:space="preserve">
     <value>包含不明确匹配项(&amp;M)</value>
   </data>
+  <data name="cbIncludeAmbiguousMatches.ToolTip" xml:space="preserve">
+    <value>Check to keep spectra that match multiple peptides.</value>
+  </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.Name" xml:space="preserve">
     <value>cbIncludeAmbiguousMatches</value>
   </data>
@@ -487,7 +490,7 @@
     <value>14</value>
   </data>
   <data name="cbKeepRedundant.Text" xml:space="preserve">
-    <value>保留冗余库(&amp;K)</value>
+    <value>K&amp;eep redundant library</value>
   </data>
   <data name="cbKeepRedundant.ToolTip" xml:space="preserve">
     <value>选中并保留冗余库的副本，您可以在
@@ -522,6 +525,9 @@
   </data>
   <data name="cbFilter.Text" xml:space="preserve">
     <value>文档肽筛选器(&amp;D)</value>
+  </data>
+  <data name="cbFilter.ToolTip" xml:space="preserve">
+    <value>Check to filter matches for only the peptides in the document.</value>
   </data>
   <data name="&gt;&gt;cbFilter.Name" xml:space="preserve">
     <value>cbFilter</value>
@@ -601,21 +607,6 @@
   <data name="&gt;&gt;panelFilesKoinaProperties.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="koinaInfoSettingsBtn.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="koinaInfoSettingsBtn.Location" type="System.Drawing.Point, System.Drawing">
-    <value>190, 44</value>
-  </data>
-  <data name="koinaInfoSettingsBtn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 13</value>
-  </data>
-  <data name="koinaInfoSettingsBtn.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="koinaInfoSettingsBtn.Text" xml:space="preserve">
-    <value>信息/设置</value>
-  </data>
   <data name="&gt;&gt;koinaInfoSettingsBtn.Name" xml:space="preserve">
     <value>koinaInfoSettingsBtn</value>
   </data>
@@ -628,24 +619,6 @@
   <data name="&gt;&gt;koinaInfoSettingsBtn.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="koinaDataSourceRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 42</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 17</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="koinaDataSourceRadioButton.Text" xml:space="preserve">
-    <value>Pro&amp;sit</value>
-  </data>
   <data name="&gt;&gt;koinaDataSourceRadioButton.Name" xml:space="preserve">
     <value>koinaDataSourceRadioButton</value>
   </data>
@@ -657,21 +630,6 @@
   </data>
   <data name="&gt;&gt;koinaDataSourceRadioButton.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 17</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="dataSourceFilesRadioButton.Text" xml:space="preserve">
-    <value>文件(&amp;F)</value>
   </data>
   <data name="&gt;&gt;dataSourceFilesRadioButton.Name" xml:space="preserve">
     <value>dataSourceFilesRadioButton</value>
@@ -757,20 +715,56 @@
   <data name="&gt;&gt;panelProperties.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="koinaInfoSettingsBtn.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="koinaInfoSettingsBtn.Location" type="System.Drawing.Point, System.Drawing">
+    <value>190, 44</value>
+  </data>
+  <data name="koinaInfoSettingsBtn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>68, 13</value>
+  </data>
+  <data name="koinaInfoSettingsBtn.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="koinaInfoSettingsBtn.Text" xml:space="preserve">
+    <value>Info/Settings</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 42</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="koinaDataSourceRadioButton.Text" xml:space="preserve">
+    <value>&amp;Koina</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 17</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="dataSourceFilesRadioButton.Text" xml:space="preserve">
+    <value>文件(&amp;F)</value>
+  </data>
   <data name="panelFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="gridInputFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="gridInputFiles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 38</value>
-  </data>
-  <data name="gridInputFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>460, 336</value>
-  </data>
-  <data name="gridInputFiles.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;gridInputFiles.Name" xml:space="preserve">
     <value>gridInputFiles</value>
@@ -784,21 +778,6 @@
   <data name="&gt;&gt;gridInputFiles.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="btnAddPaths.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnAddPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>477, 96</value>
-  </data>
-  <data name="btnAddPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 23</value>
-  </data>
-  <data name="btnAddPaths.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="btnAddPaths.Text" xml:space="preserve">
-    <value>添加路径(&amp;H)…</value>
-  </data>
   <data name="&gt;&gt;btnAddPaths.Name" xml:space="preserve">
     <value>btnAddPaths</value>
   </data>
@@ -810,21 +789,6 @@
   </data>
   <data name="&gt;&gt;btnAddPaths.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 19</value>
-  </data>
-  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
-  </data>
-  <data name="label7.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>输入文件(&amp;I)：</value>
   </data>
   <data name="&gt;&gt;label7.Name" xml:space="preserve">
     <value>label7</value>
@@ -838,25 +802,6 @@
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="btnAddDirectory.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnAddDirectory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>477, 67</value>
-  </data>
-  <data name="btnAddDirectory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 23</value>
-  </data>
-  <data name="btnAddDirectory.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="btnAddDirectory.Text" xml:space="preserve">
-    <value>添加目录(&amp;D)…</value>
-  </data>
-  <data name="btnAddDirectory.ToolTip" xml:space="preserve">
-    <value>添加在根目录下查找到的所有可接受的谱图文件。
-您可以取消选中您不希望添加到库中的文件。</value>
-  </data>
   <data name="&gt;&gt;btnAddDirectory.Name" xml:space="preserve">
     <value>btnAddDirectory</value>
   </data>
@@ -868,24 +813,6 @@
   </data>
   <data name="&gt;&gt;btnAddDirectory.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="btnAddFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnAddFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>477, 38</value>
-  </data>
-  <data name="btnAddFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 23</value>
-  </data>
-  <data name="btnAddFile.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="btnAddFile.Text" xml:space="preserve">
-    <value>添加文件(&amp;F)…</value>
-  </data>
-  <data name="btnAddFile.ToolTip" xml:space="preserve">
-    <value>从单一目录中添加一个或多个文件。</value>
   </data>
   <data name="&gt;&gt;btnAddFile.Name" xml:space="preserve">
     <value>btnAddFile</value>
@@ -922,6 +849,85 @@
   </data>
   <data name="&gt;&gt;panelFiles.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="gridInputFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="gridInputFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 38</value>
+  </data>
+  <data name="gridInputFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>460, 336</value>
+  </data>
+  <data name="gridInputFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="btnAddPaths.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnAddPaths.Location" type="System.Drawing.Point, System.Drawing">
+    <value>477, 96</value>
+  </data>
+  <data name="btnAddPaths.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 23</value>
+  </data>
+  <data name="btnAddPaths.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="btnAddPaths.Text" xml:space="preserve">
+    <value>添加路径(&amp;H)…</value>
+  </data>
+  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 19</value>
+  </data>
+  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 13</value>
+  </data>
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label7.Text" xml:space="preserve">
+    <value>输入文件(&amp;I)：</value>
+  </data>
+  <data name="btnAddDirectory.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnAddDirectory.Location" type="System.Drawing.Point, System.Drawing">
+    <value>477, 67</value>
+  </data>
+  <data name="btnAddDirectory.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 23</value>
+  </data>
+  <data name="btnAddDirectory.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="btnAddDirectory.Text" xml:space="preserve">
+    <value>添加目录(&amp;D)…</value>
+  </data>
+  <data name="btnAddDirectory.ToolTip" xml:space="preserve">
+    <value>添加在根目录下查找到的所有可接受的谱图文件。
+您可以取消选中您不希望添加到库中的文件。</value>
+  </data>
+  <data name="btnAddFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnAddFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>477, 38</value>
+  </data>
+  <data name="btnAddFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 23</value>
+  </data>
+  <data name="btnAddFile.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="btnAddFile.Text" xml:space="preserve">
+    <value>添加文件(&amp;F)…</value>
+  </data>
+  <data name="btnAddFile.ToolTip" xml:space="preserve">
+    <value>从单一目录中添加一个或多个文件。</value>
   </data>
   <data name="btnPrevious.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>

--- a/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.ja.resx
@@ -309,18 +309,6 @@
   <data name="flowLayoutPanelUseSchedulingWindow.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Name" xml:space="preserve">
-    <value>flowLayoutPanelUseSchedulingWindow</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioTimeAroundMs2Ids.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -337,18 +325,6 @@
     <value>14, 13</value>
   </data>
   <data name="radioTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>radioTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="flowLayoutPanelTimeAroundMs2Ids.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -402,18 +378,6 @@
   <data name="flowLayoutPanelTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelTimeAroundMs2Ids1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -435,18 +399,6 @@
   <data name="labelTimeAroundMs2Ids1.Text" xml:space="preserve">
     <value>のスキャンのみを使用します</value>
   </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Name" xml:space="preserve">
-    <value>labelTimeAroundMs2Ids1</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="tbxTimeAroundMs2Ids.Location" type="System.Drawing.Point, System.Drawing">
     <value>109, 0</value>
   </data>
@@ -458,18 +410,6 @@
   </data>
   <data name="tbxTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>tbxTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="labelTimeAroundMs2Ids2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -492,18 +432,6 @@
   <data name="labelTimeAroundMs2Ids2.Text" xml:space="preserve">
     <value>MS/MSのIDの時間（分）</value>
   </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Name" xml:space="preserve">
-    <value>labelTimeAroundMs2Ids2</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="radioUseSchedulingWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -517,18 +445,6 @@
     <value>14, 13</value>
   </data>
   <data name="radioUseSchedulingWindow.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Name" xml:space="preserve">
-    <value>radioUseSchedulingWindow</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="radioKeepAllTime.AutoSize" type="System.Boolean, mscorlib">
@@ -548,18 +464,6 @@
   </data>
   <data name="radioKeepAllTime.Text" xml:space="preserve">
     <value>一致する全てのスキャンを含める</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Name" xml:space="preserve">
-    <value>radioKeepAllTime</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="&gt;&gt;cbIgnoreSim.Name" xml:space="preserve">
     <value>cbIgnoreSim</value>
@@ -801,18 +705,6 @@
   <data name="cbIgnoreSim.ToolTip" xml:space="preserve">
     <value>m/z範囲{0}未満のSIMスペクトルを無視。</value>
   </data>
-  <data name="&gt;&gt;cbIgnoreSim.Name" xml:space="preserve">
-    <value>cbIgnoreSim</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="labelPrecursorPPM.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -834,18 +726,6 @@
   <data name="labelPrecursorPPM.Text" xml:space="preserve">
     <value>ppm</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Name" xml:space="preserve">
-    <value>labelPrecursorPPM</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="comboEnrichments.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 162</value>
   </data>
@@ -854,18 +734,6 @@
   </data>
   <data name="comboEnrichments.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Name" xml:space="preserve">
-    <value>comboEnrichments</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="labelEnrichments.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -884,18 +752,6 @@
   </data>
   <data name="labelEnrichments.Text" xml:space="preserve">
     <value>同位体標識濃縮(&amp;B)：</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Name" xml:space="preserve">
-    <value>labelEnrichments</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="labelPrecursorIsotopeFilterPercent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -918,18 +774,6 @@
   <data name="labelPrecursorIsotopeFilterPercent.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Name" xml:space="preserve">
-    <value>labelPrecursorIsotopeFilterPercent</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textPrecursorIsotopeFilter.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 102</value>
   </data>
@@ -938,18 +782,6 @@
   </data>
   <data name="textPrecursorIsotopeFilter.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Name" xml:space="preserve">
-    <value>textPrecursorIsotopeFilter</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="labelPrecursorIsotopeFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -969,18 +801,6 @@
   <data name="labelPrecursorIsotopeFilter.Text" xml:space="preserve">
     <value>ピーク(&amp;K)：</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Name" xml:space="preserve">
-    <value>labelPrecursorIsotopeFilter</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -999,18 +819,6 @@
   <data name="label23.Text" xml:space="preserve">
     <value>含まれる同位体ピーク(&amp;I)：</value>
   </data>
-  <data name="&gt;&gt;label23.Name" xml:space="preserve">
-    <value>label23</value>
-  </data>
-  <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="comboPrecursorIsotopes.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 41</value>
   </data>
@@ -1019,18 +827,6 @@
   </data>
   <data name="comboPrecursorIsotopes.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Name" xml:space="preserve">
-    <value>comboPrecursorIsotopes</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="labelPrecursorAt.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1050,18 +846,6 @@
   <data name="labelPrecursorAt.Text" xml:space="preserve">
     <value>以下の値で(&amp;A)：</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorAt.Name" xml:space="preserve">
-    <value>labelPrecursorAt</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="textPrecursorAt.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 102</value>
   </data>
@@ -1069,18 +853,6 @@
     <value>44, 20</value>
   </data>
   <data name="textPrecursorAt.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Name" xml:space="preserve">
-    <value>textPrecursorAt</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
   <data name="labelPrecursorTh.AutoSize" type="System.Boolean, mscorlib">
@@ -1104,18 +876,6 @@
   <data name="labelPrecursorTh.Text" xml:space="preserve">
     <value>m/z</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorTh.Name" xml:space="preserve">
-    <value>labelPrecursorTh</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="textPrecursorRes.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1127,18 +887,6 @@
   </data>
   <data name="textPrecursorRes.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Name" xml:space="preserve">
-    <value>textPrecursorRes</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.ZOrder" xml:space="preserve">
-    <value>12</value>
   </data>
   <data name="labelPrecursorRes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1158,18 +906,6 @@
   <data name="labelPrecursorRes.Text" xml:space="preserve">
     <value>分解能(&amp;R)：</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorRes.Name" xml:space="preserve">
-    <value>labelPrecursorRes</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="comboPrecursorAnalyzerType.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1184,18 +920,6 @@
   </data>
   <data name="comboPrecursorAnalyzerType.ToolTip" xml:space="preserve">
     <value>「セントロイド化」オプションは、ベンダーより提供されたピーク選択のあるデータ形式、または事前にセントロイド化データにのみ適用されます。</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Name" xml:space="preserve">
-    <value>comboPrecursorAnalyzerType</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <data name="label32.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1214,18 +938,6 @@
   </data>
   <data name="label32.Text" xml:space="preserve">
     <value>プリカーサー質量アナライザー(&amp;P)：</value>
-  </data>
-  <data name="&gt;&gt;label32.Name" xml:space="preserve">
-    <value>label32</value>
-  </data>
-  <data name="&gt;&gt;label32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label32.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;label32.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="&gt;&gt;labelProductPPM.Name" xml:space="preserve">
     <value>labelProductPPM</value>
@@ -1416,18 +1128,6 @@
   <data name="labelProductPPM.Text" xml:space="preserve">
     <value>ppm</value>
   </data>
-  <data name="&gt;&gt;labelProductPPM.Name" xml:space="preserve">
-    <value>labelProductPPM</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboIsolationScheme.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 102</value>
   </data>
@@ -1436,18 +1136,6 @@
   </data>
   <data name="comboIsolationScheme.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Name" xml:space="preserve">
-    <value>comboIsolationScheme</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="labelProductAt.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1467,18 +1155,6 @@
   <data name="labelProductAt.Text" xml:space="preserve">
     <value>以下の値で(&amp;T)：</value>
   </data>
-  <data name="&gt;&gt;labelProductAt.Name" xml:space="preserve">
-    <value>labelProductAt</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="textProductAt.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 103</value>
   </data>
@@ -1487,18 +1163,6 @@
   </data>
   <data name="textProductAt.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Name" xml:space="preserve">
-    <value>textProductAt</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="labelProductTh.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1521,18 +1185,6 @@
   <data name="labelProductTh.Text" xml:space="preserve">
     <value>m/z</value>
   </data>
-  <data name="&gt;&gt;labelProductTh.Name" xml:space="preserve">
-    <value>labelProductTh</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textProductRes.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1544,18 +1196,6 @@
   </data>
   <data name="textProductRes.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Name" xml:space="preserve">
-    <value>textProductRes</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="labelProductRes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1575,18 +1215,6 @@
   <data name="labelProductRes.Text" xml:space="preserve">
     <value>分解能(&amp;O)：</value>
   </data>
-  <data name="&gt;&gt;labelProductRes.Name" xml:space="preserve">
-    <value>labelProductRes</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="comboProductAnalyzerType.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1601,18 +1229,6 @@
   </data>
   <data name="comboProductAnalyzerType.ToolTip" xml:space="preserve">
     <value>「セントロイド化」オプションは、ベンダーより提供されたピーク選択のあるデータ形式、または事前にセントロイド化データにのみ適用されます。</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Name" xml:space="preserve">
-    <value>comboProductAnalyzerType</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1632,18 +1248,6 @@
   <data name="label22.Text" xml:space="preserve">
     <value>プロダクト質量分析(&amp;M)：</value>
   </data>
-  <data name="&gt;&gt;label22.Name" xml:space="preserve">
-    <value>label22</value>
-  </data>
-  <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label22.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="labelIsolationScheme.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1662,18 +1266,6 @@
   <data name="labelIsolationScheme.Text" xml:space="preserve">
     <value>単離スキーム(&amp;L)：</value>
   </data>
-  <data name="&gt;&gt;labelIsolationScheme.Name" xml:space="preserve">
-    <value>labelIsolationScheme</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="comboAcquisitionMethod.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 41</value>
   </data>
@@ -1682,18 +1274,6 @@
   </data>
   <data name="comboAcquisitionMethod.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Name" xml:space="preserve">
-    <value>comboAcquisitionMethod</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.ZOrder" xml:space="preserve">
-    <value>10</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1712,18 +1292,6 @@
   </data>
   <data name="label20.Text" xml:space="preserve">
     <value>取得メソッド(&amp;C)：</value>
-  </data>
-  <data name="&gt;&gt;label20.Name" xml:space="preserve">
-    <value>label20</value>
-  </data>
-  <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label20.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>11</value>
   </data>
   <data name="lblPrecursorCharges.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.resx
+++ b/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.resx
@@ -309,18 +309,6 @@
   <data name="flowLayoutPanelUseSchedulingWindow.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Name" xml:space="preserve">
-    <value>flowLayoutPanelUseSchedulingWindow</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioTimeAroundMs2Ids.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -337,18 +325,6 @@
     <value>14, 13</value>
   </data>
   <data name="radioTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>radioTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="flowLayoutPanelTimeAroundMs2Ids.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -402,18 +378,6 @@
   <data name="flowLayoutPanelTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelTimeAroundMs2Ids1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -435,18 +399,6 @@
   <data name="labelTimeAroundMs2Ids1.Text" xml:space="preserve">
     <value>Use only scans within</value>
   </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Name" xml:space="preserve">
-    <value>labelTimeAroundMs2Ids1</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="tbxTimeAroundMs2Ids.Location" type="System.Drawing.Point, System.Drawing">
     <value>109, 0</value>
   </data>
@@ -458,18 +410,6 @@
   </data>
   <data name="tbxTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>tbxTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="labelTimeAroundMs2Ids2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -492,18 +432,6 @@
   <data name="labelTimeAroundMs2Ids2.Text" xml:space="preserve">
     <value>minutes of MS/MS IDs</value>
   </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Name" xml:space="preserve">
-    <value>labelTimeAroundMs2Ids2</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="radioUseSchedulingWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -517,18 +445,6 @@
     <value>14, 13</value>
   </data>
   <data name="radioUseSchedulingWindow.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Name" xml:space="preserve">
-    <value>radioUseSchedulingWindow</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="radioKeepAllTime.AutoSize" type="System.Boolean, mscorlib">
@@ -548,18 +464,6 @@
   </data>
   <data name="radioKeepAllTime.Text" xml:space="preserve">
     <value>Include all matching scans</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Name" xml:space="preserve">
-    <value>radioKeepAllTime</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="&gt;&gt;cbIgnoreSim.Name" xml:space="preserve">
     <value>cbIgnoreSim</value>
@@ -801,18 +705,6 @@
   <data name="cbIgnoreSim.ToolTip" xml:space="preserve">
     <value>Ignores SIM spectra with m/z range less than {0}.</value>
   </data>
-  <data name="&gt;&gt;cbIgnoreSim.Name" xml:space="preserve">
-    <value>cbIgnoreSim</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="labelPrecursorPPM.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -834,18 +726,6 @@
   <data name="labelPrecursorPPM.Text" xml:space="preserve">
     <value>ppm</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Name" xml:space="preserve">
-    <value>labelPrecursorPPM</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="comboEnrichments.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 162</value>
   </data>
@@ -854,18 +734,6 @@
   </data>
   <data name="comboEnrichments.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Name" xml:space="preserve">
-    <value>comboEnrichments</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="labelEnrichments.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -884,18 +752,6 @@
   </data>
   <data name="labelEnrichments.Text" xml:space="preserve">
     <value>Isotope la&amp;beling enrichment:</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Name" xml:space="preserve">
-    <value>labelEnrichments</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="labelPrecursorIsotopeFilterPercent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -918,18 +774,6 @@
   <data name="labelPrecursorIsotopeFilterPercent.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Name" xml:space="preserve">
-    <value>labelPrecursorIsotopeFilterPercent</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textPrecursorIsotopeFilter.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 102</value>
   </data>
@@ -938,18 +782,6 @@
   </data>
   <data name="textPrecursorIsotopeFilter.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Name" xml:space="preserve">
-    <value>textPrecursorIsotopeFilter</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="labelPrecursorIsotopeFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -969,18 +801,6 @@
   <data name="labelPrecursorIsotopeFilter.Text" xml:space="preserve">
     <value>Pea&amp;ks:</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Name" xml:space="preserve">
-    <value>labelPrecursorIsotopeFilter</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -999,18 +819,6 @@
   <data name="label23.Text" xml:space="preserve">
     <value>&amp;Isotope peaks included:</value>
   </data>
-  <data name="&gt;&gt;label23.Name" xml:space="preserve">
-    <value>label23</value>
-  </data>
-  <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="comboPrecursorIsotopes.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 41</value>
   </data>
@@ -1019,18 +827,6 @@
   </data>
   <data name="comboPrecursorIsotopes.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Name" xml:space="preserve">
-    <value>comboPrecursorIsotopes</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="labelPrecursorAt.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1050,18 +846,6 @@
   <data name="labelPrecursorAt.Text" xml:space="preserve">
     <value>&amp;At:</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorAt.Name" xml:space="preserve">
-    <value>labelPrecursorAt</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="textPrecursorAt.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 102</value>
   </data>
@@ -1069,18 +853,6 @@
     <value>44, 20</value>
   </data>
   <data name="textPrecursorAt.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Name" xml:space="preserve">
-    <value>textPrecursorAt</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
   <data name="labelPrecursorTh.AutoSize" type="System.Boolean, mscorlib">
@@ -1104,18 +876,6 @@
   <data name="labelPrecursorTh.Text" xml:space="preserve">
     <value>m/z</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorTh.Name" xml:space="preserve">
-    <value>labelPrecursorTh</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="textPrecursorRes.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1127,18 +887,6 @@
   </data>
   <data name="textPrecursorRes.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Name" xml:space="preserve">
-    <value>textPrecursorRes</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.ZOrder" xml:space="preserve">
-    <value>12</value>
   </data>
   <data name="labelPrecursorRes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1158,18 +906,6 @@
   <data name="labelPrecursorRes.Text" xml:space="preserve">
     <value>&amp;Resolving power:</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorRes.Name" xml:space="preserve">
-    <value>labelPrecursorRes</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="comboPrecursorAnalyzerType.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1184,18 +920,6 @@
   </data>
   <data name="comboPrecursorAnalyzerType.ToolTip" xml:space="preserve">
     <value>The "Centroided" option only applies to data formats with available vendor-supplied peak picking,  or to pre-centroided data.</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Name" xml:space="preserve">
-    <value>comboPrecursorAnalyzerType</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <data name="label32.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1214,18 +938,6 @@
   </data>
   <data name="label32.Text" xml:space="preserve">
     <value>&amp;Precursor mass analyzer:</value>
-  </data>
-  <data name="&gt;&gt;label32.Name" xml:space="preserve">
-    <value>label32</value>
-  </data>
-  <data name="&gt;&gt;label32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label32.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;label32.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="&gt;&gt;labelProductPPM.Name" xml:space="preserve">
     <value>labelProductPPM</value>
@@ -1416,18 +1128,6 @@
   <data name="labelProductPPM.Text" xml:space="preserve">
     <value>ppm</value>
   </data>
-  <data name="&gt;&gt;labelProductPPM.Name" xml:space="preserve">
-    <value>labelProductPPM</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboIsolationScheme.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 102</value>
   </data>
@@ -1436,18 +1136,6 @@
   </data>
   <data name="comboIsolationScheme.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Name" xml:space="preserve">
-    <value>comboIsolationScheme</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="labelProductAt.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1467,18 +1155,6 @@
   <data name="labelProductAt.Text" xml:space="preserve">
     <value>A&amp;t:</value>
   </data>
-  <data name="&gt;&gt;labelProductAt.Name" xml:space="preserve">
-    <value>labelProductAt</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="textProductAt.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 103</value>
   </data>
@@ -1487,18 +1163,6 @@
   </data>
   <data name="textProductAt.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Name" xml:space="preserve">
-    <value>textProductAt</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="labelProductTh.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1521,18 +1185,6 @@
   <data name="labelProductTh.Text" xml:space="preserve">
     <value>m/z</value>
   </data>
-  <data name="&gt;&gt;labelProductTh.Name" xml:space="preserve">
-    <value>labelProductTh</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textProductRes.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1544,18 +1196,6 @@
   </data>
   <data name="textProductRes.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Name" xml:space="preserve">
-    <value>textProductRes</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="labelProductRes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1575,18 +1215,6 @@
   <data name="labelProductRes.Text" xml:space="preserve">
     <value>Res&amp;olving power:</value>
   </data>
-  <data name="&gt;&gt;labelProductRes.Name" xml:space="preserve">
-    <value>labelProductRes</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="comboProductAnalyzerType.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1601,18 +1229,6 @@
   </data>
   <data name="comboProductAnalyzerType.ToolTip" xml:space="preserve">
     <value>The "Centroided" option only applies to data formats with available vendor-supplied peak picking,  or to pre-centroided data.</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Name" xml:space="preserve">
-    <value>comboProductAnalyzerType</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1632,18 +1248,6 @@
   <data name="label22.Text" xml:space="preserve">
     <value>Product &amp;mass analyzer:</value>
   </data>
-  <data name="&gt;&gt;label22.Name" xml:space="preserve">
-    <value>label22</value>
-  </data>
-  <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label22.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="labelIsolationScheme.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1662,18 +1266,6 @@
   <data name="labelIsolationScheme.Text" xml:space="preserve">
     <value>Iso&amp;lation scheme:</value>
   </data>
-  <data name="&gt;&gt;labelIsolationScheme.Name" xml:space="preserve">
-    <value>labelIsolationScheme</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="comboAcquisitionMethod.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 41</value>
   </data>
@@ -1682,18 +1274,6 @@
   </data>
   <data name="comboAcquisitionMethod.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Name" xml:space="preserve">
-    <value>comboAcquisitionMethod</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.ZOrder" xml:space="preserve">
-    <value>10</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1712,18 +1292,6 @@
   </data>
   <data name="label20.Text" xml:space="preserve">
     <value>A&amp;cquisition method:</value>
-  </data>
-  <data name="&gt;&gt;label20.Name" xml:space="preserve">
-    <value>label20</value>
-  </data>
-  <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label20.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>11</value>
   </data>
   <data name="lblPrecursorCharges.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.zh-CHS.resx
@@ -309,18 +309,6 @@
   <data name="flowLayoutPanelUseSchedulingWindow.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Name" xml:space="preserve">
-    <value>flowLayoutPanelUseSchedulingWindow</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelUseSchedulingWindow.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioTimeAroundMs2Ids.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -337,18 +325,6 @@
     <value>14, 13</value>
   </data>
   <data name="radioTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>radioTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioTimeAroundMs2Ids.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="flowLayoutPanelTimeAroundMs2Ids.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -402,18 +378,6 @@
   <data name="flowLayoutPanelTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;flowLayoutPanelTimeAroundMs2Ids.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelTimeAroundMs2Ids1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -435,18 +399,6 @@
   <data name="labelTimeAroundMs2Ids1.Text" xml:space="preserve">
     <value>仅使用 MS/MS ID</value>
   </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Name" xml:space="preserve">
-    <value>labelTimeAroundMs2Ids1</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="tbxTimeAroundMs2Ids.Location" type="System.Drawing.Point, System.Drawing">
     <value>109, 0</value>
   </data>
@@ -458,18 +410,6 @@
   </data>
   <data name="tbxTimeAroundMs2Ids.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Name" xml:space="preserve">
-    <value>tbxTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;tbxTimeAroundMs2Ids.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="labelTimeAroundMs2Ids2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -492,18 +432,6 @@
   <data name="labelTimeAroundMs2Ids2.Text" xml:space="preserve">
     <value>分钟之内的扫描</value>
   </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Name" xml:space="preserve">
-    <value>labelTimeAroundMs2Ids2</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.Parent" xml:space="preserve">
-    <value>flowLayoutPanelTimeAroundMs2Ids</value>
-  </data>
-  <data name="&gt;&gt;labelTimeAroundMs2Ids2.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="radioUseSchedulingWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -517,18 +445,6 @@
     <value>14, 13</value>
   </data>
   <data name="radioUseSchedulingWindow.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Name" xml:space="preserve">
-    <value>radioUseSchedulingWindow</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioUseSchedulingWindow.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="radioKeepAllTime.AutoSize" type="System.Boolean, mscorlib">
@@ -548,18 +464,6 @@
   </data>
   <data name="radioKeepAllTime.Text" xml:space="preserve">
     <value>包含所有匹配的扫描</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Name" xml:space="preserve">
-    <value>radioKeepAllTime</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.Parent" xml:space="preserve">
-    <value>groupBoxRetentionTimeToKeep</value>
-  </data>
-  <data name="&gt;&gt;radioKeepAllTime.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="&gt;&gt;cbIgnoreSim.Name" xml:space="preserve">
     <value>cbIgnoreSim</value>
@@ -801,18 +705,6 @@
   <data name="cbIgnoreSim.ToolTip" xml:space="preserve">
     <value>忽略质荷比范围小于 {0} 的 SIM 谱图。</value>
   </data>
-  <data name="&gt;&gt;cbIgnoreSim.Name" xml:space="preserve">
-    <value>cbIgnoreSim</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;cbIgnoreSim.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="labelPrecursorPPM.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -834,18 +726,6 @@
   <data name="labelPrecursorPPM.Text" xml:space="preserve">
     <value>ppm</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Name" xml:space="preserve">
-    <value>labelPrecursorPPM</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorPPM.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="comboEnrichments.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 162</value>
   </data>
@@ -854,18 +734,6 @@
   </data>
   <data name="comboEnrichments.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Name" xml:space="preserve">
-    <value>comboEnrichments</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboEnrichments.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="labelEnrichments.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -884,18 +752,6 @@
   </data>
   <data name="labelEnrichments.Text" xml:space="preserve">
     <value>同位素标记富集(&amp;B)：</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Name" xml:space="preserve">
-    <value>labelEnrichments</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelEnrichments.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="labelPrecursorIsotopeFilterPercent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -918,18 +774,6 @@
   <data name="labelPrecursorIsotopeFilterPercent.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Name" xml:space="preserve">
-    <value>labelPrecursorIsotopeFilterPercent</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilterPercent.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textPrecursorIsotopeFilter.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 102</value>
   </data>
@@ -938,18 +782,6 @@
   </data>
   <data name="textPrecursorIsotopeFilter.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Name" xml:space="preserve">
-    <value>textPrecursorIsotopeFilter</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorIsotopeFilter.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="labelPrecursorIsotopeFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -969,18 +801,6 @@
   <data name="labelPrecursorIsotopeFilter.Text" xml:space="preserve">
     <value>峰(&amp;K)：</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Name" xml:space="preserve">
-    <value>labelPrecursorIsotopeFilter</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorIsotopeFilter.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -999,18 +819,6 @@
   <data name="label23.Text" xml:space="preserve">
     <value>同位素峰值包含(&amp;I)：</value>
   </data>
-  <data name="&gt;&gt;label23.Name" xml:space="preserve">
-    <value>label23</value>
-  </data>
-  <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="comboPrecursorIsotopes.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 41</value>
   </data>
@@ -1019,18 +827,6 @@
   </data>
   <data name="comboPrecursorIsotopes.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Name" xml:space="preserve">
-    <value>comboPrecursorIsotopes</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorIsotopes.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="labelPrecursorAt.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1050,18 +846,6 @@
   <data name="labelPrecursorAt.Text" xml:space="preserve">
     <value>位于(&amp;A)：</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorAt.Name" xml:space="preserve">
-    <value>labelPrecursorAt</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorAt.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="textPrecursorAt.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 102</value>
   </data>
@@ -1069,18 +853,6 @@
     <value>44, 20</value>
   </data>
   <data name="textPrecursorAt.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Name" xml:space="preserve">
-    <value>textPrecursorAt</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorAt.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
   <data name="labelPrecursorTh.AutoSize" type="System.Boolean, mscorlib">
@@ -1104,18 +876,6 @@
   <data name="labelPrecursorTh.Text" xml:space="preserve">
     <value>质荷比</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorTh.Name" xml:space="preserve">
-    <value>labelPrecursorTh</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorTh.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="textPrecursorRes.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1127,18 +887,6 @@
   </data>
   <data name="textPrecursorRes.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Name" xml:space="preserve">
-    <value>textPrecursorRes</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;textPrecursorRes.ZOrder" xml:space="preserve">
-    <value>12</value>
   </data>
   <data name="labelPrecursorRes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1158,18 +906,6 @@
   <data name="labelPrecursorRes.Text" xml:space="preserve">
     <value>分辨力(&amp;R)：</value>
   </data>
-  <data name="&gt;&gt;labelPrecursorRes.Name" xml:space="preserve">
-    <value>labelPrecursorRes</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;labelPrecursorRes.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="comboPrecursorAnalyzerType.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1184,18 +920,6 @@
   </data>
   <data name="comboPrecursorAnalyzerType.ToolTip" xml:space="preserve">
     <value>“质心”选项仅适用于供应商提供峰拣选可用的数据格式，或适用于预先质心的数据。</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Name" xml:space="preserve">
-    <value>comboPrecursorAnalyzerType</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorAnalyzerType.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <data name="label32.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1214,18 +938,6 @@
   </data>
   <data name="label32.Text" xml:space="preserve">
     <value>母离子质量分析仪(&amp;P)：</value>
-  </data>
-  <data name="&gt;&gt;label32.Name" xml:space="preserve">
-    <value>label32</value>
-  </data>
-  <data name="&gt;&gt;label32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label32.Parent" xml:space="preserve">
-    <value>groupBoxMS1</value>
-  </data>
-  <data name="&gt;&gt;label32.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="&gt;&gt;labelProductPPM.Name" xml:space="preserve">
     <value>labelProductPPM</value>
@@ -1416,18 +1128,6 @@
   <data name="labelProductPPM.Text" xml:space="preserve">
     <value>ppm</value>
   </data>
-  <data name="&gt;&gt;labelProductPPM.Name" xml:space="preserve">
-    <value>labelProductPPM</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductPPM.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboIsolationScheme.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 102</value>
   </data>
@@ -1436,18 +1136,6 @@
   </data>
   <data name="comboIsolationScheme.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Name" xml:space="preserve">
-    <value>comboIsolationScheme</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboIsolationScheme.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="labelProductAt.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1467,18 +1155,6 @@
   <data name="labelProductAt.Text" xml:space="preserve">
     <value>位于(&amp;T)：</value>
   </data>
-  <data name="&gt;&gt;labelProductAt.Name" xml:space="preserve">
-    <value>labelProductAt</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductAt.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="textProductAt.Location" type="System.Drawing.Point, System.Drawing">
     <value>244, 103</value>
   </data>
@@ -1487,18 +1163,6 @@
   </data>
   <data name="textProductAt.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Name" xml:space="preserve">
-    <value>textProductAt</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;textProductAt.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="labelProductTh.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1521,18 +1185,6 @@
   <data name="labelProductTh.Text" xml:space="preserve">
     <value>质荷比</value>
   </data>
-  <data name="&gt;&gt;labelProductTh.Name" xml:space="preserve">
-    <value>labelProductTh</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductTh.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textProductRes.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1544,18 +1196,6 @@
   </data>
   <data name="textProductRes.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Name" xml:space="preserve">
-    <value>textProductRes</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;textProductRes.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="labelProductRes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1575,18 +1215,6 @@
   <data name="labelProductRes.Text" xml:space="preserve">
     <value>分辨力(&amp;O)：</value>
   </data>
-  <data name="&gt;&gt;labelProductRes.Name" xml:space="preserve">
-    <value>labelProductRes</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelProductRes.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="comboProductAnalyzerType.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -1601,18 +1229,6 @@
   </data>
   <data name="comboProductAnalyzerType.ToolTip" xml:space="preserve">
     <value>“质心”选项仅适用于供应商提供峰拣选可用的数据格式，或适用于预先质心的数据。</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Name" xml:space="preserve">
-    <value>comboProductAnalyzerType</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboProductAnalyzerType.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1632,18 +1248,6 @@
   <data name="label22.Text" xml:space="preserve">
     <value>子离子质量分析仪(&amp;M)：</value>
   </data>
-  <data name="&gt;&gt;label22.Name" xml:space="preserve">
-    <value>label22</value>
-  </data>
-  <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label22.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="labelIsolationScheme.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1662,18 +1266,6 @@
   <data name="labelIsolationScheme.Text" xml:space="preserve">
     <value>分离方案(&amp;L)：</value>
   </data>
-  <data name="&gt;&gt;labelIsolationScheme.Name" xml:space="preserve">
-    <value>labelIsolationScheme</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;labelIsolationScheme.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="comboAcquisitionMethod.Location" type="System.Drawing.Point, System.Drawing">
     <value>14, 41</value>
   </data>
@@ -1682,18 +1274,6 @@
   </data>
   <data name="comboAcquisitionMethod.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Name" xml:space="preserve">
-    <value>comboAcquisitionMethod</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;comboAcquisitionMethod.ZOrder" xml:space="preserve">
-    <value>10</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1712,18 +1292,6 @@
   </data>
   <data name="label20.Text" xml:space="preserve">
     <value>采集方法(&amp;C)：</value>
-  </data>
-  <data name="&gt;&gt;label20.Name" xml:space="preserve">
-    <value>label20</value>
-  </data>
-  <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label20.Parent" xml:space="preserve">
-    <value>groupBoxMS2</value>
-  </data>
-  <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>11</value>
   </data>
   <data name="lblPrecursorCharges.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.ja.resx
@@ -316,18 +316,6 @@
     <value>クロマトグラムピークから計算された{0}ペプチドiRT値は保持され、
 MS/MSスキャンから計算されたより新しいiRT値は無視されます:</value>
   </data>
-  <data name="&gt;&gt;labelKeep.Name" xml:space="preserve">
-    <value>labelKeep</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.Parent" xml:space="preserve">
-    <value>panelKeep</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="listKeep.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -338,18 +326,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
     <value>437, 69</value>
   </data>
   <data name="listKeep.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Name" xml:space="preserve">
-    <value>listKeep</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Parent" xml:space="preserve">
-    <value>panelKeep</value>
-  </data>
-  <data name="&gt;&gt;listKeep.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="labelRunsFailed.AutoSize" type="System.Boolean, mscorlib">
@@ -509,18 +485,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
     <value>MS/MSスキャンから計算された{0}ペプチドiRT値は、
 クロマトグラムピークから計算されたiRT値に置き換えられます。</value>
   </data>
-  <data name="&gt;&gt;labelOverwrite.Name" xml:space="preserve">
-    <value>labelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.Parent" xml:space="preserve">
-    <value>panelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="listOverwrite.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -531,18 +495,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
     <value>437, 69</value>
   </data>
   <data name="listOverwrite.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Name" xml:space="preserve">
-    <value>listOverwrite</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Parent" xml:space="preserve">
-    <value>panelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="panelExisting.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -662,18 +614,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
   <data name="radioAverage.Text" xml:space="preserve">
     <value>新しい値と既存の値の平均をとる</value>
   </data>
-  <data name="&gt;&gt;radioAverage.Name" xml:space="preserve">
-    <value>radioAverage</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -694,18 +634,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
   </data>
   <data name="radioReplace.Text" xml:space="preserve">
     <value>既存の値を置き換え</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Name" xml:space="preserve">
-    <value>radioReplace</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="radioSkip.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -728,18 +656,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
   <data name="radioSkip.Text" xml:space="preserve">
     <value>既存の値を残す</value>
   </data>
-  <data name="&gt;&gt;radioSkip.Name" xml:space="preserve">
-    <value>radioSkip</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelChoice.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -761,18 +677,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
   <data name="labelChoice.Text" xml:space="preserve">
     <value>これらのペプチドの処理を選択してください。</value>
   </data>
-  <data name="&gt;&gt;labelChoice.Name" xml:space="preserve">
-    <value>labelChoice</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="labelExisting.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -791,18 +695,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
   <data name="labelExisting.Text" xml:space="preserve">
     <value>{0}個のペプチドについて、既にライブラリ内に値が存在します：</value>
   </data>
-  <data name="&gt;&gt;labelExisting.Name" xml:space="preserve">
-    <value>labelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="listExisting.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
@@ -814,18 +706,6 @@ MS/MSスキャンから計算されたより新しいiRT値は無視されます
   </data>
   <data name="listExisting.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Name" xml:space="preserve">
-    <value>listExisting</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;listExisting.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.resx
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.resx
@@ -316,18 +316,6 @@
     <value>{0} peptide iRT values calculated from chromatogram peaks will be kept
 and newer iRT values calculated from MS/MS scans ignored:</value>
   </data>
-  <data name="&gt;&gt;labelKeep.Name" xml:space="preserve">
-    <value>labelKeep</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.Parent" xml:space="preserve">
-    <value>panelKeep</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="listKeep.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -338,18 +326,6 @@ and newer iRT values calculated from MS/MS scans ignored:</value>
     <value>437, 69</value>
   </data>
   <data name="listKeep.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Name" xml:space="preserve">
-    <value>listKeep</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Parent" xml:space="preserve">
-    <value>panelKeep</value>
-  </data>
-  <data name="&gt;&gt;listKeep.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="labelRunsFailed.AutoSize" type="System.Boolean, mscorlib">
@@ -509,18 +485,6 @@ and newer iRT values calculated from MS/MS scans ignored:</value>
     <value>{0} peptide iRT values calculated from MS/MS scans will be replaced
 with iRT values calculated from chromatogram peaks:</value>
   </data>
-  <data name="&gt;&gt;labelOverwrite.Name" xml:space="preserve">
-    <value>labelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.Parent" xml:space="preserve">
-    <value>panelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="listOverwrite.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -531,18 +495,6 @@ with iRT values calculated from chromatogram peaks:</value>
     <value>437, 69</value>
   </data>
   <data name="listOverwrite.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Name" xml:space="preserve">
-    <value>listOverwrite</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Parent" xml:space="preserve">
-    <value>panelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="panelExisting.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -662,18 +614,6 @@ with iRT values calculated from chromatogram peaks:</value>
   <data name="radioAverage.Text" xml:space="preserve">
     <value>Average new and existing values</value>
   </data>
-  <data name="&gt;&gt;radioAverage.Name" xml:space="preserve">
-    <value>radioAverage</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -694,18 +634,6 @@ with iRT values calculated from chromatogram peaks:</value>
   </data>
   <data name="radioReplace.Text" xml:space="preserve">
     <value>Replace existing values</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Name" xml:space="preserve">
-    <value>radioReplace</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="radioSkip.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -728,18 +656,6 @@ with iRT values calculated from chromatogram peaks:</value>
   <data name="radioSkip.Text" xml:space="preserve">
     <value>Leave existing values</value>
   </data>
-  <data name="&gt;&gt;radioSkip.Name" xml:space="preserve">
-    <value>radioSkip</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelChoice.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -761,18 +677,6 @@ with iRT values calculated from chromatogram peaks:</value>
   <data name="labelChoice.Text" xml:space="preserve">
     <value>Choose how you would like to handle these peptides:</value>
   </data>
-  <data name="&gt;&gt;labelChoice.Name" xml:space="preserve">
-    <value>labelChoice</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="labelExisting.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -791,18 +695,6 @@ with iRT values calculated from chromatogram peaks:</value>
   <data name="labelExisting.Text" xml:space="preserve">
     <value>{0} peptides already have values in the library:</value>
   </data>
-  <data name="&gt;&gt;labelExisting.Name" xml:space="preserve">
-    <value>labelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="listExisting.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
@@ -814,18 +706,6 @@ with iRT values calculated from chromatogram peaks:</value>
   </data>
   <data name="listExisting.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Name" xml:space="preserve">
-    <value>listExisting</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;listExisting.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.zh-CHS.resx
@@ -316,18 +316,6 @@
     <value>从色谱峰中计算得到的 {0} 个肽段 iRT 值将被保留
 并且从 MS/MS 扫描中计算得到的新 iRT 值将被忽略：</value>
   </data>
-  <data name="&gt;&gt;labelKeep.Name" xml:space="preserve">
-    <value>labelKeep</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.Parent" xml:space="preserve">
-    <value>panelKeep</value>
-  </data>
-  <data name="&gt;&gt;labelKeep.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="listKeep.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -338,18 +326,6 @@
     <value>437, 69</value>
   </data>
   <data name="listKeep.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Name" xml:space="preserve">
-    <value>listKeep</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listKeep.Parent" xml:space="preserve">
-    <value>panelKeep</value>
-  </data>
-  <data name="&gt;&gt;listKeep.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="labelRunsFailed.AutoSize" type="System.Boolean, mscorlib">
@@ -509,18 +485,6 @@
     <value>从 MS/MS 扫描中计算得到的 {0} 个肽段 iRT 值将被替换
 为从色谱峰中计算得到的 iRT 值：</value>
   </data>
-  <data name="&gt;&gt;labelOverwrite.Name" xml:space="preserve">
-    <value>labelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.Parent" xml:space="preserve">
-    <value>panelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;labelOverwrite.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="listOverwrite.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
@@ -531,18 +495,6 @@
     <value>437, 69</value>
   </data>
   <data name="listOverwrite.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Name" xml:space="preserve">
-    <value>listOverwrite</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.Parent" xml:space="preserve">
-    <value>panelOverwrite</value>
-  </data>
-  <data name="&gt;&gt;listOverwrite.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="panelExisting.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -662,18 +614,6 @@
   <data name="radioAverage.Text" xml:space="preserve">
     <value>平均新值和现有值</value>
   </data>
-  <data name="&gt;&gt;radioAverage.Name" xml:space="preserve">
-    <value>radioAverage</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioAverage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="radioReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -694,18 +634,6 @@
   </data>
   <data name="radioReplace.Text" xml:space="preserve">
     <value>替换现有值</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Name" xml:space="preserve">
-    <value>radioReplace</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioReplace.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="radioSkip.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
@@ -728,18 +656,6 @@
   <data name="radioSkip.Text" xml:space="preserve">
     <value>离开现有值</value>
   </data>
-  <data name="&gt;&gt;radioSkip.Name" xml:space="preserve">
-    <value>radioSkip</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;radioSkip.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelChoice.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -761,18 +677,6 @@
   <data name="labelChoice.Text" xml:space="preserve">
     <value>选择您希望以何种方式处理这些肽段：</value>
   </data>
-  <data name="&gt;&gt;labelChoice.Name" xml:space="preserve">
-    <value>labelChoice</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelChoice.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="labelExisting.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -791,18 +695,6 @@
   <data name="labelExisting.Text" xml:space="preserve">
     <value>库中已经有 {0} 个肽段具有值：</value>
   </data>
-  <data name="&gt;&gt;labelExisting.Name" xml:space="preserve">
-    <value>labelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;labelExisting.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="listExisting.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
@@ -814,18 +706,6 @@
   </data>
   <data name="listExisting.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Name" xml:space="preserve">
-    <value>listExisting</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listExisting.Parent" xml:space="preserve">
-    <value>panelExisting</value>
-  </data>
-  <data name="&gt;&gt;listExisting.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/MetadataRuleSetEditor.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/MetadataRuleSetEditor.ja.resx
@@ -393,18 +393,6 @@
   <data name="dataGridViewRules.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;dataGridViewRules.Name" xml:space="preserve">
-    <value>dataGridViewRules</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <metadata name="colSource.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -461,18 +449,6 @@
   </data>
   <data name="toolStripRules.Text" xml:space="preserve">
     <value>toolStrip1</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Name" xml:space="preserve">
-    <value>toolStripRules</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="btnRemove.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -597,18 +573,6 @@
   <data name="btnCancel.Text" xml:space="preserve">
     <value>キャンセル</value>
   </data>
-  <data name="&gt;&gt;btnCancel.Name" xml:space="preserve">
-    <value>btnCancel</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.Parent" xml:space="preserve">
-    <value>panelButtons</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnOK.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
@@ -626,18 +590,6 @@
   </data>
   <data name="btnOK.Text" xml:space="preserve">
     <value>OK</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Name" xml:space="preserve">
-    <value>btnOK</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Parent" xml:space="preserve">
-    <value>panelButtons</value>
-  </data>
-  <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/MetadataRuleSetEditor.resx
+++ b/pwiz_tools/Skyline/SettingsUI/MetadataRuleSetEditor.resx
@@ -393,18 +393,6 @@
   <data name="dataGridViewRules.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;dataGridViewRules.Name" xml:space="preserve">
-    <value>dataGridViewRules</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <metadata name="colSource.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -461,18 +449,6 @@
   </data>
   <data name="toolStripRules.Text" xml:space="preserve">
     <value>toolStrip1</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Name" xml:space="preserve">
-    <value>toolStripRules</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="btnRemove.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -597,18 +573,6 @@
   <data name="btnCancel.Text" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="&gt;&gt;btnCancel.Name" xml:space="preserve">
-    <value>btnCancel</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.Parent" xml:space="preserve">
-    <value>panelButtons</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnOK.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
@@ -626,18 +590,6 @@
   </data>
   <data name="btnOK.Text" xml:space="preserve">
     <value>OK</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Name" xml:space="preserve">
-    <value>btnOK</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Parent" xml:space="preserve">
-    <value>panelButtons</value>
-  </data>
-  <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/MetadataRuleSetEditor.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/MetadataRuleSetEditor.zh-CHS.resx
@@ -393,18 +393,6 @@
   <data name="dataGridViewRules.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;dataGridViewRules.Name" xml:space="preserve">
-    <value>dataGridViewRules</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewRules.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <metadata name="colSource.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -461,18 +449,6 @@
   </data>
   <data name="toolStripRules.Text" xml:space="preserve">
     <value>toolStrip1</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Name" xml:space="preserve">
-    <value>toolStripRules</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;toolStripRules.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="btnRemove.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -597,18 +573,6 @@
   <data name="btnCancel.Text" xml:space="preserve">
     <value>取消</value>
   </data>
-  <data name="&gt;&gt;btnCancel.Name" xml:space="preserve">
-    <value>btnCancel</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.Parent" xml:space="preserve">
-    <value>panelButtons</value>
-  </data>
-  <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="btnOK.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
@@ -626,18 +590,6 @@
   </data>
   <data name="btnOK.Text" xml:space="preserve">
     <value>确定</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Name" xml:space="preserve">
-    <value>btnOK</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Parent" xml:space="preserve">
-    <value>panelButtons</value>
-  </data>
-  <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.ja.resx
@@ -724,6 +724,9 @@
   <data name="FilterMidasLibraryDlg_OkDialog_You_must_enter_a_path_for_the_filtered_library_" xml:space="preserve">
     <value>フィルタされたライブラリのパスを入力してください。</value>
   </data>
+  <data name="FormulaBox_FormulaBox_Help" xml:space="preserve">
+    <value>Help</value>
+  </data>
   <data name="FormulaBox_FormulaHelpText_Formulas_are_written_in_standard_chemical_notation__e_g___C2H6O____Heavy_isotopes_are_indicated_by_a_prime__e_g__C__for_C13__or_double_prime_for_less_abundant_stable_iostopes__e_g__O__for_O17__O__for_O18__" xml:space="preserve">
     <value>式は標準の化学表記法（例：「C2H6O」）で書かれています。  重同位体は、プライム（例：C13のC'）か、存在量が低い安定同位体の場合ダブルプライム（例：O17のO"、O18のO'）で表されます。</value>
   </data>
@@ -1133,5 +1136,55 @@
   </data>
   <data name="WindowType_MEASUREMENT_Measurement" xml:space="preserve">
     <value>測定</value>
+  </data>
+  <data name="SpectrumGraphItem_library_entry_provides_only_precursor_values" xml:space="preserve">
+    <value>
+
+This library entry only provides precursor
+information, there is no spectrum to show</value>
+  </data>
+  <data name="FullScanSettingsControl_Initialize_minutes_of_detected_features" xml:space="preserve">
+    <value>minutes of detected features</value>
+  </data>
+  <data name="FullScanSettingsControl_InitializeFeatureDetectionUI_Hardklor_looks_for_isotope_envelopes_representing_charges_1__0___The_library_will_contain_only_ions_with_the_charges_listed_here_" xml:space="preserve">
+    <value>Hardklor looks for isotope envelopes representing charges 1-{0}. The resulting library will contain only ions with the charges listed here.</value>
+  </data>
+  <data name="FullScanSettingsControl_InitializeFeatureDetectionUI_This_is_the_value_assumed_by_Hardklor__it_cannot_be_adjusted_" xml:space="preserve">
+    <value>This is the value assumed by Hardklor, it cannot be adjusted.</value>
+  </data>
+  <data name="FullScanSettingsControl_InitializeMs1FilterUI_Sets_the_MS_data_type_for_Hardklor_s_FWHM_calculation__Normally_set_to_Centroided_" xml:space="preserve">
+    <value>Sets the MS data type for Hardklor's FWHM calculation. Normally set to Centroided.</value>
+  </data>
+  <data name="FullScanSettingsControl_InitializeMs1FilterUI_Sets_the_mass_analyzer_type_for_Hardklor_s_FWHM_calculation_" xml:space="preserve">
+    <value>Sets the mass analyzer type for Hardklor's FWHM calculation.</value>
+  </data>
+  <data name="FullScanSettingsControl_ModifyOptionsForImportPeptideSearchWizard_Instrument_Values" xml:space="preserve">
+    <value>&amp;Instrument values</value>
+  </data>
+  <data name="FullScanSettingsControl_ModifyOptionsForImportPeptideSearchWizard_Instrument_Values_from_Full_Scan_Settings" xml:space="preserve">
+    <value>Instrument values (from full-scan settings)</value>
+  </data>
+  <data name="FullScanSettingsControl_GetRetentionTimeFilterWarning_EncourageFullGradient" xml:space="preserve">
+    <value>{0} methods usually specify the time range for the mass spectrometer to acquire spectra.
+
+Applying retention time filtering in Skyline is typically unnecessary and may lead to truncated extracted ion chromatograms.
+
+Use this option only if your acquisition method includes multiple targets with the same m/z.</value>
+  </data>
+  <data name="EditPeakScoringModel_ExplictPeakBoundsWarning" xml:space="preserve">
+    <value>Are you sure you want to train a peak scoring model for this document?
+      
+This document uses peak boundaries from spectral libraries. When these boundaries are used, Skyline does not perform its own peak detection.
+
+Before training a peak scoring model, it is recommended that you follow these steps:
+
+1. Navigate to "Settings &gt; Peptide Settings - Libraries" tab and click "Edit List".
+2. Select a library item, click "Edit", and uncheck the "Use explicit peak bounds" checkbox.
+3. Navigate to "Edit &gt; Manage Results" and click the "Re-score" button.
+
+This will provide Skyline with a variety of candidate peaks to evaluate peak quality.</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_ShowEditPeakScoringModelDlg_Train_Model" xml:space="preserve">
+    <value>Train Model</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.zh-CHS.resx
@@ -724,6 +724,9 @@
   <data name="FilterMidasLibraryDlg_OkDialog_You_must_enter_a_path_for_the_filtered_library_" xml:space="preserve">
     <value>您必须为已过滤的库输入路径。</value>
   </data>
+  <data name="FormulaBox_FormulaBox_Help" xml:space="preserve">
+    <value>Help</value>
+  </data>
   <data name="FormulaBox_FormulaHelpText_Formulas_are_written_in_standard_chemical_notation__e_g___C2H6O____Heavy_isotopes_are_indicated_by_a_prime__e_g__C__for_C13__or_double_prime_for_less_abundant_stable_iostopes__e_g__O__for_O17__O__for_O18__" xml:space="preserve">
     <value>以标准化学表示法写入公式，例如“C2H6O”。 重同位素以素数表示（例如，C' 表示 C13），双素数表示丰富度较低的稳定同位素（例如，O" 表示 O17，O' 表示 O18）。</value>
   </data>
@@ -1133,5 +1136,55 @@
   </data>
   <data name="WindowType_MEASUREMENT_Measurement" xml:space="preserve">
     <value>测量</value>
+  </data>
+  <data name="SpectrumGraphItem_library_entry_provides_only_precursor_values" xml:space="preserve">
+    <value>
+
+This library entry only provides precursor
+information, there is no spectrum to show</value>
+  </data>
+  <data name="FullScanSettingsControl_Initialize_minutes_of_detected_features" xml:space="preserve">
+    <value>minutes of detected features</value>
+  </data>
+  <data name="FullScanSettingsControl_InitializeFeatureDetectionUI_Hardklor_looks_for_isotope_envelopes_representing_charges_1__0___The_library_will_contain_only_ions_with_the_charges_listed_here_" xml:space="preserve">
+    <value>Hardklor looks for isotope envelopes representing charges 1-{0}. The resulting library will contain only ions with the charges listed here.</value>
+  </data>
+  <data name="FullScanSettingsControl_InitializeFeatureDetectionUI_This_is_the_value_assumed_by_Hardklor__it_cannot_be_adjusted_" xml:space="preserve">
+    <value>This is the value assumed by Hardklor, it cannot be adjusted.</value>
+  </data>
+  <data name="FullScanSettingsControl_InitializeMs1FilterUI_Sets_the_MS_data_type_for_Hardklor_s_FWHM_calculation__Normally_set_to_Centroided_" xml:space="preserve">
+    <value>Sets the MS data type for Hardklor's FWHM calculation. Normally set to Centroided.</value>
+  </data>
+  <data name="FullScanSettingsControl_InitializeMs1FilterUI_Sets_the_mass_analyzer_type_for_Hardklor_s_FWHM_calculation_" xml:space="preserve">
+    <value>Sets the mass analyzer type for Hardklor's FWHM calculation.</value>
+  </data>
+  <data name="FullScanSettingsControl_ModifyOptionsForImportPeptideSearchWizard_Instrument_Values" xml:space="preserve">
+    <value>&amp;Instrument values</value>
+  </data>
+  <data name="FullScanSettingsControl_ModifyOptionsForImportPeptideSearchWizard_Instrument_Values_from_Full_Scan_Settings" xml:space="preserve">
+    <value>Instrument values (from full-scan settings)</value>
+  </data>
+  <data name="FullScanSettingsControl_GetRetentionTimeFilterWarning_EncourageFullGradient" xml:space="preserve">
+    <value>{0} methods usually specify the time range for the mass spectrometer to acquire spectra.
+
+Applying retention time filtering in Skyline is typically unnecessary and may lead to truncated extracted ion chromatograms.
+
+Use this option only if your acquisition method includes multiple targets with the same m/z.</value>
+  </data>
+  <data name="EditPeakScoringModel_ExplictPeakBoundsWarning" xml:space="preserve">
+    <value>Are you sure you want to train a peak scoring model for this document?
+      
+This document uses peak boundaries from spectral libraries. When these boundaries are used, Skyline does not perform its own peak detection.
+
+Before training a peak scoring model, it is recommended that you follow these steps:
+
+1. Navigate to "Settings &gt; Peptide Settings - Libraries" tab and click "Edit List".
+2. Select a library item, click "Edit", and uncheck the "Use explicit peak bounds" checkbox.
+3. Navigate to "Edit &gt; Manage Results" and click the "Re-score" button.
+
+This will provide Skyline with a variety of candidate peaks to evaluate peak quality.</value>
+  </data>
+  <data name="EditPeakScoringModelDlg_ShowEditPeakScoringModelDlg_Train_Model" xml:space="preserve">
+    <value>Train Model</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.ja.resx
@@ -468,18 +468,6 @@
   <data name="tabGeneral.Text" xml:space="preserve">
     <value>予測</value>
   </data>
-  <data name="&gt;&gt;tabGeneral.Name" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboCompensationVoltage.Location" type="System.Drawing.Point, System.Drawing">
     <value>208, 179</value>
   </data>
@@ -488,18 +476,6 @@
   </data>
   <data name="comboCompensationVoltage.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Name" xml:space="preserve">
-    <value>comboCompensationVoltage</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -519,18 +495,6 @@
   <data name="label19.Text" xml:space="preserve">
     <value>補償電圧(&amp;V)：</value>
   </data>
-  <data name="&gt;&gt;label19.Name" xml:space="preserve">
-    <value>label19</value>
-  </data>
-  <data name="&gt;&gt;label19.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label19.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label19.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="comboOptimizationLibrary.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 179</value>
   </data>
@@ -539,18 +503,6 @@
   </data>
   <data name="comboOptimizationLibrary.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Name" xml:space="preserve">
-    <value>comboOptimizationLibrary</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -570,18 +522,6 @@
   <data name="label20.Text" xml:space="preserve">
     <value>最適化ライブラリ(&amp;O)：</value>
   </data>
-  <data name="&gt;&gt;label20.Name" xml:space="preserve">
-    <value>label20</value>
-  </data>
-  <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label20.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="labelOptimizeType.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -599,18 +539,6 @@
   </data>
   <data name="labelOptimizeType.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Name" xml:space="preserve">
-    <value>labelOptimizeType</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <metadata name="helpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
@@ -637,18 +565,6 @@
   <data name="comboOptimizeType.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;comboOptimizeType.Name" xml:space="preserve">
-    <value>comboOptimizeType</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="cbUseOptimized.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -669,18 +585,6 @@
 DPの最適化値が、メソッドおよびトランジションのリストで
 エクスポートされた値の選択に使用されます。 最大総ピーク面積を生成する値が選択されます。</value>
   </data>
-  <data name="&gt;&gt;cbUseOptimized.Name" xml:space="preserve">
-    <value>cbUseOptimized</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="comboDeclusterPotential.Location" type="System.Drawing.Point, System.Drawing">
     <value>208, 109</value>
   </data>
@@ -692,18 +596,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="comboDeclusterPotential.ToolTip" xml:space="preserve">
     <value>プリカーサーイオンのm/z値からデクラスタリングポテンシャル（DP）を計算するための一次方程式です。同位体標識ペプチドは、非標識ペプチドと同一のDPを使用します。（AB装置のみ）</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Name" xml:space="preserve">
-    <value>comboDeclusterPotential</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -720,18 +612,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="label12.Text" xml:space="preserve">
     <value>デクラスタリングポテンシャル(&amp;D)：</value>
   </data>
-  <data name="&gt;&gt;label12.Name" xml:space="preserve">
-    <value>label12</value>
-  </data>
-  <data name="&gt;&gt;label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label12.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="comboCollisionEnergy.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 109</value>
   </data>
@@ -743,18 +623,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="comboCollisionEnergy.ToolTip" xml:space="preserve">
     <value>プリカーサーイオンのm/z値から最適衝突エネルギー (CE) を計算するための一次方程式です。同位体標識ペプチドは、非標識ペプチドと同一のCEを使用します。</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Name" xml:space="preserve">
-    <value>comboCollisionEnergy</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.ZOrder" xml:space="preserve">
-    <value>9</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -770,18 +638,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>衝突エネルギー(&amp;C)：</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>10</value>
   </data>
   <data name="comboIonMass.Items" xml:space="preserve">
     <value>モノアイソトピック</value>
@@ -802,18 +658,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
     <value>すべてのプリカーサー質量の計算に使用する
 分子質量計算法 (モノアイソトピックまたは平均) です</value>
   </data>
-  <data name="&gt;&gt;comboIonMass.Name" xml:space="preserve">
-    <value>comboIonMass</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -828,18 +672,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>プロダクトイオン質量(&amp;D)：</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>12</value>
   </data>
   <data name="comboPrecursorMass.Items" xml:space="preserve">
     <value>モノアイソトピック</value>
@@ -860,18 +692,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
     <value>すべてのプリカーサー質量の計算に使用する
 分子質量計算法 (モノアイソトピックまたは平均) です。</value>
   </data>
-  <data name="&gt;&gt;comboPrecursorMass.Name" xml:space="preserve">
-    <value>comboPrecursorMass</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -886,18 +706,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>プリカーサー質量(&amp;P)：</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <data name="&gt;&gt;cbExclusionUseDIAWindow.Name" xml:space="preserve">
     <value>cbExclusionUseDIAWindow</value>
@@ -986,18 +794,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="tabFilter.Text" xml:space="preserve">
     <value>フィルタ</value>
   </data>
-  <data name="&gt;&gt;tabFilter.Name" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="cbExclusionUseDIAWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1022,18 +818,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="cbExclusionUseDIAWindow.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Name" xml:space="preserve">
-    <value>cbExclusionUseDIAWindow</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lbMZ.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1051,18 +835,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="lbMZ.Text" xml:space="preserve">
     <value>m/z</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Name" xml:space="preserve">
-    <value>lbMZ</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
     <value>tabPage1</value>
@@ -1096,18 +868,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="tabControlPeptidesSmallMols.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Name" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="&gt;&gt;label5.Name" xml:space="preserve">
     <value>label5</value>
@@ -1208,18 +968,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="tabPage1.Text" xml:space="preserve">
     <value>ペプチド</value>
   </data>
-  <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1235,18 +983,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="label5.Text" xml:space="preserve">
     <value>プリカーサーイオンの電荷(&amp;P)：</value>
   </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textPeptideIonTypes.Location" type="System.Drawing.Point, System.Drawing">
     <value>232, 26</value>
   </data>
@@ -1260,18 +996,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
     <value>プロダクトイオン候補の計算に用いるプロダクトイオンタイプ（a, b, c, x, y, z, z., z', p（プリカーサー）） のカンマ区切りのリストです。 z. および z’ はz+1ラジカルイオンおよびz+2イオンを意味します。
 これらは通常、ExD実験にみられます。
 代わりに z* や z" を使用することもできます。 </value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Name" xml:space="preserve">
-    <value>textPeptideIonTypes</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;btnEditSpecialTransitions.Name" xml:space="preserve">
     <value>btnEditSpecialTransitions</value>
@@ -1369,18 +1093,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="groupBox1.Text" xml:space="preserve">
     <value>プロダクトイオンの選択</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="btnEditSpecialTransitions.Location" type="System.Drawing.Point, System.Drawing">
     <value>194, 103</value>
   </data>
@@ -1395,18 +1107,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="btnEditSpecialTransitions.ToolTip" xml:space="preserve">
     <value>利用可能な特別なプロダクトイオンのリストを編集</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Name" xml:space="preserve">
-    <value>btnEditSpecialTransitions</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="label18.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1423,18 +1123,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="label18.Text" xml:space="preserve">
     <value>特別なイオン(&amp;S)：</value>
   </data>
-  <data name="&gt;&gt;label18.Name" xml:space="preserve">
-    <value>label18</value>
-  </data>
-  <data name="&gt;&gt;label18.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label18.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="listAlwaysAdd.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 103</value>
   </data>
@@ -1447,18 +1135,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="listAlwaysAdd.ToolTip" xml:space="preserve">
     <value>フィルタ範囲外であっても、存在していれば 測定される特別なプロダクトイオンのセットです</value>
   </data>
-  <data name="&gt;&gt;listAlwaysAdd.Name" xml:space="preserve">
-    <value>listAlwaysAdd</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckedListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="comboRangeFrom.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 44</value>
   </data>
@@ -1470,18 +1146,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="comboRangeFrom.ToolTip" xml:space="preserve">
     <value>フィルタ範囲のイオンに対する開始時プロダクトイオン</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Name" xml:space="preserve">
-    <value>comboRangeFrom</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1498,18 +1162,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="label3.Text" xml:space="preserve">
     <value>開始点(&amp;F)：</value>
   </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="comboRangeTo.Location" type="System.Drawing.Point, System.Drawing">
     <value>173, 43</value>
   </data>
@@ -1521,18 +1173,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="comboRangeTo.ToolTip" xml:space="preserve">
     <value>プロダクトイオンのフィルタ範囲の終了点</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Name" xml:space="preserve">
-    <value>comboRangeTo</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1549,18 +1189,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="label4.Text" xml:space="preserve">
     <value>終了点(&amp;O)：</value>
   </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1575,18 +1203,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="label6.Text" xml:space="preserve">
     <value>イオン電荷(&amp;I)：</value>
-  </data>
-  <data name="&gt;&gt;label6.Name" xml:space="preserve">
-    <value>label6</value>
-  </data>
-  <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1603,18 +1219,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="label8.Text" xml:space="preserve">
     <value>イオンタイプ(&amp;T)：</value>
   </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
-  </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textPeptidePrecursorCharges.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 26</value>
   </data>
@@ -1627,18 +1231,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="textPeptidePrecursorCharges.ToolTip" xml:space="preserve">
     <value>プリカーサーのm/z値の計算に使用する カンマ区切りの荷電状態のリストです</value>
   </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Name" xml:space="preserve">
-    <value>textPeptidePrecursorCharges</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="textPeptideIonCharges.Location" type="System.Drawing.Point, System.Drawing">
     <value>122, 26</value>
   </data>
@@ -1650,18 +1242,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="textPeptideIonCharges.ToolTip" xml:space="preserve">
     <value>プロダクトイオンのm/z値の計算に使用する カンマ区切りの荷電状態のリストです</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Name" xml:space="preserve">
-    <value>textPeptideIonCharges</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="&gt;&gt;btnPrecursorAdduct.Name" xml:space="preserve">
     <value>btnPrecursorAdduct</value>
@@ -1774,18 +1354,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   <data name="tabPage2.Text" xml:space="preserve">
     <value>分子</value>
   </data>
-  <data name="&gt;&gt;tabPage2.Name" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="btnPrecursorAdduct.Location" type="System.Drawing.Point, System.Drawing">
     <value>286, 24</value>
   </data>
@@ -1794,18 +1362,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="btnPrecursorAdduct.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Name" xml:space="preserve">
-    <value>btnPrecursorAdduct</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="btnFragmentAdduct.Location" type="System.Drawing.Point, System.Drawing">
     <value>286, 63</value>
@@ -1818,18 +1374,6 @@ DPの最適化値が、メソッドおよびトランジションのリストで
   </data>
   <data name="btnFragmentAdduct.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Name" xml:space="preserve">
-    <value>btnFragmentAdduct</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="textSmallMoleculeFragmentAdducts.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 66</value>
@@ -1855,18 +1399,6 @@ ACN (C2H3N)、DMSO (C2H6OS)、FA (CH2O2)、Hac (CH3COOH)、TFA (C2HF3O2)、IsoPr
 荷電状態はこれらの付加イオン成分から推測されます：
 H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)、HCOO (-1)、NH4 (+1)</value>
   </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Name" xml:space="preserve">
-    <value>textSmallMoleculeFragmentAdducts</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelSmallMoleculeFragmentAdducts.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1885,18 +1417,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="labelSmallMoleculeFragmentAdducts.Text" xml:space="preserve">
     <value>フラグメント付加イオン(&amp;N)：</value>
   </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Name" xml:space="preserve">
-    <value>labelSmallMoleculeFragmentAdducts</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="textSmallMoleculeIonTypes.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 112</value>
   </data>
@@ -1908,18 +1428,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="textSmallMoleculeIonTypes.ToolTip" xml:space="preserve">
     <value>スペクトルライブラリのフィルタに用いるプロダクトイオンのタイプ（fはフラグメント、pはプリカーサー） のカンマ区切りのリストです </value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Name" xml:space="preserve">
-    <value>textSmallMoleculeIonTypes</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="labelSmallMoleculeIonTypes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1938,18 +1446,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="labelSmallMoleculeIonTypes.Text" xml:space="preserve">
     <value>イオンタイプ(&amp;T)：</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Name" xml:space="preserve">
-    <value>labelSmallMoleculeIonTypes</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="textSmallMoleculePrecursorAdducts.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 26</value>
@@ -1975,18 +1471,6 @@ ACN (C2H3N)、DMSO (C2H6OS)、FA (CH2O2)、Hac (CH3COOH)、TFA (C2HF3O2)、IsoPr
 荷電状態はこれらの付加イオン成分から推測されます：
 H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)、HCOO (-1)、NH4 (+1)</value>
   </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Name" xml:space="preserve">
-    <value>textSmallMoleculePrecursorAdducts</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="lblSmallMoleculePrecursorAdducts.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2008,18 +1492,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="lblSmallMoleculePrecursorAdducts.Text" xml:space="preserve">
     <value>プリカーサー付加イオン(&amp;A)：</value>
   </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Name" xml:space="preserve">
-    <value>lblSmallMoleculePrecursorAdducts</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textExclusionWindow.Location" type="System.Drawing.Point, System.Drawing">
     <value>24, 408</value>
   </data>
@@ -2032,18 +1504,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="textExclusionWindow.ToolTip" xml:space="preserve">
     <value>プリカーサーイオンm/z近傍のトランジションを除外または空白にするm/zウィンドウです。たとえば、ウィンドウ値 20の場合は、 
 プリカーサーイオンm/z値の前後10の範囲内にあるすべてのトランジションを除外します。</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Name" xml:space="preserve">
-    <value>textExclusionWindow</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="cbAutoSelect.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2065,18 +1525,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
 トランジションが自動的に選択されます。オフにすると、すべてのトランジションを
 手動ドキュメント編集で選択する必要があります。</value>
   </data>
-  <data name="&gt;&gt;cbAutoSelect.Name" xml:space="preserve">
-    <value>cbAutoSelect</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="lbPrecursorMzWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2091,18 +1539,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="lbPrecursorMzWindow.Text" xml:space="preserve">
     <value>プリカーサーm/zのexclusionウィンドウ(&amp;X)：</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Name" xml:space="preserve">
-    <value>lbPrecursorMzWindow</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="&gt;&gt;label23.Name" xml:space="preserve">
     <value>label23</value>
@@ -2191,18 +1627,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="tabLibrary.Text" xml:space="preserve">
     <value>ライブラリ</value>
   </data>
-  <data name="&gt;&gt;tabLibrary.Name" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2224,18 +1648,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label23.Text" xml:space="preserve">
     <value>許容誤差単位(&amp;N)：</value>
   </data>
-  <data name="&gt;&gt;label23.Name" xml:space="preserve">
-    <value>label23</value>
-  </data>
-  <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboToleranceUnits.Items" xml:space="preserve">
     <value>m/z</value>
   </data>
@@ -2251,18 +1663,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="comboToleranceUnits.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <data name="&gt;&gt;comboToleranceUnits.Name" xml:space="preserve">
-    <value>comboToleranceUnits</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="label9.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2277,18 +1677,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="label9.Text" xml:space="preserve">
     <value>イオン許容誤差(&amp;I)：</value>
-  </data>
-  <data name="&gt;&gt;label9.Name" xml:space="preserve">
-    <value>label9</value>
-  </data>
-  <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="&gt;&gt;label22.Name" xml:space="preserve">
     <value>label22</value>
@@ -2395,18 +1783,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="panelPick.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;panelPick.Name" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;panelPick.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelPick.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;panelPick.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2425,18 +1801,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label22.Text" xml:space="preserve">
     <value>最小プロダクトイオン数</value>
   </data>
-  <data name="&gt;&gt;label22.Name" xml:space="preserve">
-    <value>label22</value>
-  </data>
-  <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label22.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textMinIonCount.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 51</value>
   </data>
@@ -2448,18 +1812,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="textMinIonCount.ToolTip" xml:space="preserve">
     <value>最低これだけのトランジションでプリカーサーを選択</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Name" xml:space="preserve">
-    <value>textMinIonCount</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="radioAllAndFiltered.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2482,18 +1834,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
 しかし、一致するプロダクトイオンがライブラリに見つからない場合には、
 フィルタに合うすべてのプロダクトイオンも追加します</value>
   </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Name" xml:space="preserve">
-    <value>radioAllAndFiltered</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="radioFiltered.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2511,18 +1851,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="radioFiltered.ToolTip" xml:space="preserve">
     <value>[フィルタ]タブのパラメータを適用して、ランク付けのために、一致するイオンをMS / MSピークから選択します</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Name" xml:space="preserve">
-    <value>radioFiltered</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="radioAll.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2542,18 +1870,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="radioAll.ToolTip" xml:space="preserve">
     <value>[フィルタ] タブで設定したイオン電荷数とイオンのタイプのみを用い、ランク付けのために、ライブラリと一致するプロダクトイオンをMS/MSピークから選択します。</value>
   </data>
-  <data name="&gt;&gt;radioAll.Name" xml:space="preserve">
-    <value>radioAll</value>
-  </data>
-  <data name="&gt;&gt;radioAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAll.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioAll.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="label14.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2568,18 +1884,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="label14.Text" xml:space="preserve">
     <value>選択(&amp;P)：</value>
-  </data>
-  <data name="&gt;&gt;label14.Name" xml:space="preserve">
-    <value>label14</value>
-  </data>
-  <data name="&gt;&gt;label14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label14.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label15.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2596,18 +1900,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label15.Text" xml:space="preserve">
     <value>プロダクトイオン</value>
   </data>
-  <data name="&gt;&gt;label15.Name" xml:space="preserve">
-    <value>label15</value>
-  </data>
-  <data name="&gt;&gt;label15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label15.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="textIonCount.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 25</value>
   </data>
@@ -2621,18 +1913,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>ライブラリスペクトルピーク強度ランク別に
 各プリカーサーに対してこのトランジションを選択します</value>
   </data>
-  <data name="&gt;&gt;textIonCount.Name" xml:space="preserve">
-    <value>textIonCount</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textTolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>21, 41</value>
   </data>
@@ -2645,18 +1925,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="textTolerance.ToolTip" xml:space="preserve">
     <value>予測プロダクトイオンm/z値を測定MS/MSスペクトルライブラリ
 ピークm/z値にマッチするときの最大許容誤差です。</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Name" xml:space="preserve">
-    <value>textTolerance</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="cbLibraryPick.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2676,18 +1944,6 @@ H (+1)、K (+1)、Na (+1),、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="cbLibraryPick.ToolTip" xml:space="preserve">
     <value>チェックマークをオンにすると、トランジションフィルタはペプチドがライブラリスペクトルに一致する場合には、MS /
 MSスペクトルライブラリのピークに基づいて選択されます。</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Name" xml:space="preserve">
-    <value>cbLibraryPick</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="&gt;&gt;cbxTriggeredAcquisition.Name" xml:space="preserve">
     <value>cbxTriggeredAcquisition</value>
@@ -2953,18 +2209,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="tabInstrument.Text" xml:space="preserve">
     <value>装置</value>
   </data>
-  <data name="&gt;&gt;tabInstrument.Name" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="cbxTriggeredAcquisition.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2984,18 +2228,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
     <value>特定のアナライトに対してスペクトルを取得した場合、保持時間に大きなギャップがある可能性があることを示しています。
 ピークは、これらのギャップと重ならないように切り詰められ、バックグラウンドは差し引かれません。</value>
   </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Name" xml:space="preserve">
-    <value>cbxTriggeredAcquisition</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textMaxInclusions.Location" type="System.Drawing.Point, System.Drawing">
     <value>189, 185</value>
   </data>
@@ -3008,18 +2240,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="textMaxInclusions.ToolTip" xml:space="preserve">
     <value>多重化スキャン中に使用する装置で測定した
 最大インクルージョンウィンドウ数です。</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Name" xml:space="preserve">
-    <value>textMaxInclusions</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="label21.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3036,18 +2256,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="label21.Text" xml:space="preserve">
     <value>ファームウェア包含制限(&amp;I)：</value>
   </data>
-  <data name="&gt;&gt;label21.Name" xml:space="preserve">
-    <value>label21</value>
-  </data>
-  <data name="&gt;&gt;label21.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label21.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label21.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="label30.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3062,18 +2270,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   </data>
   <data name="label30.Text" xml:space="preserve">
     <value>分</value>
-  </data>
-  <data name="&gt;&gt;label30.Name" xml:space="preserve">
-    <value>label30</value>
-  </data>
-  <data name="&gt;&gt;label30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label30.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label30.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label31.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3090,18 +2286,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="label31.Text" xml:space="preserve">
     <value>分</value>
   </data>
-  <data name="&gt;&gt;label31.Name" xml:space="preserve">
-    <value>label31</value>
-  </data>
-  <data name="&gt;&gt;label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label31.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label31.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="label33.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3116,18 +2300,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   </data>
   <data name="label33.Text" xml:space="preserve">
     <value>最大時間(&amp;A)：</value>
-  </data>
-  <data name="&gt;&gt;label33.Name" xml:space="preserve">
-    <value>label33</value>
-  </data>
-  <data name="&gt;&gt;label33.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label34.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3144,18 +2316,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="label34.Text" xml:space="preserve">
     <value>最小時間(&amp;N)：</value>
   </data>
-  <data name="&gt;&gt;label34.Name" xml:space="preserve">
-    <value>label34</value>
-  </data>
-  <data name="&gt;&gt;label34.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label34.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label34.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="textMaxTime.Location" type="System.Drawing.Point, System.Drawing">
     <value>190, 249</value>
   </data>
@@ -3170,18 +2330,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
 クロマトグラムにおける最大許容時間。 これを設定すると、データ採取に関与しない部分のグラジアントで使用される可能性のある
 メモリとディスク容量を節約できます。</value>
   </data>
-  <data name="&gt;&gt;textMaxTime.Name" xml:space="preserve">
-    <value>textMaxTime</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textMinTime.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 249</value>
   </data>
@@ -3195,18 +2343,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
     <value>分析方法を問わず、
 クロマトグラムにおける最小許容時間。 これを設定すると、データ採取に関与しない部分のグラジアントで使用される可能性のある
 メモリとディスク容量を節約できます。</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Name" xml:space="preserve">
-    <value>textMinTime</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="label26.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3226,18 +2362,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="label26.Text" xml:space="preserve">
     <value>m/z</value>
   </data>
-  <data name="&gt;&gt;label26.Name" xml:space="preserve">
-    <value>label26</value>
-  </data>
-  <data name="&gt;&gt;label26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="label25.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3256,18 +2380,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="label25.Text" xml:space="preserve">
     <value>m/z</value>
   </data>
-  <data name="&gt;&gt;label25.Name" xml:space="preserve">
-    <value>label25</value>
-  </data>
-  <data name="&gt;&gt;label25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label25.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label25.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3285,18 +2397,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   </data>
   <data name="label24.Text" xml:space="preserve">
     <value>m/z</value>
-  </data>
-  <data name="&gt;&gt;label24.Name" xml:space="preserve">
-    <value>label24</value>
-  </data>
-  <data name="&gt;&gt;label24.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label24.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>11</value>
   </data>
   <data name="cbDynamicMinimum.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3318,18 +2418,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
 プリカーサーイオンm/zから動的に計算します。
 この計算にはThermo-Scientificが提供するLTQ測定器用の特定の方程式を用います。</value>
   </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Name" xml:space="preserve">
-    <value>cbDynamicMinimum</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="textMaxTrans.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 185</value>
   </data>
@@ -3342,18 +2430,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="textMaxTrans.ToolTip" xml:space="preserve">
     <value>1 回の注入でターゲット装置により測定可能な最大総トランジション数です。
 最大値が適用されない場合は空白となります</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Name" xml:space="preserve">
-    <value>textMaxTrans</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.ZOrder" xml:space="preserve">
-    <value>13</value>
   </data>
   <data name="label17.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3370,18 +2446,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="label17.Text" xml:space="preserve">
     <value>ファームウェアトランジション制限(&amp;F)：</value>
   </data>
-  <data name="&gt;&gt;label17.Name" xml:space="preserve">
-    <value>label17</value>
-  </data>
-  <data name="&gt;&gt;label17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label17.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
   <data name="textMzMatchTolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 124</value>
   </data>
@@ -3395,18 +2459,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
     <value>装置メソッドのトランジションm/z値を
 予測トランジションm/z値とマッチする時の最大許容誤差です。
 （SRMとターゲットMS/MSデータにのみ適用。）</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Name" xml:space="preserve">
-    <value>textMzMatchTolerance</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="lblMethodMatchTolerance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3423,18 +2475,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="lblMethodMatchTolerance.Text" xml:space="preserve">
     <value>メソッド許容誤差m/z(&amp;t)：</value>
   </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Name" xml:space="preserve">
-    <value>lblMethodMatchTolerance</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
   <data name="label10.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3449,18 +2489,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   </data>
   <data name="label10.Text" xml:space="preserve">
     <value>最大m/z(&amp;X)：</value>
-  </data>
-  <data name="&gt;&gt;label10.Name" xml:space="preserve">
-    <value>label10</value>
-  </data>
-  <data name="&gt;&gt;label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>17</value>
   </data>
   <data name="label11.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3477,18 +2505,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="label11.Text" xml:space="preserve">
     <value>最小m/z(&amp;M)：</value>
   </data>
-  <data name="&gt;&gt;label11.Name" xml:space="preserve">
-    <value>label11</value>
-  </data>
-  <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
   <data name="textMaxMz.Location" type="System.Drawing.Point, System.Drawing">
     <value>190, 38</value>
   </data>
@@ -3501,18 +2517,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="textMaxMz.ToolTip" xml:space="preserve">
     <value>ターゲット装置で測定可能な最大m/z値です</value>
   </data>
-  <data name="&gt;&gt;textMaxMz.Name" xml:space="preserve">
-    <value>textMaxMz</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
   <data name="textMinMz.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 38</value>
   </data>
@@ -3524,18 +2528,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   </data>
   <data name="textMinMz.ToolTip" xml:space="preserve">
     <value>ターゲット装置で測定可能な最小m/z値です</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Name" xml:space="preserve">
-    <value>textMinMz</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.ZOrder" xml:space="preserve">
-    <value>20</value>
   </data>
   <data name="tabFullScan.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -3551,18 +2543,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   </data>
   <data name="tabFullScan.Text" xml:space="preserve">
     <value>フルスキャン</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Name" xml:space="preserve">
-    <value>tabFullScan</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="&gt;&gt;ionMobilityFilteringControl.Name" xml:space="preserve">
     <value>ionMobilityFilteringControl</value>
@@ -3588,18 +2568,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
   <data name="tabIonMobility.Text" xml:space="preserve">
     <value>イオン移動度</value>
   </data>
-  <data name="&gt;&gt;tabIonMobility.Name" xml:space="preserve">
-    <value>tabIonMobility</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="ionMobilityFilteringControl.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 13</value>
   </data>
@@ -3607,18 +2575,6 @@ MSスペクトルライブラリのピークに基づいて選択されます。
     <value>334, 281</value>
   </data>
   <data name="ionMobilityFilteringControl.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Name" xml:space="preserve">
-    <value>ionMobilityFilteringControl</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Type" xml:space="preserve">
-    <value>pwiz.Skyline.SettingsUI.IonMobility.IonMobilityFilteringUserControl, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Parent" xml:space="preserve">
-    <value>tabIonMobility</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="helpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.resx
+++ b/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.resx
@@ -468,18 +468,6 @@
   <data name="tabGeneral.Text" xml:space="preserve">
     <value>Prediction</value>
   </data>
-  <data name="&gt;&gt;tabGeneral.Name" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboCompensationVoltage.Location" type="System.Drawing.Point, System.Drawing">
     <value>208, 179</value>
   </data>
@@ -488,18 +476,6 @@
   </data>
   <data name="comboCompensationVoltage.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Name" xml:space="preserve">
-    <value>comboCompensationVoltage</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -519,18 +495,6 @@
   <data name="label19.Text" xml:space="preserve">
     <value>Compensation &amp;voltage:</value>
   </data>
-  <data name="&gt;&gt;label19.Name" xml:space="preserve">
-    <value>label19</value>
-  </data>
-  <data name="&gt;&gt;label19.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label19.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label19.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="comboOptimizationLibrary.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 179</value>
   </data>
@@ -539,18 +503,6 @@
   </data>
   <data name="comboOptimizationLibrary.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Name" xml:space="preserve">
-    <value>comboOptimizationLibrary</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -570,18 +522,6 @@
   <data name="label20.Text" xml:space="preserve">
     <value>&amp;Optimization library:</value>
   </data>
-  <data name="&gt;&gt;label20.Name" xml:space="preserve">
-    <value>label20</value>
-  </data>
-  <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label20.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="labelOptimizeType.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -599,18 +539,6 @@
   </data>
   <data name="labelOptimizeType.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Name" xml:space="preserve">
-    <value>labelOptimizeType</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <metadata name="helpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
@@ -637,18 +565,6 @@ in each precursor totaled or for each transition separately</value>
   <data name="comboOptimizeType.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;comboOptimizeType.Name" xml:space="preserve">
-    <value>comboOptimizeType</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="cbUseOptimized.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -670,18 +586,6 @@ be used to select the value exported in methods and transition
 lists. The value producing the maximum total peak area will be
 chosen.</value>
   </data>
-  <data name="&gt;&gt;cbUseOptimized.Name" xml:space="preserve">
-    <value>cbUseOptimized</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="comboDeclusterPotential.Location" type="System.Drawing.Point, System.Drawing">
     <value>208, 109</value>
   </data>
@@ -695,18 +599,6 @@ chosen.</value>
     <value>A linear equation used to predict the optimal declustering potential (DP)
 for each precursor from its mass-to-charge ratio. Isotope labeled peptides
 use the predicted DP for the unlabeled form. (AB instruments only)</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Name" xml:space="preserve">
-    <value>comboDeclusterPotential</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -723,18 +615,6 @@ use the predicted DP for the unlabeled form. (AB instruments only)</value>
   <data name="label12.Text" xml:space="preserve">
     <value>&amp;Declustering potential:</value>
   </data>
-  <data name="&gt;&gt;label12.Name" xml:space="preserve">
-    <value>label12</value>
-  </data>
-  <data name="&gt;&gt;label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label12.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="comboCollisionEnergy.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 109</value>
   </data>
@@ -748,18 +628,6 @@ use the predicted DP for the unlabeled form. (AB instruments only)</value>
     <value>A linear equation used to predict the optimal collsion energy (CE)
 for each precursor from its mass-to-charge ratio. Isotope labeled
 peptides use the predicted CE for the unlabeled form.</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Name" xml:space="preserve">
-    <value>comboCollisionEnergy</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.ZOrder" xml:space="preserve">
-    <value>9</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -775,18 +643,6 @@ peptides use the predicted CE for the unlabeled form.</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>&amp;Collision energy:</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>10</value>
   </data>
   <data name="comboIonMass.Items" xml:space="preserve">
     <value>Monoisotopic</value>
@@ -807,18 +663,6 @@ peptides use the predicted CE for the unlabeled form.</value>
     <value>Molecular mass calculation strategy (monoisotopic or average)
 to use in calculating all product ion masses</value>
   </data>
-  <data name="&gt;&gt;comboIonMass.Name" xml:space="preserve">
-    <value>comboIonMass</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -833,18 +677,6 @@ to use in calculating all product ion masses</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>Pro&amp;duct ion mass:</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>12</value>
   </data>
   <data name="comboPrecursorMass.Items" xml:space="preserve">
     <value>Monoisotopic</value>
@@ -865,18 +697,6 @@ to use in calculating all product ion masses</value>
     <value>Molecular mass calculation strategy (monoisotopic or average)
 to use in calculating all precursor masses</value>
   </data>
-  <data name="&gt;&gt;comboPrecursorMass.Name" xml:space="preserve">
-    <value>comboPrecursorMass</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -891,18 +711,6 @@ to use in calculating all precursor masses</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>&amp;Precursor mass:</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <data name="&gt;&gt;cbExclusionUseDIAWindow.Name" xml:space="preserve">
     <value>cbExclusionUseDIAWindow</value>
@@ -991,18 +799,6 @@ to use in calculating all precursor masses</value>
   <data name="tabFilter.Text" xml:space="preserve">
     <value>Filter</value>
   </data>
-  <data name="&gt;&gt;tabFilter.Name" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="cbExclusionUseDIAWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1027,18 +823,6 @@ to use in calculating all precursor masses</value>
   <data name="cbExclusionUseDIAWindow.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Name" xml:space="preserve">
-    <value>cbExclusionUseDIAWindow</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lbMZ.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1056,18 +840,6 @@ to use in calculating all precursor masses</value>
   </data>
   <data name="lbMZ.Text" xml:space="preserve">
     <value>m/z</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Name" xml:space="preserve">
-    <value>lbMZ</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
     <value>tabPage1</value>
@@ -1101,18 +873,6 @@ to use in calculating all precursor masses</value>
   </data>
   <data name="tabControlPeptidesSmallMols.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Name" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="&gt;&gt;label5.Name" xml:space="preserve">
     <value>label5</value>
@@ -1213,18 +973,6 @@ to use in calculating all precursor masses</value>
   <data name="tabPage1.Text" xml:space="preserve">
     <value>Peptides</value>
   </data>
-  <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1240,18 +988,6 @@ to use in calculating all precursor masses</value>
   <data name="label5.Text" xml:space="preserve">
     <value>&amp;Precursor charges:</value>
   </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textPeptideIonTypes.Location" type="System.Drawing.Point, System.Drawing">
     <value>232, 26</value>
   </data>
@@ -1265,18 +1001,6 @@ to use in calculating all precursor masses</value>
     <value>A list of comma separated product ion types (a, b, c, x, y, z, z., z', p for precursor) to use
 for calculating potential product ions. z. and z' stand for z+1 radical ion and z+2 ion. Those are usually found in ExD experiments.
 Alternatively, z* and z" can be used.</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Name" xml:space="preserve">
-    <value>textPeptideIonTypes</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;btnEditSpecialTransitions.Name" xml:space="preserve">
     <value>btnEditSpecialTransitions</value>
@@ -1374,18 +1098,6 @@ Alternatively, z* and z" can be used.</value>
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Product ion selection</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="btnEditSpecialTransitions.Location" type="System.Drawing.Point, System.Drawing">
     <value>209, 103</value>
   </data>
@@ -1400,18 +1112,6 @@ Alternatively, z* and z" can be used.</value>
   </data>
   <data name="btnEditSpecialTransitions.ToolTip" xml:space="preserve">
     <value>Edit the list of available special product ions</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Name" xml:space="preserve">
-    <value>btnEditSpecialTransitions</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="label18.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1428,18 +1128,6 @@ Alternatively, z* and z" can be used.</value>
   <data name="label18.Text" xml:space="preserve">
     <value>&amp;Special ions:</value>
   </data>
-  <data name="&gt;&gt;label18.Name" xml:space="preserve">
-    <value>label18</value>
-  </data>
-  <data name="&gt;&gt;label18.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label18.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="listAlwaysAdd.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 103</value>
   </data>
@@ -1453,18 +1141,6 @@ Alternatively, z* and z" can be used.</value>
     <value>Set of special product ions to measure when present, even outside
 the filtered range</value>
   </data>
-  <data name="&gt;&gt;listAlwaysAdd.Name" xml:space="preserve">
-    <value>listAlwaysAdd</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckedListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="comboRangeFrom.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 44</value>
   </data>
@@ -1476,18 +1152,6 @@ the filtered range</value>
   </data>
   <data name="comboRangeFrom.ToolTip" xml:space="preserve">
     <value>Starting product ion for a filtered range of ions</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Name" xml:space="preserve">
-    <value>comboRangeFrom</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1504,18 +1168,6 @@ the filtered range</value>
   <data name="label3.Text" xml:space="preserve">
     <value>&amp;From:</value>
   </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="comboRangeTo.Location" type="System.Drawing.Point, System.Drawing">
     <value>163, 43</value>
   </data>
@@ -1527,18 +1179,6 @@ the filtered range</value>
   </data>
   <data name="comboRangeTo.ToolTip" xml:space="preserve">
     <value>End point for a filtered range of product ions</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Name" xml:space="preserve">
-    <value>comboRangeTo</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1555,18 +1195,6 @@ the filtered range</value>
   <data name="label4.Text" xml:space="preserve">
     <value>T&amp;o:</value>
   </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1581,18 +1209,6 @@ the filtered range</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
     <value>&amp;Ion charges:</value>
-  </data>
-  <data name="&gt;&gt;label6.Name" xml:space="preserve">
-    <value>label6</value>
-  </data>
-  <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1609,18 +1225,6 @@ the filtered range</value>
   <data name="label8.Text" xml:space="preserve">
     <value>Ion &amp;types:</value>
   </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
-  </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textPeptidePrecursorCharges.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 26</value>
   </data>
@@ -1634,18 +1238,6 @@ the filtered range</value>
     <value>A list of comma separated charge states to use for calculating
 precursor mass-to-charge ratios</value>
   </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Name" xml:space="preserve">
-    <value>textPeptidePrecursorCharges</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="textPeptideIonCharges.Location" type="System.Drawing.Point, System.Drawing">
     <value>122, 26</value>
   </data>
@@ -1658,18 +1250,6 @@ precursor mass-to-charge ratios</value>
   <data name="textPeptideIonCharges.ToolTip" xml:space="preserve">
     <value>A list of comma separated charge states to use for calculating
 product ion mass-to-charge ratios</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Name" xml:space="preserve">
-    <value>textPeptideIonCharges</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="&gt;&gt;btnPrecursorAdduct.Name" xml:space="preserve">
     <value>btnPrecursorAdduct</value>
@@ -1782,18 +1362,6 @@ product ion mass-to-charge ratios</value>
   <data name="tabPage2.Text" xml:space="preserve">
     <value>Molecules</value>
   </data>
-  <data name="&gt;&gt;tabPage2.Name" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="btnPrecursorAdduct.Location" type="System.Drawing.Point, System.Drawing">
     <value>286, 24</value>
   </data>
@@ -1802,18 +1370,6 @@ product ion mass-to-charge ratios</value>
   </data>
   <data name="btnPrecursorAdduct.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Name" xml:space="preserve">
-    <value>btnPrecursorAdduct</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="btnFragmentAdduct.Location" type="System.Drawing.Point, System.Drawing">
     <value>286, 63</value>
@@ -1826,18 +1382,6 @@ product ion mass-to-charge ratios</value>
   </data>
   <data name="btnFragmentAdduct.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Name" xml:space="preserve">
-    <value>btnFragmentAdduct</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="textSmallMoleculeFragmentAdducts.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 66</value>
@@ -1863,18 +1407,6 @@ ACN (C2H3N), DMSO (C2H6OS), FA (CH2O2), Hac (CH3COOH), TFA (C2HF3O2), IsoProp (C
 Charge states are inferred from the presence of these adduct components:
 H (+1), K (+1), Na (+1), Li (+1), Br (-1), Cl (-1), F (-1), CH3COO (-1), HCOO (-1), NH4 (+1)</value>
   </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Name" xml:space="preserve">
-    <value>textSmallMoleculeFragmentAdducts</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelSmallMoleculeFragmentAdducts.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1893,18 +1425,6 @@ H (+1), K (+1), Na (+1), Li (+1), Br (-1), Cl (-1), F (-1), CH3COO (-1), HCOO (-
   <data name="labelSmallMoleculeFragmentAdducts.Text" xml:space="preserve">
     <value>Fragme&amp;nt adducts:</value>
   </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Name" xml:space="preserve">
-    <value>labelSmallMoleculeFragmentAdducts</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="textSmallMoleculeIonTypes.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 112</value>
   </data>
@@ -1917,18 +1437,6 @@ H (+1), K (+1), Na (+1), Li (+1), Br (-1), Cl (-1), F (-1), CH3COO (-1), HCOO (-
   <data name="textSmallMoleculeIonTypes.ToolTip" xml:space="preserve">
     <value>A list of comma separated product ion types (f for fragment, p for precursor) to use in filtering spectral libraries etc.
 </value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Name" xml:space="preserve">
-    <value>textSmallMoleculeIonTypes</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="labelSmallMoleculeIonTypes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1947,18 +1455,6 @@ H (+1), K (+1), Na (+1), Li (+1), Br (-1), Cl (-1), F (-1), CH3COO (-1), HCOO (-
   </data>
   <data name="labelSmallMoleculeIonTypes.Text" xml:space="preserve">
     <value>Ion &amp;types:</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Name" xml:space="preserve">
-    <value>labelSmallMoleculeIonTypes</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="textSmallMoleculePrecursorAdducts.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 26</value>
@@ -1984,18 +1480,6 @@ ACN (C2H3N), DMSO (C2H6OS), FA (CH2O2), Hac (CH3COOH), TFA (C2HF3O2), IsoProp (C
 Charge states are inferred from the presence of these adduct components:
 H (+1), K (+1), Na (+1), Li (+1), Br (-1), Cl (-1), F (-1), CH3COO (-1), HCOO (-1), NH4 (+1)</value>
   </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Name" xml:space="preserve">
-    <value>textSmallMoleculePrecursorAdducts</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="lblSmallMoleculePrecursorAdducts.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2017,18 +1501,6 @@ H (+1), K (+1), Na (+1), Li (+1), Br (-1), Cl (-1), F (-1), CH3COO (-1), HCOO (-
   <data name="lblSmallMoleculePrecursorAdducts.Text" xml:space="preserve">
     <value>Precursor &amp;adducts:</value>
   </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Name" xml:space="preserve">
-    <value>lblSmallMoleculePrecursorAdducts</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textExclusionWindow.Location" type="System.Drawing.Point, System.Drawing">
     <value>24, 408</value>
   </data>
@@ -2042,18 +1514,6 @@ H (+1), K (+1), Na (+1), Li (+1), Br (-1), Cl (-1), F (-1), CH3COO (-1), HCOO (-
     <value>A m/z window around the precursor m/z within which transitions
 are excluded, or blank. A window of 20 will exclude all transitions
 within 10 on either side of the precursor m/z.</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Name" xml:space="preserve">
-    <value>textExclusionWindow</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="cbAutoSelect.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2075,18 +1535,6 @@ within 10 on either side of the precursor m/z.</value>
 using specified filter and library settings. Otherwise, all transition
 selection must be done by manual document editing.</value>
   </data>
-  <data name="&gt;&gt;cbAutoSelect.Name" xml:space="preserve">
-    <value>cbAutoSelect</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="lbPrecursorMzWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2101,18 +1549,6 @@ selection must be done by manual document editing.</value>
   </data>
   <data name="lbPrecursorMzWindow.Text" xml:space="preserve">
     <value>Precursor m/z e&amp;xclusion window:</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Name" xml:space="preserve">
-    <value>lbPrecursorMzWindow</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="&gt;&gt;label23.Name" xml:space="preserve">
     <value>label23</value>
@@ -2201,18 +1637,6 @@ selection must be done by manual document editing.</value>
   <data name="tabLibrary.Text" xml:space="preserve">
     <value>Library</value>
   </data>
-  <data name="&gt;&gt;tabLibrary.Name" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2234,18 +1658,6 @@ selection must be done by manual document editing.</value>
   <data name="label23.Text" xml:space="preserve">
     <value>Tolerance u&amp;nits:</value>
   </data>
-  <data name="&gt;&gt;label23.Name" xml:space="preserve">
-    <value>label23</value>
-  </data>
-  <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboToleranceUnits.Items" xml:space="preserve">
     <value>m/z</value>
   </data>
@@ -2261,18 +1673,6 @@ selection must be done by manual document editing.</value>
   <data name="comboToleranceUnits.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <data name="&gt;&gt;comboToleranceUnits.Name" xml:space="preserve">
-    <value>comboToleranceUnits</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="label9.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2287,18 +1687,6 @@ selection must be done by manual document editing.</value>
   </data>
   <data name="label9.Text" xml:space="preserve">
     <value>&amp;Ion match tolerance:</value>
-  </data>
-  <data name="&gt;&gt;label9.Name" xml:space="preserve">
-    <value>label9</value>
-  </data>
-  <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="&gt;&gt;label22.Name" xml:space="preserve">
     <value>label22</value>
@@ -2405,18 +1793,6 @@ selection must be done by manual document editing.</value>
   <data name="panelPick.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;panelPick.Name" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;panelPick.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelPick.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;panelPick.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2435,18 +1811,6 @@ selection must be done by manual document editing.</value>
   <data name="label22.Text" xml:space="preserve">
     <value>minimum product ions</value>
   </data>
-  <data name="&gt;&gt;label22.Name" xml:space="preserve">
-    <value>label22</value>
-  </data>
-  <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label22.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textMinIonCount.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 51</value>
   </data>
@@ -2458,18 +1822,6 @@ selection must be done by manual document editing.</value>
   </data>
   <data name="textMinIonCount.ToolTip" xml:space="preserve">
     <value>Pick precursors with at least this many transitions</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Name" xml:space="preserve">
-    <value>textMinIonCount</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="radioAllAndFiltered.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2492,18 +1844,6 @@ the selection of MS/MS peaks matching ions for ranking, but
 also add all product ions matching the full filter, if they are
 not found in the library</value>
   </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Name" xml:space="preserve">
-    <value>radioAllAndFiltered</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="radioFiltered.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2522,18 +1862,6 @@ not found in the library</value>
   <data name="radioFiltered.ToolTip" xml:space="preserve">
     <value>Apply parameters from the Filter tab to the selection of MS/MS
 peaks matching ions for ranking</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Name" xml:space="preserve">
-    <value>radioFiltered</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="radioAll.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2554,18 +1882,6 @@ peaks matching ions for ranking</value>
     <value>Apply only the ion charges and types from the Filter tab to
 the selection of MS/MS peaks matching ions for ranking</value>
   </data>
-  <data name="&gt;&gt;radioAll.Name" xml:space="preserve">
-    <value>radioAll</value>
-  </data>
-  <data name="&gt;&gt;radioAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAll.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioAll.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="label14.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2580,18 +1896,6 @@ the selection of MS/MS peaks matching ions for ranking</value>
   </data>
   <data name="label14.Text" xml:space="preserve">
     <value>&amp;Pick:</value>
-  </data>
-  <data name="&gt;&gt;label14.Name" xml:space="preserve">
-    <value>label14</value>
-  </data>
-  <data name="&gt;&gt;label14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label14.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label15.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2608,18 +1912,6 @@ the selection of MS/MS peaks matching ions for ranking</value>
   <data name="label15.Text" xml:space="preserve">
     <value>product ions</value>
   </data>
-  <data name="&gt;&gt;label15.Name" xml:space="preserve">
-    <value>label15</value>
-  </data>
-  <data name="&gt;&gt;label15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label15.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="textIonCount.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 25</value>
   </data>
@@ -2633,18 +1925,6 @@ the selection of MS/MS peaks matching ions for ranking</value>
     <value>Pick this many transitions for each precursor by library spectrum
 peak intensity ranking</value>
   </data>
-  <data name="&gt;&gt;textIonCount.Name" xml:space="preserve">
-    <value>textIonCount</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textTolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>21, 41</value>
   </data>
@@ -2657,18 +1937,6 @@ peak intensity ranking</value>
   <data name="textTolerance.ToolTip" xml:space="preserve">
     <value>Maximum delta allowed when matching predicted product ion
 m/z values with measured MS/MS spectral library peak m/z values</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Name" xml:space="preserve">
-    <value>textTolerance</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="cbLibraryPick.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2688,18 +1956,6 @@ m/z values with measured MS/MS spectral library peak m/z values</value>
   <data name="cbLibraryPick.ToolTip" xml:space="preserve">
     <value>If checked, the transition filter is based on MS/MS spectral library peaks
 whenever peptides are matched to library spectrum.</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Name" xml:space="preserve">
-    <value>cbLibraryPick</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="&gt;&gt;cbxTriggeredAcquisition.Name" xml:space="preserve">
     <value>cbxTriggeredAcquisition</value>
@@ -2965,18 +2221,6 @@ whenever peptides are matched to library spectrum.</value>
   <data name="tabInstrument.Text" xml:space="preserve">
     <value>Instrument</value>
   </data>
-  <data name="&gt;&gt;tabInstrument.Name" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="cbxTriggeredAcquisition.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2996,18 +2240,6 @@ whenever peptides are matched to library spectrum.</value>
     <value>Indicates that there may be large gaps in the retention times when spectra were acquired for certain analytes.
 Peaks will be truncated to not overlap with these gaps and background subtraction will not be performed.</value>
   </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Name" xml:space="preserve">
-    <value>cbxTriggeredAcquisition</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textMaxInclusions.Location" type="System.Drawing.Point, System.Drawing">
     <value>189, 185</value>
   </data>
@@ -3020,18 +2252,6 @@ Peaks will be truncated to not overlap with these gaps and background subtractio
   <data name="textMaxInclusions.ToolTip" xml:space="preserve">
     <value>Maximum number of inclusion windows measured by the target
 instrument during multiplexed scanning.</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Name" xml:space="preserve">
-    <value>textMaxInclusions</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="label21.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3048,18 +2268,6 @@ instrument during multiplexed scanning.</value>
   <data name="label21.Text" xml:space="preserve">
     <value>Firmware &amp;inclusion limit:</value>
   </data>
-  <data name="&gt;&gt;label21.Name" xml:space="preserve">
-    <value>label21</value>
-  </data>
-  <data name="&gt;&gt;label21.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label21.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label21.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="label30.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3074,18 +2282,6 @@ instrument during multiplexed scanning.</value>
   </data>
   <data name="label30.Text" xml:space="preserve">
     <value>min</value>
-  </data>
-  <data name="&gt;&gt;label30.Name" xml:space="preserve">
-    <value>label30</value>
-  </data>
-  <data name="&gt;&gt;label30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label30.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label30.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label31.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3102,18 +2298,6 @@ instrument during multiplexed scanning.</value>
   <data name="label31.Text" xml:space="preserve">
     <value>min</value>
   </data>
-  <data name="&gt;&gt;label31.Name" xml:space="preserve">
-    <value>label31</value>
-  </data>
-  <data name="&gt;&gt;label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label31.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label31.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="label33.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3128,18 +2312,6 @@ instrument during multiplexed scanning.</value>
   </data>
   <data name="label33.Text" xml:space="preserve">
     <value>M&amp;ax time:</value>
-  </data>
-  <data name="&gt;&gt;label33.Name" xml:space="preserve">
-    <value>label33</value>
-  </data>
-  <data name="&gt;&gt;label33.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label34.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3156,18 +2328,6 @@ instrument during multiplexed scanning.</value>
   <data name="label34.Text" xml:space="preserve">
     <value>Mi&amp;n time:</value>
   </data>
-  <data name="&gt;&gt;label34.Name" xml:space="preserve">
-    <value>label34</value>
-  </data>
-  <data name="&gt;&gt;label34.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label34.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label34.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="textMaxTime.Location" type="System.Drawing.Point, System.Drawing">
     <value>190, 249</value>
   </data>
@@ -3182,18 +2342,6 @@ instrument during multiplexed scanning.</value>
 they were acquired.  Setting this can save memory and disk space
 that might be used on uninteresting parts of the gradient.</value>
   </data>
-  <data name="&gt;&gt;textMaxTime.Name" xml:space="preserve">
-    <value>textMaxTime</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textMinTime.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 249</value>
   </data>
@@ -3207,18 +2355,6 @@ that might be used on uninteresting parts of the gradient.</value>
     <value>Minimum time allowed in chromatograms regardless of how
 they were acquired.  Setting this can save memory and disk space
 that might be used on uninteresting parts of the gradient.</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Name" xml:space="preserve">
-    <value>textMinTime</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="label26.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3238,18 +2374,6 @@ that might be used on uninteresting parts of the gradient.</value>
   <data name="label26.Text" xml:space="preserve">
     <value>m/z</value>
   </data>
-  <data name="&gt;&gt;label26.Name" xml:space="preserve">
-    <value>label26</value>
-  </data>
-  <data name="&gt;&gt;label26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="label25.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3268,18 +2392,6 @@ that might be used on uninteresting parts of the gradient.</value>
   <data name="label25.Text" xml:space="preserve">
     <value>m/z</value>
   </data>
-  <data name="&gt;&gt;label25.Name" xml:space="preserve">
-    <value>label25</value>
-  </data>
-  <data name="&gt;&gt;label25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label25.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label25.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3297,18 +2409,6 @@ that might be used on uninteresting parts of the gradient.</value>
   </data>
   <data name="label24.Text" xml:space="preserve">
     <value>m/z</value>
-  </data>
-  <data name="&gt;&gt;label24.Name" xml:space="preserve">
-    <value>label24</value>
-  </data>
-  <data name="&gt;&gt;label24.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label24.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>11</value>
   </data>
   <data name="cbDynamicMinimum.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3330,18 +2430,6 @@ that might be used on uninteresting parts of the gradient.</value>
 dynamically from the precursor m/z using a specific equation
 provided by Thermo-Scientific for LTQ instruments</value>
   </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Name" xml:space="preserve">
-    <value>cbDynamicMinimum</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="textMaxTrans.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 185</value>
   </data>
@@ -3354,18 +2442,6 @@ provided by Thermo-Scientific for LTQ instruments</value>
   <data name="textMaxTrans.ToolTip" xml:space="preserve">
     <value>Maximum total number of transitions measurable by the target
 instrument in a single injection or blank if no maximum applies</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Name" xml:space="preserve">
-    <value>textMaxTrans</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.ZOrder" xml:space="preserve">
-    <value>13</value>
   </data>
   <data name="label17.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3382,18 +2458,6 @@ instrument in a single injection or blank if no maximum applies</value>
   <data name="label17.Text" xml:space="preserve">
     <value>&amp;Firmware transition limit:</value>
   </data>
-  <data name="&gt;&gt;label17.Name" xml:space="preserve">
-    <value>label17</value>
-  </data>
-  <data name="&gt;&gt;label17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label17.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
   <data name="textMzMatchTolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 124</value>
   </data>
@@ -3407,18 +2471,6 @@ instrument in a single injection or blank if no maximum applies</value>
     <value>Maximum delta for matching instrument method transition m/z values
 with predicted transition m/z values.
 (Applies only to SRM and targeted-MS/MS data.)</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Name" xml:space="preserve">
-    <value>textMzMatchTolerance</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="lblMethodMatchTolerance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3435,18 +2487,6 @@ with predicted transition m/z values.
   <data name="lblMethodMatchTolerance.Text" xml:space="preserve">
     <value>Method match &amp;tolerance m/z:</value>
   </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Name" xml:space="preserve">
-    <value>lblMethodMatchTolerance</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
   <data name="label10.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3461,18 +2501,6 @@ with predicted transition m/z values.
   </data>
   <data name="label10.Text" xml:space="preserve">
     <value>Ma&amp;x m/z:</value>
-  </data>
-  <data name="&gt;&gt;label10.Name" xml:space="preserve">
-    <value>label10</value>
-  </data>
-  <data name="&gt;&gt;label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>17</value>
   </data>
   <data name="label11.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3489,18 +2517,6 @@ with predicted transition m/z values.
   <data name="label11.Text" xml:space="preserve">
     <value>&amp;Min m/z:</value>
   </data>
-  <data name="&gt;&gt;label11.Name" xml:space="preserve">
-    <value>label11</value>
-  </data>
-  <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
   <data name="textMaxMz.Location" type="System.Drawing.Point, System.Drawing">
     <value>190, 38</value>
   </data>
@@ -3513,18 +2529,6 @@ with predicted transition m/z values.
   <data name="textMaxMz.ToolTip" xml:space="preserve">
     <value>Maximum measurable m/z value for the target instrument</value>
   </data>
-  <data name="&gt;&gt;textMaxMz.Name" xml:space="preserve">
-    <value>textMaxMz</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
   <data name="textMinMz.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 38</value>
   </data>
@@ -3536,18 +2540,6 @@ with predicted transition m/z values.
   </data>
   <data name="textMinMz.ToolTip" xml:space="preserve">
     <value>Minimum measurable m/z value for the target instrument</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Name" xml:space="preserve">
-    <value>textMinMz</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.ZOrder" xml:space="preserve">
-    <value>20</value>
   </data>
   <data name="tabFullScan.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -3563,18 +2555,6 @@ with predicted transition m/z values.
   </data>
   <data name="tabFullScan.Text" xml:space="preserve">
     <value>Full-Scan</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Name" xml:space="preserve">
-    <value>tabFullScan</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="&gt;&gt;ionMobilityFilteringControl.Name" xml:space="preserve">
     <value>ionMobilityFilteringControl</value>
@@ -3600,18 +2580,6 @@ with predicted transition m/z values.
   <data name="tabIonMobility.Text" xml:space="preserve">
     <value>Ion Mobility</value>
   </data>
-  <data name="&gt;&gt;tabIonMobility.Name" xml:space="preserve">
-    <value>tabIonMobility</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="ionMobilityFilteringControl.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 13</value>
   </data>
@@ -3619,18 +2587,6 @@ with predicted transition m/z values.
     <value>334, 281</value>
   </data>
   <data name="ionMobilityFilteringControl.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Name" xml:space="preserve">
-    <value>ionMobilityFilteringControl</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Type" xml:space="preserve">
-    <value>pwiz.Skyline.SettingsUI.IonMobility.IonMobilityFilteringUserControl, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Parent" xml:space="preserve">
-    <value>tabIonMobility</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="helpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.zh-CHS.resx
@@ -468,18 +468,6 @@
   <data name="tabGeneral.Text" xml:space="preserve">
     <value>预测</value>
   </data>
-  <data name="&gt;&gt;tabGeneral.Name" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabGeneral.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboCompensationVoltage.Location" type="System.Drawing.Point, System.Drawing">
     <value>208, 179</value>
   </data>
@@ -488,18 +476,6 @@
   </data>
   <data name="comboCompensationVoltage.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Name" xml:space="preserve">
-    <value>comboCompensationVoltage</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboCompensationVoltage.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -519,18 +495,6 @@
   <data name="label19.Text" xml:space="preserve">
     <value>补偿电压(&amp;V)：</value>
   </data>
-  <data name="&gt;&gt;label19.Name" xml:space="preserve">
-    <value>label19</value>
-  </data>
-  <data name="&gt;&gt;label19.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label19.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label19.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="comboOptimizationLibrary.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 179</value>
   </data>
@@ -539,18 +503,6 @@
   </data>
   <data name="comboOptimizationLibrary.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Name" xml:space="preserve">
-    <value>comboOptimizationLibrary</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizationLibrary.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="label20.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -570,18 +522,6 @@
   <data name="label20.Text" xml:space="preserve">
     <value>最优化库(&amp;O)：</value>
   </data>
-  <data name="&gt;&gt;label20.Name" xml:space="preserve">
-    <value>label20</value>
-  </data>
-  <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label20.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label20.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="labelOptimizeType.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -599,18 +539,6 @@
   </data>
   <data name="labelOptimizeType.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Name" xml:space="preserve">
-    <value>labelOptimizeType</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;labelOptimizeType.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <metadata name="helpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
@@ -637,18 +565,6 @@
   <data name="comboOptimizeType.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;comboOptimizeType.Name" xml:space="preserve">
-    <value>comboOptimizeType</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboOptimizeType.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="cbUseOptimized.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -670,18 +586,6 @@
 值。产生最大总峰面积的值将被
 选择。</value>
   </data>
-  <data name="&gt;&gt;cbUseOptimized.Name" xml:space="preserve">
-    <value>cbUseOptimized</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;cbUseOptimized.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="comboDeclusterPotential.Location" type="System.Drawing.Point, System.Drawing">
     <value>208, 109</value>
   </data>
@@ -695,18 +599,6 @@
     <value>线性方程将被用于对每个母离子从其质荷比中
 预测最优去簇电压 (DP)。同位素标记的肽段
 使用针对未标记形式预测的 DP。（仅限 AB 仪器）</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Name" xml:space="preserve">
-    <value>comboDeclusterPotential</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboDeclusterPotential.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -723,18 +615,6 @@
   <data name="label12.Text" xml:space="preserve">
     <value>去簇电压(&amp;D)：</value>
   </data>
-  <data name="&gt;&gt;label12.Name" xml:space="preserve">
-    <value>label12</value>
-  </data>
-  <data name="&gt;&gt;label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label12.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <data name="comboCollisionEnergy.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 109</value>
   </data>
@@ -748,18 +628,6 @@
     <value>线性方程用于从其质荷比中
 针对每个母离子预测最优碰撞能量 （CE）。同位素标记的
 肽段使用针对未标记形式预测的 CE。</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Name" xml:space="preserve">
-    <value>comboCollisionEnergy</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboCollisionEnergy.ZOrder" xml:space="preserve">
-    <value>9</value>
   </data>
   <data name="label7.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -775,18 +643,6 @@
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>碰撞能量(&amp;C)：</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>10</value>
   </data>
   <data name="comboIonMass.Items" xml:space="preserve">
     <value>单一同位素</value>
@@ -807,18 +663,6 @@
     <value>用于计算所有子离子质量的分子质量计算策略
 （单一同位素或平均）</value>
   </data>
-  <data name="&gt;&gt;comboIonMass.Name" xml:space="preserve">
-    <value>comboIonMass</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboIonMass.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
   <data name="label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -833,18 +677,6 @@
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>子离子质量(&amp;D)：</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>12</value>
   </data>
   <data name="comboPrecursorMass.Items" xml:space="preserve">
     <value>单一同位素</value>
@@ -865,18 +697,6 @@
     <value>用于计算所有母离子质量的分子质量计算策略
 （单一同位素或平均）</value>
   </data>
-  <data name="&gt;&gt;comboPrecursorMass.Name" xml:space="preserve">
-    <value>comboPrecursorMass</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;comboPrecursorMass.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -891,18 +711,6 @@
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>母离子质量(&amp;P)：</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>tabGeneral</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <data name="&gt;&gt;cbExclusionUseDIAWindow.Name" xml:space="preserve">
     <value>cbExclusionUseDIAWindow</value>
@@ -991,18 +799,6 @@
   <data name="tabFilter.Text" xml:space="preserve">
     <value>过滤器</value>
   </data>
-  <data name="&gt;&gt;tabFilter.Name" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabFilter.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="cbExclusionUseDIAWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1027,18 +823,6 @@
   <data name="cbExclusionUseDIAWindow.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Name" xml:space="preserve">
-    <value>cbExclusionUseDIAWindow</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;cbExclusionUseDIAWindow.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="lbMZ.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1056,18 +840,6 @@
   </data>
   <data name="lbMZ.Text" xml:space="preserve">
     <value>质荷比</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Name" xml:space="preserve">
-    <value>lbMZ</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;lbMZ.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
     <value>tabPage1</value>
@@ -1101,18 +873,6 @@
   </data>
   <data name="tabControlPeptidesSmallMols.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Name" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;tabControlPeptidesSmallMols.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="&gt;&gt;label5.Name" xml:space="preserve">
     <value>label5</value>
@@ -1213,18 +973,6 @@
   <data name="tabPage1.Text" xml:space="preserve">
     <value>肽段</value>
   </data>
-  <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1240,18 +988,6 @@
   <data name="label5.Text" xml:space="preserve">
     <value>母离子电荷(&amp;P)：</value>
   </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textPeptideIonTypes.Location" type="System.Drawing.Point, System.Drawing">
     <value>232, 26</value>
   </data>
@@ -1263,18 +999,6 @@
   </data>
   <data name="textPeptideIonTypes.ToolTip" xml:space="preserve">
     <value>逗号分隔的子离子类型列表（ 用于母离子的a、b、c、x、y、z、z.、z'、p），用于计算潜在的子离子。z. 和 z' 表示 z+1 自由基离子和 z+2 离子。这些常用于 ExD 实验。另外，也可以使用 z* 和 z"。</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Name" xml:space="preserve">
-    <value>textPeptideIonTypes</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonTypes.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;btnEditSpecialTransitions.Name" xml:space="preserve">
     <value>btnEditSpecialTransitions</value>
@@ -1372,18 +1096,6 @@
   <data name="groupBox1.Text" xml:space="preserve">
     <value>子离子选择</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="btnEditSpecialTransitions.Location" type="System.Drawing.Point, System.Drawing">
     <value>194, 103</value>
   </data>
@@ -1398,18 +1110,6 @@
   </data>
   <data name="btnEditSpecialTransitions.ToolTip" xml:space="preserve">
     <value>编辑可用的特殊子离子列表</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Name" xml:space="preserve">
-    <value>btnEditSpecialTransitions</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnEditSpecialTransitions.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="label18.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1426,18 +1126,6 @@
   <data name="label18.Text" xml:space="preserve">
     <value>特殊离子(&amp;S)：</value>
   </data>
-  <data name="&gt;&gt;label18.Name" xml:space="preserve">
-    <value>label18</value>
-  </data>
-  <data name="&gt;&gt;label18.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label18.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="listAlwaysAdd.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 103</value>
   </data>
@@ -1451,18 +1139,6 @@
     <value>即使在过滤的范围之外，在存在
 时仍要测量的特殊子离子集</value>
   </data>
-  <data name="&gt;&gt;listAlwaysAdd.Name" xml:space="preserve">
-    <value>listAlwaysAdd</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckedListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;listAlwaysAdd.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="comboRangeFrom.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 44</value>
   </data>
@@ -1474,18 +1150,6 @@
   </data>
   <data name="comboRangeFrom.ToolTip" xml:space="preserve">
     <value>针对已过滤的离子范围的起始子离子</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Name" xml:space="preserve">
-    <value>comboRangeFrom</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;comboRangeFrom.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1502,18 +1166,6 @@
   <data name="label3.Text" xml:space="preserve">
     <value>从(&amp;F)：</value>
   </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="comboRangeTo.Location" type="System.Drawing.Point, System.Drawing">
     <value>163, 43</value>
   </data>
@@ -1525,18 +1177,6 @@
   </data>
   <data name="comboRangeTo.ToolTip" xml:space="preserve">
     <value>针对子离子过滤范围的终点</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Name" xml:space="preserve">
-    <value>comboRangeTo</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;comboRangeTo.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1553,18 +1193,6 @@
   <data name="label4.Text" xml:space="preserve">
     <value>至(&amp;O)：</value>
   </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1579,18 +1207,6 @@
   </data>
   <data name="label6.Text" xml:space="preserve">
     <value>离子电荷(&amp;I)：</value>
-  </data>
-  <data name="&gt;&gt;label6.Name" xml:space="preserve">
-    <value>label6</value>
-  </data>
-  <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1607,18 +1223,6 @@
   <data name="label8.Text" xml:space="preserve">
     <value>离子类型(&amp;T)：</value>
   </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
-  </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="textPeptidePrecursorCharges.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 26</value>
   </data>
@@ -1632,18 +1236,6 @@
     <value>一列以逗号分隔用于计算
 母离子质荷比的电荷状态</value>
   </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Name" xml:space="preserve">
-    <value>textPeptidePrecursorCharges</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptidePrecursorCharges.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="textPeptideIonCharges.Location" type="System.Drawing.Point, System.Drawing">
     <value>122, 26</value>
   </data>
@@ -1656,18 +1248,6 @@
   <data name="textPeptideIonCharges.ToolTip" xml:space="preserve">
     <value>一列以逗号分隔用于计算
 子离子质荷比的电荷状态</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Name" xml:space="preserve">
-    <value>textPeptideIonCharges</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;textPeptideIonCharges.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="&gt;&gt;btnPrecursorAdduct.Name" xml:space="preserve">
     <value>btnPrecursorAdduct</value>
@@ -1780,18 +1360,6 @@
   <data name="tabPage2.Text" xml:space="preserve">
     <value>分子</value>
   </data>
-  <data name="&gt;&gt;tabPage2.Name" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
-    <value>tabControlPeptidesSmallMols</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="btnPrecursorAdduct.Location" type="System.Drawing.Point, System.Drawing">
     <value>286, 24</value>
   </data>
@@ -1800,18 +1368,6 @@
   </data>
   <data name="btnPrecursorAdduct.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Name" xml:space="preserve">
-    <value>btnPrecursorAdduct</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;btnPrecursorAdduct.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="btnFragmentAdduct.Location" type="System.Drawing.Point, System.Drawing">
     <value>286, 63</value>
@@ -1824,18 +1380,6 @@
   </data>
   <data name="btnFragmentAdduct.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Name" xml:space="preserve">
-    <value>btnFragmentAdduct</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;btnFragmentAdduct.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="textSmallMoleculeFragmentAdducts.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 66</value>
@@ -1861,18 +1405,6 @@ ACN (C2H3N)、DMSO (C2H6OS)、FA (CH2O2)、Hac (CH3COOH)、TFA (C2HF3O2)、IsoPr
 从这些加合物成分状态推断出电荷态：
 H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)、HCOO (-1)、NH4 (+1)</value>
   </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Name" xml:space="preserve">
-    <value>textSmallMoleculeFragmentAdducts</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeFragmentAdducts.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="labelSmallMoleculeFragmentAdducts.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1891,18 +1423,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="labelSmallMoleculeFragmentAdducts.Text" xml:space="preserve">
     <value>片段加合物(&amp;N)：</value>
   </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Name" xml:space="preserve">
-    <value>labelSmallMoleculeFragmentAdducts</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeFragmentAdducts.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="textSmallMoleculeIonTypes.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 112</value>
   </data>
@@ -1915,18 +1435,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="textSmallMoleculeIonTypes.ToolTip" xml:space="preserve">
     <value>逗号分隔的子离子类型列表（f 代表片段，p 代表母离子）用于过滤谱图库等。
 </value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Name" xml:space="preserve">
-    <value>textSmallMoleculeIonTypes</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculeIonTypes.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="labelSmallMoleculeIonTypes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1945,18 +1453,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="labelSmallMoleculeIonTypes.Text" xml:space="preserve">
     <value>离子类型(&amp;T)：</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Name" xml:space="preserve">
-    <value>labelSmallMoleculeIonTypes</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;labelSmallMoleculeIonTypes.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="textSmallMoleculePrecursorAdducts.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 26</value>
@@ -1982,18 +1478,6 @@ ACN (C2H3N)、DMSO (C2H6OS)、FA (CH2O2)、Hac (CH3COOH)、TFA (C2HF3O2)、IsoPr
 从这些加合物成分状态推断出电荷态：
 H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)、HCOO (-1)、NH4 (+1)</value>
   </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Name" xml:space="preserve">
-    <value>textSmallMoleculePrecursorAdducts</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;textSmallMoleculePrecursorAdducts.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="lblSmallMoleculePrecursorAdducts.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2015,18 +1499,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="lblSmallMoleculePrecursorAdducts.Text" xml:space="preserve">
     <value>母离子加合物(&amp;A)：</value>
   </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Name" xml:space="preserve">
-    <value>lblSmallMoleculePrecursorAdducts</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;lblSmallMoleculePrecursorAdducts.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textExclusionWindow.Location" type="System.Drawing.Point, System.Drawing">
     <value>24, 408</value>
   </data>
@@ -2040,18 +1512,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>围绕母离子质荷比的质荷比窗口，在其中的离子对
 被排除或是空白。20 的窗口将排除母离子质荷比
 任意一边 10 以内的所有离子对。</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Name" xml:space="preserve">
-    <value>textExclusionWindow</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;textExclusionWindow.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="cbAutoSelect.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2073,18 +1533,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
 自动从蛋白质中选择。否则，所有离子对
 段选择都必须由手动文档编辑完成。</value>
   </data>
-  <data name="&gt;&gt;cbAutoSelect.Name" xml:space="preserve">
-    <value>cbAutoSelect</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;cbAutoSelect.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="lbPrecursorMzWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2099,18 +1547,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="lbPrecursorMzWindow.Text" xml:space="preserve">
     <value>母离子质荷比排除窗口(&amp;X)：</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Name" xml:space="preserve">
-    <value>lbPrecursorMzWindow</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.Parent" xml:space="preserve">
-    <value>tabFilter</value>
-  </data>
-  <data name="&gt;&gt;lbPrecursorMzWindow.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="&gt;&gt;label23.Name" xml:space="preserve">
     <value>label23</value>
@@ -2199,18 +1635,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="tabLibrary.Text" xml:space="preserve">
     <value>库</value>
   </data>
-  <data name="&gt;&gt;tabLibrary.Name" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabLibrary.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="label23.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2232,18 +1656,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label23.Text" xml:space="preserve">
     <value>耐受性单位(&amp;N):</value>
   </data>
-  <data name="&gt;&gt;label23.Name" xml:space="preserve">
-    <value>label23</value>
-  </data>
-  <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label23.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;label23.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comboToleranceUnits.Items" xml:space="preserve">
     <value>质荷比</value>
   </data>
@@ -2259,18 +1671,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="comboToleranceUnits.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <data name="&gt;&gt;comboToleranceUnits.Name" xml:space="preserve">
-    <value>comboToleranceUnits</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;comboToleranceUnits.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="label9.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2285,18 +1685,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="label9.Text" xml:space="preserve">
     <value>离子匹配耐受性(&amp;I)：</value>
-  </data>
-  <data name="&gt;&gt;label9.Name" xml:space="preserve">
-    <value>label9</value>
-  </data>
-  <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="&gt;&gt;label22.Name" xml:space="preserve">
     <value>label22</value>
@@ -2403,18 +1791,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="panelPick.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;panelPick.Name" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;panelPick.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panelPick.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;panelPick.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="label22.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2433,18 +1809,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label22.Text" xml:space="preserve">
     <value>最小子离子</value>
   </data>
-  <data name="&gt;&gt;label22.Name" xml:space="preserve">
-    <value>label22</value>
-  </data>
-  <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label22.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label22.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textMinIonCount.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 51</value>
   </data>
@@ -2456,18 +1820,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="textMinIonCount.ToolTip" xml:space="preserve">
     <value>选择含有至少这么多离子对的母离子</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Name" xml:space="preserve">
-    <value>textMinIonCount</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;textMinIonCount.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="radioAllAndFiltered.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2490,18 +1842,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
 但同时也添加匹配完整过滤器的所有子离子，
 如果这些子离子未在库中被发现</value>
   </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Name" xml:space="preserve">
-    <value>radioAllAndFiltered</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioAllAndFiltered.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="radioFiltered.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2520,18 +1860,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="radioFiltered.ToolTip" xml:space="preserve">
     <value>从过滤器标签中应用参数来选择用于排名的 MS/MS
 峰匹配离子</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Name" xml:space="preserve">
-    <value>radioFiltered</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioFiltered.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="radioAll.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2552,18 +1880,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>只从过滤器标签中应用离子电荷和类型来选
 择用于排名的MS/MS 峰匹配离子</value>
   </data>
-  <data name="&gt;&gt;radioAll.Name" xml:space="preserve">
-    <value>radioAll</value>
-  </data>
-  <data name="&gt;&gt;radioAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioAll.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;radioAll.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="label14.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2578,18 +1894,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="label14.Text" xml:space="preserve">
     <value>选择(&amp;P)：</value>
-  </data>
-  <data name="&gt;&gt;label14.Name" xml:space="preserve">
-    <value>label14</value>
-  </data>
-  <data name="&gt;&gt;label14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label14.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label15.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2606,18 +1910,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label15.Text" xml:space="preserve">
     <value>子离子</value>
   </data>
-  <data name="&gt;&gt;label15.Name" xml:space="preserve">
-    <value>label15</value>
-  </data>
-  <data name="&gt;&gt;label15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label15.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="textIonCount.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 25</value>
   </data>
@@ -2631,18 +1923,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>通过库谱图峰强度排名来为每个母离子
 挑选离子对</value>
   </data>
-  <data name="&gt;&gt;textIonCount.Name" xml:space="preserve">
-    <value>textIonCount</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.Parent" xml:space="preserve">
-    <value>panelPick</value>
-  </data>
-  <data name="&gt;&gt;textIonCount.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textTolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>21, 41</value>
   </data>
@@ -2655,18 +1935,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="textTolerance.ToolTip" xml:space="preserve">
     <value>用于匹配预测子离子质荷比值与实测MS/MS谱图库
 峰质荷比值时所允许的最大增量（仅适用于 SRM 和靶向 MS/MS 数据。）</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Name" xml:space="preserve">
-    <value>textTolerance</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;textTolerance.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="cbLibraryPick.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2686,18 +1954,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="cbLibraryPick.ToolTip" xml:space="preserve">
     <value>如果选中，那么无论何时当肽段与库谱图匹配时，
 离子对过滤器都将基于 MS/MS 谱图库峰。</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Name" xml:space="preserve">
-    <value>cbLibraryPick</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.Parent" xml:space="preserve">
-    <value>tabLibrary</value>
-  </data>
-  <data name="&gt;&gt;cbLibraryPick.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="&gt;&gt;cbxTriggeredAcquisition.Name" xml:space="preserve">
     <value>cbxTriggeredAcquisition</value>
@@ -2963,18 +2219,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="tabInstrument.Text" xml:space="preserve">
     <value>仪器</value>
   </data>
-  <data name="&gt;&gt;tabInstrument.Name" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabInstrument.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="cbxTriggeredAcquisition.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2994,18 +2238,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>指示在获取某些分析物的谱图时，保留时间之间可能存在很大的间隙。
 为了不与这些间隙重叠，峰值将被截断，并且不执行背景减除。</value>
   </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Name" xml:space="preserve">
-    <value>cbxTriggeredAcquisition</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;cbxTriggeredAcquisition.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="textMaxInclusions.Location" type="System.Drawing.Point, System.Drawing">
     <value>189, 185</value>
   </data>
@@ -3018,18 +2250,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="textMaxInclusions.ToolTip" xml:space="preserve">
     <value>多通道扫描期间由靶向
 仪器测量的包含窗口最大数目。</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Name" xml:space="preserve">
-    <value>textMaxInclusions</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxInclusions.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="label21.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3046,18 +2266,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label21.Text" xml:space="preserve">
     <value>固件和包含限制(&amp;I)：</value>
   </data>
-  <data name="&gt;&gt;label21.Name" xml:space="preserve">
-    <value>label21</value>
-  </data>
-  <data name="&gt;&gt;label21.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label21.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label21.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="label30.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3072,18 +2280,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="label30.Text" xml:space="preserve">
     <value>分钟</value>
-  </data>
-  <data name="&gt;&gt;label30.Name" xml:space="preserve">
-    <value>label30</value>
-  </data>
-  <data name="&gt;&gt;label30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label30.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label30.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="label31.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3100,18 +2296,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label31.Text" xml:space="preserve">
     <value>分钟</value>
   </data>
-  <data name="&gt;&gt;label31.Name" xml:space="preserve">
-    <value>label31</value>
-  </data>
-  <data name="&gt;&gt;label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label31.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label31.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="label33.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3126,18 +2310,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="label33.Text" xml:space="preserve">
     <value>最大时间(&amp;A)：</value>
-  </data>
-  <data name="&gt;&gt;label33.Name" xml:space="preserve">
-    <value>label33</value>
-  </data>
-  <data name="&gt;&gt;label33.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label33.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="label34.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3154,18 +2326,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label34.Text" xml:space="preserve">
     <value>最小时间(&amp;N)：</value>
   </data>
-  <data name="&gt;&gt;label34.Name" xml:space="preserve">
-    <value>label34</value>
-  </data>
-  <data name="&gt;&gt;label34.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label34.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label34.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="textMaxTime.Location" type="System.Drawing.Point, System.Drawing">
     <value>190, 249</value>
   </data>
@@ -3180,18 +2340,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
 获得方式为何。 设置它可以节省用于
 梯度不重要部分的内存和磁盘空间。</value>
   </data>
-  <data name="&gt;&gt;textMaxTime.Name" xml:space="preserve">
-    <value>textMaxTime</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxTime.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="textMinTime.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 249</value>
   </data>
@@ -3205,18 +2353,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>色谱允许的最小时间，无论其
 获得方式为何。 设置它可以节省用于
 梯度不重要部分的内存和磁盘空间。</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Name" xml:space="preserve">
-    <value>textMinTime</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMinTime.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="label26.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3236,18 +2372,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label26.Text" xml:space="preserve">
     <value>质荷比</value>
   </data>
-  <data name="&gt;&gt;label26.Name" xml:space="preserve">
-    <value>label26</value>
-  </data>
-  <data name="&gt;&gt;label26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label26.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
   <data name="label25.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3266,18 +2390,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label25.Text" xml:space="preserve">
     <value>质荷比</value>
   </data>
-  <data name="&gt;&gt;label25.Name" xml:space="preserve">
-    <value>label25</value>
-  </data>
-  <data name="&gt;&gt;label25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label25.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label25.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
   <data name="label24.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3295,18 +2407,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="label24.Text" xml:space="preserve">
     <value>质荷比</value>
-  </data>
-  <data name="&gt;&gt;label24.Name" xml:space="preserve">
-    <value>label24</value>
-  </data>
-  <data name="&gt;&gt;label24.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label24.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label24.ZOrder" xml:space="preserve">
-    <value>11</value>
   </data>
   <data name="cbDynamicMinimum.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3328,18 +2428,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
 采用 Thermo-Scientific 特别为 LTQ 仪器提供的特定方程式
 从母离子质荷比中动态计算。</value>
   </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Name" xml:space="preserve">
-    <value>cbDynamicMinimum</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;cbDynamicMinimum.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
   <data name="textMaxTrans.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 185</value>
   </data>
@@ -3352,18 +2440,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="textMaxTrans.ToolTip" xml:space="preserve">
     <value>如果没有最大数目适用，单一注射或空白中的目标
 仪器可测量的最大离子对总数</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Name" xml:space="preserve">
-    <value>textMaxTrans</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxTrans.ZOrder" xml:space="preserve">
-    <value>13</value>
   </data>
   <data name="label17.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3380,18 +2456,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label17.Text" xml:space="preserve">
     <value>固件离子对限制(&amp;F)：</value>
   </data>
-  <data name="&gt;&gt;label17.Name" xml:space="preserve">
-    <value>label17</value>
-  </data>
-  <data name="&gt;&gt;label17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label17.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
   <data name="textMzMatchTolerance.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 124</value>
   </data>
@@ -3405,18 +2469,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>用于匹配仪器方法离子对质荷比值与
 预测离子对质荷比值的最大增量
 （仅适用于 SRM 和定向 MS/MS 数据。）</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Name" xml:space="preserve">
-    <value>textMzMatchTolerance</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMzMatchTolerance.ZOrder" xml:space="preserve">
-    <value>15</value>
   </data>
   <data name="lblMethodMatchTolerance.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3433,18 +2485,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="lblMethodMatchTolerance.Text" xml:space="preserve">
     <value>方法匹配耐受性质荷比(&amp;T)：</value>
   </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Name" xml:space="preserve">
-    <value>lblMethodMatchTolerance</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;lblMethodMatchTolerance.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
   <data name="label10.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -3459,18 +2499,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="label10.Text" xml:space="preserve">
     <value>最大质荷比(&amp;X)：</value>
-  </data>
-  <data name="&gt;&gt;label10.Name" xml:space="preserve">
-    <value>label10</value>
-  </data>
-  <data name="&gt;&gt;label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>17</value>
   </data>
   <data name="label11.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3487,18 +2515,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="label11.Text" xml:space="preserve">
     <value>最小质荷比(&amp;M)：</value>
   </data>
-  <data name="&gt;&gt;label11.Name" xml:space="preserve">
-    <value>label11</value>
-  </data>
-  <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
   <data name="textMaxMz.Location" type="System.Drawing.Point, System.Drawing">
     <value>190, 38</value>
   </data>
@@ -3511,18 +2527,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="textMaxMz.ToolTip" xml:space="preserve">
     <value>靶向仪器的最大可测量质荷比</value>
   </data>
-  <data name="&gt;&gt;textMaxMz.Name" xml:space="preserve">
-    <value>textMaxMz</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMaxMz.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
   <data name="textMinMz.Location" type="System.Drawing.Point, System.Drawing">
     <value>27, 38</value>
   </data>
@@ -3534,18 +2538,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="textMinMz.ToolTip" xml:space="preserve">
     <value>靶向仪器的最小可测量质荷比</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Name" xml:space="preserve">
-    <value>textMinMz</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.Parent" xml:space="preserve">
-    <value>tabInstrument</value>
-  </data>
-  <data name="&gt;&gt;textMinMz.ZOrder" xml:space="preserve">
-    <value>20</value>
   </data>
   <data name="tabFullScan.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -3561,18 +2553,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   </data>
   <data name="tabFullScan.Text" xml:space="preserve">
     <value>全扫描</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Name" xml:space="preserve">
-    <value>tabFullScan</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabFullScan.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="&gt;&gt;ionMobilityFilteringControl.Name" xml:space="preserve">
     <value>ionMobilityFilteringControl</value>
@@ -3598,18 +2578,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
   <data name="tabIonMobility.Text" xml:space="preserve">
     <value>离子迁移</value>
   </data>
-  <data name="&gt;&gt;tabIonMobility.Name" xml:space="preserve">
-    <value>tabIonMobility</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabIonMobility.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="ionMobilityFilteringControl.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 13</value>
   </data>
@@ -3617,18 +2585,6 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>334, 281</value>
   </data>
   <data name="ionMobilityFilteringControl.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Name" xml:space="preserve">
-    <value>ionMobilityFilteringControl</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Type" xml:space="preserve">
-    <value>pwiz.Skyline.SettingsUI.IonMobility.IonMobilityFilteringUserControl, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.Parent" xml:space="preserve">
-    <value>tabIonMobility</value>
-  </data>
-  <data name="&gt;&gt;ionMobilityFilteringControl.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="helpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.ja.resx
@@ -639,6 +639,12 @@
   <data name="textPeptide.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>436, 17</value>
+  </metadata>
+  <data name="textPeptide.ToolTip" xml:space="preserve">
+    <value>Filters beginning with * search within descriptions, e.g. *PEET will match PEETID and AAPEETB</value>
+  </data>
   <data name="&gt;&gt;textPeptide.Name" xml:space="preserve">
     <value>textPeptide</value>
   </data>
@@ -1664,6 +1670,12 @@
   </data>
   <data name="&gt;&gt;toolStripSeparator27.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ViewLibraryDlg</value>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
@@ -639,6 +639,12 @@
   <data name="textPeptide.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>436, 17</value>
+  </metadata>
+  <data name="textPeptide.ToolTip" xml:space="preserve">
+    <value>Filters beginning with * search within descriptions, e.g. *PEET will match PEETID and AAPEETB</value>
+  </data>
   <data name="&gt;&gt;textPeptide.Name" xml:space="preserve">
     <value>textPeptide</value>
   </data>
@@ -1664,6 +1670,12 @@
   </data>
   <data name="&gt;&gt;toolStripSeparator27.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ViewLibraryDlg</value>

--- a/pwiz_tools/Skyline/Skyline.ja.resx
+++ b/pwiz_tools/Skyline/Skyline.ja.resx
@@ -300,27 +300,6 @@
     <value>228, 22</value>
   </data>
   <data name="replicatesTreeContextMenuItem.Text" xml:space="preserve">
-    <value>繰り返し測定</value>
-  </data>
-  <data name="contextMenuTreeNode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>229, 374</value>
-  </data>
-  <data name="&gt;&gt;contextMenuTreeNode.Name" xml:space="preserve">
-    <value>contextMenuTreeNode</value>
-  </data>
-  <data name="&gt;&gt;contextMenuTreeNode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <metadata name="contextMenuSpectrum.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>197, 56</value>
-  </metadata>
-  <data name="replicatesTreeContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>228, 22</value>
-  </data>
-  <data name="ionTypesContextMenuItem.Text" xml:space="preserve">
-    <value>イオンタイプ</value>
-  </data>
-  <data name="replicatesTreeContextMenuItem.Text" xml:space="preserve">
     <value>Replicates</value>
   </data>
   <data name="contextMenuTreeNode.Size" type="System.Drawing.Size, System.Drawing">
@@ -331,6 +310,15 @@
   </data>
   <data name="&gt;&gt;contextMenuTreeNode.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="contextMenuSpectrum.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1304, 17</value>
+  </metadata>
+  <data name="ionTypesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 22</value>
+  </data>
+  <data name="ionTypesContextMenuItem.Text" xml:space="preserve">
+    <value>イオンタイプ</value>
   </data>
   <data name="fragmentionsContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
@@ -373,12 +361,6 @@
   </data>
   <data name="scoreContextMenuItem.Text" xml:space="preserve">
     <value>スコア</value>
-  </data>
-  <data name="massErrorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 22</value>
-  </data>
-  <data name="massErrorToolStripMenuItem.Text" xml:space="preserve">
-    <value>質量誤差を表示</value>
   </data>
   <data name="massErrorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
@@ -437,11 +419,17 @@
   <data name="spectrumGraphPropsContextMenuItem.Text" xml:space="preserve">
     <value>グラフプロパティ...</value>
   </data>
-  <data name="showSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="showLibSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
   </data>
-  <data name="showSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
-    <value>スペクトルプロパティ</value>
+  <data name="showLibSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
+    <value>Spectrum Properties</value>
+  </data>
+  <data name="showFullScanSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 22</value>
+  </data>
+  <data name="showFullScanSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
+    <value>Spectrum Properties</value>
   </data>
   <data name="toolStripSeparator15.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 6</value>
@@ -466,6 +454,9 @@
   </data>
   <data name="synchMzScaleToolStripMenuItem.Text" xml:space="preserve">
     <value>m/zスケールを同期</value>
+  </data>
+  <data name="contextMenuSpectrum.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 486</value>
   </data>
   <data name="&gt;&gt;contextMenuSpectrum.Name" xml:space="preserve">
     <value>contextMenuSpectrum</value>
@@ -768,7 +759,7 @@
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <metadata name="contextMenuPeakAreas.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 56</value>
+    <value>1124, 17</value>
   </metadata>
   <data name="areaReplicateComparisonContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 22</value>
@@ -781,6 +772,12 @@
   </data>
   <data name="areaPeptideComparisonContextMenuItem.Text" xml:space="preserve">
     <value>ペプチドの比較</value>
+  </data>
+  <data name="areaRelativeAbundanceContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>190, 22</value>
+  </data>
+  <data name="areaRelativeAbundanceContextMenuItem.Text" xml:space="preserve">
+    <value>Relative Abundance</value>
   </data>
   <data name="areaCVHistogramContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 22</value>
@@ -889,6 +886,18 @@
   </data>
   <data name="scopeContextMenuItem.Text" xml:space="preserve">
     <value>適用範囲</value>
+  </data>
+  <data name="abundanceTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="abundanceTargetsMenuItem.Text" xml:space="preserve">
+    <value>Targets</value>
+  </data>
+  <data name="excludeTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="excludeTargetsMenuItem.Text" xml:space="preserve">
+    <value>Exclude</value>
   </data>
   <data name="showPeakAreaLegendContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 22</value>
@@ -1035,13 +1044,37 @@
     <value>206, 6</value>
   </data>
   <data name="contextMenuPeakAreas.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 434</value>
+    <value>210, 478</value>
   </data>
   <data name="&gt;&gt;contextMenuPeakAreas.Name" xml:space="preserve">
     <value>contextMenuPeakAreas</value>
   </data>
   <data name="&gt;&gt;contextMenuPeakAreas.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="abundanceTargetsProteinsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="abundanceTargetsProteinsMenuItem.Text" xml:space="preserve">
+    <value>Proteins</value>
+  </data>
+  <data name="abundanceTargetsPeptidesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="abundanceTargetsPeptidesMenuItem.Text" xml:space="preserve">
+    <value>Peptides</value>
+  </data>
+  <data name="excludeTargetsPeptideListMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="excludeTargetsPeptideListMenuItem.Text" xml:space="preserve">
+    <value>Peptide Lists</value>
+  </data>
+  <data name="excludeTargetsStandardsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="excludeTargetsStandardsMenuItem.Text" xml:space="preserve">
+    <value>Standards</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="dockPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -1180,7 +1213,7 @@
     <value>7</value>
   </data>
   <metadata name="mainToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>373, 56</value>
+    <value>1480, 17</value>
   </metadata>
   <data name="newToolBarButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -1321,7 +1354,7 @@
     <value>Fuchsia</value>
   </data>
   <data name="startPageMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="startPageMenuItem.Text" xml:space="preserve">
     <value>開始(&amp;R)...</value>
@@ -1333,7 +1366,7 @@
     <value>Ctrl+N</value>
   </data>
   <data name="newMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="newMenuItem.Text" xml:space="preserve">
     <value>新規(&amp;N)</value>
@@ -1345,19 +1378,28 @@
     <value>Ctrl+O</value>
   </data>
   <data name="openMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="openMenuItem.Text" xml:space="preserve">
     <value>開く(&amp;O)...</value>
   </data>
+  <data name="openPanoramaMenuItem.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="openPanoramaMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
+  </data>
+  <data name="openPanoramaMenuItem.Text" xml:space="preserve">
+    <value>Open From Panora&amp;ma...</value>
+  </data>
   <data name="openContainingFolderMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="openContainingFolderMenuItem.Text" xml:space="preserve">
     <value>フォルダを開く(&amp;C)</value>
   </data>
   <data name="toolStripSeparator53.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
   </data>
   <data name="saveMenuItem.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Fuchsia</value>
@@ -1366,19 +1408,19 @@
     <value>Ctrl+S</value>
   </data>
   <data name="saveMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="saveMenuItem.Text" xml:space="preserve">
     <value>保存(&amp;S)</value>
   </data>
   <data name="saveAsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="saveAsMenuItem.Text" xml:space="preserve">
     <value>名前を付けて保存(&amp;A)...</value>
   </data>
   <data name="shareDocumentMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="shareDocumentMenuItem.Text" xml:space="preserve">
     <value>共有(&amp;H)...</value>
@@ -1387,13 +1429,37 @@
     <value>Fuchsia</value>
   </data>
   <data name="publishMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="publishMenuItem.Text" xml:space="preserve">
     <value>Panoramaにアップロード(&amp;U)...</value>
   </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
+  </data>
+  <data name="runPeptideSearchToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
+  <data name="runPeptideSearchToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Run Peptide Search...</value>
+  </data>
+  <data name="encyclopeDiaSearchMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
+  <data name="encyclopeDiaSearchMenuItem.Text" xml:space="preserve">
+    <value>&amp;EncyclopeDIA検索...</value>
+  </data>
+  <data name="importFeatureDetectionMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
+  <data name="importFeatureDetectionMenuItem.Text" xml:space="preserve">
+    <value>&amp;Feature Detection...</value>
+  </data>
+  <data name="searchStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
+  </data>
+  <data name="searchStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Search</value>
   </data>
   <data name="importResultsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 22</value>
@@ -1415,12 +1481,6 @@
   </data>
   <data name="importPeptideSearchMenuItem.Text" xml:space="preserve">
     <value>ペプチド検索(&amp;P)...</value>
-  </data>
-  <data name="encyclopeDiaSearchMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 22</value>
-  </data>
-  <data name="encyclopeDiaSearchMenuItem.Text" xml:space="preserve">
-    <value>&amp;EncyclopeDIA検索...</value>
   </data>
   <data name="toolStripSeparator52.Size" type="System.Drawing.Size, System.Drawing">
     <value>167, 6</value>
@@ -1456,7 +1516,7 @@
     <value>注釈(&amp;N)...</value>
   </data>
   <data name="importToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="importToolStripMenuItem.Text" xml:space="preserve">
     <value>インポート(&amp;I)</value>
@@ -1491,15 +1551,6 @@
   <data name="toolStripSeparator50.Size" type="System.Drawing.Size, System.Drawing">
     <value>180, 6</value>
   </data>
-  <data name="eSPFeaturesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>183, 22</value>
-  </data>
-  <data name="eSPFeaturesMenuItem.Text" xml:space="preserve">
-    <value>ESP機能(&amp;E)...</value>
-  </data>
-  <data name="eSPFeaturesMenuItem.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
   <data name="exportSpectralLibraryMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>183, 22</value>
   </data>
@@ -1525,22 +1576,22 @@
     <value>注釈(&amp;A)...</value>
   </data>
   <data name="exportToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="exportToolStripMenuItem.Text" xml:space="preserve">
     <value>エクスポート(&amp;E)</value>
   </data>
   <data name="mruBeforeToolStripSeparator.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
   </data>
   <data name="mruAfterToolStripSeparator.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
   </data>
   <data name="mruAfterToolStripSeparator.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="exitMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="exitMenuItem.Text" xml:space="preserve">
     <value>終了(&amp;X)</value>
@@ -1823,6 +1874,15 @@
   </data>
   <data name="&gt;&gt;menuMain.ZOrder" xml:space="preserve">
     <value>9</value>
+  </data>
+  <data name="eSPFeaturesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>183, 22</value>
+  </data>
+  <data name="eSPFeaturesMenuItem.Text" xml:space="preserve">
+    <value>ESP機能(&amp;E)...</value>
+  </data>
+  <data name="eSPFeaturesMenuItem.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <metadata name="contextMenuMassErrors.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>941, 17</value>
@@ -2223,6 +2283,12 @@
   <data name="&gt;&gt;modifyPeptideContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;editSpectrumFilterContextMenuItem.Name" xml:space="preserve">
+    <value>editSpectrumFilterContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;editSpectrumFilterContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;toggleQuantitativeContextMenuItem.Name" xml:space="preserve">
     <value>toggleQuantitativeContextMenuItem</value>
   </data>
@@ -2403,10 +2469,16 @@
   <data name="&gt;&gt;spectrumGraphPropsContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;showSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
-    <value>showSpectrumPropertiesContextMenuItem</value>
+  <data name="&gt;&gt;showLibSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
+    <value>showLibSpectrumPropertiesContextMenuItem</value>
   </data>
-  <data name="&gt;&gt;showSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
+  <data name="&gt;&gt;showLibSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showFullScanSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
+    <value>showFullScanSpectrumPropertiesContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;showFullScanSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator15.Name" xml:space="preserve">
@@ -2757,6 +2829,12 @@
   <data name="&gt;&gt;areaPeptideComparisonContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;areaRelativeAbundanceContextMenuItem.Name" xml:space="preserve">
+    <value>areaRelativeAbundanceContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;areaRelativeAbundanceContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;areaCVHistogramContextMenuItem.Name" xml:space="preserve">
     <value>areaCVHistogramContextMenuItem</value>
   </data>
@@ -2857,6 +2935,18 @@
     <value>proteinScopeContextMenuItem</value>
   </data>
   <data name="&gt;&gt;proteinScopeContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;showPeakAreaLegendContextMenuItem.Name" xml:space="preserve">
@@ -3027,6 +3117,30 @@
   <data name="&gt;&gt;toolStripSeparator57.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;abundanceTargetsProteinsMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsProteinsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsProteinsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsPeptidesMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsPeptidesMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsPeptidesMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsPeptideListMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsPeptideListMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsPeptideListMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsStandardsMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsStandardsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsStandardsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;statusGeneral.Name" xml:space="preserve">
     <value>statusGeneral</value>
   </data>
@@ -3171,6 +3285,12 @@
   <data name="&gt;&gt;openMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;openPanoramaMenuItem.Name" xml:space="preserve">
+    <value>openPanoramaMenuItem</value>
+  </data>
+  <data name="&gt;&gt;openPanoramaMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;openContainingFolderMenuItem.Name" xml:space="preserve">
     <value>openContainingFolderMenuItem</value>
   </data>
@@ -3213,6 +3333,30 @@
   <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;searchStripMenuItem.Name" xml:space="preserve">
+    <value>searchStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;searchStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;runPeptideSearchToolStripMenuItem.Name" xml:space="preserve">
+    <value>runPeptideSearchToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;runPeptideSearchToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Name" xml:space="preserve">
+    <value>encyclopeDiaSearchMenuItem</value>
+  </data>
+  <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;importFeatureDetectionMenuItem.Name" xml:space="preserve">
+    <value>importFeatureDetectionMenuItem</value>
+  </data>
+  <data name="&gt;&gt;importFeatureDetectionMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;importToolStripMenuItem.Name" xml:space="preserve">
     <value>importToolStripMenuItem</value>
   </data>
@@ -3241,12 +3385,6 @@
     <value>importPeptideSearchMenuItem</value>
   </data>
   <data name="&gt;&gt;importPeptideSearchMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Name" xml:space="preserve">
-    <value>encyclopeDiaSearchMenuItem</value>
-  </data>
-  <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator52.Name" xml:space="preserve">
@@ -3326,12 +3464,6 @@
   </data>
   <data name="&gt;&gt;toolStripSeparator50.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;eSPFeaturesMenuItem.Name" xml:space="preserve">
-    <value>eSPFeaturesMenuItem</value>
-  </data>
-  <data name="&gt;&gt;eSPFeaturesMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;exportSpectralLibraryMenuItem.Name" xml:space="preserve">
     <value>exportSpectralLibraryMenuItem</value>
@@ -3603,6 +3735,12 @@
   <data name="&gt;&gt;submitErrorReportMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;crashSkylineMenuItem.Name" xml:space="preserve">
+    <value>crashSkylineMenuItem</value>
+  </data>
+  <data name="&gt;&gt;crashSkylineMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;checkForUpdatesSeparator.Name" xml:space="preserve">
     <value>checkForUpdatesSeparator</value>
   </data>
@@ -3625,6 +3763,12 @@
     <value>aboutMenuItem</value>
   </data>
   <data name="&gt;&gt;aboutMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;eSPFeaturesMenuItem.Name" xml:space="preserve">
+    <value>eSPFeaturesMenuItem</value>
+  </data>
+  <data name="&gt;&gt;eSPFeaturesMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;massErrorGraphContextMenuItem.Name" xml:space="preserve">
@@ -3890,12 +4034,6 @@
   </data>
   <data name="&gt;&gt;detectionsToolStripSeparator3.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;crashSkylineMenuItem.Name" xml:space="preserve">
-    <value>crashSkylineMenuItem</value>
-  </data>
-  <data name="&gt;&gt;crashSkylineMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SkylineWindow</value>

--- a/pwiz_tools/Skyline/Skyline.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Skyline.zh-CHS.resx
@@ -300,27 +300,6 @@
     <value>228, 22</value>
   </data>
   <data name="replicatesTreeContextMenuItem.Text" xml:space="preserve">
-    <value>重复测定</value>
-  </data>
-  <data name="contextMenuTreeNode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>229, 374</value>
-  </data>
-  <data name="&gt;&gt;contextMenuTreeNode.Name" xml:space="preserve">
-    <value>contextMenuTreeNode</value>
-  </data>
-  <data name="&gt;&gt;contextMenuTreeNode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <metadata name="contextMenuSpectrum.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>197, 56</value>
-  </metadata>
-  <data name="replicatesTreeContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>228, 22</value>
-  </data>
-  <data name="ionTypesContextMenuItem.Text" xml:space="preserve">
-    <value>离子类型</value>
-  </data>
-  <data name="replicatesTreeContextMenuItem.Text" xml:space="preserve">
     <value>Replicates</value>
   </data>
   <data name="contextMenuTreeNode.Size" type="System.Drawing.Size, System.Drawing">
@@ -331,6 +310,15 @@
   </data>
   <data name="&gt;&gt;contextMenuTreeNode.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="contextMenuSpectrum.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1304, 17</value>
+  </metadata>
+  <data name="ionTypesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 22</value>
+  </data>
+  <data name="ionTypesContextMenuItem.Text" xml:space="preserve">
+    <value>离子类型</value>
   </data>
   <data name="fragmentionsContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
@@ -373,12 +361,6 @@
   </data>
   <data name="scoreContextMenuItem.Text" xml:space="preserve">
     <value>得分</value>
-  </data>
-  <data name="massErrorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 22</value>
-  </data>
-  <data name="massErrorToolStripMenuItem.Text" xml:space="preserve">
-    <value>显示质量误差</value>
   </data>
   <data name="massErrorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
@@ -437,11 +419,17 @@
   <data name="spectrumGraphPropsContextMenuItem.Text" xml:space="preserve">
     <value>图形属性...</value>
   </data>
-  <data name="showSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="showLibSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
   </data>
-  <data name="showSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
-    <value>谱图属性</value>
+  <data name="showLibSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
+    <value>Spectrum Properties</value>
+  </data>
+  <data name="showFullScanSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 22</value>
+  </data>
+  <data name="showFullScanSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
+    <value>Spectrum Properties</value>
   </data>
   <data name="toolStripSeparator15.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 6</value>
@@ -466,6 +454,9 @@
   </data>
   <data name="synchMzScaleToolStripMenuItem.Text" xml:space="preserve">
     <value>同步质荷比尺度</value>
+  </data>
+  <data name="contextMenuSpectrum.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 486</value>
   </data>
   <data name="&gt;&gt;contextMenuSpectrum.Name" xml:space="preserve">
     <value>contextMenuSpectrum</value>
@@ -768,7 +759,7 @@
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <metadata name="contextMenuPeakAreas.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 56</value>
+    <value>1124, 17</value>
   </metadata>
   <data name="areaReplicateComparisonContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 22</value>
@@ -781,6 +772,12 @@
   </data>
   <data name="areaPeptideComparisonContextMenuItem.Text" xml:space="preserve">
     <value>肽段比较</value>
+  </data>
+  <data name="areaRelativeAbundanceContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>190, 22</value>
+  </data>
+  <data name="areaRelativeAbundanceContextMenuItem.Text" xml:space="preserve">
+    <value>Relative Abundance</value>
   </data>
   <data name="areaCVHistogramContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 22</value>
@@ -889,6 +886,18 @@
   </data>
   <data name="scopeContextMenuItem.Text" xml:space="preserve">
     <value>范围</value>
+  </data>
+  <data name="abundanceTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="abundanceTargetsMenuItem.Text" xml:space="preserve">
+    <value>Targets</value>
+  </data>
+  <data name="excludeTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="excludeTargetsMenuItem.Text" xml:space="preserve">
+    <value>Exclude</value>
   </data>
   <data name="showPeakAreaLegendContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 22</value>
@@ -1035,13 +1044,37 @@
     <value>206, 6</value>
   </data>
   <data name="contextMenuPeakAreas.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 434</value>
+    <value>210, 478</value>
   </data>
   <data name="&gt;&gt;contextMenuPeakAreas.Name" xml:space="preserve">
     <value>contextMenuPeakAreas</value>
   </data>
   <data name="&gt;&gt;contextMenuPeakAreas.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="abundanceTargetsProteinsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="abundanceTargetsProteinsMenuItem.Text" xml:space="preserve">
+    <value>Proteins</value>
+  </data>
+  <data name="abundanceTargetsPeptidesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="abundanceTargetsPeptidesMenuItem.Text" xml:space="preserve">
+    <value>Peptides</value>
+  </data>
+  <data name="excludeTargetsPeptideListMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="excludeTargetsPeptideListMenuItem.Text" xml:space="preserve">
+    <value>Peptide Lists</value>
+  </data>
+  <data name="excludeTargetsStandardsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
+  <data name="excludeTargetsStandardsMenuItem.Text" xml:space="preserve">
+    <value>Standards</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="dockPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
@@ -1180,7 +1213,7 @@
     <value>7</value>
   </data>
   <metadata name="mainToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>373, 56</value>
+    <value>1480, 17</value>
   </metadata>
   <data name="newToolBarButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -1321,7 +1354,7 @@
     <value>Fuchsia</value>
   </data>
   <data name="startPageMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="startPageMenuItem.Text" xml:space="preserve">
     <value>开始(&amp;R)…</value>
@@ -1333,7 +1366,7 @@
     <value>Ctrl+N</value>
   </data>
   <data name="newMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="newMenuItem.Text" xml:space="preserve">
     <value>新建(&amp;N)</value>
@@ -1345,19 +1378,28 @@
     <value>Ctrl+O</value>
   </data>
   <data name="openMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="openMenuItem.Text" xml:space="preserve">
     <value>打开(&amp;O)…</value>
   </data>
+  <data name="openPanoramaMenuItem.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="openPanoramaMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
+  </data>
+  <data name="openPanoramaMenuItem.Text" xml:space="preserve">
+    <value>Open From Panora&amp;ma...</value>
+  </data>
   <data name="openContainingFolderMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="openContainingFolderMenuItem.Text" xml:space="preserve">
     <value>打开包含文件夹(&amp;C)</value>
   </data>
   <data name="toolStripSeparator53.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
   </data>
   <data name="saveMenuItem.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Fuchsia</value>
@@ -1366,19 +1408,19 @@
     <value>Ctrl+S</value>
   </data>
   <data name="saveMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="saveMenuItem.Text" xml:space="preserve">
     <value>保存(&amp;S)</value>
   </data>
   <data name="saveAsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="saveAsMenuItem.Text" xml:space="preserve">
     <value>另存为(&amp;A)…</value>
   </data>
   <data name="shareDocumentMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="shareDocumentMenuItem.Text" xml:space="preserve">
     <value>共享(&amp;H)…</value>
@@ -1387,13 +1429,37 @@
     <value>Fuchsia</value>
   </data>
   <data name="publishMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="publishMenuItem.Text" xml:space="preserve">
     <value>上传至 Panorama(&amp;U)…</value>
   </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
+  </data>
+  <data name="runPeptideSearchToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
+  <data name="runPeptideSearchToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Run Peptide Search...</value>
+  </data>
+  <data name="encyclopeDiaSearchMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
+  <data name="encyclopeDiaSearchMenuItem.Text" xml:space="preserve">
+    <value>EncyclopeDIA 搜索...</value>
+  </data>
+  <data name="importFeatureDetectionMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
+  <data name="importFeatureDetectionMenuItem.Text" xml:space="preserve">
+    <value>&amp;Feature Detection...</value>
+  </data>
+  <data name="searchStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
+  </data>
+  <data name="searchStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Search</value>
   </data>
   <data name="importResultsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 22</value>
@@ -1415,12 +1481,6 @@
   </data>
   <data name="importPeptideSearchMenuItem.Text" xml:space="preserve">
     <value>肽段搜索(&amp;P)…</value>
-  </data>
-  <data name="encyclopeDiaSearchMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 22</value>
-  </data>
-  <data name="encyclopeDiaSearchMenuItem.Text" xml:space="preserve">
-    <value>EncyclopeDIA 搜索...</value>
   </data>
   <data name="toolStripSeparator52.Size" type="System.Drawing.Size, System.Drawing">
     <value>167, 6</value>
@@ -1456,7 +1516,7 @@
     <value>注释…(&amp;A)</value>
   </data>
   <data name="importToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="importToolStripMenuItem.Text" xml:space="preserve">
     <value>导入(&amp;I)</value>
@@ -1491,15 +1551,6 @@
   <data name="toolStripSeparator50.Size" type="System.Drawing.Size, System.Drawing">
     <value>180, 6</value>
   </data>
-  <data name="eSPFeaturesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>183, 22</value>
-  </data>
-  <data name="eSPFeaturesMenuItem.Text" xml:space="preserve">
-    <value>ESP 特征(&amp;E)…</value>
-  </data>
-  <data name="eSPFeaturesMenuItem.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
   <data name="exportSpectralLibraryMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>183, 22</value>
   </data>
@@ -1525,22 +1576,22 @@
     <value>注释(&amp;A)…</value>
   </data>
   <data name="exportToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="exportToolStripMenuItem.Text" xml:space="preserve">
     <value>导出(&amp;E)</value>
   </data>
   <data name="mruBeforeToolStripSeparator.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
   </data>
   <data name="mruAfterToolStripSeparator.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
   </data>
   <data name="mruAfterToolStripSeparator.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="exitMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
+    <value>200, 22</value>
   </data>
   <data name="exitMenuItem.Text" xml:space="preserve">
     <value>退出(&amp;X)</value>
@@ -1823,6 +1874,15 @@
   </data>
   <data name="&gt;&gt;menuMain.ZOrder" xml:space="preserve">
     <value>9</value>
+  </data>
+  <data name="eSPFeaturesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>183, 22</value>
+  </data>
+  <data name="eSPFeaturesMenuItem.Text" xml:space="preserve">
+    <value>ESP 特征(&amp;E)…</value>
+  </data>
+  <data name="eSPFeaturesMenuItem.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <metadata name="contextMenuMassErrors.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>941, 17</value>
@@ -2223,6 +2283,12 @@
   <data name="&gt;&gt;modifyPeptideContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;editSpectrumFilterContextMenuItem.Name" xml:space="preserve">
+    <value>editSpectrumFilterContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;editSpectrumFilterContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;toggleQuantitativeContextMenuItem.Name" xml:space="preserve">
     <value>toggleQuantitativeContextMenuItem</value>
   </data>
@@ -2403,10 +2469,16 @@
   <data name="&gt;&gt;spectrumGraphPropsContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;showSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
-    <value>showSpectrumPropertiesContextMenuItem</value>
+  <data name="&gt;&gt;showLibSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
+    <value>showLibSpectrumPropertiesContextMenuItem</value>
   </data>
-  <data name="&gt;&gt;showSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
+  <data name="&gt;&gt;showLibSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showFullScanSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
+    <value>showFullScanSpectrumPropertiesContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;showFullScanSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator15.Name" xml:space="preserve">
@@ -2757,6 +2829,12 @@
   <data name="&gt;&gt;areaPeptideComparisonContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;areaRelativeAbundanceContextMenuItem.Name" xml:space="preserve">
+    <value>areaRelativeAbundanceContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;areaRelativeAbundanceContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;areaCVHistogramContextMenuItem.Name" xml:space="preserve">
     <value>areaCVHistogramContextMenuItem</value>
   </data>
@@ -2857,6 +2935,18 @@
     <value>proteinScopeContextMenuItem</value>
   </data>
   <data name="&gt;&gt;proteinScopeContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;showPeakAreaLegendContextMenuItem.Name" xml:space="preserve">
@@ -3027,6 +3117,30 @@
   <data name="&gt;&gt;toolStripSeparator57.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;abundanceTargetsProteinsMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsProteinsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsProteinsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsPeptidesMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsPeptidesMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsPeptidesMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsPeptideListMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsPeptideListMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsPeptideListMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsStandardsMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsStandardsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsStandardsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;statusGeneral.Name" xml:space="preserve">
     <value>statusGeneral</value>
   </data>
@@ -3171,6 +3285,12 @@
   <data name="&gt;&gt;openMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;openPanoramaMenuItem.Name" xml:space="preserve">
+    <value>openPanoramaMenuItem</value>
+  </data>
+  <data name="&gt;&gt;openPanoramaMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;openContainingFolderMenuItem.Name" xml:space="preserve">
     <value>openContainingFolderMenuItem</value>
   </data>
@@ -3213,6 +3333,30 @@
   <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;searchStripMenuItem.Name" xml:space="preserve">
+    <value>searchStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;searchStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;runPeptideSearchToolStripMenuItem.Name" xml:space="preserve">
+    <value>runPeptideSearchToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;runPeptideSearchToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Name" xml:space="preserve">
+    <value>encyclopeDiaSearchMenuItem</value>
+  </data>
+  <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;importFeatureDetectionMenuItem.Name" xml:space="preserve">
+    <value>importFeatureDetectionMenuItem</value>
+  </data>
+  <data name="&gt;&gt;importFeatureDetectionMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;importToolStripMenuItem.Name" xml:space="preserve">
     <value>importToolStripMenuItem</value>
   </data>
@@ -3241,12 +3385,6 @@
     <value>importPeptideSearchMenuItem</value>
   </data>
   <data name="&gt;&gt;importPeptideSearchMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Name" xml:space="preserve">
-    <value>encyclopeDiaSearchMenuItem</value>
-  </data>
-  <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator52.Name" xml:space="preserve">
@@ -3326,12 +3464,6 @@
   </data>
   <data name="&gt;&gt;toolStripSeparator50.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;eSPFeaturesMenuItem.Name" xml:space="preserve">
-    <value>eSPFeaturesMenuItem</value>
-  </data>
-  <data name="&gt;&gt;eSPFeaturesMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;exportSpectralLibraryMenuItem.Name" xml:space="preserve">
     <value>exportSpectralLibraryMenuItem</value>
@@ -3603,6 +3735,12 @@
   <data name="&gt;&gt;submitErrorReportMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;crashSkylineMenuItem.Name" xml:space="preserve">
+    <value>crashSkylineMenuItem</value>
+  </data>
+  <data name="&gt;&gt;crashSkylineMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;checkForUpdatesSeparator.Name" xml:space="preserve">
     <value>checkForUpdatesSeparator</value>
   </data>
@@ -3625,6 +3763,12 @@
     <value>aboutMenuItem</value>
   </data>
   <data name="&gt;&gt;aboutMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;eSPFeaturesMenuItem.Name" xml:space="preserve">
+    <value>eSPFeaturesMenuItem</value>
+  </data>
+  <data name="&gt;&gt;eSPFeaturesMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;massErrorGraphContextMenuItem.Name" xml:space="preserve">
@@ -3890,12 +4034,6 @@
   </data>
   <data name="&gt;&gt;detectionsToolStripSeparator3.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;crashSkylineMenuItem.Name" xml:space="preserve">
-    <value>crashSkylineMenuItem</value>
-  </data>
-  <data name="&gt;&gt;crashSkylineMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SkylineWindow</value>

--- a/pwiz_tools/Skyline/SkylineResources.ja.resx
+++ b/pwiz_tools/Skyline/SkylineResources.ja.resx
@@ -117,7 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="AddZipToolHelper_ShouldOverwrite__and_a_conflicting_tool" xml:space="preserve">
     <value> があり、</value>
   </data>
@@ -141,6 +140,9 @@
   </data>
   <data name="AddZipToolHelper_ShouldOverwrite_Overwriting_reports___0_" xml:space="preserve">
     <value>上書きレポート：{0}</value>
+  </data>
+  <data name="CommandArgs_ARG_BGPROTEOME_NAME_name_to_give_protdb_imported_by___background_proteome_file" xml:space="preserve">
+    <value>name to give protdb imported by --background-proteome-file</value>
   </data>
   <data name="CommandArgs_DwellTime_The_dwell_time__0__must_be_between__1__and__2__" xml:space="preserve">
     <value>ドウェル時間{0}は{1}から{2}の間でなければなりません。</value>
@@ -187,6 +189,9 @@
   </data>
   <data name="CommandArgs_ParseArgsInternal_Warning__The_instrument_type__0__is_not_valid__Please_choose_from_" xml:space="preserve">
     <value>警告： 装置タイプ{0}が有効ではありません。次から選択してください：</value>
+  </data>
+  <data name="CommandArgs_ParseExcludeObject_Error__Attempting_to_exclude_an_unknown_object_name___0____Try_one_of_the_following_" xml:space="preserve">
+    <value>Error: Attempting to exclude an unknown object name '{0}'. Try one of the following:</value>
   </data>
   <data name="CommandArgs_PrimaryTransitionCount_The_primary_transition_count__0__must_be_between__1__and__2__" xml:space="preserve">
     <value>プライマリトランジション数{0}は{1}と{2}の間でなければなりません。</value>
@@ -236,6 +241,9 @@
   <data name="CommandLine_CreateUntrainedScoringModel_Error__Excluding_feature_scores_is_not_permitted_with_the_default_Skyline_model_" xml:space="preserve">
     <value>エラー：デフォルトのSkylineモデルではフィーチャースコアを除外できません。</value>
   </data>
+  <data name="CommandLine_ExportAnnotations_Error__Failure_attempting_to_save_annotations_file__0__" xml:space="preserve">
+    <value>Error: Failure attempting to save annotations file {0}.</value>
+  </data>
   <data name="CommandLine_ExportChromatograms_Chromatograms_file__0__exported_successfully_" xml:space="preserve">
     <value>クロマトグラムファイル{0}が正常にエクスポートされました。</value>
   </data>
@@ -284,6 +292,9 @@
   <data name="CommandLine_ExportInstrumentFile_Error__To_export_a_scheduled_method__you_must_first_import_results_for_all_peptides_in_the_document_" xml:space="preserve">
     <value>エラー： スケジュールメソッドをエクスポートするには、まずドキュメント内のすべてのペプチドに対する結果をインポートする必要があります。</value>
   </data>
+  <data name="CommandLine_ExportInstrumentFile_The_folder__0__does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
+    <value>The folder {0} does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+  </data>
   <data name="CommandLine_ExportInstrumentFile_Warning__Max_transitions_per_injection_must_be_set_to_some_value_between__0__and__1__for_export_strategies__protein__and__buckets__and_for_scheduled_methods__You_specified__3___Defaulting_to__2__" xml:space="preserve">
     <value>警告： インジェクション毎の最大トランジションは、エクスポート方法「タンパク質」と「バケット」、またスケジュールメソッドに対し、{0}と{1}の間の値に設定されなければなりません。{3}が指定されました。{2}にデフォルト中。</value>
   </data>
@@ -316,6 +327,12 @@
   </data>
   <data name="CommandLine_ExportLiveReport_Report__0__exported_successfully_to__1__" xml:space="preserve">
     <value>レポート{0}が{1}に正常にエクスポートされました。</value>
+  </data>
+  <data name="CommandLine_ExportMProphetFeatures_Error__Failure_attempting_to_save_mProphet_features_file__0__" xml:space="preserve">
+    <value>Error: Failure attempting to save mProphet features file {0}.</value>
+  </data>
+  <data name="CommandLine_ExportSpecLib_Error__Failure_attempting_to_save_spectral_library_file__0__" xml:space="preserve">
+    <value>Error: Failure attempting to save spectral library file {0}.</value>
   </data>
   <data name="CommandLine_FindBackgroundProteome_Warning__Could_not_find_the_background_proteome_file__0__" xml:space="preserve">
     <value>警告： バックグラウンドプロテオームファイル{0}が見つかりませんでした。</value>
@@ -483,6 +500,9 @@
   <data name="CommandLine_SaveSettings_Error__Failed_saving_to_the_user_configuration_file_" xml:space="preserve">
     <value>エラー：ユーザー設定ファイルへの保存に失敗しました。</value>
   </data>
+  <data name="CommandLine_SetAnnotations_" xml:space="preserve">
+    <value>Error: An annotation titled '{0}' already exists.  Please use --annotation-conflict-resolution= &lt;overwrite | skip&gt;.  Annotation titled '{0}' was not added.</value>
+  </data>
   <data name="CommandLine_SetFilterSettings_Error__Failed_attempting_to_change_the_transition_filter_settings_" xml:space="preserve">
     <value>エラー：トランジションフィルタ設定の変更に失敗しました。</value>
   </data>
@@ -506,6 +526,12 @@
   </data>
   <data name="CommandLine_SetLibrarySettings_Error__Failed_attempting_to_change_the_transition_library_settings_" xml:space="preserve">
     <value>エラー：トランジションライブラリ設定を変更しようとして失敗しました。</value>
+  </data>
+  <data name="CommandLine_SetPeptideDigestSettings_Error__Failed_attempting_to_change_the_peptide_digestion_settings_" xml:space="preserve">
+    <value>Error: Failed attempting to change the peptide digestion settings.</value>
+  </data>
+  <data name="CommandLine_SetPeptideFilterSettings_Error__Failed_attempting_to_change_the_peptide_filter_settings_" xml:space="preserve">
+    <value>Error: Failed attempting to change the peptide filter settings.</value>
   </data>
   <data name="CommandLine_SetPredictTranSettings_Error__Failed_attempting_to_change_the_transition_prediction_settings_" xml:space="preserve">
     <value>エラー：トランジション予測設定の変更に失敗しました。</value>
@@ -576,7 +602,7 @@
     <value>切り替える前に現在の設定を保存しますか？</value>
   </data>
   <data name="SkylineWindow_Add" xml:space="preserve">
-    <value>追加</value>
+    <value>Add</value>
   </data>
   <data name="SkylineWindow_AddMolecule_Add_custom_product_ion__0_" xml:space="preserve">
     <value>カスタムプロダクトイオン{0}を追加</value>
@@ -920,6 +946,21 @@
   <data name="SkylineWindow_OpenFile_Loading___" xml:space="preserve">
     <value>読み込み中...</value>
   </data>
+  <data name="SkylineWindow_OpenFromPanorama_Downloading_file__0_" xml:space="preserve">
+    <value>Downloading file {0}</value>
+  </data>
+  <data name="SkylineWindow_OpenFromPanorama_Loading_remote_server_folders" xml:space="preserve">
+    <value>Loading remote server folders</value>
+  </data>
+  <data name="SkylineWindow_OpenFromPanorama_No_Panorama_servers_were_found_" xml:space="preserve">
+    <value>No Panorama servers were found.</value>
+  </data>
+  <data name="SkylineWindow_OpenFromPanorama_Open_From_Panorama" xml:space="preserve">
+    <value>Open From Panorama</value>
+  </data>
+  <data name="SkylineWindow_OpenFromPanorama_Press__Add__to_add_a_new_server_" xml:space="preserve">
+    <value>Press 'Add' to add a new server.</value>
+  </data>
   <data name="SkylineWindow_OpenSharedFile_The_zip_file__0__cannot_be_read" xml:space="preserve">
     <value>zipファイル{0}を読み取れません。</value>
   </data>
@@ -1037,6 +1078,12 @@
   <data name="SkylineWindow_ShowPublishDlg_Continue" xml:space="preserve">
     <value>続行</value>
   </data>
+  <data name="SkylineWindow_ShowPublishDlg_Document_cannot_be_uploaded_to_a_Panorama_server_without_a_user_account_" xml:space="preserve">
+    <value>Document cannot be uploaded to a Panorama server without a user account.</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg_Edit_existing" xml:space="preserve">
+    <value>Edit existing</value>
+  </data>
   <data name="SkylineWindow_ShowPublishDlg_Press_Continue_to_use_the_server_of_your_choice_" xml:space="preserve">
     <value>続行を押して選択したサーバーを使用します。</value>
   </data>
@@ -1094,7 +1141,40 @@
   <data name="UpgradeManager_updateCheck_Complete_Upgrading__0_" xml:space="preserve">
     <value>{0}をアップグレードしています</value>
   </data>
+  <data name="ValueInvalidAnnotationTargetListException_ValueInvalidAnnotationTargetListException_The_value__0___is_not_valid_for_the_argument___1___which_requires_a_comma_separated_list_of_annotation_targets___2___" xml:space="preserve">
+    <value>The value '{0}' is not valid for the argument {1} which requires a comma-separated list of annotation targets {2}.</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg_Press__Edit_existing__to_add_user_account_information_for_an_existing_server_" xml:space="preserve">
+    <value>Press 'Edit existing' to add user account information for an existing server.</value>
+  </data>
+  <data name="CommandLine_SetPeptideModSettings_Error__Failed_attempting_to_change_the_peptide_modification_settings_" xml:space="preserve">
+    <value>Error: Failed attempting to change the peptide modification settings.</value>
+  </data>
+  <data name="SkylineWindow_ShowImportPeptideSearchDlg_The_document_must_be_fully_loaded_before_performing_feature_detection_" xml:space="preserve">
+    <value>The document must be fully loaded before performing feature detection.</value>
+  </data>
+  <data name="SkylineWindow_ShowImportPeptideSearchDlg_You_must_save_this_document_before_performing_feature_detection_" xml:space="preserve">
+    <value>You must save this document before performing feature detection.</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg__0__is_not_a_valid_file_name_for_uploading_to_Panorama_" xml:space="preserve">
+    <value>{0} is not a valid file name for uploading to Panorama.</value>
+  </data>
   <data name="CommandLine_AssociateProteins_Associating_peptides_with_proteins" xml:space="preserve">
-    <value>ペプチドをタンパク質と関連付け</value>
+    <value>ペプチドをタンパク質に関連付け</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_RunPeptideSearchRadioDIAText_DIA_with_DIA_Umpire" xml:space="preserve">
+    <value>DIA with DIA-Umpire</value>
+  </data>
+  <data name="SkylineWindow_ShowRunPeptideSearchDlg_Run_Peptide_Search" xml:space="preserve">
+    <value>Run Peptide Search</value>
+  </data>
+  <data name="SkylineWindow_ShowRunPeptideSearchDlg_You_must_save_this_document_before_running_a_peptide_search_" xml:space="preserve">
+    <value>You must save this document before running a peptide search.</value>
+  </data>
+  <data name="SkylineWindow_ShowRunPeptideSearchDlg_The_document_must_be_fully_loaded_before_running_a_peptide_search_" xml:space="preserve">
+    <value>The document must be fully loaded before running a peptide search.</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibraryControl_Library_from_DIA_deconvoluted_to_single_precursor_MS_MS_spectra_and_chromatograms_from_raw_DIA_spectra_of_same_runs" xml:space="preserve">
+    <value>Library from DIA deconvoluted to single-precursor MS/MS spectra and chromatograms from raw DIA spectra of same runs</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
@@ -117,7 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="AddZipToolHelper_ShouldOverwrite__and_a_conflicting_tool" xml:space="preserve">
     <value> 和一个冲突工具</value>
   </data>
@@ -141,6 +140,9 @@
   </data>
   <data name="AddZipToolHelper_ShouldOverwrite_Overwriting_reports___0_" xml:space="preserve">
     <value>覆盖报告：{0}</value>
+  </data>
+  <data name="CommandArgs_ARG_BGPROTEOME_NAME_name_to_give_protdb_imported_by___background_proteome_file" xml:space="preserve">
+    <value>name to give protdb imported by --background-proteome-file</value>
   </data>
   <data name="CommandArgs_DwellTime_The_dwell_time__0__must_be_between__1__and__2__" xml:space="preserve">
     <value>驻留时间 {0} 必须在 {1} 和 {2} 之间。</value>
@@ -187,6 +189,9 @@
   </data>
   <data name="CommandArgs_ParseArgsInternal_Warning__The_instrument_type__0__is_not_valid__Please_choose_from_" xml:space="preserve">
     <value>警告：仪器类型{0}无效。请从下方选项中选择：</value>
+  </data>
+  <data name="CommandArgs_ParseExcludeObject_Error__Attempting_to_exclude_an_unknown_object_name___0____Try_one_of_the_following_" xml:space="preserve">
+    <value>Error: Attempting to exclude an unknown object name '{0}'. Try one of the following:</value>
   </data>
   <data name="CommandArgs_PrimaryTransitionCount_The_primary_transition_count__0__must_be_between__1__and__2__" xml:space="preserve">
     <value>主要离子对计数 {0} 必须在 {1} 和 {2} 之间。</value>
@@ -236,6 +241,9 @@
   <data name="CommandLine_CreateUntrainedScoringModel_Error__Excluding_feature_scores_is_not_permitted_with_the_default_Skyline_model_" xml:space="preserve">
     <value>错误：默认 Skyline 模型不允许排除特征得分。</value>
   </data>
+  <data name="CommandLine_ExportAnnotations_Error__Failure_attempting_to_save_annotations_file__0__" xml:space="preserve">
+    <value>Error: Failure attempting to save annotations file {0}.</value>
+  </data>
   <data name="CommandLine_ExportChromatograms_Chromatograms_file__0__exported_successfully_" xml:space="preserve">
     <value>色谱图文件{0}导出成功。</value>
   </data>
@@ -284,6 +292,9 @@
   <data name="CommandLine_ExportInstrumentFile_Error__To_export_a_scheduled_method__you_must_first_import_results_for_all_peptides_in_the_document_" xml:space="preserve">
     <value>错误：如要导出预定方法，您必须首先在文档中导入针对所有肽段的结果。</value>
   </data>
+  <data name="CommandLine_ExportInstrumentFile_The_folder__0__does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
+    <value>The folder {0} does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+  </data>
   <data name="CommandLine_ExportInstrumentFile_Warning__Max_transitions_per_injection_must_be_set_to_some_value_between__0__and__1__for_export_strategies__protein__and__buckets__and_for_scheduled_methods__You_specified__3___Defaulting_to__2__" xml:space="preserve">
     <value>警告：每次注射的最大离子对数必须针对导出策略“蛋白质”和“存储桶”以及预定的方法设定为 {0} 和 {1} 之间的某个数值。您指定了 {3}。默认设置为 {2}。</value>
   </data>
@@ -316,6 +327,12 @@
   </data>
   <data name="CommandLine_ExportLiveReport_Report__0__exported_successfully_to__1__" xml:space="preserve">
     <value>报告{0}已成功导出至{1}。</value>
+  </data>
+  <data name="CommandLine_ExportMProphetFeatures_Error__Failure_attempting_to_save_mProphet_features_file__0__" xml:space="preserve">
+    <value>Error: Failure attempting to save mProphet features file {0}.</value>
+  </data>
+  <data name="CommandLine_ExportSpecLib_Error__Failure_attempting_to_save_spectral_library_file__0__" xml:space="preserve">
+    <value>Error: Failure attempting to save spectral library file {0}.</value>
   </data>
   <data name="CommandLine_FindBackgroundProteome_Warning__Could_not_find_the_background_proteome_file__0__" xml:space="preserve">
     <value>警告：无法找到背景蛋白质组文件{0}。</value>
@@ -483,6 +500,9 @@
   <data name="CommandLine_SaveSettings_Error__Failed_saving_to_the_user_configuration_file_" xml:space="preserve">
     <value>错误：未能保存至用户配置文件。</value>
   </data>
+  <data name="CommandLine_SetAnnotations_" xml:space="preserve">
+    <value>Error: An annotation titled '{0}' already exists.  Please use --annotation-conflict-resolution= &lt;overwrite | skip&gt;.  Annotation titled '{0}' was not added.</value>
+  </data>
   <data name="CommandLine_SetFilterSettings_Error__Failed_attempting_to_change_the_transition_filter_settings_" xml:space="preserve">
     <value>错误：尝试更改离子对过滤设置失败。</value>
   </data>
@@ -499,13 +519,19 @@
     <value>错误：尝试更改离子迁移设置失败。</value>
   </data>
   <data name="CommandLine_SetInstrumentSettings_Error__Failed_attempting_to_change_the_transition_instrument_settings_" xml:space="preserve">
-    <value>错误：尝试更改离子对仪器设置失败。</value>
+    <value>错误：尝试更改离子对的仪器设置失败。</value>
   </data>
   <data name="CommandLine_SetLibrary_Error__The_file__0__appears_to_be_a_redundant_library_" xml:space="preserve">
     <value>错误：文件{0}貌似冗余库。</value>
   </data>
   <data name="CommandLine_SetLibrarySettings_Error__Failed_attempting_to_change_the_transition_library_settings_" xml:space="preserve">
-    <value>错误：尝试更改离子对库设置失败。</value>
+    <value>错误：尝试更改离子对的库设置失败。</value>
+  </data>
+  <data name="CommandLine_SetPeptideDigestSettings_Error__Failed_attempting_to_change_the_peptide_digestion_settings_" xml:space="preserve">
+    <value>Error: Failed attempting to change the peptide digestion settings.</value>
+  </data>
+  <data name="CommandLine_SetPeptideFilterSettings_Error__Failed_attempting_to_change_the_peptide_filter_settings_" xml:space="preserve">
+    <value>Error: Failed attempting to change the peptide filter settings.</value>
   </data>
   <data name="CommandLine_SetPredictTranSettings_Error__Failed_attempting_to_change_the_transition_prediction_settings_" xml:space="preserve">
     <value>错误：尝试更改离子对预测设置失败。</value>
@@ -576,7 +602,7 @@
     <value>您是否想要在转换前保存您的当前设置？</value>
   </data>
   <data name="SkylineWindow_Add" xml:space="preserve">
-    <value>添加</value>
+    <value>Add</value>
   </data>
   <data name="SkylineWindow_AddMolecule_Add_custom_product_ion__0_" xml:space="preserve">
     <value>添加自定义子离子 {0}</value>
@@ -920,6 +946,21 @@
   <data name="SkylineWindow_OpenFile_Loading___" xml:space="preserve">
     <value>加载中...</value>
   </data>
+  <data name="SkylineWindow_OpenFromPanorama_Downloading_file__0_" xml:space="preserve">
+    <value>Downloading file {0}</value>
+  </data>
+  <data name="SkylineWindow_OpenFromPanorama_Loading_remote_server_folders" xml:space="preserve">
+    <value>Loading remote server folders</value>
+  </data>
+  <data name="SkylineWindow_OpenFromPanorama_No_Panorama_servers_were_found_" xml:space="preserve">
+    <value>No Panorama servers were found.</value>
+  </data>
+  <data name="SkylineWindow_OpenFromPanorama_Open_From_Panorama" xml:space="preserve">
+    <value>Open From Panorama</value>
+  </data>
+  <data name="SkylineWindow_OpenFromPanorama_Press__Add__to_add_a_new_server_" xml:space="preserve">
+    <value>Press 'Add' to add a new server.</value>
+  </data>
   <data name="SkylineWindow_OpenSharedFile_The_zip_file__0__cannot_be_read" xml:space="preserve">
     <value>压缩文件{0}不可读。</value>
   </data>
@@ -1037,6 +1078,12 @@
   <data name="SkylineWindow_ShowPublishDlg_Continue" xml:space="preserve">
     <value>继续</value>
   </data>
+  <data name="SkylineWindow_ShowPublishDlg_Document_cannot_be_uploaded_to_a_Panorama_server_without_a_user_account_" xml:space="preserve">
+    <value>Document cannot be uploaded to a Panorama server without a user account.</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg_Edit_existing" xml:space="preserve">
+    <value>Edit existing</value>
+  </data>
   <data name="SkylineWindow_ShowPublishDlg_Press_Continue_to_use_the_server_of_your_choice_" xml:space="preserve">
     <value>按下“继续”，以使用您选择的服务器。</value>
   </data>
@@ -1094,7 +1141,40 @@
   <data name="UpgradeManager_updateCheck_Complete_Upgrading__0_" xml:space="preserve">
     <value>正在升级 {0}</value>
   </data>
+  <data name="ValueInvalidAnnotationTargetListException_ValueInvalidAnnotationTargetListException_The_value__0___is_not_valid_for_the_argument___1___which_requires_a_comma_separated_list_of_annotation_targets___2___" xml:space="preserve">
+    <value>The value '{0}' is not valid for the argument {1} which requires a comma-separated list of annotation targets {2}.</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg_Press__Edit_existing__to_add_user_account_information_for_an_existing_server_" xml:space="preserve">
+    <value>Press 'Edit existing' to add user account information for an existing server.</value>
+  </data>
+  <data name="CommandLine_SetPeptideModSettings_Error__Failed_attempting_to_change_the_peptide_modification_settings_" xml:space="preserve">
+    <value>Error: Failed attempting to change the peptide modification settings.</value>
+  </data>
+  <data name="SkylineWindow_ShowImportPeptideSearchDlg_The_document_must_be_fully_loaded_before_performing_feature_detection_" xml:space="preserve">
+    <value>The document must be fully loaded before performing feature detection.</value>
+  </data>
+  <data name="SkylineWindow_ShowImportPeptideSearchDlg_You_must_save_this_document_before_performing_feature_detection_" xml:space="preserve">
+    <value>You must save this document before performing feature detection.</value>
+  </data>
+  <data name="SkylineWindow_ShowPublishDlg__0__is_not_a_valid_file_name_for_uploading_to_Panorama_" xml:space="preserve">
+    <value>{0} is not a valid file name for uploading to Panorama.</value>
+  </data>
   <data name="CommandLine_AssociateProteins_Associating_peptides_with_proteins" xml:space="preserve">
     <value>正在关联肽段与蛋白质</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_RunPeptideSearchRadioDIAText_DIA_with_DIA_Umpire" xml:space="preserve">
+    <value>DIA with DIA-Umpire</value>
+  </data>
+  <data name="SkylineWindow_ShowRunPeptideSearchDlg_Run_Peptide_Search" xml:space="preserve">
+    <value>Run Peptide Search</value>
+  </data>
+  <data name="SkylineWindow_ShowRunPeptideSearchDlg_You_must_save_this_document_before_running_a_peptide_search_" xml:space="preserve">
+    <value>You must save this document before running a peptide search.</value>
+  </data>
+  <data name="SkylineWindow_ShowRunPeptideSearchDlg_The_document_must_be_fully_loaded_before_running_a_peptide_search_" xml:space="preserve">
+    <value>The document must be fully loaded before running a peptide search.</value>
+  </data>
+  <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibraryControl_Library_from_DIA_deconvoluted_to_single_precursor_MS_MS_spectra_and_chromatograms_from_raw_DIA_spectra_of_same_runs" xml:space="preserve">
+    <value>Library from DIA deconvoluted to single-precursor MS/MS spectra and chromatograms from raw DIA spectra of same runs</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/ToolsUI/EditRemoteAccountDlg.ja.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditRemoteAccountDlg.ja.resx
@@ -243,7 +243,7 @@
   <data name="textPassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>15, 111</value>
   </data>
-  <data name="textPassword.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="textPassword.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="textPassword.Size" type="System.Drawing.Size, System.Drawing">
@@ -432,7 +432,7 @@
   <data name="tbxClientSecret.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 113</value>
   </data>
-  <data name="tbxClientSecret.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="tbxClientSecret.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="tbxClientSecret.Size" type="System.Drawing.Size, System.Drawing">

--- a/pwiz_tools/Skyline/ToolsUI/EditRemoteAccountDlg.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditRemoteAccountDlg.resx
@@ -243,7 +243,7 @@
   <data name="textPassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>15, 111</value>
   </data>
-  <data name="textPassword.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="textPassword.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="textPassword.Size" type="System.Drawing.Size, System.Drawing">
@@ -432,7 +432,7 @@
   <data name="tbxClientSecret.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 113</value>
   </data>
-  <data name="tbxClientSecret.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="tbxClientSecret.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="tbxClientSecret.Size" type="System.Drawing.Size, System.Drawing">

--- a/pwiz_tools/Skyline/ToolsUI/EditRemoteAccountDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditRemoteAccountDlg.zh-CHS.resx
@@ -243,7 +243,7 @@
   <data name="textPassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>15, 111</value>
   </data>
-  <data name="textPassword.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="textPassword.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="textPassword.Size" type="System.Drawing.Size, System.Drawing">
@@ -432,7 +432,7 @@
   <data name="tbxClientSecret.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 113</value>
   </data>
-  <data name="tbxClientSecret.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="tbxClientSecret.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="tbxClientSecret.Size" type="System.Drawing.Size, System.Drawing">

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.ja.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.ja.resx
@@ -145,7 +145,7 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -172,7 +172,7 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="instructionLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -206,6 +206,39 @@
   <data name="InputPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="cbAnonymous.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAnonymous.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 51</value>
+  </data>
+  <data name="cbAnonymous.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 17</value>
+  </data>
+  <data name="cbAnonymous.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="cbAnonymous.Text" xml:space="preserve">
+    <value>Anonymous access</value>
+  </data>
+  <metadata name="toolTipAnonymous.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
+  </metadata>
+  <data name="cbAnonymous.ToolTip" xml:space="preserve">
+    <value>Check this box if you do not have an account on the server.  Without a user account you can anonymously browse, download and open publicly available documents on the server, but you cannot upload documents to the server.</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Name" xml:space="preserve">
+    <value>cbAnonymous</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Parent" xml:space="preserve">
+    <value>InputPanel</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="lblProjectInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -231,7 +264,7 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;lblProjectInfo.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="textServerURL.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 26</value>
@@ -255,12 +288,12 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;textServerURL.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="textPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 148</value>
+    <value>16, 152</value>
   </data>
-  <data name="textPassword.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="textPassword.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="textPassword.Size" type="System.Drawing.Size, System.Drawing">
@@ -279,13 +312,13 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;textPassword.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="lblPassword.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="lblPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 128</value>
+    <value>13, 132</value>
   </data>
   <data name="lblPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>56, 13</value>
@@ -306,13 +339,13 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;lblPassword.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="lblUsername.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="lblUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 69</value>
+    <value>13, 81</value>
   </data>
   <data name="lblUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>35, 13</value>
@@ -333,10 +366,10 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;lblUsername.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="textUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 87</value>
+    <value>16, 99</value>
   </data>
   <data name="textUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>207, 20</value>
@@ -354,10 +387,10 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;textUsername.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="InputPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 65</value>
+    <value>3, 61</value>
   </data>
   <data name="InputPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>337, 220</value>
@@ -387,7 +420,7 @@
     <value>3, 3</value>
   </data>
   <data name="InstructionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>337, 56</value>
+    <value>337, 52</value>
   </data>
   <data name="InstructionPanel.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -426,7 +459,7 @@
     <value>2</value>
   </data>
   <data name="ComponentOrganizer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>343, 288</value>
+    <value>343, 284</value>
   </data>
   <data name="ComponentOrganizer.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -459,13 +492,19 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>343, 288</value>
+    <value>343, 284</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>サーバーを編集</value>
+    <value>Edit Panorama Server</value>
+  </data>
+  <data name="&gt;&gt;toolTipAnonymous.Name" xml:space="preserve">
+    <value>toolTipAnonymous</value>
+  </data>
+  <data name="&gt;&gt;toolTipAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>EditServerDlg</value>

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.resx
@@ -293,7 +293,7 @@ user account below.</value>
   <data name="textPassword.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 152</value>
   </data>
-  <data name="textPassword.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="textPassword.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="textPassword.Size" type="System.Drawing.Size, System.Drawing">

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.zh-CHS.resx
@@ -145,7 +145,7 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -172,7 +172,7 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="instructionLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -206,6 +206,39 @@
   <data name="InputPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="cbAnonymous.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAnonymous.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 51</value>
+  </data>
+  <data name="cbAnonymous.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 17</value>
+  </data>
+  <data name="cbAnonymous.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="cbAnonymous.Text" xml:space="preserve">
+    <value>Anonymous access</value>
+  </data>
+  <metadata name="toolTipAnonymous.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>155, 17</value>
+  </metadata>
+  <data name="cbAnonymous.ToolTip" xml:space="preserve">
+    <value>Check this box if you do not have an account on the server.  Without a user account you can anonymously browse, download and open publicly available documents on the server, but you cannot upload documents to the server.</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Name" xml:space="preserve">
+    <value>cbAnonymous</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Parent" xml:space="preserve">
+    <value>InputPanel</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="lblProjectInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -231,7 +264,7 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;lblProjectInfo.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="textServerURL.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 26</value>
@@ -255,12 +288,12 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;textServerURL.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="textPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 148</value>
+    <value>16, 152</value>
   </data>
-  <data name="textPassword.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+  <data name="textPassword.PasswordChar" xml:space="preserve" type="System.Char, mscorlib">
     <value>*</value>
   </data>
   <data name="textPassword.Size" type="System.Drawing.Size, System.Drawing">
@@ -279,13 +312,13 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;textPassword.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="lblPassword.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="lblPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 128</value>
+    <value>13, 132</value>
   </data>
   <data name="lblPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>56, 13</value>
@@ -306,13 +339,13 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;lblPassword.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="lblUsername.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="lblUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 69</value>
+    <value>13, 81</value>
   </data>
   <data name="lblUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>35, 13</value>
@@ -333,10 +366,10 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;lblUsername.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="textUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 87</value>
+    <value>16, 99</value>
   </data>
   <data name="textUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>207, 20</value>
@@ -354,10 +387,10 @@
     <value>InputPanel</value>
   </data>
   <data name="&gt;&gt;textUsername.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="InputPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 65</value>
+    <value>3, 61</value>
   </data>
   <data name="InputPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>337, 220</value>
@@ -387,7 +420,7 @@
     <value>3, 3</value>
   </data>
   <data name="InstructionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>337, 56</value>
+    <value>337, 52</value>
   </data>
   <data name="InstructionPanel.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -426,7 +459,7 @@
     <value>2</value>
   </data>
   <data name="ComponentOrganizer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>343, 288</value>
+    <value>343, 284</value>
   </data>
   <data name="ComponentOrganizer.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -459,13 +492,19 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>343, 288</value>
+    <value>343, 284</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>编辑服务器</value>
+    <value>Edit Panorama Server</value>
+  </data>
+  <data name="&gt;&gt;toolTipAnonymous.Name" xml:space="preserve">
+    <value>toolTipAnonymous</value>
+  </data>
+  <data name="&gt;&gt;toolTipAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>EditServerDlg</value>

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.ja.resx
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.ja.resx
@@ -129,7 +129,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="listboxServers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 22</value>
+    <value>9, 23</value>
   </data>
   <data name="listboxServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>264, 199</value>
@@ -154,7 +154,7 @@
     <value>True</value>
   </data>
   <data name="lblServers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>6, 7</value>
   </data>
   <data name="lblServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>46, 13</value>
@@ -163,7 +163,7 @@
     <value>0</value>
   </data>
   <data name="lblServers.Text" xml:space="preserve">
-    <value>サーバー：</value>
+    <value>&amp;Servers:</value>
   </data>
   <data name="&gt;&gt;lblServers.Name" xml:space="preserve">
     <value>lblServers</value>
@@ -181,7 +181,7 @@
     <value>Top, Right</value>
   </data>
   <data name="btnEditServers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 22</value>
+    <value>308, 23</value>
   </data>
   <data name="btnEditServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>100, 23</value>
@@ -235,7 +235,7 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="listBoxRemoteAccounts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 33</value>
+    <value>9, 23</value>
   </data>
   <data name="listBoxRemoteAccounts.Size" type="System.Drawing.Size, System.Drawing">
     <value>293, 199</value>
@@ -262,7 +262,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblRemoteAccounts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 17</value>
+    <value>6, 7</value>
   </data>
   <data name="lblRemoteAccounts.Size" type="System.Drawing.Size, System.Drawing">
     <value>94, 13</value>
@@ -271,7 +271,7 @@
     <value>3</value>
   </data>
   <data name="lblRemoteAccounts.Text" xml:space="preserve">
-    <value>リモートアカウント：</value>
+    <value>&amp;Remote accounts:</value>
   </data>
   <data name="&gt;&gt;lblRemoteAccounts.Name" xml:space="preserve">
     <value>lblRemoteAccounts</value>
@@ -292,7 +292,7 @@
     <value>NoControl</value>
   </data>
   <data name="btnEditRemoteAccountList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>308, 33</value>
+    <value>308, 23</value>
   </data>
   <data name="btnEditRemoteAccountList.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -346,10 +346,10 @@
     <value>13, 108</value>
   </data>
   <data name="tbxKoinaServer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 20</value>
+    <value>175, 20</value>
   </data>
   <data name="tbxKoinaServer.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;tbxKoinaServer.Name" xml:space="preserve">
     <value>tbxKoinaServer</value>
@@ -376,7 +376,7 @@
     <value>32, 13</value>
   </data>
   <data name="ceLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>8</value>
   </data>
   <data name="ceLabel.Text" xml:space="preserve">
     <value>N&amp;CE：</value>
@@ -394,13 +394,13 @@
     <value>1</value>
   </data>
   <data name="ceCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>237, 110</value>
+    <value>237, 108</value>
   </data>
   <data name="ceCombo.Size" type="System.Drawing.Size, System.Drawing">
     <value>122, 21</value>
   </data>
   <data name="ceCombo.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;ceCombo.Name" xml:space="preserve">
     <value>ceCombo</value>
@@ -418,7 +418,7 @@
     <value>True</value>
   </data>
   <data name="koinaServerStatusLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>137, 111</value>
+    <value>10, 131</value>
   </data>
   <data name="koinaServerStatusLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 0, 1, 0</value>
@@ -427,10 +427,10 @@
     <value>97, 13</value>
   </data>
   <data name="koinaServerStatusLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>3</value>
   </data>
   <data name="koinaServerStatusLabel.Text" xml:space="preserve">
-    <value>サーバーステータス</value>
+    <value>SERVER STATUS</value>
   </data>
   <data name="&gt;&gt;koinaServerStatusLabel.Name" xml:space="preserve">
     <value>koinaServerStatusLabel</value>
@@ -451,16 +451,16 @@
     <value>NoControl</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 172</value>
+    <value>10, 196</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
     <value>58, 13</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>iRTモデル：</value>
+    <value>i&amp;RT model:</value>
   </data>
   <data name="&gt;&gt;label3.Name" xml:space="preserve">
     <value>label3</value>
@@ -475,10 +475,10 @@
     <value>4</value>
   </data>
   <data name="iRTModelCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 188</value>
+    <value>13, 212</value>
   </data>
   <data name="iRTModelCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 21</value>
+    <value>175, 21</value>
   </data>
   <data name="iRTModelCombo.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -502,16 +502,16 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 133</value>
+    <value>10, 154</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>80, 13</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>4</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>強度モデル：</value>
+    <value>I&amp;ntensity model:</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -526,10 +526,10 @@
     <value>6</value>
   </data>
   <data name="intensityModelCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 149</value>
+    <value>13, 170</value>
   </data>
   <data name="intensityModelCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 21</value>
+    <value>175, 21</value>
   </data>
   <data name="intensityModelCombo.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -559,10 +559,10 @@
     <value>41, 13</value>
   </data>
   <data name="koinaServerLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="koinaServerLabel.Text" xml:space="preserve">
-    <value>サーバー（&amp;S）：</value>
+    <value>&amp;Server:</value>
   </data>
   <data name="&gt;&gt;koinaServerLabel.Name" xml:space="preserve">
     <value>koinaServerLabel</value>
@@ -592,13 +592,13 @@
     <value>322, 55</value>
   </data>
   <data name="koinaDescrLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="koinaDescrLabel.Text" xml:space="preserve">
-    <value>Koinaは、iRTの予測のみならず、あらゆる有機体およびプロテ
-アーゼ向けに非常に高品質な予測HCD MS2スペクトルを使用
-してカスタムスペクトルライブラリを自由かつ簡単に作成できる、
-ディープラーニングフレームワークです。</value>
+    <value>Koina is a deep learning framework that offers free and easy
+generation of custom spectral libraries using very high quality
+predicted HCD MS2 spectra for any organism and protease as
+well as iRT prediction.</value>
   </data>
   <data name="&gt;&gt;koinaDescrLabel.Name" xml:space="preserve">
     <value>koinaDescrLabel</value>
@@ -616,7 +616,7 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 3</value>
+    <value>13, 2</value>
   </data>
   <data name="pictureBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 1, 1, 1</value>
@@ -750,8 +750,59 @@
   <data name="&gt;&gt;tabLanguage.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="tbxSettingsFilePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="tbxSettingsFilePath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 174</value>
+  </data>
+  <data name="tbxSettingsFilePath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>357, 20</value>
+  </data>
+  <data name="tbxSettingsFilePath.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Name" xml:space="preserve">
+    <value>tbxSettingsFilePath</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Parent" xml:space="preserve">
+    <value>tabMisc</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblSettingsPath.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSettingsPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 158</value>
+  </data>
+  <data name="lblSettingsPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>109, 13</value>
+  </data>
+  <data name="lblSettingsPath.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblSettingsPath.Text" xml:space="preserve">
+    <value>Settings are stored in:</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Name" xml:space="preserve">
+    <value>lblSettingsPath</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Parent" xml:space="preserve">
+    <value>tabMisc</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="btnResetSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 165</value>
+    <value>17, 200</value>
   </data>
   <data name="btnResetSettings.Size" type="System.Drawing.Size, System.Drawing">
     <value>115, 37</value>
@@ -772,7 +823,7 @@
     <value>tabMisc</value>
   </data>
   <data name="&gt;&gt;btnResetSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="comboCompactFormatOption.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 32</value>
@@ -793,7 +844,7 @@
     <value>tabMisc</value>
   </data>
   <data name="&gt;&gt;comboCompactFormatOption.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="lblCompactDocumentFormat.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -820,7 +871,7 @@
     <value>tabMisc</value>
   </data>
   <data name="&gt;&gt;lblCompactDocumentFormat.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="checkBoxShowWizard.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -850,7 +901,7 @@
     <value>tabMisc</value>
   </data>
   <data name="&gt;&gt;checkBoxShowWizard.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="tabMisc.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -1075,7 +1126,7 @@
     <value>modeUIHandler</value>
   </data>
   <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=19.1.1.298, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ToolOptionsUI</value>

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.zh-CHS.resx
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.zh-CHS.resx
@@ -129,7 +129,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="listboxServers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 22</value>
+    <value>9, 23</value>
   </data>
   <data name="listboxServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>293, 199</value>
@@ -154,7 +154,7 @@
     <value>True</value>
   </data>
   <data name="lblServers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>6, 7</value>
   </data>
   <data name="lblServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>46, 13</value>
@@ -163,7 +163,7 @@
     <value>0</value>
   </data>
   <data name="lblServers.Text" xml:space="preserve">
-    <value>服务器：</value>
+    <value>&amp;Servers:</value>
   </data>
   <data name="&gt;&gt;lblServers.Name" xml:space="preserve">
     <value>lblServers</value>
@@ -181,7 +181,7 @@
     <value>Top, Right</value>
   </data>
   <data name="btnEditServers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>308, 22</value>
+    <value>308, 23</value>
   </data>
   <data name="btnEditServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -235,7 +235,7 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="listBoxRemoteAccounts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 33</value>
+    <value>9, 23</value>
   </data>
   <data name="listBoxRemoteAccounts.Size" type="System.Drawing.Size, System.Drawing">
     <value>293, 199</value>
@@ -262,7 +262,7 @@
     <value>NoControl</value>
   </data>
   <data name="lblRemoteAccounts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 17</value>
+    <value>6, 7</value>
   </data>
   <data name="lblRemoteAccounts.Size" type="System.Drawing.Size, System.Drawing">
     <value>94, 13</value>
@@ -271,7 +271,7 @@
     <value>3</value>
   </data>
   <data name="lblRemoteAccounts.Text" xml:space="preserve">
-    <value>远程账户：</value>
+    <value>&amp;Remote accounts:</value>
   </data>
   <data name="&gt;&gt;lblRemoteAccounts.Name" xml:space="preserve">
     <value>lblRemoteAccounts</value>
@@ -292,7 +292,7 @@
     <value>NoControl</value>
   </data>
   <data name="btnEditRemoteAccountList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>308, 33</value>
+    <value>308, 23</value>
   </data>
   <data name="btnEditRemoteAccountList.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -346,10 +346,10 @@
     <value>13, 108</value>
   </data>
   <data name="tbxKoinaServer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 20</value>
+    <value>175, 20</value>
   </data>
   <data name="tbxKoinaServer.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;tbxKoinaServer.Name" xml:space="preserve">
     <value>tbxKoinaServer</value>
@@ -376,10 +376,10 @@
     <value>32, 13</value>
   </data>
   <data name="ceLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>8</value>
   </data>
   <data name="ceLabel.Text" xml:space="preserve">
-    <value>N&amp;CE:</value>
+    <value>N&amp;CE：</value>
   </data>
   <data name="&gt;&gt;ceLabel.Name" xml:space="preserve">
     <value>ceLabel</value>
@@ -394,13 +394,13 @@
     <value>1</value>
   </data>
   <data name="ceCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>237, 110</value>
+    <value>237, 108</value>
   </data>
   <data name="ceCombo.Size" type="System.Drawing.Size, System.Drawing">
     <value>122, 21</value>
   </data>
   <data name="ceCombo.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;ceCombo.Name" xml:space="preserve">
     <value>ceCombo</value>
@@ -418,7 +418,7 @@
     <value>True</value>
   </data>
   <data name="koinaServerStatusLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>137, 111</value>
+    <value>10, 131</value>
   </data>
   <data name="koinaServerStatusLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 0, 1, 0</value>
@@ -427,10 +427,10 @@
     <value>97, 13</value>
   </data>
   <data name="koinaServerStatusLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>3</value>
   </data>
   <data name="koinaServerStatusLabel.Text" xml:space="preserve">
-    <value>服务器状态</value>
+    <value>SERVER STATUS</value>
   </data>
   <data name="&gt;&gt;koinaServerStatusLabel.Name" xml:space="preserve">
     <value>koinaServerStatusLabel</value>
@@ -451,16 +451,16 @@
     <value>NoControl</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 172</value>
+    <value>10, 196</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
     <value>58, 13</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>6</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>iRT 模型：</value>
+    <value>i&amp;RT model:</value>
   </data>
   <data name="&gt;&gt;label3.Name" xml:space="preserve">
     <value>label3</value>
@@ -475,10 +475,10 @@
     <value>4</value>
   </data>
   <data name="iRTModelCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 188</value>
+    <value>13, 212</value>
   </data>
   <data name="iRTModelCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 21</value>
+    <value>175, 21</value>
   </data>
   <data name="iRTModelCombo.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -502,16 +502,16 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 133</value>
+    <value>10, 154</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>80, 13</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>4</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>强度模型：</value>
+    <value>I&amp;ntensity model:</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -526,10 +526,10 @@
     <value>6</value>
   </data>
   <data name="intensityModelCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 149</value>
+    <value>13, 170</value>
   </data>
   <data name="intensityModelCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 21</value>
+    <value>175, 21</value>
   </data>
   <data name="intensityModelCombo.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -559,10 +559,10 @@
     <value>41, 13</value>
   </data>
   <data name="koinaServerLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>1</value>
   </data>
   <data name="koinaServerLabel.Text" xml:space="preserve">
-    <value>&amp;服务器：</value>
+    <value>&amp;Server:</value>
   </data>
   <data name="&gt;&gt;koinaServerLabel.Name" xml:space="preserve">
     <value>koinaServerLabel</value>
@@ -592,13 +592,13 @@
     <value>322, 55</value>
   </data>
   <data name="koinaDescrLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="koinaDescrLabel.Text" xml:space="preserve">
-    <value>Koina 是一个深度学习框架，
-可使用任何物种和蛋白质的
-预测的高质量 HCD MS2 谱图以及 iRT预测，
-免费且轻松地生成自定义谱图库。</value>
+    <value>Koina is a deep learning framework that offers free and easy
+generation of custom spectral libraries using very high quality
+predicted HCD MS2 spectra for any organism and protease as
+well as iRT prediction.</value>
   </data>
   <data name="&gt;&gt;koinaDescrLabel.Name" xml:space="preserve">
     <value>koinaDescrLabel</value>
@@ -616,7 +616,7 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 3</value>
+    <value>13, 2</value>
   </data>
   <data name="pictureBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>1, 1, 1, 1</value>
@@ -750,8 +750,59 @@
   <data name="&gt;&gt;tabLanguage.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="tbxSettingsFilePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="tbxSettingsFilePath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 174</value>
+  </data>
+  <data name="tbxSettingsFilePath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>357, 20</value>
+  </data>
+  <data name="tbxSettingsFilePath.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Name" xml:space="preserve">
+    <value>tbxSettingsFilePath</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Parent" xml:space="preserve">
+    <value>tabMisc</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblSettingsPath.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSettingsPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 158</value>
+  </data>
+  <data name="lblSettingsPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>109, 13</value>
+  </data>
+  <data name="lblSettingsPath.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblSettingsPath.Text" xml:space="preserve">
+    <value>Settings are stored in:</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Name" xml:space="preserve">
+    <value>lblSettingsPath</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Parent" xml:space="preserve">
+    <value>tabMisc</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="btnResetSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>134, 165</value>
+    <value>17, 200</value>
   </data>
   <data name="btnResetSettings.Size" type="System.Drawing.Size, System.Drawing">
     <value>115, 37</value>
@@ -772,7 +823,7 @@
     <value>tabMisc</value>
   </data>
   <data name="&gt;&gt;btnResetSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="comboCompactFormatOption.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 32</value>
@@ -793,7 +844,7 @@
     <value>tabMisc</value>
   </data>
   <data name="&gt;&gt;comboCompactFormatOption.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="lblCompactDocumentFormat.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -820,7 +871,7 @@
     <value>tabMisc</value>
   </data>
   <data name="&gt;&gt;lblCompactDocumentFormat.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="checkBoxShowWizard.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -850,7 +901,7 @@
     <value>tabMisc</value>
   </data>
   <data name="&gt;&gt;checkBoxShowWizard.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="tabMisc.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -1075,7 +1126,7 @@
     <value>modeUIHandler</value>
   </data>
   <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=19.1.1.298, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ToolOptionsUI</value>

--- a/pwiz_tools/Skyline/Util/UtilResources.ja.resx
+++ b/pwiz_tools/Skyline/Util/UtilResources.ja.resx
@@ -302,6 +302,9 @@
   <data name="PublishDocumentDlg_UploadSharedZipFile_Uploading_File" xml:space="preserve">
     <value>ファイルのアップロード中</value>
   </data>
+  <data name="Server_GetKey___anonymous_" xml:space="preserve">
+    <value> (anonymous)</value>
+  </data>
   <data name="Server_ReadXml_A_Panorama_server_must_be_specified" xml:space="preserve">
     <value>Panoramaサーバーを指定しなければなりません。</value>
   </data>
@@ -328,5 +331,14 @@
   </data>
   <data name="XmlUtil_WriteElements_Attempt_to_serialize_list_missing_an_element" xml:space="preserve">
     <value>要素が欠損しているリストを直列化しようとしました。</value>
+  </data>
+  <data name="ParsedMolecule_SplitFormulaAndMasses_Cannot_parse___0___as_a_mass_offset_in_the_text___1___" xml:space="preserve">
+    <value>Cannot parse "{0}" as a mass offset in the text "{1}"</value>
+  </data>
+  <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_Would_you_like_to_go_to_Panorama_" xml:space="preserve">
+    <value>Would you like to go to Panorama?</value>
+  </data>
+  <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_An_import_error_occurred_on_the_Panorama_server__0__" xml:space="preserve">
+    <value>An import error occurred on the Panorama server {0}.</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Util/UtilResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Util/UtilResources.zh-CHS.resx
@@ -305,6 +305,9 @@
   <data name="PublishDocumentDlg_UploadSharedZipFile_Uploading_File" xml:space="preserve">
     <value>上传文件</value>
   </data>
+  <data name="Server_GetKey___anonymous_" xml:space="preserve">
+    <value> (anonymous)</value>
+  </data>
   <data name="Server_ReadXml_A_Panorama_server_must_be_specified" xml:space="preserve">
     <value>必须指定 Panorama 服务器。</value>
   </data>
@@ -331,5 +334,14 @@
   </data>
   <data name="XmlUtil_WriteElements_Attempt_to_serialize_list_missing_an_element" xml:space="preserve">
     <value>尝试将缺少一个元素的列表序列化。</value>
+  </data>
+  <data name="ParsedMolecule_SplitFormulaAndMasses_Cannot_parse___0___as_a_mass_offset_in_the_text___1___" xml:space="preserve">
+    <value>Cannot parse "{0}" as a mass offset in the text "{1}"</value>
+  </data>
+  <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_Would_you_like_to_go_to_Panorama_" xml:space="preserve">
+    <value>Would you like to go to Panorama?</value>
+  </data>
+  <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_An_import_error_occurred_on_the_Panorama_server__0__" xml:space="preserve">
+    <value>An import error occurred on the Panorama server {0}.</value>
   </data>
 </root>


### PR DESCRIPTION
This change makes it so that entries in the .ja.resx and .zh-CHS.resx files have the English text for all of the cases where the English text has changed between 23.1 and 24.1.
It also ensures that the order of elements in the .resx files are identical.