### PR TITLE
* removed TestKoinaOutputToEncyclopediaLibraries

### DIFF
--- a/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
+++ b/pwiz_tools/Skyline/Test/EncyclopeDiaHelpersTest.cs
@@ -17,15 +17,10 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading;
-using pwiz.Common.Database;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline;
 using pwiz.Skyline.Model.Lib;
-using pwiz.Skyline.Model.Results;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTest
@@ -56,79 +51,6 @@ namespace pwiz.SkylineTest
             EncyclopeDiaHelpers.ConvertFastaToKoinaInputCsv(fastaFilepath, koinaCsvOutputFilepath, pm, ref status, testConfig);
             Assert.IsTrue(File.Exists(koinaCsvOutputFilepath));
             AssertEx.NoDiff(File.ReadAllText(koinaExpectedCsvOutputFilepath), File.ReadAllText(koinaCsvOutputFilepath));
-        }
-
-        [TestMethod]
-        public void TestKoinaOutputToEncyclopediaLibraries()
-        {
-            // Wine has mysterious issues running EncylopeDia, but SkylineCmd currently can't run EncyclopeDia anyway, so skip these tests
-            if (ProcessEx.IsRunningOnWine)
-                return;
-
-            TestFilesDir = new TestFilesDir(TestContext, TEST_ZIP_PATH);
-            string fastaFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705.fasta");
-            string dlibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.dlib");
-            string elibFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33.elib");
-            string elibQuantFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-quant-elib.elib");
-            var columnTolerances = new Dictionary<int, double>() { { -1, 0.000005 } };  // Allow some numerical wiggle in any column numerical column ("-1" means all columns)
-            IProgressStatus status = new ProgressStatus();
-
-            // test koina output to dlib
-            {
-                string koinaBlibOutputFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-output.blib");
-                string dlibExpectedTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-dlib.tsv");
-                var pm = new CommandProgressMonitor(new StringWriter(), new ProgressStatus());
-                EncyclopeDiaHelpers.ConvertKoinaOutputToDlib(koinaBlibOutputFilepath, fastaFilepath, dlibFilepath, pm, ref status);
-                Assert.IsTrue(File.Exists(dlibFilepath));
-                var actual = SqliteOperations.DumpTable(dlibFilepath, "entries");
-                //string dlibActualTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-dlib-actual.tsv");
-                //File.WriteAllLines(dlibActualTsvFilepath, actual);
-                AssertEx.NoDiff(File.ReadAllText(dlibExpectedTsvFilepath), string.Join("\n", actual), null, columnTolerances);
-            }
-
-            // test generate libraries
-            {
-                string elibExpectedTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-elib.tsv");
-                string elibQuantExpectedTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-quant-elib.tsv");
-                var testConfig = new EncyclopeDiaHelpers.EncyclopeDiaConfig
-                {
-                    PercolatorTrainingFDR = 0.5,
-                    PercolatorThreshold = 0.5,
-                    MinNumOfQuantitativePeaks = 1,
-                    NumberOfQuantitativePeaks = 1,
-                    V2scoring = false
-                };
-                var narrowWindowFiles = new MsDataFileUri[]
-                {
-                    new MsDataFilePath(TestFilesDir.GetTestPath("23aug2017_hela_serum_timecourse_4mz_narrow_3.mzML")),
-                    new MsDataFilePath(TestFilesDir.GetTestPath("23aug2017_hela_serum_timecourse_4mz_narrow_4.mzML")),
-                };
-                var wideWindowFiles = new MsDataFileUri[]
-                {
-                    new MsDataFilePath(TestFilesDir.GetTestPath("23aug2017_hela_serum_timecourse_wide_1c.mzML")),
-                    new MsDataFilePath(TestFilesDir.GetTestPath("23aug2017_hela_serum_timecourse_wide_1d.mzML")),
-                };
-                var pm = new CommandProgressMonitor(new StringWriter(), new ProgressStatus());
-                EncyclopeDiaHelpers.Generate(dlibFilepath, elibFilepath, elibQuantFilepath, fastaFilepath, testConfig,
-                    narrowWindowFiles, wideWindowFiles, pm, pm, CancellationToken.None, new ProgressStatus());
-
-                var actual = SqliteOperations.DumpTable(elibFilepath, "entries", sortColumns: new[] { "PrecursorMz" })
-                    .Concat(SqliteOperations.DumpTable(elibFilepath, "peptidescores", sortColumns: new[] { "PeptideModSeq", "PrecursorCharge" }))
-                    .Concat(SqliteOperations.DumpTable(elibFilepath, "retentiontimes", sortColumns: new[] { "SourceFile", "Library", "Actual" }))
-                    .Concat(SqliteOperations.DumpTable(elibFilepath, "peptidequants", sortColumns: new [] { "PeptideModSeq", "PrecursorCharge", "SourceFile"}));
-                //string elibActualTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-elib-actual.tsv");
-                //File.WriteAllLines(elibActualTsvFilepath, actual);
-                AssertEx.NoDiff(File.ReadAllText(elibExpectedTsvFilepath), string.Join("\n", actual), null, columnTolerances);
-
-                var actualQuant = SqliteOperations.DumpTable(elibQuantFilepath, "entries", sortColumns: new[] { "PrecursorMz" })
-                    .Concat(SqliteOperations.DumpTable(elibQuantFilepath, "peptidescores", sortColumns: new[] { "PeptideModSeq", "PrecursorCharge" }, excludeColumns: new[] { "SourceFile", "PosteriorErrorProbability" }))
-                    .Concat(SqliteOperations.DumpTable(elibQuantFilepath, "retentiontimes", sortColumns: new[] { "SourceFile", "Library", "Actual" }))
-                    .Concat(SqliteOperations.DumpTable(elibQuantFilepath, "peptidequants", sortColumns: new[] { "PeptideModSeq", "PrecursorCharge", "SourceFile" }));
-                //string elibQuantActualTsvFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705-z3_nce33-expected-quant-elib-actual.tsv");
-                //File.WriteAllLines(elibQuantActualTsvFilepath, actualQuant);
-                AssertEx.NoDiff(File.ReadAllText(elibQuantExpectedTsvFilepath), string.Join("\n", actualQuant), null, columnTolerances);
-            }
-            TestFilesDir.Cleanup();
         }
     }
 }


### PR DESCRIPTION
* removed TestKoinaOutputToEncyclopediaLibraries that is slow to run (especially for a unit test) and offers basically no extra coverage over the TestEncyclopeDiaSearch functional test