### PR TITLE
Ensure that localized .resx files have same entries as English .resx files

### DIFF
--- a/pwiz_tools/Shared/Common/Controls/MultiProgressControl.ja.resx
+++ b/pwiz_tools/Shared/Common/Controls/MultiProgressControl.ja.resx
@@ -118,7 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ProgressSplit.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ProgressSplit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="ProgressSplit.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
   <metadata name="NameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -134,7 +143,133 @@
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ProgressColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>50</value>
+  </data>
+  <data name="progressGridView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="progressGridView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="progressGridView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 491</value>
+  </data>
+  <data name="progressGridView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Name" xml:space="preserve">
+    <value>progressGridView</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Parent" xml:space="preserve">
+    <value>ProgressSplit.Panel1</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Name" xml:space="preserve">
+    <value>ProgressSplit.Panel1</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Parent" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ProgressSplit.Panel1MinSize" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="progressLogTextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="progressLogTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="progressLogTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="progressLogTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 175</value>
+  </data>
+  <data name="progressLogTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Name" xml:space="preserve">
+    <value>progressLogTextBox</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Parent" xml:space="preserve">
+    <value>ProgressSplit.Panel2</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Name" xml:space="preserve">
+    <value>ProgressSplit.Panel2</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Parent" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ProgressSplit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 670</value>
+  </data>
+  <data name="ProgressSplit.SplitterDistance" type="System.Int32, mscorlib">
+    <value>491</value>
+  </data>
+  <data name="ProgressSplit.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Name" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 670</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Name" xml:space="preserve">
+    <value>NameColumn</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressColumn.Name" xml:space="preserve">
+    <value>ProgressColumn</value>
+  </data>
+  <data name="&gt;&gt;ProgressColumn.Type" xml:space="preserve">
+    <value>CustomProgressCell.DataGridViewProgressColumn, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MultiProgressControl</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/Controls/MultiProgressControl.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/Controls/MultiProgressControl.zh-CHS.resx
@@ -118,7 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ProgressSplit.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="ProgressSplit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="ProgressSplit.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
   <metadata name="NameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -134,7 +143,133 @@
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="ProgressColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>50</value>
+  </data>
+  <data name="progressGridView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="progressGridView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="progressGridView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 491</value>
+  </data>
+  <data name="progressGridView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Name" xml:space="preserve">
+    <value>progressGridView</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.Parent" xml:space="preserve">
+    <value>ProgressSplit.Panel1</value>
+  </data>
+  <data name="&gt;&gt;progressGridView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Name" xml:space="preserve">
+    <value>ProgressSplit.Panel1</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.Parent" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ProgressSplit.Panel1MinSize" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="progressLogTextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="progressLogTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="progressLogTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="progressLogTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 175</value>
+  </data>
+  <data name="progressLogTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Name" xml:space="preserve">
+    <value>progressLogTextBox</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.Parent" xml:space="preserve">
+    <value>ProgressSplit.Panel2</value>
+  </data>
+  <data name="&gt;&gt;progressLogTextBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Name" xml:space="preserve">
+    <value>ProgressSplit.Panel2</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.Parent" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ProgressSplit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 670</value>
+  </data>
+  <data name="ProgressSplit.SplitterDistance" type="System.Int32, mscorlib">
+    <value>491</value>
+  </data>
+  <data name="ProgressSplit.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Name" xml:space="preserve">
+    <value>ProgressSplit</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ProgressSplit.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1041, 670</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Name" xml:space="preserve">
+    <value>NameColumn</value>
+  </data>
+  <data name="&gt;&gt;NameColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ProgressColumn.Name" xml:space="preserve">
+    <value>ProgressColumn</value>
+  </data>
+  <data name="&gt;&gt;ProgressColumn.Type" xml:space="preserve">
+    <value>CustomProgressCell.DataGridViewProgressColumn, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MultiProgressControl</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.ja.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.ja.resx
@@ -118,31 +118,124 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="listView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>126, 150</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="listView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;listView.Name" xml:space="preserve">
+    <value>listView</value>
+  </data>
+  <data name="&gt;&gt;listView.Type" xml:space="preserve">
+    <value>pwiz.Common.DataBinding.Controls.ColumnListView, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;listView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;listView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="toolStrip1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="toolStrip1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="btnRemove.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnRemove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
   <data name="btnRemove.Text" xml:space="preserve">
     <value>Remove</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="btnUp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnUp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
   </data>
   <data name="btnUp.Text" xml:space="preserve">
     <value>Up</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
+  <data name="btnDown.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
   <data name="btnDown.Text" xml:space="preserve">
     <value>Down</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="toolStrip1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>126, 0</value>
+  </data>
+  <data name="toolStrip1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 150</value>
+  </data>
+  <data name="toolStrip1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
   <data name="toolStrip1.Text" xml:space="preserve">
     <value>toolStrip1</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
+  <data name="&gt;&gt;toolStrip1.Name" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="&gt;&gt;btnRemove.Name" xml:space="preserve">
+    <value>btnRemove</value>
+  </data>
+  <data name="&gt;&gt;btnRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnUp.Name" xml:space="preserve">
+    <value>btnUp</value>
+  </data>
+  <data name="&gt;&gt;btnUp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnDown.Name" xml:space="preserve">
+    <value>btnDown</value>
+  </data>
+  <data name="&gt;&gt;btnDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>ColumnListEditor</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.zh-CHS.resx
@@ -118,31 +118,124 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="listView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>126, 150</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="listView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;listView.Name" xml:space="preserve">
+    <value>listView</value>
+  </data>
+  <data name="&gt;&gt;listView.Type" xml:space="preserve">
+    <value>pwiz.Common.DataBinding.Controls.ColumnListView, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;listView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;listView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="toolStrip1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="toolStrip1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="btnRemove.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnRemove.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
   <data name="btnRemove.Text" xml:space="preserve">
     <value>Remove</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="btnUp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnUp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
   </data>
   <data name="btnUp.Text" xml:space="preserve">
     <value>Up</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
+  <data name="btnDown.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
   <data name="btnDown.Text" xml:space="preserve">
     <value>Down</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="toolStrip1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>126, 0</value>
+  </data>
+  <data name="toolStrip1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 150</value>
+  </data>
+  <data name="toolStrip1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
   <data name="toolStrip1.Text" xml:space="preserve">
     <value>toolStrip1</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
+  <data name="&gt;&gt;toolStrip1.Name" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="&gt;&gt;btnRemove.Name" xml:space="preserve">
+    <value>btnRemove</value>
+  </data>
+  <data name="&gt;&gt;btnRemove.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnUp.Name" xml:space="preserve">
+    <value>btnUp</value>
+  </data>
+  <data name="&gt;&gt;btnUp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnDown.Name" xml:space="preserve">
+    <value>btnDown</value>
+  </data>
+  <data name="&gt;&gt;btnDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>ColumnListEditor</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/SourceTab.ja.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/SourceTab.ja.resx
@@ -118,9 +118,48 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="textBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="textBox1.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="textBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 150</value>
+  </data>
+  <data name="textBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
+    <value>textBox1</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 150</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SourceTab</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.DataBinding.Controls.Editor.ViewEditorWidget, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/SourceTab.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/SourceTab.zh-CHS.resx
@@ -118,9 +118,48 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="textBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="textBox1.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="textBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 150</value>
+  </data>
+  <data name="textBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
+    <value>textBox1</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textBox1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 150</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SourceTab</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.DataBinding.Controls.Editor.ViewEditorWidget, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.ja.resx
@@ -133,6 +133,9 @@
     <value>No</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
   <data name="Retry" xml:space="preserve">
     <value>Retry</value>
     <comment>Needs Review:New resource</comment>

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/Images.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/Images.ja.resx
@@ -118,4 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/Images.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/Images.zh-CHS.resx
@@ -118,4 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/CommonUtil/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/Properties/Resources.ja.resx
@@ -118,6 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Units_mz" xml:space="preserve">
+    <value>m/z</value>
+  </data>
+  <data name="Units_ppm" xml:space="preserve">
+    <value>ppm</value>
+  </data>
   <data name="StreamEx_ReadOrThrow_Failed_reading__0__bytes__Source_may_be_corrupted_" xml:space="preserve">
     <value>{0}バイトの読み込みに失敗しました。ソースが壊れている可能性があります。</value>
   </data>

--- a/pwiz_tools/Shared/CommonUtil/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/Properties/Resources.zh-CHS.resx
@@ -121,6 +121,9 @@
   <data name="Units_mz" xml:space="preserve">
     <value>质荷比</value>
   </data>
+  <data name="Units_ppm" xml:space="preserve">
+    <value>ppm</value>
+  </data>
   <data name="StreamEx_ReadOrThrow_Failed_reading__0__bytes__Source_may_be_corrupted_" xml:space="preserve">
     <value>读取 {0} 字节失败。源可能已损坏。</value>
   </data>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.ja.resx
@@ -118,47 +118,309 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="folderPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 54</value>
+  </data>
+  <data name="folderPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 241</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Name" xml:space="preserve">
+    <value>folderPanel</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>360, 304</value>
+  </data>
+  <data name="cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
   <data name="cancel.Text" xml:space="preserve">
     <value>Cancel</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;cancel.Name" xml:space="preserve">
+    <value>cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cancel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="open.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="open.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 304</value>
+  </data>
+  <data name="open.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="open.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
   <data name="open.Text" xml:space="preserve">
     <value>Open</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;open.Name" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="&gt;&gt;open.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;open.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;open.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
   <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="toolStrip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="back.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAElSURBVFhH7Y6xSgNBEIbv0SxS2NqkSWEnpBBLSZCAZQqL
+        gI0oIiSEI4IIgqRJiCGFBDtLwVcZmb1/uM3eRg3sTAjkg5+53Zm9b7I9O0nn8YMGiy/C0RaWS3Blhy83
+        XyCUmy7QzpdOGFa0dWHZumBEj/PhO6UKLyz1afn99/LhD1IHmjixB6kDVZWzh7kb0Kwc6FaRpkWgLAkH
+        Tu/fVM/QFoRDFhXqgubtlKwDdYnf5A39s0agXeXkZuKax9djt4ScuUrkB/7dJpH3UFZhOQ+E1f9BeLdp
+        +D10cXhAO1CtJ/YoZaD5nUbvlTRyN/n83wLMUfeZ6lcv7iF/+xUj+rAwFrRtOLwcEYfF8o2WHSLe2gJM
+        rZOTBFf2HFwMqdWfbW+BPenIsh9lGoeCmcAw0gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="back.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="back.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
   <data name="back.Text" xml:space="preserve">
     <value>Back</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="forward.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEySURBVFhH7ZaxS0JRFMbfn+bQ0OrS0uAWNERjCPLA0aFB
+        aIkkgsIsQQRBWpSKhhK3xqB/5cSn39H39LyX+rz3IfiDj+s759z7u3cz2LPzPHz8SNgeCz/9A7mGJb9E
+        L5DLJSpPI1kMW36wLoCw7R5LruHI/3RGv1J+/DIPuWh+ZgoV6UQ3nN+9T8RYo/UsoSYZa9O2Q5UNXlu+
+        f5292tVK3TIY8BUq46BxdvsWG1z3e51QO0cPy7quGsxTPeX0Zii+Q/UUa2CT4GVWfTHUzkHx5HowaWLd
+        NKWrl8QztE5lHN2YdsAqSduLs6lbBk3XocrG2rDNUJNMY/Atx/W+k1DhjqPLnmggLNa6s5UjboHICtvu
+        Oaw+CwKp/mbLDyrNRQ4OwpZoWPIL/kcUKs185HuyEwR/UFmHnV3u2vkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="forward.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="forward.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
   </data>
   <data name="forward.Text" xml:space="preserve">
     <value>Forward</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="up.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="toolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 7</value>
+  </data>
+  <data name="toolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 31</value>
+  </data>
+  <data name="toolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="toolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Name" xml:space="preserve">
+    <value>toolStrip</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="urlLink.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="urlLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 309</value>
+  </data>
+  <data name="urlLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 13</value>
+  </data>
+  <data name="urlLink.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="urlLink.Text" xml:space="preserve">
     <value>&lt;placeholder&gt;</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;urlLink.Name" xml:space="preserve">
+    <value>urlLink</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;urlLink.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>115, 17</value>
   </metadata>
+  <data name="copyLinkAddressToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 22</value>
+  </data>
   <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
     <value>Copy link address</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 26</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="folderLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="folderLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="folderLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 38</value>
+  </data>
+  <data name="folderLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="folderLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="folderLabel.Text" xml:space="preserve">
     <value>&amp;Remote folders:</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
+    <value>folderLabel</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>447, 336</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAMMOAADDDgAAAAAAAAAA
+        AAD1p3f/9ad3//Wnd//1p3f/9ad3//Smdv/uoHD/9KV1//Sldf/0pXX/9aZ3//Wnd//1p3f/9ad3//Wn
+        d//4vZn/7Z9v/+2fb//tn2//7qBw/++hcf/sn27/45Zj/9iMWP/YjFj/z4NO/8h8Rv/MgEv/7Z9v/+2f
+        b//tn2//8reT/+WYZv/MgUv/zIFL/8yBS//lmGb/5Zhm/9mNWf/MgUv/zIFL/8yBS//cj1z/zoNN////
+        ///lmGb/5Zhm/+yyjP/ekV7/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn/0IRO////
+        //8BwyX//////+u7m//56+H/08Gr/+vFq/+vZSv/5raW/9aKVv/Wilb/jEUF/4xFBf+sYij/rGIo////
+        //8BwyX/AcMl/wHDJf///////////8f1////////r2Ur//DYx//Xmm//zoJN/4xFBf+MRQX/nFMX////
+        //8BwyX/AcMl/wHDJf8BwyX/AcMl/+/4/f+H4P///////69lK//x3tD/1Jx0/8Z7Rf+3gVT/jEUF////
+        //8BwyX/AcMl/wHDJf8BwyX/AcMl/wHDJf8BwyX/h+D//4fg//+vZSv/79zO/86Xbf++dDz/79zO/4xF
+        Bf////////////////8BwyX/AcMl/wHDJf///////////+/8//+NyMv/r2Ur/+TIsv/Jkmf/t200/+3a
+        zP+MRQX/yaWG/7dtNP//////AcMl/wHDJf8BwyX//////7/i9///////09TK/69lK/+/rJT/06mJ/8SM
+        Yf/w4tf/n1ca/59XGv+9lXL//////wHDJf8BwyX/AcMl///////f8Pv/7uDV/5x+WP+nXiP/nH5Y/5jB
+        xP/P8v3/h+D///////////////////////8BwyX/AcMl/wHDJf//////it3//59XGv+fVxr/n1ca/59X
+        Gv+fVxr/DcX//w3F//+H4P//h+D//4fg/////////////////////////////4rd////////n1ca/5dP
+        Ef+fVxr/+fTw/4fg//+H4P//h+D//zLE//8yxP//F7n//xe5//8Xuf//F7n//xe5//9c0v//////////
+        //+fVxr//////////////////////4fg//+H4P//XNL//1zS//9c0v//XNL//1zS//+H4P//////////
+        ////////6dvP////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAA==
+</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Panorama Folders</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;back.Name" xml:space="preserve">
+    <value>back</value>
+  </data>
+  <data name="&gt;&gt;back.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;forward.Name" xml:space="preserve">
+    <value>forward</value>
+  </data>
+  <data name="&gt;&gt;forward.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;up.Name" xml:space="preserve">
+    <value>up</value>
+  </data>
+  <data name="&gt;&gt;up.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyLinkAddressToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaDirectoryPicker</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.zh-CHS.resx
@@ -118,47 +118,309 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="folderPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 54</value>
+  </data>
+  <data name="folderPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 241</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Name" xml:space="preserve">
+    <value>folderPanel</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderPanel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>360, 304</value>
+  </data>
+  <data name="cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
   <data name="cancel.Text" xml:space="preserve">
     <value>Cancel</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;cancel.Name" xml:space="preserve">
+    <value>cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cancel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="open.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="open.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 304</value>
+  </data>
+  <data name="open.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="open.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
   <data name="open.Text" xml:space="preserve">
     <value>Open</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;open.Name" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="&gt;&gt;open.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;open.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;open.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
   <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="toolStrip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="back.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAElSURBVFhH7Y6xSgNBEIbv0SxS2NqkSWEnpBBLSZCAZQqL
+        gI0oIiSEI4IIgqRJiCGFBDtLwVcZmb1/uM3eRg3sTAjkg5+53Zm9b7I9O0nn8YMGiy/C0RaWS3Blhy83
+        XyCUmy7QzpdOGFa0dWHZumBEj/PhO6UKLyz1afn99/LhD1IHmjixB6kDVZWzh7kb0Kwc6FaRpkWgLAkH
+        Tu/fVM/QFoRDFhXqgubtlKwDdYnf5A39s0agXeXkZuKax9djt4ScuUrkB/7dJpH3UFZhOQ+E1f9BeLdp
+        +D10cXhAO1CtJ/YoZaD5nUbvlTRyN/n83wLMUfeZ6lcv7iF/+xUj+rAwFrRtOLwcEYfF8o2WHSLe2gJM
+        rZOTBFf2HFwMqdWfbW+BPenIsh9lGoeCmcAw0gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="back.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="back.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
   <data name="back.Text" xml:space="preserve">
     <value>Back</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="forward.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEySURBVFhH7ZaxS0JRFMbfn+bQ0OrS0uAWNERjCPLA0aFB
+        aIkkgsIsQQRBWpSKhhK3xqB/5cSn39H39LyX+rz3IfiDj+s759z7u3cz2LPzPHz8SNgeCz/9A7mGJb9E
+        L5DLJSpPI1kMW36wLoCw7R5LruHI/3RGv1J+/DIPuWh+ZgoV6UQ3nN+9T8RYo/UsoSYZa9O2Q5UNXlu+
+        f5292tVK3TIY8BUq46BxdvsWG1z3e51QO0cPy7quGsxTPeX0Zii+Q/UUa2CT4GVWfTHUzkHx5HowaWLd
+        NKWrl8QztE5lHN2YdsAqSduLs6lbBk3XocrG2rDNUJNMY/Atx/W+k1DhjqPLnmggLNa6s5UjboHICtvu
+        Oaw+CwKp/mbLDyrNRQ4OwpZoWPIL/kcUKs185HuyEwR/UFmHnV3u2vkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="forward.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="forward.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
   </data>
   <data name="forward.Text" xml:space="preserve">
     <value>Forward</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="up.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="toolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 7</value>
