### PR TITLE
- fixed search errors from Search control to be more specific

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.cs
@@ -98,7 +98,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
             if (status.IsError)
             {
-                MessageDlg.ShowWithException(Program.MainWindow, Resources.CommandLineTest_ConsoleAddFastaTest_Error, status.ErrorException);
+                MessageDlg.ShowWithException(Program.MainWindow, status.ErrorException.Message, status.ErrorException);
                 return;
             }
 

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.cs
@@ -25,7 +25,6 @@ using pwiz.Common.Collections;
 using pwiz.Common.Controls;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Alerts;
-using pwiz.Skyline.Properties;
 
 namespace pwiz.Skyline.FileUI.PeptideSearch
 {

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -21,6 +21,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Chemistry;
 using pwiz.Skyline.Alerts;
@@ -45,8 +47,9 @@ namespace pwiz.SkylineTestFunctional
     [TestClass]
     public class DdaSearchTest : AbstractFunctionalTest
     {
-        public struct ExpectedResults
+        public class ExpectedResults
         {
+            public Exception expectedException;
             public int proteinCount;
             public int peptideCount;
             public int precursorCount;
@@ -61,9 +64,14 @@ namespace pwiz.SkylineTestFunctional
                 this.transitionCount = transitionCount;
                 this.unmappedOrRemovedCount = unmappedOrRemovedCount;
             }
+
+            public ExpectedResults(Exception expected)
+            {
+                expectedException = expected;
+            }
         }
 
-        public struct DdaTestSettings
+        public class DdaTestSettings
         {
             private SearchSettingsControl.SearchEngine _searchEngine;
             public SearchSettingsControl.SearchEngine SearchEngine
@@ -76,6 +84,7 @@ namespace pwiz.SkylineTestFunctional
                 }
             }
 
+            public string FastaFilename { get; set; } = "rpal-subset.fasta";
             public string FragmentIons { get; set; }
             public string Ms2Analyzer { get; set; }
             public MzTolerance PrecursorTolerance { get; set; }
@@ -173,6 +182,36 @@ namespace pwiz.SkylineTestFunctional
             Assert.IsFalse(IsRecordMode);
         }
 
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoUnicodeTesting(TestExclusionReason.MSFRAGGER_UNICODE_ISSUES)]
+        public void TestDdaSearchMsFraggerBadFasta()
+        {
+            TestFilesZip = @"TestFunctional\DdaSearchTest.zip";
+
+            if (RedownloadTools)
+                foreach (var requiredFile in MsFraggerSearchEngine.FilesToDownload)
+                    if (requiredFile.Unzip)
+                        DirectoryEx.SafeDelete(requiredFile.InstallPath);
+                    else
+                        FileEx.SafeDelete(Path.Combine(requiredFile.InstallPath, requiredFile.Filename));
+
+            TestSettings = new DdaTestSettings
+            {
+                SearchEngine = SearchSettingsControl.SearchEngine.MSFragger,
+                FragmentIons = "b,y",
+                Ms2Analyzer = "Default",
+                PrecursorTolerance = new MzTolerance(50, MzTolerance.Units.ppm),
+                FragmentTolerance = new MzTolerance(50, MzTolerance.Units.ppm),
+                AdditionalSettings = new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>("check_spectral_files", "0")
+                },
+                ExpectedResultsFinal = new ExpectedResults(new FileNotFoundException())
+            };
+
+            RunFunctionalTest();
+            Assert.IsFalse(IsRecordMode);
+        }
+
         public bool IsRecordMode => false;
         private bool RedownloadTools => !IsRecordMode && IsPass0;
 
@@ -221,8 +260,6 @@ namespace pwiz.SkylineTestFunctional
             var importPeptideSearchDlg = ShowDialog<ImportPeptideSearchDlg>(SkylineWindow.ShowRunPeptideSearchDlg);
 
             // We're on the "Build Spectral Library" page of the wizard.
