### PR TITLE
Prompt user to configure Koina before EncyclopeDIA search

### DIFF
--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -50,6 +50,7 @@ using pwiz.Skyline.Model.ElementLocators.ExportAnnotations;
 using pwiz.Skyline.Model.Esp;
 using pwiz.Skyline.Model.IonMobility;
 using pwiz.Skyline.Model.Irt;
+using pwiz.Skyline.Model.Koina.Models;
 using pwiz.Skyline.Model.Lib;
 using pwiz.Skyline.Model.Lib.BlibData;
 using pwiz.Skyline.Model.Lib.Midas;
@@ -3369,7 +3370,11 @@ namespace pwiz.Skyline
 
         public void ShowEncyclopeDiaSearchDlg()
         {
-
+            KoinaUIHelpers.CheckKoinaSettings(this, this);
+            if (!KoinaHelpers.KoinaSettingsValid)
+            {
+                return;
+            }
             if (!CheckDocumentExists(SkylineResources.SkylineWindow_ShowImportPeptideSearchDlg_You_must_save_this_document_before_importing_a_peptide_search_))
             {
                 return;

--- a/pwiz_tools/Skyline/TestFunctional/EncyclopeDiaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EncyclopeDiaSearchTest.cs
@@ -57,6 +57,8 @@ namespace pwiz.SkylineTestFunctional
             PrepareDocument("EncyclopeDiaSearchTest.sky");
             string fastaFilepath = TestFilesDir.GetTestPath("pan_human_library_690to705.fasta");
 
+            Settings.Default.KoinaIntensityModel = KoinaIntensityModel.Models.First();
+            Settings.Default.KoinaRetentionTimeModel = KoinaRetentionTimeModel.Models.First();
             var searchDlg = ShowDialog<EncyclopeDiaSearchDlg>(SkylineWindow.ShowEncyclopeDiaSearchDlg);
             RunUI(() => searchDlg.ImportFastaControl.SetFastaContent(fastaFilepath));
             //PauseTest();
@@ -68,8 +70,6 @@ namespace pwiz.SkylineTestFunctional
 
             RunUI(searchDlg.NextPage); // now on Koina settings
 
-            Settings.Default.KoinaIntensityModel = KoinaIntensityModel.Models.First();
-            Settings.Default.KoinaRetentionTimeModel = KoinaRetentionTimeModel.Models.First();
             RunUI(() =>
             {
                 searchDlg.DefaultCharge = 3;

--- a/pwiz_tools/Skyline/TestPerf/EncyclopeDiaSearchTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/EncyclopeDiaSearchTutorialTest.cs
@@ -35,6 +35,7 @@ using pwiz.Skyline.Util;
 using System;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.DocSettings;
+using pwiz.Skyline.ToolsUI;
 
 namespace TestPerf
 {
@@ -187,8 +188,13 @@ namespace TestPerf
             PrepareDocument("EncyclopeDiaSearchTutorialTest.sky");
             string fastaFilepath = TestFilesDir.GetTestPath(_analysisValues.FastaPath);
 
-            Settings.Default.KoinaIntensityModel = KoinaIntensityModel.Models.First();
-            Settings.Default.KoinaRetentionTimeModel = KoinaRetentionTimeModel.Models.First();
+            RunDlg<ToolOptionsUI>(SkylineWindow.ShowToolOptionsUI, toolOptionsUi =>
+            {
+                toolOptionsUi.SelectedTab = ToolOptionsUI.TABS.Koina;
+                toolOptionsUi.KoinaIntensityModelCombo = KoinaIntensityModel.Models.First();
+                toolOptionsUi.KoinaRetentionTimeModelCombo = KoinaRetentionTimeModel.Models.First();
+                toolOptionsUi.OkDialog();
+            });
             var searchDlg = ShowDialog<EncyclopeDiaSearchDlg>(SkylineWindow.ShowEncyclopeDiaSearchDlg);
             RunUI(() => searchDlg.ImportFastaControl.SetFastaContent(fastaFilepath));
 

--- a/pwiz_tools/Skyline/TestPerf/EncyclopeDiaSearchTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/EncyclopeDiaSearchTutorialTest.cs
@@ -187,6 +187,8 @@ namespace TestPerf
             PrepareDocument("EncyclopeDiaSearchTutorialTest.sky");
             string fastaFilepath = TestFilesDir.GetTestPath(_analysisValues.FastaPath);
 
+            Settings.Default.KoinaIntensityModel = KoinaIntensityModel.Models.First();
+            Settings.Default.KoinaRetentionTimeModel = KoinaRetentionTimeModel.Models.First();
             var searchDlg = ShowDialog<EncyclopeDiaSearchDlg>(SkylineWindow.ShowEncyclopeDiaSearchDlg);
             RunUI(() => searchDlg.ImportFastaControl.SetFastaContent(fastaFilepath));
 
@@ -205,8 +207,6 @@ namespace TestPerf
 
             RunUI(searchDlg.NextPage); // now on Koina settings
 
-            Settings.Default.KoinaIntensityModel = KoinaIntensityModel.Models.First();
-            Settings.Default.KoinaRetentionTimeModel = KoinaRetentionTimeModel.Models.First();
             RunUI(() =>
             {
                 searchDlg.DefaultCharge = 3;


### PR DESCRIPTION
Added prompt to configure Koina before running EncyclopeDIA search (reported by Eric)

If the user does "File > Search > EncyclopeDIA Search..." and they have not configured Koina yet they will see this message:
![image](https://github.com/user-attachments/assets/37248611-7213-40d0-87ca-fe92b27e750c)

The wizard will not start if they choose "No" or if they don't actually configure Koina.