+  </data>
+  <data name="toolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 31</value>
+  </data>
+  <data name="toolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="toolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Name" xml:space="preserve">
+    <value>toolStrip</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;toolStrip.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="urlLink.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="urlLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 309</value>
+  </data>
+  <data name="urlLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 13</value>
+  </data>
+  <data name="urlLink.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="urlLink.Text" xml:space="preserve">
     <value>&lt;placeholder&gt;</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;urlLink.Name" xml:space="preserve">
+    <value>urlLink</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;urlLink.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>115, 17</value>
   </metadata>
+  <data name="copyLinkAddressToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 22</value>
+  </data>
   <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
     <value>Copy link address</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 26</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="folderLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="folderLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="folderLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 38</value>
+  </data>
+  <data name="folderLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="folderLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="folderLabel.Text" xml:space="preserve">
     <value>&amp;Remote folders:</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
+    <value>folderLabel</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>447, 336</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAMMOAADDDgAAAAAAAAAA
+        AAD1p3f/9ad3//Wnd//1p3f/9ad3//Smdv/uoHD/9KV1//Sldf/0pXX/9aZ3//Wnd//1p3f/9ad3//Wn
+        d//4vZn/7Z9v/+2fb//tn2//7qBw/++hcf/sn27/45Zj/9iMWP/YjFj/z4NO/8h8Rv/MgEv/7Z9v/+2f
+        b//tn2//8reT/+WYZv/MgUv/zIFL/8yBS//lmGb/5Zhm/9mNWf/MgUv/zIFL/8yBS//cj1z/zoNN////
+        ///lmGb/5Zhm/+yyjP/ekV7/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn/0IRO////
+        //8BwyX//////+u7m//56+H/08Gr/+vFq/+vZSv/5raW/9aKVv/Wilb/jEUF/4xFBf+sYij/rGIo////
+        //8BwyX/AcMl/wHDJf///////////8f1////////r2Ur//DYx//Xmm//zoJN/4xFBf+MRQX/nFMX////
+        //8BwyX/AcMl/wHDJf8BwyX/AcMl/+/4/f+H4P///////69lK//x3tD/1Jx0/8Z7Rf+3gVT/jEUF////
+        //8BwyX/AcMl/wHDJf8BwyX/AcMl/wHDJf8BwyX/h+D//4fg//+vZSv/79zO/86Xbf++dDz/79zO/4xF
+        Bf////////////////8BwyX/AcMl/wHDJf///////////+/8//+NyMv/r2Ur/+TIsv/Jkmf/t200/+3a
+        zP+MRQX/yaWG/7dtNP//////AcMl/wHDJf8BwyX//////7/i9///////09TK/69lK/+/rJT/06mJ/8SM
+        Yf/w4tf/n1ca/59XGv+9lXL//////wHDJf8BwyX/AcMl///////f8Pv/7uDV/5x+WP+nXiP/nH5Y/5jB
+        xP/P8v3/h+D///////////////////////8BwyX/AcMl/wHDJf//////it3//59XGv+fVxr/n1ca/59X
+        Gv+fVxr/DcX//w3F//+H4P//h+D//4fg/////////////////////////////4rd////////n1ca/5dP
+        Ef+fVxr/+fTw/4fg//+H4P//h+D//zLE//8yxP//F7n//xe5//8Xuf//F7n//xe5//9c0v//////////
+        //+fVxr//////////////////////4fg//+H4P//XNL//1zS//9c0v//XNL//1zS//+H4P//////////
+        ////////6dvP////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAA==
+</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Panorama Folders</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;back.Name" xml:space="preserve">
+    <value>back</value>
+  </data>
+  <data name="&gt;&gt;back.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;forward.Name" xml:space="preserve">
+    <value>forward</value>
+  </data>
+  <data name="&gt;&gt;forward.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;up.Name" xml:space="preserve">
+    <value>up</value>
+  </data>
+  <data name="&gt;&gt;up.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyLinkAddressToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaDirectoryPicker</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.ja.resx
@@ -118,18 +118,146 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="folderLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 36</value>
+  </data>
+  <data name="folderLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="folderLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="folderLabel.Text" xml:space="preserve">
     <value>&amp;Remote folders:</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
+    <value>folderLabel</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
   <metadata name="treeViewIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="treeViewIcons.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADy
+        CgAAAk1TRnQBSQFMAgEBBAEAARABBQEQAQUBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ABQAP1QHc
+        Av8B7QrsARwB/wH0BEYBlAT/ARcFRgFvAQAC/wz0Af8G1QO0AbMBrQGzA9UB3AH/AfcBvArwAZIB6wH/
+        AigBhgG2AZQBFwEWAfQBFwElASkEKAFQAQAB9AHzCvEC8gHzAbQDswO0A7MBtAGzAa0CtAHcAf8BbQLw
+        AQkBBwH3AbUC7wEHAQkB8gEHAesB/wKYAbUB5gGuAUsBlAHjASUBlAFPAZcEmAEAAfEG7AfrAbwBtAmt
+        AbMBtAKLAQkB9AH/AesB8AEJAbQBrgGLAYYCrgGRAbQB8AHvAesE/wHWAa0BiwEcARYBJQFzAZgBCAT/
+        AQACUgFMCioBEgHrAbsBCQGLAQkDtAH/AosBrQK0AZkBGgL/Au8BBwG1Aa4EhgGuAfcBvAH3AewF/wHW
+        Aa0BiwHzAWIBAgEIBf8BUgF6AVIBoAh6AVIBoAEqARIBwwH/AYsBGQG0AbMBtAH/AooBrQHxAf8BwwF6
+        AfYC/wHrAQcB8AGRBIYBrgG8Ae8B9wf/AdYByAEZAfwBSAEIBf8BUgF6AVIBoAh6AVIBoAEqARIBoAH/
+        AYsBGQG0Aa0BtAH/AqYBiwEZAv8BmgEaAv8B9wEHAbwBtAGuAoYB6wG1AfABkgHsB/8B1gHIAd0B/AFI
+        AQgF/wFSAXoBUgmgAVgBoAEqARIBoAHDAYsB8QG0Aa0B8QH/AbUCiwP/AZoBGgP/Ae0B7wHwAbQC6wG0
+        AfIB7wEHCP8B1gP8AUgBCAX/AVIBegFSCaABegGgASoB6gH2AZkBiwEJAbQBrQHxAf8BtQKmAv8B9gF6
+        ARoD/wH3AQcB8AO0AbUB8gHsAfcJ/wHWAvwBSAEIBf8BUgF6AVIJoAF6AaABKgHqAf8BvAGLArUBtAEZ
+        Av8BtAHxAv8BGgF6AcMD/wHzAu8E8gHvAQcB8gn/Ad0ByAHdAU8BCAX/AVIBegFSCf8BmgH/ASoBbQHy
+        Aa4BiwGuAZkBwwH2BP8B9gGaAXoBGgX/Ae8B9wT/AewBBwr/AbwBbAH/AU8BCAX/AVIBoAGaDFIB7AWL
+        AZoBegSaAXoBmgEaBv8B8AHvAQcC/wHvAfcB8Qr/AQgBAgKYAfIF/wFSBqAF/wEqAeoBBwL/AYsBpgGL
+        Af8B9gLDApoBGgHDAfYI/wEHAewC/wHqAbwL/wHxAXIBAgHyBv8BUgH/BKAB/wVSAUwDAAL/AYsR/wHz
+        Ae8B7QL/AesBBwH0C/8B8gECAfIG/wEAAVIE/wFSAf8BAAH/BgAC/wHxEf8B7wFtAZIC8wHsAesBvAv/
+        AfMBTwHzBv8CAARSAf8JABT/AQcBrgLrA0oBBxT/EAABQgFNAT4HAAE+AwABKAMAAUADAAEgAwABAQEA
+        AQEGAAEBFgAD/4cAAYAHAAGABwABgAcAAYBIAAEHBgABgAG/BgABwQH/BgAC/ws=
+</value>
+  </data>
   <metadata name="fileIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>127, 17</value>
   </metadata>
+  <data name="fileIcons.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAA0
+        CQAAAk1TRnQBSQFMAgEBAgEAAfABBAHwAQQBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAARADAAEBAQABCAYAAQQYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD/wIADu8FAAGuAWwKZiEA
+        AQcM8gHvBQAB9AH/CRkB1SEAAQcM/wHvBQAB9AH/BxkByAEZAdUhAAEHAf8K7AH/Ae8FAAH0Av8BGQP0
+        AYsBzgKnAdUhAAEHAf8BBwj0AewB/wHvBQAF/wH0Af8BxwHVAQkBGQHVIQABBwH/AQcC/wGTAv8CmAH0
+        AewB/wHvBQAG/wHHAc4BpwH0ARkB1SEAAQcB/wEHAf8BkwEWAf8B1gHhAdYB9AHsAf8B7wEABdUDtAL/
+        Ac0B3AH/AfQBGQHWIQABBwH/AQcB/wGgAZMC/wHWAf8B9AHsAf8B7wIAAgkBrQG0Aq0BswH/AfQB1QGt
+        Af8C9AEJIQABBwH/AQcH/wH0AewB/wHvAgACCQGtAbQCpgGtBv8B9AEJIQABBwH/AQcItQHsAf8B7wIA
+        AbsBCQKtAf8BiwG0Bv8B9AEJIQABBwH/AQcBtQGaBrUB7AH/Ae8CAAK0AQABtAH/AbsI/wEJIQABBwH/
+        CQcB7AHyAe8BAAG0AosBtAn/Aa4CbCEAAQcJ/wG8A+8CAAHPAbQBAAn/ARkB3QHyIQABBwn/AbwB/wHv
+        BgAJ/wEZAfIiAAEHCfQBvAHvBwAJ/wHyIwAKBwG8NAABQgFNAT4HAAE+AwABKAMAAUADAAEQAwABAQEA
+        AQEFAAGAFwAD/wEAAYABAQHwBQABgAEBAfAFAAGAAQEB8AUAAYABAQHwBQABgAEBAfAFAAGAAQEB8AUA
+        AYABAQYAAYABAQGABQABgAEBAYAFAAGAAQEBgAUAAYABAQGQBQABgAEBBgABgAEBAZAFAAGAAQMB8AEB
+        BAABgAEHAfABAwQAAYABDwL/BAAL
+</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="versionOptions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
   <data name="versionOptions.Items" xml:space="preserve">
     <value>All</value>
     <comment>Needs Review:New resource</comment>
@@ -138,63 +266,434 @@
     <value>Most recent</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="versionOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>574, 26</value>
+  </data>
+  <data name="versionOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="versionOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="versionOptions.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Name" xml:space="preserve">
+    <value>versionOptions</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="open.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="open.Location" type="System.Drawing.Point, System.Drawing">
+    <value>556, 530</value>
+  </data>
+  <data name="open.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="open.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
   <data name="open.Text" xml:space="preserve">
     <value>&amp;Open</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;open.Name" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="&gt;&gt;open.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;open.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;open.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>637, 530</value>
+  </data>
+  <data name="cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="cancel.Text" xml:space="preserve">
     <value>Cancel</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;cancel.Name" xml:space="preserve">
+    <value>cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cancel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="versionLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="versionLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="versionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>571, 10</value>
+  </data>
+  <data name="versionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
+  </data>
+  <data name="versionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="versionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="versionLabel.Text" xml:space="preserve">
     <value>&amp;Versions:</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="versionLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Name" xml:space="preserve">
+    <value>versionLabel</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="browserSplitContainer.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="browserSplitContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="browserSplitContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Name" xml:space="preserve">
+    <value>browserSplitContainer.Panel1</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Parent" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="noFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="noFiles.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="noFiles.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9.75pt</value>
+  </data>
+  <data name="noFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>115, 209</value>
+  </data>
+  <data name="noFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 16</value>
+  </data>
+  <data name="noFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
   <data name="noFiles.Text" xml:space="preserve">
     <value>There are no Skyline files in this folder</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="noFiles.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Name" xml:space="preserve">
+    <value>noFiles</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Parent" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;noFiles.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="colName.Text" xml:space="preserve">
     <value>Name</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="colName.Width" type="System.Int32, mscorlib">
+    <value>175</value>
   </data>
   <data name="colSize.Text" xml:space="preserve">
     <value>Size</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="colSize.Width" type="System.Int32, mscorlib">
+    <value>75</value>
+  </data>
   <data name="colVersions.Text" xml:space="preserve">
     <value>Versions</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="colVersions.Width" type="System.Int32, mscorlib">
+    <value>52</value>
   </data>
   <data name="colReplacedBy.Text" xml:space="preserve">
     <value>Replaced By</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="colReplacedBy.Width" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
   <data name="colCreated.Text" xml:space="preserve">
     <value>Created</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="listView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="listView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>462, 472</value>
+  </data>
+  <data name="listView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;listView.Name" xml:space="preserve">
+    <value>listView</value>
+  </data>
+  <data name="&gt;&gt;listView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;listView.Parent" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;listView.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Name" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Parent" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="browserSplitContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>702, 472</value>
+  </data>
+  <data name="browserSplitContainer.SplitterDistance" type="System.Int32, mscorlib">
+    <value>237</value>
+  </data>
+  <data name="browserSplitContainer.SplitterWidth" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="browserSplitContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Name" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Parent" xml:space="preserve">
+    <value>browserPanel</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="browserPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="browserPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 52</value>
+  </data>
+  <data name="browserPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>702, 472</value>
+  </data>
+  <data name="browserPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Name" xml:space="preserve">
+    <value>browserPanel</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <metadata name="navToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>237, 17</value>
   </metadata>
+  <data name="navToolStrip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="back.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAElSURBVFhH7Y6xSgNBEIbv0SxS2NqkSWEnpBBLSZCAZQqL
+        gI0oIiSEI4IIgqRJiCGFBDtLwVcZmb1/uM3eRg3sTAjkg5+53Zm9b7I9O0nn8YMGiy/C0RaWS3Blhy83
+        XyCUmy7QzpdOGFa0dWHZumBEj/PhO6UKLyz1afn99/LhD1IHmjixB6kDVZWzh7kb0Kwc6FaRpkWgLAkH
+        Tu/fVM/QFoRDFhXqgubtlKwDdYnf5A39s0agXeXkZuKax9djt4ScuUrkB/7dJpH3UFZhOQ+E1f9BeLdp
+        +D10cXhAO1CtJ/YoZaD5nUbvlTRyN/n83wLMUfeZ6lcv7iF/+xUj+rAwFrRtOLwcEYfF8o2WHSLe2gJM
+        rZOTBFf2HFwMqdWfbW+BPenIsh9lGoeCmcAw0gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="back.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="back.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
   <data name="back.Text" xml:space="preserve">
     <value>Back</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="forward.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEySURBVFhH7ZaxS0JRFMbfn+bQ0OrS0uAWNERjCPLA0aFB
+        aIkkgsIsQQRBWpSKhhK3xqB/5cSn39H39LyX+rz3IfiDj+s759z7u3cz2LPzPHz8SNgeCz/9A7mGJb9E
+        L5DLJSpPI1kMW36wLoCw7R5LruHI/3RGv1J+/DIPuWh+ZgoV6UQ3nN+9T8RYo/UsoSYZa9O2Q5UNXlu+
+        f5292tVK3TIY8BUq46BxdvsWG1z3e51QO0cPy7quGsxTPeX0Zii+Q/UUa2CT4GVWfTHUzkHx5HowaWLd
+        NKWrl8QztE5lHN2YdsAqSduLs6lbBk3XocrG2rDNUJNMY/Atx/W+k1DhjqPLnmggLNa6s5UjboHICtvu
+        Oaw+CwKp/mbLDyrNRQ4OwpZoWPIL/kcUKs185HuyEwR/UFmHnV3u2vkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="forward.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="forward.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
   </data>
   <data name="forward.Text" xml:space="preserve">
     <value>Forward</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="up.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADVSURBVFhH5ZXBDcIwEARdGqWklJSSF3XkTTV0ABzaQydn
+        gzhjs0JZaR4kwTOPSCl/vWlZbwZ+/nYul0TUcge3x46JI3hszJgwMgM83ndMyBgSwUQMl3eNmGYu26Nr
+        xFOeCKjlDo7L7ZSUOyzAwLGfzeSvgEQEE0dw/Pu1yh0mjkDD5/LWCCZkQLed3dwEPK5lqGU158s1/1Iy
+        EaOW4e/fj8n2kAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAGBKwrFzGcHnTZ/eAK+UO
+        mzeHG7y1XsoAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="up.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="up.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="navToolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 2</value>
+  </data>
+  <data name="navToolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 31</value>
+  </data>
+  <data name="navToolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="navToolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Name" xml:space="preserve">
+    <value>navToolStrip</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="urlLink.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
   <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>335, 17</value>
   </metadata>
+  <data name="copyLinkAddressToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 22</value>
+  </data>
   <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
     <value>Copy link address</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 26</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="urlLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 535</value>
+  </data>
+  <data name="urlLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>538, 13</value>
+  </data>
+  <data name="urlLink.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
   <data name="urlLink.Text" xml:space="preserve">
     <value>&lt;placeholder&gt;</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;urlLink.Name" xml:space="preserve">
