### PR TITLE
Fix IndexOutOfRangeException in ApplyPeak (#3136)

### DIFF
--- a/pwiz_tools/Skyline/Model/PeakMatcher.cs
+++ b/pwiz_tools/Skyline/Model/PeakMatcher.cs
@@ -263,7 +263,8 @@ namespace pwiz.Skyline.Model
 
                     float scale = (chromGroupMaxTime - chromGroupMinTime)/(referenceTarget.MaxTime - referenceTarget.MinTime);
                     manualMatch = MakePeakMatchBetween(scale, referenceTarget, prev, next);
-                    if (chromGroupMinTime >= manualMatch.EndTime || manualMatch.StartTime >= chromGroupMaxTime)
+                    if (chromGroupMinTime >= manualMatch.EndTime || manualMatch.StartTime >= chromGroupMaxTime ||
+                        manualMatch.EndTime <= manualMatch.StartTime)
                         manualMatch = null;
 
                     float curMinTime = prev == null ? chromGroupMinTime : prev.AlignedPeak.RetentionTime;


### PR DESCRIPTION
Fixed unhandled error doing "Apply peak to all" sometimes (reported by Gustavo)