### PR TITLE
Skyline: Fixes to importing peptide lists for FragPipe team

### DIFF
--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -2800,11 +2800,11 @@ namespace pwiz.Skyline
         public void ImportPeptideList(string name, string path)
         {
             var lineList = new List<string>(File.ReadAllLines(PathEx.SafePath(path)));
-            if (!lineList.Any(l => l.StartsWith(@">>")))
+            if (!lineList.Any(l => l.StartsWith(PeptideGroupBuilder.PEPTIDE_LIST_PREFIX)))
             {
                 if (string.IsNullOrEmpty(name))
                     name = _doc.GetPeptideGroupId(true);
-                lineList.Insert(0, @">>" + name);
+                lineList.Insert(0, PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + name);
                 _out.WriteLine(Resources.CommandLine_ImportPeptideList_Importing_peptide_list__0__from_file__1____, name, Path.GetFileName(path));
             }
             else
@@ -2816,9 +2816,10 @@ namespace pwiz.Skyline
 
             var matcher = new ModificationMatcher();
             var sequences = new List<string>();
-            foreach (var line in lineList.Where(l => !l.StartsWith(@">")))
+            foreach (var line in lineList.Where(l => !l.StartsWith(PeptideGroupBuilder.PEPTIDE_LIST_PREFIX)))
             {
                 string sequence = FastaSequence.NormalizeNTerminalMod(line.Trim());
+                sequence = Transition.StripChargeIndicators(sequence, TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE, true);
                 sequences.Add(sequence);
             }
             matcher.CreateMatches(_doc.Settings, sequences, Settings.Default.StaticModList, Settings.Default.HeavyModList);

--- a/pwiz_tools/Skyline/Menus/EditMenu.cs
+++ b/pwiz_tools/Skyline/Menus/EditMenu.cs
@@ -358,13 +358,13 @@ namespace pwiz.Skyline.Menus
             char separator;
 
             // Check for a FASTA header
-            if (text.StartsWith(@">>"))
+            if (text.StartsWith(PeptideGroupBuilder.PEPTIDE_LIST_PREFIX))
             {
                 // This is multi-peptide-list text. Let the text be what it is and
                 // let the importer try to import it.
                 peptideList = true;
             }
-            else if (text.StartsWith(@">"))
+            else if (text.StartsWith(PeptideGroupBuilder.PROTEIN_SPEC_PREFIX))
             {
                 // Make sure there is sequence information
                 string[] lines = text.Split('\n');
@@ -372,7 +372,7 @@ namespace pwiz.Skyline.Menus
                 for (int i = 0; i < lines.Length; i++)
                 {
                     string line = lines[i];
-                    if (line.StartsWith(@">"))
+                    if (line.StartsWith(PeptideGroupBuilder.PROTEIN_SPEC_PREFIX))
                     {
                         if (i > 0 && aa == 0)
                         {
@@ -473,12 +473,12 @@ namespace pwiz.Skyline.Menus
                     // First make sure it looks like a sequence.
                     List<double> lineLengths = new List<double>();
                     int lineLen = 0;
-                var textNoMods = FastaSequence.StripModifications(Transition.StripChargeIndicators(text, TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE));
+                    var textNoMods = FastaSequence.StripModifications(Transition.StripChargeIndicators(text, TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE, true));
                     foreach (char c in textNoMods)
                     {
                         if (!AminoAcid.IsExAA(c) && !char.IsWhiteSpace(c) && c != '*' && c != '.')
                         {
-                        MessageDlg.Show(SkylineWindow, string.Format(MenusResources.SkylineWindow_Unexpected_character__0__found_on_line__1__, c, lineLengths.Count + 1));
+                            MessageDlg.Show(SkylineWindow, string.Format(MenusResources.SkylineWindow_Unexpected_character__0__found_on_line__1__, c, lineLengths.Count + 1));
                             return;
                         }
                         if (c == '\n')
@@ -533,7 +533,7 @@ namespace pwiz.Skyline.Menus
                     string seqId = Document.GetPeptideGroupId(peptideList);
 
                     // Construct valid FASTA format (with >> to indicate custom name)
-                    text = @">>" + TextUtil.LineSeparate(seqId, text);
+                    text = PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + TextUtil.LineSeparate(seqId, text);
                 }
             }
 
@@ -557,7 +557,7 @@ namespace pwiz.Skyline.Menus
             for (int i = 0; i < pepSequences.Length; i++)
             {
                 var charge = Transition.GetChargeFromIndicator(pepSequences[i].Trim(), TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE);
-                string pepSeqMod = CleanPeptideSequence(Transition.StripChargeIndicators(pepSequences[i], TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE));
+                string pepSeqMod = CleanPeptideSequence(Transition.StripChargeIndicators(pepSequences[i], TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE, true));
                 string pepSeqClean = FastaSequence.StripModifications(pepSeqMod);
                 if (!charge.IsEmpty)
                     pepSeqMod += Transition.GetChargeIndicator(charge);

--- a/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
@@ -627,7 +627,7 @@ namespace pwiz.Skyline.Model
                 return CreateCrosslinkDocNode(peptide, crosslinkLibraryKey, diff, out nodeGroupMatched);
             }
             var seq = target.Sequence;
-            seq = Transition.StripChargeIndicators(seq, TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE);
+            seq = Transition.StripChargeIndicators(seq, TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE, true);
             if (peptide == null)
             {
                 string seqUnmod = FastaSequence.StripModifications(seq);
@@ -1221,8 +1221,10 @@ namespace pwiz.Skyline.Model
             public override string ToString()
             {
                 return string.Format(CultureInfo.InvariantCulture, UserIndicatedHeavy ? @"{0}{{{1}{2}}}" : @"{0}[{1}{2}]",
-                    AA, Mass > 0 ? @"+" : string.Empty, Mass);
+                    AA, Mass > 0 ? @"+" : string.Empty, Mass) + TerminusText;
             }
+
+            public string TerminusText => Terminus.HasValue ? @"-" + Terminus.Value : string.Empty;
         }
 
         public struct AAModMatch

--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -124,7 +124,7 @@ namespace pwiz.Skyline.Model
                         progressMonitor.UpdateProgress(status = status.ChangePercentComplete(progressPercent = progressNew));
                 }
 
-                if (line.StartsWith(@">"))
+                if (line.StartsWith(PeptideGroupBuilder.PROTEIN_SPEC_PREFIX))
                 {
                     if (!requireLibraryMatch && progressMonitor == null)
                     {
@@ -150,7 +150,7 @@ namespace pwiz.Skyline.Model
                     }
                     catch (Exception x)
                     {
-                        throw new InvalidDataException(string.Format(ModelResources.FastaImporter_Import_Error_at_or_around_line__0____1_, linesRead, x.Message), x);
+                        throw new LineColNumberedIoException(x.Message, linesRead, -1, x);
                     }
 
                     if (progressMonitor != null)
@@ -175,7 +175,7 @@ namespace pwiz.Skyline.Model
                 }
                 else
                 {
-                    seqBuilder.AppendSequence(line);
+                    seqBuilder.AppendSequence(line, linesRead);
                 }
             }
             // Add last sequence.
@@ -189,7 +189,7 @@ namespace pwiz.Skyline.Model
             ICollection<FastaSequence> set,
             PeptideGroupBuilder builder)
         {
-            PeptideGroupDocNode nodeGroup = builder.ToDocNode();
+            PeptideGroupDocNode nodeGroup = builder.ToDocNode().Merge();
             FastaSequence fastaSeq = nodeGroup.Id as FastaSequence;
             if (fastaSeq != null && set.Contains(fastaSeq))
                 return;
@@ -285,7 +285,7 @@ namespace pwiz.Skyline.Model
                     throw new LineColNumberedIoException(
                         ModelResources.FastaImporter_ToFasta_Last_column_does_not_contain_a_valid_protein_sequence, lineNum,
                         fastaCol);
-                sb.Append(@">").Append(columns[0].Trim().Replace(@" ", @"_")); // ID
+                sb.Append(PeptideGroupBuilder.PROTEIN_SPEC_PREFIX).Append(columns[0].Trim().Replace(@" ", @"_")); // ID
                 for (int i = 1; i < fastaCol; i++)
                     sb.Append(@" ").Append(columns[i].Trim()); // Description
                 sb.AppendLine();
@@ -828,7 +828,8 @@ namespace pwiz.Skyline.Model
                     string safeName = name != null ?
                         Helpers.GetUniqueName(name, dictNameSeq.Keys) :
                         Document.GetPeptideGroupId(true);
-                    seqBuilder = new PeptideGroupBuilder(@">>" + safeName, true, Document.Settings, sourceFile, null) {BaseName = name};
+                    seqBuilder = new PeptideGroupBuilder(PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + safeName,
+                        true, Document.Settings, sourceFile, null) {BaseName = name};
                 }
             }
             try