+    <value>urlLink</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;urlLink.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -202,8 +701,116 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>52</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>724, 562</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAMMOAADDDgAAAAAAAAAA
+        AAD1p3f/9ad3//Wnd//1p3f/9ad3//Smdv/uoHD/9KV1//Sldf/0pXX/9aZ3//Wnd//1p3f/9ad3//Wn
+        d//4vZn/7Z9v/+2fb//tn2//7qBw/++hcf/sn27/45Zj/9iMWP/YjFj/z4NO/8h8Rv/MgEv/7Z9v/+2f
+        b//tn2//8reT/+WYZv/MgUv/zIFL/8yBS//lmGb/5Zhm/9mNWf/MgUv//////8yBS//cj1z/zoNN/8B1
+        Pv/lmGb/5Zhm/+yyjP/ekV7/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn//////wHDJf//////0IRO/9qO
+        Wv+kWx//rGMo/+u7m//56+H/08Gr/+vFq/+vZSv/5raW/9aKVv/Wilb//////wHDJf8BwyX/AcMl////
+        //+sYij/xHhB/5G/1v9Wxf///////1zS////////r2Ur//DYx//Xmm///////wHDJf8BwyX/AcMl/wHD
+        Jf8BwyX//////7htNP/f8fv/Gsr//+/4/f8ayv///////69lK//x3tD//////wHDJf8BwyX/AcMl/wHD
+        Jf8BwyX/AcMl/wHDJf///////////xrK//9c0v//Gsr//1zS//+vZSv/79zO/86Xbf///////////wHD
+        Jf8BwyX/AcMl////////////n1ca//////9Wxf//XNL//+/8//+NyMv/r2Ur/+TIsv/Jkmf/t200////
+        //8BwyX/AcMl/wHDJf//////k0sN/5NLDf/3/P7/Gsr//1zS////////09TK/69lK/+/rJT/06mJ/8SM
+        Yf//////AcMl/wHDJf8BwyX//////72Vcv/p3ND//////xrK///f8Pv/7uDV/5x+WP+nXiP/nH5Y/5jB
+        xP981P3/9/3//wHDJf8BwyX/AcMl///////v+f3//////1bF//8ayv///////59XGv+fVxr/n1ca/59X
+        Gv+fVxr/o+r//////////////////////////////////1bF//8ayv//VsX/////////////n1ca/5dP
+        Ef+fVxr/+fTw/xrK//8ayv//O83//03Q//87zf//O83//xrK//8ayv//VsX/////////////////////
+        //+fVxr/////////////////XNL//1bF//9c0v//XNL//1bF//9Wxf//////////////////////////
+        ////////6dvP////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAA==
+</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Panorama Folders</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;treeViewIcons.Name" xml:space="preserve">
+    <value>treeViewIcons</value>
+  </data>
+  <data name="&gt;&gt;treeViewIcons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fileIcons.Name" xml:space="preserve">
+    <value>fileIcons</value>
+  </data>
+  <data name="&gt;&gt;fileIcons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colName.Name" xml:space="preserve">
+    <value>colName</value>
+  </data>
+  <data name="&gt;&gt;colName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colSize.Name" xml:space="preserve">
+    <value>colSize</value>
+  </data>
+  <data name="&gt;&gt;colSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colVersions.Name" xml:space="preserve">
+    <value>colVersions</value>
+  </data>
+  <data name="&gt;&gt;colVersions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colReplacedBy.Name" xml:space="preserve">
+    <value>colReplacedBy</value>
+  </data>
+  <data name="&gt;&gt;colReplacedBy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colCreated.Name" xml:space="preserve">
+    <value>colCreated</value>
+  </data>
+  <data name="&gt;&gt;colCreated.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;back.Name" xml:space="preserve">
+    <value>back</value>
+  </data>
+  <data name="&gt;&gt;back.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;forward.Name" xml:space="preserve">
+    <value>forward</value>
+  </data>
+  <data name="&gt;&gt;forward.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;up.Name" xml:space="preserve">
+    <value>up</value>
+  </data>
+  <data name="&gt;&gt;up.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyLinkAddressToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaFilePicker</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.zh-CHS.resx
@@ -118,18 +118,146 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="folderLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="folderLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 36</value>
+  </data>
+  <data name="folderLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 13</value>
+  </data>
+  <data name="folderLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="folderLabel.Text" xml:space="preserve">
     <value>&amp;Remote folders:</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
+    <value>folderLabel</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;folderLabel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
   <metadata name="treeViewIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="treeViewIcons.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADy
+        CgAAAk1TRnQBSQFMAgEBBAEAARABBQEQAQUBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ABQAP1QHc
+        Av8B7QrsARwB/wH0BEYBlAT/ARcFRgFvAQAC/wz0Af8G1QO0AbMBrQGzA9UB3AH/AfcBvArwAZIB6wH/
+        AigBhgG2AZQBFwEWAfQBFwElASkEKAFQAQAB9AHzCvEC8gHzAbQDswO0A7MBtAGzAa0CtAHcAf8BbQLw
+        AQkBBwH3AbUC7wEHAQkB8gEHAesB/wKYAbUB5gGuAUsBlAHjASUBlAFPAZcEmAEAAfEG7AfrAbwBtAmt
+        AbMBtAKLAQkB9AH/AesB8AEJAbQBrgGLAYYCrgGRAbQB8AHvAesE/wHWAa0BiwEcARYBJQFzAZgBCAT/
+        AQACUgFMCioBEgHrAbsBCQGLAQkDtAH/AosBrQK0AZkBGgL/Au8BBwG1Aa4EhgGuAfcBvAH3AewF/wHW
+        Aa0BiwHzAWIBAgEIBf8BUgF6AVIBoAh6AVIBoAEqARIBwwH/AYsBGQG0AbMBtAH/AooBrQHxAf8BwwF6
+        AfYC/wHrAQcB8AGRBIYBrgG8Ae8B9wf/AdYByAEZAfwBSAEIBf8BUgF6AVIBoAh6AVIBoAEqARIBoAH/
+        AYsBGQG0Aa0BtAH/AqYBiwEZAv8BmgEaAv8B9wEHAbwBtAGuAoYB6wG1AfABkgHsB/8B1gHIAd0B/AFI
+        AQgF/wFSAXoBUgmgAVgBoAEqARIBoAHDAYsB8QG0Aa0B8QH/AbUCiwP/AZoBGgP/Ae0B7wHwAbQC6wG0
+        AfIB7wEHCP8B1gP8AUgBCAX/AVIBegFSCaABegGgASoB6gH2AZkBiwEJAbQBrQHxAf8BtQKmAv8B9gF6
+        ARoD/wH3AQcB8AO0AbUB8gHsAfcJ/wHWAvwBSAEIBf8BUgF6AVIJoAF6AaABKgHqAf8BvAGLArUBtAEZ
+        Av8BtAHxAv8BGgF6AcMD/wHzAu8E8gHvAQcB8gn/Ad0ByAHdAU8BCAX/AVIBegFSCf8BmgH/ASoBbQHy
+        Aa4BiwGuAZkBwwH2BP8B9gGaAXoBGgX/Ae8B9wT/AewBBwr/AbwBbAH/AU8BCAX/AVIBoAGaDFIB7AWL
+        AZoBegSaAXoBmgEaBv8B8AHvAQcC/wHvAfcB8Qr/AQgBAgKYAfIF/wFSBqAF/wEqAeoBBwL/AYsBpgGL
+        Af8B9gLDApoBGgHDAfYI/wEHAewC/wHqAbwL/wHxAXIBAgHyBv8BUgH/BKAB/wVSAUwDAAL/AYsR/wHz
+        Ae8B7QL/AesBBwH0C/8B8gECAfIG/wEAAVIE/wFSAf8BAAH/BgAC/wHxEf8B7wFtAZIC8wHsAesBvAv/
+        AfMBTwHzBv8CAARSAf8JABT/AQcBrgLrA0oBBxT/EAABQgFNAT4HAAE+AwABKAMAAUADAAEgAwABAQEA
+        AQEGAAEBFgAD/4cAAYAHAAGABwABgAcAAYBIAAEHBgABgAG/BgABwQH/BgAC/ws=
+</value>
+  </data>
   <metadata name="fileIcons.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>127, 17</value>
   </metadata>
+  <data name="fileIcons.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAA0
+        CQAAAk1TRnQBSQFMAgEBAgEAAfABBAHwAQQBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAARADAAEBAQABCAYAAQQYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD/wIADu8FAAGuAWwKZiEA
+        AQcM8gHvBQAB9AH/CRkB1SEAAQcM/wHvBQAB9AH/BxkByAEZAdUhAAEHAf8K7AH/Ae8FAAH0Av8BGQP0
+        AYsBzgKnAdUhAAEHAf8BBwj0AewB/wHvBQAF/wH0Af8BxwHVAQkBGQHVIQABBwH/AQcC/wGTAv8CmAH0
+        AewB/wHvBQAG/wHHAc4BpwH0ARkB1SEAAQcB/wEHAf8BkwEWAf8B1gHhAdYB9AHsAf8B7wEABdUDtAL/
+        Ac0B3AH/AfQBGQHWIQABBwH/AQcB/wGgAZMC/wHWAf8B9AHsAf8B7wIAAgkBrQG0Aq0BswH/AfQB1QGt
+        Af8C9AEJIQABBwH/AQcH/wH0AewB/wHvAgACCQGtAbQCpgGtBv8B9AEJIQABBwH/AQcItQHsAf8B7wIA
+        AbsBCQKtAf8BiwG0Bv8B9AEJIQABBwH/AQcBtQGaBrUB7AH/Ae8CAAK0AQABtAH/AbsI/wEJIQABBwH/
+        CQcB7AHyAe8BAAG0AosBtAn/Aa4CbCEAAQcJ/wG8A+8CAAHPAbQBAAn/ARkB3QHyIQABBwn/AbwB/wHv
+        BgAJ/wEZAfIiAAEHCfQBvAHvBwAJ/wHyIwAKBwG8NAABQgFNAT4HAAE+AwABKAMAAUADAAEQAwABAQEA
+        AQEFAAGAFwAD/wEAAYABAQHwBQABgAEBAfAFAAGAAQEB8AUAAYABAQHwBQABgAEBAfAFAAGAAQEB8AUA
+        AYABAQYAAYABAQGABQABgAEBAYAFAAGAAQEBgAUAAYABAQGQBQABgAEBBgABgAEBAZAFAAGAAQMB8AEB
+        BAABgAEHAfABAwQAAYABDwL/BAAL
+</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="versionOptions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
   <data name="versionOptions.Items" xml:space="preserve">
     <value>All</value>
     <comment>Needs Review:New resource</comment>
@@ -138,63 +266,434 @@
     <value>Most recent</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="versionOptions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>574, 26</value>
+  </data>
+  <data name="versionOptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="versionOptions.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="versionOptions.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Name" xml:space="preserve">
+    <value>versionOptions</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;versionOptions.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="open.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="open.Location" type="System.Drawing.Point, System.Drawing">
+    <value>556, 530</value>
+  </data>
+  <data name="open.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="open.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
   <data name="open.Text" xml:space="preserve">
     <value>&amp;Open</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;open.Name" xml:space="preserve">
+    <value>open</value>
+  </data>
+  <data name="&gt;&gt;open.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;open.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;open.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>637, 530</value>
+  </data>
+  <data name="cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="cancel.Text" xml:space="preserve">
     <value>Cancel</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;cancel.Name" xml:space="preserve">
+    <value>cancel</value>
+  </data>
+  <data name="&gt;&gt;cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cancel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="versionLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="versionLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="versionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>571, 10</value>
+  </data>
+  <data name="versionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
+  </data>
+  <data name="versionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 13</value>
+  </data>
+  <data name="versionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="versionLabel.Text" xml:space="preserve">
     <value>&amp;Versions:</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="versionLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Name" xml:space="preserve">
+    <value>versionLabel</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;versionLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="browserSplitContainer.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="browserSplitContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="browserSplitContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Name" xml:space="preserve">
+    <value>browserSplitContainer.Panel1</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.Parent" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="noFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="noFiles.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="noFiles.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9.75pt</value>
+  </data>
+  <data name="noFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>115, 209</value>
+  </data>
+  <data name="noFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 16</value>
+  </data>
+  <data name="noFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
   <data name="noFiles.Text" xml:space="preserve">
     <value>There are no Skyline files in this folder</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="noFiles.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Name" xml:space="preserve">
+    <value>noFiles</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;noFiles.Parent" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;noFiles.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="colName.Text" xml:space="preserve">
     <value>Name</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="colName.Width" type="System.Int32, mscorlib">
+    <value>175</value>
   </data>
   <data name="colSize.Text" xml:space="preserve">
     <value>Size</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="colSize.Width" type="System.Int32, mscorlib">
+    <value>75</value>
+  </data>
   <data name="colVersions.Text" xml:space="preserve">
     <value>Versions</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="colVersions.Width" type="System.Int32, mscorlib">
+    <value>52</value>
   </data>
   <data name="colReplacedBy.Text" xml:space="preserve">
     <value>Replaced By</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="colReplacedBy.Width" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
   <data name="colCreated.Text" xml:space="preserve">
     <value>Created</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="listView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="listView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="listView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>462, 472</value>
+  </data>
+  <data name="listView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;listView.Name" xml:space="preserve">
+    <value>listView</value>
+  </data>
+  <data name="&gt;&gt;listView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;listView.Parent" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;listView.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Name" xml:space="preserve">
+    <value>browserSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.Parent" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="browserSplitContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>702, 472</value>
+  </data>
+  <data name="browserSplitContainer.SplitterDistance" type="System.Int32, mscorlib">
+    <value>237</value>
+  </data>
+  <data name="browserSplitContainer.SplitterWidth" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="browserSplitContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Name" xml:space="preserve">
+    <value>browserSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.Parent" xml:space="preserve">
+    <value>browserPanel</value>
+  </data>
+  <data name="&gt;&gt;browserSplitContainer.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="browserPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="browserPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 52</value>
+  </data>
+  <data name="browserPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>702, 472</value>
+  </data>
+  <data name="browserPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Name" xml:space="preserve">
+    <value>browserPanel</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;browserPanel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <metadata name="navToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>237, 17</value>
   </metadata>
+  <data name="navToolStrip.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="back.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAElSURBVFhH7Y6xSgNBEIbv0SxS2NqkSWEnpBBLSZCAZQqL
+        gI0oIiSEI4IIgqRJiCGFBDtLwVcZmb1/uM3eRg3sTAjkg5+53Zm9b7I9O0nn8YMGiy/C0RaWS3Blhy83
+        XyCUmy7QzpdOGFa0dWHZumBEj/PhO6UKLyz1afn99/LhD1IHmjixB6kDVZWzh7kb0Kwc6FaRpkWgLAkH
+        Tu/fVM/QFoRDFhXqgubtlKwDdYnf5A39s0agXeXkZuKax9djt4ScuUrkB/7dJpH3UFZhOQ+E1f9BeLdp
+        +D10cXhAO1CtJ/YoZaD5nUbvlTRyN/n83wLMUfeZ6lcv7iF/+xUj+rAwFrRtOLwcEYfF8o2WHSLe2gJM
+        rZOTBFf2HFwMqdWfbW+BPenIsh9lGoeCmcAw0gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="back.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="back.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
   <data name="back.Text" xml:space="preserve">
     <value>Back</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="forward.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEySURBVFhH7ZaxS0JRFMbfn+bQ0OrS0uAWNERjCPLA0aFB
+        aIkkgsIsQQRBWpSKhhK3xqB/5cSn39H39LyX+rz3IfiDj+s759z7u3cz2LPzPHz8SNgeCz/9A7mGJb9E
+        L5DLJSpPI1kMW36wLoCw7R5LruHI/3RGv1J+/DIPuWh+ZgoV6UQ3nN+9T8RYo/UsoSYZa9O2Q5UNXlu+
+        f5292tVK3TIY8BUq46BxdvsWG1z3e51QO0cPy7quGsxTPeX0Zii+Q/UUa2CT4GVWfTHUzkHx5HowaWLd
+        NKWrl8QztE5lHN2YdsAqSduLs6lbBk3XocrG2rDNUJNMY/Atx/W+k1DhjqPLnmggLNa6s5UjboHICtvu
+        Oaw+CwKp/mbLDyrNRQ4OwpZoWPIL/kcUKs185HuyEwR/UFmHnV3u2vkAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="forward.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="forward.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
   </data>
   <data name="forward.Text" xml:space="preserve">
     <value>Forward</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="up.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADVSURBVFhH5ZXBDcIwEARdGqWklJSSF3XkTTV0ABzaQydn
+        gzhjs0JZaR4kwTOPSCl/vWlZbwZ+/nYul0TUcge3x46JI3hszJgwMgM83ndMyBgSwUQMl3eNmGYu26Nr
+        xFOeCKjlDo7L7ZSUOyzAwLGfzeSvgEQEE0dw/Pu1yh0mjkDD5/LWCCZkQLed3dwEPK5lqGU158s1/1Iy
+        EaOW4e/fj8n2kAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAkAZEuSTAGBKwrFzGcHnTZ/eAK+UO
+        mzeHG7y1XsoAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="up.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="up.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 28</value>
+  </data>
+  <data name="navToolStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 2</value>
+  </data>
+  <data name="navToolStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 31</value>
+  </data>
+  <data name="navToolStrip.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="navToolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Name" xml:space="preserve">
+    <value>navToolStrip</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;navToolStrip.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="urlLink.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
   <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>335, 17</value>
   </metadata>
+  <data name="copyLinkAddressToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 22</value>
+  </data>
   <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
     <value>Copy link address</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 26</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Name" xml:space="preserve">
+    <value>contextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;contextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="urlLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 535</value>
+  </data>
+  <data name="urlLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>538, 13</value>
+  </data>
+  <data name="urlLink.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
   <data name="urlLink.Text" xml:space="preserve">
     <value>&lt;placeholder&gt;</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;urlLink.Name" xml:space="preserve">
+    <value>urlLink</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;urlLink.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;urlLink.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -202,8 +701,116 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>52</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>724, 562</value>
+  </data>
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAMMOAADDDgAAAAAAAAAA
+        AAD1p3f/9ad3//Wnd//1p3f/9ad3//Smdv/uoHD/9KV1//Sldf/0pXX/9aZ3//Wnd//1p3f/9ad3//Wn
+        d//4vZn/7Z9v/+2fb//tn2//7qBw/++hcf/sn27/45Zj/9iMWP/YjFj/z4NO/8h8Rv/MgEv/7Z9v/+2f
+        b//tn2//8reT/+WYZv/MgUv/zIFL/8yBS//lmGb/5Zhm/9mNWf/MgUv//////8yBS//cj1z/zoNN/8B1
+        Pv/lmGb/5Zhm/+yyjP/ekV7/vHI5/7xyOf+8cjn/vHI5/7xyOf+8cjn//////wHDJf//////0IRO/9qO
+        Wv+kWx//rGMo/+u7m//56+H/08Gr/+vFq/+vZSv/5raW/9aKVv/Wilb//////wHDJf8BwyX/AcMl////
+        //+sYij/xHhB/5G/1v9Wxf///////1zS////////r2Ur//DYx//Xmm///////wHDJf8BwyX/AcMl/wHD
+        Jf8BwyX//////7htNP/f8fv/Gsr//+/4/f8ayv///////69lK//x3tD//////wHDJf8BwyX/AcMl/wHD
+        Jf8BwyX/AcMl/wHDJf///////////xrK//9c0v//Gsr//1zS//+vZSv/79zO/86Xbf///////////wHD
+        Jf8BwyX/AcMl////////////n1ca//////9Wxf//XNL//+/8//+NyMv/r2Ur/+TIsv/Jkmf/t200////
+        //8BwyX/AcMl/wHDJf//////k0sN/5NLDf/3/P7/Gsr//1zS////////09TK/69lK/+/rJT/06mJ/8SM
+        Yf//////AcMl/wHDJf8BwyX//////72Vcv/p3ND//////xrK///f8Pv/7uDV/5x+WP+nXiP/nH5Y/5jB
+        xP981P3/9/3//wHDJf8BwyX/AcMl///////v+f3//////1bF//8ayv///////59XGv+fVxr/n1ca/59X
+        Gv+fVxr/o+r//////////////////////////////////1bF//8ayv//VsX/////////////n1ca/5dP
+        Ef+fVxr/+fTw/xrK//8ayv//O83//03Q//87zf//O83//xrK//8ayv//VsX/////////////////////
+        //+fVxr/////////////////XNL//1bF//9c0v//XNL//1bF//9Wxf//////////////////////////
+        ////////6dvP////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAA==
+</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Panorama Folders</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;treeViewIcons.Name" xml:space="preserve">
+    <value>treeViewIcons</value>
+  </data>
+  <data name="&gt;&gt;treeViewIcons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fileIcons.Name" xml:space="preserve">
+    <value>fileIcons</value>
+  </data>
+  <data name="&gt;&gt;fileIcons.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colName.Name" xml:space="preserve">
+    <value>colName</value>
+  </data>
+  <data name="&gt;&gt;colName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colSize.Name" xml:space="preserve">
+    <value>colSize</value>
+  </data>
+  <data name="&gt;&gt;colSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colVersions.Name" xml:space="preserve">
+    <value>colVersions</value>
+  </data>
+  <data name="&gt;&gt;colVersions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colReplacedBy.Name" xml:space="preserve">
+    <value>colReplacedBy</value>
+  </data>
+  <data name="&gt;&gt;colReplacedBy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colCreated.Name" xml:space="preserve">
+    <value>colCreated</value>
+  </data>
+  <data name="&gt;&gt;colCreated.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;back.Name" xml:space="preserve">
+    <value>back</value>
+  </data>
+  <data name="&gt;&gt;back.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;forward.Name" xml:space="preserve">
+    <value>forward</value>
+  </data>
+  <data name="&gt;&gt;forward.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;up.Name" xml:space="preserve">
+    <value>up</value>
+  </data>
+  <data name="&gt;&gt;up.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyLinkAddressToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyLinkAddressToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaFilePicker</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.ja.resx
@@ -120,10 +120,112 @@
   <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="imageList1.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADy
