### PR TITLE
Skyline: Fixed --import-pep-list to turn of auto-manage when any modi…

### DIFF
--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -2816,7 +2816,7 @@ namespace pwiz.Skyline
 
             var matcher = new ModificationMatcher();
             var sequences = new List<string>();
-            foreach (var line in lineList)
+            foreach (var line in lineList.Where(l => !l.StartsWith(@">")))
             {
                 string sequence = FastaSequence.NormalizeNTerminalMod(line.Trim());
                 sequences.Add(sequence);

--- a/pwiz_tools/Skyline/Menus/EditMenu.cs
+++ b/pwiz_tools/Skyline/Menus/EditMenu.cs
@@ -358,7 +358,13 @@ namespace pwiz.Skyline.Menus
             char separator;
 
             // Check for a FASTA header
-            if (text.StartsWith(@">"))
+            if (text.StartsWith(@">>"))
+            {
+                // This is multi-peptide-list text. Let the text be what it is and
+                // let the importer try to import it.
+                peptideList = true;
+            }
+            else if (text.StartsWith(@">"))
             {
                 // Make sure there is sequence information
                 string[] lines = text.Split('\n');

--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -2952,6 +2952,8 @@ namespace pwiz.Skyline.Model
             : this(line, true, settings, sourceFile, irtTargets)
         {
             _modMatcher = modMatcher;
+            if (modMatcher != null)
+                _autoManageChildren = !modMatcher.HasSeenMods;   // Any specified matches turns off auto-manage
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/Model/ModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/ModificationMatcher.cs
@@ -40,6 +40,8 @@ namespace pwiz.Skyline.Model
         private IProgressStatus _status;
         private const int DEFAULT_ROUNDING_DIGITS = 6;
 
+        public bool HasSeenMods { get; private set; }
+
         public void CreateMatches(SrmSettings settings, IEnumerable<string> sequences,
             MappedList<string, StaticMod> defSetStatic, MappedList<string, StaticMod> defSetHeavy, 
             IProgressMonitor progressMonitor = null, IProgressStatus status = null)
@@ -75,13 +77,20 @@ namespace pwiz.Skyline.Model
                 return false;
             // Skip sequences that can be created from the current settings.
             // Check first if the sequence has any modifications, because creating doc nodes is expensive
-            while (!HasMods(_sequences.Current) ||
+            while (!HasModsChecked(_sequences.Current) ||
                    CreateDocNodeFromSettings(new Target(_sequences.Current), null, DIFF_GROUPS, out _) != null)
             {
                 if (!MoveNextSingleSequence())
                     return false;
             }
             return true;
+        }
+
+        private bool HasModsChecked(string sequence)
+        {
+            bool hasMods = HasMods(sequence);
+            HasSeenMods = HasSeenMods || hasMods;
+            return hasMods;
         }
 
         private bool MoveNextSingleSequence()


### PR DESCRIPTION
…fications are present. (reported by Dan)

- Also added support for multi-peptide lists to Edit > Paste to make this easier to test and make support comparable to --import-pep-list