@@ -2882,6 +2883,8 @@ namespace pwiz.Skyline.Model
     {
         // filename to use if no file has been specified
         public const string CLIPBOARD_FILENAME = @"Clipboard";
+        public const string PEPTIDE_LIST_PREFIX = @">>";
+        public const string PROTEIN_SPEC_PREFIX = @">";
         private readonly StringBuilder _sequence = new StringBuilder();
         private readonly List<PeptideDocNode> _peptides;
         private readonly Dictionary<int, Adduct> _charges;
@@ -2999,10 +3002,10 @@ namespace pwiz.Skyline.Model
         }
         public bool PeptideList { get; private set; }
 
-        public void AppendSequence(string seqMod)
+        public void AppendSequence(string seqMod, long lineNum)
         {
             var charge = Transition.GetChargeFromIndicator(seqMod, TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE);
-            seqMod = Transition.StripChargeIndicators(seqMod, TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE);
+            seqMod = Transition.StripChargeIndicators(seqMod, TransitionGroup.MIN_PRECURSOR_CHARGE, TransitionGroup.MAX_PRECURSOR_CHARGE, true);
             var seq = FastaSequence.StripModifications(seqMod);
             // Auto manage the children unless there is at least one modified sequence in the fasta
             _autoManageChildren = _autoManageChildren && Equals(seq, seqMod);
@@ -3019,7 +3022,11 @@ namespace pwiz.Skyline.Model
                 // If there is a ModificationMatcher, use it to create the DocNode.
                 PeptideDocNode nodePep;
                 if (_modMatcher != null)
+                {
                     nodePep = _modMatcher.GetModifiedNode(seqMod);
+                    if (nodePep == null)
+                        throw new LineColNumberedIoException(string.Format(ModelResources.PeptideGroupBuilder_AppendSequence_Failed_to_interpret_modified_sequence__0_, seqMod), lineNum, -1);
+                }
                 else
                 {
                     Peptide peptide = new Peptide(null, seq, null, null, _enzyme.CountCleavagePoints(seq));
@@ -3610,7 +3617,7 @@ namespace pwiz.Skyline.Model
                             ModelResources.FastaData_ParseFastaFile_Error_on_line__0___invalid_non_ASCII_character___1___at_position__2___are_you_sure_this_is_a_FASTA_file_,
                             lineNum, line[i], i));
                     