+        CgAAAk1TRnQBSQFMAgEBBAEAAagBAAGoAQABEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ABQAP1QHc
+        Av8B7QrsARwB/wH0BEYBlAT/ARcFRgFvAQAC/wz0Af8G1QO0AbMBrQGzA9UB3AH/AfcBvArwAZIB6wH/
+        AigBhgG2AZQBFwEWAfQBFwElASkEKAFQAQAB9AHzCvEC8gHzAbQDswO0A7MBtAGzAa0CtAHcAf8BbQLw
+        AQkBBwH3AbUC7wEHAQkB8gEHAesB/wKYAbUB5gGuAUsBlAHjASUBlAFPAZcEmAEAAfEG7AfrAbwBtAmt
+        AbMBtAKLAQkB9AH/AesB8AEJAbQBrgGLAYYCrgGRAbQB8AHvAesE/wHWAa0BiwEcARYBJQFzAZgBCAT/
+        AQACUgFMCioBEgHrAbsBCQGLAQkDtAH/AosBrQK0AZkBGgL/Au8BBwG1Aa4EhgGuAfcBvAH3AewF/wHW
+        Aa0BiwHzAWIBAgEIBf8BUgF6AVIBoAh6AVIBoAEqARIBwwH/AYsBGQG0AbMBtAH/AooBrQHxAf8BwwF6
+        AfYC/wHrAQcB8AGRBIYBrgG8Ae8B9wf/AdYByAEZAfwBSAEIBf8BUgF6AVIBoAh6AVIBoAEqARIBoAH/
+        AYsBGQG0Aa0BtAH/AqYBiwEZAv8BmgEaAv8B9wEHAbwBtAGuAoYB6wG1AfABkgHsB/8B1gHIAd0B/AFI
+        AQgF/wFSAXoBUgmgAVgBoAEqARIBoAHDAYsB8QG0Aa0B8QH/AbUCiwP/AZoBGgP/Ae0B7wHwAbQC6wG0
+        AfIB7wEHCP8B1gP8AUgBCAX/AVIBegFSCaABegGgASoB6gH2AZkBiwEJAbQBrQHxAf8BtQKmAv8B9gF6
+        ARoD/wH3AQcB8AO0AbUB8gHsAfcJ/wHWAvwBSAEIBf8BUgF6AVIJoAF6AaABKgHqAf8BvAGLArUBtAEZ
+        Av8BtAHxAv8BGgF6AcMD/wHzAu8E8gHvAQcB8gn/Ad0ByAHdAU8BCAX/AVIBegFSCf8BmgH/ASoBbQHy
+        Aa4BiwGuAZkBwwH2BP8B9gGaAXoBGgX/Ae8B9wT/AewBBwr/AbwBbAH/AU8BCAX/AVIBoAGaDFIB7AWL
+        AZoBegSaAXoBmgEaBv8B8AHvAQcC/wHvAfcB8Qr/AQgBAgKYAfIF/wFSBqAF/wEqAeoBBwL/AYsBpgGL
+        Af8B9gLDApoBGgHDAfYI/wEHAewC/wHqAbwL/wHxAXIBAgHyBv8BUgH/BKAB/wVSAUwDAAL/AYsR/wHz
+        Ae8B7QL/AesBBwH0C/8B8gECAfIG/wEAAVIE/wFSAf8BAAH/BgAC/wHxEf8B7wFtAZIC8wHsAesBvAv/
+        AfMBTwHzBv8CAARSAf8JABT/AQcBrgLrA0oBBxT/EAABQgFNAT4HAAE+AwABKAMAAUADAAEgAwABAQEA
+        AQEGAAEBFgAD/4cAAYAHAAGABwABgAcAAYBIAAEHBgABgAG/BgABwQH/BgAC/ws=
+</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="treeView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="treeView.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="treeView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="treeView.SelectedImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="treeView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>425, 203</value>
+  </data>
+  <data name="treeView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;treeView.Name" xml:space="preserve">
+    <value>treeView</value>
+  </data>
+  <data name="&gt;&gt;treeView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;treeView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;treeView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>425, 203</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaFolderBrowser</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.zh-CHS.resx
@@ -120,10 +120,112 @@
   <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="imageList1.ImageStream" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADy
+        CgAAAk1TRnQBSQFMAgEBBAEAAagBAAGoAQABEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
+        AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
+        AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
+        AWYDAAGZAwABzAIAATMDAAIzAgABMwFmAgABMwGZAgABMwHMAgABMwH/AgABZgMAAWYBMwIAAmYCAAFm
+        AZkCAAFmAcwCAAFmAf8CAAGZAwABmQEzAgABmQFmAgACmQIAAZkBzAIAAZkB/wIAAcwDAAHMATMCAAHM
+        AWYCAAHMAZkCAALMAgABzAH/AgAB/wFmAgAB/wGZAgAB/wHMAQABMwH/AgAB/wEAATMBAAEzAQABZgEA
+        ATMBAAGZAQABMwEAAcwBAAEzAQAB/wEAAf8BMwIAAzMBAAIzAWYBAAIzAZkBAAIzAcwBAAIzAf8BAAEz
+        AWYCAAEzAWYBMwEAATMCZgEAATMBZgGZAQABMwFmAcwBAAEzAWYB/wEAATMBmQIAATMBmQEzAQABMwGZ
+        AWYBAAEzApkBAAEzAZkBzAEAATMBmQH/AQABMwHMAgABMwHMATMBAAEzAcwBZgEAATMBzAGZAQABMwLM
+        AQABMwHMAf8BAAEzAf8BMwEAATMB/wFmAQABMwH/AZkBAAEzAf8BzAEAATMC/wEAAWYDAAFmAQABMwEA
+        AWYBAAFmAQABZgEAAZkBAAFmAQABzAEAAWYBAAH/AQABZgEzAgABZgIzAQABZgEzAWYBAAFmATMBmQEA
+        AWYBMwHMAQABZgEzAf8BAAJmAgACZgEzAQADZgEAAmYBmQEAAmYBzAEAAWYBmQIAAWYBmQEzAQABZgGZ
+        AWYBAAFmApkBAAFmAZkBzAEAAWYBmQH/AQABZgHMAgABZgHMATMBAAFmAcwBmQEAAWYCzAEAAWYBzAH/
+        AQABZgH/AgABZgH/ATMBAAFmAf8BmQEAAWYB/wHMAQABzAEAAf8BAAH/AQABzAEAApkCAAGZATMBmQEA
+        AZkBAAGZAQABmQEAAcwBAAGZAwABmQIzAQABmQEAAWYBAAGZATMBzAEAAZkBAAH/AQABmQFmAgABmQFm
+        ATMBAAGZATMBZgEAAZkBZgGZAQABmQFmAcwBAAGZATMB/wEAApkBMwEAApkBZgEAA5kBAAKZAcwBAAKZ
+        Af8BAAGZAcwCAAGZAcwBMwEAAWYBzAFmAQABmQHMAZkBAAGZAswBAAGZAcwB/wEAAZkB/wIAAZkB/wEz
+        AQABmQHMAWYBAAGZAf8BmQEAAZkB/wHMAQABmQL/AQABzAMAAZkBAAEzAQABzAEAAWYBAAHMAQABmQEA
+        AcwBAAHMAQABmQEzAgABzAIzAQABzAEzAWYBAAHMATMBmQEAAcwBMwHMAQABzAEzAf8BAAHMAWYCAAHM
+        AWYBMwEAAZkCZgEAAcwBZgGZAQABzAFmAcwBAAGZAWYB/wEAAcwBmQIAAcwBmQEzAQABzAGZAWYBAAHM
+        ApkBAAHMAZkBzAEAAcwBmQH/AQACzAIAAswBMwEAAswBZgEAAswBmQEAA8wBAALMAf8BAAHMAf8CAAHM
+        Af8BMwEAAZkB/wFmAQABzAH/AZkBAAHMAf8BzAEAAcwC/wEAAcwBAAEzAQAB/wEAAWYBAAH/AQABmQEA
+        AcwBMwIAAf8CMwEAAf8BMwFmAQAB/wEzAZkBAAH/ATMBzAEAAf8BMwH/AQAB/wFmAgAB/wFmATMBAAHM
+        AmYBAAH/AWYBmQEAAf8BZgHMAQABzAFmAf8BAAH/AZkCAAH/AZkBMwEAAf8BmQFmAQAB/wKZAQAB/wGZ
+        AcwBAAH/AZkB/wEAAf8BzAIAAf8BzAEzAQAB/wHMAWYBAAH/AcwBmQEAAf8CzAEAAf8BzAH/AQAC/wEz
+        AQABzAH/AWYBAAL/AZkBAAL/AcwBAAJmAf8BAAFmAf8BZgEAAWYC/wEAAf8CZgEAAf8BZgH/AQAC/wFm
+        AQABIQEAAaUBAANfAQADdwEAA4YBAAOWAQADywEAA7IBAAPXAQAD3QEAA+MBAAPqAQAD8QEAA/gBAAHw
+        AfsB/wEAAaQCoAEAA4ADAAH/AgAB/wMAAv8BAAH/AwAB/wEAAf8BAAL/AgAD//8A/wD/AP8ABQAP1QHc
+        Av8B7QrsARwB/wH0BEYBlAT/ARcFRgFvAQAC/wz0Af8G1QO0AbMBrQGzA9UB3AH/AfcBvArwAZIB6wH/
+        AigBhgG2AZQBFwEWAfQBFwElASkEKAFQAQAB9AHzCvEC8gHzAbQDswO0A7MBtAGzAa0CtAHcAf8BbQLw
+        AQkBBwH3AbUC7wEHAQkB8gEHAesB/wKYAbUB5gGuAUsBlAHjASUBlAFPAZcEmAEAAfEG7AfrAbwBtAmt
+        AbMBtAKLAQkB9AH/AesB8AEJAbQBrgGLAYYCrgGRAbQB8AHvAesE/wHWAa0BiwEcARYBJQFzAZgBCAT/
+        AQACUgFMCioBEgHrAbsBCQGLAQkDtAH/AosBrQK0AZkBGgL/Au8BBwG1Aa4EhgGuAfcBvAH3AewF/wHW
+        Aa0BiwHzAWIBAgEIBf8BUgF6AVIBoAh6AVIBoAEqARIBwwH/AYsBGQG0AbMBtAH/AooBrQHxAf8BwwF6
+        AfYC/wHrAQcB8AGRBIYBrgG8Ae8B9wf/AdYByAEZAfwBSAEIBf8BUgF6AVIBoAh6AVIBoAEqARIBoAH/
+        AYsBGQG0Aa0BtAH/AqYBiwEZAv8BmgEaAv8B9wEHAbwBtAGuAoYB6wG1AfABkgHsB/8B1gHIAd0B/AFI
+        AQgF/wFSAXoBUgmgAVgBoAEqARIBoAHDAYsB8QG0Aa0B8QH/AbUCiwP/AZoBGgP/Ae0B7wHwAbQC6wG0
+        AfIB7wEHCP8B1gP8AUgBCAX/AVIBegFSCaABegGgASoB6gH2AZkBiwEJAbQBrQHxAf8BtQKmAv8B9gF6
+        ARoD/wH3AQcB8AO0AbUB8gHsAfcJ/wHWAvwBSAEIBf8BUgF6AVIJoAF6AaABKgHqAf8BvAGLArUBtAEZ
+        Av8BtAHxAv8BGgF6AcMD/wHzAu8E8gHvAQcB8gn/Ad0ByAHdAU8BCAX/AVIBegFSCf8BmgH/ASoBbQHy
+        Aa4BiwGuAZkBwwH2BP8B9gGaAXoBGgX/Ae8B9wT/AewBBwr/AbwBbAH/AU8BCAX/AVIBoAGaDFIB7AWL
+        AZoBegSaAXoBmgEaBv8B8AHvAQcC/wHvAfcB8Qr/AQgBAgKYAfIF/wFSBqAF/wEqAeoBBwL/AYsBpgGL
+        Af8B9gLDApoBGgHDAfYI/wEHAewC/wHqAbwL/wHxAXIBAgHyBv8BUgH/BKAB/wVSAUwDAAL/AYsR/wHz
+        Ae8B7QL/AesBBwH0C/8B8gECAfIG/wEAAVIE/wFSAf8BAAH/BgAC/wHxEf8B7wFtAZIC8wHsAesBvAv/
+        AfMBTwHzBv8CAARSAf8JABT/AQcBrgLrA0oBBxT/EAABQgFNAT4HAAE+AwABKAMAAUADAAEgAwABAQEA
+        AQEGAAEBFgAD/4cAAYAHAAGABwABgAcAAYBIAAEHBgABgAG/BgABwQH/BgAC/ws=
+</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="treeView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="treeView.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="treeView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="treeView.SelectedImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="treeView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>425, 203</value>
+  </data>
+  <data name="treeView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;treeView.Name" xml:space="preserve">
+    <value>treeView</value>
+  </data>
+  <data name="&gt;&gt;treeView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;treeView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;treeView.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>425, 203</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PanoramaFolderBrowser</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/Properties/Resources.ja.resx
@@ -127,6 +127,9 @@
     <value>{0}はPanoramaフォルダではありません</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Folder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Folder.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
     <value>サーバーからの予期しないJSON応答：{0}</value>
   </data>
@@ -140,6 +143,9 @@
   <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
     <value>サーバー{0}に接続できません。</value>
   </data>
+  <data name="ChromLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="ServerState_GetErrorMessage_The_server__0__does_not_exist_" xml:space="preserve">
     <value>The server {0} does not exist.</value>
     <comment>Needs Review:New resource</comment>
@@ -147,6 +153,9 @@
   <data name="WebPanoramaClient_SaveFile_Select_the_folder_where_the_file_will_be_downloaded" xml:space="preserve">
     <value>Select the folder where the file will be downloaded</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="UserState_GetErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
     <value>There was an error authenticating user credentials on the server {0}.</value>
