### PR TITLE
Reduce memory usage when outputting reports

### DIFF
--- a/pwiz_tools/Shared/Common/Common.csproj
+++ b/pwiz_tools/Shared/Common/Common.csproj
@@ -299,6 +299,7 @@
     <Compile Include="DataBinding\Filtering\FilterPage.cs" />
     <Compile Include="DataBinding\Filtering\FilterPages.cs" />
     <Compile Include="DataBinding\Filtering\IFilterAutoComplete.cs" />
+    <Compile Include="DataBinding\RowItemEnumerator.cs" />
     <Compile Include="DataBinding\TabularFileFormat.cs" />
     <Compile Include="DataBinding\DataSchema.cs" />
     <Compile Include="DataBinding\DisplayColumn.cs" />

--- a/pwiz_tools/Shared/Common/DataBinding/RowItemEnumerator.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/RowItemEnumerator.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2024 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using pwiz.Common.DataBinding.Controls;
+
+namespace pwiz.Common.DataBinding
+{
+    /// <summary>
+    /// Single-use enumerator throw a list of RowItem objects.
+    /// Nulls out items in its array after they have been returned so that they can be garbage collected.
+    /// </summary>
+    public class RowItemEnumerator : IEnumerator<RowItem>
+    {
+        private RowItem[] _rowItems;
+        private RowItem _current;
+        private int _index;
+        public RowItemEnumerator(IEnumerable<RowItem> rowItems, ItemProperties itemProperties,
+            ColumnFormats columnFormats)
+        {
+            _rowItems = rowItems.ToArray();
+            ItemProperties = itemProperties;
+            ColumnFormats = columnFormats;
+        }
+
+        public static RowItemEnumerator FromBindingListSource(BindingListSource source)
+        {
+            return new RowItemEnumerator(source.Cast<RowItem>(), source.ItemProperties, source.ColumnFormats);
+        }
+
+        public int Count
+        {
+            get { return _rowItems.Length; }
+        }
+
+        public ItemProperties ItemProperties { get; }
+        public ColumnFormats ColumnFormats { get; }
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        void IEnumerator.Reset()
+        {
+            throw new InvalidOperationException();
+        }
+
+        public bool MoveNext()
+        {
+            if (_index >= _rowItems.Length)
+            {
+                return false;
+            }
+
+            _current = _rowItems[_index];
+            _rowItems[_index] = null;
+            _index++;
+            return true;
+        }
+
+        object IEnumerator.Current => Current;
+
+        public RowItem Current
+        {
+            get
+            {
+                return _current;
+            }
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Controls/Databinding/SkylineViewContext.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/SkylineViewContext.cs
@@ -369,6 +369,8 @@ namespace pwiz.Skyline.Controls.Databinding
             progressMonitor.UpdateProgress(status = status.ChangePercentComplete(5)
                 .ChangeMessage(DatabindingResources.ExportReportDlg_ExportReport_Writing_report));
             WriteDataWithStatus(progressMonitor, ref status, writer, rowItemEnumerator, separator);
+            if (progressMonitor.IsCanceled)
+                return false;
             writer.Flush();
             progressMonitor.UpdateProgress(status = status.Complete());
             return true;

--- a/pwiz_tools/Skyline/Controls/Databinding/SkylineViewContext.cs
+++ b/pwiz_tools/Skyline/Controls/Databinding/SkylineViewContext.cs
@@ -351,6 +351,10 @@ namespace pwiz.Skyline.Controls.Databinding
         public bool Export(CancellationToken cancellationToken, IProgressMonitor progressMonitor, ref IProgressStatus status, ViewInfo viewInfo, ViewLayout viewLayout, TextWriter writer, char separator)
         {
             progressMonitor ??= new SilentProgressMonitor(cancellationToken);
+            RowItem[] rowItems;
+            DsvWriter dsvWriter;
+            IList<PropertyDescriptor> itemProperties;
+            int rowCount;
             using (var bindingListSource = new BindingListSource(cancellationToken))
             {
                 bindingListSource.SetViewContext(this, viewInfo);
@@ -361,18 +365,31 @@ namespace pwiz.Skyline.Controls.Databinding
                         bindingListSource.ColumnFormats.SetFormat(column.Item1, column.Item2);
                     }
                 }
+
+                itemProperties = bindingListSource.GetItemProperties(null).Cast<PropertyDescriptor>().ToList();
+                rowCount = bindingListSource.Count;
+                rowItems = bindingListSource.Cast<RowItem>().ToArray();
+                dsvWriter = CreateDsvWriter(separator, bindingListSource.ColumnFormats);
                 progressMonitor.UpdateProgress(status = status.ChangePercentComplete(5)
                     .ChangeMessage(DatabindingResources.ExportReportDlg_ExportReport_Writing_report));
-
-                WriteDataWithStatus( progressMonitor, ref status, writer, bindingListSource, separator);
-                if (progressMonitor.IsCanceled)
-                    return false;
-
-                writer.Flush();
-                progressMonitor.UpdateProgress(status = status.Complete());
             }
+
+            using var rowItemEnumerator = NullingEnumerator(rowItems);
+            WriteRowItems(progressMonitor, ref status, writer, dsvWriter, itemProperties, rowCount, rowItemEnumerator);
+            writer.Flush();
+            progressMonitor.UpdateProgress(status = status.Complete());
             return true;
         }
+
+        private static IEnumerator<T> NullingEnumerator<T>(T[] array)
+        {
+            for (int index = 0; index < array.Length; index++)
+            {
+                yield return array[index];
+                array[index] = default;
+            }
+        }
+
 
         protected override bool SafeWriteToFile(Control owner, string fileName, Func<Stream, bool> writeFunc)
         {


### PR DESCRIPTION
Fixed Skyline uses too much memory outputting report with "Normalized Area" column when document has Peptide Quantification regression method set to something other than "None" (reported by Genn)

This change allows the "RowItem" objects that contain the objects in the report to be garbage collected right after they are written. This enables the "CalibrationCurveFitter" held onto by "pwiz.Skyline.Model.Databinding.Entities.Peptide" to be collected.