### PR TITLE
Update translated text for items whose text we already had translations for.

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.ja.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.ja.resx
@@ -160,8 +160,7 @@
     <value>21, 20</value>
   </data>
   <data name="btnRemove.Text" xml:space="preserve">
-    <value>Remove</value>
-    <comment>Needs Review:Missing translation</comment>
+    <value>削除</value>
   </data>
   <data name="btnUp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -170,8 +169,7 @@
     <value>21, 20</value>
   </data>
   <data name="btnUp.Text" xml:space="preserve">
-    <value>Up</value>
-    <comment>Needs Review:Missing translation</comment>
+    <value>上へ</value>
   </data>
   <data name="btnDown.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.zh-CHS.resx
@@ -160,8 +160,7 @@
     <value>21, 20</value>
   </data>
   <data name="btnRemove.Text" xml:space="preserve">
-    <value>Remove</value>
-    <comment>Needs Review:Missing translation</comment>
+    <value>删除</value>
   </data>
   <data name="btnUp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -170,8 +169,7 @@
     <value>21, 20</value>
   </data>
   <data name="btnUp.Text" xml:space="preserve">
-    <value>Up</value>
-    <comment>Needs Review:Missing translation</comment>
+    <value>向上</value>
   </data>
   <data name="btnDown.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -180,8 +178,7 @@
     <value>21, 20</value>
   </data>
   <data name="btnDown.Text" xml:space="preserve">
-    <value>Down</value>
-    <comment>Needs Review:Missing translation</comment>
+    <value>向下</value>
   </data>
   <data name="toolStrip1.Location" type="System.Drawing.Point, System.Drawing">
     <value>126, 0</value>

--- a/pwiz_tools/Shared/PanoramaClient/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/Properties/Resources.ja.resx
@@ -158,15 +158,13 @@
     <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="UserState_GetErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
-    <value>There was an error authenticating user credentials on the server {0}.</value>
-    <comment>Needs Review:New resource</comment>
+    <value>サーバー{0}でのユーザー認証情報の認証中にエラーがありました。</value>
   </data>
   <data name="PanoramaUtil_VerifyFolder_Folder__0__does_not_exist_on_the_Panorama_server__1_" xml:space="preserve">
     <value>フォルダ{0}はPanoramaサーバー{1}上に存在しません</value>
   </data>
   <data name="WebPanoramaClient_DownloadFile_Downloading__0_" xml:space="preserve">
-    <value>Downloading {0}</value>
-    <comment>Needs Review:New resource</comment>
+    <value>{0}のダウンロード中</value>
   </data>
   <data name="Icojam-Blueberry-Basic-Arrow-up" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Icojam-Blueberry-Basic-Arrow-up2.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
@@ -267,8 +265,7 @@
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="WebPanoramaClient_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
-    <value>Server did not return a valid JSON response. {0} is not a Panorama server.</value>
-    <comment>Needs Review:New resource</comment>
+    <value>サーバーは有効なJSON応答を返しませんでした。{0}はPanoramaサーバーではありません。</value>
   </data>
   <data name="AbstractPanoramaClient_WaitForDocumentImportCompleted_There_was_an_error_getting_the_status_of_the_document_import_pipeline_job_" xml:space="preserve">
     <value>There was an error getting the status of the document import pipeline job.</value>

--- a/pwiz_tools/Shared/PanoramaClient/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/Properties/Resources.zh-CHS.resx
@@ -158,15 +158,13 @@
     <value>..\Resources\Icojam-Blueberry-Basic-Arrow-right.ico;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="UserState_GetErrorMessage_There_was_an_error_authenticating_user_credentials_on_the_server__0__" xml:space="preserve">
-    <value>There was an error authenticating user credentials on the server {0}.</value>
-    <comment>Needs Review:New resource</comment>
+    <value>验证服务器 {0} 上的用户凭据时出错。</value>
   </data>
   <data name="PanoramaUtil_VerifyFolder_Folder__0__does_not_exist_on_the_Panorama_server__1_" xml:space="preserve">
     <value>文件夹{0}不存在于 Panorama 服务器{1}中</value>
   </data>
   <data name="WebPanoramaClient_DownloadFile_Downloading__0_" xml:space="preserve">
-    <value>Downloading {0}</value>
-    <comment>Needs Review:New resource</comment>
+    <value>下载{0}</value>
   </data>
   <data name="Icojam-Blueberry-Basic-Arrow-up" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Icojam-Blueberry-Basic-Arrow-up2.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