@@ -159,8 +168,29 @@
     <value>Downloading {0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-up2.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam_Blueberry_Basic_Arrow_left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="up_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\up-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Edit_Undo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Edit_Undo.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam_Blueberry_Basic_Arrow_right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="PanoramaUtil_VerifyFolder_User__0__does_not_have_permissions_to_upload_to_the_Panorama_folder__1_" xml:space="preserve">
     <value>ユーザー{0}には、Panoramaフォルダ{1}にアップロードする権限がありません</value>
+  </data>
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="PanoramaFilePicker_Open_Click_You_must_select_a_file_first_" xml:space="preserve">
     <value>You must select a file first!</value>

--- a/pwiz_tools/Shared/PanoramaClient/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/Properties/Resources.zh-CHS.resx
@@ -120,10 +120,16 @@
   <data name="PanoramaUtil_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
     <value>服务器未返回有效的 JSON 响应。{0} 并非 Panorama  服务器。</value>
   </data>
+  <data name="GenericState_AppendErrorAndUri_URL___0_" xml:space="preserve">
+    <value>URL: {0}</value>
+  </data>
   <data name="PanoramaUtil_VerifyFolder__0__is_not_a_Panorama_folder" xml:space="preserve">
     <value>{0}不是 Panorama 文件夹</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Folder" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Folder.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="PanoramaUtil_EnsureLogin_Unexpected_JSON_response_from_the_server___0_" xml:space="preserve">
     <value>服务器 {0} 的JSON响应异常</value>
   </data>
@@ -137,6 +143,9 @@
   <data name="ServerState_GetErrorMessage_Unable_to_connect_to_the_server__0__" xml:space="preserve">
     <value>无法连接到服务器 {0}。</value>
   </data>
+  <data name="ChromLib" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="ServerState_GetErrorMessage_The_server__0__does_not_exist_" xml:space="preserve">
     <value>The server {0} does not exist.</value>
     <comment>Needs Review:New resource</comment>
@@ -144,6 +153,9 @@
   <data name="WebPanoramaClient_SaveFile_Select_the_folder_where_the_file_will_be_downloaded" xml:space="preserve">
     <value>Select the folder where the file will be downloaded</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="UserState_GetErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
     <value>There was an error authenticating user credentials on the server {0}.</value>
@@ -156,8 +168,29 @@
     <value>Downloading {0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-up" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-up2.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam_Blueberry_Basic_Arrow_left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="up_pro32" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\up-pro32.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Edit_Undo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Edit_Undo.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam_Blueberry_Basic_Arrow_right" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="Icojam-Blueberry-Basic-Arrow-left" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icojam-Blueberry-Basic-Arrow-left.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="PanoramaUtil_VerifyFolder_User__0__does_not_have_permissions_to_upload_to_the_Panorama_folder__1_" xml:space="preserve">
     <value>用户{0}没有权限上传至 Panorama 文件夹{1}</value>
+  </data>
+  <data name="Copy" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="PanoramaFilePicker_Open_Click_You_must_select_a_file_first_" xml:space="preserve">
     <value>You must select a file first!</value>

--- a/pwiz_tools/Skyline/Alerts/AboutDlg.ja.resx
+++ b/pwiz_tools/Skyline/Alerts/AboutDlg.ja.resx
@@ -457,9 +457,36 @@ Skylineウェブサイトをご覧ください。</value>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
+  <data name="textSoftwareVersion.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 12pt, style=Bold</value>
+  </data>
+  <data name="textSoftwareVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>164, 12</value>
+  </data>
+  <data name="textSoftwareVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="textSoftwareVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>461, 19</value>
+  </data>
+  <data name="textSoftwareVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
   <data name="textSoftwareVersion.Text" xml:space="preserve">
     <value>Skyline (64-bit : developer build) 00.0.0.000 (abc123456)</value>
     <comment>Testing text to make sure the form is wide enough</comment>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Name" xml:space="preserve">
+    <value>textSoftwareVersion</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -475,6 +502,12 @@ Skylineウェブサイトをご覧ください。</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Skylineについて</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>AboutDlg</value>

--- a/pwiz_tools/Skyline/Alerts/AboutDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Alerts/AboutDlg.zh-CHS.resx
@@ -456,9 +456,36 @@ https://www.zlib.net</value>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
+  <data name="textSoftwareVersion.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 12pt, style=Bold</value>
+  </data>
+  <data name="textSoftwareVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>164, 12</value>
+  </data>
+  <data name="textSoftwareVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="textSoftwareVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>461, 19</value>
+  </data>
+  <data name="textSoftwareVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
   <data name="textSoftwareVersion.Text" xml:space="preserve">
     <value>Skyline (64-bit : developer build) 00.0.0.000 (abc123456)</value>
     <comment>Testing text to make sure the form is wide enough</comment>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Name" xml:space="preserve">
+    <value>textSoftwareVersion</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textSoftwareVersion.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -474,6 +501,12 @@ https://www.zlib.net</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>关于 Skyline</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>AboutDlg</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.ja.resx
@@ -121,14 +121,116 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="proteinsTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="proteinsTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 31</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="proteinsTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="proteinsTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>432, 381</value>
+  </data>
+  <data name="proteinsTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Name" xml:space="preserve">
+    <value>proteinsTextBox</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Type" xml:space="preserve">
+    <value>pwiz.Common.Controls.AutoScrollTextBox, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 12</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>201, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="label1.Text" xml:space="preserve">
     <value>Enter a list of identifiers on separate lines.</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="buttonOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonOk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>288, 418</value>
+  </data>
+  <data name="buttonOk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonOk.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Name" xml:space="preserve">
+    <value>buttonOk</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>369, 418</value>
+  </data>
+  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>キャンセル</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Name" xml:space="preserve">
+    <value>buttonCancel</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -136,8 +238,26 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>66</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>456, 450</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Enter List</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MatchExpressionListDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.ModeUIInvariantFormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.zh-CHS.resx
@@ -121,17 +121,116 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="proteinsTextBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="proteinsTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 31</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="proteinsTextBox.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="proteinsTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>432, 381</value>
+  </data>
+  <data name="proteinsTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Name" xml:space="preserve">
+    <value>proteinsTextBox</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Type" xml:space="preserve">
+    <value>pwiz.Common.Controls.AutoScrollTextBox, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;proteinsTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 12</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>201, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="label1.Text" xml:space="preserve">
     <value>Enter a list of identifiers on separate lines.</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="buttonOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonOk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>288, 418</value>
+  </data>
+  <data name="buttonOk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonOk.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="buttonOk.Text" xml:space="preserve">
     <value>确定</value>
   </data>
+  <data name="&gt;&gt;buttonOk.Name" xml:space="preserve">
+    <value>buttonOk</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonOk.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>369, 418</value>
+  </data>
+  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>取消</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Name" xml:space="preserve">
+    <value>buttonCancel</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonCancel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -139,8 +238,26 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>66</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>456, 450</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Enter List</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MatchExpressionListDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.ModeUIInvariantFormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.ja.resx
@@ -447,9 +447,30 @@
   <data name="&gt;&gt;linkRegex.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="enterListButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 22</value>
+  </data>
+  <data name="enterListButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="enterListButton.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
   <data name="enterListButton.Text" xml:space="preserve">
     <value>&amp;Enter List...</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;enterListButton.Name" xml:space="preserve">
+    <value>enterListButton</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.zh-CHS.resx
@@ -447,9 +447,30 @@
   <data name="&gt;&gt;linkRegex.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="enterListButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 22</value>
+  </data>
+  <data name="enterListButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="enterListButton.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
   <data name="enterListButton.Text" xml:space="preserve">
     <value>&amp;Enter List...</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;enterListButton.Name" xml:space="preserve">
+    <value>enterListButton</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;enterListButton.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.ja.resx
@@ -234,9 +234,39 @@
   <data name="&gt;&gt;advancedCheckBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="layoutLabelsBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="layoutLabelsBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="layoutLabelsBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>430, 223</value>
+  </data>
+  <data name="layoutLabelsBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>139, 24</value>
+  </data>
+  <data name="layoutLabelsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="layoutLabelsBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
   <data name="layoutLabelsBox.Text" xml:space="preserve">
     <value>Auto arrange labels</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Name" xml:space="preserve">
+    <value>layoutLabelsBox</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -252,6 +282,12 @@
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>ボルケーノプロット形式</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;colorDialog1.Name" xml:space="preserve">
     <value>colorDialog1</value>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.zh-CHS.resx
@@ -234,9 +234,39 @@
   <data name="&gt;&gt;advancedCheckBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="layoutLabelsBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="layoutLabelsBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="layoutLabelsBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>430, 223</value>
+  </data>
+  <data name="layoutLabelsBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>139, 24</value>
+  </data>
+  <data name="layoutLabelsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="layoutLabelsBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
   <data name="layoutLabelsBox.Text" xml:space="preserve">
     <value>Auto arrange labels</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Name" xml:space="preserve">
+    <value>layoutLabelsBox</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;layoutLabelsBox.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -252,6 +282,12 @@
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>火山图格式</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;colorDialog1.Name" xml:space="preserve">
     <value>colorDialog1</value>

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.ja.resx
@@ -118,11 +118,38 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="databoundGridControl.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="databoundGridControl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 123</value>
+  </data>
+  <data name="databoundGridControl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>765, 286</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Name" xml:space="preserve">
+    <value>databoundGridControl</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.Databinding.DataboundGridControl, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="ModeUIExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="btnCancelReadingFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="btnCancelReadingFile.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>160, 17</value>
   </metadata>
@@ -168,6 +195,15 @@
         AeMGAAGHAfMGAAGPAf8GAAL/BgAL
 </value>
   </data>
+  <data name="btnCancelReadingFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>767, 6</value>
+  </data>
+  <data name="btnCancelReadingFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnCancelReadingFile.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>270, 17</value>
   </metadata>
@@ -175,28 +211,328 @@
     <value>Cancel</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Name" xml:space="preserve">
+    <value>btnCancelReadingFile</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="progressBar1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>547, 6</value>
+  </data>
+  <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>217, 23</value>
+  </data>
+  <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Name" xml:space="preserve">
+    <value>progressBar1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="lblStatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 6</value>
+  </data>
+  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>538, 23</value>
+  </data>
+  <data name="lblStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="lblStatus.Text" xml:space="preserve">
     <value>File reading status</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="lblStatus.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Name" xml:space="preserve">
+    <value>lblStatus</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="statusPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="statusPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 415</value>
+  </data>
+  <data name="statusPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>800, 35</value>
+  </data>
+  <data name="statusPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="statusPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Name" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="splitContainer1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="splitContainer1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="splitContainer1.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <data name="lblSummary.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="lblSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 100</value>
+  </data>
+  <data name="lblSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 23</value>
+  </data>
+  <data name="lblSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="lblSummary.Text" xml:space="preserve">
     <value>Summary</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
+    <value>lblSummary</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnRemoveFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnRemoveFile.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnRemoveFile.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnRemoveFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 3</value>
+  </data>
+  <data name="btnRemoveFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnRemoveFile.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
   <data name="btnRemoveFile.ToolTip" xml:space="preserve">
     <value>Remove from list</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;btnRemoveFile.Name" xml:space="preserve">
+    <value>btnRemoveFile</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnBrowse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnBrowse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>675, 3</value>
+  </data>
+  <data name="btnBrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 28</value>
+  </data>
+  <data name="btnBrowse.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
   <data name="btnBrowse.Text" xml:space="preserve">
     <value>参照...</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Name" xml:space="preserve">
+    <value>btnBrowse</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 96</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>149, 23</value>
+  </data>
+  <data name="btnAddSpectrumFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
   <data name="btnAddSpectrumFilter.Text" xml:space="preserve">
     <value>Add Spectrum Filter...</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Name" xml:space="preserve">
+    <value>btnAddSpectrumFilter</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>285, 93</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Name" xml:space="preserve">
+    <value>checkedListBoxSpectrumClassColumns</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckedListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="listBoxFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="listBoxFiles.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="listBoxFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>294, 3</value>
+  </data>
+  <data name="listBoxFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>339, 93</value>
+  </data>
+  <data name="listBoxFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="listBoxFiles.ToolTip" xml:space="preserve">
     <value>Remove from list</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Name" xml:space="preserve">
+    <value>listBoxFiles</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Name" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Name" xml:space="preserve">
+    <value>splitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="splitContainer1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>800, 415</value>
+  </data>
+  <data name="splitContainer1.SplitterDistance" type="System.Int32, mscorlib">
+    <value>122</value>
+  </data>
+  <data name="splitContainer1.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Name" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -204,6 +540,12 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>77</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>800, 450</value>
+  </data>
   <data name="$this.TabText" xml:space="preserve">
     <value>SpectraGridForm</value>
     <comment>Needs Review:Missing translation</comment>
@@ -211,5 +553,29 @@
   <data name="$this.Text" xml:space="preserve">
     <value>SpectraGridForm</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;ModeUIExtender.Name" xml:space="preserve">
+    <value>ModeUIExtender</value>
+  </data>
+  <data name="&gt;&gt;ModeUIExtender.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SpectrumGridForm</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.Databinding.DataboundGridForm, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
@@ -118,11 +118,38 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="databoundGridControl.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>None</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="databoundGridControl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 123</value>
+  </data>
+  <data name="databoundGridControl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>765, 286</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Name" xml:space="preserve">
+    <value>databoundGridControl</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.Databinding.DataboundGridControl, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;databoundGridControl.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="ModeUIExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="btnCancelReadingFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="btnCancelReadingFile.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <metadata name="imageList1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>160, 17</value>
   </metadata>
@@ -168,6 +195,15 @@
         AeMGAAGHAfMGAAGPAf8GAAL/BgAL
 </value>
   </data>
+  <data name="btnCancelReadingFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>767, 6</value>
+  </data>
+  <data name="btnCancelReadingFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnCancelReadingFile.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>270, 17</value>
   </metadata>
@@ -175,28 +211,328 @@
     <value>Cancel</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Name" xml:space="preserve">
+    <value>btnCancelReadingFile</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;btnCancelReadingFile.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="progressBar1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>547, 6</value>
+  </data>
+  <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>217, 23</value>
+  </data>
+  <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Name" xml:space="preserve">
+    <value>progressBar1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="lblStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="lblStatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 6</value>
+  </data>
+  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>538, 23</value>
+  </data>
+  <data name="lblStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="lblStatus.Text" xml:space="preserve">
     <value>File reading status</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="lblStatus.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Name" xml:space="preserve">
+    <value>lblStatus</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Parent" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="statusPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="statusPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 415</value>
+  </data>
+  <data name="statusPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>800, 35</value>
+  </data>
+  <data name="statusPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="statusPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Name" xml:space="preserve">
+    <value>statusPanel</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;statusPanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="splitContainer1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="splitContainer1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="splitContainer1.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <data name="lblSummary.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="lblSummary.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 100</value>
+  </data>
+  <data name="lblSummary.Size" type="System.Drawing.Size, System.Drawing">
+    <value>623, 23</value>
+  </data>
+  <data name="lblSummary.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="lblSummary.Text" xml:space="preserve">
     <value>Summary</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
+    <value>lblSummary</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;lblSummary.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnRemoveFile.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnRemoveFile.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnRemoveFile.ImageIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnRemoveFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 3</value>
+  </data>
+  <data name="btnRemoveFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="btnRemoveFile.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
   <data name="btnRemoveFile.ToolTip" xml:space="preserve">
     <value>Remove from list</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;btnRemoveFile.Name" xml:space="preserve">
+    <value>btnRemoveFile</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnRemoveFile.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnBrowse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnBrowse.Location" type="System.Drawing.Point, System.Drawing">
+    <value>675, 3</value>
+  </data>
+  <data name="btnBrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 28</value>
+  </data>
+  <data name="btnBrowse.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
   <data name="btnBrowse.Text" xml:space="preserve">
     <value>浏览…</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Name" xml:space="preserve">
+    <value>btnBrowse</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>639, 96</value>
+  </data>
+  <data name="btnAddSpectrumFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>149, 23</value>
+  </data>
+  <data name="btnAddSpectrumFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
   </data>
   <data name="btnAddSpectrumFilter.Text" xml:space="preserve">
     <value>Add Spectrum Filter...</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Name" xml:space="preserve">
+    <value>btnAddSpectrumFilter</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;btnAddSpectrumFilter.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.Size" type="System.Drawing.Size, System.Drawing">
+    <value>285, 93</value>
+  </data>
+  <data name="checkedListBoxSpectrumClassColumns.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Name" xml:space="preserve">
+    <value>checkedListBoxSpectrumClassColumns</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckedListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;checkedListBoxSpectrumClassColumns.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="listBoxFiles.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="listBoxFiles.IntegralHeight" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="listBoxFiles.Location" type="System.Drawing.Point, System.Drawing">
+    <value>294, 3</value>
+  </data>
+  <data name="listBoxFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>339, 93</value>
+  </data>
+  <data name="listBoxFiles.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="listBoxFiles.ToolTip" xml:space="preserve">
     <value>Remove from list</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Name" xml:space="preserve">
+    <value>listBoxFiles</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;listBoxFiles.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Name" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Name" xml:space="preserve">
+    <value>splitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="splitContainer1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>800, 415</value>
+  </data>
+  <data name="splitContainer1.SplitterDistance" type="System.Int32, mscorlib">
+    <value>122</value>
+  </data>
+  <data name="splitContainer1.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Name" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -204,6 +540,12 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>77</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>800, 450</value>
+  </data>
   <data name="$this.TabText" xml:space="preserve">
     <value>SpectraGridForm</value>
     <comment>Needs Review:Missing translation</comment>
@@ -211,5 +553,29 @@
   <data name="$this.Text" xml:space="preserve">
     <value>SpectraGridForm</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;ModeUIExtender.Name" xml:space="preserve">
+    <value>ModeUIExtender</value>
+  </data>
+  <data name="&gt;&gt;ModeUIExtender.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Name" xml:space="preserve">
+    <value>imageList1</value>
+  </data>
+  <data name="&gt;&gt;imageList1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ImageList, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SpectrumGridForm</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.Databinding.DataboundGridForm, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/Startup/StartPage.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Startup/StartPage.ja.resx
@@ -579,11 +579,23 @@
   <data name="$this.Text" xml:space="preserve">
     <value>開始ページ</value>
   </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
   <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
     <value>toolTip</value>
   </data>
   <data name="&gt;&gt;toolTip.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripButtonModeUI.Name" xml:space="preserve">
+    <value>toolStripButtonModeUI</value>
+  </data>
+  <data name="&gt;&gt;toolStripButtonModeUI.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripDropDownButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>StartPage</value>

--- a/pwiz_tools/Skyline/Controls/Startup/StartPage.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Startup/StartPage.zh-CHS.resx
@@ -579,11 +579,23 @@
   <data name="$this.Text" xml:space="preserve">
     <value>开始页面</value>
   </data>
+  <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">
+    <value>modeUIHandler</value>
+  </data>
+  <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
   <data name="&gt;&gt;toolTip.Name" xml:space="preserve">
     <value>toolTip</value>
   </data>
   <data name="&gt;&gt;toolTip.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripButtonModeUI.Name" xml:space="preserve">
+    <value>toolStripButtonModeUI</value>
+  </data>
+  <data name="&gt;&gt;toolStripButtonModeUI.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripDropDownButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>StartPage</value>

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.ja.resx
@@ -315,6 +315,57 @@
   <data name="&gt;&gt;lnkHelpProteinGroups.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbGeneLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbGeneLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbGeneLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 23</value>
+  </data>
+  <data name="cbGeneLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="cbGeneLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 14</value>
+  </data>
+  <data name="cbGeneLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="cbGeneLevel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Name" xml:space="preserve">
+    <value>cbGeneLevel</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 23</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
   <data name="lblGroupAtGeneLevel.Text" xml:space="preserve">
     <value>Group at g&amp;ene level</value>
     <comment>Needs Review:New resource</comment>
@@ -322,6 +373,18 @@
   <data name="lblGroupAtGeneLevel.ToolTip" xml:space="preserve">
     <value>Peptides will be associated and grouped by gene instead of by protein.</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Name" xml:space="preserve">
+    <value>lblGroupAtGeneLevel</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="lblSharedPeptides.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.zh-CHS.resx
@@ -315,6 +315,57 @@
   <data name="&gt;&gt;lnkHelpProteinGroups.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbGeneLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbGeneLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbGeneLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 23</value>
+  </data>
+  <data name="cbGeneLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="cbGeneLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>15, 14</value>
+  </data>
+  <data name="cbGeneLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="cbGeneLevel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Name" xml:space="preserve">
+    <value>cbGeneLevel</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cbGeneLevel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 23</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 3</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 13</value>
+  </data>
+  <data name="lblGroupAtGeneLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
   <data name="lblGroupAtGeneLevel.Text" xml:space="preserve">
     <value>Group at g&amp;ene level</value>
     <comment>Needs Review:New resource</comment>
@@ -322,6 +373,18 @@
   <data name="lblGroupAtGeneLevel.ToolTip" xml:space="preserve">
     <value>Peptides will be associated and grouped by gene instead of by protein.</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Name" xml:space="preserve">
+    <value>lblGroupAtGeneLevel</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;lblGroupAtGeneLevel.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="lblSharedPeptides.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.ja.resx
@@ -122,28 +122,175 @@
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="propertyColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
   <data name="operationColumn.HeaderText" xml:space="preserve">
     <value>Operation</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="operationColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
   </data>
   <data name="valueColumn.HeaderText" xml:space="preserve">
     <value>Value</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="dataGridViewEx1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="dataGridViewEx1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="dataGridViewEx1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>682, 181</value>
+  </data>
+  <data name="dataGridViewEx1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Name" xml:space="preserve">
+    <value>dataGridViewEx1</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Parent" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cbCreateCopy.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cbCreateCopy.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbCreateCopy.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbCreateCopy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>714, 84</value>
+  </data>
+  <data name="cbCreateCopy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 17</value>
+  </data>
+  <data name="cbCreateCopy.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
   <data name="cbCreateCopy.Text" xml:space="preserve">
     <value>コピーを作成(&amp;C)</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Name" xml:space="preserve">
+    <value>cbCreateCopy</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnReset.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnReset.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnReset.Location" type="System.Drawing.Point, System.Drawing">
+    <value>714, 200</value>
+  </data>
+  <data name="btnReset.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnReset.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
   <data name="btnReset.Text" xml:space="preserve">
     <value>リセット(&amp;R)</value>
   </data>
+  <data name="&gt;&gt;btnReset.Name" xml:space="preserve">
+    <value>btnReset</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnReset.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>713, 41</value>
+  </data>
+  <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <data name="btnCancel.Text" xml:space="preserve">
     <value>キャンセル</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Name" xml:space="preserve">
+    <value>btnCancel</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnOk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>713, 12</value>
+  </data>
+  <data name="btnOk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnOk.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="btnOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Name" xml:space="preserve">
+    <value>btnOk</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnOk.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <metadata name="toolStripFilter.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
   </metadata>
+  <data name="toolStripFilter.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
   <data name="btnDeleteFilter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -156,8 +303,80 @@
         RpBSo3HrM0G6Uq7pl2zvhvNDBcClE8YH4HDv2/A/SKV6BYojAxyEJtLJAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="btnDeleteFilter.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnDeleteFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
   <data name="btnDeleteFilter.Text" xml:space="preserve">
     <value>削除</value>
+  </data>
+  <data name="toolStripFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>682, 0</value>
+  </data>
+  <data name="toolStripFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 181</value>
+  </data>
+  <data name="toolStripFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="toolStripFilter.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Name" xml:space="preserve">
+    <value>toolStripFilter</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Parent" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelClauses.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panelClauses.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 55</value>
+  </data>
+  <data name="panelClauses.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 181</value>
+  </data>
+  <data name="panelClauses.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Name" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblDescription.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblDescription.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="lblDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="lblDescription.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="lblDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 19</value>
+  </data>
+  <data name="lblDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
   </data>
   <data name="lblDescription.Text" xml:space="preserve">
     <value>FASTAファイルかバックグラウンドプロテオームのいずれかを用いて、ドキュメント内のペプチドすべてを関連するタンパク質かタンパク質グループに再編成します。 既存のタンパク質の関連付けは破棄されます。</value>
@@ -166,14 +385,119 @@ Old English:Use either a FASTA file or a background proteome to reorganize all d
 Current English:Description
 Old Localized:FASTAファイルかバックグラウンドプロテオームのいずれかを用いて、ドキュメント内のペプチドすべてを関連するタンパク質かタンパク質グループに再編成します。 既存のタンパク質の関連付けは破棄されます。</comment>
   </data>
+  <data name="lblDescription.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Name" xml:space="preserve">
+    <value>lblDescription</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelPages.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelPages.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 19</value>
+  </data>
+  <data name="panelPages.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 36</value>
+  </data>
+  <data name="panelPages.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Name" xml:space="preserve">
+    <value>panelPages</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelPages.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1, -1</value>
+  </data>
+  <data name="panelEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 236</value>
+  </data>
+  <data name="panelEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Name" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>280, 17</value>
   </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>800, 235</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Edit Spectrum Filter</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;propertyColumn.Name" xml:space="preserve">
+    <value>propertyColumn</value>
+  </data>
+  <data name="&gt;&gt;propertyColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewComboBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;operationColumn.Name" xml:space="preserve">
+    <value>operationColumn</value>
+  </data>
+  <data name="&gt;&gt;operationColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewComboBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;valueColumn.Name" xml:space="preserve">
+    <value>valueColumn</value>
+  </data>
+  <data name="&gt;&gt;valueColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnDeleteFilter.Name" xml:space="preserve">
+    <value>btnDeleteFilter</value>
+  </data>
+  <data name="&gt;&gt;btnDeleteFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>EditSpectrumFilterDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.zh-CHS.resx
@@ -122,31 +122,175 @@
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="propertyColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
+  </data>
   <data name="operationColumn.HeaderText" xml:space="preserve">
     <value>Operation</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="operationColumn.Width" type="System.Int32, mscorlib">
+    <value>150</value>
   </data>
   <data name="valueColumn.HeaderText" xml:space="preserve">
     <value>Value</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="dataGridViewEx1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="dataGridViewEx1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="dataGridViewEx1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>682, 181</value>
+  </data>
+  <data name="dataGridViewEx1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Name" xml:space="preserve">
+    <value>dataGridViewEx1</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Type" xml:space="preserve">
+    <value>pwiz.Skyline.Controls.DataGridViewEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.Parent" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewEx1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cbCreateCopy.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cbCreateCopy.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbCreateCopy.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbCreateCopy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>714, 84</value>
+  </data>
+  <data name="cbCreateCopy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 17</value>
+  </data>
+  <data name="cbCreateCopy.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
   <data name="cbCreateCopy.Text" xml:space="preserve">
     <value>创建副本(&amp;C)</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Name" xml:space="preserve">
+    <value>cbCreateCopy</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbCreateCopy.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnReset.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnReset.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnReset.Location" type="System.Drawing.Point, System.Drawing">
+    <value>714, 200</value>
+  </data>
+  <data name="btnReset.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnReset.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
   <data name="btnReset.Text" xml:space="preserve">
     <value>重置(&amp;R)</value>
   </data>
+  <data name="&gt;&gt;btnReset.Name" xml:space="preserve">
+    <value>btnReset</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnReset.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnReset.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>713, 41</value>
+  </data>
+  <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnCancel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <data name="btnCancel.Text" xml:space="preserve">
     <value>取消</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Name" xml:space="preserve">
+    <value>btnCancel</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnOk.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnOk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOk.Location" type="System.Drawing.Point, System.Drawing">
+    <value>713, 12</value>
+  </data>
+  <data name="btnOk.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnOk.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
   <data name="btnOk.Text" xml:space="preserve">
     <value>确定</value>
   </data>
+  <data name="&gt;&gt;btnOk.Name" xml:space="preserve">
+    <value>btnOk</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOk.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnOk.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <metadata name="toolStripFilter.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
   </metadata>
+  <data name="toolStripFilter.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Right</value>
+  </data>
   <data name="btnDeleteFilter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -159,8 +303,80 @@
         RpBSo3HrM0G6Uq7pl2zvhvNDBcClE8YH4HDv2/A/SKV6BYojAxyEJtLJAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="btnDeleteFilter.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="btnDeleteFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 20</value>
+  </data>
   <data name="btnDeleteFilter.Text" xml:space="preserve">
     <value>删除</value>
+  </data>
+  <data name="toolStripFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>682, 0</value>
+  </data>
+  <data name="toolStripFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>24, 181</value>
+  </data>
+  <data name="toolStripFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="toolStripFilter.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Name" xml:space="preserve">
+    <value>toolStripFilter</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.Parent" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;toolStripFilter.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelClauses.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panelClauses.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 55</value>
+  </data>
+  <data name="panelClauses.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 181</value>
+  </data>
+  <data name="panelClauses.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Name" xml:space="preserve">
+    <value>panelClauses</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelClauses.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblDescription.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblDescription.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="lblDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="lblDescription.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="lblDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 19</value>
+  </data>
+  <data name="lblDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
   </data>
   <data name="lblDescription.Text" xml:space="preserve">
     <value>利用 FASTA 文件或背景蛋白质组的信息，将文档中的所有肽段重组为关联的蛋白质或蛋白质组。现有蛋白质的关联性将被丢弃。</value>
@@ -169,14 +385,119 @@ Old English:Use either a FASTA file or a background proteome to reorganize all d
 Current English:Description
 Old Localized:利用 FASTA 文件或背景蛋白质组的信息，将文档中的所有肽段重组为关联的蛋白质或蛋白质组。现有蛋白质的关联性将被丢弃。</comment>
   </data>
+  <data name="lblDescription.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Name" xml:space="preserve">
+    <value>lblDescription</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;lblDescription.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelPages.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panelPages.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 19</value>
+  </data>
+  <data name="panelPages.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 36</value>
+  </data>
+  <data name="panelPages.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Name" xml:space="preserve">
+    <value>panelPages</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelPages.Parent" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelPages.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="panelEditor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1, -1</value>
+  </data>
+  <data name="panelEditor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>706, 236</value>
+  </data>
+  <data name="panelEditor.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Name" xml:space="preserve">
+    <value>panelEditor</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelEditor.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>280, 17</value>
   </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>800, 235</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Edit Spectrum Filter</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;propertyColumn.Name" xml:space="preserve">
+    <value>propertyColumn</value>
+  </data>
+  <data name="&gt;&gt;propertyColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewComboBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;operationColumn.Name" xml:space="preserve">
+    <value>operationColumn</value>
+  </data>
+  <data name="&gt;&gt;operationColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewComboBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;valueColumn.Name" xml:space="preserve">
+    <value>valueColumn</value>
+  </data>
+  <data name="&gt;&gt;valueColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnDeleteFilter.Name" xml:space="preserve">
+    <value>btnDeleteFilter</value>
+  </data>
+  <data name="&gt;&gt;btnDeleteFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>EditSpectrumFilterDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>pwiz.Common.SystemUtil.CommonFormEx, pwiz.CommonUtil, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.ja.resx
@@ -1717,6 +1717,24 @@ Skylineで制御されないトランジション値に対しては、単一の�
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>pwiz.Skyline.Util.CreateHandleDebugBase, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
+  <data name="cbExportSciexOSQuantMethod.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 9</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>254, 24</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="cbExportSciexOSQuantMethod.Text" xml:space="preserve">
     <value>Create SCIEX &amp;OS 
     Quant method</value>
@@ -1726,8 +1744,104 @@ Skylineで制御されないトランジション値に対しては、単一の�
     <value>Exports a SCIEX OS Quant compatible analysis method to the same directory and base name as the Analyst acquisition method.</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Name" xml:space="preserve">
+    <value>cbExportSciexOSQuantMethod</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelXICWidth.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelXICWidth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 40</value>
+  </data>
+  <data name="labelXICWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 6, 0</value>
+  </data>
+  <data name="labelXICWidth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="labelXICWidth.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelXICWidth.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="labelXICWidth.Text" xml:space="preserve">
     <value>XIC Width (Da):</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Name" xml:space="preserve">
+    <value>labelXICWidth</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="textXICWidth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 58</value>
+  </data>
+  <data name="textXICWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 8, 6, 8</value>
+  </data>
+  <data name="textXICWidth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 26</value>
+  </data>
+  <data name="textXICWidth.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="textXICWidth.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Name" xml:space="preserve">
+    <value>textXICWidth</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelAbiSciexOS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>500, 211</value>
+  </data>
+  <data name="panelAbiSciexOS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 9, 6, 9</value>
+  </data>
+  <data name="panelAbiSciexOS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 90</value>
+  </data>
+  <data name="panelAbiSciexOS.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="panelAbiSciexOS.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Name" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.zh-CHS.resx
@@ -1720,6 +1720,24 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>pwiz.Skyline.Util.CreateHandleDebugBase, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
+  <data name="cbExportSciexOSQuantMethod.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 9</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>254, 24</value>
+  </data>
+  <data name="cbExportSciexOSQuantMethod.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="cbExportSciexOSQuantMethod.Text" xml:space="preserve">
     <value>Create SCIEX &amp;OS 
     Quant method</value>
@@ -1729,8 +1747,104 @@
     <value>Exports a SCIEX OS Quant compatible analysis method to the same directory and base name as the Analyst acquisition method.</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Name" xml:space="preserve">
+    <value>cbExportSciexOSQuantMethod</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;cbExportSciexOSQuantMethod.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="labelXICWidth.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelXICWidth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 40</value>
+  </data>
+  <data name="labelXICWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 0, 6, 0</value>
+  </data>
+  <data name="labelXICWidth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 20</value>
+  </data>
+  <data name="labelXICWidth.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="labelXICWidth.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="labelXICWidth.Text" xml:space="preserve">
     <value>XIC Width (Da):</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Name" xml:space="preserve">
+    <value>labelXICWidth</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;labelXICWidth.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="textXICWidth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 58</value>
+  </data>
+  <data name="textXICWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 8, 6, 8</value>
+  </data>
+  <data name="textXICWidth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 26</value>
+  </data>
+  <data name="textXICWidth.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="textXICWidth.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Name" xml:space="preserve">
+    <value>textXICWidth</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.Parent" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;textXICWidth.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="panelAbiSciexOS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>500, 211</value>
+  </data>
+  <data name="panelAbiSciexOS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 9, 6, 9</value>
+  </data>
+  <data name="panelAbiSciexOS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 90</value>
+  </data>
+  <data name="panelAbiSciexOS.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="panelAbiSciexOS.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Name" xml:space="preserve">
+    <value>panelAbiSciexOS</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panelAbiSciexOS.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.ja.resx
@@ -231,6 +231,9 @@
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="checkBoxBestOnly.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
   <data name="checkBoxBestOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -260,6 +263,9 @@
   </data>
   <data name="&gt;&gt;checkBoxBestOnly.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="checkBoxTargetsOnly.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
   </data>
   <data name="checkBoxTargetsOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/MProphetFeaturesDlg.zh-CHS.resx
@@ -231,6 +231,9 @@
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="checkBoxBestOnly.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
   <data name="checkBoxBestOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -260,6 +263,9 @@
   </data>
   <data name="&gt;&gt;checkBoxBestOnly.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="checkBoxTargetsOnly.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
   </data>
   <data name="checkBoxTargetsOnly.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.ja.resx
@@ -463,6 +463,13 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
   <data name="gridSearchFiles.Location" type="System.Drawing.Point, System.Drawing">
     <value>11, 26</value>
   </data>
+  <data name="gridSearchFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 270</value>
+    <comment>Needs Review:English text changed
+Old English:261, 147
+Current English:261, 270
+Old Localized:241, 147</comment>
+  </data>
   <data name="gridSearchFiles.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
@@ -622,6 +629,13 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
   <data name="btnRemFile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <data name="btnRemFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>278, 55</value>
+    <comment>Needs Review:English text changed
+Old English:278, 99
+Current English:278, 55
+Old Localized:258, 99</comment>
+  </data>
   <data name="btnRemFile.Size" type="System.Drawing.Size, System.Drawing">
     <value>113, 23</value>
   </data>
@@ -750,6 +764,12 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>381, 652</value>
+  </data>
+  <data name="&gt;&gt;helpTip.Name" xml:space="preserve">
+    <value>helpTip</value>
+  </data>
+  <data name="&gt;&gt;helpTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;dataGridViewTextBoxColumn1.Name" xml:space="preserve">
     <value>dataGridViewTextBoxColumn1</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.zh-CHS.resx
@@ -757,6 +757,12 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>381, 652</value>
   </data>
+  <data name="&gt;&gt;helpTip.Name" xml:space="preserve">
+    <value>helpTip</value>
+  </data>
+  <data name="&gt;&gt;helpTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;dataGridViewTextBoxColumn1.Name" xml:space="preserve">
     <value>dataGridViewTextBoxColumn1</value>
   </data>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.ja.resx
@@ -843,6 +843,9 @@
   <data name="transitionSettingsUiPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
+  <data name="transitionSettingsUiPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
   <data name="transitionSettingsUiPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
   </data>
@@ -945,6 +948,9 @@
   <data name="&gt;&gt;ms1FullScanSettingsPage.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="lblFasta.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblFasta.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
   </data>
@@ -1022,6 +1028,9 @@
   </data>
   <data name="&gt;&gt;importFastaPage.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="label2.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
@@ -1105,6 +1114,9 @@
   <data name="&gt;&gt;converterSettingsPage.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="lblSearchSettings.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblSearchSettings.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
   </data>
@@ -1166,6 +1178,9 @@ Old Localized:検索設定の調整</comment>
   <data name="ddaSearchSettingsPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
+  <data name="ddaSearchSettingsPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
   <data name="ddaSearchSettingsPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
   </data>
@@ -1186,6 +1201,9 @@ Old Localized:検索設定の調整</comment>
   </data>
   <data name="&gt;&gt;ddaSearchSettingsPage.ZOrder" xml:space="preserve">
     <value>7</value>
+  </data>
+  <data name="lblDDASearch.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="lblDDASearch.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
@@ -1241,8 +1259,32 @@ Old Localized:検索設定の調整</comment>
   <data name="&gt;&gt;ddaSearchTitlePanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="ddaSearchPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="ddaSearchPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="ddaSearchPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>576, 573</value>
+  </data>
+  <data name="ddaSearchPage.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
   <data name="ddaSearchPage.Text" xml:space="preserve">
     <value>9</value>
+  </data>
+  <data name="&gt;&gt;ddaSearchPage.Name" xml:space="preserve">
+    <value>ddaSearchPage</value>
+  </data>
+  <data name="&gt;&gt;ddaSearchPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ddaSearchPage.Parent" xml:space="preserve">
+    <value>wizardPagesImportPeptideSearch</value>
+  </data>
+  <data name="&gt;&gt;ddaSearchPage.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <data name="wizardPagesImportPeptideSearch.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.zh-CHS.resx
@@ -847,6 +847,9 @@
   <data name="transitionSettingsUiPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
+  <data name="transitionSettingsUiPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
   <data name="transitionSettingsUiPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
   </data>
@@ -949,6 +952,9 @@
   <data name="&gt;&gt;ms1FullScanSettingsPage.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="lblFasta.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblFasta.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
   </data>
@@ -1026,6 +1032,9 @@
   </data>
   <data name="&gt;&gt;importFastaPage.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="label2.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
@@ -1109,6 +1118,9 @@
   <data name="&gt;&gt;converterSettingsPage.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="lblSearchSettings.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="lblSearchSettings.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
   </data>
@@ -1170,6 +1182,9 @@ Old Localized:调整搜索设置</comment>
   <data name="ddaSearchSettingsPage.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
+  <data name="ddaSearchSettingsPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
   <data name="ddaSearchSettingsPage.Size" type="System.Drawing.Size, System.Drawing">
     <value>576, 573</value>
   </data>
@@ -1190,6 +1205,9 @@ Old Localized:调整搜索设置</comment>
   </data>
   <data name="&gt;&gt;ddaSearchSettingsPage.ZOrder" xml:space="preserve">
     <value>7</value>
+  </data>
+  <data name="lblDDASearch.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="lblDDASearch.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 12pt</value>
@@ -1245,8 +1263,32 @@ Old Localized:调整搜索设置</comment>
   <data name="&gt;&gt;ddaSearchTitlePanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="ddaSearchPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="ddaSearchPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="ddaSearchPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>576, 573</value>
+  </data>
+  <data name="ddaSearchPage.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
   <data name="ddaSearchPage.Text" xml:space="preserve">
     <value>9</value>
+  </data>
+  <data name="&gt;&gt;ddaSearchPage.Name" xml:space="preserve">
+    <value>ddaSearchPage</value>
+  </data>
+  <data name="&gt;&gt;ddaSearchPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ddaSearchPage.Parent" xml:space="preserve">
+    <value>wizardPagesImportPeptideSearch</value>
+  </data>
+  <data name="&gt;&gt;ddaSearchPage.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <data name="wizardPagesImportPeptideSearch.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.ja.resx
@@ -273,6 +273,9 @@
   <data name="&gt;&gt;txtSearchProgress.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="panelTextBoxBorder.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="panelTextBoxBorder.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
@@ -292,6 +295,60 @@
     <value>progressSplitContainer.Panel2</value>
   </data>
   <data name="&gt;&gt;panelTextBoxBorder.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="progressSplitContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="progressSplitContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 32</value>
+  </data>
+  <data name="progressSplitContainer.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Name" xml:space="preserve">
+    <value>progressSplitContainer.Panel1</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Parent" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Name" xml:space="preserve">
+    <value>progressSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Parent" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="progressSplitContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 353</value>
+  </data>
+  <data name="progressSplitContainer.SplitterDistance" type="System.Int32, mscorlib">
+    <value>96</value>
+  </data>
+  <data name="progressSplitContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Name" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.zh-CHS.resx
@@ -273,6 +273,9 @@
   <data name="&gt;&gt;txtSearchProgress.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="panelTextBoxBorder.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
   <data name="panelTextBoxBorder.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
@@ -292,6 +295,60 @@
     <value>progressSplitContainer.Panel2</value>
   </data>
   <data name="&gt;&gt;panelTextBoxBorder.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="progressSplitContainer.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="progressSplitContainer.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 32</value>
+  </data>
+  <data name="progressSplitContainer.Orientation" type="System.Windows.Forms.Orientation, System.Windows.Forms">
+    <value>Horizontal</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Name" xml:space="preserve">
+    <value>progressSplitContainer.Panel1</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.Parent" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Name" xml:space="preserve">
+    <value>progressSplitContainer.Panel2</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.Parent" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="progressSplitContainer.Size" type="System.Drawing.Size, System.Drawing">
+    <value>334, 353</value>
+  </data>
+  <data name="progressSplitContainer.SplitterDistance" type="System.Int32, mscorlib">
+    <value>96</value>
+  </data>
+  <data name="progressSplitContainer.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Name" xml:space="preserve">
+    <value>progressSplitContainer</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;progressSplitContainer.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.ja.resx
@@ -603,9 +603,42 @@
   <data name="&gt;&gt;lblMs2Analyzer.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="labelPPM.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>66, 138</value>
+  </data>
+  <data name="labelPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 13</value>
+  </data>
+  <data name="labelPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <data name="labelPPM.Text" xml:space="preserve">
     <value>PPM</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;labelPPM.Name" xml:space="preserve">
+    <value>labelPPM</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 135</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 20</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -614,26 +647,188 @@
     <value>Ignore features whose intensity relative to the sum of all detected feature intensities in a sample is less than this</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Name" xml:space="preserve">
+    <value>textHardklorMinIntensityPPM</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelMinIntensityPPM.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelMinIntensityPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 119</value>
+  </data>
+  <data name="labelMinIntensityPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 13</value>
+  </data>
+  <data name="labelMinIntensityPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
   <data name="labelMinIntensityPPM.Text" xml:space="preserve">
     <value>Min &amp;intensity proportion:</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Name" xml:space="preserve">
+    <value>labelMinIntensityPPM</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="textHardklorMinIdotP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 36</value>
+  </data>
+  <data name="textHardklorMinIdotP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="textHardklorMinIdotP.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Name" xml:space="preserve">
+    <value>textHardklorMinIdotP</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="labelHardklorMinIdotP.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelHardklorMinIdotP.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 20</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 13</value>
+  </data>
+  <data name="labelHardklorMinIdotP.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="labelHardklorMinIdotP.Text" xml:space="preserve">
     <value>Min isotope &amp;dot product:</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Name" xml:space="preserve">
+    <value>labelHardklorMinIdotP</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="textHardklorSignalToNoise.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 85</value>
+  </data>
+  <data name="textHardklorSignalToNoise.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="textHardklorSignalToNoise.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
   <data name="textHardklorSignalToNoise.ToolTip" xml:space="preserve">
     <value>Sets Hardklor configuration's signal-to-noise threshold, i.e. the relative abundance a peak must exceed in the spectrum window to be considered in the scoring algorithm.
 Note that this is a local noise threshold for the area of the spectrum that the peptide was identified in.</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Name" xml:space="preserve">
+    <value>textHardklorSignalToNoise</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 69</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Size" type="System.Drawing.Size, System.Drawing">
+    <value>97, 13</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="lblHardklorSignalToNoise.Text" xml:space="preserve">
     <value>Min &amp;signal to noise:</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Name" xml:space="preserve">
+    <value>lblHardklorSignalToNoise</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="groupBoxHardklor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>178, 254</value>
+  </data>
+  <data name="groupBoxHardklor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 168</value>
+  </data>
+  <data name="groupBoxHardklor.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
   <data name="groupBoxHardklor.Text" xml:space="preserve">
     <value>Search parameters</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Name" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="textCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 339</value>
+  </data>
+  <data name="textCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 20</value>
+  </data>
+  <data name="textCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
   </data>
   <data name="textCutoff.ToolTip" xml:space="preserve">
     <value>A score from 1.0 - 0, with 1.0 most likely to be correct,
@@ -645,6 +840,33 @@ For Mascot this is 1 - the maximum expectation value.
 For SEQUEST SQT this is 1 - the maximum FDR.</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;textCutoff.Name" xml:space="preserve">
+    <value>textCutoff</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelCutoff.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelCutoff.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 323</value>
+  </data>
+  <data name="labelCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 13</value>
+  </data>
+  <data name="labelCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
   <data name="labelCutoff.Text" xml:space="preserve">
     <value>Q値のカットオフ：</value>
     <comment>Needs Review:English text changed
@@ -652,9 +874,45 @@ Old English:Q value cutoff:
 Current English:&amp;Cut-off score:
 Old Localized:Q値のカットオフ：</comment>
   </data>
+  <data name="&gt;&gt;labelCutoff.Name" xml:space="preserve">
+    <value>labelCutoff</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Location" type="System.Drawing.Point, System.Drawing">
+    <value>348, 57</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Size" type="System.Drawing.Size, System.Drawing">
+    <value>36, 230</value>
+  </data>
+  <data name="lblSearchEngineBlurb.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
   <data name="lblSearchEngineBlurb.Text" xml:space="preserve">
     <value>(blurb)</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Name" xml:space="preserve">
+    <value>lblSearchEngineBlurb</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -664,6 +922,12 @@ Old Localized:Q値のカットオフ：</comment>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>381, 425</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SearchSettingsControl</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.zh-CHS.resx
@@ -603,9 +603,42 @@
   <data name="&gt;&gt;lblMs2Analyzer.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="labelPPM.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>66, 138</value>
+  </data>
+  <data name="labelPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 13</value>
+  </data>
+  <data name="labelPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <data name="labelPPM.Text" xml:space="preserve">
     <value>PPM</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;labelPPM.Name" xml:space="preserve">
+    <value>labelPPM</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelPPM.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 135</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>46, 20</value>
+  </data>
+  <data name="textHardklorMinIntensityPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
@@ -614,26 +647,188 @@
     <value>Ignore features whose intensity relative to the sum of all detected feature intensities in a sample is less than this</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Name" xml:space="preserve">
+    <value>textHardklorMinIntensityPPM</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIntensityPPM.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelMinIntensityPPM.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelMinIntensityPPM.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 119</value>
+  </data>
+  <data name="labelMinIntensityPPM.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 13</value>
+  </data>
+  <data name="labelMinIntensityPPM.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
   <data name="labelMinIntensityPPM.Text" xml:space="preserve">
     <value>Min &amp;intensity proportion:</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Name" xml:space="preserve">
+    <value>labelMinIntensityPPM</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelMinIntensityPPM.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="textHardklorMinIdotP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 36</value>
+  </data>
+  <data name="textHardklorMinIdotP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="textHardklorMinIdotP.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Name" xml:space="preserve">
+    <value>textHardklorMinIdotP</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorMinIdotP.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="labelHardklorMinIdotP.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelHardklorMinIdotP.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 20</value>
+  </data>
+  <data name="labelHardklorMinIdotP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 13</value>
+  </data>
+  <data name="labelHardklorMinIdotP.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
   <data name="labelHardklorMinIdotP.Text" xml:space="preserve">
     <value>Min isotope &amp;dot product:</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Name" xml:space="preserve">
+    <value>labelHardklorMinIdotP</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;labelHardklorMinIdotP.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="textHardklorSignalToNoise.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 85</value>
+  </data>
+  <data name="textHardklorSignalToNoise.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 20</value>
+  </data>
+  <data name="textHardklorSignalToNoise.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
   <data name="textHardklorSignalToNoise.ToolTip" xml:space="preserve">
     <value>Sets Hardklor configuration's signal-to-noise threshold, i.e. the relative abundance a peak must exceed in the spectrum window to be considered in the scoring algorithm.
 Note that this is a local noise threshold for the area of the spectrum that the peptide was identified in.</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Name" xml:space="preserve">
+    <value>textHardklorSignalToNoise</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;textHardklorSignalToNoise.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 69</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.Size" type="System.Drawing.Size, System.Drawing">
+    <value>97, 13</value>
+  </data>
+  <data name="lblHardklorSignalToNoise.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
   <data name="lblHardklorSignalToNoise.Text" xml:space="preserve">
     <value>Min &amp;signal to noise:</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Name" xml:space="preserve">
+    <value>lblHardklorSignalToNoise</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.Parent" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;lblHardklorSignalToNoise.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="groupBoxHardklor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>178, 254</value>
+  </data>
+  <data name="groupBoxHardklor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 168</value>
+  </data>
+  <data name="groupBoxHardklor.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
   <data name="groupBoxHardklor.Text" xml:space="preserve">
     <value>Search parameters</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Name" xml:space="preserve">
+    <value>groupBoxHardklor</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBoxHardklor.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="textCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 339</value>
+  </data>
+  <data name="textCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 20</value>
+  </data>
+  <data name="textCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
   </data>
   <data name="textCutoff.ToolTip" xml:space="preserve">
     <value>A score from 1.0 - 0, with 1.0 most likely to be correct,
@@ -645,6 +840,33 @@ For Mascot this is 1 - the maximum expectation value.
 For SEQUEST SQT this is 1 - the maximum FDR.</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="&gt;&gt;textCutoff.Name" xml:space="preserve">
+    <value>textCutoff</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;textCutoff.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="labelCutoff.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelCutoff.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelCutoff.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 323</value>
+  </data>
+  <data name="labelCutoff.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 13</value>
+  </data>
+  <data name="labelCutoff.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
   <data name="labelCutoff.Text" xml:space="preserve">
     <value>Q 值截止：</value>
     <comment>Needs Review:English text changed
@@ -652,9 +874,45 @@ Old English:Q value cutoff:
 Current English:&amp;Cut-off score:
 Old Localized:Q 值截止：</comment>
   </data>
+  <data name="&gt;&gt;labelCutoff.Name" xml:space="preserve">
+    <value>labelCutoff</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;labelCutoff.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Location" type="System.Drawing.Point, System.Drawing">
+    <value>348, 57</value>
+  </data>
+  <data name="lblSearchEngineBlurb.Size" type="System.Drawing.Size, System.Drawing">
+    <value>36, 230</value>
+  </data>
+  <data name="lblSearchEngineBlurb.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
   <data name="lblSearchEngineBlurb.Text" xml:space="preserve">
     <value>(blurb)</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Name" xml:space="preserve">
+    <value>lblSearchEngineBlurb</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblSearchEngineBlurb.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -664,6 +922,12 @@ Old Localized:Q 值截止：</comment>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>381, 425</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SearchSettingsControl</value>

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.ja.resx
@@ -303,6 +303,21 @@
   <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="cbAnonymousServers.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="cbAnonymousServers.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAnonymousServers.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 296</value>
+  </data>
+  <data name="cbAnonymousServers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 17</value>
+  </data>
+  <data name="cbAnonymousServers.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
   <data name="cbAnonymousServers.Text" xml:space="preserve">
     <value>Show anonymous servers</value>
     <comment>Needs Review:New resource</comment>
@@ -313,6 +328,18 @@
   <data name="cbAnonymousServers.ToolTip" xml:space="preserve">
     <value>Anonymous servers are not associated with a user account. A user account is required to upload documents to a server.</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Name" xml:space="preserve">
+    <value>cbAnonymousServers</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -328,6 +355,12 @@
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>ドキュメントをアップロード</value>
+  </data>
+  <data name="&gt;&gt;toolTipShowAnonymous.Name" xml:space="preserve">
+    <value>toolTipShowAnonymous</value>
+  </data>
+  <data name="&gt;&gt;toolTipShowAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PublishDocumentDlg</value>

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.zh-CHS.resx
@@ -303,6 +303,21 @@
   <data name="&gt;&gt;btnBrowse.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="cbAnonymousServers.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="cbAnonymousServers.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAnonymousServers.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 296</value>
+  </data>
+  <data name="cbAnonymousServers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 17</value>
+  </data>
+  <data name="cbAnonymousServers.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
   <data name="cbAnonymousServers.Text" xml:space="preserve">
     <value>Show anonymous servers</value>
     <comment>Needs Review:New resource</comment>
@@ -313,6 +328,18 @@
   <data name="cbAnonymousServers.ToolTip" xml:space="preserve">
     <value>Anonymous servers are not associated with a user account. A user account is required to upload documents to a server.</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Name" xml:space="preserve">
+    <value>cbAnonymousServers</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymousServers.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -328,6 +355,12 @@
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>上传文档</value>
+  </data>
+  <data name="&gt;&gt;toolTipShowAnonymous.Name" xml:space="preserve">
+    <value>toolTipShowAnonymous</value>
+  </data>
+  <data name="&gt;&gt;toolTipShowAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PublishDocumentDlg</value>

--- a/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.ja.resx
+++ b/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.ja.resx
@@ -217,6 +217,9 @@
   <data name="transitionsContextMenuItem.Text" xml:space="preserve">
     <value>トランジション</value>
   </data>
+  <data name="relativeAbundanceFormattingMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>212, 22</value>
+  </data>
   <data name="relativeAbundanceFormattingMenuItem.Text" xml:space="preserve">
     <value>Formatting...</value>
     <comment>Needs Review:New resource</comment>

--- a/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.zh-CHS.resx
@@ -217,6 +217,9 @@
   <data name="transitionsContextMenuItem.Text" xml:space="preserve">
     <value>离子对</value>
   </data>
+  <data name="relativeAbundanceFormattingMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>212, 22</value>
+  </data>
   <data name="relativeAbundanceFormattingMenuItem.Text" xml:space="preserve">
     <value>Formatting...</value>
     <comment>Needs Review:New resource</comment>

--- a/pwiz_tools/Skyline/Menus/ViewMenu.ja.resx
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.ja.resx
@@ -702,6 +702,9 @@
   <data name="areaPeptideComparisonMenuItem.Text" xml:space="preserve">
     <value>ペプチドの比較(&amp;P)</value>
   </data>
+  <data name="areaRelativeAbundanceMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 22</value>
+  </data>
   <data name="areaRelativeAbundanceMenuItem.Text" xml:space="preserve">
     <value>Relative &amp;Abundance</value>
     <comment>Needs Review:New resource</comment>

--- a/pwiz_tools/Skyline/Menus/ViewMenu.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.zh-CHS.resx
@@ -702,6 +702,9 @@
   <data name="areaPeptideComparisonMenuItem.Text" xml:space="preserve">
     <value>肽段比较(&amp;P)</value>
   </data>
+  <data name="areaRelativeAbundanceMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 22</value>
+  </data>
   <data name="areaRelativeAbundanceMenuItem.Text" xml:space="preserve">
     <value>Relative &amp;Abundance</value>
     <comment>Needs Review:New resource</comment>

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -827,6 +827,9 @@ Skylineにインポートする前に必要に応じてライブラリをフィ�
   <data name="LabKey" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\LabKey.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="HardklorLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\hardklor_logo.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="MProphetPeakScoringModel_CreateTransitionGroups_MProphetScoringModel_was_given_a_peak_with__0__features__but_it_has__1__peak_feature_calculators" xml:space="preserve">
     <value>MProphetScoringModeには{0}個の機能を持つピークが与えられましたが、ピーク機能カルキュレータが{1}個あります</value>
   </data>
@@ -3842,6 +3845,9 @@ Skylineでの列の順序は、列のヘッダーを左右にドラッグする�
   <data name="PasteDlg_AddFasta_This_must_start_with" xml:space="preserve">
     <value>これは「&gt;」から始まる必要があります</value>
   </data>
+  <data name="PanoramaDownload" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\PanoramaDownload.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
     <value>ユーザーを認証できませんでした。サーバーから受信した応答：{0} {1}</value>
   </data>
@@ -3981,6 +3987,9 @@ Skylineでの列の順序は、列のヘッダーを左右にドラッグする�
   <data name="PeptideMod_SetTerminus_A_peptide_modification_must_be_added_before_giving_it_a_terminal_or_amino_acid_specificity_" xml:space="preserve">
     <value>A peptide modification must be added before giving it a terminal or amino acid specificity.</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="koina_logo_fdf731d5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\koina-logo.fdf731d5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CommandLine_ImportPeptideList_Importing_peptide_list__0__from_file__1____" xml:space="preserve">
     <value>Importing peptide list {0} from file {1}...</value>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -830,6 +830,9 @@
   <data name="LabKey" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\LabKey.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="HardklorLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\hardklor_logo.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="MProphetPeakScoringModel_CreateTransitionGroups_MProphetScoringModel_was_given_a_peak_with__0__features__but_it_has__1__peak_feature_calculators" xml:space="preserve">
     <value>MProphetScoringModel 被赋予带有{0}特征的峰，但它拥有 {1} 个峰特征计算器</value>
   </data>
@@ -3845,6 +3848,9 @@
   <data name="PasteDlg_AddFasta_This_must_start_with" xml:space="preserve">
     <value>它必须以“&gt;”开始</value>
   </data>
+  <data name="PanoramaDownload" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\PanoramaDownload.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
   <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
     <value>无法验证用户身份。服务器的反馈:{0} {1}</value>
   </data>
@@ -3984,6 +3990,9 @@
   <data name="PeptideMod_SetTerminus_A_peptide_modification_must_be_added_before_giving_it_a_terminal_or_amino_acid_specificity_" xml:space="preserve">
     <value>A peptide modification must be added before giving it a terminal or amino acid specificity.</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="koina_logo_fdf731d5" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\koina-logo.fdf731d5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CommandLine_ImportPeptideList_Importing_peptide_list__0__from_file__1____" xml:space="preserve">
     <value>Importing peptide list {0} from file {1}...</value>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.ja.resx
@@ -1672,6 +1672,12 @@
   <data name="&gt;&gt;toolStripSeparator27.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ViewLibraryDlg</value>
   </data>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
@@ -1672,6 +1672,12 @@
   <data name="&gt;&gt;toolStripSeparator27.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>ViewLibraryDlg</value>
   </data>

--- a/pwiz_tools/Skyline/Skyline.ja.resx
+++ b/pwiz_tools/Skyline/Skyline.ja.resx
@@ -421,9 +421,15 @@
   <data name="spectrumGraphPropsContextMenuItem.Text" xml:space="preserve">
     <value>グラフプロパティ...</value>
   </data>
+  <data name="showLibSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 22</value>
+  </data>
   <data name="showLibSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
     <value>Spectrum Properties</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="showFullScanSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 22</value>
   </data>
   <data name="showFullScanSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
     <value>Spectrum Properties</value>
@@ -771,6 +777,9 @@
   <data name="areaPeptideComparisonContextMenuItem.Text" xml:space="preserve">
     <value>ペプチドの比較</value>
   </data>
+  <data name="areaRelativeAbundanceContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>190, 22</value>
+  </data>
   <data name="areaRelativeAbundanceContextMenuItem.Text" xml:space="preserve">
     <value>Relative Abundance</value>
     <comment>Needs Review:New resource</comment>
@@ -883,9 +892,15 @@
   <data name="scopeContextMenuItem.Text" xml:space="preserve">
     <value>適用範囲</value>
   </data>
+  <data name="abundanceTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
   <data name="abundanceTargetsMenuItem.Text" xml:space="preserve">
     <value>Targets</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="excludeTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
   </data>
   <data name="excludeTargetsMenuItem.Text" xml:space="preserve">
     <value>Exclude</value>
@@ -1044,17 +1059,29 @@
   <data name="&gt;&gt;contextMenuPeakAreas.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="abundanceTargetsProteinsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
   <data name="abundanceTargetsProteinsMenuItem.Text" xml:space="preserve">
     <value>Proteins</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="abundanceTargetsPeptidesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
   </data>
   <data name="abundanceTargetsPeptidesMenuItem.Text" xml:space="preserve">
     <value>Peptides</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="excludeTargetsPeptideListMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
   <data name="excludeTargetsPeptideListMenuItem.Text" xml:space="preserve">
     <value>Peptide Lists</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="excludeTargetsStandardsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
   </data>
   <data name="excludeTargetsStandardsMenuItem.Text" xml:space="preserve">
     <value>Standards</value>
@@ -1367,6 +1394,12 @@
   <data name="openMenuItem.Text" xml:space="preserve">
     <value>開く(&amp;O)...</value>
   </data>
+  <data name="openPanoramaMenuItem.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="openPanoramaMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
+  </data>
   <data name="openPanoramaMenuItem.Text" xml:space="preserve">
     <value>Open From Panora&amp;ma...</value>
     <comment>Needs Review:New resource</comment>
@@ -1414,7 +1447,10 @@
     <value>Panoramaにアップロード(&amp;U)...</value>
   </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
+  </data>
+  <data name="runPeptideSearchToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
   </data>
   <data name="runPeptideSearchToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Run Peptide Search...</value>
@@ -1426,9 +1462,15 @@
   <data name="encyclopeDiaSearchMenuItem.Text" xml:space="preserve">
     <value>&amp;EncyclopeDIA検索...</value>
   </data>
+  <data name="importFeatureDetectionMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
   <data name="importFeatureDetectionMenuItem.Text" xml:space="preserve">
     <value>&amp;Feature Detection...</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="searchStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
   </data>
   <data name="searchStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Search</value>
@@ -2256,6 +2298,12 @@
   <data name="&gt;&gt;modifyPeptideContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;editSpectrumFilterContextMenuItem.Name" xml:space="preserve">
+    <value>editSpectrumFilterContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;editSpectrumFilterContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;toggleQuantitativeContextMenuItem.Name" xml:space="preserve">
     <value>toggleQuantitativeContextMenuItem</value>
   </data>
@@ -2434,6 +2482,18 @@
     <value>spectrumGraphPropsContextMenuItem</value>
   </data>
   <data name="&gt;&gt;spectrumGraphPropsContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showLibSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
+    <value>showLibSpectrumPropertiesContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;showLibSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showFullScanSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
+    <value>showFullScanSpectrumPropertiesContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;showFullScanSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator15.Name" xml:space="preserve">
@@ -2784,6 +2844,12 @@
   <data name="&gt;&gt;areaPeptideComparisonContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;areaRelativeAbundanceContextMenuItem.Name" xml:space="preserve">
+    <value>areaRelativeAbundanceContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;areaRelativeAbundanceContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;areaCVHistogramContextMenuItem.Name" xml:space="preserve">
     <value>areaCVHistogramContextMenuItem</value>
   </data>
@@ -2884,6 +2950,18 @@
     <value>proteinScopeContextMenuItem</value>
   </data>
   <data name="&gt;&gt;proteinScopeContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;showPeakAreaLegendContextMenuItem.Name" xml:space="preserve">
@@ -3054,6 +3132,30 @@
   <data name="&gt;&gt;toolStripSeparator57.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;abundanceTargetsProteinsMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsProteinsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsProteinsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsPeptidesMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsPeptidesMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsPeptidesMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsPeptideListMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsPeptideListMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsPeptideListMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsStandardsMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsStandardsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsStandardsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;statusGeneral.Name" xml:space="preserve">
     <value>statusGeneral</value>
   </data>
@@ -3198,6 +3300,12 @@
   <data name="&gt;&gt;openMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;openPanoramaMenuItem.Name" xml:space="preserve">
+    <value>openPanoramaMenuItem</value>
+  </data>
+  <data name="&gt;&gt;openPanoramaMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;openContainingFolderMenuItem.Name" xml:space="preserve">
     <value>openContainingFolderMenuItem</value>
   </data>
@@ -3240,10 +3348,28 @@
   <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;searchStripMenuItem.Name" xml:space="preserve">
+    <value>searchStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;searchStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;runPeptideSearchToolStripMenuItem.Name" xml:space="preserve">
+    <value>runPeptideSearchToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;runPeptideSearchToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Name" xml:space="preserve">
     <value>encyclopeDiaSearchMenuItem</value>
   </data>
   <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;importFeatureDetectionMenuItem.Name" xml:space="preserve">
+    <value>importFeatureDetectionMenuItem</value>
+  </data>
+  <data name="&gt;&gt;importFeatureDetectionMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;importToolStripMenuItem.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Skyline.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Skyline.zh-CHS.resx
@@ -421,9 +421,15 @@
   <data name="spectrumGraphPropsContextMenuItem.Text" xml:space="preserve">
     <value>图形属性...</value>
   </data>
+  <data name="showLibSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 22</value>
+  </data>
   <data name="showLibSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
     <value>Spectrum Properties</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="showFullScanSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 22</value>
   </data>
   <data name="showFullScanSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
     <value>Spectrum Properties</value>
@@ -771,6 +777,9 @@
   <data name="areaPeptideComparisonContextMenuItem.Text" xml:space="preserve">
     <value>肽段比较</value>
   </data>
+  <data name="areaRelativeAbundanceContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>190, 22</value>
+  </data>
   <data name="areaRelativeAbundanceContextMenuItem.Text" xml:space="preserve">
     <value>Relative Abundance</value>
     <comment>Needs Review:New resource</comment>
@@ -883,9 +892,15 @@
   <data name="scopeContextMenuItem.Text" xml:space="preserve">
     <value>范围</value>
   </data>
+  <data name="abundanceTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
   <data name="abundanceTargetsMenuItem.Text" xml:space="preserve">
     <value>Targets</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="excludeTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
   </data>
   <data name="excludeTargetsMenuItem.Text" xml:space="preserve">
     <value>Exclude</value>
@@ -1044,17 +1059,29 @@
   <data name="&gt;&gt;contextMenuPeakAreas.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="abundanceTargetsProteinsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
   <data name="abundanceTargetsProteinsMenuItem.Text" xml:space="preserve">
     <value>Proteins</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="abundanceTargetsPeptidesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
   </data>
   <data name="abundanceTargetsPeptidesMenuItem.Text" xml:space="preserve">
     <value>Peptides</value>
     <comment>Needs Review:New resource</comment>
   </data>
+  <data name="excludeTargetsPeptideListMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
+  </data>
   <data name="excludeTargetsPeptideListMenuItem.Text" xml:space="preserve">
     <value>Peptide Lists</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="excludeTargetsStandardsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 22</value>
   </data>
   <data name="excludeTargetsStandardsMenuItem.Text" xml:space="preserve">
     <value>Standards</value>
@@ -1367,6 +1394,12 @@
   <data name="openMenuItem.Text" xml:space="preserve">
     <value>打开(&amp;O)…</value>
   </data>
+  <data name="openPanoramaMenuItem.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="openPanoramaMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
+  </data>
   <data name="openPanoramaMenuItem.Text" xml:space="preserve">
     <value>Open From Panora&amp;ma...</value>
     <comment>Needs Review:New resource</comment>
@@ -1414,7 +1447,10 @@
     <value>上传至 Panorama(&amp;U)…</value>
   </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 6</value>
+    <value>197, 6</value>
+  </data>
+  <data name="runPeptideSearchToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
   </data>
   <data name="runPeptideSearchToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Run Peptide Search...</value>
@@ -1426,9 +1462,15 @@
   <data name="encyclopeDiaSearchMenuItem.Text" xml:space="preserve">
     <value>EncyclopeDIA 搜索...</value>
   </data>
+  <data name="importFeatureDetectionMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 22</value>
+  </data>
   <data name="importFeatureDetectionMenuItem.Text" xml:space="preserve">
     <value>&amp;Feature Detection...</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="searchStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 22</value>
   </data>
   <data name="searchStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Search</value>
@@ -2256,6 +2298,12 @@
   <data name="&gt;&gt;modifyPeptideContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;editSpectrumFilterContextMenuItem.Name" xml:space="preserve">
+    <value>editSpectrumFilterContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;editSpectrumFilterContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;toggleQuantitativeContextMenuItem.Name" xml:space="preserve">
     <value>toggleQuantitativeContextMenuItem</value>
   </data>
@@ -2434,6 +2482,18 @@
     <value>spectrumGraphPropsContextMenuItem</value>
   </data>
   <data name="&gt;&gt;spectrumGraphPropsContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showLibSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
+    <value>showLibSpectrumPropertiesContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;showLibSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showFullScanSpectrumPropertiesContextMenuItem.Name" xml:space="preserve">
+    <value>showFullScanSpectrumPropertiesContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;showFullScanSpectrumPropertiesContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator15.Name" xml:space="preserve">
@@ -2784,6 +2844,12 @@
   <data name="&gt;&gt;areaPeptideComparisonContextMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;areaRelativeAbundanceContextMenuItem.Name" xml:space="preserve">
+    <value>areaRelativeAbundanceContextMenuItem</value>
+  </data>
+  <data name="&gt;&gt;areaRelativeAbundanceContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;areaCVHistogramContextMenuItem.Name" xml:space="preserve">
     <value>areaCVHistogramContextMenuItem</value>
   </data>
@@ -2884,6 +2950,18 @@
     <value>proteinScopeContextMenuItem</value>
   </data>
   <data name="&gt;&gt;proteinScopeContextMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;showPeakAreaLegendContextMenuItem.Name" xml:space="preserve">
@@ -3054,6 +3132,30 @@
   <data name="&gt;&gt;toolStripSeparator57.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;abundanceTargetsProteinsMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsProteinsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsProteinsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsPeptidesMenuItem.Name" xml:space="preserve">
+    <value>abundanceTargetsPeptidesMenuItem</value>
+  </data>
+  <data name="&gt;&gt;abundanceTargetsPeptidesMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsPeptideListMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsPeptideListMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsPeptideListMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsStandardsMenuItem.Name" xml:space="preserve">
+    <value>excludeTargetsStandardsMenuItem</value>
+  </data>
+  <data name="&gt;&gt;excludeTargetsStandardsMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;statusGeneral.Name" xml:space="preserve">
     <value>statusGeneral</value>
   </data>
@@ -3198,6 +3300,12 @@
   <data name="&gt;&gt;openMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;openPanoramaMenuItem.Name" xml:space="preserve">
+    <value>openPanoramaMenuItem</value>
+  </data>
+  <data name="&gt;&gt;openPanoramaMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;openContainingFolderMenuItem.Name" xml:space="preserve">
     <value>openContainingFolderMenuItem</value>
   </data>
@@ -3240,10 +3348,28 @@
   <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;searchStripMenuItem.Name" xml:space="preserve">
+    <value>searchStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;searchStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;runPeptideSearchToolStripMenuItem.Name" xml:space="preserve">
+    <value>runPeptideSearchToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;runPeptideSearchToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Name" xml:space="preserve">
     <value>encyclopeDiaSearchMenuItem</value>
   </data>
   <data name="&gt;&gt;encyclopeDiaSearchMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;importFeatureDetectionMenuItem.Name" xml:space="preserve">
+    <value>importFeatureDetectionMenuItem</value>
+  </data>
+  <data name="&gt;&gt;importFeatureDetectionMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;importToolStripMenuItem.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.ja.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.ja.resx
@@ -206,6 +206,18 @@
   <data name="InputPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="cbAnonymous.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAnonymous.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 51</value>
+  </data>
+  <data name="cbAnonymous.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 17</value>
+  </data>
+  <data name="cbAnonymous.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
   <data name="cbAnonymous.Text" xml:space="preserve">
     <value>Anonymous access</value>
     <comment>Needs Review:New resource</comment>
@@ -216,6 +228,18 @@
   <data name="cbAnonymous.ToolTip" xml:space="preserve">
     <value>Check this box if you do not have an account on the server.  Without a user account you can anonymously browse, download and open publicly available documents on the server, but you cannot upload documents to the server.</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Name" xml:space="preserve">
+    <value>cbAnonymous</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Parent" xml:space="preserve">
+    <value>InputPanel</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblProjectInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -478,6 +502,12 @@
   <data name="$this.Text" xml:space="preserve">
     <value>サーバーを編集</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;toolTipAnonymous.Name" xml:space="preserve">
+    <value>toolTipAnonymous</value>
+  </data>
+  <data name="&gt;&gt;toolTipAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>EditServerDlg</value>

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.zh-CHS.resx
@@ -206,6 +206,18 @@
   <data name="InputPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
   </data>
+  <data name="cbAnonymous.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbAnonymous.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 51</value>
+  </data>
+  <data name="cbAnonymous.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 17</value>
+  </data>
+  <data name="cbAnonymous.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
   <data name="cbAnonymous.Text" xml:space="preserve">
     <value>Anonymous access</value>
     <comment>Needs Review:New resource</comment>
@@ -216,6 +228,18 @@
   <data name="cbAnonymous.ToolTip" xml:space="preserve">
     <value>Check this box if you do not have an account on the server.  Without a user account you can anonymously browse, download and open publicly available documents on the server, but you cannot upload documents to the server.</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Name" xml:space="preserve">
+    <value>cbAnonymous</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.Parent" xml:space="preserve">
+    <value>InputPanel</value>
+  </data>
+  <data name="&gt;&gt;cbAnonymous.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="lblProjectInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -478,6 +502,12 @@
   <data name="$this.Text" xml:space="preserve">
     <value>编辑服务器</value>
     <comment>Needs Review:Missing translation</comment>
+  </data>
+  <data name="&gt;&gt;toolTipAnonymous.Name" xml:space="preserve">
+    <value>toolTipAnonymous</value>
+  </data>
+  <data name="&gt;&gt;toolTipAnonymous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>EditServerDlg</value>

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.zh-CHS.resx
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.zh-CHS.resx
@@ -751,9 +751,57 @@
   <data name="&gt;&gt;tabLanguage.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="tbxSettingsFilePath.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="tbxSettingsFilePath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 174</value>
+  </data>
+  <data name="tbxSettingsFilePath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>357, 20</value>
+  </data>
+  <data name="tbxSettingsFilePath.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Name" xml:space="preserve">
+    <value>tbxSettingsFilePath</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.Parent" xml:space="preserve">
+    <value>tabMisc</value>
+  </data>
+  <data name="&gt;&gt;tbxSettingsFilePath.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblSettingsPath.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSettingsPath.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 158</value>
+  </data>
+  <data name="lblSettingsPath.Size" type="System.Drawing.Size, System.Drawing">
+    <value>109, 13</value>
+  </data>
+  <data name="lblSettingsPath.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
   <data name="lblSettingsPath.Text" xml:space="preserve">
     <value>Settings are stored in:</value>
     <comment>Needs Review:New resource</comment>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Name" xml:space="preserve">
+    <value>lblSettingsPath</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.Parent" xml:space="preserve">
+    <value>tabMisc</value>
+  </data>
+  <data name="&gt;&gt;lblSettingsPath.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="btnResetSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>17, 200</value>


### PR DESCRIPTION
Ran the localization tool with "--overrideAll" flag which ensures that the "ja" and "zh-CHS" resx files have all of the same entries as the English .resx file.
The previous version would avoid adding new entries to a localized .resx file if the localized string was the same as the english string, and the entry was not already present in the localized resx file.