### PR TITLE
Update localization files that we got back from translation

### DIFF
--- a/pwiz_tools/Shared/Common/Controls/MultiProgressControl.ja.resx
+++ b/pwiz_tools/Shared/Common/Controls/MultiProgressControl.ja.resx
@@ -138,7 +138,7 @@
     <value>True</value>
   </metadata>
   <data name="ProgressColumn.HeaderText" xml:space="preserve">
-    <value>Progress</value>
+    <value>進捗状況</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />

--- a/pwiz_tools/Shared/Common/Controls/MultiProgressControl.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/Controls/MultiProgressControl.zh-CHS.resx
@@ -138,7 +138,7 @@
     <value>True</value>
   </metadata>
   <data name="ProgressColumn.HeaderText" xml:space="preserve">
-    <value>Progress</value>
+    <value>进度</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.ja.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/ColumnListEditor.ja.resx
@@ -178,7 +178,7 @@
     <value>21, 20</value>
   </data>
   <data name="btnDown.Text" xml:space="preserve">
-    <value>Down</value>
+    <value>下へ</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="toolStrip1.Location" type="System.Drawing.Point, System.Drawing">

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ManageViewsForm.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ManageViewsForm.zh-CHS.resx
@@ -373,7 +373,7 @@
     <value>btnShare</value>
   </data>
   <data name="openViewEditorContextMenuItem.Text" xml:space="preserve">
-    <value>打开报告编辑器...</value>
+    <value>打开报告编辑器…</value>
   </data>
   <data name="&gt;&gt;btnShare.ZOrder" xml:space="preserve">
     <value>4</value>

--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ViewEditor.ja.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/ViewEditor.ja.resx
@@ -187,7 +187,7 @@
     <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>レポート名(&amp;N):</value>
+    <value>レポート名(&amp;N)：</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>

--- a/pwiz_tools/Shared/Common/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/Common/Properties/Resources.zh-CHS.resx
@@ -440,16 +440,16 @@
     <value>设置默认</value>
   </data>
   <data name="NavBar_UpdateGroupTotalDropdown_New_Pivot___" xml:space="preserve">
-    <value>新枢轴...</value>
+    <value>新枢轴…</value>
   </data>
   <data name="NavBar_UpdateGroupTotalDropdown_Remember_current_layout___" xml:space="preserve">
-    <value>记住当前布局...</value>
+    <value>记住当前布局…</value>
   </data>
   <data name="NavBar_UpdateGroupTotalDropdown_Manage_layouts___" xml:space="preserve">
-    <value>管理布局...</value>
+    <value>管理布局…</value>
   </data>
   <data name="NavBar_UpdateGroupTotalDropdown_Modify_Current_Pivot___" xml:space="preserve">
-    <value>修改当前枢轴...</value>
+    <value>修改当前枢轴…</value>
   </data>
   <data name="ManageLayoutsForm_UpdateUi_Manage_layouts_for__0_" xml:space="preserve">
     <value>管理 {0} 的布局</value>

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.ja.resx
@@ -118,14 +118,14 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Abort" xml:space="preserve">
-    <value>Abort</value>
+    <value>中断</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Cancel" xml:space="preserve">
     <value>キャンセル</value>
   </data>
   <data name="Ignore" xml:space="preserve">
-    <value>Ignore</value>
+    <value>無視</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="No" xml:space="preserve">

--- a/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/CommonResources/GeneralTerms.zh-CHS.resx
@@ -118,14 +118,14 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Abort" xml:space="preserve">
-    <value>Abort</value>
+    <value>终止</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Cancel" xml:space="preserve">
     <value>取消</value>
   </data>
   <data name="Ignore" xml:space="preserve">
-    <value>Ignore</value>
+    <value>忽略</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="No" xml:space="preserve">

--- a/pwiz_tools/Shared/CommonUtil/GUI/GuiMessages.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/GUI/GuiMessages.ja.resx
@@ -98,7 +98,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AbstractAlertDlg_Message_truncated" xml:space="preserve">
-    <value>Message truncated. Press Ctrl+C to copy entire message to the clipboard.</value>
+    <value>メッセージが途切れています。Ctrl+Cを押してメッセージ全体をクリップボードにコピーしてください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Shared/CommonUtil/GUI/GuiMessages.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/GUI/GuiMessages.zh-CHS.resx
@@ -98,7 +98,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AbstractAlertDlg_Message_truncated" xml:space="preserve">
-    <value>Message truncated. Press Ctrl+C to copy entire message to the clipboard.</value>
+    <value>消息被截短。按 Ctrl+C 将完整消息复制到剪贴板。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Shared/CommonUtil/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/CommonUtil/Properties/Resources.ja.resx
@@ -128,7 +128,7 @@
     <value>{0}バイトの読み込みに失敗しました。ソースが壊れている可能性があります。</value>
   </data>
   <data name="ProcessRunner_Run_Run_command_" xml:space="preserve">
-    <value>Run command:</value>
+    <value>実行コマンド：</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Shared/CommonUtil/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/CommonUtil/Properties/Resources.zh-CHS.resx
@@ -128,7 +128,7 @@
     <value>读取 {0} 字节失败。源可能已损坏。</value>
   </data>
   <data name="ProcessRunner_Run_Run_command_" xml:space="preserve">
-    <value>Run command:</value>
+    <value>运行命令：</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.ja.resx
@@ -242,7 +242,7 @@
     <value>28, 28</value>
   </data>
   <data name="forward.Text" xml:space="preserve">
-    <value>Forward</value>
+    <value>次へ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="up.Size" type="System.Drawing.Size, System.Drawing">
@@ -306,7 +306,7 @@
     <value>167, 22</value>
   </data>
   <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
-    <value>Copy link address</value>
+    <value>リンクのアドレスをコピー</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
@@ -334,7 +334,7 @@
     <value>0</value>
   </data>
   <data name="folderLabel.Text" xml:space="preserve">
-    <value>&amp;Remote folders:</value>
+    <value>リモートフォルダ(&amp;R)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
@@ -386,7 +386,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Panorama Folders</value>
+    <value>Panoramaフォルダ</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;back.Name" xml:space="preserve">

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.zh-CHS.resx
@@ -334,7 +334,7 @@
     <value>0</value>
   </data>
   <data name="folderLabel.Text" xml:space="preserve">
-    <value>远程文件夹(&amp;R):</value>
+    <value>远程文件夹(&amp;R)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaDirectoryPicker.zh-CHS.resx
@@ -242,7 +242,7 @@
     <value>28, 28</value>
   </data>
   <data name="forward.Text" xml:space="preserve">
-    <value>Forward</value>
+    <value>前进</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="up.Size" type="System.Drawing.Size, System.Drawing">
@@ -306,7 +306,7 @@
     <value>167, 22</value>
   </data>
   <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
-    <value>Copy link address</value>
+    <value>复制链接地址</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
@@ -334,7 +334,7 @@
     <value>0</value>
   </data>
   <data name="folderLabel.Text" xml:space="preserve">
-    <value>&amp;Remote folders:</value>
+    <value>远程文件夹(&amp;R):</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
@@ -386,7 +386,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Panorama Folders</value>
+    <value>Panorama 文件夹</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;back.Name" xml:space="preserve">

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.ja.resx
@@ -132,7 +132,7 @@
     <value>0</value>
   </data>
   <data name="folderLabel.Text" xml:space="preserve">
-    <value>&amp;Remote folders:</value>
+    <value>リモートフォルダ(&amp;R)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
@@ -262,7 +262,7 @@
     <value>すべて</value>
   </data>
   <data name="versionOptions.Items1" xml:space="preserve">
-    <value>Most recent</value>
+    <value>最近</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="versionOptions.Location" type="System.Drawing.Point, System.Drawing">
@@ -362,7 +362,7 @@
     <value>2</value>
   </data>
   <data name="versionLabel.Text" xml:space="preserve">
-    <value>&amp;Versions:</value>
+    <value>バージョン(&amp;V)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="versionLabel.Visible" type="System.Boolean, mscorlib">
@@ -420,7 +420,7 @@
     <value>1</value>
   </data>
   <data name="noFiles.Text" xml:space="preserve">
-    <value>There are no Skyline files in this folder</value>
+    <value>このフォルダにSkylineファイルはありません</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="noFiles.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
@@ -451,21 +451,21 @@
     <value>75</value>
   </data>
   <data name="colVersions.Text" xml:space="preserve">
-    <value>Versions</value>
+    <value>バージョン</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="colVersions.Width" type="System.Int32, mscorlib">
     <value>52</value>
   </data>
   <data name="colReplacedBy.Text" xml:space="preserve">
-    <value>Replaced By</value>
+    <value>次により置換</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="colReplacedBy.Width" type="System.Int32, mscorlib">
     <value>100</value>
   </data>
   <data name="colCreated.Text" xml:space="preserve">
-    <value>Created</value>
+    <value>作成しました</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -599,7 +599,7 @@
     <value>28, 28</value>
   </data>
   <data name="forward.Text" xml:space="preserve">
-    <value>Forward</value>
+    <value>次へ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="up.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -652,7 +652,7 @@
     <value>167, 22</value>
   </data>
   <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
-    <value>Copy link address</value>
+    <value>リンクのアドレスをコピー</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
@@ -731,7 +731,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Panorama Folders</value>
+    <value>Panoramaフォルダ</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;treeViewIcons.Name" xml:space="preserve">

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.zh-CHS.resx
@@ -132,7 +132,7 @@
     <value>0</value>
   </data>
   <data name="folderLabel.Text" xml:space="preserve">
-    <value>&amp;Remote folders:</value>
+    <value>远程文件夹(&amp;R):</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">
@@ -262,7 +262,7 @@
     <value>全部</value>
   </data>
   <data name="versionOptions.Items1" xml:space="preserve">
-    <value>Most recent</value>
+    <value>最近</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="versionOptions.Location" type="System.Drawing.Point, System.Drawing">
@@ -362,7 +362,7 @@
     <value>2</value>
   </data>
   <data name="versionLabel.Text" xml:space="preserve">
-    <value>&amp;Versions:</value>
+    <value>版本(&amp;V)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="versionLabel.Visible" type="System.Boolean, mscorlib">
@@ -420,7 +420,7 @@
     <value>1</value>
   </data>
   <data name="noFiles.Text" xml:space="preserve">
-    <value>There are no Skyline files in this folder</value>
+    <value>此文件夹中没有 Skyline 文件</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="noFiles.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
@@ -451,21 +451,21 @@
     <value>75</value>
   </data>
   <data name="colVersions.Text" xml:space="preserve">
-    <value>Versions</value>
+    <value>版本</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="colVersions.Width" type="System.Int32, mscorlib">
     <value>52</value>
   </data>
   <data name="colReplacedBy.Text" xml:space="preserve">
-    <value>Replaced By</value>
+    <value>已替换为</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="colReplacedBy.Width" type="System.Int32, mscorlib">
     <value>100</value>
   </data>
   <data name="colCreated.Text" xml:space="preserve">
-    <value>Created</value>
+    <value>已创建</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="listView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -599,7 +599,7 @@
     <value>28, 28</value>
   </data>
   <data name="forward.Text" xml:space="preserve">
-    <value>Forward</value>
+    <value>前进</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="up.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -652,7 +652,7 @@
     <value>167, 22</value>
   </data>
   <data name="copyLinkAddressToolStripMenuItem.Text" xml:space="preserve">
-    <value>Copy link address</value>
+    <value>复制链接地址</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="contextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
@@ -731,7 +731,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Panorama Folders</value>
+    <value>Panorama 文件夹</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;treeViewIcons.Name" xml:space="preserve">

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.zh-CHS.resx
@@ -132,7 +132,7 @@
     <value>0</value>
   </data>
   <data name="folderLabel.Text" xml:space="preserve">
-    <value>远程文件夹(&amp;R):</value>
+    <value>远程文件夹(&amp;R)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;folderLabel.Name" xml:space="preserve">

--- a/pwiz_tools/Shared/PanoramaClient/Properties/Resources.ja.resx
+++ b/pwiz_tools/Shared/PanoramaClient/Properties/Resources.ja.resx
@@ -134,7 +134,7 @@
     <value>サーバーからの予期しないJSON応答：{0}</value>
   </data>
   <data name="UserState_GetErrorMessage_The_username_and_password_could_not_be_authenticated_with_the_panorama_server_" xml:space="preserve">
-    <value>The username and password could not be authenticated with the panorama server.</value>
+    <value>Panoramaサーバーでユーザー名とパスワードが認証できませんでした。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
@@ -147,11 +147,11 @@
     <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="ServerState_GetErrorMessage_The_server__0__does_not_exist_" xml:space="preserve">
-    <value>The server {0} does not exist.</value>
+    <value>サーバー{0}が存在していません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="WebPanoramaClient_SaveFile_Select_the_folder_where_the_file_will_be_downloaded" xml:space="preserve">
-    <value>Select the folder where the file will be downloaded</value>
+    <value>ファイルのダウンロード先フォルダを選択</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
@@ -191,160 +191,160 @@
     <value>..\Resources\Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="PanoramaFilePicker_Open_Click_You_must_select_a_file_first_" xml:space="preserve">
-    <value>You must select a file first!</value>
+    <value>最初にファイルを選択してください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFolderBrowser_InitializeServers_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password" xml:space="preserve">
-    <value>Go to Tools - Options - Panorama tab to update the username and password</value>
+    <value>[ツール] - [オプション] - [Panorama] タブへ移動し、ユーザー名とパスワードを更新してください</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFolderBrowser_InitializeServers_Failed_attempting_to_retrieve_information_from_the_following_servers" xml:space="preserve">
-    <value>Failed attempting to retrieve information from the following servers</value>
+    <value>以下のサーバーからの情報の取得に失敗しました</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaDirectoryPicker_DirectoryPicker_Load_Open" xml:space="preserve">
     <value>開</value>
   </data>
   <data name="WebDavBrowser_AddWebDavFolders_Failed_attempting_to_retrieve_information_from_the_following_folders_" xml:space="preserve">
-    <value>Failed attempting to retrieve information from the following folders:</value>
+    <value>以下のフォルダからの情報の取得に失敗しました</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFilePicker_ShowFiles_There_are_no_files_in_this_folder" xml:space="preserve">
-    <value>There are no files in this folder</value>
+    <value>このフォルダにファイルはありません</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFilePicker_ShowFiles_There_are_no_Skyline_files_in_this_folder" xml:space="preserve">
-    <value>There are no Skyline files in this folder</value>
+    <value>このフォルダにSkylineファイルはありません</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFilePicker_ALL_VER_All" xml:space="preserve">
     <value>すべて</value>
   </data>
   <data name="PanoramaFilePicker_RECENT_VER_Most_recent" xml:space="preserve">
-    <value>Most recent</value>
+    <value>最近</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="LabKeyError_ToString_Response_status___0_" xml:space="preserve">
-    <value>Response status: {0}</value>
+    <value>応答ステータス：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_SendZipFile_Deleting_temporary_file_on_server" xml:space="preserve">
-    <value>Deleting temporary file on server</value>
+    <value>サーバーの一時ファイルの削除中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_SendZipFile_Waiting_for_data_import_completion___" xml:space="preserve">
-    <value>Waiting for data import completion...</value>
+    <value>データインポートの完了待ち...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_ValidateFolder_Error_validating_folder___0__" xml:space="preserve">
-    <value>Error validating folder '{0}'</value>
+    <value>フォルダ「{0}」検証中のエラー</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_GetInfoForFolders_Error_getting_information_for_folder___0__" xml:space="preserve">
-    <value>Error getting information for folder '{0}'</value>
+    <value>フォルダ「{0}」情報取得中のエラー</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_GetWebDavPath_There_was_an_error_getting_the_WebDAV_url_for_folder___0__" xml:space="preserve">
-    <value>There was an error getting the WebDAV url for folder '{0}'</value>
+    <value>フォルダ「{0}」のWebDAV url取得中にエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_updateProgressAndWait_Importing_data___0___complete_" xml:space="preserve">
-    <value>Importing data. {0}% complete.</value>
+    <value>データをインポート中。{0}%完了。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_updateProgressAndWait_Status_on_server_is___0_" xml:space="preserve">
-    <value>Status on server is: {0}</value>
+    <value>サーバーのステータス：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_webClient_UploadProgressChanged_Progress_Updated" xml:space="preserve">
-    <value>Progress Updated</value>
+    <value>進捗状況を更新しました</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_webClient_UploadProgressChanged_Uploaded__0_fs__of__1_fs_" xml:space="preserve">
-    <value>Uploaded {0:fs} of {1:fs}</value>
+    <value>{1:fs}中{0:fs}がアップロード済み</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="WebPanoramaClient_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
     <value>サーバーは有効なJSON応答を返しませんでした。{0}はPanoramaサーバーではありません。</value>
   </data>
   <data name="AbstractPanoramaClient_WaitForDocumentImportCompleted_There_was_an_error_getting_the_status_of_the_document_import_pipeline_job_" xml:space="preserve">
-    <value>There was an error getting the status of the document import pipeline job.</value>
+    <value>ドキュメントのインポートパイプラインジョブのステータス取得中にエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_QueueDocUploadPipelineJob_There_was_an_error_adding_the_document_import_job_on_the_server_" xml:space="preserve">
-    <value>There was an error adding the document import job on the server.</value>
+    <value>サーバーでドキュメントのインポートジョブ追加中にエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_UploadTempZipFile_There_was_an_error_uploading_the_file_" xml:space="preserve">
-    <value>There was an error uploading the file.</value>
+    <value>ファイルのアップロード中にエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_RenameTempZipFile_There_was_an_error_renaming_the_temporary_zip_file_on_the_server_" xml:space="preserve">
-    <value>There was an error renaming the temporary zip file on the server.</value>
+    <value>サーバーで一時zipファイルの名称変更中にエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_DeleteTempZipFile_There_was_an_error_deleting_the_temporary_zip_file_on_the_server_" xml:space="preserve">
-    <value>There was an error deleting the temporary zip file on the server.</value>
+    <value>サーバーで一時zipファイルの削除エラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ServerStateErrors_Error_The_server__0__is_not_a_Panorama_server_" xml:space="preserve">
-    <value>The server {0} is not a Panorama server.</value>
+    <value>サーバー{0}はPanoramaサーバーではありません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ErrorMessageBuilder_Build_Response__" xml:space="preserve">
-    <value>Response: </value>
+    <value>応答： </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractRequestHelper_DoRequest__0__request_was_unsuccessful_" xml:space="preserve">
-    <value>{0} request was unsuccessful.</value>
+    <value>{0}のリクエストが失敗しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_GetWebDavPath_Missing_webDavURL_in_response_" xml:space="preserve">
-    <value>Missing webDavURL in response.</value>
+    <value>応答にwebDavURLが不足しています。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_ConfirmFileOnServer_File_was_not_uploaded_to_the_server__Please_try_again__or_if_the_problem_persists__please_contact_your_Panorama_server_administrator_" xml:space="preserve">
-    <value>File was not uploaded to the server. Please try again, or if the problem persists, please contact your Panorama server administrator.</value>
+    <value>ファイルがサーバーにアップロードされませんでした。もう一度試すか、mataもしくは問題が続くようであればPanoramaサーバー管理者に問い合わせてください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractRequestHelper_ParseJsonResponse_Error_parsing_response_as_JSON_" xml:space="preserve">
-    <value>Error parsing response as JSON.</value>
+    <value>応答をJSONとして解析できませんでした。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaRequestHelper_Post_There_was_an_error_getting_a_CSRF_token_from_the_server_" xml:space="preserve">
-    <value>There was an error getting a CSRF token from the server.</value>
+    <value>サーバーからのCSRFトークン取得中にエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ErrorMessageBuilder_Build_Error__" xml:space="preserve">
-    <value>Error: </value>
+    <value>エラー： </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ErrorMessageBuilder_Build_Response_status___0_" xml:space="preserve">
-    <value>Response status: {0}</value>
+    <value>応答ステータス：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FolderStateErrors_Error_Unrecognized_error_trying_to_get_the_status_for_folder__0__" xml:space="preserve">
-    <value>Unrecognized error trying to get the status for folder {0}.</value>
+    <value>フォルダ{0}のステータスを取得中に認識できないエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_contain_any_of_these_characters___0_" xml:space="preserve">
-    <value>File name may not contain any of these characters: {0}</value>
+    <value>ファイル名に次の文字を使用することはできません：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_begin_with_any_of_these_characters___0_" xml:space="preserve">
-    <value>File name may not begin with any of these characters: {0}</value>
+    <value>ファイル名を次の文字で始めることはできません：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_contain_space_followed_by_dash" xml:space="preserve">
-    <value>File name may not contain space followed by dash</value>
+    <value>ファイル名では、スペースの後にダッシュを使用することはできません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_ParseUploadFileCompletedEventArgs_Request_cancelled" xml:space="preserve">
-    <value>Request cancelled</value>
+    <value>リクエストがキャンセルされました</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_ParseUploadFileCompletedEventArgs_There_was_an_error_reading_the_server_response_" xml:space="preserve">
-    <value>There was an error reading the server response.</value>
+    <value>サーバー応答の読み取り中にエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Shared/PanoramaClient/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Shared/PanoramaClient/Properties/Resources.zh-CHS.resx
@@ -134,7 +134,7 @@
     <value>服务器 {0} 的JSON响应异常</value>
   </data>
   <data name="UserState_GetErrorMessage_The_username_and_password_could_not_be_authenticated_with_the_panorama_server_" xml:space="preserve">
-    <value>The username and password could not be authenticated with the panorama server.</value>
+    <value>用户名和密码无法采用 panorama 服务器验证。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaUtil_EnsureLogin_Could_not_authenticate_user__Response_received_from_server___0___1_" xml:space="preserve">
@@ -147,11 +147,11 @@
     <value>..\Resources\ChromLib.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="ServerState_GetErrorMessage_The_server__0__does_not_exist_" xml:space="preserve">
-    <value>The server {0} does not exist.</value>
+    <value>服务器{0}不存在。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="WebPanoramaClient_SaveFile_Select_the_folder_where_the_file_will_be_downloaded" xml:space="preserve">
-    <value>Select the folder where the file will be downloaded</value>
+    <value>选择将下载该文件的文件夹</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Icojam-Blueberry-Basic-Arrow-right" type="System.Resources.ResXFileRef, System.Windows.Forms">
@@ -191,160 +191,160 @@
     <value>..\Resources\Copy.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="PanoramaFilePicker_Open_Click_You_must_select_a_file_first_" xml:space="preserve">
-    <value>You must select a file first!</value>
+    <value>您必须先选择一个文件！</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFolderBrowser_InitializeServers_Go_to_Tools___Options___Panorama_tab_to_update_the_username_and_password" xml:space="preserve">
-    <value>Go to Tools - Options - Panorama tab to update the username and password</value>
+    <value>转到工具 &gt; 选项 &gt; Panorama 选项卡，更新用户名和密码</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFolderBrowser_InitializeServers_Failed_attempting_to_retrieve_information_from_the_following_servers" xml:space="preserve">
-    <value>Failed attempting to retrieve information from the following servers</value>
+    <value>尝试从下列服务器检索信息失败</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaDirectoryPicker_DirectoryPicker_Load_Open" xml:space="preserve">
     <value>打开</value>
   </data>
   <data name="WebDavBrowser_AddWebDavFolders_Failed_attempting_to_retrieve_information_from_the_following_folders_" xml:space="preserve">
-    <value>Failed attempting to retrieve information from the following folders:</value>
+    <value>尝试从下列文件夹检索信息失败：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFilePicker_ShowFiles_There_are_no_files_in_this_folder" xml:space="preserve">
-    <value>There are no files in this folder</value>
+    <value>此文件夹中没有文件</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFilePicker_ShowFiles_There_are_no_Skyline_files_in_this_folder" xml:space="preserve">
-    <value>There are no Skyline files in this folder</value>
+    <value>此文件夹中没有 Skyline 文件</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaFilePicker_ALL_VER_All" xml:space="preserve">
     <value>全部</value>
   </data>
   <data name="PanoramaFilePicker_RECENT_VER_Most_recent" xml:space="preserve">
-    <value>Most recent</value>
+    <value>最近</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="LabKeyError_ToString_Response_status___0_" xml:space="preserve">
-    <value>Response status: {0}</value>
+    <value>响应状态：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_SendZipFile_Deleting_temporary_file_on_server" xml:space="preserve">
-    <value>Deleting temporary file on server</value>
+    <value>正在删除服务器上的临时文件</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_SendZipFile_Waiting_for_data_import_completion___" xml:space="preserve">
-    <value>Waiting for data import completion...</value>
+    <value>正在等待数据导入完成…</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_ValidateFolder_Error_validating_folder___0__" xml:space="preserve">
-    <value>Error validating folder '{0}'</value>
+    <value>验证文件夹“{0}”出错</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_GetInfoForFolders_Error_getting_information_for_folder___0__" xml:space="preserve">
-    <value>Error getting information for folder '{0}'</value>
+    <value>获取文件夹“{0}”的信息出错</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_GetWebDavPath_There_was_an_error_getting_the_WebDAV_url_for_folder___0__" xml:space="preserve">
-    <value>There was an error getting the WebDAV url for folder '{0}'</value>
+    <value>获取文件夹“{0}”的 WebDAV url 时出错</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_updateProgressAndWait_Importing_data___0___complete_" xml:space="preserve">
-    <value>Importing data. {0}% complete.</value>
+    <value>完成 {0}% 数据导入。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_updateProgressAndWait_Status_on_server_is___0_" xml:space="preserve">
-    <value>Status on server is: {0}</value>
+    <value>服务器状态为：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_webClient_UploadProgressChanged_Progress_Updated" xml:space="preserve">
-    <value>Progress Updated</value>
+    <value>进度已更新</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_webClient_UploadProgressChanged_Uploaded__0_fs__of__1_fs_" xml:space="preserve">
-    <value>Uploaded {0:fs} of {1:fs}</value>
+    <value>已上传 {0:fs}，共 {1:fs}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="WebPanoramaClient_EnsureLogin_Server_did_not_return_a_valid_JSON_response___0__is_not_a_Panorama_server_" xml:space="preserve">
     <value>服务器未返回有效的 JSON 响应。{0} 并非 Panorama  服务器。</value>
   </data>
   <data name="AbstractPanoramaClient_WaitForDocumentImportCompleted_There_was_an_error_getting_the_status_of_the_document_import_pipeline_job_" xml:space="preserve">