@@ -267,8 +265,7 @@
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="WebPanoramaClient_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
-    <value>Server did not return a valid JSON response. {0} is not a Panorama server.</value>
-    <comment>Needs Review:New resource</comment>
+    <value>服务器未返回有效的 JSON 响应。{0} 并非 Panorama  服务器。</value>
   </data>
   <data name="AbstractPanoramaClient_WaitForDocumentImportCompleted_There_was_an_error_getting_the_status_of_the_document_import_pipeline_job_" xml:space="preserve">
     <value>There was an error getting the status of the document import pipeline job.</value>

--- a/pwiz_tools/Skyline/CommandArgUsage.ja.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.ja.resx
@@ -538,12 +538,10 @@ http://localhost:8080</value>
     <value>提供されたZIPファイルが原因で重複となったカスタム注釈が、既存の注釈を上書きすべき（True）かスキップすべき(False)かを指定します。</value>
   </data>
   <data name="CommandArgs_GROUP_SETTINGS_Transition_Settings" xml:space="preserve">
-    <value>Transition Settings</value>
-    <comment>Needs Review:New resource</comment>
+    <value>トランジションの設定</value>
   </data>
   <data name="CommandArgs_GROUP_SETTINGS_Peptide_Settings" xml:space="preserve">
-    <value>Peptide Settings</value>
-    <comment>Needs Review:New resource</comment>
+    <value>ペプチド設定</value>
   </data>
   <data name="CommandArgs_PATH_TO_FILE_path_to_file" xml:space="preserve">
     <value>path/to/file（ファイル）</value>

--- a/pwiz_tools/Skyline/CommandArgUsage.zh-CHS.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.zh-CHS.resx
@@ -538,12 +538,10 @@ http://localhost:8080</value>
     <value>指定提供的 ZIP 文件中的冲突的自定义注释是否应覆盖（“true”）或跳过（“false”）现有注释。</value>
   </data>
   <data name="CommandArgs_GROUP_SETTINGS_Transition_Settings" xml:space="preserve">
-    <value>Transition Settings</value>
-    <comment>Needs Review:New resource</comment>
+    <value>离子对设置</value>
   </data>
   <data name="CommandArgs_GROUP_SETTINGS_Peptide_Settings" xml:space="preserve">
-    <value>Peptide Settings</value>
-    <comment>Needs Review:New resource</comment>
+    <value>肽段设置</value>
   </data>
   <data name="CommandArgs_PATH_TO_FILE_path_to_file" xml:space="preserve">
     <value>路径/到/文件</value>

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.ja.resx
@@ -326,8 +326,7 @@
     <value>6</value>
   </data>
   <data name="lblSummary.Text" xml:space="preserve">
-    <value>Summary</value>
-    <comment>Needs Review:New resource</comment>
+    <value>概要</value>
   </data>
   <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
     <value>lblSummary</value>

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
@@ -326,8 +326,7 @@
     <value>6</value>
   </data>
   <data name="lblSummary.Text" xml:space="preserve">
-    <value>Summary</value>
-    <comment>Needs Review:New resource</comment>
+    <value>总结</value>
   </data>
   <data name="&gt;&gt;lblSummary.Name" xml:space="preserve">
     <value>lblSummary</value>

--- a/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.ja.resx
@@ -126,15 +126,13 @@
     <value>150</value>
   </data>
   <data name="operationColumn.HeaderText" xml:space="preserve">
-    <value>Operation</value>
-    <comment>Needs Review:New resource</comment>
+    <value>操作</value>
   </data>
   <data name="operationColumn.Width" type="System.Int32, mscorlib">
     <value>150</value>
   </data>
   <data name="valueColumn.HeaderText" xml:space="preserve">
-    <value>Value</value>
-    <comment>Needs Review:New resource</comment>
+    <value>値</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="dataGridViewEx1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">

--- a/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.zh-CHS.resx
@@ -126,15 +126,13 @@
     <value>150</value>
   </data>
   <data name="operationColumn.HeaderText" xml:space="preserve">
-    <value>Operation</value>
-    <comment>Needs Review:New resource</comment>
+    <value>操作</value>
   </data>
   <data name="operationColumn.Width" type="System.Int32, mscorlib">
     <value>150</value>
   </data>
   <data name="valueColumn.HeaderText" xml:space="preserve">
-    <value>Value</value>
-    <comment>Needs Review:New resource</comment>
+    <value>值</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="dataGridViewEx1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -379,11 +377,7 @@
     <value>12</value>
   </data>
   <data name="lblDescription.Text" xml:space="preserve">
