### PR TITLE
- added isolationWindows and isolationWidth spectrum list filters

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumListFactoryTest.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumListFactoryTest.cpp
@@ -24,6 +24,7 @@
 #include "SpectrumListFactory.hpp"
 #include "pwiz/utility/misc/unit.hpp"
 #include "pwiz/utility/misc/Std.hpp"
+#include "pwiz/data/msdata/TextWriter.hpp"
 #include <cstring>
 
 
@@ -567,7 +568,6 @@ void testWrapThermoScanFilter()
         msd.run.spectrumListPtr = originalSL;
         SpectrumListFactory::wrap(msd, "thermoScanFilter contains exclude 395.0000-1005.0000");
         SpectrumListPtr& sl = msd.run.spectrumListPtr;
-        cout << sl->size()<<endl;
         unit_assert(sl->size() == 4);
         unit_assert(sl->spectrumIdentity(0).id == "scan=19");
         unit_assert(sl->spectrumIdentity(1).id == "scan=20");
@@ -680,6 +680,124 @@ void testWrapPrecursorMzSet()
     unit_assert_throws_what(SpectrumListFactory::wrap(msd, "mzPrecursors [0,445.34] target=42"), user_error, "[SpectrumListFactory::filterCreator_mzPrecursors()] invalid value for 'target' parameter: 42");
 }
 
+void testWrapIsolationWindowSet()
+{
+    MSData msd;
+    ostringstream str;
+    examples::initializeTiny(msd);
+    auto originalSL = msd.run.spectrumListPtr;
+
+    {
+        SpectrumListFactory::wrap(msd, "isolationWindows [444,446]"); // default tolerance does not match to 1.0 (-0.5, 0.5)
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(0, sl->size());
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "isolationWindows [444,446] mzTol=1mz");
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(1, sl->size());
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(0).id);
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "isolationWindows [444,446] mzTol=1 mz"); // mzTol should still parse correctly with a space
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(1, sl->size());
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(0).id);
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "isolationWindows [444.8,445.8] mode=exclude"); // only 1 MS2 left, but MS1s aren't excluded now
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal_message(4, sl->size(), "\n" + (TextWriter(str)(sl), str.str()));
+        unit_assert_operator_equal("scan=19", sl->spectrumIdentity(0).id);
+        unit_assert_operator_equal("scan=21", sl->spectrumIdentity(1).id);
+        unit_assert_operator_equal("scan=22", sl->spectrumIdentity(2).id);
+        unit_assert_operator_equal("sample=1 period=1 cycle=23 experiment=1", sl->spectrumIdentity(3).id);
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "isolationWindows [0,0] [445, 446] mzTol=1mz"); // bring back the MS1s explicitly
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal_message(4, sl->size(), "\n" + (TextWriter(str)(sl), str.str()));
+        unit_assert_operator_equal("scan=19", sl->spectrumIdentity(0).id);
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(1).id);
+        unit_assert_operator_equal("scan=21", sl->spectrumIdentity(2).id);
+        unit_assert_operator_equal("sample=1 period=1 cycle=23 experiment=1", sl->spectrumIdentity(3).id);
+    }
+
+    msd.run.spectrumListPtr = originalSL;
+    string expectedError = "[SpectrumListFactory::filterCreator_isolationWindows()] expected a list of isolation windows formatted like \"[123.4,234.5] [345.6,456.7]\"";
+    unit_assert_throws_what(SpectrumListFactory::wrap(msd, "isolationWindows mode=include"), user_error, expectedError);
+    unit_assert_throws_what(SpectrumListFactory::wrap(msd, "isolationWindows (123)"), user_error, expectedError);
+    unit_assert_throws_what(SpectrumListFactory::wrap(msd, "isolationWindows [123]"), user_error, expectedError);
+    unit_assert_throws_what(SpectrumListFactory::wrap(msd, "isolationWindows [123;124]"), user_error, expectedError);
+    unit_assert_throws_what(SpectrumListFactory::wrap(msd, "isolationWindows [123-124]"), user_error, expectedError);
+}
+
+void testWrapIsolationWidthSet()
+{
+    MSData msd;
+    ostringstream str;
+    examples::initializeTiny(msd);
+    auto originalSL = msd.run.spectrumListPtr;
+
+    {
+        SpectrumListFactory::wrap(msd, "isolationWidth [0.9]"); // default tolerance does not match to 1.0 (-0.5, 0.5)
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(0, sl->size());
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "isolationWidth [0.9] mzTol=0.2mz");
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(2, sl->size());
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(0).id);
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "isolationWidth [0.9] mzTol=0.2 mz"); // mzTol should still parse correctly with a space
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal(2, sl->size());
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(0).id);
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "isolationWidth [0.9] mode=exclude"); // only 1 MS2 left, but MS1s aren't excluded now
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal_message(5, sl->size(), "\n" + (TextWriter(str)(sl), str.str()));
+        unit_assert_operator_equal("scan=19", sl->spectrumIdentity(0).id);
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(1).id);
+        unit_assert_operator_equal("scan=21", sl->spectrumIdentity(2).id);
+        unit_assert_operator_equal("scan=22", sl->spectrumIdentity(3).id);
+        unit_assert_operator_equal("sample=1 period=1 cycle=23 experiment=1", sl->spectrumIdentity(4).id);
+    }
+
+    {
+        msd.run.spectrumListPtr = originalSL;
+        SpectrumListFactory::wrap(msd, "isolationWidth [0,1.0]"); // bring back the MS1s explicitly
+        SpectrumListPtr& sl = msd.run.spectrumListPtr;
+        unit_assert_operator_equal_message(5, sl->size(), "\n" + (TextWriter(str)(sl), str.str()));
+        unit_assert_operator_equal("scan=19", sl->spectrumIdentity(0).id);
+        unit_assert_operator_equal("scan=20", sl->spectrumIdentity(1).id);
+        unit_assert_operator_equal("scan=21", sl->spectrumIdentity(2).id);
+        unit_assert_operator_equal("scan=22", sl->spectrumIdentity(3).id);
+        unit_assert_operator_equal("sample=1 period=1 cycle=23 experiment=1", sl->spectrumIdentity(4).id);
+    }
+
+    msd.run.spectrumListPtr = originalSL;
+    unit_assert_throws_what(SpectrumListFactory::wrap(msd, "isolationWidth mode=include"), user_error,
+        "[SpectrumListFactory::filterCreator_isolationWidth()] expected a list of m/z values formatted like \"[1.23,5.67,7.89]\"");
+}
+
 void testWrapMZPresent()
 {
     MSData msd;
@@ -774,6 +892,8 @@ void test()
     testWrapTitleMaker();
     testWrapThermoScanFilter();
     testWrapPrecursorMzSet();
+    testWrapIsolationWindowSet();
+    testWrapIsolationWidthSet();
     testWrapMZPresent();
     testWrapETDFilter();
 }