-            // Add the test xml file to the search files list and try to 
-            // build the document library.
 
             // We're on the "Match Modifications" page. Add M+16 mod.
             RunUI(() =>
@@ -242,58 +279,62 @@ namespace pwiz.SkylineTestFunctional
                 Assert.IsTrue(importPeptideSearchDlg.CurrentPage == ImportPeptideSearchDlg.Pages.match_modifications_page);
             });
 
-            // In PerformDDASearch mode, ClickAddStructuralModification launches edit list dialog
-            var editListUI =
-                ShowDialog<EditListDlg<SettingsListBase<StaticMod>, StaticMod>>(importPeptideSearchDlg.MatchModificationsControl.ClickAddStructuralModification);
-            RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
-            {
-                editModDlg.SetModification("Oxidation (M)"); // Not L10N
-                editModDlg.OkDialog();
-            });
+            bool errorExpected = TestSettings.ExpectedResultsFinal.expectedException != null;
 
-            // Test a non-Unimod mod that won't affect the search
-            RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
+            if (!errorExpected)
             {
-                editModDlg.Modification = new StaticMod("NotUniModMod (U)", "U", null, "C3P1O1", LabelAtoms.None, null, null);
-                editModDlg.OkDialog();
-            });
+                // In PerformDDASearch mode, ClickAddStructuralModification launches edit list dialog
+                var editListUI =
+                    ShowDialog<EditListDlg<SettingsListBase<StaticMod>, StaticMod>>(importPeptideSearchDlg.MatchModificationsControl.ClickAddStructuralModification);
+                RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
+                {
+                    editModDlg.SetModification("Oxidation (M)"); // Not L10N
+                    editModDlg.OkDialog();
+                });
 
-            // Test a N terminal mod with no AA
-            RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
-            {
-                editModDlg.Modification = new StaticMod("NotUniModMod (N-term)", null, ModTerminus.N, "C42", LabelAtoms.None, null, null);
-                editModDlg.Modification = editModDlg.Modification.ChangeVariable(true);
-                editModDlg.OkDialog();
-            });
+                // Test a non-Unimod mod that won't affect the search
+                RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
+                {
+                    editModDlg.Modification = new StaticMod("NotUniModMod (U)", "U", null, "C3P1O1", LabelAtoms.None, null, null);
+                    editModDlg.OkDialog();
+                });
 
-            // Test a C terminal mod with no AA and one with AA - commented out because it changes results a bit to include it
-            /*RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
-            {
-                editModDlg.Modification = new StaticMod("NotUniModMod (C-term)", null, ModTerminus.C, null, LabelAtoms.None, 0.01, 0.01);
-                editModDlg.Modification = editModDlg.Modification.ChangeVariable(true);
-                editModDlg.OkDialog();
-            }); 
-            RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
-            {
-                editModDlg.Modification = new StaticMod("NotUniModMod4 (C-term)", "K,R", null, null, LabelAtoms.None, -1.01, -1.01);
-                editModDlg.OkDialog();
-            });*/
-            OkDialog(editListUI, editListUI.OkDialog);
+                // Test a N terminal mod with no AA
+                RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
+                {
+                    editModDlg.Modification = new StaticMod("NotUniModMod (N-term)", null, ModTerminus.N, "C42", LabelAtoms.None, null, null);
+                    editModDlg.Modification = editModDlg.Modification.ChangeVariable(true);
+                    editModDlg.OkDialog();
+                });
 