-    <value>利用 FASTA 文件或背景蛋白质组的信息，将文档中的所有肽段重组为关联的蛋白质或蛋白质组。现有蛋白质的关联性将被丢弃。</value>
-    <comment>Needs Review:English text changed
-Old English:Use either a FASTA file or a background proteome to reorganize all document peptides into associated proteins or protein groups. Existing protein associations will be discarded.
-Current English:Description
-Old Localized:利用 FASTA 文件或背景蛋白质组的信息，将文档中的所有肽段重组为关联的蛋白质或蛋白质组。现有蛋白质的关联性将被丢弃。</comment>
+    <value>描述</value>
   </data>
   <data name="lblDescription.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.ja.resx
@@ -356,8 +356,7 @@
 上記にリストしたディレクトリの1つにオリジナルのスペクトルファイルを入れた後、もう一度構築を試みるには「再試行」をクリックしてください。</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Add_spectral_library" xml:space="preserve">
-    <value>Add spectral library</value>
-    <comment>Needs Review:New resource</comment>
+    <value>スペクトルライブラリを追加</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_Detected_Features_Library" xml:space="preserve">
     <value>Building detected features library</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.zh-CHS.resx
@@ -356,8 +356,7 @@
 将原始谱图文件放在上面列出的其中一个目录后，单击 "重试" 再次尝试构建。</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Add_spectral_library" xml:space="preserve">
-    <value>Add spectral library</value>
-    <comment>Needs Review:New resource</comment>
+    <value>添加谱图库</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_Detected_Features_Library" xml:space="preserve">
     <value>Building detected features library</value>

--- a/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.ja.resx
+++ b/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.ja.resx
@@ -221,8 +221,7 @@
     <value>212, 22</value>
   </data>
   <data name="relativeAbundanceFormattingMenuItem.Text" xml:space="preserve">
-    <value>Formatting...</value>
-    <comment>Needs Review:New resource</comment>
+    <value>フォーマット中...</value>
   </data>
   <data name="transformChromContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>212, 22</value>

--- a/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.zh-CHS.resx
@@ -221,8 +221,7 @@
     <value>212, 22</value>
   </data>
   <data name="relativeAbundanceFormattingMenuItem.Text" xml:space="preserve">
-    <value>Formatting...</value>
-    <comment>Needs Review:New resource</comment>
+    <value>格式化...</value>
   </data>
   <data name="transformChromContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>212, 22</value>

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.ja.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.ja.resx
@@ -1104,28 +1104,23 @@
     <value>S-レンズ</value>
   </data>
   <data name="HardklorSettings_Charges" xml:space="preserve">
-    <value>Charges</value>
-    <comment>Needs Review:New resource</comment>
+    <value>電荷</value>
   </data>
   <data name="HardklorSettings_MinIntensityPPM" xml:space="preserve">
     <value>Min intensity PPM</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSettings_MinIdotP" xml:space="preserve">
-    <value>Min idotp</value>
-    <comment>Needs Review:New resource</comment>
+    <value>最小同位体内積</value>
   </data>
   <data name="HardklorSettings_Instrument" xml:space="preserve">
-    <value>Instrument</value>
-    <comment>Needs Review:New resource</comment>
+    <value>装置</value>
   </data>
   <data name="HardklorSettings_Resolution" xml:space="preserve">
-    <value>Resolution</value>
-    <comment>Needs Review:New resource</comment>
+    <value>分解能</value>
   </data>
   <data name="HardklorSettings_SignalToNoise" xml:space="preserve">
-    <value>Signal to noise</value>
-    <comment>Needs Review:New resource</comment>
+    <value>信号対ノイズ比</value>
   </data>
   <data name="ImportFastaSettings_AutoTrain" xml:space="preserve">
     <value>mProphetのモデルを自動的にトレーニングする</value>
@@ -1800,19 +1795,16 @@
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RelativeAbundanceFormatting_ColorRows" xml:space="preserve">
-    <value>Formatting rows</value>
-    <comment>Needs Review:New resource</comment>
+    <value>フォーマット行</value>
   </data>
   <data name="CutoffScore_PERCOLATOR_QVALUE" xml:space="preserve">
     <value>Max q-value</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DdaSearchSettings_ScoreThreshold" xml:space="preserve">
-    <value>Score threshold</value>
-    <comment>Needs Review:New resource</comment>
+    <value>スコアの閾値</value>
   </data>
   <data name="DdaSearchSettings_ScoreType" xml:space="preserve">