--- a/pwiz/analysis/spectrum_processing/SpectrumList_Filter.hpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_Filter.hpp
@@ -226,6 +226,41 @@ class PWIZ_API_DECL SpectrumList_FilterPredicate_PrecursorMzSet : public Spectru
 };
 
 
+class PWIZ_API_DECL SpectrumList_FilterPredicate_IsolationWindowSet : public SpectrumList_Filter::Predicate
+{
+public:
+
+    SpectrumList_FilterPredicate_IsolationWindowSet(const std::set<std::pair<double, double>>& isolationWindowSet, chemistry::MZTolerance tolerance, FilterMode mode);
+    virtual boost::logic::tribool accept(const msdata::SpectrumIdentity& spectrumIdentity) const { return boost::logic::indeterminate; }
+    virtual boost::logic::tribool accept(const msdata::Spectrum& spectrum) const;
+    virtual std::string describe() const { return "set of precursor isolation windows"; }
+
+private:
+    std::set<std::pair<double, double>> isolationWindowSet_;
+    chemistry::MZTolerance tolerance_;
+    FilterMode mode_;
+
+    static std::pair<double, double> getIsolationWindow(const msdata::Spectrum& spectrum);
+};
+
+
+class PWIZ_API_DECL SpectrumList_FilterPredicate_IsolationWidthSet : public SpectrumList_Filter::Predicate
+{
+public:
+    SpectrumList_FilterPredicate_IsolationWidthSet(const std::set<double>& isolationWidthSet, chemistry::MZTolerance tolerance, FilterMode mode);
+    virtual boost::logic::tribool accept(const msdata::SpectrumIdentity& spectrumIdentity) const { return boost::logic::indeterminate; }
+    virtual boost::logic::tribool accept(const msdata::Spectrum& spectrum) const;
+    virtual std::string describe() const { return "set of precursor isolation window widths"; }
+
+private:
+    std::set<double> isolationWidthSet_;
+    chemistry::MZTolerance tolerance_;
+    FilterMode mode_;
+
+    static double getIsolationWidth(const msdata::Spectrum& spectrum);
+};
+
+
 class PWIZ_API_DECL SpectrumList_FilterPredicate_DefaultArrayLengthSet : public SpectrumList_Filter::Predicate
 {
     public:

--- a/pwiz/utility/misc/unit.hpp
+++ b/pwiz/utility/misc/unit.hpp
@@ -88,8 +88,10 @@ inline std::string quote_string(const string& str) {return "\"" + str + "\"";}
     ((os) << (!(x) ? pwiz::util::unit_assert_message(__FILE__, __LINE__, #x) + "\n" : ""))
 
 
-#define unit_assert_operator_equal(expected, actual) \
-    (!((expected) == (actual)) ? throw std::runtime_error(pwiz::util::unit_assert_equal_message(__FILE__, __LINE__, lexical_cast<string>(expected), lexical_cast<string>(actual), #actual)) : 0)
+#define unit_assert_operator_equal(expected, actual) unit_assert_operator_equal_message(expected, actual, "")
+
+#define unit_assert_operator_equal_message(expected, actual, message) \
+    (!((expected) == (actual)) ? throw std::runtime_error(pwiz::util::unit_assert_equal_message(__FILE__, __LINE__, lexical_cast<string>(expected), lexical_cast<string>(actual), #actual) + (message)) : 0)
 
 #define unit_assert_operator_equal_to_stream(expected, actual, os) \
     ((os) << (!((expected) == (actual)) ? pwiz::util::unit_assert_equal_message(__FILE__, __LINE__, lexical_cast<string>(expected), lexical_cast<string>(actual), #actual) + "\n" : ""))


### PR DESCRIPTION
- added isolationWindows spectrum list filter which filters by absolute m/z pairs (like `[123.4,125.4] [234.5,236.5]` to only accept spectra with one of those two isolation windows)
- added isolationWidth spectrum list filter which filters by width (like `[2.5,3.5]` to only accept spectra with an isolation width of 2.5 or 3.5)