### PR TITLE
In parallelized feature finding, the order in which Hardklor/Bullseye jobs complete is unpredictable and this led to some test failures.

### DIFF
--- a/pwiz_tools/Skyline/Model/DdaSearch/HardklorSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/HardklorSearchEngine.cs
@@ -406,6 +406,7 @@ namespace pwiz.Skyline.Model.DdaSearch
         {
             _contents = new List<string[]>();
             _bfiles = _inputsAndOutputs.Keys.Select(GetSearchResultFilepath).ToArray();
+            Array.Sort(_bfiles); // For consistency in uncertain parallel completion order
             _summedIntensityPerFile = new double[_bfiles.Length];
 
             for (var fileIndex = 0; fileIndex < _bfiles.Length; fileIndex++)


### PR DESCRIPTION
This is a quick fix for stable testing, but I still need to determine why order matters, and if it does, what order is best.