-    <value>Score type</value>
-    <comment>Needs Review:New resource</comment>
+    <value>スコアタイプ</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.zh-CHS.resx
@@ -1104,28 +1104,23 @@
     <value>S-Lens</value>
   </data>
   <data name="HardklorSettings_Charges" xml:space="preserve">
-    <value>Charges</value>
-    <comment>Needs Review:New resource</comment>
+    <value>电荷</value>
   </data>
   <data name="HardklorSettings_MinIntensityPPM" xml:space="preserve">
     <value>Min intensity PPM</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSettings_MinIdotP" xml:space="preserve">
-    <value>Min idotp</value>
-    <comment>Needs Review:New resource</comment>
+    <value>最小同位素点积</value>
   </data>
   <data name="HardklorSettings_Instrument" xml:space="preserve">
-    <value>Instrument</value>
-    <comment>Needs Review:New resource</comment>
+    <value>仪器</value>
   </data>
   <data name="HardklorSettings_Resolution" xml:space="preserve">
-    <value>Resolution</value>
-    <comment>Needs Review:New resource</comment>
+    <value>分辨率</value>
   </data>
   <data name="HardklorSettings_SignalToNoise" xml:space="preserve">
-    <value>Signal to noise</value>
-    <comment>Needs Review:New resource</comment>
+    <value>噪声信号</value>
   </data>
   <data name="ImportFastaSettings_AutoTrain" xml:space="preserve">
     <value>自动训练 mProphet 模型</value>
@@ -1800,19 +1795,16 @@
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RelativeAbundanceFormatting_ColorRows" xml:space="preserve">
-    <value>Formatting rows</value>
-    <comment>Needs Review:New resource</comment>
+    <value>格式化行</value>
   </data>
   <data name="CutoffScore_PERCOLATOR_QVALUE" xml:space="preserve">
     <value>Max q-value</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DdaSearchSettings_ScoreThreshold" xml:space="preserve">
-    <value>Score threshold</value>
-    <comment>Needs Review:New resource</comment>
+    <value>得分阈值</value>
   </data>
   <data name="DdaSearchSettings_ScoreType" xml:space="preserve">
-    <value>Score type</value>
-    <comment>Needs Review:New resource</comment>
+    <value>得分类型</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.ja.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.ja.resx
@@ -721,8 +721,7 @@
     <value>ピーク面積の中央値</value>
   </data>
   <data name="Message">
-    <value>Message</value>
-    <comment>Needs Review:New resource</comment>
+    <value>メッセージ</value>
   </data>
   <data name="Min">
     <value>最小</value>

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.zh-CHS.resx
@@ -721,8 +721,7 @@
     <value>中位数峰面积</value>
   </data>
   <data name="Message">
-    <value>Message</value>
-    <comment>Needs Review:New resource</comment>
+    <value>消息</value>
   </data>
   <data name="Min">
     <value>最小</value>

--- a/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.ja.resx
+++ b/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.ja.resx
@@ -160,8 +160,7 @@
     <value>ライブラリ内にあるこのペプチドに対して測定されたスペクトルの数</value>
   </data>
   <data name="Adduct" xml:space="preserve">
-    <value>Adduct</value>
-    <comment>Needs Review:New resource</comment>
+    <value>付加物</value>
   </data>
   <data name="FileName" xml:space="preserve">
     <value>ファイル名</value>

--- a/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.zh-CHS.resx
@@ -160,8 +160,7 @@
     <value>谱图库中该肽段的测量谱图数量</value>
   </data>
   <data name="Adduct" xml:space="preserve">
-    <value>Adduct</value>
-    <comment>Needs Review:New resource</comment>
+    <value>加合物</value>
   </data>
   <data name="FileName" xml:space="preserve">
     <value>文件名</value>
@@ -170,8 +169,7 @@
     <value>文件路径</value>
   </data>
   <data name="Formula" xml:space="preserve">
-    <value>Formula</value>
-    <comment>Needs Review:New resource</comment>
+    <value>公式</value>
   </data>
   <data name="IdFileName" xml:space="preserve">
     <value>Id 文件名</value>

--- a/pwiz_tools/Skyline/Skyline.ja.resx
+++ b/pwiz_tools/Skyline/Skyline.ja.resx
@@ -427,15 +427,13 @@ Old Localized:Show Mass Error</comment>
     <value>193, 22</value>
   </data>
   <data name="showLibSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