-            // Test back/next buttons
-            RunUI(() =>
-            {
-                Assert.IsTrue(importPeptideSearchDlg.ClickBackButton());
-                Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
+                // Test a C terminal mod with no AA and one with AA - commented out because it changes results a bit to include it
+                /*RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
+                {
+                    editModDlg.Modification = new StaticMod("NotUniModMod (C-term)", null, ModTerminus.C, null, LabelAtoms.None, 0.01, 0.01);
+                    editModDlg.Modification = editModDlg.Modification.ChangeVariable(true);
+                    editModDlg.OkDialog();
+                }); 
+                RunDlg<EditStaticModDlg>(editListUI.AddItem, editModDlg =>
+                {
+                    editModDlg.Modification = new StaticMod("NotUniModMod4 (C-term)", "K,R", null, null, LabelAtoms.None, -1.01, -1.01);
+                    editModDlg.OkDialog();
+                });*/
+                OkDialog(editListUI, editListUI.OkDialog);
 
-                Assert.IsTrue(importPeptideSearchDlg.CurrentPage == ImportPeptideSearchDlg.Pages.match_modifications_page);
+                // Test back/next buttons
+                RunUI(() =>
+                {
+                    Assert.IsTrue(importPeptideSearchDlg.ClickBackButton());
+                    Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
 
-                Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
-            });
+                    Assert.IsTrue(importPeptideSearchDlg.CurrentPage == ImportPeptideSearchDlg.Pages.match_modifications_page);
+                });
+            }
 
             // We're on the MS1 full scan settings page.
             RunUI(() =>
             {
+                Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
                 Assert.IsTrue(importPeptideSearchDlg.CurrentPage == ImportPeptideSearchDlg.Pages.full_scan_settings_page);
                 importPeptideSearchDlg.FullScanSettingsControl.PrecursorCharges = new[] { 2, 3 };
                 Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
@@ -304,7 +345,7 @@ namespace pwiz.SkylineTestFunctional
             {
                 Assert.IsTrue(importPeptideSearchDlg.CurrentPage == ImportPeptideSearchDlg.Pages.import_fasta_page);
                 Assert.IsFalse(importPeptideSearchDlg.ImportFastaControl.DecoyGenerationEnabled);
-                importPeptideSearchDlg.ImportFastaControl.SetFastaContent(GetTestPath("rpal-subset.fasta"));
+                importPeptideSearchDlg.ImportFastaControl.SetFastaContent(GetTestPath(TestSettings.FastaFilename));
                 Assert.IsTrue(importPeptideSearchDlg.ClickNextButton());
             });
 
@@ -342,6 +383,10 @@ namespace pwiz.SkylineTestFunctional
                 }
             }
 
+            // delete the FASTA to cause the error
+            if (errorExpected)
+                File.Delete(GetTestPath(TestSettings.FastaFilename));
+
             RunUI(() =>
             {
                 foreach (var setting in TestSettings.AdditionalSettings)
@@ -364,6 +409,17 @@ namespace pwiz.SkylineTestFunctional
                 // Cancel search
                 importPeptideSearchDlg.SearchControl.Cancel();
             });
+
+            if (errorExpected)
+            {
+                var fastaFileNotFoundDlg = WaitForOpenForm<MessageDlg>();
+                var expectedMsg = new FileNotFoundException(GetSystemResourceString("IO.FileNotFound_FileName", GetTestPath(TestSettings.FastaFilename))).Message;
+                Assert.AreEqual(expectedMsg, fastaFileNotFoundDlg.Message);
+                OkDialog(fastaFileNotFoundDlg, fastaFileNotFoundDlg.ClickOk);
+                WaitForConditionUI(60000, () => searchSucceeded.HasValue);
+                OkDialog(importPeptideSearchDlg, importPeptideSearchDlg.ClickCancelButton);
+                return;
+            }
 
             WaitForConditionUI(60000, () => searchSucceeded.HasValue);
             Assert.IsFalse(searchSucceeded.Value);

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -21,8 +21,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.Chemistry;
 using pwiz.Skyline.Alerts;

--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTestEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTestEx.cs
@@ -17,9 +17,11 @@
  * limitations under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Resources;
 using System.Text;
 using System.Xml.Serialization;
 using System.Xml;
@@ -31,6 +33,8 @@ using pwiz.Skyline.Model.AuditLog;
 using pwiz.Skyline.Model.Koina.Config;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Util.Extensions;
+using System.Globalization;
+using System.Reflection;
 
 
 namespace pwiz.SkylineTestUtil