-                if (line.StartsWith(@">"))
+                if (line.StartsWith(PeptideGroupBuilder.PROTEIN_SPEC_PREFIX))
                 {
                     if (!string.IsNullOrEmpty(fastaDescriptionLine))
                     {
@@ -3632,7 +3639,7 @@ namespace pwiz.Skyline.Model
 
         public static FastaSequence MakeFastaSequence(string fastaDescriptionLine, string sequence)
         {
-            int start = fastaDescriptionLine.StartsWith(@">") ? 1 : 0;
+            int start = fastaDescriptionLine.StartsWith(PeptideGroupBuilder.PROTEIN_SPEC_PREFIX) ? 1 : 0;
             int split = IndexEndId(fastaDescriptionLine);
             string name;
             string description;

--- a/pwiz_tools/Skyline/Model/ModelResources.designer.cs
+++ b/pwiz_tools/Skyline/Model/ModelResources.designer.cs
@@ -1419,6 +1419,15 @@ namespace pwiz.Skyline.Model {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to interpret modified sequence {0}.
+        /// </summary>
+        public static string PeptideGroupBuilder_AppendSequence_Failed_to_interpret_modified_sequence__0_ {
+            get {
+                return ResourceManager.GetString("PeptideGroupBuilder_AppendSequence_Failed_to_interpret_modified_sequence__0_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to explain all transitions for m/z {0} (peptide {1}) with a single precursor..
         /// </summary>
         public static string PeptideGroupBuilder_AppendTransition_Failed_to_explain_all_transitions_for_m_z__0___peptide__1___with_a_single_precursor {

--- a/pwiz_tools/Skyline/Model/ModelResources.resx
+++ b/pwiz_tools/Skyline/Model/ModelResources.resx
@@ -818,4 +818,7 @@
   <data name="PasteDlg_UpdateMoleculeType_Library_Intensity" xml:space="preserve">
     <value>Library Intensity</value>
   </data>
+  <data name="PeptideGroupBuilder_AppendSequence_Failed_to_interpret_modified_sequence__0_" xml:space="preserve">
+      <value>Failed to interpret modified sequence {0}</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/Optimization/OptimizationDb.cs
+++ b/pwiz_tools/Skyline/Model/Optimization/OptimizationDb.cs
@@ -337,7 +337,7 @@ namespace pwiz.Skyline.Model.Optimization
             matcher.CreateMatches(newDoc.Settings, peptideList, Settings.Default.StaticModList, Settings.Default.HeavyModList);
             FastaImporter importer = new FastaImporter(newDoc, matcher);
             // ReSharper disable LocalizableElement
-            string text = string.Format(">>{0}\r\n{1}", newDoc.GetPeptideGroupId(true), TextUtil.LineSeparate(peptideList));
+            string text = TextUtil.LineSeparate(PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + newDoc.GetPeptideGroupId(true), TextUtil.LineSeparate(peptideList));
             // ReSharper restore LocalizableElement
             PeptideGroupDocNode imported = importer.Import(new StringReader(text), null, Helpers.CountLinesInString(text)).First();
 

--- a/pwiz_tools/Skyline/Test/SrmDocEditTest.cs
+++ b/pwiz_tools/Skyline/Test/SrmDocEditTest.cs
@@ -336,7 +336,7 @@ namespace pwiz.SkylineTest
             AssertEx.IsDocumentState(docPeptides3, 3, 2, 1, 3);
         }
 
-        public const string TEXT_FASTA_YEAST_FRAGMENT = ">>Sequence{0}\n" +
+        public const string TEXT_FASTA_YEAST_FRAGMENT = PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + "Sequence{0}\n" +
             "MVLTIYPDELVQIVSDKIASNKGKITLNQLWDISGKYFDLSDKKVKQFVLSCVILKKDIE\n" +
             "VYCDGAITTKNVTDIIGDANHSYSVGITEDSLWTLLTGYTKKESTIGNSAFELLLEVAKS\n" +
             "GEKGINTMDLAQVTGQDPRSVTGRIKKINHLLTSSQLIYKGHVVKQLKLKKFSHDGVDSN\n" +
@@ -344,7 +344,7 @@ namespace pwiz.SkylineTest
             "VLVVSPKNPAIKIRCVKYVKDIPDSKGSPSFEYDSNSADEDSVSDSKAAFEDEDLVEGLD\n" +
             "NFNATDLLQNQGLVMEEKEDAVKNEVLLNRFYPLQNQTYDIADKSGLKGISTMDVVNRIT";
 
-        public const string TEXT_BOVINE_PEPTIDES1 = ">>Peptides1\n" +
+        public const string TEXT_BOVINE_PEPTIDES1 = PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + "Peptides1\n" +
                                                 "FALPQYLK\n" +
                                                 "ALNEINQFYQK\n" +
                                                 "ALPMHIR\n" +
@@ -359,7 +359,7 @@ namespace pwiz.SkylineTest
                                                 "FWWENPGVFTEK\n" +
                                                 "IVGYLDEEGVLDQNR";
 
-        public const string TEXT_BOVINE_PEPTIDES2 = ">>Peptides2\n" +
+        public const string TEXT_BOVINE_PEPTIDES2 = PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + "Peptides2\n" +
                                                 "LVTDLTK\n" +
                                                 "AEFVEVTK\n" +
                                                 "LVNELTEFAK\n" +

--- a/pwiz_tools/Skyline/TestData/CommandLineImportTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineImportTest.cs
@@ -398,7 +398,7 @@ namespace pwiz.SkylineTestData
             // without need of modification expansion.
             File.AppendAllLines(listsPath, new[]
             {
-                ">>Unmodified",
+                PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + "Unmodified",
                 "MVNNGHSFNVEYDDSQDR"
             });
             output = RunCommand(true, CommandArgs.ARG_NEW.GetArgumentTextWithValue(outPath),
@@ -491,7 +491,7 @@ namespace pwiz.SkylineTestData
 
             foreach (var protein in doc.PeptideGroups)
             {
-                writerList.WriteLine(">>" + protein.Name);
+                writerList.WriteLine(PeptideGroupBuilder.PEPTIDE_LIST_PREFIX + protein.Name);
                 foreach (var nodePep in protein.Peptides)
                 {
                     var modifiedSeq =

--- a/pwiz_tools/Skyline/TestFunctional/ReportErrorDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ReportErrorDlgTest.cs
@@ -21,12 +21,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Windows.Forms;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Skyline;
 using pwiz.Skyline.Alerts;
-using pwiz.Skyline.Model;
 using pwiz.Skyline.Properties;
 using pwiz.Skyline.Util.Extensions;
 using pwiz.SkylineTestUtil;
@@ -86,18 +84,10 @@ namespace pwiz.SkylineTestFunctional
             WaitForClosedForm(reportErrorDlg2);
 
             // Add 50,000 peptides to the document so that its size will exceed ReportErrorDlg.MAX_ATTACHMENT_SIZE
-            var random = new Random(0); // Pseudo random but consistent sequence because of the fixed seed
-            // They have to be unique to avoid getting collapsed by PeptideGroupDocNode.Merge() during the paste
-            var setPepsUnique = new HashSet<string>(50_000);
-            // Use all AAs except K and R to avoid missed cleavages
-            var allAas = AminoAcid.All.Where(aa => aa != 'K' && aa != 'R').ToArray();
-            for (int i = 0; i < 50_000; i++)
-            {
-                setPepsUnique.Add(GetUniquePep(setPepsUnique, random, allAas));
-            }
+            var peptideSequences = RescoreInPlaceTest.PermuteString("ELVISLIVES").Distinct().Take(50_000);
             RunUI(() =>
             {
-                SkylineWindow.Paste(TextUtil.LineSeparate(setPepsUnique));
+                SkylineWindow.Paste(TextUtil.LineSeparate(peptideSequences));
             });
 
             // Verify that the "Report Error" menu item on the Help menu is hidden unless the user holds down the shift key
@@ -177,21 +167,6 @@ namespace pwiz.SkylineTestFunctional
                 Assert.AreEqual(ReportErrorDlg.MAX_ATTACHMENT_SIZE, detailedDlg.SkylineFileBytes.Length);
             });
             WaitForClosedForm(reportErrorDlg3);
-        }
-
-        private string GetUniquePep(HashSet<string> setPeps, Random random, char[] allAas)
-        {
-            for (;;)
-            {
-                var sb = new StringBuilder(10);
-                for (int aaIndex = 0; aaIndex < 10; aaIndex++)
-                {
-                    sb.Append(allAas[random.Next(allAas.Length - 1)]);
-                }
-                var nextPep = sb.ToString();
-                if (!setPeps.Contains(nextPep))
-                    return nextPep;
-            }
         }
 
         [DllImport("user32.dll")]


### PR DESCRIPTION
- More consistently strip charge state indicators
- Merge PeptideGroupDocNodes from peptide lists to avoid creating different peptides for every precursor
- Improve error message when modification matcher fails to create PeptideDocNode instead of NRE
- Fix File > Import > Fasta to recognize peptide list files
- Speed up StripChargeIndicators by not looking for adducts on a known peptide sequence
- Create single constant strings for FASTA prefix ">" and peptide list prefix ">>"