-    <value>Spectrum Properties</value>
-    <comment>Needs Review:New resource</comment>
+    <value>スペクトルプロパティ</value>
   </data>
   <data name="showFullScanSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
   </data>
   <data name="showFullScanSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
-    <value>Spectrum Properties</value>
-    <comment>Needs Review:New resource</comment>
+    <value>スペクトルプロパティ</value>
   </data>
   <data name="toolStripSeparator15.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 6</value>
@@ -898,8 +896,7 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="abundanceTargetsMenuItem.Text" xml:space="preserve">
-    <value>Targets</value>
-    <comment>Needs Review:New resource</comment>
+    <value>ターゲット</value>
   </data>
   <data name="excludeTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 22</value>
@@ -1065,15 +1062,13 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="abundanceTargetsProteinsMenuItem.Text" xml:space="preserve">
-    <value>Proteins</value>
-    <comment>Needs Review:New resource</comment>
+    <value>タンパク質</value>
   </data>
   <data name="abundanceTargetsPeptidesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 22</value>
   </data>
   <data name="abundanceTargetsPeptidesMenuItem.Text" xml:space="preserve">
-    <value>Peptides</value>
-    <comment>Needs Review:New resource</comment>
+    <value>ペプチド</value>
   </data>
   <data name="excludeTargetsPeptideListMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 22</value>
@@ -1086,8 +1081,7 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="excludeTargetsStandardsMenuItem.Text" xml:space="preserve">
-    <value>Standards</value>
-    <comment>Needs Review:New resource</comment>
+    <value>標準</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="dockPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">

--- a/pwiz_tools/Skyline/Skyline.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Skyline.zh-CHS.resx
@@ -427,15 +427,13 @@ Old Localized:Show Mass Error</comment>
     <value>193, 22</value>
   </data>
   <data name="showLibSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
-    <value>Spectrum Properties</value>
-    <comment>Needs Review:New resource</comment>
+    <value>谱图属性</value>
   </data>
   <data name="showFullScanSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
   </data>
   <data name="showFullScanSpectrumPropertiesContextMenuItem.Text" xml:space="preserve">
-    <value>Spectrum Properties</value>
-    <comment>Needs Review:New resource</comment>
+    <value>谱图属性</value>
   </data>
   <data name="toolStripSeparator15.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 6</value>
@@ -898,8 +896,7 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="abundanceTargetsMenuItem.Text" xml:space="preserve">
-    <value>Targets</value>
-    <comment>Needs Review:New resource</comment>
+    <value>目标</value>
   </data>
   <data name="excludeTargetsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 22</value>
@@ -1065,15 +1062,13 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="abundanceTargetsProteinsMenuItem.Text" xml:space="preserve">
-    <value>Proteins</value>
-    <comment>Needs Review:New resource</comment>
+    <value>蛋白质</value>
   </data>
   <data name="abundanceTargetsPeptidesMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 22</value>
   </data>
   <data name="abundanceTargetsPeptidesMenuItem.Text" xml:space="preserve">
-    <value>Peptides</value>
-    <comment>Needs Review:New resource</comment>
+    <value>肽段</value>
   </data>
   <data name="excludeTargetsPeptideListMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 22</value>
@@ -1086,8 +1081,7 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="excludeTargetsStandardsMenuItem.Text" xml:space="preserve">
-    <value>Standards</value>
-    <comment>Needs Review:New resource</comment>
+    <value>标准</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="dockPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">

--- a/pwiz_tools/Skyline/SkylineResources.ja.resx
+++ b/pwiz_tools/Skyline/SkylineResources.ja.resx
@@ -612,7 +612,6 @@
   </data>
   <data name="SkylineWindow_Add" xml:space="preserve">
     <value>追加</value>
-    <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_AddMolecule_Add_custom_product_ion__0_" xml:space="preserve">
     <value>カスタムプロダクトイオン{0}を追加</value>

--- a/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
@@ -612,7 +612,6 @@
   </data>
   <data name="SkylineWindow_Add" xml:space="preserve">
     <value>添加</value>
-    <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_AddMolecule_Add_custom_product_ion__0_" xml:space="preserve">
     <value>添加自定义子离子 {0}</value>


### PR DESCRIPTION
There were a few terms that have been translated in more than one way into Japanese, and those ambiguous translation are not included in this pull request.

| English | Translation A | Translation B |
|--|--|--|
Formula|分子式|式
Down|下|下へ
Description|表記|説明

There were no ambiguous translations in Chinese.
So, there are 32 Chinese changes and 29 Japanese changes.