@@ -199,5 +203,25 @@ namespace pwiz.SkylineTestUtil
         {
             return !string.IsNullOrEmpty(KoinaConfig.GetKoinaConfig().Server);
         }
+
+        /// <summary>
+        /// Get a system resource string. Useful when checking that a test throws an expected error message but the text comes from the OS or .NET.
+        /// Use an ID from https://github.com/ng256/Tools/blob/main/MscorlibMessage.md
+        /// </summary>
+        /// <example>GetSystemResourceString("IO.FileNotFound_FileName", "SomeFilepath")</example>
+        public string GetSystemResourceString(string resourceId, params object[] args)
+        {
+            if (_systemResources == null)
+            {
+                var assembly = Assembly.GetAssembly(typeof(object));
+                var assemblyName = assembly.GetName().Name;
+                var manager = new ResourceManager(assemblyName, assembly);
+                _systemResources = manager.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
+            }
+
+            return string.Format(_systemResources.GetString(resourceId) ?? throw new ArgumentException(nameof(resourceId)), args);
+        }
+
+        private static ResourceSet _systemResources;
     }
 }

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -1795,6 +1796,9 @@ namespace pwiz.SkylineTestUtil
             return result.ToString();
         }
 
+        // could get more codes from https://github.com/joshudson/Emet/blob/master/FileSystems/IOErrors.cs
+        private const int ERROR_SHARING_VIOLATION = unchecked((int)0x80070020);
+
         private void WaitForSkyline()
         {
             try
@@ -1820,6 +1824,27 @@ namespace pwiz.SkylineTestUtil
             }
             catch (Exception x)
             {
+                // if it's a file locking issue, wrap the exception to report the locking process
+                if (x is IOException ioException && ioException.HResult == ERROR_SHARING_VIOLATION)
+                {
+                    var match = Regex.Match(ioException.Message, "'(.*)'");
+                    if (match.Success)
+                    {
+                        string lockedFilepath = match.Captures[0].Value.Trim('\'');
+                        if (!File.Exists(lockedFilepath))
+                        {
+                            x = new IOException(string.Format("file '{0}' was locked but has since been deleted", lockedFilepath), x);
+                        }
+                        else
+                        {
+                            int currentProcessId = Process.GetCurrentProcess().Id;
+                            Func<int, string> pidOrThisProcess = pid => pid == currentProcessId ? "this process" : $"PID: {pid}";
+                            var processesLockingFile = FileLockingProcessFinder.GetProcessesUsingFile(lockedFilepath);
+                            var names = string.Join(@", ", processesLockingFile.Select(p => $"{p.ProcessName} ({pidOrThisProcess(p.Id)})"));
+                            x = new IOException(string.Format("file '{0}' locked by: {1}", lockedFilepath, names), x);
+                        }
+                    }
+                }
                 // Save exception for reporting from main thread.
                 Program.AddTestException(x);
             }

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SQLite;
-using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using System.IO;
@@ -1837,7 +1836,7 @@ namespace pwiz.SkylineTestUtil
                         }
                         else
                         {
-                            int currentProcessId = Process.GetCurrentProcess().Id;
+                            int currentProcessId = System.Diagnostics.Process.GetCurrentProcess().Id;
                             Func<int, string> pidOrThisProcess = pid => pid == currentProcessId ? "this process" : $"PID: {pid}";
                             var processesLockingFile = FileLockingProcessFinder.GetProcessesUsingFile(lockedFilepath);
                             var names = string.Join(@", ", processesLockingFile.Select(p => $"{p.ProcessName} ({pidOrThisProcess(p.Id)})"));


### PR DESCRIPTION
- fixed search errors from Search control to be more specific (the main message from the Exception is put in the message box instead of just "Error")
* added TestDdaSearchMsFraggerBadFasta to check for specific error message
* added special handling for "process cannot access the file 'X' because it is being used by another process" in functional tests: now the locking process will be reported