### PR TITLE
Skyline: Fix window widths for Agilent method/list export

### DIFF
--- a/pwiz_tools/Skyline/Model/Export.cs
+++ b/pwiz_tools/Skyline/Model/Export.cs
@@ -3214,7 +3214,7 @@ namespace pwiz.Skyline.Model
 
             return predictedRT.HasValue
                 ? (RetentionTimeRegression.GetRetentionTimeDisplay(predictedRT) ?? 0).ToString(c.parent.CultureInfo) +
-                  c.parent.FieldSeparator + Math.Round(windowRT/2, 1).ToString(c.parent.CultureInfo)
+                  c.parent.FieldSeparator + Math.Round(windowRT, 1).ToString(c.parent.CultureInfo)
                 : c.parent.FieldSeparator.ToString();
         });
         public TransitionField FRAGMENTOR_FIELD = new TransitionField(c => c.parent.Fragmentor.ToString(c.parent.CultureInfo));
@@ -3544,7 +3544,7 @@ namespace pwiz.Skyline.Model
                 {
                     predictedRT = Math.Max(predictedRT.Value, windowRT.Window/2 + AGILENT_MIN_START_ACQUISITION_TIME);
                     retentionTime = (RetentionTimeRegression.GetRetentionTimeDisplay(predictedRT) ?? 0).ToString(CultureInfo);  // Ret. Time (min)
-                    deltaRetentionTime = Math.Round(windowRT.Window/2, 1).ToString(CultureInfo); // Delta Ret. Time (min)
+                    deltaRetentionTime = Math.Round(windowRT, 1).ToString(CultureInfo); // Delta Ret. Time (min)
                 }
             }
             string isolationWidth = string.Format(CultureInfo, @"Narrow (~{0:0.0} m/z)", 1.3);

--- a/pwiz_tools/Skyline/TestFunctional/ExportIsolationListTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExportIsolationListTest.cs
@@ -165,8 +165,8 @@ namespace pwiz.SkylineTestFunctional
                 "AgilentScheduledDda.csv", 
                 ExportInstrumentType.AGILENT_TOF, FullScanAcquisitionMethod.None, ExportMethodType.Scheduled,
                 AgilentIsolationListExporter.GetDdaHeader(_fieldSeparator),
-                FieldSeparate("True", mzFirst, 20, zFirst, "Preferred", t46, halfWin, isolationWidth, ceFirst),
-                FieldSeparate("True", mzLast, 20, zLast, "Preferred", t39, halfWin, isolationWidth, ceLast));
+                FieldSeparate("True", mzFirst, 20, zFirst, "Preferred", t46, 2*halfWin, isolationWidth, ceFirst),
+                FieldSeparate("True", mzLast, 20, zLast, "Preferred", t39, 2*halfWin, isolationWidth, ceLast));
 
             // Export Thermo unscheduled DDA list.
             const double nce = ThermoQExactiveIsolationListExporter.NARROW_NCE;
@@ -214,8 +214,8 @@ namespace pwiz.SkylineTestFunctional
                 "AgilentScheduledTargeted.csv", 
                 ExportInstrumentType.AGILENT_TOF, FullScanAcquisitionMethod.Targeted, ExportMethodType.Scheduled,
                 AgilentIsolationListExporter.GetTargetedHeader(_fieldSeparator),
-                FieldSeparate("True", mzFirst, zFirst, t46, halfWin, isolationWidth, ceFirst, string.Empty),
-                FieldSeparate("True", mzLast, zLast, t39, halfWin, isolationWidth, ceLast, string.Empty));
+                FieldSeparate("True", mzFirst, zFirst, t46, 2*halfWin, isolationWidth, ceFirst, string.Empty),
+                FieldSeparate("True", mzLast, zLast, t39, 2*halfWin, isolationWidth, ceLast, string.Empty));
 
             // Export Thermo unscheduled Targeted list.
             ExportIsolationList(
@@ -482,9 +482,10 @@ namespace pwiz.SkylineTestFunctional
                     dlg.OkDialog();
                 });
             // Set RT predictor to produce negative times
+            const float regressionWindow = 1.4f;
             var rtRegression = new RetentionTimeRegression("NegativeRt",
                 new RetentionScoreCalculator(RetentionTimeRegression.SSRCALC_100_A), 
-                .45, -7.8, 1.4, new MeasuredRetentionTime[0]);
+                .45, -7.8, regressionWindow, new MeasuredRetentionTime[0]);
             RunUI(() =>
             {
                 SkylineWindow.ModifyDocument("Set RT prediction with negative RTs", doc =>
@@ -530,22 +531,25 @@ namespace pwiz.SkylineTestFunctional
                 {
                     Assert.IsTrue(float.TryParse(resReader.GetFieldByName("RT Window (min)"),
                         NumberStyles.Float | NumberStyles.AllowThousands, _cultureInfo, out var rtWindow));
+                    Assert.AreEqual(regressionWindow, rtWindow);
                     Assert.IsTrue(float.TryParse(resReader.GetFieldByName("RT (min)"),
                         NumberStyles.Float | NumberStyles.AllowThousands, _cultureInfo, out var rtPredicted));
                     var pepSequence = resReader.GetFieldByName("Compound Name");
+                    float halfWindow = rtWindow / 2;
+                    float minPredictedTime = halfWindow + AgilentMassListExporter.AGILENT_MIN_START_ACQUISITION_TIME;
                     if (pepSequence == "YIC[+57.021464]DNQDTISSK.light" || pepSequence == "IKNLQSLDPSH.light")
                     {
                         // These two peptides are known to have predicted retention times less than rtWindow
-                        Assert.AreEqual(rtPredicted, rtWindow + AgilentMassListExporter.AGILENT_MIN_START_ACQUISITION_TIME,
-                            "Peptide {0} retention time {1} should be equal to RT Window {2} plus minimum {3}",
-                            pepSequence, rtPredicted, rtWindow, AgilentMassListExporter.AGILENT_MIN_START_ACQUISITION_TIME);
+                        Assert.AreEqual(rtPredicted, minPredictedTime,
+                            "Peptide {0} retention time {1} should be equal to half-RT Window {2} plus minimum {3}",
+                            pepSequence, rtPredicted, halfWindow, AgilentMassListExporter.AGILENT_MIN_START_ACQUISITION_TIME);
                     }
                     else
                     {
                         // All other peptides should have a predicted retention time that is greater than rtWindow
-                        Assert.IsTrue(rtPredicted >= rtWindow + AgilentMassListExporter.AGILENT_MIN_START_ACQUISITION_TIME,
-                            "Peptide {0} retention time {1} should be greater than or equal to RT Window {2} plus minimum {3}",
-                            pepSequence, rtPredicted, rtWindow, AgilentMassListExporter.AGILENT_MIN_START_ACQUISITION_TIME);
+                        Assert.IsTrue(rtPredicted >= minPredictedTime,
+                            "Peptide {0} retention time {1} should be greater than or equal to half-RT Window {2} plus minimum {3}",
+                            pepSequence, rtPredicted, halfWindow, AgilentMassListExporter.AGILENT_MIN_START_ACQUISITION_TIME);
                     }
                 }
             }


### PR DESCRIPTION
- Agilent reported that halving the window width was a mistake
- This PR puts the window width back to the way it was before the negative predicted RT fix