-    <value>There was an error getting the status of the document import pipeline job.</value>
+    <value>获取文档导入管道任务状态时出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_QueueDocUploadPipelineJob_There_was_an_error_adding_the_document_import_job_on_the_server_" xml:space="preserve">
-    <value>There was an error adding the document import job on the server.</value>
+    <value>在服务器上添加文档导入任务时出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_UploadTempZipFile_There_was_an_error_uploading_the_file_" xml:space="preserve">
-    <value>There was an error uploading the file.</value>
+    <value>上传文件时出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_RenameTempZipFile_There_was_an_error_renaming_the_temporary_zip_file_on_the_server_" xml:space="preserve">
-    <value>There was an error renaming the temporary zip file on the server.</value>
+    <value>重命名服务器上的临时压缩文件时出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_DeleteTempZipFile_There_was_an_error_deleting_the_temporary_zip_file_on_the_server_" xml:space="preserve">
-    <value>There was an error deleting the temporary zip file on the server.</value>
+    <value>删除服务器上的临时压缩文件出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ServerStateErrors_Error_The_server__0__is_not_a_Panorama_server_" xml:space="preserve">
-    <value>The server {0} is not a Panorama server.</value>
+    <value>服务器{0}不是 Panorama 服务器。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ErrorMessageBuilder_Build_Response__" xml:space="preserve">
-    <value>Response: </value>
+    <value>响应： </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractRequestHelper_DoRequest__0__request_was_unsuccessful_" xml:space="preserve">
-    <value>{0} request was unsuccessful.</value>
+    <value>{0} 请求失败。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_GetWebDavPath_Missing_webDavURL_in_response_" xml:space="preserve">
-    <value>Missing webDavURL in response.</value>
+    <value>响应中缺失 webDavURL。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_ConfirmFileOnServer_File_was_not_uploaded_to_the_server__Please_try_again__or_if_the_problem_persists__please_contact_your_Panorama_server_administrator_" xml:space="preserve">
-    <value>File was not uploaded to the server. Please try again, or if the problem persists, please contact your Panorama server administrator.</value>
+    <value>文件未上传至服务器。请重试，如果仍有问题，请联系 Panorama 服务器管理员。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractRequestHelper_ParseJsonResponse_Error_parsing_response_as_JSON_" xml:space="preserve">
-    <value>Error parsing response as JSON.</value>
+    <value>以 JSON 格式解析响应时出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaRequestHelper_Post_There_was_an_error_getting_a_CSRF_token_from_the_server_" xml:space="preserve">
-    <value>There was an error getting a CSRF token from the server.</value>
+    <value>从服务器获取 CSRF 令牌出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ErrorMessageBuilder_Build_Error__" xml:space="preserve">
-    <value>Error: </value>
+    <value>错误： </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ErrorMessageBuilder_Build_Response_status___0_" xml:space="preserve">
-    <value>Response status: {0}</value>
+    <value>响应状态：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FolderStateErrors_Error_Unrecognized_error_trying_to_get_the_status_for_folder__0__" xml:space="preserve">
-    <value>Unrecognized error trying to get the status for folder {0}.</value>
+    <value>尝试获取文件夹 {0} 的状态时发生了无法识别的错误。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_contain_any_of_these_characters___0_" xml:space="preserve">
-    <value>File name may not contain any of these characters: {0}</value>
+    <value>文件名不得包含这些字符：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_begin_with_any_of_these_characters___0_" xml:space="preserve">
-    <value>File name may not begin with any of these characters: {0}</value>
+    <value>文件名不得以这些字符开头：{0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PanoramaUtil_LabKeyAllowedFileName_File_name_may_not_contain_space_followed_by_dash" xml:space="preserve">
-    <value>File name may not contain space followed by dash</value>
+    <value>文件名不得包含空格和破折号</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_ParseUploadFileCompletedEventArgs_Request_cancelled" xml:space="preserve">
-    <value>Request cancelled</value>
+    <value>请求已取消</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaClient_ParseUploadFileCompletedEventArgs_There_was_an_error_reading_the_server_response_" xml:space="preserve">
-    <value>There was an error reading the server response.</value>
+    <value>读取服务器响应出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphLocale.zh-CHS.resx
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/ZedGraphLocale.zh-CHS.resx
@@ -124,7 +124,7 @@
     <value>复制到剪贴板</value>
   </data>
   <data name="save_as" xml:space="preserve">
-    <value>另存图表...</value>
+    <value>另存图表…</value>
   </data>
   <data name="set_default" xml:space="preserve">
     <value>恢复默认大小</value>
@@ -151,9 +151,9 @@
     <value>Y 轴</value>
   </data>
   <data name="page_setup" xml:space="preserve">
-    <value>页面设置...</value>
+    <value>页面设置…</value>
   </data>
   <data name="print" xml:space="preserve">
-    <value>打印...</value>
+    <value>打印…</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Alerts/AlertsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Alerts/AlertsResources.zh-CHS.resx
@@ -218,7 +218,7 @@
     <value>请选择缺失文件的所属文件夹。</value>
   </data>
   <data name="SimpleFileDownloaderDlg_Show_Downloading_required_files___" xml:space="preserve">
-    <value>正在下载所需的文件...</value>
+    <value>正在下载所需的文件…</value>
   </data>
   <data name="SimpleFileDownloaderDlg_Show_The_following_file_is_required__Do_you_want_to_download_it_" xml:space="preserve">
     <value>需要以下文件。您是否要下载?</value>

--- a/pwiz_tools/Skyline/Alerts/ShareResultsFilesDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Alerts/ShareResultsFilesDlg.zh-CHS.resx
@@ -352,7 +352,7 @@
     <value>2</value>
   </data>
   <data name="btnLocateFiles.Text" xml:space="preserve">
-    <value>定位文件(&amp;L)...</value>
+    <value>定位文件(&amp;L)…</value>
   </data>
   <data name="&gt;&gt;btnLocateFiles.Name" xml:space="preserve">
     <value>btnLocateFiles</value>
@@ -403,7 +403,7 @@
     <value>3</value>
   </data>
   <data name="btnFindInFolder.Text" xml:space="preserve">
-    <value>在文件夹中查找(&amp;F)...</value>
+    <value>在文件夹中查找(&amp;F)…</value>
   </data>
   <data name="&gt;&gt;btnFindInFolder.Name" xml:space="preserve">
     <value>btnFindInFolder</value>

--- a/pwiz_tools/Skyline/Alerts/ShareTypeDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Alerts/ShareTypeDlg.zh-CHS.resx
@@ -393,7 +393,7 @@
     <value>1</value>
   </data>
   <data name="btnSelectReplicateFiles.Text" xml:space="preserve">
-    <value>选择文件...</value>
+    <value>选择文件…</value>
   </data>
   <data name="&gt;&gt;btnSelectReplicateFiles.Name" xml:space="preserve">
     <value>btnSelectReplicateFiles</value>

--- a/pwiz_tools/Skyline/CommandArgUsage.ja.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.ja.resx
@@ -289,11 +289,11 @@
     <value>多数のファイルが、メインプロセスのスレッド（ユーザーインターフェイスの[同時にインポートするファイル]に相当）を使用して並行にインポートされます。その後、それぞれの単一ファイルからの結果が結合されます。これにより、正しい条件の下では2～4倍に性能がアップされる可能性があります。お使いのシステムで必ずテストしてください。</value>
   </data>
   <data name="_import_pep_list" xml:space="preserve">
-    <value>Import a list of peptides or peptide precursors (with charge state) with an optional list name specified by --import-pep-list-name.</value>
+    <value>ペプチドまたはペプチドプリカーサー（電荷状態）のリストを--import-pep-list-nameで指定したオプションのリスト名でインポートします。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_import_pep_list_name" xml:space="preserve">
-    <value>Name of imported peptide list specified by --import-pep-list.</value>
+    <value>--import-pep-listで指定されたインポート対象のペプチドリストの名前です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_import_transition_list" xml:space="preserve">
@@ -924,185 +924,182 @@ Waters</value>
     <value>単離スキームのインポート元となるpath/to/result-file</value>
   </data>
   <data name="CommandArgs_GROUP_OTHER_FILE_TYPES" xml:space="preserve">
-    <value>Exporting other file types</value>
+    <value>その他のファイルタイプのエクスポート中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_speclib_file" xml:space="preserve">
-    <value>Export experimental data in the current document to a spectral library file. Peak areas are used as spectrum intensities, peak apex times are used as retention times, and if the document has iRT values they will also be stored in the library.</value>
+    <value>現在のドキュメントの実験データをスペクトルライブラリファイルにエクスポートします。ピーク面積はスペクトル強度として、ピーク頂点時間は保持時間として使用され、ドキュメントにiRT値がある場合は、それもライブラリに保存されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_mprophet_exclude_feature" xml:space="preserve">
-    <value>Use to exclude a particular feature score by name from the exported file. Names can be found in the user interface. This argument may be used multiple times to exclude multiple features. Requires the --exp-mprophet-features argument.</value>
+    <value>エクスポートしたファイルから名前で特定のフィーチャースコアを除外するために使用します。名前はユーザーインターフェースで見つけられます。この引数を複数回使用すると、複数のフィーチャーを除外できます。--exp-mprophet-features引数が必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_mprophet_features" xml:space="preserve">
-    <value>Export all the individual feature scores for each peptide, as well as the composite score, the p value, and the q value into the mProphet format.</value>
+    <value>各ペプチドの個々のフィーチャースコア、複合スコア、p値、q値をすべてmProphet形式にエクスポートします。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_mprophet_best_peaks_only" xml:space="preserve">
-    <value>Include feature scores only for the best scoring peaks. Requires the --exp-mprophet-features argument.</value>
+    <value>最良スコアのピークに対してのみフィーチャースコアを含めます。--exp-mprophet-features引数が必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_mprophet_targets_only" xml:space="preserve">
-    <value>Include feature scores only for targets. Requires the --exp-mprophet-features argument.</value>
+    <value>ターゲットに対してのみフィーチャースコアを含めます。--exp-mprophet-features引数が必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_annotations" xml:space="preserve">
-    <value>Export all the annotations in the document into a text file with an ElementLocator field in the format required by --import-annotations. Use --exp-annotations-include-properties to include properties as well.</value>
+    <value>--import-annotationsで要求される形式のElementLocatorフィールドがあるテキストファイルに、ドキュメント内のすべての注釈をエクスポートします。--exp-annotations-include-propertiesを使用すると、プロパティも含まれます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_annotations_remove_blank_rows" xml:space="preserve">
-    <value>Use to remove blank rows from the exported annotations. Requires the --exp-annotations argument.</value>
+    <value>エクスポートした注釈から空白行を削除するために使用します。 --exp-annotations引数が必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_annotations_include_object" xml:space="preserve">
-    <value>Use to specify which object types to include in the exported annotations. By default all object types are included. This argument can be used multiple times to specify multiple object types. Requires the --exp-annotations argument.</value>
+    <value>エクスポートする注釈に含めるオブジェクトタイプの指定に使用します。デフォルトでは、すべてのオブジェクトタイプが含まれます。この引数を複数回使用すると、複数のオブジェクトタイプを指定できます。--exp-annotations引数が必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_annotations_include_properties" xml:space="preserve">
-    <value>Use to include all properties in the exported annotations. By default no properties are included. Requires the --exp-annotations argument.</value>
+    <value>エクスポートされた注釈にすべてのプロパティを含めるために使用します。デフォルトではどのプロパティも含まれません。--exp-annotations引数が必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_exclude_nterminal_aas" xml:space="preserve">
-    <value>Exclude all peptides starting before this amino acid position in each protein.</value>
+    <value>各タンパク質内でこのアミノ酸の位置より前にあるすべてのペプチドを除外します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_exclude_potential_ragged_ends" xml:space="preserve">
-    <value>Exclude peptides resulting from cleavage sites with immediate preceding or following cleavage sites. e.g. RR, KK, RK, KR for trypsin</value>
+    <value>切断部位の直前か直後にある切断部位によるペプチドを除外します。 例：トリプシンのRR、KK、RK、KR</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_max_length" xml:space="preserve">
-    <value>The maximum length of a peptide to add to the document.</value>
+    <value>ドキュメントに追加するペプチドの最大長。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_min_length" xml:space="preserve">
-    <value>The minimum length of a peptide to add to the document.</value>
+    <value>ドキュメントに追加するペプチドの最小長。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_GROUP_DOCUMENT_SETTINGS" xml:space="preserve">
-    <value>Document settings</value>
+    <value>ドキュメント設定</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_name" xml:space="preserve">
-    <value>Add an annotation to the document with the specified name. Existing annotations with the same name will be overwritten.</value>
+    <value>指定した名前でドキュメントに注釈を追加します。同名の既存の注釈は上書きされます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_targets" xml:space="preserve">
-    <value>A comma-separated list of target types to apply the annotation to in an --annotation-name operation.</value>
+    <value>--annotation-name操作で注釈を適用するターゲットタイプのカンマ区切りリスト。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_type" xml:space="preserve">
-    <value>Define the data type of the annotation in an --annotation-name operation. Defaults to text.</value>
+    <value>--annotation-name操作の注釈のデータタイプを定義します。デフォルトはテキストです。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_values" xml:space="preserve">
-    <value>A comma-separated list of values for a value_list type annotation in an --annotation-name operation. Required only in an --annotation-type=value_list operation.</value>
+    <value>--annotation-name操作でvalue_listタイプの注釈で使う値のカンマ区切りリスト。--annotation-type=value_list操作でのみ必須となります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_ANNOTATION_VALUES_VALUE" xml:space="preserve">
-    <value>"&lt;value&gt;, &lt;value&gt;, &lt;value&gt;..."</value>
+    <value>「&lt;value&gt;、&lt;value&gt;、&lt;value&gt;...」</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_conflict_resolution" xml:space="preserve">
-    <value>Specifies how to resolve annotation name conflicts, by either overwriting or skipping them, when using --annotation-name, --annotation-file, or --annotation-add-from-environment (default is to output an error message for conflicts).</value>
+    <value>--annotation-name、--annotation-file、または--annotation-add-from-environmentを使用する際、注釈名の重複を解決する方法を、上書き、重複をスキップする、のいずれかで指定します（デフォルトは、重複のエラーメッセージの出力です。）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_file" xml:space="preserve">
-    <value>Add an annotation to the document and environment from an XML format file. For an example of an XML format file, view the user.config file specified in the user interface window Tools &gt;Options &gt; Miscellaneous. Existing annotations with the same name will be overwritten.</value>
+    <value>XML形式のファイルからドキュメントと環境に注釈を追加します。XML形式ファイルの例は、ユーザーインターフェースウィンドウの [ツール] &gt; [オプション] &gt; [その他] で指定されるuser.configファイルをご覧ください。同名の既存の注釈は上書きされます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_background_proteome_file" xml:space="preserve">
-    <value>The path to the background proteome (protdb) file to apply to the opened document. The name may be optionally specified by --background-proteome-name, and if not it defaults to the filename.</value>
+    <value>開いたドキュメントに適用するバックグラウンドプロテオーム（protdb）ファイルへのパス。この名前は、オプションで--background-proteome-nameを使って指定できます。指定しない場合、filenameがデフォルトとして使用されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_background_proteome_name" xml:space="preserve">
-    <value>The name of a background proteome to apply to the opened document. The background proteome specifies the full set of proteins that may be present in the sample matrix to be injected into the mass spectrometer. If the name is not already defined in Skyline, the path to the protdb file must also be set by --background-proteome-file.</value>
+    <value>開いたドキュメントに適用するバックグラウンドプロテオームの名前。バックグラウンドプロテオームは、質量分析計に導入される試料マトリックス内に存在し得るすべてのタンパク質を指定します。名前がSkylineで定義されていない場合は、protdbファイルへのパスも--background-proteome-fileで設定する必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_digest_enzyme" xml:space="preserve">
-    <value>The protease enzyme definition used to parse peptide sequences from protein sequences added as targets to the document. Peptide lists added as targets ignore this setting other than counting missed cleavages.</value>
+    <value>ドキュメントにターゲットとして追加されたタンパク質配列からペプチド配列を解析するために使用されるプロテアーゼ酵素の定義。ペプチドリストがターゲットとして追加された場合、この設定は未切断数をカウントする以外は無視されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_max_missed_cleavages" xml:space="preserve">
-    <value>The maximum number of missed cleavages allowed in a peptide when considering protein digestion.</value>
+    <value>タンパク質消化時にペプチドで許容される最大未切断数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_unique_by" xml:space="preserve">
-    <value>"Protein" excludes any peptide that appears in more than one protein in the background proteome.  
-"Gene" excludes any peptide that appears in proteins for more than one gene in the background proteome.  
-"Species" excludes any peptide that appears in proteins for more than one species in the background proteome.
-Useful in sample mixtures including multiple species.</value>
+    <value>「タンパク質」は、バックグラウンドプロテオームで2つ以上のタンパク質に出現するペプチドを全て除外します。 「遺伝子」は、バックグラウンドプロテオームで2つ以上の遺伝子のタンパク質に出現するペプチドを全て除外します。 「種」は、バックグラウンドプロテオームで2つ以上の種のタンパク質に出現するペプチドを全て除外します。複数の種を含む試料混合物に有用です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_verbose_errors" xml:space="preserve">
-    <value>Adds additional information to the program output in the case of an error, that may be helpful to Skyline developers.</value>
+    <value>エラーが発生した場合、Skylineの開発者に役立つ可能性のある追加情報をプログラムの出力に追加します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_associate_proteins_gene_level_parsimony" xml:space="preserve">
-    <value>Associate peptides with genes (or gene groups) instead of proteins, and apply parsimony options to that association.</value>
+    <value>タンパク質ではなく遺伝子（または遺伝子グループ）とペプチドを関連付け、その関連付けに倹約オプションを適用します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_MOD_NAME_VALUE_full_name__e_g___Oxidation__M______short_name__Oxi_" xml:space="preserve">
-    <value>full name (e.g. "Oxidation (M)") | short name (Oxi)</value>
+    <value>フルネーム（例「Oxidation (M)」）| ショートネーム(Oxi)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_MOD_UNIMOD_VALUE_UniMod_ID__e_g___35__" xml:space="preserve">
-    <value>UniMod ID (e.g. "35")</value>
+    <value>UniMod ID（例「35」）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_integrate_all" xml:space="preserve">
-    <value>When set all transitions contributing any signal between the integration boundaries are considered found. When not set, only transitions that are coeluting are considered found. Regardless of the setting all signal from the quantitative transitions between the integration boundaries is summed to produce the TotalArea for the precursor.</value>
+    <value>設定されると、積分領域間のシグナルに貢献するすべてのトランジションが検出されたと見なされます。設定されない場合、共溶出しているトランジションのみが検出されたと見なされます。設定にかかわらず、積分領域間の定量的トランジションからのシグナルはすべて合計され、プリカーサーのTotalAreaとなります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_mod" xml:space="preserve">
-    <value>Add a UniMod modification to the document. The modification must be specified by PSI-MS name and site together ("Oxidation (M)").</value>
+    <value>ドキュメントにUniMod修飾を追加します。修飾は、PSI-MS名と部位を共に指定する必要があります（「酸化(M)」）。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_unimod_aa" xml:space="preserve">
-    <value>Provides the amino acid specificity for the last peptide modification added by --pep-add-unimod.</value>
+    <value>--pep-add-unimod により最後に追加されたペプチド修飾のアミノ酸特異性が提供されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_unimod_term" xml:space="preserve">
-    <value>Provides the terminus specificity for the last peptide modification added by --pep-add-unimod.</value>
+    <value>--pep-add-unimod により最後に追加されたペプチド修飾の末端特異性が提供されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_unimod" xml:space="preserve">
-    <value>Add a UniMod modification to the document by its UniMod ID. If the modification has multiple specificities, you must use --pep-add-unimod-aa or --pep-add-unimod-term to choose which specificity you want to add to the document.</value>
+    <value>UniMod IDでドキュメントにUniMod修飾を追加します。修飾に複数の特異性がある場合は、--pep-add-unimod-aaまたは--pep-add-unimod-termを使用して、ドキュメントに追加する特異性を選ぶ必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_clear_mods" xml:space="preserve">
-    <value>Clears all peptide modifications from the currently open document.</value>
+    <value>現在開いているドキュメントからすべてのペプチド修飾を消去します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_max_losses" xml:space="preserve">
-    <value>The maximum number of neutral loss events allowed to occur in combination on any fragment instance.</value>
+    <value>どのフラグメントインスタンスにおける組み合わせでも発生可能な 最大ニュートラルロスイベント数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_max_variable_mods" xml:space="preserve">
-    <value>The maximum number of variable modifications allowed to occur in combination on any peptide instance.</value>
+    <value>どのペプチドインスタンスにおける組み合わせでも発生可能な 最大可変修飾数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_BOOL_VALUE__0__or__1_" xml:space="preserve">
-    <value>{0} or {1}</value>
+    <value>{0} または {1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ValueInvalidException_ValueInvalidException_The_value___0___is_not_valid_for_the_argument__1___Use_one_of__2_" xml:space="preserve">
     <value>値「{0}」は引数{1}に対して有効ではありません。{2}の1つを使用します。</value>
   </data>
   <data name="ValueInvalidModException_ValueInvalidModException_Unable_to_add_peptide_modification___0_____1_" xml:space="preserve">
-    <value>Unable to add peptide modification '{0}': {1}</value>
+    <value>ペプチド修飾「{0}」を追加できません：{1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ValueInvalidBoolException_ValueInvalidBoolException_The_value___0___is_not_valid_for_the_argument___1____it_must_be__2_" xml:space="preserve">
-    <value>The value '{0}' is not valid for the argument '{1}': it must be {2}</value>
+    <value>値「{0}」は引数{1}には有効ではありません。{2}である必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_associate_proteins_fasta" xml:space="preserve">
-    <value>Associate peptides in the document with proteins from the given FASTA. If this argument is not provided but other --associate-proteins options are, then the FASTA from --import-fasta will be used. If --import-fasta is not provided either, then the last FASTA used for protein association will be used.</value>
+    <value>ドキュメント内のペプチドを、指定されたFASTAファイル内のタンパク質と関連付けます。この引数がなく、他の--associate-proteinsオプションがある場合は、--import-fastaからのFASTAが使用されます。--import-fastaもない場合は、タンパク質の関連付けに使用された最後のFASTAが使用されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_mod_variable" xml:space="preserve">
-    <value>Adds a modification as variable if 'true' or static if 'false'. Only valid for structural modifications except for loss-only modifications(e.g. Ammonia and Water Loss).</value>
+    <value>「true」の場合は修飾を変数として、「false」の場合は静的として追加します。損失のみの修飾（アンモニアと水の損失など）を除く構造修飾にのみ有効です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/CommandArgUsage.zh-CHS.resx
+++ b/pwiz_tools/Skyline/CommandArgUsage.zh-CHS.resx
@@ -289,11 +289,11 @@
     <value>将使用主进程中的线程并行导入的文件数量（相当于用户界面中的“同时导入的文件”），之后各个文件的结果将被汇集。在适当的条件下，这可以带来 2-4 倍的性能提升。务必使用您的系统进行测试。</value>
   </data>
   <data name="_import_pep_list" xml:space="preserve">
-    <value>Import a list of peptides or peptide precursors (with charge state) with an optional list name specified by --import-pep-list-name.</value>
+    <value>导入肽段或肽段母离子（带电荷状态）列表，列表名称可由 --import-pep-list-name 指定。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_import_pep_list_name" xml:space="preserve">
-    <value>Name of imported peptide list specified by --import-pep-list.</value>
+    <value>导入的肽段列表名称由 --import-pep-list 指定。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_import_transition_list" xml:space="preserve">
@@ -920,79 +920,79 @@ Waters</value>
     <value>用于从中导入分离方案的 path/to/result-file</value>
   </data>
   <data name="CommandArgs_GROUP_OTHER_FILE_TYPES" xml:space="preserve">
-    <value>Exporting other file types</value>
+    <value>导出其他文件类型</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_speclib_file" xml:space="preserve">
-    <value>Export experimental data in the current document to a spectral library file. Peak areas are used as spectrum intensities, peak apex times are used as retention times, and if the document has iRT values they will also be stored in the library.</value>
+    <value>将当前文档中的实验数据导出为谱图库文件。峰面积用作谱图强度，峰顶点时间用作保留时间，如果文档中有 iRT 值，这些值也会存储在库中。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_mprophet_exclude_feature" xml:space="preserve">
-    <value>Use to exclude a particular feature score by name from the exported file. Names can be found in the user interface. This argument may be used multiple times to exclude multiple features. Requires the --exp-mprophet-features argument.</value>
+    <value>用于从导出的文件中按名称排除特定的特征得分。用户界面中可以找到这些名称。该参数可多次使用，以排除多个特征。需要使用 --exp-mprophet-features 参数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_mprophet_features" xml:space="preserve">
-    <value>Export all the individual feature scores for each peptide, as well as the composite score, the p value, and the q value into the mProphet format.</value>
+    <value>以 mProphet 格式导出每个肽段的所有单个特征得分、复合物得分、p 值和 q 值。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_mprophet_best_peaks_only" xml:space="preserve">
-    <value>Include feature scores only for the best scoring peaks. Requires the --exp-mprophet-features argument.</value>
+    <value>仅包含最佳得分峰的特征得分。需要使用 --exp-mprophet-features 参数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_mprophet_targets_only" xml:space="preserve">
-    <value>Include feature scores only for targets. Requires the --exp-mprophet-features argument.</value>
+    <value>只包含目标特征得分。需要使用 --exp-mprophet-features 参数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_annotations" xml:space="preserve">
-    <value>Export all the annotations in the document into a text file with an ElementLocator field in the format required by --import-annotations. Use --exp-annotations-include-properties to include properties as well.</value>
+    <value>按照 --import-annotations 要求的格式，将文档中的所有注释导出到包含 ElementLocator 字段的文本文件。也可以使用 --exp-annotations-include-properties 来包含属性。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_annotations_remove_blank_rows" xml:space="preserve">
-    <value>Use to remove blank rows from the exported annotations. Requires the --exp-annotations argument.</value>
+    <value>用于删除所导出注释中的空白行。需要使用 --exp-annotations 参数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_annotations_include_object" xml:space="preserve">
-    <value>Use to specify which object types to include in the exported annotations. By default all object types are included. This argument can be used multiple times to specify multiple object types. Requires the --exp-annotations argument.</value>
+    <value>用于指定在导出的注释中包含哪些对象类型。默认为包含所有对象类型。该参数可多次使用，来指定多种对象类型。需要使用 --exp-annotations 参数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_exp_annotations_include_properties" xml:space="preserve">
-    <value>Use to include all properties in the exported annotations. By default no properties are included. Requires the --exp-annotations argument.</value>
+    <value>用于在导出的注释中包含所有属性。默认为不包含任何属性。需要使用 --exp-annotations 参数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_exclude_nterminal_aas" xml:space="preserve">
-    <value>Exclude all peptides starting before this amino acid position in each protein.</value>
+    <value>在每个蛋白质中排除所有在此氨基酸位置前开始的肽段。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_exclude_potential_ragged_ends" xml:space="preserve">
-    <value>Exclude peptides resulting from cleavage sites with immediate preceding or following cleavage sites. e.g. RR, KK, RK, KR for trypsin</value>
+    <value>排除因紧邻前方或后方位置具有剪切位点而产生的肽段， 例如，针对胰蛋白酶的 RR、KK、RK 和 KR</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_max_length" xml:space="preserve">
-    <value>The maximum length of a peptide to add to the document.</value>
+    <value>要向文档添加的肽段的最大长度。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_min_length" xml:space="preserve">
-    <value>The minimum length of a peptide to add to the document.</value>
+    <value>要向文档添加的肽段的最小长度。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_GROUP_DOCUMENT_SETTINGS" xml:space="preserve">
-    <value>Document settings</value>
+    <value>文档设置</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_name" xml:space="preserve">
-    <value>Add an annotation to the document with the specified name. Existing annotations with the same name will be overwritten.</value>
+    <value>向文档添加指定名称的注释。具有相同名称的现有注释将被覆盖。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_targets" xml:space="preserve">
-    <value>A comma-separated list of target types to apply the annotation to in an --annotation-name operation.</value>
+    <value>逗号分隔的目标类型列表，用于在 --annotation-name 操作中应用注释。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_type" xml:space="preserve">
-    <value>Define the data type of the annotation in an --annotation-name operation. Defaults to text.</value>
+    <value>在 --annotation-name 操作中定义注释的数据类型。默认为文本。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_values" xml:space="preserve">
-    <value>A comma-separated list of values for a value_list type annotation in an --annotation-name operation. Required only in an --annotation-type=value_list operation.</value>
+    <value>在 --annotation-name 操作中为 value_list 类型注释提供的逗号分隔值列表。仅在 --annotation-type=value_list 操作中需要使用。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_ANNOTATION_VALUES_VALUE" xml:space="preserve">
@@ -1000,105 +1000,102 @@ Waters</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_conflict_resolution" xml:space="preserve">
-    <value>Specifies how to resolve annotation name conflicts, by either overwriting or skipping them, when using --annotation-name, --annotation-file, or --annotation-add-from-environment (default is to output an error message for conflicts).</value>
+    <value>指定在使用 --annotation-name、--annotation-file 或 --annotation-add-from-environment 时，如何通过覆盖或跳过注释名称冲突来解决注释名称冲突（默认情况下是为冲突输出错误消息）。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_annotation_file" xml:space="preserve">
-    <value>Add an annotation to the document and environment from an XML format file. For an example of an XML format file, view the user.config file specified in the user interface window Tools &gt;Options &gt; Miscellaneous. Existing annotations with the same name will be overwritten.</value>
+    <value>从 XML 格式文件向文档和环境添加注释。有关 XML 格式文件的示例，请查看用户界面窗口“工具 &gt; 选项 &gt;杂项”中指定的 user.config 文件。具有相同名称的现有注释将被覆盖。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_background_proteome_file" xml:space="preserve">
-    <value>The path to the background proteome (protdb) file to apply to the opened document. The name may be optionally specified by --background-proteome-name, and if not it defaults to the filename.</value>
+    <value>要应用于打开的文档的背景蛋白质组 (protdb) 文件的路径。可以通过 --background-proteome-name 指定文件名，否则默认为此文件名。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_background_proteome_name" xml:space="preserve">
-    <value>The name of a background proteome to apply to the opened document. The background proteome specifies the full set of proteins that may be present in the sample matrix to be injected into the mass spectrometer. If the name is not already defined in Skyline, the path to the protdb file must also be set by --background-proteome-file.</value>
+    <value>要应用于打开的文档的背景蛋白质组名称。背景蛋白质组指定注入质谱仪的样品基质中可能存在的全部蛋白质。如果 Skyline 中尚未定义该名称，还必须通过 --background-proteome-file 设置 protdb 文件路径。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_digest_enzyme" xml:space="preserve">
-    <value>The protease enzyme definition used to parse peptide sequences from protein sequences added as targets to the document. Peptide lists added as targets ignore this setting other than counting missed cleavages.</value>
+    <value>蛋白酶定义用于解析蛋白质序列（作为目标添加到文档）中的肽段序列。作为目标添加的肽段列表会忽略此设置，但会计算遗漏的酶解位点数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_max_missed_cleavages" xml:space="preserve">
-    <value>The maximum number of missed cleavages allowed in a peptide when considering protein digestion.</value>
+    <value>当考虑到蛋白质酶解时，肽段中允许的 最大遗漏的酶解位点数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_unique_by" xml:space="preserve">
-    <value>"Protein" excludes any peptide that appears in more than one protein in the background proteome.  
-"Gene" excludes any peptide that appears in proteins for more than one gene in the background proteome.  
-"Species" excludes any peptide that appears in proteins for more than one species in the background proteome.
-Useful in sample mixtures including multiple species.</value>
+    <value>“蛋白质”不包括出现在背景蛋白质组中的多个蛋白质中的任何肽段。 “基因”不包括出现在背景蛋白质组中的多个基因蛋白质中的任何肽段。 “物种”不包括出现在背景蛋白质组中的多个物种蛋白质中的任何肽段。适用于包含多个物种的样品混合物。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_verbose_errors" xml:space="preserve">
-    <value>Adds additional information to the program output in the case of an error, that may be helpful to Skyline developers.</value>
+    <value>请在出错时为程序输出添加额外信息，此举可能对 Skyline 开发人员有所帮助。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_associate_proteins_gene_level_parsimony" xml:space="preserve">
-    <value>Associate peptides with genes (or gene groups) instead of proteins, and apply parsimony options to that association.</value>
+    <value>关联肽段与基因（或基因组）而不关联蛋白质，并对这种关联应用简约法选项。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_MOD_NAME_VALUE_full_name__e_g___Oxidation__M______short_name__Oxi_" xml:space="preserve">
-    <value>full name (e.g. "Oxidation (M)") | short name (Oxi)</value>
+    <value>完整名称（如“Oxidation (M)” | 简称 (Oxi)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_MOD_UNIMOD_VALUE_UniMod_ID__e_g___35__" xml:space="preserve">
-    <value>UniMod ID (e.g. "35")</value>
+    <value>UniMod ID (如“35”)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_integrate_all" xml:space="preserve">
-    <value>When set all transitions contributing any signal between the integration boundaries are considered found. When not set, only transitions that are coeluting are considered found. Regardless of the setting all signal from the quantitative transitions between the integration boundaries is summed to produce the TotalArea for the precursor.</value>
+    <value>如果设置，所有在积分边界之间贡献任何信号的离子对都会被视为找到的离子对。如未设置，只有共洗脱的离子对才视为找到的离子对。无论设置与否，积分边界之间的所有定量离子对信号都会相加，从而得出母离子的总面积。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_mod" xml:space="preserve">
-    <value>Add a UniMod modification to the document. The modification must be specified by PSI-MS name and site together ("Oxidation (M)").</value>
+    <value>向文档中添加 UniMod 修饰。必须通过 PSI-MS 名称和位点（“Oxidation (M)”）来指定修饰。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_unimod_aa" xml:space="preserve">
-    <value>Provides the amino acid specificity for the last peptide modification added by --pep-add-unimod.</value>
+    <value>提供 --pep-add-unimod 添加的最后一个肽段修饰的氨基酸特异性。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_unimod_term" xml:space="preserve">
-    <value>Provides the terminus specificity for the last peptide modification added by --pep-add-unimod.</value>
+    <value>提供 --pep-add-unimod 添加的最后一个肽段修饰的末端特异性。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_unimod" xml:space="preserve">
-    <value>Add a UniMod modification to the document by its UniMod ID. If the modification has multiple specificities, you must use --pep-add-unimod-aa or --pep-add-unimod-term to choose which specificity you want to add to the document.</value>
+    <value>通过 UniMod ID 向文档中添加 UniMod 修饰。如果修饰有多个特异性，必须使用 --pep-add-unimod-aa 或 --pep-add-unimod-term 来选择要向文档添加的特异性。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_clear_mods" xml:space="preserve">
-    <value>Clears all peptide modifications from the currently open document.</value>
+    <value>清除当前打开文档中的所有肽段修饰。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_max_losses" xml:space="preserve">
-    <value>The maximum number of neutral loss events allowed to occur in combination on any fragment instance.</value>
+    <value>在任何肽段上允许出现的最大 中性丢失数目。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_max_variable_mods" xml:space="preserve">
-    <value>The maximum number of variable modifications allowed to occur in combination on any peptide instance.</value>
+    <value>在任何肽段上允许出现的 最大可变修饰数目。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_BOOL_VALUE__0__or__1_" xml:space="preserve">
-    <value>{0} or {1}</value>
+    <value>{0} 或 {1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ValueInvalidException_ValueInvalidException_The_value___0___is_not_valid_for_the_argument__1___Use_one_of__2_" xml:space="preserve">
     <value>值“{0}”对于参数 {1} 无效。使用 {2} 中的一个</value>
   </data>
   <data name="ValueInvalidModException_ValueInvalidModException_Unable_to_add_peptide_modification___0_____1_" xml:space="preserve">
-    <value>Unable to add peptide modification '{0}': {1}</value>
+    <value>无法添加肽段修饰“{0}”：{1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ValueInvalidBoolException_ValueInvalidBoolException_The_value___0___is_not_valid_for_the_argument___1____it_must_be__2_" xml:space="preserve">
-    <value>The value '{0}' is not valid for the argument '{1}': it must be {2}</value>
+    <value>值“{0}”对于参数“{1}”无效：必须为 {2}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_associate_proteins_fasta" xml:space="preserve">
-    <value>Associate peptides in the document with proteins from the given FASTA. If this argument is not provided but other --associate-proteins options are, then the FASTA from --import-fasta will be used. If --import-fasta is not provided either, then the last FASTA used for protein association will be used.</value>
+    <value>关联文档中的肽段与给定 FASTA 中的蛋白质。如果未提供此参数，但提供了其他 --associate-proteins 选项，将使用 --import-fasta 中的 FASTA。如果 --import-fasta 也未提供，则使用上次用来关联蛋白质的 FASTA。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="_pep_add_mod_variable" xml:space="preserve">
-    <value>Adds a modification as variable if 'true' or static if 'false'. Only valid for structural modifications except for loss-only modifications(e.g. Ammonia and Water Loss).</value>
+    <value>若为“true”，则添加可变修饰；若为“false”，则添加静态修饰。仅对结构修饰有效，但仅限丢失的修饰（如氨和水损失）除外。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/Databinding/RowActions/RowActionsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Databinding/RowActions/RowActionsResources.zh-CHS.resx
@@ -119,22 +119,22 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="DeletePeptides_GetMenuItemText_Delete_Molecules___" xml:space="preserve">
-    <value>删除分子...</value>
+    <value>删除分子…</value>
   </data>
   <data name="DeletePeptides_MenuItemText_Delete_Peptides___" xml:space="preserve">
-    <value>删除肽段...</value>
+    <value>删除肽段…</value>
   </data>
   <data name="DeletePrecursors_MenuItemText_Delete_Precursors___" xml:space="preserve">
-    <value>删除母离子...</value>
+    <value>删除母离子…</value>
   </data>
   <data name="DeleteProteins_MenuItemText_Delete_Molecule_Lists___" xml:space="preserve">
-    <value>删除分子列表...</value>
+    <value>删除分子列表…</value>
   </data>
   <data name="DeleteProteins_MenuItemText_Delete_Proteins___" xml:space="preserve">
-    <value>删除蛋白质...</value>
+    <value>删除蛋白质…</value>
   </data>
   <data name="DeleteTransitions_MenuItemText_Delete_Transitions___" xml:space="preserve">
-    <value>删除离子对...</value>
+    <value>删除离子对…</value>
   </data>
   <data name="RemovePeaksAction_RemovePeaks_No_peaks_are_selected" xml:space="preserve">
     <value>未选择峰</value>
@@ -161,10 +161,10 @@
     <value>您是否确定想要删除此肽段峰？</value>
   </data>
   <data name="RemovePeptides_MenuItemText_Remove_Molecule_Peaks___" xml:space="preserve">
-    <value>删除分子峰...</value>
+    <value>删除分子峰…</value>
   </data>
   <data name="RemovePeptides_MenuItemText_Remove_Peptide_Peaks___" xml:space="preserve">
-    <value>删除肽段峰...</value>
+    <value>删除肽段峰…</value>
   </data>
   <data name="RemovePrecursors_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from__1__precursors_" xml:space="preserve">
     <value>您是否确定想要从 {1} 个母离子中删除这 {0} 个峰？</value>
@@ -173,7 +173,7 @@
     <value>您是否确定想要删除此母离子峰？</value>
   </data>
   <data name="RemovePrecursors_MenuItemText_Remove_Precursor_Peaks___" xml:space="preserve">
-    <value>删除母离子峰...</value>
+    <value>删除母离子峰…</value>
   </data>
   <data name="RemoveTransitions_GetConfirmRemoveMessage_Are_you_sure_you_want_to_remove_these__0__peaks_from__1__transitions_" xml:space="preserve">
     <value>您是否确定想要从 {1} 个离子对中删除这 {0} 个峰？</value>
@@ -185,7 +185,7 @@
     <value>您是否确定想要删除此离子对峰？</value>
   </data>
   <data name="RemoveTransitions_MenuItemText_Remove_Transition_Peaks___" xml:space="preserve">
-    <value>删除离子对峰...</value>
+    <value>删除离子对峰…</value>
   </data>
   <data name="SkylineViewContext_DeleteDocNodes_Delete_items" xml:space="preserve">
     <value>删除项</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/AllChromatogramsGraph.zh-CHS.resx
@@ -969,7 +969,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>正在导入结果...</value>
+    <value>正在导入结果…</value>
   </data>
   <data name="&gt;&gt;imageListLock.Name" xml:space="preserve">
     <value>imageListLock</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/AreaCVToolbarProperties.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/AreaCVToolbarProperties.ja.resx
@@ -313,7 +313,7 @@
     <value>OK</value>
   </data>
   <data name="labelMinLog10.Text" xml:space="preserve">
-    <value>最小値の Log10 のエリア(&amp;A):</value>
+    <value>最小値の Log10 のエリア(&amp;A)：</value>
   </data>
   <data name="labelMaxLog10.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -469,7 +469,7 @@
     <value>1</value>
   </data>
   <data name="labelMaxLog10.Text" xml:space="preserve">
-    <value>最大 Log10 のエリア(&amp;E):</value>
+    <value>最大 Log10 のエリア(&amp;E)：</value>
   </data>
   <data name="&gt;&gt;labelQValueCutoff.Parent" xml:space="preserve">
     <value>$this</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.ja.resx
@@ -248,7 +248,7 @@
     <value>ステップ{0}</value>
   </data>
   <data name="AreaReplicateGraphPane_Tooltip_Total" xml:space="preserve">
-    <value>Total:</value>
+    <value>合計：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AsyncChromatogramsGraph_AsyncChromatogramsGraph_Intensity" xml:space="preserve">
@@ -717,31 +717,31 @@
     <value>スペクトル情報が利用不可</value>
   </data>
   <data name="AreaPeptideGraphPane_UpdateAxes_Peptide_Rank" xml:space="preserve">
-    <value>Peptide Rank</value>
+    <value>ペプチドランク</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Extensions_CustomToString_Relative_Abundance" xml:space="preserve">
-    <value>Relative Abundance</value>
+    <value>相対的存在量</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SummaryIntensityGraphPane_SummaryIntensityGraphPane_Protein_Rank" xml:space="preserve">
-    <value>Protein Rank</value>
+    <value>タンパク質のランク</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SummaryRelativeAbundanceGraphPane_UpdateAxes_Molecule_Rank" xml:space="preserve">
-    <value>Molecule Rank</value>
+    <value>分子のランク</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FoldChangeVolcanoPlot_BuildContextMenu_Auto_Arrange_Labels" xml:space="preserve">
-    <value>Auto Arrange Labels</value>
+    <value>ラベルの自動配置</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FoldChangeVolcanoPlot_BuildContextMenu_PauseLabelLayout" xml:space="preserve">
-    <value>Suspend Label Layout</value>
+    <value>ラベルレイアウトを中断</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FoldChangeVolcanoPlot_BuildContextMenu_RestartLabelLayout" xml:space="preserve">
-    <value>Resume Label Layout</value>
+    <value>ラベルレイアウトを再開</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AlignmentForm_UpdateGraph_Peptides" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.zh-CHS.resx
@@ -248,7 +248,7 @@
     <value>步骤 {0}</value>
   </data>
   <data name="AreaReplicateGraphPane_Tooltip_Total" xml:space="preserve">
-    <value>Total:</value>
+    <value>总数:</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AsyncChromatogramsGraph_AsyncChromatogramsGraph_Intensity" xml:space="preserve">
@@ -717,31 +717,31 @@
     <value>谱图信息不可用</value>
   </data>
   <data name="AreaPeptideGraphPane_UpdateAxes_Peptide_Rank" xml:space="preserve">
-    <value>Peptide Rank</value>
+    <value>肽段排名</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Extensions_CustomToString_Relative_Abundance" xml:space="preserve">
-    <value>Relative Abundance</value>
+    <value>相对丰度</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SummaryIntensityGraphPane_SummaryIntensityGraphPane_Protein_Rank" xml:space="preserve">
-    <value>Protein Rank</value>
+    <value>蛋白质排名</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SummaryRelativeAbundanceGraphPane_UpdateAxes_Molecule_Rank" xml:space="preserve">
-    <value>Molecule Rank</value>
+    <value>分子排名</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FoldChangeVolcanoPlot_BuildContextMenu_Auto_Arrange_Labels" xml:space="preserve">
-    <value>Auto Arrange Labels</value>
+    <value>自动排列标签</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FoldChangeVolcanoPlot_BuildContextMenu_PauseLabelLayout" xml:space="preserve">
-    <value>Suspend Label Layout</value>
+    <value>暂停标签布局</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FoldChangeVolcanoPlot_BuildContextMenu_RestartLabelLayout" xml:space="preserve">
-    <value>Resume Label Layout</value>
+    <value>恢复标签布局</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AlignmentForm_UpdateGraph_Peptides" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.zh-CHS.resx
@@ -179,7 +179,7 @@
     <value>数据不够</value>
   </data>
   <data name="AreaCVHistogram2DGraphPane_UpdateGraph_Calculating____" xml:space="preserve">
-    <value>正在计算...</value>
+    <value>正在计算…</value>
   </data>
   <data name="AreaCVHistogram2DGraphPane_UpdateGraph_CV" xml:space="preserve">
     <value>变异系数</value>
@@ -191,7 +191,7 @@
     <value>中位数：{0}</value>
   </data>
   <data name="AreaCVHistogramGraphPane_AddLabels_Calculating____" xml:space="preserve">
-    <value>正在计算...</value>
+    <value>正在计算…</value>
   </data>
   <data name="AreaCVHistogramGraphPane_AddLabels_Median___0_" xml:space="preserve">
     <value>中位数：{0}</value>
@@ -343,7 +343,7 @@
     <value>  标准偏差：{1:#,##0}</value>
   </data>
   <data name="DetectionPlotPane_WaitingForData_Label" xml:space="preserve">
-    <value>正在计算（按 Esc 取消）...</value>
+    <value>正在计算（按 Esc 取消）…</value>
   </data>
   <data name="DetectionPlotPane_XAxis_Name" xml:space="preserve">
     <value>重复测定</value>
@@ -531,7 +531,7 @@
     <comment>replaces 3D graph filter button's tooltip when "ion mobility" data is actually Waters SONAR</comment>
   </data>
   <data name="GraphFullScan_LoadScan_Loading___" xml:space="preserve">
-    <value>加载中...</value>
+    <value>加载中…</value>
   </data>
   <data name="GraphFullScan_LoadScan_Spectrum_unavailable" xml:space="preserve">
     <value>谱图不可用</value>

--- a/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.ja.resx
@@ -163,7 +163,7 @@
     <value>0</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>Enter a list of identifiers on separate lines.</value>
+    <value>別の行で識別子のリストを入力してください。</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
@@ -245,7 +245,7 @@
     <value>456, 450</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Enter List</value>
+    <value>リストの入力</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/MatchExpressionListDlg.zh-CHS.resx
@@ -163,7 +163,7 @@
     <value>0</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>Enter a list of identifiers on separate lines.</value>
+    <value>在不同的行输入标识符列表。</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
@@ -245,7 +245,7 @@
     <value>456, 450</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Enter List</value>
+    <value>输入列表</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;modeUIHandler.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.ja.resx
@@ -457,7 +457,7 @@
     <value>9</value>
   </data>
   <data name="enterListButton.Text" xml:space="preserve">
-    <value>&amp;Enter List...</value>
+    <value>リストの入力(&amp;E)...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;enterListButton.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.zh-CHS.resx
@@ -457,7 +457,7 @@
     <value>9</value>
   </data>
   <data name="enterListButton.Text" xml:space="preserve">
-    <value>&amp;Enter List...</value>
+    <value>输入列表(&amp;E)...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;enterListButton.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/CreateMatchExpressionDlg.zh-CHS.resx
@@ -457,7 +457,7 @@
     <value>9</value>
   </data>
   <data name="enterListButton.Text" xml:space="preserve">
-    <value>输入列表(&amp;E)...</value>
+    <value>输入列表(&amp;E)…</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;enterListButton.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/GroupComparison/GroupComparisonResources.ja.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/GroupComparisonResources.ja.resx
@@ -131,7 +131,7 @@
     <value>ボルケーノプロット</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Protein_Expression_Formatting" xml:space="preserve">
-    <value>Relative Abundance Formatting</value>
+    <value>相対的存在量のフォーマット</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/GroupComparisonResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/GroupComparisonResources.zh-CHS.resx
@@ -131,7 +131,7 @@
     <value>火山图</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Protein_Expression_Formatting" xml:space="preserve">
-    <value>Relative Abundance Formatting</value>
+    <value>相对丰度格式</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.ja.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.ja.resx
@@ -253,7 +253,7 @@
     <value>1</value>
   </data>
   <data name="layoutLabelsBox.Text" xml:space="preserve">
-    <value>Auto arrange labels</value>
+    <value>ラベルの自動配置</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;layoutLabelsBox.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.zh-CHS.resx
@@ -253,7 +253,7 @@
     <value>1</value>
   </data>
   <data name="layoutLabelsBox.Text" xml:space="preserve">
-    <value>Auto arrange labels</value>
+    <value>自动排列标签</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;layoutLabelsBox.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/SeqNode/SeqNodeResources.ja.resx
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SeqNodeResources.ja.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="NodeTip_Timer_Tick_An_error_occurred_displaying_a_tooltip_" xml:space="preserve">
-    <value>An error occurred displaying a tooltip.</value>
+    <value>ツールヒントの表示中にエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideGroupTreeNode_ChildHeading__0__" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/SeqNode/SeqNodeResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/SeqNode/SeqNodeResources.zh-CHS.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="NodeTip_Timer_Tick_An_error_occurred_displaying_a_tooltip_" xml:space="preserve">
-    <value>An error occurred displaying a tooltip.</value>
+    <value>显示工具提示时出错。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideGroupTreeNode_ChildHeading__0__" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.ja.resx
@@ -259,7 +259,7 @@
     <value>0</value>
   </data>
   <data name="lblStatus.Text" xml:space="preserve">
-    <value>File reading status</value>
+    <value>ファイル読み取りステータス</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="lblStatus.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
@@ -359,7 +359,7 @@
     <value>5</value>
   </data>
   <data name="btnRemoveFile.ToolTip" xml:space="preserve">
-    <value>Remove from list</value>
+    <value>リストから削除</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;btnRemoveFile.Name" xml:space="preserve">
@@ -414,7 +414,7 @@
     <value>4</value>
   </data>
   <data name="btnAddSpectrumFilter.Text" xml:space="preserve">
-    <value>Add Spectrum Filter...</value>
+    <value>スペクトルフィルタを追加...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;btnAddSpectrumFilter.Name" xml:space="preserve">
@@ -472,7 +472,7 @@
     <value>2</value>
   </data>
   <data name="listBoxFiles.ToolTip" xml:space="preserve">
-    <value>Remove from list</value>
+    <value>リストから削除</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;listBoxFiles.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
@@ -414,7 +414,7 @@
     <value>4</value>
   </data>
   <data name="btnAddSpectrumFilter.Text" xml:space="preserve">
-    <value>添加 Spectrum 过滤器...</value>
+    <value>添加 Spectrum 过滤器…</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;btnAddSpectrumFilter.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Spectra/SpectrumGridForm.zh-CHS.resx
@@ -259,7 +259,7 @@
     <value>0</value>
   </data>
   <data name="lblStatus.Text" xml:space="preserve">
-    <value>File reading status</value>
+    <value>文件读取状态</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="lblStatus.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
@@ -359,7 +359,7 @@
     <value>5</value>
   </data>
   <data name="btnRemoveFile.ToolTip" xml:space="preserve">
-    <value>Remove from list</value>
+    <value>移出列表</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;btnRemoveFile.Name" xml:space="preserve">
@@ -414,7 +414,7 @@
     <value>4</value>
   </data>
   <data name="btnAddSpectrumFilter.Text" xml:space="preserve">
-    <value>Add Spectrum Filter...</value>
+    <value>添加 Spectrum 过滤器...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;btnAddSpectrumFilter.Name" xml:space="preserve">
@@ -472,7 +472,7 @@
     <value>2</value>
   </data>
   <data name="listBoxFiles.ToolTip" xml:space="preserve">
-    <value>Remove from list</value>
+    <value>移出列表</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;listBoxFiles.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/EditUI/ArrangeGraphsGroupedDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/ArrangeGraphsGroupedDlg.ja.resx
@@ -423,7 +423,7 @@
     <value>4</value>
   </data>
   <data name="labelDisplay.Text" xml:space="preserve">
-    <value>表示(&amp;S):</value>
+    <value>表示(&amp;S)：</value>
   </data>
   <data name="&gt;&gt;labelDisplay.Name" xml:space="preserve">
     <value>labelDisplay</value>

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.ja.resx
@@ -367,11 +367,11 @@
     <value>14</value>
   </data>
   <data name="lblGroupAtGeneLevel.Text" xml:space="preserve">
-    <value>Group at g&amp;ene level</value>
+    <value>遺伝子レベルでグループ化(&amp;E)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="lblGroupAtGeneLevel.ToolTip" xml:space="preserve">
-    <value>Peptides will be associated and grouped by gene instead of by protein.</value>
+    <value>ペプチドがタンパク質ではなく遺伝子ごとに関連付けられ、グループ化されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;lblGroupAtGeneLevel.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.zh-CHS.resx
@@ -367,11 +367,11 @@
     <value>14</value>
   </data>
   <data name="lblGroupAtGeneLevel.Text" xml:space="preserve">
-    <value>Group at g&amp;ene level</value>
+    <value>按基因水平分组(&amp;E)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="lblGroupAtGeneLevel.ToolTip" xml:space="preserve">
-    <value>Peptides will be associated and grouped by gene instead of by protein.</value>
+    <value>肽段将按基因而非蛋白质进行关联和分组。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;lblGroupAtGeneLevel.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.ja.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="propertyColumn.HeaderText" xml:space="preserve">
-    <value>Property</value>
+    <value>プロパティ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
@@ -377,7 +377,7 @@
     <value>12</value>
   </data>
   <data name="lblDescription.Text" xml:space="preserve">
-    <value>FASTAファイルかバックグラウンドプロテオームのいずれかを用いて、ドキュメント内のペプチドすべてを関連するタンパク質かタンパク質グループに再編成します。 既存のタンパク質の関連付けは破棄されます。</value>
+    <value>説明</value>
     <comment>Needs Review:English text changed
 Old English:Use either a FASTA file or a background proteome to reorganize all document peptides into associated proteins or protein groups. Existing protein associations will be discarded.
 Current English:Description
@@ -459,7 +459,7 @@ Old Localized:FASTAファイルかバックグラウンドプロテオームの�
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Edit Spectrum Filter</value>
+    <value>スペクトラムフィルタの編集</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;propertyColumn.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/EditSpectrumFilterDlg.zh-CHS.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="propertyColumn.HeaderText" xml:space="preserve">
-    <value>Property</value>
+    <value>属性</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
@@ -455,7 +455,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Edit Spectrum Filter</value>
+    <value>编辑谱图过滤器</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="&gt;&gt;propertyColumn.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/EditUI/EditUIResources.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/EditUIResources.ja.resx
@@ -463,15 +463,15 @@ Example: Looplink: T [4]
     <value>これらのタンパク質に含まれるもの：</value>
   </data>
   <data name="AssociateProteinsDlg_Find_minimal_gene_group_list_that_explains_all_peptides" xml:space="preserve">
-    <value>Find &amp;minimal gene group list that explains all peptides</value>
+    <value>すべてのペプチドを説明する最小の遺伝子グループを検索する(&amp;M)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AssociateProteinsDlg_Min_peptides_per_gene" xml:space="preserve">
-    <value>Mi&amp;n peptides per gene</value>
+    <value>遺伝子あたりの最小ペプチド数(&amp;N)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AssociateProteinsDlg_Remove_subset_genes" xml:space="preserve">
-    <value>&amp;Remove subset genes</value>
+    <value>サブセットの遺伝子を削除(&amp;R)</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/EditUI/EditUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/EditUIResources.zh-CHS.resx
@@ -463,15 +463,15 @@ Example: Looplink: T [4]
     <value>这些蛋白质包含：</value>
   </data>
   <data name="AssociateProteinsDlg_Find_minimal_gene_group_list_that_explains_all_peptides" xml:space="preserve">
-    <value>Find &amp;minimal gene group list that explains all peptides</value>
+    <value>查找可以解释所有肽段的最小基因组列表(&amp;M)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AssociateProteinsDlg_Min_peptides_per_gene" xml:space="preserve">
-    <value>Mi&amp;n peptides per gene</value>
+    <value>每个基因的最少肽段数(&amp;N)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AssociateProteinsDlg_Remove_subset_genes" xml:space="preserve">
-    <value>&amp;Remove subset genes</value>
+    <value>删除子集基因(&amp;R)</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/EditUI/EditUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/EditUI/EditUIResources.zh-CHS.resx
@@ -134,7 +134,7 @@
     <value>无</value>
   </data>
   <data name="AlignItem_ToString_Retention_time_calculator___" xml:space="preserve">
-    <value>保留时间计算器...</value>
+    <value>保留时间计算器…</value>
   </data>
   <data name="AlignItem_ToString_Retention_time_calculator___0__" xml:space="preserve">
     <value>保留时间计算器 ({0})</value>

--- a/pwiz_tools/Skyline/EditUI/FindNodeDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/FindNodeDlg.ja.resx
@@ -193,7 +193,7 @@
     <value>0</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>検索項目(&amp;F):</value>
+    <value>検索項目(&amp;F)：</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>

--- a/pwiz_tools/Skyline/EditUI/RTChartPropertyDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/RTChartPropertyDlg.ja.resx
@@ -208,7 +208,7 @@
     <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>最大時間(&amp;T):</value>
+    <value>最大時間(&amp;T)：</value>
   </data>
   <data name="&gt;&gt;label2.Name" xml:space="preserve">
     <value>label2</value>
@@ -310,7 +310,7 @@
     <value>3</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>最小時間(&amp;T):</value>
+    <value>最小時間(&amp;T)：</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -436,7 +436,7 @@
     <value>0</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
-    <value>時間領域をグラフ化(&amp;G):</value>
+    <value>時間領域をグラフ化(&amp;G)：</value>
   </data>
   <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
     <value>groupBox1</value>

--- a/pwiz_tools/Skyline/EditUI/RefineDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/RefineDlg.ja.resx
@@ -1570,7 +1570,7 @@
     <value>3</value>
   </data>
   <data name="labelNormalize.Text" xml:space="preserve">
-    <value>正規化（&amp;N）：</value>
+    <value>正規化(&amp;N)：</value>
   </data>
   <data name="&gt;&gt;labelNormalize.Name" xml:space="preserve">
     <value>labelNormalize</value>
@@ -1687,7 +1687,7 @@
     <value>2</value>
   </data>
   <data name="labelDetections.Text" xml:space="preserve">
-    <value>検出（&amp;D）：</value>
+    <value>検出(&amp;D)：</value>
   </data>
   <data name="&gt;&gt;labelDetections.Name" xml:space="preserve">
     <value>labelDetections</value>

--- a/pwiz_tools/Skyline/EditUI/RefineProteinListDlg.ja.resx
+++ b/pwiz_tools/Skyline/EditUI/RefineProteinListDlg.ja.resx
@@ -286,7 +286,7 @@
     <value>0</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>残して置おくタンパク質(&amp;P):</value>
+    <value>残して置おくタンパク質(&amp;P)：</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>

--- a/pwiz_tools/Skyline/FileUI/CreateIrtCalculatorDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/CreateIrtCalculatorDlg.ja.resx
@@ -400,7 +400,7 @@
     <value>7</value>
   </data>
   <data name="radioUseList.Text" xml:space="preserve">
-    <value>別々のトランジションリストから新しいiRTカルキュレータを作成(&amp;C):</value>
+    <value>別々のトランジションリストから新しいiRTカルキュレータを作成(&amp;C)：</value>
   </data>
   <data name="&gt;&gt;radioUseList.Name" xml:space="preserve">
     <value>radioUseList</value>
@@ -451,7 +451,7 @@
     <value>11</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>iRTデータベース(&amp;D):</value>
+    <value>iRTデータベース(&amp;D)：</value>
   </data>
   <data name="&gt;&gt;label1.Name" xml:space="preserve">
     <value>label1</value>
@@ -481,7 +481,7 @@
     <value>8</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>トランジションリスト(&amp;T):</value>
+    <value>トランジションリスト(&amp;T)：</value>
   </data>
   <data name="&gt;&gt;label3.Name" xml:space="preserve">
     <value>label3</value>
@@ -556,7 +556,7 @@
     <value>14</value>
   </data>
   <data name="radioUseProtein.Text" xml:space="preserve">
-    <value>インポートされたトランジションリストのタンパク質から新しいiRTカルキュレータを作成(&amp;W):</value>
+    <value>インポートされたトランジションリストのタンパク質から新しいiRTカルキュレータを作成(&amp;W)：</value>
   </data>
   <data name="&gt;&gt;radioUseProtein.Name" xml:space="preserve">
     <value>radioUseProtein</value>
@@ -586,7 +586,7 @@
     <value>17</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
-    <value>iRTデータベース(&amp;D):</value>
+    <value>iRTデータベース(&amp;D)：</value>
   </data>
   <data name="&gt;&gt;label6.Name" xml:space="preserve">
     <value>label6</value>

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.ja.resx
@@ -1736,12 +1736,12 @@ Skylineで制御されないトランジション値に対しては、単一の�
     <value>0</value>
   </data>
   <data name="cbExportSciexOSQuantMethod.Text" xml:space="preserve">
-    <value>Create SCIEX &amp;OS 
-    Quant method</value>
+    <value>SCIEX OS 
+ Quantメソッドを作成(&amp;O)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="cbExportSciexOSQuantMethod.ToolTip" xml:space="preserve">
-    <value>Exports a SCIEX OS Quant compatible analysis method to the same directory and base name as the Analyst acquisition method.</value>
+    <value>SCIEX OS Quantと互換性のある分析メソッドを、Analyst取得メソッドと同じディレクトリと同じベース名でエクスポートします。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbExportSciexOSQuantMethod.Name" xml:space="preserve">
@@ -1775,7 +1775,7 @@ Skylineで制御されないトランジション値に対しては、単一の�
     <value>False</value>
   </data>
   <data name="labelXICWidth.Text" xml:space="preserve">
-    <value>XIC Width (Da):</value>
+    <value>XIC幅（Da）：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;labelXICWidth.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/FileUI/ExportMethodDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/ExportMethodDlg.zh-CHS.resx
@@ -1739,12 +1739,12 @@
     <value>0</value>
   </data>
   <data name="cbExportSciexOSQuantMethod.Text" xml:space="preserve">
-    <value>Create SCIEX &amp;OS 
-    Quant method</value>
+    <value>创建 SCIEX OS 
+ Quant 方法(&amp;O)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="cbExportSciexOSQuantMethod.ToolTip" xml:space="preserve">
-    <value>Exports a SCIEX OS Quant compatible analysis method to the same directory and base name as the Analyst acquisition method.</value>
+    <value>将 SCIEX OS Quant 兼容的分析方法导出到相同目录，基本名称与 Analyst 采集方法相同。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbExportSciexOSQuantMethod.Name" xml:space="preserve">
@@ -1778,7 +1778,7 @@
     <value>False</value>
   </data>
   <data name="labelXICWidth.Text" xml:space="preserve">
-    <value>XIC Width (Da):</value>
+    <value>XIC 宽度 (Da):</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;labelXICWidth.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/FileUI/FileUIResources.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/FileUIResources.ja.resx
@@ -185,11 +185,11 @@
     <value>選択したフォルダにBruker TOFメソッドテンプレートが含まれていないようです。フォルダは、.m拡張子が付き、submethods.xmlファイルを含むと予測されています。</value>
   </data>
   <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
-    <value>The chosen folder does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+    <value>選択したフォルダにはAgilent MassHunter 12メソッドテンプレートが含まれていないようです。このフォルダには拡張子.mが必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_an_Agilent_QQQ_method_template_The_folder_is_expected_to_have_a_m_extension_and_contain_the_file_qqqacqmethod_xsd" xml:space="preserve">
-    <value>選択したフォルダには、Agilent QQQメソッドテンプレートが含まれていないようです。フォルダには.m拡張子が付き、qqqacqmethod.xsdファイルを含むと予測されています。</value>
+    <value>Agilent 6400シリーズ装置タイプのメソッドには.m拡張子が付き、qqqacqmethod.xsdファイルが含まれると予測されています。これがAgilent TQメソッドである場合は、装置タイプとして「Agilent MassHunter 12以降」を選択してください。</value>
     <comment>Needs Review:English text changed
 Old English:The chosen folder does not appear to contain an Agilent QQQ method template. The folder is expected to have a .m extension, and contain the file qqqacqmethod.xsd.
 Current English:Agilent 6400 series instrument type methods are expected to have a .m extension, and contain the file qqqacqmethod.xsd. If this is an Agilent TQ method, please choose "Agilent MassHunter 12 or higher" as your instrument type.
@@ -289,7 +289,7 @@ Old Localized:選択したフォルダには、Agilent QQQメソッドテンプ�
     <value>フォルダ{0}にBruker TOFメソッドテンプレートが含まれていないようです。フォルダは、.m拡張子が付き、submethods.xmlファイルを含むと予測されています。</value>
   </data>
   <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
-    <value>The folder {0} does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+    <value>フォルダ{0}にはAgilent MassHunter 12メソッドテンプレートが含まれていないようです。このフォルダには拡張子.mが必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_an_Agilent_QQQ_method_template_The_folder_is_expected_to_have_a_m_extension_and_contain_the_file_qqqacqmethod_xsd" xml:space="preserve">

--- a/pwiz_tools/Skyline/FileUI/FileUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/FileUIResources.zh-CHS.resx
@@ -422,7 +422,7 @@ Old Localized:选定的文件夹无 Agilent QQQ 方法模板。文件夹预计�
     <value>文本“{0}”并不是选定文件的后缀。</value>
   </data>
   <data name="ImportTransitionListColumnSelectDlg_CheckForErrors_Checking_for_errors___" xml:space="preserve">
-    <value>正在检查错误...</value>
+    <value>正在检查错误…</value>
   </data>
   <data name="ImportTransitionListColumnSelectDlg_CheckMoleculeColumns_Molecular_Formula_and_or_Precursor_m_z" xml:space="preserve">
     <value>分子式和/或母离子质荷比</value>

--- a/pwiz_tools/Skyline/FileUI/FileUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/FileUIResources.zh-CHS.resx
@@ -185,11 +185,11 @@
     <value>选定的文件夹无 Bruker TOF 方法模板。文件夹应包括一个 .m 文件，以及 submethods.xml。</value>
   </data>
   <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
-    <value>The chosen folder does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+    <value>所选文件夹似乎不包含 Agilent MassHunter 12 方法模板。该文件夹的扩展名应为 .m。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ExportMethodDlg_btnBrowseTemplate_Click_The_chosen_folder_does_not_appear_to_contain_an_Agilent_QQQ_method_template_The_folder_is_expected_to_have_a_m_extension_and_contain_the_file_qqqacqmethod_xsd" xml:space="preserve">
-    <value>选定的文件夹无 Agilent QQQ 方法模板。文件夹预计将拥有 .m 扩展名，并且包含文件 qqqacqmethod.xsd。</value>
+    <value>Agilent 6400 系列仪器类型方法的扩展名应为 .m，并且应当包含文件 qqqacqmethod.xsd。如果是采用 Agilent TQ 方法，请选择“Agilent MassHunter 12 或更高版本”作为仪器类型。</value>
     <comment>Needs Review:English text changed
 Old English:The chosen folder does not appear to contain an Agilent QQQ method template. The folder is expected to have a .m extension, and contain the file qqqacqmethod.xsd.
 Current English:Agilent 6400 series instrument type methods are expected to have a .m extension, and contain the file qqqacqmethod.xsd. If this is an Agilent TQ method, please choose "Agilent MassHunter 12 or higher" as your instrument type.
@@ -289,7 +289,7 @@ Old Localized:选定的文件夹无 Agilent QQQ 方法模板。文件夹预计�
     <value>文件夹{0}无 Bruker TOF 方法模板。文件夹应包括一个 .m 文件，以及 submethods.xml。</value>
   </data>
   <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
-    <value>The folder {0} does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+    <value>文件夹 {0} 似乎不包含 Agilent MassHunter 12 方法模板。该文件夹的扩展名应为 .m。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ExportMethodDlg_OkDialog_The_folder__0__does_not_appear_to_contain_an_Agilent_QQQ_method_template_The_folder_is_expected_to_have_a_m_extension_and_contain_the_file_qqqacqmethod_xsd" xml:space="preserve">

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.ja.resx
@@ -142,7 +142,7 @@
     <value>17, 17</value>
   </metadata>
   <data name="radioDIA.ToolTip" xml:space="preserve">
-    <value>Library spectra from DDA MS/MS with chromatograms from separate DIA runs</value>
+    <value>DDA MS/MSからのライブラリスペクトルと、個別のDIAランからのクロマトグラム</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;radioDIA.Name" xml:space="preserve">
@@ -176,7 +176,7 @@
     <value>&amp;PRM</value>
   </data>
   <data name="radioPRM.ToolTip" xml:space="preserve">
-    <value>Library spectra and chromatograms from the same PRM runs</value>
+    <value>同じPRMランからのライブラリスペクトルとクロマトグラム</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;radioPRM.Name" xml:space="preserve">
@@ -210,7 +210,7 @@
     <value>MS&amp;1フィルタを用いたDDA</value>
   </data>
   <data name="radioDDA.ToolTip" xml:space="preserve">
-    <value>Library spectra from DDA MS/MS with chromatograms from MS1</value>
+    <value>DDA MS/MSからのライブラリスペクトルと、MS1からのクロマトグラム</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;radioDDA.Name" xml:space="preserve">
@@ -271,8 +271,7 @@
     <value>構築(&amp;B)</value>
   </data>
   <data name="radioButtonNewLibrary.ToolTip" xml:space="preserve">
-    <value>Build a new library from existing search results files,
-like TPP pepXML, Mascot .dat, SEQUEST SQT, etc.</value>
+    <value>TPP pepXML、Mascot .dat、SEQUEST SQT などの既存の検索結果ファイルから新しいライブラリを構築します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;radioButtonNewLibrary.Name" xml:space="preserve">
@@ -354,8 +353,7 @@ like TPP pepXML, Mascot .dat, SEQUEST SQT, etc.</value>
     <value>1</value>
   </data>
   <data name="tbxLibraryPath.ToolTip" xml:space="preserve">
-    <value>Path to an existing library in a recognized format,
-like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
+    <value>BiblioSpec .blib、EncyclopeDIA .elib、SpectraST .sqtなど認識可能な形式の既存ライブラリへのパス</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;tbxLibraryPath.Name" xml:space="preserve">
@@ -527,7 +525,7 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
     <value>5</value>
   </data>
   <data name="comboStandards.ToolTip" xml:space="preserve">
-    <value>Choose a set of know iRT standard peptides to use for retention time normalization.</value>
+    <value>保持時間の正規化に使用する既知のiRT標準ペプチドセットを選択します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;comboStandards.Name" xml:space="preserve">
@@ -564,7 +562,7 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
     <value>曖昧な一致を含む(&amp;I)</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.ToolTip" xml:space="preserve">
-    <value>Check to keep spectra that match multiple peptides.</value>
+    <value>オンにすると、複数のペプチドに一致するスペクトルが残ります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.Name" xml:space="preserve">
@@ -601,7 +599,7 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
     <value>ドキュメント内のペプチドをフィルタリング(&amp;E)</value>
   </data>
   <data name="cbFilterForDocumentPeptides.ToolTip" xml:space="preserve">
-    <value>Check to filter matches for only the peptides in the document.</value>
+    <value>オンにすると、ドキュメント内のペプチドのみに対して一致する結果がフィルタリングされます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbFilterForDocumentPeptides.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/BuildPeptideSearchLibraryControl.zh-CHS.resx
@@ -142,7 +142,7 @@
     <value>17, 17</value>
   </metadata>
   <data name="radioDIA.ToolTip" xml:space="preserve">
-    <value>Library spectra from DDA MS/MS with chromatograms from separate DIA runs</value>
+    <value>来自 DDA MS/MS 的库谱图与来自单独 DIA 运行的色谱图</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;radioDIA.Name" xml:space="preserve">
@@ -176,7 +176,7 @@
     <value>&amp;PRM</value>
   </data>
   <data name="radioPRM.ToolTip" xml:space="preserve">
-    <value>Library spectra and chromatograms from the same PRM runs</value>
+    <value>来自相同 PRM 运行的库谱图和色谱图</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;radioPRM.Name" xml:space="preserve">
@@ -210,7 +210,7 @@
     <value>含有 MS&amp;1 筛选器的 DDA</value>
   </data>
   <data name="radioDDA.ToolTip" xml:space="preserve">
-    <value>Library spectra from DDA MS/MS with chromatograms from MS1</value>
+    <value>来自 DDA MS/MS 的库谱图与来自 MS1 的色谱图</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;radioDDA.Name" xml:space="preserve">
@@ -271,8 +271,8 @@
     <value>构建(&amp;B)</value>
   </data>
   <data name="radioButtonNewLibrary.ToolTip" xml:space="preserve">
-    <value>Build a new library from existing search results files,
-like TPP pepXML, Mascot .dat, SEQUEST SQT, etc.</value>
+    <value>从搜索到的
+TPP pepXML、Mascot .dat、SEQUEST SQT 等现有结果文件建立新库。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;radioButtonNewLibrary.Name" xml:space="preserve">
@@ -354,8 +354,7 @@ like TPP pepXML, Mascot .dat, SEQUEST SQT, etc.</value>
     <value>1</value>
   </data>
   <data name="tbxLibraryPath.ToolTip" xml:space="preserve">
-    <value>Path to an existing library in a recognized format,
-like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
+    <value>以可识别的格式提供的现有库的路径，如 BiblioSpec .blib、EncyclopeDIA .elib、SpectraST .sqt</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;tbxLibraryPath.Name" xml:space="preserve">
@@ -527,7 +526,7 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
     <value>5</value>
   </data>
   <data name="comboStandards.ToolTip" xml:space="preserve">
-    <value>Choose a set of know iRT standard peptides to use for retention time normalization.</value>
+    <value>选择一组已知的 iRT 标准肽段，用于保留时间归一化。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;comboStandards.Name" xml:space="preserve">
@@ -564,7 +563,7 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
     <value>包含模糊的匹配项(&amp;I)</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.ToolTip" xml:space="preserve">
-    <value>Check to keep spectra that match multiple peptides.</value>
+    <value>选中将保留与多个肽段匹配的谱图。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.Name" xml:space="preserve">
@@ -601,7 +600,7 @@ like BiblioSpec .blib, EncyclopeDIA .elib, SpectraST .sqt</value>
     <value>文档中肽段的筛选器(&amp;E)</value>
   </data>
   <data name="cbFilterForDocumentPeptides.ToolTip" xml:space="preserve">
-    <value>Check to filter matches for only the peptides in the document.</value>
+    <value>选中将仅过滤文档中的肽段。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbFilterForDocumentPeptides.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.zh-CHS.resx
@@ -478,7 +478,7 @@
     <value>20</value>
   </data>
   <data name="ceLabel.Text" xml:space="preserve">
-    <value>默认 NCE(&amp;C):</value>
+    <value>默认 NCE(&amp;C)：</value>
   </data>
   <data name="&gt;&gt;ceLabel.Name" xml:space="preserve">
     <value>ceLabel</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.ja.resx
@@ -1048,7 +1048,7 @@
     <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>変換設定を調整</value>
+    <value>変換設定</value>
     <comment>Needs Review:English text changed
 Old English:Adjust Conversion Settings
 Current English:Conversion Settings
@@ -1136,7 +1136,7 @@ Old Localized:変換設定を調整</comment>
     <value>0</value>
   </data>
   <data name="lblSearchSettings.Text" xml:space="preserve">
-    <value>検索設定の調整</value>
+    <value>検索設定</value>
     <comment>Needs Review:English text changed
 Old English:Adjust Search Settings
 Current English:Search Settings

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.zh-CHS.resx
@@ -1052,7 +1052,7 @@
     <value>0</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>调整转换设置</value>
+    <value>转换设置</value>
     <comment>Needs Review:English text changed
 Old English:Adjust Conversion Settings
 Current English:Conversion Settings
@@ -1140,7 +1140,7 @@ Old Localized:调整转换设置</comment>
     <value>0</value>
   </data>
   <data name="lblSearchSettings.Text" xml:space="preserve">
-    <value>调整搜索设置</value>
+    <value>搜索设置</value>
     <comment>Needs Review:English text changed
 Old English:Adjust Search Settings
 Current English:Search Settings

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.ja.resx
@@ -287,7 +287,7 @@
     <value>まだ欠損している結果ファイルがあります。本当に続行しますか？</value>
   </data>
   <data name="ImportPeptideSearchDlg_ImportPeptideSearchDlg_Feature_Detection" xml:space="preserve">
-    <value>Feature Detection</value>
+    <value>フィーチャーの検出</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ImportPeptideSearchDlg_UpdateFullScanSettings_Full_scan_MS1_filtering_must_be_enabled_in_order_to_import_a_peptide_search_" xml:space="preserve">
@@ -300,7 +300,7 @@
     <value>ペプチド検索のインポート</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_btnAddFile_Click_Select_Files_to_Search" xml:space="preserve">
-    <value>Select Files to Search</value>
+    <value>検索するファイルを選択</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ImportResultsControl_findResultsFilesButton_Click_Could_not_find_all_the_missing_results_files_" xml:space="preserve">
@@ -359,11 +359,11 @@
     <value>スペクトルライブラリを追加</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_Detected_Features_Library" xml:space="preserve">
-    <value>Building detected features library</value>
+    <value>検出したフィーチャーのライブラリを構築中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ImportPeptideSearchDlg_NextPage_Adding_detected_features_to_document" xml:space="preserve">
-    <value>Adding detected features to document</value>
+    <value>検出したフィーチャーをドキュメントに追加中</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.zh-CHS.resx
@@ -215,7 +215,7 @@
     <value>搜索失败。</value>
   </data>
   <data name="DDASearchControl_SearchProgress_Starting_search" xml:space="preserve">
-    <value>正在启动搜索...</value>
+    <value>正在启动搜索…</value>
   </data>
   <data name="EncyclopeDiaSearchControl_Search_Reusing_Koina_predictions_from___0_" xml:space="preserve">
     <value>再次使用来自 {0} 的 Koina 预测</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.zh-CHS.resx
@@ -287,7 +287,7 @@
     <value>部分结果文件仍然缺失。您确定想要继续？</value>
   </data>
   <data name="ImportPeptideSearchDlg_ImportPeptideSearchDlg_Feature_Detection" xml:space="preserve">
-    <value>Feature Detection</value>
+    <value>特征检测</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ImportPeptideSearchDlg_UpdateFullScanSettings_Full_scan_MS1_filtering_must_be_enabled_in_order_to_import_a_peptide_search_" xml:space="preserve">
@@ -300,7 +300,7 @@
     <value>导入肽段搜索</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_btnAddFile_Click_Select_Files_to_Search" xml:space="preserve">
-    <value>Select Files to Search</value>
+    <value>选择要搜索的文件</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ImportResultsControl_findResultsFilesButton_Click_Could_not_find_all_the_missing_results_files_" xml:space="preserve">
@@ -359,11 +359,11 @@
     <value>添加谱图库</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibrary_Building_Detected_Features_Library" xml:space="preserve">
-    <value>Building detected features library</value>
+    <value>正在建立检测的特征库</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ImportPeptideSearchDlg_NextPage_Adding_detected_features_to_document" xml:space="preserve">
-    <value>Adding detected features to document</value>
+    <value>正在向文档中添加检测到的特征</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.ja.resx
@@ -644,7 +644,7 @@
     <value>17, 17</value>
   </metadata>
   <data name="textHardklorMinIntensityPPM.ToolTip" xml:space="preserve">
-    <value>Ignore features whose intensity relative to the sum of all detected feature intensities in a sample is less than this</value>
+    <value>試料内で検出されたすべてのフィーチャーの強度の合計に対して強度がこれより低いフィーチャーを無視</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;textHardklorMinIntensityPPM.Name" xml:space="preserve">
@@ -672,7 +672,7 @@
     <value>4</value>
   </data>
   <data name="labelMinIntensityPPM.Text" xml:space="preserve">
-    <value>Min &amp;intensity proportion:</value>
+    <value>最小強度比(&amp;I)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;labelMinIntensityPPM.Name" xml:space="preserve">
@@ -724,7 +724,7 @@
     <value>0</value>
   </data>
   <data name="labelHardklorMinIdotP.Text" xml:space="preserve">
-    <value>Min isotope &amp;dot product:</value>
+    <value>最小同位体ドット積(&amp;D)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;labelHardklorMinIdotP.Name" xml:space="preserve">
@@ -749,8 +749,7 @@
     <value>3</value>
   </data>
   <data name="textHardklorSignalToNoise.ToolTip" xml:space="preserve">
-    <value>Sets Hardklor configuration's signal-to-noise threshold, i.e. the relative abundance a peak must exceed in the spectrum window to be considered in the scoring algorithm.
-Note that this is a local noise threshold for the area of the spectrum that the peptide was identified in.</value>
+    <value>Hardklor設定の信号対ノイズ比の閾値を設定します。つまり、スコア算出アルゴリズムで考慮されるにはスペクトルウィンドウでピークが超える必要のある相対的存在量です。これは、ペプチドが同定されたスペクトル領域のローカルノイズ閾値であることに留意してください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;textHardklorSignalToNoise.Name" xml:space="preserve">
@@ -781,7 +780,7 @@ Note that this is a local noise threshold for the area of the spectrum that the 
     <value>2</value>
   </data>
   <data name="lblHardklorSignalToNoise.Text" xml:space="preserve">
-    <value>Min &amp;signal to noise:</value>
+    <value>最小信号対ノイズ比(&amp;S)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;lblHardklorSignalToNoise.Name" xml:space="preserve">
@@ -806,7 +805,7 @@ Note that this is a local noise threshold for the area of the spectrum that the 
     <value>18</value>
   </data>
   <data name="groupBoxHardklor.Text" xml:space="preserve">
-    <value>Search parameters</value>
+    <value>検索パラメータ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;groupBoxHardklor.Name" xml:space="preserve">
@@ -831,13 +830,8 @@ Note that this is a local noise threshold for the area of the spectrum that the 
     <value>17</value>
   </data>
   <data name="textCutoff.ToolTip" xml:space="preserve">
-    <value>A score from 1.0 - 0, with 1.0 most likely to be correct,
-used to provide a cut-off for spectra in the results that will
-be included in the library.
-
-For TPP pepXML this is the minimum PeptideProphet probability.
-For Mascot this is 1 - the maximum expectation value.
-For SEQUEST SQT this is 1 - the maximum FDR.</value>
+    <value>ライブラリに含める結果のスペクトルに対するカットオフに使用される1.0から 0までのスコア（1.0が最も高確率と考えられる）。
+TPP pepXMLでは、この値は最小PeptideProphet確率です。Mascotでは、この値は1 - 最大期待値です。SEQUEST SQTでは、この値は1 - 最大FDRです。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;textCutoff.Name" xml:space="preserve">
@@ -868,7 +862,7 @@ For SEQUEST SQT this is 1 - the maximum FDR.</value>
     <value>16</value>
   </data>
   <data name="labelCutoff.Text" xml:space="preserve">
-    <value>Q値のカットオフ：</value>
+    <value>カットオフスコア(&amp;C)：</value>
     <comment>Needs Review:English text changed
 Old English:Q value cutoff:
 Current English:&amp;Cut-off score:

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.zh-CHS.resx
@@ -644,7 +644,7 @@
     <value>17, 17</value>
   </metadata>
   <data name="textHardklorMinIntensityPPM.ToolTip" xml:space="preserve">
-    <value>Ignore features whose intensity relative to the sum of all detected feature intensities in a sample is less than this</value>
+    <value>忽略相对于样品中所有检测到的特征强度总和小于此值的特征</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;textHardklorMinIntensityPPM.Name" xml:space="preserve">
@@ -672,7 +672,7 @@
     <value>4</value>
   </data>
   <data name="labelMinIntensityPPM.Text" xml:space="preserve">
-    <value>Min &amp;intensity proportion:</value>
+    <value>最小强度比例(&amp;I):</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;labelMinIntensityPPM.Name" xml:space="preserve">
@@ -724,7 +724,7 @@
     <value>0</value>
   </data>
   <data name="labelHardklorMinIdotP.Text" xml:space="preserve">
-    <value>Min isotope &amp;dot product:</value>
+    <value>最小同位素点积(&amp;D)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;labelHardklorMinIdotP.Name" xml:space="preserve">
@@ -749,8 +749,7 @@
     <value>3</value>
   </data>
   <data name="textHardklorSignalToNoise.ToolTip" xml:space="preserve">
-    <value>Sets Hardklor configuration's signal-to-noise threshold, i.e. the relative abundance a peak must exceed in the spectrum window to be considered in the scoring algorithm.
-Note that this is a local noise threshold for the area of the spectrum that the peptide was identified in.</value>
+    <value>设置 Hardklor 配置的信噪比阈值，即峰在谱图窗口中要被纳入得分算法考虑范围而必须超过的相对丰度。请注意，这是局部噪声阈值，适用于识别该肽段的谱图面积。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;textHardklorSignalToNoise.Name" xml:space="preserve">
@@ -781,7 +780,7 @@ Note that this is a local noise threshold for the area of the spectrum that the 
     <value>2</value>
   </data>
   <data name="lblHardklorSignalToNoise.Text" xml:space="preserve">
-    <value>Min &amp;signal to noise:</value>
+    <value>最小信噪比(&amp;S):</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;lblHardklorSignalToNoise.Name" xml:space="preserve">
@@ -806,7 +805,7 @@ Note that this is a local noise threshold for the area of the spectrum that the 
     <value>18</value>
   </data>
   <data name="groupBoxHardklor.Text" xml:space="preserve">
-    <value>Search parameters</value>
+    <value>搜索参数</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;groupBoxHardklor.Name" xml:space="preserve">
@@ -831,13 +830,8 @@ Note that this is a local noise threshold for the area of the spectrum that the 
     <value>17</value>
   </data>
   <data name="textCutoff.ToolTip" xml:space="preserve">
-    <value>A score from 1.0 - 0, with 1.0 most likely to be correct,
-used to provide a cut-off for spectra in the results that will
-be included in the library.
-
-For TPP pepXML this is the minimum PeptideProphet probability.
-For Mascot this is 1 - the maximum expectation value.
-For SEQUEST SQT this is 1 - the maximum FDR.</value>
+    <value>得分为 1.0 至 0，1.0 最有可能正确，用来为将包含在库结果中的谱图提供截止值。
+对于 TPP pepXML，此值为 PeptideProphet 的最小概率。对于 Mascot，此值为 1，即最大预期值。对于 SEQUEST SQT，此值为 1，即最大 FDR。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;textCutoff.Name" xml:space="preserve">
@@ -868,7 +862,7 @@ For SEQUEST SQT this is 1 - the maximum FDR.</value>
     <value>16</value>
   </data>
   <data name="labelCutoff.Text" xml:space="preserve">
-    <value>Q 值截止：</value>
+    <value>截止得分(&amp;C)：</value>
     <comment>Needs Review:English text changed
 Old English:Q value cutoff:
 Current English:&amp;Cut-off score:

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.zh-CHS.resx
@@ -672,7 +672,7 @@
     <value>4</value>
   </data>
   <data name="labelMinIntensityPPM.Text" xml:space="preserve">
-    <value>最小强度比例(&amp;I):</value>
+    <value>最小强度比例(&amp;I)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;labelMinIntensityPPM.Name" xml:space="preserve">
@@ -780,7 +780,7 @@
     <value>2</value>
   </data>
   <data name="lblHardklorSignalToNoise.Text" xml:space="preserve">
-    <value>最小信噪比(&amp;S):</value>
+    <value>最小信噪比(&amp;S)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;lblHardklorSignalToNoise.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.ja.resx
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.ja.resx
@@ -319,14 +319,14 @@
     <value>7</value>
   </data>
   <data name="cbAnonymousServers.Text" xml:space="preserve">
-    <value>Show anonymous servers</value>
+    <value>匿名サーバーを表示</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <metadata name="toolTipShowAnonymous.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
   </metadata>
   <data name="cbAnonymousServers.ToolTip" xml:space="preserve">
-    <value>Anonymous servers are not associated with a user account. A user account is required to upload documents to a server.</value>
+    <value>匿名サーバーはユーザーアカウントには関連付けられません。サーバーにドキュメントをアップロードするには、ユーザーアカウントが必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbAnonymousServers.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.zh-CHS.resx
@@ -319,14 +319,14 @@
     <value>7</value>
   </data>
   <data name="cbAnonymousServers.Text" xml:space="preserve">
-    <value>Show anonymous servers</value>
+    <value>显示匿名服务器</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <metadata name="toolTipShowAnonymous.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
   </metadata>
   <data name="cbAnonymousServers.ToolTip" xml:space="preserve">
-    <value>Anonymous servers are not associated with a user account. A user account is required to upload documents to a server.</value>
+    <value>匿名服务器未关联用户帐户。需要有用户帐户才能向服务器上传文档。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbAnonymousServers.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/ChromatogramContextMenu.zh-CHS.resx
@@ -161,7 +161,7 @@
     <value>212, 22</value>
   </data>
   <data name="synchronizeIntegrationContextMenuItem.Text" xml:space="preserve">
-    <value>同步积分...</value>
+    <value>同步积分…</value>
   </data>
   <data name="toolStripSeparator33.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 6</value>
@@ -221,7 +221,7 @@
     <value>212, 22</value>
   </data>
   <data name="relativeAbundanceFormattingMenuItem.Text" xml:space="preserve">
-    <value>格式化...</value>
+    <value>格式化…</value>
   </data>
   <data name="transformChromContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>212, 22</value>
@@ -296,7 +296,7 @@
     <value>172, 22</value>
   </data>
   <data name="thresholdRTContextMenuItem.Text" xml:space="preserve">
-    <value>高于阈值...</value>
+    <value>高于阈值…</value>
   </data>
   <data name="noneRTContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>172, 22</value>

--- a/pwiz_tools/Skyline/Menus/MenusResources.ja.resx
+++ b/pwiz_tools/Skyline/Menus/MenusResources.ja.resx
@@ -320,18 +320,16 @@
     <value>予期しない文字「{0}」が{1}行目で見つかりました。</value>
   </data>
   <data name="RefineMenu_ShowGenerateDecoysDlg_Are_you_sure_you_want_to_add_decoys_to_this_document_" xml:space="preserve">
-    <value>Are you sure you want to add decoys to this document?
-    
-This document uses peak boundaries from spectral libraries. When these boundaries are used, Skyline does not perform its own peak detection.
+    <value>このドキュメントにデコイを追加してもよろしいですか？ 
+このドキュメントはスペクトルライブラリから得たピーク境界を使用します。このような境界を使用している場合、Skylineで独自のピーク検出は実行されません。
+ピークスコアモデルを効果的にトレーニングできるようにするには、以下の手順に従います。
 
-To be ready to train a peak scoring model effectively, follow these steps:
-
-1. Navigate to the "Settings &gt; Peptide Settings - Libraries" tab and click "Edit List".
-2. Select a library item, click "Edit", and uncheck the "Use explicit peak bounds" checkbox.</value>
+1. [設定] &gt; [ペプチド設定 - ライブラリ] タブに移動して [リストの編集] をクリックします。
+2. ライブラリのアイテムを選択して [編集] をクリックし、[指定されたピーク境界を使用する] チェックボックスをオフにします。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RefineMenu_ShowGenerateDecoysDlg_Add_Decoys" xml:space="preserve">
-    <value>Add Decoys</value>
+    <value>デコイを追加</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Menus/MenusResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/MenusResources.zh-CHS.resx
@@ -320,18 +320,16 @@
     <value>第 {1} 行发现意外字符“{0}”。</value>
   </data>
   <data name="RefineMenu_ShowGenerateDecoysDlg_Are_you_sure_you_want_to_add_decoys_to_this_document_" xml:space="preserve">
-    <value>Are you sure you want to add decoys to this document?
-    
-This document uses peak boundaries from spectral libraries. When these boundaries are used, Skyline does not perform its own peak detection.
+    <value>确定要向本文档添加诱饵吗？ 
+该文档使用谱图库中的峰边界。使用这些边界时，Skyline 不会自行检测峰。
+要准备有效地训练峰得分模型，请按照以下步骤操作：
 
-To be ready to train a peak scoring model effectively, follow these steps:
-
-1. Navigate to the "Settings &gt; Peptide Settings - Libraries" tab and click "Edit List".
-2. Select a library item, click "Edit", and uncheck the "Use explicit peak bounds" checkbox.</value>
+1. 导航至“设置 &gt; 肽段设置 - 库”选项卡，然后单击“编辑列表”。
+2. 选择库中的某项，单击“编辑”，然后取消选中“使用明示峰界限”复选框。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RefineMenu_ShowGenerateDecoysDlg_Add_Decoys" xml:space="preserve">
-    <value>Add Decoys</value>
+    <value>添加诱饵</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Menus/ViewMenu.ja.resx
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.ja.resx
@@ -706,7 +706,7 @@
     <value>228, 22</value>
   </data>
   <data name="areaRelativeAbundanceMenuItem.Text" xml:space="preserve">
-    <value>Relative &amp;Abundance</value>
+    <value>相対的存在量(&amp;A)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="areaCVHistogramMenuItem.Size" type="System.Drawing.Size, System.Drawing">

--- a/pwiz_tools/Skyline/Menus/ViewMenu.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.zh-CHS.resx
@@ -706,7 +706,7 @@
     <value>228, 22</value>
   </data>
   <data name="areaRelativeAbundanceMenuItem.Text" xml:space="preserve">
-    <value>Relative &amp;Abundance</value>
+    <value>相对丰度(&amp;A)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="areaCVHistogramMenuItem.Size" type="System.Drawing.Size, System.Drawing">

--- a/pwiz_tools/Skyline/Model/AuditLog/EnumNames.ja.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/EnumNames.ja.resx
@@ -373,7 +373,7 @@
     <value>PRM</value>
   </data>
   <data name="Workflow_feature_detection" xml:space="preserve">
-    <value>Feature Detection</value>
+    <value>フィーチャーの検出</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="TransitionLibraryPick_none" xml:space="preserve">
@@ -722,19 +722,19 @@
     <value>Lightに対する比率</value>
   </data>
   <data name="SharedPeptidesGene_AssignedToBestProtein" xml:space="preserve">
-    <value>Assigned to the gene with the most peptides</value>
+    <value>ペプチドの最も多い遺伝子に割り当て</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SharedPeptidesGene_AssignedToFirstProtein" xml:space="preserve">
-    <value>Assigned to the first gene</value>
+    <value>最初の遺伝子に割り当て</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SharedPeptidesGene_DuplicatedBetweenProteins" xml:space="preserve">
-    <value>Duplicated between genes</value>
+    <value>遺伝子間で重複</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SharedPeptidesGene_Removed" xml:space="preserve">
-    <value>Removed (peptides must be unique to a single gene)</value>
+    <value>削除済み（ペプチドは1つの遺伝子に固有の必要がある）</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/AuditLog/EnumNames.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/EnumNames.zh-CHS.resx
@@ -373,7 +373,7 @@
     <value>PRM（并行反应离子监测）</value>
   </data>
   <data name="Workflow_feature_detection" xml:space="preserve">
-    <value>Feature Detection</value>
+    <value>特征检测</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="TransitionLibraryPick_none" xml:space="preserve">
@@ -722,19 +722,19 @@
     <value>相对于轻的比率</value>
   </data>
   <data name="SharedPeptidesGene_AssignedToBestProtein" xml:space="preserve">
-    <value>Assigned to the gene with the most peptides</value>
+    <value>已分配给肽段最多的基因 </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SharedPeptidesGene_AssignedToFirstProtein" xml:space="preserve">
-    <value>Assigned to the first gene</value>
+    <value>已分配给第一个基因</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SharedPeptidesGene_DuplicatedBetweenProteins" xml:space="preserve">
-    <value>Duplicated between genes</value>
+    <value>基因之间重复</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SharedPeptidesGene_Removed" xml:space="preserve">
-    <value>Removed (peptides must be unique to a single gene)</value>
+    <value>已删除（肽段必须对单个基因唯一）</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.ja.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.ja.resx
@@ -1107,7 +1107,7 @@
     <value>電荷</value>
   </data>
   <data name="HardklorSettings_MinIntensityPPM" xml:space="preserve">
-    <value>Min intensity PPM</value>
+    <value>最小強度PPM</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSettings_MinIdotP" xml:space="preserve">
@@ -1150,7 +1150,7 @@
     <value>フルスキャン設定を行う</value>
   </data>
   <data name="ImportPeptideSearchSettings_HardklorSearchSettings" xml:space="preserve">
-    <value>Hardklor Search Settings</value>
+    <value>Hardklor検索設定</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ImportPeptideSearchSettings_ImportFastaSettings" xml:space="preserve">
@@ -1787,18 +1787,18 @@
     <value>最小m/z</value>
   </data>
   <data name="ParsimonySettings_GeneLevelParsimony" xml:space="preserve">
-    <value>Group at gene level</value>
+    <value>遺伝子レベルでグループ化</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DataSettings_RelativeAbundanceFormatting" xml:space="preserve">
-    <value>Relative Abundance Formatting</value>
+    <value>相対的存在量のフォーマット</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RelativeAbundanceFormatting_ColorRows" xml:space="preserve">
     <value>フォーマット行</value>
   </data>
   <data name="CutoffScore_PERCOLATOR_QVALUE" xml:space="preserve">
-    <value>Max q-value</value>
+    <value>最大Q値</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DdaSearchSettings_ScoreThreshold" xml:space="preserve">

--- a/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/AuditLog/PropertyNames.zh-CHS.resx
@@ -1107,7 +1107,7 @@
     <value>电荷</value>
   </data>
   <data name="HardklorSettings_MinIntensityPPM" xml:space="preserve">
-    <value>Min intensity PPM</value>
+    <value>最小强度 PPM</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSettings_MinIdotP" xml:space="preserve">
@@ -1150,7 +1150,7 @@
     <value>配置全扫描设置</value>
   </data>
   <data name="ImportPeptideSearchSettings_HardklorSearchSettings" xml:space="preserve">
-    <value>Hardklor Search Settings</value>
+    <value>Hardklor 搜索设置</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ImportPeptideSearchSettings_ImportFastaSettings" xml:space="preserve">
@@ -1787,18 +1787,18 @@
     <value>最小质荷比</value>
   </data>
   <data name="ParsimonySettings_GeneLevelParsimony" xml:space="preserve">
-    <value>Group at gene level</value>
+    <value>按基因水平分组</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DataSettings_RelativeAbundanceFormatting" xml:space="preserve">
-    <value>Relative Abundance Formatting</value>
+    <value>相对丰度格式</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RelativeAbundanceFormatting_ColorRows" xml:space="preserve">
     <value>格式化行</value>
   </data>
   <data name="CutoffScore_PERCOLATOR_QVALUE" xml:space="preserve">
-    <value>Max q-value</value>
+    <value>最大 Q 值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DdaSearchSettings_ScoreThreshold" xml:space="preserve">

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.ja.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.ja.resx
@@ -220,15 +220,15 @@
     <value>計算濃度</value>
   </data>
   <data name="CalculatedConcentrationMessage">
-    <value>Calculated Concentration Message</value>
+    <value>計算濃度メッセージ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalculatedConcentrationRaw">
-    <value>Calculated Concentration Raw</value>
+    <value>計算濃度（生データ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalculatedConcentrationStrict">
-    <value>Calculated Concentration Strict</value>
+    <value>計算濃度（厳密なデータ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalibrationCurve">
@@ -784,19 +784,19 @@
     <value>分子リスト存在量</value>
   </data>
   <data name="MoleculeListAbundanceMessage">
-    <value>Molecule List Abundance Message</value>
+    <value>分子リストの存在量に関するメッセージ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceStrict">
-    <value>Molecule List Abundance Strict</value>
+    <value>分子リスト存在量（厳密なデータ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceTransitionAveraged">
-    <value>Molecule List Abundance Transition Averaged</value>
+    <value>分子リスト存在量トランジション（平均）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceTransitionSummed">
-    <value>Molecule List Abundance Transition Summed</value>
+    <value>分子リスト存在量トランジション（合計）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListLocator">
@@ -869,15 +869,15 @@
     <value>正規化面積</value>
   </data>
   <data name="NormalizedAreaMessage">
-    <value>Normalized Area Message</value>
+    <value>正規化面積に関するメッセージ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NormalizedAreaRaw">
-    <value>Normalized Area Raw</value>
+    <value>正規化面積（生データ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NormalizedAreaStrict">
-    <value>Normalized Area Strict</value>
+    <value>正規化面積（厳密なデータ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NumberOfPoints">
@@ -977,7 +977,7 @@
     <value>ペプチドシーケンス長</value>
   </data>
   <data name="PeptideSpectrumMatchCount">
-    <value>Peptide Spectrum Match Count</value>
+    <value>ペプチドスペクトル一致数</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PointCount">
@@ -999,15 +999,15 @@
     <value>プリカーサー計算濃度</value>
   </data>
   <data name="PrecursorCalculatedConcentrationMessage">
-    <value>Precursor Calculated Concentration Message</value>
+    <value>プリカーサー計算濃度に関するメッセージ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCalculatedConcentrationRaw">
-    <value>Precursor Calculated Concentration Raw</value>
+    <value>プリカーサー計算濃度（生データ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCalculatedConcentrationStrict">
-    <value>Precursor Calculated Concentration Strict</value>
+    <value>プリカーサー計算濃度（厳密なデータ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCharge">
@@ -1041,15 +1041,15 @@
     <value>プリカーサー正規化面積</value>
   </data>
   <data name="PrecursorNormalizedAreaMessage">
-    <value>Precursor Normalized Area Message</value>
+    <value>プリカーサー正規化面積に関するメッセージ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNormalizedAreaRaw">
-    <value>Precursor Normalized Area Raw</value>
+    <value>プリカーサー正規化面積（生データ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNormalizedAreaStrict">
-    <value>Precursor Normalized Area Strict</value>
+    <value>プリカーサー正規化面積（厳密なデータ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNote">
@@ -1119,19 +1119,19 @@
     <value>タンパク質存在量</value>
   </data>
   <data name="ProteinAbundanceMessage">
-    <value>Protein Abundance Message</value>
+    <value>タンパク質存在量に関するメッセージ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceStrict">
-    <value>Protein Abundance Strict</value>
+    <value>タンパク質存在量（厳密なデータ）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceTransitionAveraged">
-    <value>Protein Abundance Transition Averaged</value>
+    <value>タンパク質存在量トランジション（平均）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceTransitionSummed">
-    <value>Protein Abundance Transition Summed</value>
+    <value>タンパク質存在量トランジション（合計）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAccession">
@@ -1207,7 +1207,7 @@
     <value>標準に対する比率</value>
   </data>
   <data name="Raw">
-    <value>Raw</value>
+    <value>生データ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RawData">
@@ -1391,14 +1391,14 @@
     <value>Stdev総面積比</value>
   </data>
   <data name="Strict">
-    <value>Strict</value>
+    <value>厳密なデータ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SummaryMessage">
     <value>概要に関するメッセージ</value>
   </data>
   <data name="SurrogateExternalStandard">
-    <value>Surrogate External Standard</value>
+    <value>サロゲート外部標準</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="TargetQualitativeIonRatio">

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnCaptions.zh-CHS.resx
@@ -220,15 +220,15 @@
     <value>计算的浓度</value>
   </data>
   <data name="CalculatedConcentrationMessage">
-    <value>Calculated Concentration Message</value>
+    <value>计算的浓度消息</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalculatedConcentrationRaw">
-    <value>Calculated Concentration Raw</value>
+    <value>计算的浓度原始值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalculatedConcentrationStrict">
-    <value>Calculated Concentration Strict</value>
+    <value>计算的浓度精确值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalibrationCurve">
@@ -784,19 +784,19 @@
     <value>分子列表丰度</value>
   </data>
   <data name="MoleculeListAbundanceMessage">
-    <value>Molecule List Abundance Message</value>
+    <value>分子列表丰度消息</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceStrict">
-    <value>Molecule List Abundance Strict</value>
+    <value>分子列表丰度精确值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceTransitionAveraged">
-    <value>Molecule List Abundance Transition Averaged</value>
+    <value>分子列表丰度离子对平均值 </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceTransitionSummed">
-    <value>Molecule List Abundance Transition Summed</value>
+    <value>分子列表丰度离子对总和</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListLocator">
@@ -869,15 +869,15 @@
     <value>校准后面积</value>
   </data>
   <data name="NormalizedAreaMessage">
-    <value>Normalized Area Message</value>
+    <value>归一化面积消息</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NormalizedAreaRaw">
-    <value>Normalized Area Raw</value>
+    <value>归一化面积原始值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NormalizedAreaStrict">
-    <value>Normalized Area Strict</value>
+    <value>归一化面积精确值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NumberOfPoints">
@@ -977,7 +977,7 @@
     <value>肽段序列长度</value>
   </data>
   <data name="PeptideSpectrumMatchCount">
-    <value>Peptide Spectrum Match Count</value>
+    <value>肽段谱图匹配计数</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PointCount">
@@ -999,15 +999,15 @@
     <value>母离子计算的浓度</value>
   </data>
   <data name="PrecursorCalculatedConcentrationMessage">
-    <value>Precursor Calculated Concentration Message</value>
+    <value>母离子计算的浓度消息</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCalculatedConcentrationRaw">
-    <value>Precursor Calculated Concentration Raw</value>
+    <value>母离子计算的浓度原始值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCalculatedConcentrationStrict">
-    <value>Precursor Calculated Concentration Strict</value>
+    <value>母离子计算的浓度精确值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCharge">
@@ -1041,15 +1041,15 @@
     <value>母离子校准后面积</value>
   </data>
   <data name="PrecursorNormalizedAreaMessage">
-    <value>Precursor Normalized Area Message</value>
+    <value>母离子归一化面积消息</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNormalizedAreaRaw">
-    <value>Precursor Normalized Area Raw</value>
+    <value>母离子归一化面积原始值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNormalizedAreaStrict">
-    <value>Precursor Normalized Area Strict</value>
+    <value>母离子归一化面积精确值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNote">
@@ -1119,19 +1119,19 @@
     <value>蛋白质丰度</value>
   </data>
   <data name="ProteinAbundanceMessage">
-    <value>Protein Abundance Message</value>
+    <value>蛋白质丰度消息</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceStrict">
-    <value>Protein Abundance Strict</value>
+    <value>蛋白质丰度精确值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceTransitionAveraged">
-    <value>Protein Abundance Transition Averaged</value>
+    <value>蛋白质丰度离子对平均值 </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceTransitionSummed">
-    <value>Protein Abundance Transition Summed</value>
+    <value>蛋白质丰度离子对总和</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAccession">
@@ -1207,7 +1207,7 @@
     <value>相对于标准品比率</value>
   </data>
   <data name="Raw">
-    <value>Raw</value>
+    <value>原始</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RawData">
@@ -1391,14 +1391,14 @@
     <value>总面积比标准偏差</value>
   </data>
   <data name="Strict">
-    <value>Strict</value>
+    <value>精确</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SummaryMessage">
     <value>总结消息</value>
   </data>
   <data name="SurrogateExternalStandard">
-    <value>Surrogate External Standard</value>
+    <value>替代外部标准</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="TargetQualitativeIonRatio">

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.ja.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.ja.resx
@@ -107,7 +107,7 @@
     <value>倍率変化の計算に使用されたこの繰り返し測定の値です。数値は正規化メソッドの他、倍率変化がタンパク質レベルで計算されているかペプチドレベルで計算されているかに依存します。</value>
   </data>
   <data name="Accuracy">
-    <value>アナライトの濃度と算出される濃度の比率（繰り返し測定で指定）</value>
+    <value>指定したアナライト濃度と算出される濃度の比率</value>
     <comment>Needs Review:English text changed
 Old English:Ratio of Calculated Concentration the Analyte Concentration (specified on the Replicate)
 Current English:Ratio of Calculated Concentration to the specified Analyte Concentration
@@ -202,9 +202,9 @@ Old Localized:アナライトの濃度と算出される濃度の比率（繰り
     <value>プリカーサーに対し、最も強度が高いトランジションの 保持時間の値です。</value>
   </data>
   <data name="CalculatedConcentration">
-    <value>アナライト濃度は、以下のいずれかによって計算されます：  
-1. 校正曲線を使用する（[ペプチド設定] &gt; [定量]に[回帰式に合わせる]が指定されている場合）  
-2. 内標準（またはサロゲート）に対する比率を使用し、内標準物質の濃度を乗じる</value>
+    <value>アナライト濃度は、以下のいずれかによって計算されます： 
+1. 校正曲線（[ペプチド設定] &gt; [定量] に[回帰適合] が指定されている場合）
+2. 内部標準（またはサロゲート）に対する比率と内部標準濃度による乗算</value>
     <comment>Needs Review:English text changed
 Old English:The concentration of the analyte is calculated by either:
     1. Using the calibration curve (if the Peptide Settings &gt; Quantification has a Regression Fit specified)
@@ -217,15 +217,15 @@ Old Localized:アナライト濃度は、以下のいずれかによって計算
 2. 内標準（またはサロゲート）に対する比率を使用し、内標準物質の濃度を乗じる</comment>
   </data>
   <data name="CalculatedConcentrationMessage">
-    <value>Warning if missing data impacts comparisons of the "Calculated Concentration" between replicates</value>
+    <value>繰り返し測定間の「計算濃度」の比較に欠損データの影響がある場合に警告を表示</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalculatedConcentrationRaw">
-    <value>Calculated concentration value available even when missing data impacts comparisons between replicates</value>
+    <value>繰り返し測定間の比較に欠損データの影響がある場合でも計算濃度値が利用可能</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalculatedConcentrationStrict">
-    <value>Calculated concentration value unavailable when missing data impacts comparisons between replicates</value>
+    <value>繰り返し測定間の比較に欠損データの影響がある場合には計算濃度値が利用不可能</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalibrationCurve">
@@ -583,7 +583,11 @@ Old Localized:アナライト濃度は、以下のいずれかによって計算
     <value>イオン移動度ライブラリからのプリカーサーの衝突断面積</value>
   </data>
   <data name="LibraryDotProduct">
-    <value>プリカーサーの各トランジションのピーク面積と一致したMS/MSスペクトルライブラリスペクトルにおける一致するイオンピークの強度との内積です（注：v1.4同様、 これは現在1 – Arcos(dotp)/(Pi/2)となっています。ここでdotpが上記に説明する値であり、 正規化スペクトルコントラスト角度とも言います）。プリカーサーに一致するライブラリスペクトルがない 場合やトランジションが4個未満の場合には#N/Aとなります。これは35であり、 メソッドの最適化に使用します。トランジションが6個以上ある場合に最もうまく機能します。</value>
+    <value>ユーザーインターフェイスに表示される「dotp」と同じ意味です。プリカーサーの各トランジションピーク面積
+と一致したMS/MSスペクトルライブラリスペクトルにおける一致するイオンピーク強度との内積です（注：v1.4同様、 これは現在1 â€“ Arcos(dotp)/(Pi/2)となっています。ここでdotpが上記に説明する値であり、 正規化スペクトルコントラスト角度とも言います）。
+プリカーサーに一致するライブラリスペクトルがない場合やトランジションが4個未満の場合には#N/Aとなります。これは35であり、
+メソッドの最適化に使用します。トランジションが6個以上
+ある場合に最もうまく機能します。</value>
     <comment>Needs Review:English text changed
 Old English:The dot-product between the individual transition peak areas
 of the precursor and the intensities of the matching ion peaks in the matched MS/MS
@@ -659,7 +663,7 @@ Old Localized:プリカーサーの各トランジションのピーク面積と
     <value>このフラグメントからのすべてのニュートラルロスの合計質量</value>
   </data>
   <data name="MassErrorPPM">
-    <value>質量誤差（ppm）</value>
+    <value>期待値と測定値のm/z値の差を百万分率（PPM）で表示</value>
     <comment>Needs Review:English text changed
 Old English:Mass Error PPM
 Current English:The difference between the expected and measured m/z values expressed in parts per million (PPM)
@@ -744,7 +748,7 @@ Old Localized:質量誤差（ppm）</comment>
 内標準ピーク面積がない場合はすべてのトランジションピーク面積からトランジションピーク面積の中央値が計算されます。</value>
   </data>
   <data name="Message">
-    <value>Warning, if any, of missing values that might impact comparisons of the "Raw" value between replicates.</value>
+    <value>繰り返し測定間の 「生データ」値の比較に影響を与えうる欠損値がある場合に警告を表示。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Min">
@@ -805,9 +809,7 @@ Old Localized:質量誤差（ppm）</comment>
     <value>Skylineドキュメントにある分子のグループ化です。</value>
   </data>
   <data name="MoleculeListAbundance">
-    <value>分子リストの存在量を表す数値です。この数値は、分子リストの下にある正規化面積を平均して得られます。
-面積は分子定量化設定で指定される正規化メソッドに従って正規化されます。
-この繰り返し測定中に値のないトランジションがある場合には、正規化メソッドが標識に対する比率でない限り、分子リスト存在量は空白となります。</value>
+    <value>[分子定量化] 設定で指定された「正規化メソッド」に従って算出された、分子リストの存在量を示す数値</value>
     <comment>Needs Review:English text changed
 Old English:A number representing the abundance of the molecule list. This number is obtained by averaging the normalized areas of all of the transitions under this Molecule List.
 The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings.
@@ -818,22 +820,19 @@ Old Localized:分子リストの存在量を表す数値です。この数値は
 この繰り返し測定中に値のないトランジションがある場合には、正規化メソッドが標識に対する比率でない限り、分子リスト存在量は空白となります。</comment>
   </data>
   <data name="MoleculeListAbundanceMessage">
-    <value>Warning if missing data impacts comparisons of "Molecule List Abundance" between replicates</value>
+    <value>繰り返し測定間の「分子リスト存在量」の比較に欠損データが影響する場合に警告を表示</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceStrict">
-    <value>A number representing the abundance of the molecule list, calculated according to the "Normalization Method" specified in the Molecule Quantification settings.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>[分子定量化] 設定で指定された「正規化メソッド」に従って算出された、分子リストの存在量を示す数値。繰り返し測定間の比較に欠損データの影響がある場合には利用できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceTransitionAveraged">
-    <value>Average of the normalized areas of the transitions under the Molecule List.
-The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings.</value>
+    <value>分子リストの下にあるトランジションの平均正規化面積。この面積は [分子定量化] 設定で指定された正規化メソッドに従って正規化されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceTransitionSummed">
-    <value>Sum of the normalized areas of the transitions under the Molecule List.
-The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings</value>
+    <value>分子リストの下にあるトランジションの合計正規化面積。この面積は [分子定量化] 設定で指定された正規化メソッドに従って正規化されます</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListLocator">
@@ -897,7 +896,7 @@ The areas are normalized according to the Normalization Method specified in the 
     <value>プリカーサーの強度（MS1レベル）かプロダクトの強度（MS2レベル）のみを使用して結果を取得したかを示します。</value>
   </data>
   <data name="NextAa">
-    <value>次のAa</value>
+    <value>タンパク質配列中のペプチドの直後に位置するアミノ酸残基。</value>
     <comment>Needs Review:English text changed
 Old English:Next Aa
 Current English:The amino acid residue found immediately after the peptide in the protein sequence.
@@ -911,7 +910,7 @@ Old Localized:次のAa</comment>
     <value>絶対定量とグループ比較のために、特定の分子で使用する正規化のメソッドを無効にします。</value>
   </data>
   <data name="NormalizedArea">
-    <value>そのペプチド/分子に指定された「正規化メソッド」または  [設定] &gt; [ペプチド設定] &gt; [定量化]で指定される正規化メソッドを使用したペプチド/分子の強度の正規化によって取得される値です。</value>
+    <value>そのペプチド/分子の明示的な「正規化メソッド」または [設定] &gt; [ペプチド設定] &gt; [定量化]で指定される正規化メソッドでペプチド/分子強度を正規化して取得される値です。</value>
     <comment>Needs Review:English text changed
 Old English:Value obtained by normalizing the peptide/molecule intensity according to either the explicit "Normalization Method" for the peptide/molecule or the normalization method specified on:
     Settings &gt; Peptide Settings &gt; Quantification
@@ -921,21 +920,15 @@ or the normalization method specified on Settings &gt; Peptide Settings &gt; Qua
 Old Localized:そのペプチド/分子に指定された「正規化メソッド」または  [設定] &gt; [ペプチド設定] &gt; [定量化]で指定される正規化メソッドを使用したペプチド/分子の強度の正規化によって取得される値です。</comment>
   </data>
   <data name="NormalizedAreaMessage">
-    <value>Warning if missing data impacts of the "Normalized Area" value between replicates</value>
+    <value>繰り返し測定間で「正規化面積」の値に欠損データの影響がある場合に警告を表示</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NormalizedAreaRaw">
-    <value>Value obtained by normalizing the peptide/molecule intensity according to either
-the explicit "Normalization Method" for the peptide/molecule
-or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification.
-Available even when missing data impacts comparisons between replicates.</value>
+    <value>そのペプチド/分子の明示的な「正規化メソッド」または [設定] &gt; [ペプチド設定] &gt; [定量化]で指定される正規化メソッドでペプチド/分子強度を正規化して取得される値です。繰り返し測定間の比較に欠損データの影響がある場合に利用可能です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NormalizedAreaStrict">
-    <value>Value obtained by normalizing the peptide/molecule intensity according to either
-the explicit "Normalization Method" for the peptide/molecule
-or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>そのペプチド/分子に指定された「正規化メソッド」または [設定] &gt; [ペプチド設定] &gt; [定量化]で指定される正規化メソッドを使用したペプチド/分子の強度の正規化によって取得される値です。繰り返し測定間の比較に欠損データの影響がある場合には利用できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NumberOfPoints">
@@ -1037,7 +1030,7 @@ Unavailable when missing data impacts comparisons between replicates.</value>
     <value>ペプチドシークエンスのアミノ酸数です。</value>
   </data>
   <data name="PeptideSpectrumMatchCount">
-    <value>Number of spectra in the spectral library which match the peptide and result file.</value>
+    <value>ペプチドと結果ファイルに一致するスペクトルライブラリ内のスペクトル数。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PointCount">
@@ -1059,21 +1052,19 @@ Unavailable when missing data impacts comparisons between replicates.</value>
     <value>アイソトポログ反応曲線を使用して計算されたプリカーサー結果の濃度です。</value>
   </data>
   <data name="PrecursorCalculatedConcentrationMessage">
-    <value>Warning if missing data impacts comparisons of "Precursor Calculated Concentration" between replicates</value>
+    <value>繰り返し測定間の「プリカーサー計算濃度」の比較に欠損データの影響がある場合に警告を表示</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCalculatedConcentrationRaw">
-    <value>The concentration of the Precursor Result calculated using the isotopolog response curve.
-Available even when missing data impacts comparisons between replicates.</value>
+    <value>アイソトポログ反応曲線を使用して計算されたプリカーサー結果の濃度です。繰り返し測定間の比較に欠損データの影響がある場合でも利用可能です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCalculatedConcentrationStrict">
-    <value>The concentration of the Precursor Result calculated using the isotopolog response curve.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>アイソトポログ反応曲線を使用して計算されたプリカーサー結果の濃度です。繰り返し測定間の比較に欠損データの影響がある場合には利用できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCharge">
-    <value>  プリカーサーイオンと関連付けられた電荷。</value>
+    <value>プリカーサーイオンと関連付けられた電荷。</value>
     <comment>Needs Review:English text changed
 Old English:
       The charge associated with the precursor ion.
@@ -1107,9 +1098,7 @@ Old Localized:  プリカーサーイオンと関連付けられた電荷。</co
     <value>プリカーサーのニュートラルな質量（Da）</value>
   </data>
   <data name="PrecursorNormalizedArea">
-    <value>プリカーサー結果の正規化面積。
-これはペプチドの正規化メソッドに従い正規化されたプリカーサー結果の合計面積と同じです。
-ペプチド正規化メソッドが「なし」または標識に対する比率である場合、プリカーサー正規化面積はプリカーサー合計面積と同じです。</value>
+    <value>プリカーサー結果の正規化面積。ペプチド正規化メソッドに従って正規化されたプリカーサー結果の総面積に等しい。ペプチド正規化メソッドが「なし」またはラベルに対する比率の場合、プリカーサーの正規化面積はプリカーサーの総面積と等しくなります。</value>
     <comment>Needs Review:English text changed
 Old English:The normalized area of the Precursor Result.
 This is equal to the Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
@@ -1122,21 +1111,15 @@ Old Localized:プリカーサー結果の正規化面積。
 ペプチド正規化メソッドが「なし」または標識に対する比率である場合、プリカーサー正規化面積はプリカーサー合計面積と同じです。</comment>
   </data>
   <data name="PrecursorNormalizedAreaMessage">
-    <value>Warning if missing values impacts comparisons of the "Precursor Normalized Area" value between replicates</value>
+    <value>繰り返し測定間の「プリカーサー正規化面積」の値の比較に欠損値の影響がある場合に警告を表示</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNormalizedAreaRaw">
-    <value>Normalized area of the Precursor Result.
-Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
-If the Peptide Normalization Method is "None" or ratio to a label, then the Precursor Normalized Area will be equal to the Total Area of the Precursor.
-Available even when missing data impacts comparisons between replicates.</value>
+    <value>プリカーサー結果の正規化面積。ペプチドの正規化メソッドに従って正規化されたプリカーサー結果の総面積に等しい。ペプチド正規化メソッドが「なし」またはラベルに対する比率の場合、プリカーサーの正規化面積はプリカーサーの総面積と等しくなります。繰り返し測定間の比較に欠損データの影響がある場合でも利用可能です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNormalizedAreaStrict">
-    <value>Normalized area of the Precursor Result.
-Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
-If the Peptide Normalization Method is "None" or ratio to a label, then the Precursor Normalized Area will be equal to the Total Area of the Precursor.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>プリカーサー結果の正規化面積。ペプチドの正規化メソッドに従って正規化されたプリカーサー結果の総面積に等しい。ペプチド正規化メソッドが「なし」またはラベルに対する比率の場合、プリカーサーの正規化面積はプリカーサーの総面積と等しくなります。繰り返し測定間の比較に欠損データの影響がある場合には利用できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNote">
@@ -1204,10 +1187,7 @@ Unavailable when missing data impacts comparisons between replicates.</value>
     <value>タンパク質</value>
   </data>
   <data name="ProteinAbundance">
-    <value>特定の繰り返し測定のタンパク質の存在量を表す数値です。
-タンパク質存在量は、タンパク質に帰属するすべてのトランジションの正規化面積の平均を使用して計算されます。
-トランジション面積はペプチド定量設定で指定される正規化メソッドに従って正規化されます。
-この繰り返し測定中にピーク面積のないトランジションがある場合、又は正規化メソッドが標識に対する比率でない限り、タンパク質リスト存在量は空白となります。</value>
+    <value>[ペプチド定量化] 設定で指定された「正規化メソッド」に従って算出された、タンパク質の存在量を示す数値。</value>
     <comment>Needs Review:English text changed
 Old English:A number representing the abundance of the protein in the particular replicate.
 The Protein Abundance is calculated by taking the average of the normalized areas of all of the Transitions under the Protein.
@@ -1220,22 +1200,19 @@ Old Localized:特定の繰り返し測定のタンパク質の存在量を表す
 この繰り返し測定中にピーク面積のないトランジションがある場合、又は正規化メソッドが標識に対する比率でない限り、タンパク質リスト存在量は空白となります。</comment>
   </data>
   <data name="ProteinAbundanceMessage">
-    <value>Warning if missing data impacts comparisons of "Protein Abundance" between replicates</value>
+    <value>繰り返し測定間の「タンパク質存在量」の比較に欠損データが影響がある場合に警告を表示</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceStrict">
-    <value>A number representing the abundance of the protein, calculated according to the "Normalization Method" specified in the Peptide Quantification settings.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>[ペプチド定量化] 設定で指定された「正規化メソッド」に従って算出された、タンパク質の存在量を示す数値。繰り返し測定間の比較に欠損データの影響がある場合には利用できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceTransitionAveraged">
-    <value>Average of the normalized areas of the transitions under the Protein.
-The areas are normalized according to the Normalization Method specified in the Peptide Quantification settings.</value>
+    <value>タンパク質の下にあるトランジションの平均正規化面積。この面積は、[ペプチド定量化] 設定で指定された正規化メソッドに従って正規化されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceTransitionSummed">
-    <value>Sum of the normalized areas of the transitions under the Protein.
-The areas are normalized according to the Normalization Method specified in the Peptide Quantification settings.</value>
+    <value>タンパク質の下にあるトランジションの合計正規化面積。この面積は、[ペプチド定量化] 設定で指定された正規化メソッドに従って正規化されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAccession">
@@ -1308,7 +1285,7 @@ The areas are normalized according to the Normalization Method specified in the 
     <value>MaxRetentionTimeとMinRetentionTime との差です。これを使用すると測定された保持時間の広がりの幅を評価できます。</value>
   </data>
   <data name="RatioDotProduct">
-    <value>内積比率</value>
+    <value>ユーザーインターフェイスに表示される「rdotp」と同じ意味です。ライブラリ内積の内積の計算を説明していますが、これはプリカーサーのピーク面積（例えばライト）と標準タイプのプリカーサーのピーク面積（例えばヘビー）との間の場合であり、標準タイプが存在しない場合またはプリカーサーが標準タイプの場合は#N/Aとなります。</value>
     <comment>Needs Review:English text changed
 Old English:Ratio Dot Product
 Current English:Equivalent to "rdotp" displayed in the user interface. The dot-product calculation described for Library Dot Product, but between the peak areas of the precursor (e.g. light) and the peak areas of the standard type precursor (e.g. heavy), or #N/A if there is either no standard type or the precursor is the standard type.
@@ -1318,7 +1295,7 @@ Old Localized:内積比率</comment>
     <value>LightのHeavyに対するペプチドの面積比</value>
   </data>
   <data name="Raw">
-    <value>Calculated value available even when missing data impacts comparisons between replicates.</value>
+    <value>繰り返し測定間の比較に欠損データの影響がある場合でも計算値が利用できます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RawData">
@@ -1513,14 +1490,14 @@ Double Blank（ダブルブランク）</value>
     <value>プリカーサーのTotalAreaNormalized値の標準偏差。</value>
   </data>
   <data name="Strict">
-    <value>Calculated value unavailable when missing data could comparisons between replicates.</value>
+    <value>繰り返し測定間の比較に欠損データが影響する可能性がある場合には計算値が利用できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SummaryMessage">
     <value>変更の説明</value>
   </data>
   <data name="SurrogateExternalStandard">
-    <value>Name of another peptide or molecule whose fitted calibration curve will be used for quantification of this peptide or molecule</value>
+    <value>このペプチドまたは分子の定量に使用される、適合した校正曲線を有する別のペプチドまたは分子の名前</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="TargetQualitativeIonRatio">

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.zh-CHS.resx
@@ -107,7 +107,7 @@
     <value>重复测定的值是用于计算倍数的变化。此数值取决于归一化方法以及是基于蛋白质还是肽段级别来计算倍数的变化。</value>
   </data>
   <data name="Accuracy">
-    <value>分析物浓度（在重复测定中指定的）与计算浓度比</value>
+    <value>计算的浓度与指定的分析物浓度之比</value>
     <comment>Needs Review:English text changed
 Old English:Ratio of Calculated Concentration the Analyte Concentration (specified on the Replicate)
 Current English:Ratio of Calculated Concentration to the specified Analyte Concentration
@@ -211,9 +211,9 @@ Old Localized:分析物浓度（在重复测定中指定的）与计算浓度比
 离子对的保留时间值。</value>
   </data>
   <data name="CalculatedConcentration">
-    <value>分析物的浓度由以下任一一种方式计算：
-    1.使用校正曲线（前提是“肽段设定 &gt; 定量”指定了回归拟合）
-    2.使用与内标（或替代）的比，并乘以内标浓度</value>
+    <value>分析物浓度通过以下任意一种方式计算：
+1. 使用校准曲线（前提是“肽段设置 &gt; 定量”指定了回归拟合）
+2. 使用与内标 (或替代) 的比，并乘以内标浓度。</value>
     <comment>Needs Review:English text changed
 Old English:The concentration of the analyte is calculated by either:
     1. Using the calibration curve (if the Peptide Settings &gt; Quantification has a Regression Fit specified)
@@ -226,15 +226,15 @@ Old Localized:分析物的浓度由以下任一一种方式计算：
     2.使用与内标（或替代）的比，并乘以内标浓度</comment>
   </data>
   <data name="CalculatedConcentrationMessage">
-    <value>Warning if missing data impacts comparisons of the "Calculated Concentration" between replicates</value>
+    <value>如果缺失的数据影响到比较重复测定之间“计算的浓度”，则发出警告</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalculatedConcentrationRaw">
-    <value>Calculated concentration value available even when missing data impacts comparisons between replicates</value>
+    <value>即使缺失的数据影响到重复测定之间的比较，仍可获取计算的浓度值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalculatedConcentrationStrict">
-    <value>Calculated concentration value unavailable when missing data impacts comparisons between replicates</value>
+    <value>缺失的数据影响到重复测定之间的比较时，不可获取计算的浓度值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CalibrationCurve">
@@ -617,13 +617,13 @@ Old Localized:分析物的浓度由以下任一一种方式计算：
     <value>离子迁移库中母离子的碰撞横截面</value>
   </data>
   <data name="LibraryDotProduct">
-    <value>母离子的单个离子对峰面积与匹配的串联质谱谱图库谱图
-中匹配离子峰的强度之间的点积（注释：截止版本 v1.4，为 1 – Arcos(dotp)/(Pi/2)，
-其中 dotp 是上文所述的值，
-又称归一化谱图对比角度）；或者如果母离子没有匹配的
-库谱图或离子对少于 4 个，则为 #N/A。这是用于
-方法调整的 35 个有用值。当存在 6 个或更多离子对时，
-效果最佳。</value>
+    <value>相当于用户界面中显示的“dotp”。母离子的单个离子对峰面积
+与匹配的 MS/MS
+谱图库谱图中匹配离子峰的强度之间的点积（注释：截止版本 v1.4，为 1 â€“ Arcos(dotp)/(Pi/2)，
+其中 dotp 是上文所述的值， 又称归一化谱图对比角度）；或者如果母离子没有匹配的
+库谱图或离子对少于 4 个，则为 #N/A。这是用于方法调整的 35 
+个有用值。当
+存在 6 个或更多离子对时， 效果最佳。</value>
     <comment>Needs Review:English text changed
 Old English:The dot-product between the individual transition peak areas
 of the precursor and the intensities of the matching ion peaks in the matched MS/MS
@@ -714,7 +714,7 @@ Old Localized:母离子的单个离子对峰面积与匹配的串联质谱谱图
     <value>此片段中所有中性丢失的总质量。</value>
   </data>
   <data name="MassErrorPPM">
-    <value>质量误差 PPM</value>
+    <value>以百万分之几 (PPM) 表示的预期质荷比值与测量值之差</value>
     <comment>Needs Review:English text changed
 Old English:Mass Error PPM
 Current English:The difference between the expected and measured m/z values expressed in parts per million (PPM)
@@ -801,7 +801,7 @@ Old Localized:质量误差 PPM</comment>
 如果没有内标峰面积，则根据所有离子对峰面积计算中位数离子对峰面积。</value>
   </data>
   <data name="Message">
-    <value>Warning, if any, of missing values that might impact comparisons of the "Raw" value between replicates.</value>
+    <value>缺失值（若有）可能影响重复测定之间进行“原始”值比较时，则发出警告。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Min">
@@ -865,9 +865,7 @@ Old Localized:质量误差 PPM</comment>
     <value>Skyline 文档中的一组分子。</value>
   </data>
   <data name="MoleculeListAbundance">
-    <value>表示分子列表丰度的数值。对该分子列表下所有离子对的归一化面积求平均值，即可得出该数值。
-根据“分子定量”设置中指定的归一化方法对面积进行归一化处理。
-如果该重复测定中有任何离子对缺少值，则除非归一化方法是与标记之间的比率，否则分子列表丰度将为空白</value>
+    <value>代表分子列表丰度的数值，该数值根据分子定量设置中指定的“归一化方法”计算得出</value>
     <comment>Needs Review:English text changed
 Old English:A number representing the abundance of the molecule list. This number is obtained by averaging the normalized areas of all of the transitions under this Molecule List.
 The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings.
@@ -878,22 +876,19 @@ Old Localized:表示分子列表丰度的数值。对该分子列表下所有离
 如果该重复测定中有任何离子对缺少值，则除非归一化方法是与标记之间的比率，否则分子列表丰度将为空白</comment>
   </data>
   <data name="MoleculeListAbundanceMessage">
-    <value>Warning if missing data impacts comparisons of "Molecule List Abundance" between replicates</value>
+    <value>如果缺失的数据影响到比较重复测定之间的“分子列表丰度”，则发出警告</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceStrict">
-    <value>A number representing the abundance of the molecule list, calculated according to the "Normalization Method" specified in the Molecule Quantification settings.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>代表分子列表丰度的数值，该数值根据分子定量设置中指定的“归一化方法”计算得出。在缺失的数据影响到重复测定之间的比较时不可获取</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceTransitionAveraged">
-    <value>Average of the normalized areas of the transitions under the Molecule List.
-The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings.</value>
+    <value>分子列表下的离子对面积归一化的平均值。这些面积根据“分子定量”设置中指定的“归一化方法”进行归一化。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListAbundanceTransitionSummed">
-    <value>Sum of the normalized areas of the transitions under the Molecule List.
-The areas are normalized according to the Normalization Method specified in the Molecule Quantification settings</value>
+    <value>分子列表下的离子对面积归一化总和。这些面积根据“分子定量”设置中指定的“归一化方法”进行归一化</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MoleculeListLocator">
@@ -957,7 +952,7 @@ The areas are normalized according to the Normalization Method specified in the 
     <value>指明该结果是否仅使用母离子强度（一级质谱）或子离子强度（二级质谱）获得。</value>
   </data>
   <data name="NextAa">
-    <value>下一个氨基酸</value>
+    <value>蛋白质序列中紧跟肽段之后的氨基酸残基。</value>
     <comment>Needs Review:English text changed
 Old English:Next Aa
 Current English:The amino acid residue found immediately after the peptide in the protein sequence.
@@ -971,8 +966,9 @@ Old Localized:下一个氨基酸</comment>
     <value>覆盖与该特定分子一起使用的归一化方法，进行绝对定量和组间比较。</value>
   </data>
   <data name="NormalizedArea">
-    <value>根据明示的肽段/分子“归一化方法”或在“设定 &gt; 肽段设定 &gt; 定量”中指定的归一化方法:
-    归一化肽段/分子强度而得的值</value>
+    <value>根据
+明示的肽段/分子“归一化方法”
+或在“设置 &gt; 肽段设置 &gt; 定量”中指定的归一化方法归一化肽段/分子强度而得出的值</value>
     <comment>Needs Review:English text changed
 Old English:Value obtained by normalizing the peptide/molecule intensity according to either the explicit "Normalization Method" for the peptide/molecule or the normalization method specified on:
     Settings &gt; Peptide Settings &gt; Quantification
@@ -983,21 +979,17 @@ Old Localized:根据明示的肽段/分子“归一化方法”或在“设定 &
     归一化肽段/分子强度而得的值</comment>
   </data>
   <data name="NormalizedAreaMessage">
-    <value>Warning if missing data impacts of the "Normalized Area" value between replicates</value>
+    <value>缺失的数据影响到重复测定之间的“归一化面积”值时发出警告</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NormalizedAreaRaw">
-    <value>Value obtained by normalizing the peptide/molecule intensity according to either
-the explicit "Normalization Method" for the peptide/molecule
-or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification.
-Available even when missing data impacts comparisons between replicates.</value>
+    <value>根据
+明示的肽段/分子“归一化方法”或在“设置 &gt; 肽段设置 &gt; 定量”中指定的归一化方法归一化肽段/分子强度而得出的值。在缺失的数据影响到重复测定之间的比较时仍可获取</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NormalizedAreaStrict">
-    <value>Value obtained by normalizing the peptide/molecule intensity according to either
-the explicit "Normalization Method" for the peptide/molecule
-or the normalization method specified on Settings &gt; Peptide Settings &gt; Quantification.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>根据
+明示的肽段/分子“归一化方法”或在“设置 &gt; 肽段设置 &gt; 定量”中指定的归一化方法归一化肽段/分子强度而得出的值。在缺失的数据影响到重复测定之间的比较时不可获取</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="NumberOfPoints">
@@ -1106,7 +1098,7 @@ Unavailable when missing data impacts comparisons between replicates.</value>
     <value>肽段序列中的氨基酸计数。</value>
   </data>
   <data name="PeptideSpectrumMatchCount">
-    <value>Number of spectra in the spectral library which match the peptide and result file.</value>
+    <value>谱图库中与肽段和结果文件相匹配的谱图数量。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PointCount">
@@ -1128,17 +1120,15 @@ Unavailable when missing data impacts comparisons between replicates.</value>
     <value>使用同位素响应曲线所计算母离子结果浓度。</value>
   </data>
   <data name="PrecursorCalculatedConcentrationMessage">
-    <value>Warning if missing data impacts comparisons of "Precursor Calculated Concentration" between replicates</value>
+    <value>如果缺失的数据影响到比较重复测定之间“母离子计算的浓度”，则发出警告</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCalculatedConcentrationRaw">
-    <value>The concentration of the Precursor Result calculated using the isotopolog response curve.
-Available even when missing data impacts comparisons between replicates.</value>
+    <value>使用同位素响应曲线所计算母离子结果浓度。在缺失的数据影响到重复测定之间的比较时仍可获取</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCalculatedConcentrationStrict">
-    <value>The concentration of the Precursor Result calculated using the isotopolog response curve.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>使用同位素响应曲线所计算母离子结果浓度。在缺失的数据影响到重复测定之间的比较时不可获取</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorCharge">
@@ -1176,9 +1166,7 @@ Old Localized:与母离子相关的电荷。</comment>
     <value>母离子的中性质量（以道尔顿为单位）</value>
   </data>
   <data name="PrecursorNormalizedArea">
-    <value>母离子结果的校准后面积。
-其等同于根据肽段校准方法所校准的母离子结果总面积。
-若肽段校准方法为“无”或相对于标记的比率。那么母离子校准后面积将等于母离子总面积。</value>
+    <value>母离子归一化面积结果。等于根据肽段归一化方法归一化的母离子总面积结果。如果肽段归一化方法为“无”或为与标签的比率，则母离子归一化面积将等于母离子总面积。</value>
     <comment>Needs Review:English text changed
 Old English:The normalized area of the Precursor Result.
 This is equal to the Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
@@ -1191,21 +1179,15 @@ Old Localized:母离子结果的校准后面积。
 若肽段校准方法为“无”或相对于标记的比率。那么母离子校准后面积将等于母离子总面积。</comment>
   </data>
   <data name="PrecursorNormalizedAreaMessage">
-    <value>Warning if missing values impacts comparisons of the "Precursor Normalized Area" value between replicates</value>
+    <value>缺失值影响到比较重复测定的“母离子归一化面积”值时发出警告</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNormalizedAreaRaw">
-    <value>Normalized area of the Precursor Result.
-Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
-If the Peptide Normalization Method is "None" or ratio to a label, then the Precursor Normalized Area will be equal to the Total Area of the Precursor.
-Available even when missing data impacts comparisons between replicates.</value>
+    <value>母离子归一化面积结果。等于根据肽段归一化方法归一化的母离子总面积结果。如果肽段归一化方法为“无”或为与标签的比率，则母离子归一化面积将等于母离子总面积。在缺失的数据影响到重复测定之间的比较时仍可获取</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNormalizedAreaStrict">
-    <value>Normalized area of the Precursor Result.
-Equal to Total Area of the Precursor Result normalized according to the Normalization Method of the Peptide.
-If the Peptide Normalization Method is "None" or ratio to a label, then the Precursor Normalized Area will be equal to the Total Area of the Precursor.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>母离子归一化面积结果。等于根据肽段归一化方法归一化的母离子总面积结果。如果肽段归一化方法为“无”或为与标签的比率，则母离子归一化面积将等于母离子总面积。在缺失的数据影响到重复测定之间的比较时不可获取</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PrecursorNote">
@@ -1280,11 +1262,7 @@ Unavailable when missing data impacts comparisons between replicates.</value>
     <value>蛋白质</value>
   </data>
   <data name="ProteinAbundance">
-    <value>表示特定重复测定中蛋白质丰度的数值。
-对蛋白质下所有离子对的归一化面积取平均值，即可计算出蛋白质丰度。
-离子对面积根据“肽段定量”设置中指定的归一化方法进行归一化处理。
-如果任何离子对在“重复测定”中缺少峰面积，蛋白质丰度将为空白，除非归一化方法是与标记的比率设置中指定的归一化方法进行归一化处理。
-如果该重复测定中有任何离子对缺少峰面积，则除非归一化方法是与标记之间的比率，否则蛋白质丰度将为空白。</value>
+    <value>代表蛋白质列表丰度的数值，该数值根据肽段定量设置中指定的“归一化方法”计算得出。</value>
     <comment>Needs Review:English text changed
 Old English:A number representing the abundance of the protein in the particular replicate.
 The Protein Abundance is calculated by taking the average of the normalized areas of all of the Transitions under the Protein.
@@ -1298,22 +1276,19 @@ Old Localized:表示特定重复测定中蛋白质丰度的数值。
 如果该重复测定中有任何离子对缺少峰面积，则除非归一化方法是与标记之间的比率，否则蛋白质丰度将为空白。</comment>
   </data>
   <data name="ProteinAbundanceMessage">
-    <value>Warning if missing data impacts comparisons of "Protein Abundance" between replicates</value>
+    <value>如果缺失的数据影响到比较重复测定之间的“蛋白质丰度”，则发出警告</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceStrict">
-    <value>A number representing the abundance of the protein, calculated according to the "Normalization Method" specified in the Peptide Quantification settings.
-Unavailable when missing data impacts comparisons between replicates.</value>
+    <value>代表蛋白质列表丰度的数值，该数值根据肽段定量设置中指定的“归一化方法”计算得出。在缺失的数据影响到重复测定之间的比较时不可获取。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceTransitionAveraged">
-    <value>Average of the normalized areas of the transitions under the Protein.
-The areas are normalized according to the Normalization Method specified in the Peptide Quantification settings.</value>
+    <value>“蛋白质”下的离子对面积归一化的平均值。这些面积根据“肽段定量”设置中指定的“归一化方法”进行归一化。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAbundanceTransitionSummed">
-    <value>Sum of the normalized areas of the transitions under the Protein.
-The areas are normalized according to the Normalization Method specified in the Peptide Quantification settings.</value>
+    <value>“蛋白质”下的离子对面积归一化总和。这些面积根据“肽段定量”设置中指定的“归一化方法”进行归一化。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAccession">
@@ -1397,7 +1372,7 @@ The areas are normalized according to the Normalization Method specified in the 
 漂移范围。</value>
   </data>
   <data name="RatioDotProduct">
-    <value>比率点积</value>
+    <value>相当于用户界面中显示的“rdotp”。库点积中所述的点积计算，但在母离子峰面积（如轻标）和标准类型母离子峰面积（如重标）之间进行计算，如果没有标准类型或母离子为标准类型则为 #N/A。</value>
     <comment>Needs Review:English text changed
 Old English:Ratio Dot Product
 Current English:Equivalent to "rdotp" displayed in the user interface. The dot-product calculation described for Library Dot Product, but between the peak areas of the precursor (e.g. light) and the peak areas of the standard type precursor (e.g. heavy), or #N/A if there is either no standard type or the precursor is the standard type.
@@ -1407,7 +1382,7 @@ Old Localized:比率点积</comment>
     <value>肽段的轻标/重标面积比</value>
   </data>
   <data name="Raw">
-    <value>Calculated value available even when missing data impacts comparisons between replicates.</value>
+    <value>即使缺失的数据影响到重复测定之间的比较，仍可获取计算值。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="RawData">
@@ -1607,14 +1582,14 @@ Old Localized:比率点积</comment>
 偏差。</value>
   </data>
   <data name="Strict">
-    <value>Calculated value unavailable when missing data could comparisons between replicates.</value>
+    <value>缺失的数据影响到重复测定之间的比较时，不可获取计算值。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SummaryMessage">
     <value>更改的描述</value>
   </data>
   <data name="SurrogateExternalStandard">
-    <value>Name of another peptide or molecule whose fitted calibration curve will be used for quantification of this peptide or molecule</value>
+    <value>将使用其拟合校准曲线来对该肽段或分子定量的其他肽段或分子的名称</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="TargetQualitativeIonRatio">

--- a/pwiz_tools/Skyline/Model/DdaSearch/DdaSearchResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/DdaSearch/DdaSearchResources.ja.resx
@@ -173,43 +173,43 @@
     <value>msconvert変換を開始しています</value>
   </data>
   <data name="HardklorSearchEngine_PerformAllAlignments_Performing_retention_time_alignment__0__vs__1_" xml:space="preserve">
-    <value>Retention time alignment: {0} vs {1}</value>
+    <value>保持時間のアラインメント：{0}対{1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_FindSimilarFeatures_Looking_for_features_occurring_in_multiple_replicates" xml:space="preserve">
-    <value>Looking for features occurring in multiple replicates</value>
+    <value>複数の繰り返し測定で発生するフィーチャーの検索中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_Run_See_Hardklor_Bullseye_log_for_details" xml:space="preserve">
-    <value>See Hardklor/Bullseye log for details</value>
+    <value>詳細はHardklor/Bullseyeログをご覧ください</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_PerformAllAlignments_Error_performing_alignment_between__0__and__1____2_" xml:space="preserve">
-    <value>Error performing alignment between {0} and {1}: {2}</value>
+    <value>{0}と{1}のアラインメント中のエラー：{2}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_PerformAllAlignments_Preparing_for_retention_time_alignment_on___0__" xml:space="preserve">
-    <value>Preparing for retention time alignment on "{0}"</value>
+    <value>「{0}」の保持時間アラインメントの準備中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_Run_Searching_for_peptide_like_features_with__0_" xml:space="preserve">
-    <value>Searching for peptide-like features with {0}</value>
+    <value>{0}を有するペプチド様フィーチャーの検索中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_Run_Searching_for_persistent_features_in_Hardklor_results_with__0_" xml:space="preserve">
-    <value>Searching for persistent features in Hardklor results with {0}</value>
+    <value>{0}を有するHardklor結果内の一貫したフィーチャーを検索中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MsconvertDdaConverter_Run_Converting_file___0___to__1_" xml:space="preserve">
-    <value>Converting file "{0}" to {1}</value>
+    <value>ファイル「{0}」を{1}に変換中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_CutoffScoreLabel_Min_isotope__dot_product_" xml:space="preserve">
-    <value>Min isotope &amp;dot product:</value>
+    <value>最小同位体ドット積(&amp;D)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_SearchEngineBlurb" xml:space="preserve">
-    <value>Hardklor searches for peptide-like features in MS1 scans using an averagine model. Features found by Hardklor are represented in Skyline as small molecules with the chemical formula that Hardklor used to generate the isotope distribution it matched to the feature, plus a mass offset to match the high-res peak mass to charge ratio. This is not the actual formula of the molecule responsible for the MS1 peaks in the mass spectrometer, but rather an approximation with a matching isotope distribution.</value>
+    <value>Hardklorは、アベラジンモデルを使用してMS1スキャンでペプチド様フィーチャーを検索します。Hardklorが発見したフィーチャーは、SkylineではHardklorがその特徴に一致する同位体分布を生成するために使用した化学式を持つ小分子として表現されます。さらに、高分解能ピークの質量対電荷比に一致させるために質量オフセットも付加されます。これは質量分析計のMS1ピークの原因となる分子の実際の式ではなく、一致する同位体分布の近似値です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DdaSearch/DdaSearchResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/DdaSearch/DdaSearchResources.zh-CHS.resx
@@ -173,43 +173,43 @@
     <value>正在启动 msconvert 转换。</value>
   </data>
   <data name="HardklorSearchEngine_PerformAllAlignments_Performing_retention_time_alignment__0__vs__1_" xml:space="preserve">
-    <value>Retention time alignment: {0} vs {1}</value>
+    <value>保留时间校准：{0} 与 {1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_FindSimilarFeatures_Looking_for_features_occurring_in_multiple_replicates" xml:space="preserve">
-    <value>Looking for features occurring in multiple replicates</value>
+    <value>正在查找在多个重复测定中出现的特征</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_Run_See_Hardklor_Bullseye_log_for_details" xml:space="preserve">
-    <value>See Hardklor/Bullseye log for details</value>
+    <value>参见 Hardklor/Bullseye 日志了解详细信息</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_PerformAllAlignments_Error_performing_alignment_between__0__and__1____2_" xml:space="preserve">
-    <value>Error performing alignment between {0} and {1}: {2}</value>
+    <value>在 {0} 和 {1} 之间进行校准时出错：{2}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_PerformAllAlignments_Preparing_for_retention_time_alignment_on___0__" xml:space="preserve">
-    <value>Preparing for retention time alignment on "{0}"</value>
+    <value>正在准备对“{0}”进行保留时间校准</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_Run_Searching_for_peptide_like_features_with__0_" xml:space="preserve">
-    <value>Searching for peptide-like features with {0}</value>
+    <value>正在使用 {0} 搜索类似肽段的特征</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_Run_Searching_for_persistent_features_in_Hardklor_results_with__0_" xml:space="preserve">
-    <value>Searching for persistent features in Hardklor results with {0}</value>
+    <value>正在使用 {0} 搜索 Hardklor 结果中的持久特征</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="MsconvertDdaConverter_Run_Converting_file___0___to__1_" xml:space="preserve">
-    <value>Converting file "{0}" to {1}</value>
+    <value>文件“{0}”正在转换为 {1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_CutoffScoreLabel_Min_isotope__dot_product_" xml:space="preserve">
-    <value>Min isotope &amp;dot product:</value>
+    <value>最小同位素点积(&amp;D)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="HardklorSearchEngine_SearchEngineBlurb" xml:space="preserve">
-    <value>Hardklor searches for peptide-like features in MS1 scans using an averagine model. Features found by Hardklor are represented in Skyline as small molecules with the chemical formula that Hardklor used to generate the isotope distribution it matched to the feature, plus a mass offset to match the high-res peak mass to charge ratio. This is not the actual formula of the molecule responsible for the MS1 peaks in the mass spectrometer, but rather an approximation with a matching isotope distribution.</value>
+    <value>Hardklor 使用平均氨基酸模型在 MS1 扫描中搜索类似肽段的特征。Hardklor 所发现的特征在 Skyline 中表示为小分子，Hardklor 使用其化学式来生成与特征相匹配的同位素分布，再加上用来匹配高分辨率峰质量与电荷比的质量偏移。这并非质谱仪中产生 MS1 峰的分子的实际化学式，而是匹配同位素分布的近似值。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/DocSettingsResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/DocSettings/DocSettingsResources.ja.resx
@@ -681,7 +681,7 @@
     <value>名前のプロパティが欠落している、または空にしておくことはできません。</value>
   </data>
   <data name="StaticMod_DoValidate_Isotope_modifications_may_not_be_variable_" xml:space="preserve">
-    <value>Isotope modifications may not be variable.</value>
+    <value>同位体修飾は変更できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/DocSettingsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/DocSettings/DocSettingsResources.zh-CHS.resx
@@ -682,7 +682,7 @@
     <value>名称属性不得缺失或为空。</value>
   </data>
   <data name="StaticMod_DoValidate_Isotope_modifications_may_not_be_variable_" xml:space="preserve">
-    <value>Isotope modifications may not be variable.</value>
+    <value>同位素修饰可能不可变。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/FullScanPropertiesRes.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/FullScanPropertiesRes.zh-CHS.resx
@@ -191,7 +191,7 @@
     <value>MS 级别</value>
   </data>
   <data name="Description_MSLevel" xml:space="preserve">
-    <value>质谱级: MS1、MS2 等...</value>
+    <value>质谱级: MS1、MS2 等…</value>
   </data>
   <data name="Instrument" xml:space="preserve">
     <value>仪器</value>

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonResources.ja.resx
@@ -125,25 +125,25 @@
     <value>サロゲート{0}に対する比率</value>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_Transition___0___is_missing" xml:space="preserve">
-    <value>Transition '{0}' is missing</value>
+    <value>トランジション「{0}」がありません</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_Missing_values_for__0___1__transitions" xml:space="preserve">
-    <value>Missing values for {0}/{1} transitions</value>
+    <value>{0}/{1}個のトランジションの値が欠損しています</value>
     <comment>{0} and {1} are numbers
 Needs Review:New resource</comment>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_Transition___0___is_truncated" xml:space="preserve">
-    <value>Transition '{0}' is truncated</value>
+    <value>トランジション「{0}」が切断されています</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_All__0__peaks_are_truncated" xml:space="preserve">
-    <value>All {0} peaks are truncated</value>
+    <value>{0}個のピークすべてが切断されています</value>
     <comment>{0} is a number
 Needs Review:New resource</comment>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_Truncated_peaks_for__0___1__transitions" xml:space="preserve">
-    <value>Truncated peaks for {0}/{1} transitions</value>
+    <value>{0}/{1}個のトランジションの切断ピーク</value>
     <comment>{0} and {1} are numbers
 Needs Review:New resource</comment>
   </data>

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonResources.zh-CHS.resx
@@ -125,25 +125,25 @@
     <value>与替代的比例 {0}</value>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_Transition___0___is_missing" xml:space="preserve">
-    <value>Transition '{0}' is missing</value>
+    <value>缺失离子对“{0}”</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_Missing_values_for__0___1__transitions" xml:space="preserve">
-    <value>Missing values for {0}/{1} transitions</value>
+    <value>缺失 {0}/{1} 离子对值</value>
     <comment>{0} and {1} are numbers
 Needs Review:New resource</comment>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_Transition___0___is_truncated" xml:space="preserve">
-    <value>Transition '{0}' is truncated</value>
+    <value>离子对“{0}”被截短</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_All__0__peaks_are_truncated" xml:space="preserve">
-    <value>All {0} peaks are truncated</value>
+    <value>所有 {0} 峰均被截短</value>
     <comment>{0} is a number
 Needs Review:New resource</comment>
   </data>
   <data name="PeptideQuantifier_SumTransitionQuantities_Truncated_peaks_for__0___1__transitions" xml:space="preserve">
-    <value>Truncated peaks for {0}/{1} transitions</value>
+    <value>{0}/{1} 离子对的峰被截短</value>
     <comment>{0} and {1} are numbers
 Needs Review:New resource</comment>
   </data>

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.zh-CHS.resx
@@ -288,7 +288,7 @@
     <value>肽段序列</value>
   </data>
   <data name="FoldChangeVolcanoPlot_BuildContextMenu_Formatting___" xml:space="preserve">
-    <value>格式化...</value>
+    <value>格式化…</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Expression" xml:space="preserve">
     <value>表达式</value>

--- a/pwiz_tools/Skyline/Model/Koina/KoinaResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Koina/KoinaResources.ja.resx
@@ -155,7 +155,7 @@
     <value>サーバーを選択</value>
   </data>
   <data name="ToolOptionsUI_SetServerStatus_Select_both_models" xml:space="preserve">
-    <value>両方のモデルを選択</value>
+    <value>接続する両方のモデルを選択</value>
     <comment>Needs Review:English text changed
 Old English:Select both models
 Current English:Select both models to connect

--- a/pwiz_tools/Skyline/Model/Koina/KoinaResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Koina/KoinaResources.zh-CHS.resx
@@ -155,7 +155,7 @@
     <value>选择一个服务器</value>
   </data>
   <data name="ToolOptionsUI_SetServerStatus_Select_both_models" xml:space="preserve">
-    <value>选择两个模型</value>
+    <value>选择连接这两个模型</value>
     <comment>Needs Review:English text changed
 Old English:Select both models
 Current English:Select both models to connect

--- a/pwiz_tools/Skyline/Model/Lib/LibResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Lib/LibResources.ja.resx
@@ -197,7 +197,7 @@
     <value>Koina出力のEncyclopeDIAライブラリへの変換</value>
   </data>
   <data name="EncyclopeDiaHelpers_Generate_Waiting_for_chromatogram_library" xml:space="preserve">
-    <value>Waiting for chromatogram library</value>
+    <value>クロマトグラムライブラリの待機中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="EncyclopeDiaHelpers_GenerateLibrary_Generating_chromatogram_library_0_of_1_2" xml:space="preserve">
@@ -292,11 +292,11 @@
     <value>TFRatio</value>
   </data>
   <data name="ParallelRunner_Generate_An_EncyclopeDIA_task_failed_" xml:space="preserve">
-    <value>An EncyclopeDIA task failed.</value>
+    <value>EncyclopeDIAタスクが失敗しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProgressMonitorForFile_UpdateProgress_Demultiplexing_spectra___0___1_" xml:space="preserve">
-    <value>Demultiplexing spectra: {0}/{1}</value>
+    <value>スペクトルの逆多重化：{0}/{1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Average_mass" xml:space="preserve">

--- a/pwiz_tools/Skyline/Model/Lib/LibResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Lib/LibResources.zh-CHS.resx
@@ -197,7 +197,7 @@
     <value>正在将 Koina 输出转换为 EncyclopeDIA 库</value>
   </data>
   <data name="EncyclopeDiaHelpers_Generate_Waiting_for_chromatogram_library" xml:space="preserve">
-    <value>Waiting for chromatogram library</value>
+    <value>正在等待色谱图库</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="EncyclopeDiaHelpers_GenerateLibrary_Generating_chromatogram_library_0_of_1_2" xml:space="preserve">
@@ -292,11 +292,11 @@
     <value>TF 比率</value>
   </data>
   <data name="ParallelRunner_Generate_An_EncyclopeDIA_task_failed_" xml:space="preserve">
-    <value>An EncyclopeDIA task failed.</value>
+    <value>EncyclopeDIA 任务失败。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProgressMonitorForFile_UpdateProgress_Demultiplexing_spectra___0___1_" xml:space="preserve">
-    <value>Demultiplexing spectra: {0}/{1}</value>
+    <value>分用谱图：{0}/{1}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SmallMoleculeLibraryAttributes_KeyValuePairs_Average_mass" xml:space="preserve">

--- a/pwiz_tools/Skyline/Model/ModelResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/ModelResources.ja.resx
@@ -798,22 +798,22 @@
     <value>「{0}」という名前は既にパス{1}で使用されています。</value>
   </data>
   <data name="ModificationMatcher_GetStaticMod_found_more_than_one_UniMod_match__add_terminus_and_or_amino_acid_specificity_to_choose_a_single_match" xml:space="preserve">
-    <value>found more than one UniMod match; add terminus and/or amino acid specificity to choose a single match</value>
+    <value>UniModに一致する結果が複数見つかりました。末端および/またはアミノ酸の特異性で絞り込み、一致する結果を1つだけ選択してください</value>
     <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.
 Needs Review:New resource</comment>
   </data>
   <data name="ModificationMatcher_GetStaticMod_found_more_than_one_UniMod_match_but_the_given_specificity___0___does_not_match_any_of_them_" xml:space="preserve">
-    <value>found more than one UniMod match but the given specificity ({0}) does not match any of them.</value>
+    <value>UniModに一致する結果が複数見つかりましたが、指定した特異性（{0}）に一致するものはありませんでした。</value>
     <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.
 Needs Review:New resource</comment>
   </data>
   <data name="ModificationMatcher_GetStaticMod_no_UniMod_match" xml:space="preserve">
-    <value>no UniMod match</value>
+    <value>UniModに一致する結果はありません</value>
     <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.
 Needs Review:New resource</comment>
   </data>
   <data name="ImportPeptideSearch_GetLibBuilder_detected_features" xml:space="preserve">
-    <value>detected features</value>
+    <value>検出されたフィーチャー</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/ModelResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/ModelResources.zh-CHS.resx
@@ -798,22 +798,22 @@
     <value>在路径 {1} 中已经使用了名称“{0}”</value>
   </data>
   <data name="ModificationMatcher_GetStaticMod_found_more_than_one_UniMod_match__add_terminus_and_or_amino_acid_specificity_to_choose_a_single_match" xml:space="preserve">
-    <value>found more than one UniMod match; add terminus and/or amino acid specificity to choose a single match</value>
+    <value>发现多个 UniMod 匹配项；添加末端和/或氨基酸特异性以选择单个匹配项</value>
     <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.
 Needs Review:New resource</comment>
   </data>
   <data name="ModificationMatcher_GetStaticMod_found_more_than_one_UniMod_match_but_the_given_specificity___0___does_not_match_any_of_them_" xml:space="preserve">
-    <value>found more than one UniMod match but the given specificity ({0}) does not match any of them.</value>
+    <value>发现一个以上的 UniMod 匹配项，但给定的特异性 ({0}) 不匹配其中任何一项。</value>
     <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.
 Needs Review:New resource</comment>
   </data>
   <data name="ModificationMatcher_GetStaticMod_no_UniMod_match" xml:space="preserve">
-    <value>no UniMod match</value>
+    <value>无 UniMod 匹配项</value>
     <comment>Intended to be appended to a "Lookup failed" message as the reason for lookup failure.
 Needs Review:New resource</comment>
   </data>
   <data name="ImportPeptideSearch_GetLibBuilder_detected_features" xml:space="preserve">
-    <value>detected features</value>
+    <value>检测到的特征</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/ModelResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/ModelResources.zh-CHS.resx
@@ -181,7 +181,7 @@
     <value>所有目标的离子迁移值必须介于此模板方法中指定的 {0} 和 {1} 之间。请使用其他模板方法，或更改下列目标的离子迁移值:</value>
   </data>
   <data name="BrukerTimsTofMethodExporter_ExportMethod_Getting_scheduling___" xml:space="preserve">
-    <value>正在获取时序安排...</value>
+    <value>正在获取时序安排…</value>
   </data>
   <data name="BrukerTimsTofMethodExporter_ExportMethod_Scheduling_failure__no_targets__" xml:space="preserve">
     <value>时序安排故障（无目标？）</value>

--- a/pwiz_tools/Skyline/Model/Proteome/ProteomeResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Proteome/ProteomeResources.ja.resx
@@ -161,7 +161,7 @@
     <value>タンパク質詳細の分解中</value>
   </data>
   <data name="ProteinAssociation_CalculateProteinOrGeneGroups_Calculating_gene_groups" xml:space="preserve">
-    <value>Calculating gene groups</value>
+    <value>遺伝子グループを計算中</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Proteome/ProteomeResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Proteome/ProteomeResources.zh-CHS.resx
@@ -161,7 +161,7 @@
     <value>蛋白质细节分辨中</value>
   </data>
   <data name="ProteinAssociation_CalculateProteinOrGeneGroups_Calculating_gene_groups" xml:space="preserve">
-    <value>Calculating gene groups</value>
+    <value>正在计算基因组</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Results/ResultsResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Results/ResultsResources.ja.resx
@@ -297,7 +297,7 @@ Skylineがもう一度生データファイルからクロマトグラムを抽�
     <value>成分が見つかりません</value>
   </data>
   <data name="ScanProvider_GetMsDataFileSpectraWithCommonRetentionTime_The_scan_ID___0___could_not_be_found_in_the_file___1___" xml:space="preserve">
-    <value>The scan ID '{0}' could not be found in the file '{1}'.</value>
+    <value>ファイル「{1}」内でスキャンID「{0}」を見つけられませんでした。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ScanProvider_GetScans_The_data_file__0__could_not_be_found__either_at_its_original_location_or_in_the_document_or_document_parent_folder_" xml:space="preserve">
@@ -331,23 +331,23 @@ Skylineがもう一度生データファイルからクロマトグラムを抽�
     <value>ディレクトリ{2}で{0}または{1}を見つけられません。 .groupファイルの処理を可能にするため、ProteinPilotソフトウェアを再インストールしてください。</value>
   </data>
   <data name="PeptideChromDataSets_FilterByRetentionTime_Discarding_chromatograms_for___0___because_the_explicit_retention_time__1__is_not_between__2__and__3_" xml:space="preserve">
-    <value>Discarding chromatograms for '{0}' because the explicit retention time {1} is not between {2} and {3}</value>
+    <value>明示的保持時間{1}が{2}と{3}の間でないため「{0}」 のクロマトグラムを破棄中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="IonMobilityFinder_EvaluateBestIonMobilityValue_need_a_value_for_Transition_Settings___ion_mobility_filtering___Window_type" xml:space="preserve">
-    <value>need a value for  Transition Settings  Ion mobility filtering  Window type</value>
+    <value>トランジション設定のイオン移動度フィルタウィンドウタイプの値が必要</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="IonMobilityFinder_FindIonMobilityPeaks_mixed_ion_mobility_types_are_not_supported" xml:space="preserve">
-    <value>mixed ion mobility types are not supported</value>
+    <value>混合イオン移動度タイプには対応していません</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DataFileInstrumentInfo_CCSFromIonMobility_no_conversion" xml:space="preserve">
-    <value>Vendor-supplied library is unable to determine CCS for {0} with mobility={1:0.###}, mz={2:0.####}, and charge={3}.</value>
+    <value>ベンダー提供のライブラリでは、{0}のCSSを移動度={1:0.###}、mz={2:0.####}、電荷={3}で決定できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DataFileInstrumentInfo_IonMobilityFromCCS_no_conversion" xml:space="preserve">
-    <value>Vendor-supplied library is unable to determine ion mobility for {0} with CCS={1:0.###}, mz={2:0.####}, and charge={3}.</value>
+    <value>ベンダー提供のライブラリでは、{0}のイオン移動度をCSS={1:0.###}、mz={2:0.####}、電荷={3}で決定できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Results/ResultsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/Results/ResultsResources.zh-CHS.resx
@@ -297,7 +297,7 @@
     <value>未发现元素</value>
   </data>
   <data name="ScanProvider_GetMsDataFileSpectraWithCommonRetentionTime_The_scan_ID___0___could_not_be_found_in_the_file___1___" xml:space="preserve">
-    <value>The scan ID '{0}' could not be found in the file '{1}'.</value>
+    <value>在文件“{1}”中找不到扫描 ID“{0}”。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ScanProvider_GetScans_The_data_file__0__could_not_be_found__either_at_its_original_location_or_in_the_document_or_document_parent_folder_" xml:space="preserve">
@@ -331,23 +331,23 @@
     <value>无法在目录{2}中找到 {0}或{1}。 请重新安装 ProteinPilot 软件以便处理 .group 文件。</value>
   </data>
   <data name="PeptideChromDataSets_FilterByRetentionTime_Discarding_chromatograms_for___0___because_the_explicit_retention_time__1__is_not_between__2__and__3_" xml:space="preserve">
-    <value>Discarding chromatograms for '{0}' because the explicit retention time {1} is not between {2} and {3}</value>
+    <value>由于明确保留时间 {1} 不介于 {2} 和 {3} 之间，因此丢弃“{0}”的色谱图</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="IonMobilityFinder_EvaluateBestIonMobilityValue_need_a_value_for_Transition_Settings___ion_mobility_filtering___Window_type" xml:space="preserve">
-    <value>need a value for  Transition Settings  Ion mobility filtering  Window type</value>
+    <value>需要提供离子对设置离子迁移过滤窗口类型值</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="IonMobilityFinder_FindIonMobilityPeaks_mixed_ion_mobility_types_are_not_supported" xml:space="preserve">
-    <value>mixed ion mobility types are not supported</value>
+    <value>不支持混合离子迁移类型</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DataFileInstrumentInfo_CCSFromIonMobility_no_conversion" xml:space="preserve">
-    <value>Vendor-supplied library is unable to determine CCS for {0} with mobility={1:0.###}, mz={2:0.####}, and charge={3}.</value>
+    <value>供应商提供的库无法确定迁移率为 {1:0.###}、质荷比为 {2:0.####}、电荷为 {3} 的 {0} 的 CCS。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="DataFileInstrumentInfo_IonMobilityFromCCS_no_conversion" xml:space="preserve">
-    <value>Vendor-supplied library is unable to determine ion mobility for {0} with CCS={1:0.###}, mz={2:0.####}, and charge={3}.</value>
+    <value>供应商提供的库无法确定 CCS 为 {1:0.###}、质荷比为 {2:0.####}、电荷为 {3} 的 {0} 的离子迁移。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimesResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimesResources.ja.resx
@@ -98,7 +98,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DocumentRetentionTimes_RecalculateAlignments_Aligning_retention_times" xml:space="preserve">
-    <value>Aligning retention times</value>
+    <value>保持時間をアライン中</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimesResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimesResources.zh-CHS.resx
@@ -98,7 +98,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DocumentRetentionTimes_RecalculateAlignments_Aligning_retention_times" xml:space="preserve">
-    <value>Aligning retention times</value>
+    <value>校准保留时间</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.ja.resx
+++ b/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.ja.resx
@@ -122,14 +122,14 @@
     <value>選択されたイオンのプリカーサー電荷</value>
   </data>
   <data name="Description_Adduct" xml:space="preserve">
-    <value>Adduct of the selected ion</value>
+    <value>選択したイオンの付加物</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Description_FileName" xml:space="preserve">
     <value>ファイル名およびスペクトルの元データとなるファイルへのフルパス</value>
   </data>
   <data name="Description_Formula" xml:space="preserve">
-    <value>Neutral chemical formula of the selected ion</value>
+    <value>選択したイオンの中性化学式</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Description_IdFileName" xml:space="preserve">
@@ -169,7 +169,7 @@
     <value>ファイルパス</value>
   </data>
   <data name="Formula" xml:space="preserve">
-    <value>Formula</value>
+    <value>分子式</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="IdFileName" xml:space="preserve">

--- a/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Model/SpectrumPropertiesResx.zh-CHS.resx
@@ -122,14 +122,14 @@
     <value>所选离子的母离子电荷</value>
   </data>
   <data name="Description_Adduct" xml:space="preserve">
-    <value>Adduct of the selected ion</value>
+    <value>所选离子的加合物</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Description_FileName" xml:space="preserve">
     <value>作为谱图源的文件的文件名和可能的完整路径</value>
   </data>
   <data name="Description_Formula" xml:space="preserve">
-    <value>Neutral chemical formula of the selected ion</value>
+    <value>所选离子的中性化学式</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Description_IdFileName" xml:space="preserve">

--- a/pwiz_tools/Skyline/Properties/Resources.ja.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.ja.resx
@@ -1200,11 +1200,11 @@ Skylineにインポートする前に必要に応じてライブラリをフィ�
     <value>ペプチドRT結果</value>
   </data>
   <data name="ReportSpecList_GetDefaults_Molecule_RT_Results" xml:space="preserve">
-    <value>Molecule RT Results</value>
+    <value>分子RT結果</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="ReportSpecList_GetDefaults_Molecule_Transition_Results" xml:space="preserve">
-    <value>Molecule Transition Results</value>
+    <value>分子トランジション結果</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty" xml:space="preserve">
@@ -3893,130 +3893,130 @@ Skylineでの列の順序は、列のヘッダーを左右にドラッグする�
     <value>コマンドの実行：{0} {1}</value>
   </data>
   <data name="SkylineWindow_DownloadPanoramaFile_File_does_not_exist__It_may_have_been_deleted_on_the_server_" xml:space="preserve">
-    <value>File does not exist. It may have been deleted on the server.</value>
+    <value>ファイルが存在しません。サーバーで削除済みの可能性があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_There_are_no_Panorama_servers_with_a_user_account__To_upload_documents_to_a_server_a_user_account_is_required_" xml:space="preserve">
-    <value>There are no Panorama servers with a user account. To upload documents to a server a user account is required.</value>
+    <value>ユーザーアカウントがあるPanoramaサーバーがありません。サーバーにドキュメントをアップロードするには、ユーザーアカウントが必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAssociation_CreateDocTree_Unmapped_Peptides" xml:space="preserve">
-    <value>Unmapped Peptides</value>
+    <value>マップ解除されたペプチド</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportSpecLib_Spectral_library_file__0__exported_successfully_" xml:space="preserve">
-    <value>Spectral library file {0} exported successfully.</value>
+    <value>スペクトルライブラリファイル{0}をエクスポートしました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportSpecLib_Error__The_document_must_contain_at_least_one_precursor_to_export_a_spectral_library_" xml:space="preserve">
-    <value>Error: The document must contain at least one precursor to export a spectral library.</value>
+    <value>エラー：スペクトルライブラリをエクスポートするには、ドキュメントに1つ以上のプリカーサーが含まれている必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportSpecLib_Error__The_document_must_contain_results_to_export_a_spectral_library_" xml:space="preserve">
-    <value>Error: The document must contain results to export a spectral library.</value>
+    <value>エラー：スペクトルライブラリをエクスポートするには、ドキュメントに結果が含まれている必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportMProphetFeatures_mProphet_features_file__0__exported_successfully_" xml:space="preserve">
-    <value>mProphet features file {0} exported successfully.</value>
+    <value>mProphetフィーチャーファイル{0}をエクスポートしました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportMProphetFeatures_Error__The_document_must_contain_targets_for_which_to_export_mProphet_features_" xml:space="preserve">
-    <value>Error: The document must contain targets for which to export mProphet features.</value>
+    <value>エラー：ドキュメントには、mProphetフィーチャーをエクスポートするターゲットを含める必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportMProphetFeatures_Error__The_document_must_contain_results_to_export_mProphet_features_" xml:space="preserve">
-    <value>Error: The document must contain results to export mProphet features.</value>
+    <value>エラー：mProphetフィーチャーをエクスポートするには、ドキュメントに結果が含まれている必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_ParseAnnotationTypes_Error__Attempting_to_exclude_an_unknown_annotation_type__0___Try_one_of_the_following_" xml:space="preserve">
-    <value>Error: Attempting to exclude an unknown annotation type '{0}'. Try one of the following:</value>
+    <value>エラー：不明な注釈タイプ「{0}」を除外しようとしています。次のいずれかをお試しください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AddAnnotations_Annotations_successfully_defined_from_file__0__" xml:space="preserve">
-    <value>Annotations successfully defined from file {0}.</value>
+    <value>ファイル{0}から注釈を定義しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Extensions_CustomToString_Protein_Expression" xml:space="preserve">
-    <value>Protein Expression</value>
+    <value>タンパク質発現</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportAnnotations_Annotations_file__0__exported_successfully_" xml:space="preserve">
-    <value>Annotations file {0} exported successfully.</value>
+    <value>注釈ファイル{0}をエクスポートしました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AddAnnotations_Error__Unable_to_read_annotations_from_file__0__" xml:space="preserve">
-    <value>Error: Unable to read annotations from file {0}.</value>
+    <value>エラー：ファイル{0}から注釈を読み取れませんでした。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_ParseAnnotationTypes_Error__Attempting_to_specify_an_unknown_annotation_type___0____Try_one_of_the_following_" xml:space="preserve">
-    <value>Error: Attempting to specify an unknown annotation type '{0}'. Try one of the following:</value>
+    <value>エラー：不明な注釈タイプ「{0}」を指定しようとしています。次のいずれかをお試しください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_ParseAnnotationTarget_Error__Attempting_to_specify_an_unknown_annotation_target___0____Try_one_of_the_following_" xml:space="preserve">
-    <value>Error: Attempting to specify an unknown annotation target '{0}'. Try one of the following:</value>
+    <value>エラー：不明な注釈対象「{0}」を指定しようとしています。次のいずれかをお試しください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetAnnotations_Warning__Skipping_annotation___0___due_to_a_name_conflict_" xml:space="preserve">
-    <value>Warning: Skipping annotation '{0}' due to a name conflict with an existing annotation.</value>
+    <value>警告：既存の注釈と名前が重複しているため、注釈「{0}」をスキップします。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetAnnotations_Warning__The_annotation___0___was_overwritten_" xml:space="preserve">
-    <value>Warning: Overwriting existing annotation '{0}' due to a name conflict.</value>
+    <value>警告：名前が重複しているため既存の注釈「{0}」を上書きします。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AddAnnotationsFromArguments_Error__Cannot_add_a__0__type_annotation_without_providing_a_list_values_of_through__1__" xml:space="preserve">
-    <value>Error: Cannot add a {0} type annotation without providing a list of values through {1}.</value>
+    <value>エラー：{1}を通じて値リストを提供しなければ、{0}タイプの注釈は追加できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AddAnnotationFromEnvironment_Error__Cannot_add_new_annotation___0___without_providing_at_least_one_target_through__1__" xml:space="preserve">
-    <value>Error: Cannot add new annotation '{0}' without providing at least one target through {1}.</value>
+    <value>エラー：{1}を通じて1つ以上のターゲットを指定しなければ、新しい注釈「{0}」は追加できません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportAnnotations_Try_one_of_the_following_" xml:space="preserve">
-    <value>Try one of the following:</value>
+    <value>次のいずれかをお試しください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportAnnotations_Error__The_document_must_contain_annotations_in_order_to_export_annotations_" xml:space="preserve">
-    <value>Error: The document must contain annotations in order to export annotations.</value>
+    <value>エラー：注釈をエクスポートするにはドキュメントに注釈を含む必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetPeptideDigestSettings_Error__Could_not_find_background_proteome_file__0_" xml:space="preserve">
-    <value>Error: Could not find background proteome file {0}</value>
+    <value>エラー：バックグラウンドプロテオームファイル{0}が見つかりませんでした</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideMod_SetTerminus_A_peptide_modification_must_be_added_before_giving_it_a_terminal_or_amino_acid_specificity_" xml:space="preserve">
-    <value>A peptide modification must be added before giving it a terminal or amino acid specificity.</value>
+    <value>末端またはアミノ酸特異性を付与する前に、ペプチド修飾を追加する必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="koina_logo_fdf731d5" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\koina-logo.fdf731d5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CommandLine_ImportPeptideList_Importing_peptide_list__0__from_file__1____" xml:space="preserve">
-    <value>Importing peptide list {0} from file {1}...</value>
+    <value>ファイル{1}からペプチドリスト{0}をインポート中...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ImportPeptideList_Importing_peptide_lists_from_file__0____" xml:space="preserve">
-    <value>Importing peptide lists from file {0}...</value>
+    <value>ファイル{0}からペプチドリストをインポート中...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ImportPeptideList_Warning__peptide_list_file_contains_lines_with_____Ignoring_provided_list_name_" xml:space="preserve">
-    <value>Warning: peptide list file contains lines with &gt;&gt;. Ignoring provided list name.</value>
+    <value>警告：ペプチドリストファイルに、&gt;&gt;が存在する行が含まれています。提供されたリスト名を無視します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AssociateProteins_Associating_peptides_with_proteins_from_FASTA_file__0_" xml:space="preserve">
-    <value>Associating peptides with proteins from FASTA file {0}</value>
+    <value>FASTAファイル{0}のタンパク質とペプチドを関連付け中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="BuildLibraryDlg_ValidateBuilder_Add_peptide_precursors_to_the_document_to_build_a_library_from_Koina_predictions_" xml:space="preserve">
-    <value>Add peptide precursors to the document to build a library from Koina predictions.</value>
+    <value>ペプチドプリカーサーをドキュメントに追加して、Koina予測からライブラリを構築します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ImportPeptideList_Using_the_Unimod_definitions_for_the_following_modifications_" xml:space="preserve">
-    <value>Using the Unimod definitions for the following modifications:</value>
+    <value>以下の修飾にUnimod定義を使用：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideMod_SetVariable_A_peptide_modification_must_be_added_before_assigning_its_variable_status_" xml:space="preserve">
-    <value>A peptide modification must be added before assigning its variable status.</value>
+    <value>その変数ステータスを割り当てる前に、ペプチド修飾を追加する必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -1203,11 +1203,11 @@
     <value>肽段RT 结果</value>
   </data>
   <data name="ReportSpecList_GetDefaults_Molecule_RT_Results" xml:space="preserve">
-    <value>Molecule RT Results</value>
+    <value>分子保留时间结果</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="ReportSpecList_GetDefaults_Molecule_Transition_Results" xml:space="preserve">
-    <value>Molecule Transition Results</value>
+    <value>分子离子对结果</value>
     <comment>Needs Review:Missing translation</comment>
   </data>
   <data name="MessageBoxHelper_ValidateNameTextBox__0__cannot_be_empty" xml:space="preserve">
@@ -3896,130 +3896,130 @@
     <value>正在运行命令:{0} {1}</value>
   </data>
   <data name="SkylineWindow_DownloadPanoramaFile_File_does_not_exist__It_may_have_been_deleted_on_the_server_" xml:space="preserve">
-    <value>File does not exist. It may have been deleted on the server.</value>
+    <value>文件不存在。可能已在服务器上删除。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_There_are_no_Panorama_servers_with_a_user_account__To_upload_documents_to_a_server_a_user_account_is_required_" xml:space="preserve">
-    <value>There are no Panorama servers with a user account. To upload documents to a server a user account is required.</value>
+    <value>没有包含用户帐户的 Panorama 服务器。要将文档上传到服务器，必须要有用户帐户。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="ProteinAssociation_CreateDocTree_Unmapped_Peptides" xml:space="preserve">
-    <value>Unmapped Peptides</value>
+    <value>未映射的肽段</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportSpecLib_Spectral_library_file__0__exported_successfully_" xml:space="preserve">
-    <value>Spectral library file {0} exported successfully.</value>
+    <value>成功导出谱图库文件 {0}。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportSpecLib_Error__The_document_must_contain_at_least_one_precursor_to_export_a_spectral_library_" xml:space="preserve">
-    <value>Error: The document must contain at least one precursor to export a spectral library.</value>
+    <value>错误：文档必须至少包含一个母离子，才能导出谱图库。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportSpecLib_Error__The_document_must_contain_results_to_export_a_spectral_library_" xml:space="preserve">
-    <value>Error: The document must contain results to export a spectral library.</value>
+    <value>错误：文档必须包含结果才能导出谱图库。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportMProphetFeatures_mProphet_features_file__0__exported_successfully_" xml:space="preserve">
-    <value>mProphet features file {0} exported successfully.</value>
+    <value>成功导出 mProphet 特征文件 {0}。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportMProphetFeatures_Error__The_document_must_contain_targets_for_which_to_export_mProphet_features_" xml:space="preserve">
-    <value>Error: The document must contain targets for which to export mProphet features.</value>
+    <value>错误：文档必须包含要导出 mProphet 特征的目标。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportMProphetFeatures_Error__The_document_must_contain_results_to_export_mProphet_features_" xml:space="preserve">
-    <value>Error: The document must contain results to export mProphet features.</value>
+    <value>错误：文档必须包含 mProphet 特征导出结果。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_ParseAnnotationTypes_Error__Attempting_to_exclude_an_unknown_annotation_type__0___Try_one_of_the_following_" xml:space="preserve">
-    <value>Error: Attempting to exclude an unknown annotation type '{0}'. Try one of the following:</value>
+    <value>错误：试图排除未知注释类型“{0}”。尝试其中一种方法：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AddAnnotations_Annotations_successfully_defined_from_file__0__" xml:space="preserve">
-    <value>Annotations successfully defined from file {0}.</value>
+    <value>从文件 {0} 成功定义注释。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Extensions_CustomToString_Protein_Expression" xml:space="preserve">
-    <value>Protein Expression</value>
+    <value>蛋白质表达</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportAnnotations_Annotations_file__0__exported_successfully_" xml:space="preserve">
-    <value>Annotations file {0} exported successfully.</value>
+    <value>成功导出注释文件 {0}。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AddAnnotations_Error__Unable_to_read_annotations_from_file__0__" xml:space="preserve">
-    <value>Error: Unable to read annotations from file {0}.</value>
+    <value>错误：无法读取文件 {0} 中的注释。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_ParseAnnotationTypes_Error__Attempting_to_specify_an_unknown_annotation_type___0____Try_one_of_the_following_" xml:space="preserve">
-    <value>Error: Attempting to specify an unknown annotation type '{0}'. Try one of the following:</value>
+    <value>错误：试图指定未知注释类型“{0}”。尝试其中一种方法：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_ParseAnnotationTarget_Error__Attempting_to_specify_an_unknown_annotation_target___0____Try_one_of_the_following_" xml:space="preserve">
-    <value>Error: Attempting to specify an unknown annotation target '{0}'. Try one of the following:</value>
+    <value>错误：试图指定未知注释目标“{0}”。尝试其中一种方法：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetAnnotations_Warning__Skipping_annotation___0___due_to_a_name_conflict_" xml:space="preserve">
-    <value>Warning: Skipping annotation '{0}' due to a name conflict with an existing annotation.</value>
+    <value>警告：由于名称与现有注释冲突，将跳过注释“{0}”。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetAnnotations_Warning__The_annotation___0___was_overwritten_" xml:space="preserve">
-    <value>Warning: Overwriting existing annotation '{0}' due to a name conflict.</value>
+    <value>警告：由于名称冲突，将覆盖现有注释“{0}”。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AddAnnotationsFromArguments_Error__Cannot_add_a__0__type_annotation_without_providing_a_list_values_of_through__1__" xml:space="preserve">
-    <value>Error: Cannot add a {0} type annotation without providing a list of values through {1}.</value>
+    <value>错误：如果未通过 {1} 提供值列表，则无法添加 {0} 类型注释。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AddAnnotationFromEnvironment_Error__Cannot_add_new_annotation___0___without_providing_at_least_one_target_through__1__" xml:space="preserve">
-    <value>Error: Cannot add new annotation '{0}' without providing at least one target through {1}.</value>
+    <value>错误：在未通过 {1} 至少提供一个目标的情况下，无法添加新注释“{0}”。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportAnnotations_Try_one_of_the_following_" xml:space="preserve">
-    <value>Try one of the following:</value>
+    <value>尝试以下一种方法：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportAnnotations_Error__The_document_must_contain_annotations_in_order_to_export_annotations_" xml:space="preserve">
-    <value>Error: The document must contain annotations in order to export annotations.</value>
+    <value>错误：要导出注释，文档中必须包含注释。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetPeptideDigestSettings_Error__Could_not_find_background_proteome_file__0_" xml:space="preserve">
-    <value>Error: Could not find background proteome file {0}</value>
+    <value>错误：无法找到背景蛋白质组文件 {0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideMod_SetTerminus_A_peptide_modification_must_be_added_before_giving_it_a_terminal_or_amino_acid_specificity_" xml:space="preserve">
-    <value>A peptide modification must be added before giving it a terminal or amino acid specificity.</value>
+    <value>必须先添加肽段修饰，然后再为之赋予末端或氨基酸特异性。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="koina_logo_fdf731d5" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\koina-logo.fdf731d5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CommandLine_ImportPeptideList_Importing_peptide_list__0__from_file__1____" xml:space="preserve">
-    <value>Importing peptide list {0} from file {1}...</value>
+    <value>正在导入文件 {1} 中的肽段列表 {0}...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ImportPeptideList_Importing_peptide_lists_from_file__0____" xml:space="preserve">
-    <value>Importing peptide lists from file {0}...</value>
+    <value>正在导入文件 {0} 中的肽段列表...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ImportPeptideList_Warning__peptide_list_file_contains_lines_with_____Ignoring_provided_list_name_" xml:space="preserve">
-    <value>Warning: peptide list file contains lines with &gt;&gt;. Ignoring provided list name.</value>
+    <value>警告：肽段列表文件中含有 &gt;&gt; 行。忽略所提供的列表名称。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AssociateProteins_Associating_peptides_with_proteins_from_FASTA_file__0_" xml:space="preserve">
-    <value>Associating peptides with proteins from FASTA file {0}</value>
+    <value>正在关联肽段与 FASTA 文件 {0} 中的蛋白质</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="BuildLibraryDlg_ValidateBuilder_Add_peptide_precursors_to_the_document_to_build_a_library_from_Koina_predictions_" xml:space="preserve">
-    <value>Add peptide precursors to the document to build a library from Koina predictions.</value>
+    <value>向文档中添加肽段母离子，根据 Koina 预测建立库。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ImportPeptideList_Using_the_Unimod_definitions_for_the_following_modifications_" xml:space="preserve">
-    <value>Using the Unimod definitions for the following modifications:</value>
+    <value>针对下列修饰使用 Unimod 定义：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="PeptideMod_SetVariable_A_peptide_modification_must_be_added_before_assigning_its_variable_status_" xml:space="preserve">
-    <value>A peptide modification must be added before assigning its variable status.</value>
+    <value>必须先添加肽段修饰，然后再指定其可变状态。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Properties/Resources.zh-CHS.resx
@@ -519,7 +519,7 @@
     <value>错误：您试图添加的库与文件中已经存在的库发生冲突。</value>
   </data>
   <data name="CommandLine_ImportResultsFile_Warning__Failed_importing_the_results_file__0____Ignoring___" xml:space="preserve">
-    <value>警告：导入结果文件{0}失败。 忽视...</value>
+    <value>警告：导入结果文件{0}失败。 忽视…</value>
   </data>
   <data name="TestToolStoreClient_GetToolZipFile_Error_downloading_tool" xml:space="preserve">
     <value>下载工具出错</value>
@@ -1251,7 +1251,7 @@
     <value>匹配的谱图</value>
   </data>
   <data name="PeptidesPerProteinDlg_UpdateRemaining_Calculating___" xml:space="preserve">
-    <value>正在计算...</value>
+    <value>正在计算…</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_AddIrtLibraryTable_Processing_Retention_Times" xml:space="preserve">
     <value>正在处理保留时间</value>
@@ -1614,7 +1614,7 @@
     <value>模型在用于峰值边界比较前必须被训练。</value>
   </data>
   <data name="CommandLine_ImportTool_The_tool_was_not_imported___" xml:space="preserve">
-    <value>工具未导入...</value>
+    <value>工具未导入…</value>
   </data>
   <data name="SkylineDoc" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\skylinedoc.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
@@ -1988,7 +1988,7 @@
     <value>未能在文件{1}中找到扫描ID{0}。</value>
   </data>
   <data name="CommandLine_ImportTransitionList_Importing_transiton_list__0____" xml:space="preserve">
-    <value>正在导入离子对列表{0}...</value>
+    <value>正在导入离子对列表{0}…</value>
   </data>
   <data name="PeptideToMoleculeText_Protein" xml:space="preserve">
     <value>蛋白质</value>
@@ -2396,7 +2396,7 @@
     <value>成功更新下列工具</value>
   </data>
   <data name="SkylineWindow_SaveDocument_Saving___" xml:space="preserve">
-    <value>保存...</value>
+    <value>保存…</value>
   </data>
   <data name="ImportTransitionListColumnSelectDlg_PopulateComboBoxes_Fragment_Name" xml:space="preserve">
     <value>片段名称</value>
@@ -2405,7 +2405,7 @@
     <value>下载失败。</value>
   </data>
   <data name="CommandLine_ImportTool_Error__to_import_a_tool_it_must_have_a_name_and_a_command___Use___tool_add_to_specify_a_name_and_use___tool_command_to_specify_a_command___The_tool_was_not_imported___" xml:space="preserve">
-    <value>错误：如要导入工具，则必须含有名称和命令。 使用“--工具-添加”来指定一个名称，并且使用“--工具-命令”来指定一个命令。 工具未导入...</value>
+    <value>错误：如要导入工具，则必须含有名称和命令。 使用“--工具-添加”来指定一个名称，并且使用“--工具-命令”来指定一个命令。 工具未导入…</value>
   </data>
   <data name="PeptideToMoleculeText_Peptide_Sequence" xml:space="preserve">
     <value>肽段序列</value>
@@ -2615,7 +2615,7 @@
     <value>..\resources\comment.bmp;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CommandLine_ImportFasta_Importing_FASTA_file__0____" xml:space="preserve">
-    <value>FASTA 文件{0}导入中...</value>
+    <value>FASTA 文件{0}导入中…</value>
   </data>
   <data name="UniquePeptidesDlg_SelectPeptidesWithNumberOfMatchesAtOrBelowThreshold_Some_background_proteome_proteins_did_not_have_gene_information__this_selection_may_be_suspect_" xml:space="preserve">
     <value>一些背景蛋白质组蛋白没有基因信息，此选择可疑。</value>
@@ -2627,7 +2627,7 @@
     <value>异常值</value>
   </data>
   <data name="RTLinearRegressionGraphPane_UpdateGraph_Calculating___" xml:space="preserve">
-    <value>正在计算...</value>
+    <value>正在计算…</value>
   </data>
   <data name="SkylineWindow_ImportFasta_Unexpected_document_change_during_operation" xml:space="preserve">
     <value>操作过程中的意外文档修改。</value>
@@ -2681,7 +2681,7 @@
     <value>{0}必须至少包含一个氨基酸。</value>
   </data>
   <data name="CommandLine_RefineDocument_Refining_document___" xml:space="preserve">
-    <value>正在细化文档...</value>
+    <value>正在细化文档…</value>
   </data>
   <data name="ResultsGrid_ResultsGrid_File_Name" xml:space="preserve">
     <value>文件名称</value>
@@ -3152,7 +3152,7 @@
     <value>无效的 S-Lens 值 {0}</value>
   </data>
   <data name="CommandLine_OpenSkyFile_Opening_file___" xml:space="preserve">
-    <value>文件打开中...</value>
+    <value>文件打开中…</value>
   </data>
   <data name="PasteDlg_AddFasta_An_unexpected_error_occurred" xml:space="preserve">
     <value>发生意外错误：</value>
@@ -3231,7 +3231,7 @@
     <value>截尾计数</value>
   </data>
   <data name="CommandLine_RemoveImportedFiles__0______1___Note__The_file_has_already_been_imported__Ignoring___" xml:space="preserve">
-    <value>{0} -&gt; {1} 注释：文件已导入。忽视...</value>
+    <value>{0} -&gt; {1} 注释：文件已导入。忽视…</value>
   </data>
   <data name="IIrtRegression_DisplayEquation_Measured_RT" xml:space="preserve">
     <value>测量的 RT</value>
@@ -3633,7 +3633,7 @@
     <value>软件包安装已完成。</value>
   </data>
   <data name="CommandLine_ExportReport_Exporting_report__0____" xml:space="preserve">
-    <value>报告{0}导出中...</value>
+    <value>报告{0}导出中…</value>
   </data>
   <data name="ConfigureToolsDlg_UnpackZipTool_There_is_a_naming_conflict__You_already_installed_a_tool_from_a_zip_folder_with_the_name__0___Would_you_like_to_overwrite_or_install_in_parallel_" xml:space="preserve">
     <value>出现命名冲突。您已经从压缩文件夹内使用名称{0}安装一个工具。您是否想要覆盖或并行安装？</value>
@@ -3995,11 +3995,11 @@
     <value>..\Resources\koina-logo.fdf731d5.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="CommandLine_ImportPeptideList_Importing_peptide_list__0__from_file__1____" xml:space="preserve">
-    <value>正在导入文件 {1} 中的肽段列表 {0}...</value>
+    <value>正在导入文件 {1} 中的肽段列表 {0}…</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ImportPeptideList_Importing_peptide_lists_from_file__0____" xml:space="preserve">
-    <value>正在导入文件 {0} 中的肽段列表...</value>
+    <value>正在导入文件 {0} 中的肽段列表…</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ImportPeptideList_Warning__peptide_list_file_contains_lines_with_____Ignoring_provided_list_name_" xml:space="preserve">

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.ja.resx
@@ -458,7 +458,7 @@
     <value>曖昧な一致を含む(&amp;M)</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.ToolTip" xml:space="preserve">
-    <value>Check to keep spectra that match multiple peptides.</value>
+    <value>オンにすると、複数のペプチドに一致するスペクトルが残ります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.Name" xml:space="preserve">
@@ -525,7 +525,7 @@
     <value>ドキュメント内のペプチドをフィルタリング(&amp;D)</value>
   </data>
   <data name="cbFilter.ToolTip" xml:space="preserve">
-    <value>Check to filter matches for only the peptides in the document.</value>
+    <value>オンにすると、ドキュメント内のペプチドのみに対して一致する結果がフィルタリングされます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbFilter.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.zh-CHS.resx
@@ -460,7 +460,7 @@
     <value>包含不明确匹配项(&amp;M)</value>
   </data>
   <data name="cbIncludeAmbiguousMatches.ToolTip" xml:space="preserve">
-    <value>Check to keep spectra that match multiple peptides.</value>
+    <value>选中将保留与多个肽段匹配的谱图。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbIncludeAmbiguousMatches.Name" xml:space="preserve">
@@ -528,7 +528,7 @@
     <value>文档肽筛选器(&amp;D)</value>
   </data>
   <data name="cbFilter.ToolTip" xml:space="preserve">
-    <value>Check to filter matches for only the peptides in the document.</value>
+    <value>选中将仅过滤文档中的肽段。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbFilter.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtCalculatorDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtCalculatorDlg.ja.resx
@@ -289,7 +289,7 @@
     <value>8</value>
   </data>
   <data name="radioFile.Text" xml:space="preserve">
-    <value>iRTデータベースファイル(&amp;D):</value>
+    <value>iRTデータベースファイル(&amp;D)：</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -328,7 +328,7 @@
     <value>iRTデータベースを追加</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>カルキュレータ名(&amp;C):</value>
+    <value>カルキュレータ名(&amp;C)：</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>

--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtStandardsDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtStandardsDlg.zh-CHS.resx
@@ -259,7 +259,7 @@
     <value>3</value>
   </data>
   <data name="btnGraph.Text" xml:space="preserve">
-    <value>图形...</value>
+    <value>图形…</value>
   </data>
   <data name="btnGraph.Visible" type="System.Boolean, mscorlib">
     <value>False</value>

--- a/pwiz_tools/Skyline/SettingsUI/Optimization/AddOptimizationLibraryDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/Optimization/AddOptimizationLibraryDlg.ja.resx
@@ -223,7 +223,7 @@
     <value>4</value>
   </data>
   <data name="radioFile.Text" xml:space="preserve">
-    <value>最適化ライブラリファイル(&amp;O):</value>
+    <value>最適化ライブラリファイル(&amp;O)：</value>
   </data>
   <data name="&gt;&gt;radioFile.Name" xml:space="preserve">
     <value>radioFile</value>

--- a/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.ja.resx
@@ -725,7 +725,7 @@
     <value>フィルタされたライブラリのパスを入力してください。</value>
   </data>
   <data name="FormulaBox_FormulaBox_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>ヘルプ</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FormulaBox_FormulaHelpText_Formulas_are_written_in_standard_chemical_notation__e_g___C2H6O____Heavy_isotopes_are_indicated_by_a_prime__e_g__C__for_C13__or_double_prime_for_less_abundant_stable_iostopes__e_g__O__for_O17__O__for_O18__" xml:space="preserve">
@@ -1141,62 +1141,56 @@
   <data name="SpectrumGraphItem_library_entry_provides_only_precursor_values" xml:space="preserve">
     <value>
 
-This library entry only provides precursor
-information, there is no spectrum to show</value>
+このライブラリエントリはプリカーサー情報のみを提供します。表示できるスペクトルはありません</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_Initialize_minutes_of_detected_features" xml:space="preserve">
-    <value>minutes of detected features</value>
+    <value>分間の検出されたフィーチャー</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_InitializeFeatureDetectionUI_Hardklor_looks_for_isotope_envelopes_representing_charges_1__0___The_library_will_contain_only_ions_with_the_charges_listed_here_" xml:space="preserve">
-    <value>Hardklor looks for isotope envelopes representing charges 1-{0}. The resulting library will contain only ions with the charges listed here.</value>
+    <value>Hardklorは、1価から{0}価の同位体エンベロープを参照します。その結果のライブラリには、ここに記載された電荷のイオンのみが含まれます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_InitializeFeatureDetectionUI_This_is_the_value_assumed_by_Hardklor__it_cannot_be_adjusted_" xml:space="preserve">
-    <value>This is the value assumed by Hardklor, it cannot be adjusted.</value>
+    <value>これはHardklorが想定する値であり、変更はできません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_InitializeMs1FilterUI_Sets_the_MS_data_type_for_Hardklor_s_FWHM_calculation__Normally_set_to_Centroided_" xml:space="preserve">
-    <value>Sets the MS data type for Hardklor's FWHM calculation. Normally set to Centroided.</value>
+    <value>HardklorのFWHM計算に使うMSデータタイプを設定します。通常は [セントロイド化] に設定します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_InitializeMs1FilterUI_Sets_the_mass_analyzer_type_for_Hardklor_s_FWHM_calculation_" xml:space="preserve">
-    <value>Sets the mass analyzer type for Hardklor's FWHM calculation.</value>
+    <value>HardklorのFWHM計算に使う質量分析計のタイプを設定します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_ModifyOptionsForImportPeptideSearchWizard_Instrument_Values" xml:space="preserve">
-    <value>&amp;Instrument values</value>
+    <value>装置の値(&amp;I)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_ModifyOptionsForImportPeptideSearchWizard_Instrument_Values_from_Full_Scan_Settings" xml:space="preserve">
-    <value>Instrument values (from full-scan settings)</value>
+    <value>装置の値（フルスキャン設定より）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_GetRetentionTimeFilterWarning_EncourageFullGradient" xml:space="preserve">
-    <value>{0} methods usually specify the time range for the mass spectrometer to acquire spectra.
-
-Applying retention time filtering in Skyline is typically unnecessary and may lead to truncated extracted ion chromatograms.
-
-Use this option only if your acquisition method includes multiple targets with the same m/z.</value>
+    <value>{0}メソッドは通常、質量分析計がスペクトルを取得する時間範囲を指定します。
+Skylineで保持時間フィルタリングを適用する必要は通常ありません。適用すると、抽出イオンクロマトグラムの切断につながる可能性があります。
+このオプションは、取得方法に同じm/zの複数ターゲットが含まれている場合にのみ使用してください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="EditPeakScoringModel_ExplictPeakBoundsWarning" xml:space="preserve">
-    <value>Are you sure you want to train a peak scoring model for this document?
-      
-This document uses peak boundaries from spectral libraries. When these boundaries are used, Skyline does not perform its own peak detection.
+    <value>このドキュメントに対してピークスコアモデルをトレーニングしますか？ 
+このドキュメントはスペクトルライブラリから得たピーク境界を使用します。このような境界を使用する場合、Skylineは独自のピーク検出を実行しません。
+ピークスコアモデルをトレーニングする前に、以下の手順に従うことを推奨します。
 
-Before training a peak scoring model, it is recommended that you follow these steps:
-
-1. Navigate to "Settings &gt; Peptide Settings - Libraries" tab and click "Edit List".
-2. Select a library item, click "Edit", and uncheck the "Use explicit peak bounds" checkbox.
-3. Navigate to "Edit &gt; Manage Results" and click the "Re-score" button.
-
-This will provide Skyline with a variety of candidate peaks to evaluate peak quality.</value>
+1. [設定] &gt; [ペプチド設定 - ライブラリ] タブに移動して [リストの編集] をクリックします。
+2. ライブラリのアイテムを選択して [編集] をクリックし、[指定されたピーク境界を使用する] チェックボックスをオフにします。
+3. [編集] &gt; [結果を管理] に移動して [再スコア] ボタンをクリックします。
+これにより、Skylineにはピークの質を評価するためのさまざまな候補ピークが提示されます。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="EditPeakScoringModelDlg_ShowEditPeakScoringModelDlg_Train_Model" xml:space="preserve">
-    <value>Train Model</value>
+    <value>モデルのトレーニング</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.zh-CHS.resx
@@ -405,7 +405,7 @@
     <value>重叠需要偶数个窗口数目。</value>
   </data>
   <data name="EditIsolationSchemeDlg_ImportRangesFromFiles_Reading_isolation_scheme___" xml:space="preserve">
-    <value>正在读取分离方案...</value>
+    <value>正在读取分离方案…</value>
   </data>
   <data name="EditIsolationSchemeDlg_OpenGraph_Graphing_multiplexing_is_not_supported_" xml:space="preserve">
     <value>不支持多重绘图。</value>

--- a/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/SettingsUIResources.zh-CHS.resx
@@ -725,7 +725,7 @@
     <value>您必须为已过滤的库输入路径。</value>
   </data>
   <data name="FormulaBox_FormulaBox_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>帮助</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FormulaBox_FormulaHelpText_Formulas_are_written_in_standard_chemical_notation__e_g___C2H6O____Heavy_isotopes_are_indicated_by_a_prime__e_g__C__for_C13__or_double_prime_for_less_abundant_stable_iostopes__e_g__O__for_O17__O__for_O18__" xml:space="preserve">
@@ -1141,62 +1141,56 @@
   <data name="SpectrumGraphItem_library_entry_provides_only_precursor_values" xml:space="preserve">
     <value>
 
-This library entry only provides precursor
-information, there is no spectrum to show</value>
+该库条目只提供母离子信息，没有可以显示的谱图</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_Initialize_minutes_of_detected_features" xml:space="preserve">
-    <value>minutes of detected features</value>
+    <value>检测到特征的分钟数 </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_InitializeFeatureDetectionUI_Hardklor_looks_for_isotope_envelopes_representing_charges_1__0___The_library_will_contain_only_ions_with_the_charges_listed_here_" xml:space="preserve">
-    <value>Hardklor looks for isotope envelopes representing charges 1-{0}. The resulting library will contain only ions with the charges listed here.</value>
+    <value>Hardklor 查找代表电荷 1-{0} 的同位素包络。生成的库中只包含此处所列电荷的离子。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_InitializeFeatureDetectionUI_This_is_the_value_assumed_by_Hardklor__it_cannot_be_adjusted_" xml:space="preserve">
-    <value>This is the value assumed by Hardklor, it cannot be adjusted.</value>
+    <value>这是 Hardklor 假定的值，不能调整。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_InitializeMs1FilterUI_Sets_the_MS_data_type_for_Hardklor_s_FWHM_calculation__Normally_set_to_Centroided_" xml:space="preserve">
-    <value>Sets the MS data type for Hardklor's FWHM calculation. Normally set to Centroided.</value>
+    <value>针对 Hardklor FWHM 计算设置 MS 数据类型。通常设置为 Centroided。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_InitializeMs1FilterUI_Sets_the_mass_analyzer_type_for_Hardklor_s_FWHM_calculation_" xml:space="preserve">
-    <value>Sets the mass analyzer type for Hardklor's FWHM calculation.</value>
+    <value>针对 Hardklor FWHM 计算设置质量分析仪类型。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_ModifyOptionsForImportPeptideSearchWizard_Instrument_Values" xml:space="preserve">
-    <value>&amp;Instrument values</value>
+    <value>仪器值(&amp;I)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_ModifyOptionsForImportPeptideSearchWizard_Instrument_Values_from_Full_Scan_Settings" xml:space="preserve">
-    <value>Instrument values (from full-scan settings)</value>
+    <value>（全扫描设置的）仪器值 </value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="FullScanSettingsControl_GetRetentionTimeFilterWarning_EncourageFullGradient" xml:space="preserve">
-    <value>{0} methods usually specify the time range for the mass spectrometer to acquire spectra.
-
-Applying retention time filtering in Skyline is typically unnecessary and may lead to truncated extracted ion chromatograms.
-
-Use this option only if your acquisition method includes multiple targets with the same m/z.</value>
+    <value>{0} 方法通常指定质谱仪采集谱图的时间范围。
+在 Skyline 中通常不必应用保留时间过滤，否则可能会导致提取的离子色谱图被截短。
+只有在采集方法包括多个质荷比相同的目标时，才使用该选项。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="EditPeakScoringModel_ExplictPeakBoundsWarning" xml:space="preserve">
-    <value>Are you sure you want to train a peak scoring model for this document?
-      
-This document uses peak boundaries from spectral libraries. When these boundaries are used, Skyline does not perform its own peak detection.
+    <value>您是否确定要为该文档训练峰得分模型？ 
+该文档使用谱图库中的峰边界。使用这些边界时，Skyline 不会自行检测峰。
+在训练峰得分模型前，建议您按照以下步骤进行操作：
 
-Before training a peak scoring model, it is recommended that you follow these steps:
-
-1. Navigate to "Settings &gt; Peptide Settings - Libraries" tab and click "Edit List".
-2. Select a library item, click "Edit", and uncheck the "Use explicit peak bounds" checkbox.
-3. Navigate to "Edit &gt; Manage Results" and click the "Re-score" button.
-
-This will provide Skyline with a variety of candidate peaks to evaluate peak quality.</value>
+1. 导航至“设置 &gt; 肽段设置 - 库”选项卡，然后单击“编辑列表”。
+2. 选择库中的某项，单击“编辑”，然后取消选中“使用明示峰界限”复选框。
+3. 导航至“编辑  &gt; 管理结果”，然后单击“再次计分”按钮。
+该操作将为 Skyline 提供各种候选峰，用来评估峰质量。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="EditPeakScoringModelDlg_ShowEditPeakScoringModelDlg_Train_Model" xml:space="preserve">
-    <value>Train Model</value>
+    <value>训练模型</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.zh-CHS.resx
@@ -1654,7 +1654,7 @@ H (+1)、K (+1)、Na (+1)、Li (+1)、Br (-1)、Cl (-1)、F (-1)、CH3COO (-1)�
     <value>6</value>
   </data>
   <data name="label23.Text" xml:space="preserve">
-    <value>耐受性单位(&amp;N):</value>
+    <value>耐受性单位(&amp;N)：</value>
   </data>
   <data name="comboToleranceUnits.Items" xml:space="preserve">
     <value>质荷比</value>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.ja.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.ja.resx
@@ -643,7 +643,7 @@
     <value>436, 17</value>
   </metadata>
   <data name="textPeptide.ToolTip" xml:space="preserve">
-    <value>Filters beginning with * search within descriptions, e.g. *PEET will match PEETID and AAPEETB</value>
+    <value>*で始まるフィルタは表記内を検索します。例えば*PEETではPEETIDやAAPEETBが一致します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;textPeptide.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
@@ -932,7 +932,7 @@
     <value>0</value>
   </data>
   <data name="labelFilename.Text" xml:space="preserve">
-    <value>文件(&amp;E):</value>
+    <value>文件(&amp;E)：</value>
   </data>
   <data name="&gt;&gt;labelFilename.Name" xml:space="preserve">
     <value>labelFilename</value>
@@ -1337,7 +1337,7 @@
     <value>263, 32</value>
   </data>
   <data name="graphPropsContextMenuItem.Text" xml:space="preserve">
-    <value>图形属性...</value>
+    <value>图形属性…</value>
   </data>
   <data name="spectrumPropsContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>263, 32</value>

--- a/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SettingsUI/ViewLibraryDlg.zh-CHS.resx
@@ -643,7 +643,7 @@
     <value>436, 17</value>
   </metadata>
   <data name="textPeptide.ToolTip" xml:space="preserve">
-    <value>Filters beginning with * search within descriptions, e.g. *PEET will match PEETID and AAPEETB</value>
+    <value>以 * 开头的过滤器将在描述中进行搜索，例如 *PEET 将匹配 PEETID 和 AAPEETB</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;textPeptide.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Skyline.ja.resx
+++ b/pwiz_tools/Skyline/Skyline.ja.resx
@@ -366,7 +366,7 @@
     <value>193, 22</value>
   </data>
   <data name="massErrorToolStripMenuItem.Text" xml:space="preserve">
-    <value>Show Mass Error</value>
+    <value>質量誤差を表示</value>
     <comment>Needs Review:English text changed
 Old English:Mass Error
 Current English:Show Mass Error
@@ -781,7 +781,7 @@ Old Localized:Show Mass Error</comment>
     <value>190, 22</value>
   </data>
   <data name="areaRelativeAbundanceContextMenuItem.Text" xml:space="preserve">
-    <value>Relative Abundance</value>
+    <value>相対的存在量</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="areaCVHistogramContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -902,7 +902,7 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="excludeTargetsMenuItem.Text" xml:space="preserve">
-    <value>Exclude</value>
+    <value>除外</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="showPeakAreaLegendContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1074,7 +1074,7 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="excludeTargetsPeptideListMenuItem.Text" xml:space="preserve">
-    <value>Peptide Lists</value>
+    <value>ペプチドのリスト</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="excludeTargetsStandardsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1397,7 +1397,7 @@ Old Localized:Show Mass Error</comment>
     <value>200, 22</value>
   </data>
   <data name="openPanoramaMenuItem.Text" xml:space="preserve">
-    <value>Open From Panora&amp;ma...</value>
+    <value>Panoramaから開く(&amp;M)...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="openContainingFolderMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1449,7 +1449,7 @@ Old Localized:Show Mass Error</comment>
     <value>194, 22</value>
   </data>
   <data name="runPeptideSearchToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Run Peptide Search...</value>
+    <value>ペプチド検索の実行(&amp;R)...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="encyclopeDiaSearchMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1462,14 +1462,14 @@ Old Localized:Show Mass Error</comment>
     <value>194, 22</value>
   </data>
   <data name="importFeatureDetectionMenuItem.Text" xml:space="preserve">
-    <value>&amp;Feature Detection...</value>
+    <value>フィーチャーの検出(&amp;F)...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="searchStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
   </data>
   <data name="searchStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Search</value>
+    <value>検索(&amp;S)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="importResultsMenuItem.Size" type="System.Drawing.Size, System.Drawing">

--- a/pwiz_tools/Skyline/Skyline.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Skyline.zh-CHS.resx
@@ -243,7 +243,7 @@
     <value>228, 22</value>
   </data>
   <data name="editSpectrumFilterContextMenuItem.Text" xml:space="preserve">
-    <value>编辑谱图过滤器...</value>
+    <value>编辑谱图过滤器…</value>
   </data>
   <data name="toggleQuantitativeContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>228, 22</value>
@@ -421,7 +421,7 @@ Old Localized:Show Mass Error</comment>
     <value>193, 22</value>
   </data>
   <data name="spectrumGraphPropsContextMenuItem.Text" xml:space="preserve">
-    <value>图形属性...</value>
+    <value>图形属性…</value>
   </data>
   <data name="showLibSpectrumPropertiesContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>193, 22</value>
@@ -1397,7 +1397,7 @@ Old Localized:Show Mass Error</comment>
     <value>200, 22</value>
   </data>
   <data name="openPanoramaMenuItem.Text" xml:space="preserve">
-    <value>从 Panorama 打开(&amp;M)...</value>
+    <value>从 Panorama 打开(&amp;M)…</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="openContainingFolderMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1456,13 +1456,13 @@ Old Localized:Show Mass Error</comment>
     <value>194, 22</value>
   </data>
   <data name="encyclopeDiaSearchMenuItem.Text" xml:space="preserve">
-    <value>EncyclopeDIA 搜索...</value>
+    <value>EncyclopeDIA 搜索…</value>
   </data>
   <data name="importFeatureDetectionMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>194, 22</value>
   </data>
   <data name="importFeatureDetectionMenuItem.Text" xml:space="preserve">
-    <value>特征检测(&amp;F)...</value>
+    <value>特征检测(&amp;F)…</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="searchStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1500,7 +1500,7 @@ Old Localized:Show Mass Error</comment>
     <value>170, 22</value>
   </data>
   <data name="importFASTAMenuItem.Text" xml:space="preserve">
-    <value>&amp;FASTA...</value>
+    <value>&amp;FASTA…</value>
   </data>
   <data name="importAssayLibraryMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 22</value>

--- a/pwiz_tools/Skyline/Skyline.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Skyline.zh-CHS.resx
@@ -366,7 +366,7 @@
     <value>193, 22</value>
   </data>
   <data name="massErrorToolStripMenuItem.Text" xml:space="preserve">
-    <value>Show Mass Error</value>
+    <value>显示质量误差</value>
     <comment>Needs Review:English text changed
 Old English:Mass Error
 Current English:Show Mass Error
@@ -781,7 +781,7 @@ Old Localized:Show Mass Error</comment>
     <value>190, 22</value>
   </data>
   <data name="areaRelativeAbundanceContextMenuItem.Text" xml:space="preserve">
-    <value>Relative Abundance</value>
+    <value>相对丰度</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="areaCVHistogramContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -902,7 +902,7 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="excludeTargetsMenuItem.Text" xml:space="preserve">
-    <value>Exclude</value>
+    <value>排除</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="showPeakAreaLegendContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1074,7 +1074,7 @@ Old Localized:Show Mass Error</comment>
     <value>209, 22</value>
   </data>
   <data name="excludeTargetsPeptideListMenuItem.Text" xml:space="preserve">
-    <value>Peptide Lists</value>
+    <value>肽段列表</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="excludeTargetsStandardsMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1397,7 +1397,7 @@ Old Localized:Show Mass Error</comment>
     <value>200, 22</value>
   </data>
   <data name="openPanoramaMenuItem.Text" xml:space="preserve">
-    <value>Open From Panora&amp;ma...</value>
+    <value>从 Panorama 打开(&amp;M)...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="openContainingFolderMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1449,7 +1449,7 @@ Old Localized:Show Mass Error</comment>
     <value>194, 22</value>
   </data>
   <data name="runPeptideSearchToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Run Peptide Search...</value>
+    <value>运行肽段搜索(&amp;R)…</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="encyclopeDiaSearchMenuItem.Size" type="System.Drawing.Size, System.Drawing">
@@ -1462,14 +1462,14 @@ Old Localized:Show Mass Error</comment>
     <value>194, 22</value>
   </data>
   <data name="importFeatureDetectionMenuItem.Text" xml:space="preserve">
-    <value>&amp;Feature Detection...</value>
+    <value>特征检测(&amp;F)...</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="searchStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 22</value>
   </data>
   <data name="searchStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Search</value>
+    <value>搜索(&amp;S)</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="importResultsMenuItem.Size" type="System.Drawing.Size, System.Drawing">

--- a/pwiz_tools/Skyline/SkylineResources.ja.resx
+++ b/pwiz_tools/Skyline/SkylineResources.ja.resx
@@ -142,7 +142,7 @@
     <value>上書きレポート：{0}</value>
   </data>
   <data name="CommandArgs_ARG_BGPROTEOME_NAME_name_to_give_protdb_imported_by___background_proteome_file" xml:space="preserve">
-    <value>name to give protdb imported by --background-proteome-file</value>
+    <value>--background-proteome-file操作でインポートされたprotdbに与える名前</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_DwellTime_The_dwell_time__0__must_be_between__1__and__2__" xml:space="preserve">
@@ -192,7 +192,7 @@
     <value>警告： 装置タイプ{0}が有効ではありません。次から選択してください：</value>
   </data>
   <data name="CommandArgs_ParseExcludeObject_Error__Attempting_to_exclude_an_unknown_object_name___0____Try_one_of_the_following_" xml:space="preserve">
-    <value>Error: Attempting to exclude an unknown object name '{0}'. Try one of the following:</value>
+    <value>エラー：不明なオブジェクト名「{0}」を除外しようとしています。次のいずれかをお試しください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_PrimaryTransitionCount_The_primary_transition_count__0__must_be_between__1__and__2__" xml:space="preserve">
@@ -244,7 +244,7 @@
     <value>エラー：デフォルトのSkylineモデルではフィーチャースコアを除外できません。</value>
   </data>
   <data name="CommandLine_ExportAnnotations_Error__Failure_attempting_to_save_annotations_file__0__" xml:space="preserve">
-    <value>Error: Failure attempting to save annotations file {0}.</value>
+    <value>エラー：注釈ファイル{0}の保存に失敗しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportChromatograms_Chromatograms_file__0__exported_successfully_" xml:space="preserve">
@@ -296,7 +296,7 @@
     <value>エラー： スケジュールメソッドをエクスポートするには、まずドキュメント内のすべてのペプチドに対する結果をインポートする必要があります。</value>
   </data>
   <data name="CommandLine_ExportInstrumentFile_The_folder__0__does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
-    <value>The folder {0} does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+    <value>フォルダ{0}にはAgilent MassHunter 12メソッドテンプレートが含まれていないようです。このフォルダには拡張子.mが必要です。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportInstrumentFile_Warning__Max_transitions_per_injection_must_be_set_to_some_value_between__0__and__1__for_export_strategies__protein__and__buckets__and_for_scheduled_methods__You_specified__3___Defaulting_to__2__" xml:space="preserve">
@@ -333,11 +333,11 @@
     <value>レポート{0}が{1}に正常にエクスポートされました。</value>
   </data>
   <data name="CommandLine_ExportMProphetFeatures_Error__Failure_attempting_to_save_mProphet_features_file__0__" xml:space="preserve">
-    <value>Error: Failure attempting to save mProphet features file {0}.</value>
+    <value>エラー：mProphetフィーチャーファイル{0}の保存に失敗しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportSpecLib_Error__Failure_attempting_to_save_spectral_library_file__0__" xml:space="preserve">
-    <value>Error: Failure attempting to save spectral library file {0}.</value>
+    <value>エラー：スペクトルライブラリファイル{0}の保存に失敗しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_FindBackgroundProteome_Warning__Could_not_find_the_background_proteome_file__0__" xml:space="preserve">
@@ -507,7 +507,7 @@
     <value>エラー：ユーザー設定ファイルへの保存に失敗しました。</value>
   </data>
   <data name="CommandLine_SetAnnotations_" xml:space="preserve">
-    <value>Error: An annotation titled '{0}' already exists.  Please use --annotation-conflict-resolution= &lt;overwrite | skip&gt;.  Annotation titled '{0}' was not added.</value>
+    <value>エラー：「{0}」というタイトルの注釈が既に存在しています。--annotation-conflict-resolution= &lt;overwrite | skip&gt;を使用してください。「{0}」というタイトルの注釈は追加されませんでした。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetFilterSettings_Error__Failed_attempting_to_change_the_transition_filter_settings_" xml:space="preserve">
@@ -535,11 +535,11 @@
     <value>エラー：トランジションライブラリ設定を変更しようとして失敗しました。</value>
   </data>
   <data name="CommandLine_SetPeptideDigestSettings_Error__Failed_attempting_to_change_the_peptide_digestion_settings_" xml:space="preserve">
-    <value>Error: Failed attempting to change the peptide digestion settings.</value>
+    <value>エラー：ペプチド消化設定の変更に失敗しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetPeptideFilterSettings_Error__Failed_attempting_to_change_the_peptide_filter_settings_" xml:space="preserve">
-    <value>Error: Failed attempting to change the peptide filter settings.</value>
+    <value>エラー：ペプチドフィルタ設定の変更に失敗しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetPredictTranSettings_Error__Failed_attempting_to_change_the_transition_prediction_settings_" xml:space="preserve">
@@ -956,23 +956,23 @@
     <value>読み込み中...</value>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Downloading_file__0_" xml:space="preserve">
-    <value>Downloading file {0}</value>
+    <value>ファイル{0}をダウンロード中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Loading_remote_server_folders" xml:space="preserve">
-    <value>Loading remote server folders</value>
+    <value>リモートサーバーのフォルダを読み込み中</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_No_Panorama_servers_were_found_" xml:space="preserve">
-    <value>No Panorama servers were found.</value>
+    <value>Panoramaサーバーが見つかりませんでした。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Open_From_Panorama" xml:space="preserve">
-    <value>Open From Panorama</value>
+    <value>Panoramaから開く</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Press__Add__to_add_a_new_server_" xml:space="preserve">
-    <value>Press 'Add' to add a new server.</value>
+    <value>[追加] を押して新規サーバーを追加してください。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenSharedFile_The_zip_file__0__cannot_be_read" xml:space="preserve">
@@ -1093,11 +1093,11 @@
     <value>続行</value>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_Document_cannot_be_uploaded_to_a_Panorama_server_without_a_user_account_" xml:space="preserve">
-    <value>Document cannot be uploaded to a Panorama server without a user account.</value>
+    <value>ユーザーアカウントがないと、ドキュメントをPanoramaサーバーにアップロードできません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_Edit_existing" xml:space="preserve">
-    <value>Edit existing</value>
+    <value>既存の編集</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_Press_Continue_to_use_the_server_of_your_choice_" xml:space="preserve">
@@ -1158,50 +1158,50 @@
     <value>{0}をアップグレードしています</value>
   </data>
   <data name="ValueInvalidAnnotationTargetListException_ValueInvalidAnnotationTargetListException_The_value__0___is_not_valid_for_the_argument___1___which_requires_a_comma_separated_list_of_annotation_targets___2___" xml:space="preserve">
-    <value>The value '{0}' is not valid for the argument {1} which requires a comma-separated list of annotation targets {2}.</value>
+    <value>値「{0}」は、注釈ターゲット{2}のカンマ区切りリストを必要とする引数{1}には有効ではありません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_Press__Edit_existing__to_add_user_account_information_for_an_existing_server_" xml:space="preserve">
-    <value>Press 'Edit existing' to add user account information for an existing server.</value>
+    <value>[既存の編集] をクリックして、既存のサーバーのユーザーアカウント情報を追加します。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetPeptideModSettings_Error__Failed_attempting_to_change_the_peptide_modification_settings_" xml:space="preserve">
-    <value>Error: Failed attempting to change the peptide modification settings.</value>
+    <value>エラー：ペプチド修飾設定の変更に失敗しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowImportPeptideSearchDlg_The_document_must_be_fully_loaded_before_performing_feature_detection_" xml:space="preserve">
-    <value>The document must be fully loaded before performing feature detection.</value>
+    <value>フィーチャー検出を実行する前に、ドキュメントを完全に読み込む必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowImportPeptideSearchDlg_You_must_save_this_document_before_performing_feature_detection_" xml:space="preserve">
-    <value>You must save this document before performing feature detection.</value>
+    <value>フィーチャー検出を実行する前に、このドキュメントを保存する必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg__0__is_not_a_valid_file_name_for_uploading_to_Panorama_" xml:space="preserve">
-    <value>{0} is not a valid file name for uploading to Panorama.</value>
+    <value>{0}は、Panoramaにアップロードできる有効なファイル名ではありません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AssociateProteins_Associating_peptides_with_proteins" xml:space="preserve">
     <value>ペプチドをタンパク質に関連付け</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_RunPeptideSearchRadioDIAText_DIA_with_DIA_Umpire" xml:space="preserve">
-    <value>DIA with DIA-Umpire</value>
+    <value>DIA-Umpireを使用したDIA</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowRunPeptideSearchDlg_Run_Peptide_Search" xml:space="preserve">
-    <value>Run Peptide Search</value>
+    <value>ペプチド検索の実行</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowRunPeptideSearchDlg_You_must_save_this_document_before_running_a_peptide_search_" xml:space="preserve">
-    <value>You must save this document before running a peptide search.</value>
+    <value>ペプチド検索の実行前に、このドキュメントを保存する必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowRunPeptideSearchDlg_The_document_must_be_fully_loaded_before_running_a_peptide_search_" xml:space="preserve">
-    <value>The document must be fully loaded before running a peptide search.</value>
+    <value>ペプチド検索を実行する前に、ドキュメントを完全に読み込む必要があります。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibraryControl_Library_from_DIA_deconvoluted_to_single_precursor_MS_MS_spectra_and_chromatograms_from_raw_DIA_spectra_of_same_runs" xml:space="preserve">
-    <value>Library from DIA deconvoluted to single-precursor MS/MS spectra and chromatograms from raw DIA spectra of same runs</value>
+    <value>シングルプリカーサーMS/MSスペクトルにデコンボリューションしたDIAから得られたライブラリと、同じランの生DIAスペクトルから得られたクロマトグラム</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
@@ -226,7 +226,7 @@
     <value>样品名“{0}”不符合模式“{1}”。忽视{2}</value>
   </data>
   <data name="CommandLine_CreateImsDb_Creating_ion_mobility_library___0___in___1_____" xml:space="preserve">
-    <value>正在“{1}”中创建离子迁移库“{0}”...</value>
+    <value>正在“{1}”中创建离子迁移库“{0}”…</value>
   </data>
   <data name="CommandLine_CreateScoringModel_Error__Failed_to_create_scoring_model_" xml:space="preserve">
     <value>错误：创建得分模型失败。</value>
@@ -260,7 +260,7 @@
     <value>错误：文档必须拥有导入的结果</value>
   </data>
   <data name="CommandLine_ExportChromatograms_Exporting_chromatograms_file__0____" xml:space="preserve">
-    <value>正在导出色谱图文件{0}...</value>
+    <value>正在导出色谱图文件{0}…</value>
   </data>
   <data name="CommandLine_ExportInstrumentFile_" xml:space="preserve">
     <value>错误：您必须借助“--exp-file=path/to/file”参数来指定写入的导出文件。无离子对列表将被导出。</value>
@@ -309,7 +309,7 @@
     <value>警告：“添加-能量-斜坡”参数仅适用于 Thermo 离子对列表。该参数将被忽视。</value>
   </data>
   <data name="CommandLine_ExportInstrumentFile_Warning__The_vendor__0__does_not_match_the_vendor_in_either_the_CE_or_DP_prediction_setting___Continuing_exporting_a_transition_list_anyway___" xml:space="preserve">
-    <value>警告：供应商{0}在 CE 或 DP 预测设置中不匹配供应商。 无论如何继续导出离子对列表...</value>
+    <value>警告：供应商{0}在 CE 或 DP 预测设置中不匹配供应商。 无论如何继续导出离子对列表…</value>
   </data>
   <data name="CommandLine_ExportInstrumentFile_You_must_export_a__0__transition_list_and_manually_import_it_into_a_method_file_using_vendor_software_" xml:space="preserve">
     <value>您必须导出一个{0}离子对列表并使用供应商软件来将其手动导入方法文件。</value>
@@ -327,7 +327,7 @@
     <value>错误：报告{0}不存在。如果名称中存在空格，请在整个命令参数列表周围使用“双引号”。</value>
   </data>
   <data name="CommandLine_ExportLiveReport_Exporting_report__0____" xml:space="preserve">
-    <value>报告{0}导出中...</value>
+    <value>报告{0}导出中…</value>
   </data>
   <data name="CommandLine_ExportLiveReport_Report__0__exported_successfully_to__1__" xml:space="preserve">
     <value>报告{0}已成功导出至{1}。</value>
@@ -368,16 +368,16 @@
     <value>正在从 {0} 导入峰边界 </value>
   </data>
   <data name="CommandLine_ImportResultsFile__0______1___Note__The_file_has_already_been_imported__Ignoring___" xml:space="preserve">
-    <value>{0} -&gt; {1} 注释：文件已导入。忽视...</value>
+    <value>{0} -&gt; {1} 注释：文件已导入。忽视…</value>
   </data>
   <data name="CommandLine_ImportResultsFile_Adding_results___" xml:space="preserve">
     <value>结果添加中…</value>
   </data>
   <data name="CommandLine_ImportResultsFile_File_write_date__0__is_after___import_before_date__1___Ignoring___" xml:space="preserve">
-    <value>文件写入日期 {0} 晚于 --导入-之前日期 {1}。忽视...</value>
+    <value>文件写入日期 {0} 晚于 --导入-之前日期 {1}。忽视…</value>
   </data>
   <data name="CommandLine_ImportResultsFile_File_write_date__0__is_before___import_on_or_after_date__1___Ignoring___" xml:space="preserve">
-    <value>文件写入日期 {0} 早于 --导入-在-或-之前日期 {1}。忽视...</value>
+    <value>文件写入日期 {0} 早于 --导入-在-或-之前日期 {1}。忽视…</value>
   </data>
   <data name="CommandLine_ImportResultsInDir_Error__Could_not_get_last_write_time_for_file__0__" xml:space="preserve">
     <value>错误：无法找到文件{0}的上次写入时间。</value>
@@ -434,13 +434,13 @@
     <value>已删除：{0}</value>
   </data>
   <data name="CommandLine_MinimizeResults_Limiting_chromatogram_noise_to______0__minutes_around_peak___" xml:space="preserve">
-    <value>正在将峰周围的色谱图噪声限制为 +/- {0} 分钟...</value>
+    <value>正在将峰周围的色谱图噪声限制为 +/- {0} 分钟…</value>
   </data>
   <data name="CommandLine_MinimizeResults_Minimizing_results_to__0_" xml:space="preserve">
     <value>结果最小化为 {0}</value>
   </data>
   <data name="CommandLine_MinimizeResults_Removing_unused_chromatograms___" xml:space="preserve">
-    <value>正在删除未使用的色谱图...</value>
+    <value>正在删除未使用的色谱图…</value>
   </data>
   <data name="CommandLine_PerformExportOperations_Error__No_new_results_added__Skipping_Panorama_import_" xml:space="preserve">
     <value>错误：未添加新结果。跳过 Panorama 导入。</value>
@@ -480,13 +480,13 @@
     <value>错误：打开日志文件 {0} 失败</value>
   </data>
   <data name="CommandLine_Run_Error__Failure_occurred__Exiting___" xml:space="preserve">
-    <value>错误：发生故障。正在退出...</value>
+    <value>错误：发生故障。正在退出…</value>
   </data>
   <data name="CommandLine_Run_Error__You_cannot_simultaneously_export_a_transition_list_and_a_method___Neither_will_be_exported__" xml:space="preserve">
     <value>错误：您无法同时导出离子对列表和方法。 这样操作不会导出任何内容。请更改命令行参数。</value>
   </data>
   <data name="CommandLine_Run_Exiting___" xml:space="preserve">
-    <value>退出中...</value>
+    <value>退出中…</value>
   </data>
   <data name="CommandLine_Run_Not_setting_library_" xml:space="preserve">
     <value>未设定库。</value>
@@ -501,7 +501,7 @@
     <value>错误：打开文件{0}失败。“--批次-命令”命令失败。</value>
   </data>
   <data name="CommandLine_SaveFile_Saving_file___" xml:space="preserve">
-    <value>文件保存中...</value>
+    <value>文件保存中…</value>
   </data>
   <data name="CommandLine_SaveSettings_Error__Failed_saving_to_the_user_configuration_file_" xml:space="preserve">
     <value>错误：未能保存至用户配置文件。</value>
@@ -549,7 +549,7 @@
     <value>消息：</value>
   </data>
   <data name="CommandWaitBroker_UpdateProgress_Waiting___" xml:space="preserve">
-    <value>正在等待...</value>
+    <value>正在等待…</value>
   </data>
   <data name="CommandWaitBroker_Wait_Done" xml:space="preserve">
     <value>已完成</value>
@@ -953,7 +953,7 @@
     <value>打开{0}失败。</value>
   </data>
   <data name="SkylineWindow_OpenFile_Loading___" xml:space="preserve">
-    <value>加载中...</value>
+    <value>加载中…</value>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Downloading_file__0_" xml:space="preserve">
     <value>正在下载文件 {0}</value>
@@ -1003,7 +1003,7 @@
     <value>写入{0}失败。</value>
   </data>
   <data name="SkylineWindow_SaveDocument_Optimizing_data_file___" xml:space="preserve">
-    <value>优化数据文件...</value>
+    <value>优化数据文件…</value>
   </data>
   <data name="SkylineWindow_SaveDocumentAs_The_document_must_be_fully_loaded_before_it_can_be_saved_to_a_new_name" xml:space="preserve">
     <value>文档必须在可以保存为新名称之前被完全加载。</value>
@@ -1072,7 +1072,7 @@
     <value>导出谱图库</value>
   </data>
   <data name="SkylineWindow_ShowExportSpectralLibraryDialog_Exporting_spectral_library__0____" xml:space="preserve">
-    <value>正在导出谱图库 {0}...</value>
+    <value>正在导出谱图库 {0}…</value>
   </data>
   <data name="SkylineWindow_ShowExportSpectralLibraryDialog_Failed_exporting_spectral_library_to__0__" xml:space="preserve">
     <value>向 {0} 导出谱图库失败。</value>

--- a/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/SkylineResources.zh-CHS.resx
@@ -142,7 +142,7 @@
     <value>覆盖报告：{0}</value>
   </data>
   <data name="CommandArgs_ARG_BGPROTEOME_NAME_name_to_give_protdb_imported_by___background_proteome_file" xml:space="preserve">
-    <value>name to give protdb imported by --background-proteome-file</value>
+    <value>为通过 --background-proteome-file 导入的 protdb 命名</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_DwellTime_The_dwell_time__0__must_be_between__1__and__2__" xml:space="preserve">
@@ -192,7 +192,7 @@
     <value>警告：仪器类型{0}无效。请从下方选项中选择：</value>
   </data>
   <data name="CommandArgs_ParseExcludeObject_Error__Attempting_to_exclude_an_unknown_object_name___0____Try_one_of_the_following_" xml:space="preserve">
-    <value>Error: Attempting to exclude an unknown object name '{0}'. Try one of the following:</value>
+    <value>错误：试图排除未知对象名称“{0}”。尝试其中一种方法：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandArgs_PrimaryTransitionCount_The_primary_transition_count__0__must_be_between__1__and__2__" xml:space="preserve">
@@ -244,7 +244,7 @@
     <value>错误：默认 Skyline 模型不允许排除特征得分。</value>
   </data>
   <data name="CommandLine_ExportAnnotations_Error__Failure_attempting_to_save_annotations_file__0__" xml:space="preserve">
-    <value>Error: Failure attempting to save annotations file {0}.</value>
+    <value>错误：保存注释文件 {0} 失败。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportChromatograms_Chromatograms_file__0__exported_successfully_" xml:space="preserve">
@@ -296,7 +296,7 @@
     <value>错误：如要导出预定方法，您必须首先在文档中导入针对所有肽段的结果。</value>
   </data>
   <data name="CommandLine_ExportInstrumentFile_The_folder__0__does_not_appear_to_contain_an_Agilent_MassHunter_12_method_template__The_folder_is_expected_to_have_a__m_extension_" xml:space="preserve">
-    <value>The folder {0} does not appear to contain an Agilent MassHunter 12 method template. The folder is expected to have a .m extension.</value>
+    <value>文件夹 {0} 似乎不包含 Agilent MassHunter 12 方法模板。该文件夹的扩展名应为 .m。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportInstrumentFile_Warning__Max_transitions_per_injection_must_be_set_to_some_value_between__0__and__1__for_export_strategies__protein__and__buckets__and_for_scheduled_methods__You_specified__3___Defaulting_to__2__" xml:space="preserve">
@@ -333,11 +333,11 @@
     <value>报告{0}已成功导出至{1}。</value>
   </data>
   <data name="CommandLine_ExportMProphetFeatures_Error__Failure_attempting_to_save_mProphet_features_file__0__" xml:space="preserve">
-    <value>Error: Failure attempting to save mProphet features file {0}.</value>
+    <value>错误：试图保存 mProphet 特征文件 {0} 失败。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_ExportSpecLib_Error__Failure_attempting_to_save_spectral_library_file__0__" xml:space="preserve">
-    <value>Error: Failure attempting to save spectral library file {0}.</value>
+    <value>错误：试图保存谱图库文件 {0} 失败。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_FindBackgroundProteome_Warning__Could_not_find_the_background_proteome_file__0__" xml:space="preserve">
@@ -507,7 +507,7 @@
     <value>错误：未能保存至用户配置文件。</value>
   </data>
   <data name="CommandLine_SetAnnotations_" xml:space="preserve">
-    <value>Error: An annotation titled '{0}' already exists.  Please use --annotation-conflict-resolution= &lt;overwrite | skip&gt;.  Annotation titled '{0}' was not added.</value>
+    <value>错误：已有标题为“{0}”的注释。请使用 --annotation-conflict-resolution= &lt;overwrite | skip&gt;。未添加标题为“{0}”的注释。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetFilterSettings_Error__Failed_attempting_to_change_the_transition_filter_settings_" xml:space="preserve">
@@ -535,11 +535,11 @@
     <value>错误：尝试更改离子对的库设置失败。</value>
   </data>
   <data name="CommandLine_SetPeptideDigestSettings_Error__Failed_attempting_to_change_the_peptide_digestion_settings_" xml:space="preserve">
-    <value>Error: Failed attempting to change the peptide digestion settings.</value>
+    <value>错误：尝试更改肽段酶解设置失败。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetPeptideFilterSettings_Error__Failed_attempting_to_change_the_peptide_filter_settings_" xml:space="preserve">
-    <value>Error: Failed attempting to change the peptide filter settings.</value>
+    <value>错误：尝试更改肽段过滤设置失败。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetPredictTranSettings_Error__Failed_attempting_to_change_the_transition_prediction_settings_" xml:space="preserve">
@@ -956,23 +956,23 @@
     <value>加载中...</value>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Downloading_file__0_" xml:space="preserve">
-    <value>Downloading file {0}</value>
+    <value>正在下载文件 {0}</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Loading_remote_server_folders" xml:space="preserve">
-    <value>Loading remote server folders</value>
+    <value>正在加载远程服务器文件夹</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_No_Panorama_servers_were_found_" xml:space="preserve">
-    <value>No Panorama servers were found.</value>
+    <value>找不到 Panorama 服务器。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Open_From_Panorama" xml:space="preserve">
-    <value>Open From Panorama</value>
+    <value>从 Panorama 打开</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenFromPanorama_Press__Add__to_add_a_new_server_" xml:space="preserve">
-    <value>Press 'Add' to add a new server.</value>
+    <value>按“添加”以添加新服务器。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_OpenSharedFile_The_zip_file__0__cannot_be_read" xml:space="preserve">
@@ -1093,11 +1093,11 @@
     <value>继续</value>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_Document_cannot_be_uploaded_to_a_Panorama_server_without_a_user_account_" xml:space="preserve">
-    <value>Document cannot be uploaded to a Panorama server without a user account.</value>
+    <value>没有用户帐户，文档无法上传到 Panorama 服务器。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_Edit_existing" xml:space="preserve">
-    <value>Edit existing</value>
+    <value>编辑现有</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_Press_Continue_to_use_the_server_of_your_choice_" xml:space="preserve">
@@ -1158,50 +1158,50 @@
     <value>正在升级 {0}</value>
   </data>
   <data name="ValueInvalidAnnotationTargetListException_ValueInvalidAnnotationTargetListException_The_value__0___is_not_valid_for_the_argument___1___which_requires_a_comma_separated_list_of_annotation_targets___2___" xml:space="preserve">
-    <value>The value '{0}' is not valid for the argument {1} which requires a comma-separated list of annotation targets {2}.</value>
+    <value>值“{0}”对参数 {1} 无效，因为该参数要求使用逗号分隔的注释目标列表 {2}。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg_Press__Edit_existing__to_add_user_account_information_for_an_existing_server_" xml:space="preserve">
-    <value>Press 'Edit existing' to add user account information for an existing server.</value>
+    <value>按“编辑现有”为现有服务器添加用户帐户信息。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_SetPeptideModSettings_Error__Failed_attempting_to_change_the_peptide_modification_settings_" xml:space="preserve">
-    <value>Error: Failed attempting to change the peptide modification settings.</value>
+    <value>错误：尝试更改肽段修饰设置失败。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowImportPeptideSearchDlg_The_document_must_be_fully_loaded_before_performing_feature_detection_" xml:space="preserve">
-    <value>The document must be fully loaded before performing feature detection.</value>
+    <value>必须完全加载文档，然后才能检测特征。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowImportPeptideSearchDlg_You_must_save_this_document_before_performing_feature_detection_" xml:space="preserve">
-    <value>You must save this document before performing feature detection.</value>
+    <value>您必须在保存此文档后才能检测特征。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowPublishDlg__0__is_not_a_valid_file_name_for_uploading_to_Panorama_" xml:space="preserve">
-    <value>{0} is not a valid file name for uploading to Panorama.</value>
+    <value>{0} 不是有效文件名，无法上传到 Panorama。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="CommandLine_AssociateProteins_Associating_peptides_with_proteins" xml:space="preserve">
     <value>正在关联肽段与蛋白质</value>
   </data>
   <data name="BuildPeptideSearchLibraryControl_RunPeptideSearchRadioDIAText_DIA_with_DIA_Umpire" xml:space="preserve">
-    <value>DIA with DIA-Umpire</value>
+    <value>DIA 和 DIA-Umpire</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowRunPeptideSearchDlg_Run_Peptide_Search" xml:space="preserve">
-    <value>Run Peptide Search</value>
+    <value>运行肽段搜索</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowRunPeptideSearchDlg_You_must_save_this_document_before_running_a_peptide_search_" xml:space="preserve">
-    <value>You must save this document before running a peptide search.</value>
+    <value>必须保存此文档，然后才能搜索肽段。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="SkylineWindow_ShowRunPeptideSearchDlg_The_document_must_be_fully_loaded_before_running_a_peptide_search_" xml:space="preserve">
-    <value>The document must be fully loaded before running a peptide search.</value>
+    <value>在运行肽段搜索之前，必须完全加载文档。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="BuildPeptideSearchLibraryControl_BuildPeptideSearchLibraryControl_Library_from_DIA_deconvoluted_to_single_precursor_MS_MS_spectra_and_chromatograms_from_raw_DIA_spectra_of_same_runs" xml:space="preserve">
-    <value>Library from DIA deconvoluted to single-precursor MS/MS spectra and chromatograms from raw DIA spectra of same runs</value>
+    <value>DIA 去卷积后得到的单母离子 MS/MS 谱图库，以及来自于相同运行的原始 DIA 谱图的色谱图</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.ja.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.ja.resx
@@ -219,14 +219,14 @@
     <value>10</value>
   </data>
   <data name="cbAnonymous.Text" xml:space="preserve">
-    <value>Anonymous access</value>
+    <value>匿名アクセス</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <metadata name="toolTipAnonymous.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
   </metadata>
   <data name="cbAnonymous.ToolTip" xml:space="preserve">
-    <value>Check this box if you do not have an account on the server.  Without a user account you can anonymously browse, download and open publicly available documents on the server, but you cannot upload documents to the server.</value>
+    <value>サーバーにアカウントを持っていない場合は、このボックスをオンにします。ユーザーアカウントがない場合、サーバー上の公開ドキュメントは匿名で閲覧、ダウンロード、開くことができますが、サーバーにドキュメントをアップロードすることはできません。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbAnonymous.Name" xml:space="preserve">
@@ -500,7 +500,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>サーバーを編集</value>
+    <value>Panoramaサーバーの編集</value>
     <comment>Needs Review:English text changed
 Old English:Edit Server
 Current English:Edit Panorama Server

--- a/pwiz_tools/Skyline/ToolsUI/EditServerDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/ToolsUI/EditServerDlg.zh-CHS.resx
@@ -219,14 +219,14 @@
     <value>10</value>
   </data>
   <data name="cbAnonymous.Text" xml:space="preserve">
-    <value>Anonymous access</value>
+    <value>匿名访问</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <metadata name="toolTipAnonymous.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>155, 17</value>
   </metadata>
   <data name="cbAnonymous.ToolTip" xml:space="preserve">
-    <value>Check this box if you do not have an account on the server.  Without a user account you can anonymously browse, download and open publicly available documents on the server, but you cannot upload documents to the server.</value>
+    <value>如果您没有服务器帐户，请选中该复选框。如果没有用户帐户，可以匿名浏览、下载和打开服务器上可以公开获取的文档，但是您不能上传文档到服务器。</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;cbAnonymous.Name" xml:space="preserve">
@@ -500,7 +500,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>编辑服务器</value>
+    <value>编辑 Panorama 服务器</value>
     <comment>Needs Review:English text changed
 Old English:Edit Server
 Current English:Edit Panorama Server

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.ja.resx
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.ja.resx
@@ -566,7 +566,7 @@ Old Localized:279, 22</comment>
     <value>1</value>
   </data>
   <data name="koinaServerLabel.Text" xml:space="preserve">
-    <value>サーバー（&amp;S）：</value>
+    <value>サーバー(&amp;S)：</value>
   </data>
   <data name="&gt;&gt;koinaServerLabel.Name" xml:space="preserve">
     <value>koinaServerLabel</value>

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.ja.resx
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.ja.resx
@@ -791,7 +791,7 @@ Old Localized:279, 22</comment>
     <value>5</value>
   </data>
   <data name="lblSettingsPath.Text" xml:space="preserve">
-    <value>Settings are stored in:</value>
+    <value>設定の保存場所：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;lblSettingsPath.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.zh-CHS.resx
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.zh-CHS.resx
@@ -562,7 +562,7 @@
     <value>1</value>
   </data>
   <data name="koinaServerLabel.Text" xml:space="preserve">
-    <value>&amp;服务器：</value>
+    <value>服务器(&amp;S):</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;koinaServerLabel.Name" xml:space="preserve">
@@ -788,7 +788,7 @@
     <value>5</value>
   </data>
   <data name="lblSettingsPath.Text" xml:space="preserve">
-    <value>Settings are stored in:</value>
+    <value>设置存储位置:</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;lblSettingsPath.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.zh-CHS.resx
+++ b/pwiz_tools/Skyline/ToolsUI/ToolOptionsUI.zh-CHS.resx
@@ -562,7 +562,7 @@
     <value>1</value>
   </data>
   <data name="koinaServerLabel.Text" xml:space="preserve">
-    <value>服务器(&amp;S):</value>
+    <value>服务器(&amp;S)：</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="&gt;&gt;koinaServerLabel.Name" xml:space="preserve">

--- a/pwiz_tools/Skyline/Util/UtilResources.ja.resx
+++ b/pwiz_tools/Skyline/Util/UtilResources.ja.resx
@@ -303,7 +303,7 @@
     <value>ファイルのアップロード中</value>
   </data>
   <data name="Server_GetKey___anonymous_" xml:space="preserve">
-    <value> (anonymous)</value>
+    <value> （匿名）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Server_ReadXml_A_Panorama_server_must_be_specified" xml:space="preserve">
@@ -334,15 +334,15 @@
     <value>要素が欠損しているリストを直列化しようとしました。</value>
   </data>
   <data name="ParsedMolecule_SplitFormulaAndMasses_Cannot_parse___0___as_a_mass_offset_in_the_text___1___" xml:space="preserve">
-    <value>Cannot parse "{0}" as a mass offset in the text "{1}"</value>
+    <value>テキスト「{1}」内の質量オフセットとして「{0}」を解析できません</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_Would_you_like_to_go_to_Panorama_" xml:space="preserve">
-    <value>Would you like to go to Panorama?</value>
+    <value>Panoramaに移動しますか？</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_An_import_error_occurred_on_the_Panorama_server__0__" xml:space="preserve">
-    <value>An import error occurred on the Panorama server {0}.</value>
+    <value>Panoramaサーバー{0}でインポートエラーが発生しました。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Util/UtilResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Util/UtilResources.zh-CHS.resx
@@ -306,7 +306,7 @@
     <value>上传文件</value>
   </data>
   <data name="Server_GetKey___anonymous_" xml:space="preserve">
-    <value> (anonymous)</value>
+    <value> （匿名）</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="Server_ReadXml_A_Panorama_server_must_be_specified" xml:space="preserve">
@@ -337,15 +337,15 @@
     <value>尝试将缺少一个元素的列表序列化。</value>
   </data>
   <data name="ParsedMolecule_SplitFormulaAndMasses_Cannot_parse___0___as_a_mass_offset_in_the_text___1___" xml:space="preserve">
-    <value>Cannot parse "{0}" as a mass offset in the text "{1}"</value>
+    <value>无法将“{0}”解析为文本“{1}”中的质量偏移</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_Would_you_like_to_go_to_Panorama_" xml:space="preserve">
-    <value>Would you like to go to Panorama?</value>
+    <value>您想前往 Panorama 吗?</value>
     <comment>Needs Review:New resource</comment>
   </data>
   <data name="AbstractPanoramaPublishClient_UploadSharedZipFile_An_import_error_occurred_on_the_Panorama_server__0__" xml:space="preserve">
-    <value>An import error occurred on the Panorama server {0}.</value>
+    <value>Panorama 服务器 {0} 上发生导入错误。</value>
     <comment>Needs Review:New resource</comment>
   </data>
 </root>


### PR DESCRIPTION
The steps that were used to update these files were:
1.  Extract the .csv files from the translation team and rename them to "localization.ja.csv" and "localization.zh-CHS.csv"
2.  `pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\readResxFiles.bat`
3.  `pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\exe\ResourcesOrganizer.exe importLocalizationCsv`
4.  `pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\exe\ResourcesOrganizer.exe exportResx resxFiles.zip`
5.  Extract files from resxFiles.zip into the source tree

We could either cherry pick this commit to master, or we could run these same commands in master, whichever is easier