### PR TITLE
Make Precursor Collision Energy nullable in the Document Grid

### DIFF
--- a/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/Precursor.cs
@@ -29,6 +29,7 @@ using pwiz.Skyline.Model.Databinding.Collections;
 using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Model.ElementLocators;
 using pwiz.Skyline.Model.Hibernate;
+using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
 
@@ -190,14 +191,21 @@ namespace pwiz.Skyline.Model.Databinding.Entities
             get { return SequenceMassCalc.PersistentMZ(DocNode.PrecursorMz); }
         }
 
+        /// <summary>
+        /// Predicted collision energy, not to be confused with <see cref="ExplicitCollisionEnergy"/>.
+        /// </summary>
         [Format(Formats.OPT_PARAMETER, NullValue = TextUtil.EXCEL_NA)]
-        public double CollisionEnergy
+        public double? CollisionEnergy
         {
             get
             {
-                // Note this is the predicited CE, explicit CE has its own display column
-                return SrmDocument.Settings.TransitionSettings.Prediction.CollisionEnergy
-                                  .GetCollisionEnergy(DocNode.PrecursorAdduct, GetRegressionMz());
+                var collisionEnergyRegression = SrmDocument.Settings.TransitionSettings.Prediction.CollisionEnergy;
+                if (collisionEnergyRegression == null || Equals(collisionEnergyRegression, CollisionEnergyList.NONE))
+                {
+                    return null;
+                }
+
+                return collisionEnergyRegression.GetCollisionEnergy(DocNode.PrecursorAdduct, GetRegressionMz());
             }
         }
 


### PR DESCRIPTION
Changed to display "#N/A" for Collision Energy in Document Grid when no collision energy formula provided (not reported by anyone but inspired by import transition list Issue #1006)