### PR TITLE
added static code inspection for values that don't agree between Settings.settings and app.config

### DIFF
--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -3479,19 +3479,7 @@ namespace pwiz.Skyline.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("10.0")]
-        public double FeatureFindingMinIntensityPPM {
-            get {
-                return ((double)(this["FeatureFindingMinIntensityPPM"]));
-            }
-            set {
-                this["FeatureFindingMinIntensityPPM"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0.98")]
+        [global::System.Configuration.DefaultSettingValueAttribute("0.9")]
         public double FeatureFindingMinIdotP {
             get {
                 return ((double)(this["FeatureFindingMinIdotP"]));
@@ -3526,7 +3514,7 @@ namespace pwiz.Skyline.Properties {
                 this["GroupComparisonAvoidLabelOverlap"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -3551,6 +3539,18 @@ namespace pwiz.Skyline.Properties {
             set {
                 this["RelativeAbundanceLogScale"] = value;
             }
-        }		
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("100")]
+        public double FeatureFindingMinIntensityPPM {
+            get {
+                return ((double)(this["FeatureFindingMinIntensityPPM"]));
+            }
+            set {
+                this["FeatureFindingMinIntensityPPM"] = value;
+            }
+        }
     }
 }

--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -3479,6 +3479,18 @@ namespace pwiz.Skyline.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("100.0")]
+        public double FeatureFindingMinIntensityPPM {
+            get {
+                return ((double)(this["FeatureFindingMinIntensityPPM"]));
+            }
+            set {
+                this["FeatureFindingMinIntensityPPM"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0.9")]
         public double FeatureFindingMinIdotP {
             get {
@@ -3538,18 +3550,6 @@ namespace pwiz.Skyline.Properties {
             }
             set {
                 this["RelativeAbundanceLogScale"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("100")]
-        public double FeatureFindingMinIntensityPPM {
-            get {
-                return ((double)(this["FeatureFindingMinIntensityPPM"]));
-            }
-            set {
-                this["FeatureFindingMinIntensityPPM"] = value;
             }
         }
     }

--- a/pwiz_tools/Skyline/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Properties/Settings.settings
@@ -869,6 +869,9 @@
     <Setting Name="FullScanPropertySheetVisible" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="FeatureFindingMinIntensityPPM" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">100.0</Value>
+    </Setting>
     <Setting Name="FeatureFindingMinIdotP" Type="System.Double" Scope="User">
       <Value Profile="(Default)">0.9</Value>
     </Setting>
@@ -883,9 +886,6 @@
     </Setting>
     <Setting Name="RelativeAbundanceLogScale" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
-    </Setting>
-    <Setting Name="FeatureFindingMinIntensityPPM" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">100</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/pwiz_tools/Skyline/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Properties/Settings.settings
@@ -869,11 +869,8 @@
     <Setting Name="FullScanPropertySheetVisible" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="FeatureFindingMinIntensityPPM" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">10.0</Value>
-    </Setting>
     <Setting Name="FeatureFindingMinIdotP" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">0.98</Value>
+      <Value Profile="(Default)">0.9</Value>
     </Setting>
     <Setting Name="FeatureFindingSignalToNoise" Type="System.Double" Scope="User">
       <Value Profile="(Default)">3</Value>
@@ -886,6 +883,9 @@
     </Setting>
     <Setting Name="RelativeAbundanceLogScale" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
-    </Setting>	
+    </Setting>
+    <Setting Name="FeatureFindingMinIntensityPPM" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">100</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
+++ b/pwiz_tools/Skyline/Test/CodeInspectionTest.cs
@@ -35,6 +35,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
+using System.Xml.Linq;
 using AssortResources;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.Common.DataBinding.Controls.Editor;
@@ -397,6 +398,126 @@ namespace pwiz.SkylineTest
         }
 
         /// <summary>
+        ///  Look for conflicts between settings.settings and app.config
+        /// </summary>
+        void InspectInconsistentSetting(string root, List<string> errors) 
+        {
+            var EMPTY_STRING_ARRAY = "</ArrayOfString>";
+
+            // Extract key-value pairs from settings.settings
+            var settingsValues = ExtractSettingsSettings();
+
+            // Extract key-value pairs from app.config
+            var configValues = ExtractAppConfigSettings();
+
+            // Find keys that exist in both but have different values
+            foreach (var key in settingsValues.Keys.Intersect(configValues.Keys).Where(k => (settingsValues[k] != configValues[k])))
+            {
+                var settingsValue = settingsValues[key];
+                var configValue = configValues[key];
+                // An empty string array in settings.settings is just empty text in app.config
+                if (!(settingsValue.Equals(EMPTY_STRING_ARRAY) && string.IsNullOrEmpty(configValue)))
+                {
+                    NoteMismatch(key, settingsValue, configValue);
+                }
+            }
+
+
+            // Find settings that exist only in one of the files
+            foreach (var key in settingsValues.Keys.Except(configValues.Keys))
+            {
+                var settingsValue = settingsValues[key];
+                // IDE seems to be OK with missing value in app.config if the setting is an empty string array
+                if (!settingsValue.Equals(EMPTY_STRING_ARRAY))
+                {
+                    NoteMismatch(key, settingsValue, null);
+                }
+            }
+            foreach (var key in configValues.Keys.Except(settingsValues.Keys))
+            {
+                NoteMismatch(key, null, configValues[key]);
+            }
+
+            return;
+
+
+            void NoteMismatch(string name, string settingsValue, string configValue)
+            {
+                errors.Add($"Settings mismatch for \"{name}\": {FormatValue(settingsValue)} in Settings.settings, {FormatValue(configValue)} in app.config.");
+                return;
+                string FormatValue(string s) => s == null ? "not found" : $"\"{s}\"";
+            }
+
+            string CheckStringArray(string value)
+            {
+                if (value.Contains("<ArrayOfString"))
+                {
+                    var result = string.Empty;
+                    foreach (var part in value.Split(new[] { "<string>" }, StringSplitOptions.None))
+                    {
+                        if (part.Contains("</string>"))
+                        {
+                            var val = part.Trim().Split(new[] { "</string>" }, StringSplitOptions.None).FirstOrDefault();
+                            if (!string.IsNullOrEmpty(val))
+                            {
+                                result += val.Trim();
+                            }
+                        }
+                    }
+                    return result;
+                }
+                else if (string.IsNullOrEmpty(value))
+                {
+                    // Special case - settings designer won't update app.config if the value is empty (that is, not even an empty description in XML - just blank text)
+                    value = EMPTY_STRING_ARRAY;
+                }
+
+                return value;
+            }
+
+            Dictionary<string, string> ExtractSettingsSettings()
+            {
+                var settingsPath = Path.Combine(root, @"Properties\Settings.settings");
+                var doc = XDocument.Load(settingsPath);
+                var settings = new Dictionary<string, string>();
+                XNamespace settingsNamespace = "http://schemas.microsoft.com/VisualStudio/2004/01/settings";
+                var settingsElements = doc.Descendants(settingsNamespace + "Settings")
+                    .Descendants(settingsNamespace + "Setting")
+                    .ToArray();
+                AssertEx.AreNotEqual(settingsElements.Length, 0, "trouble reading settings.settings");
+                foreach (var setting in settingsElements)
+                {
+                    var key = setting.Attribute("Name")?.Value;
+                    if (key != null)
+                    {
+                        var value = CheckStringArray(setting.Value);
+                        settings[key] = value;
+                    }
+                }
+                return settings;
+            }
+
+            Dictionary<string, string> ExtractAppConfigSettings()
+            {
+                var configPath = Path.Combine(root, @"app.config");
+                var doc = XDocument.Load(configPath);
+                var settings = new Dictionary<string, string>();
+                var appSettingsElements = doc.Descendants(@"setting").ToArray();
+                AssertEx.AreNotEqual(appSettingsElements.Length, 0, "trouble reading app.config");
+                foreach (var setting in appSettingsElements)
+                {
+                    var key = setting.Attribute("name")?.Value;
+                    if (key != null)
+                    {
+                        var value = setting.Value;
+                        settings[key] = value;
+                    }
+                }
+                return settings;
+            }
+        }
+
+        /// <summary>
         /// Look for strings which have been localized but not moved from main Resources.resx to more appropriate locations 
         /// </summary>
         void InspectMisplacedResources(string root, List<string> errors) 
@@ -609,6 +730,8 @@ namespace pwiz.SkylineTest
             InspectTutorialAuditLogs(root, results);
 
             InspectMisplacedResources(root, results); // Look for strings which have been localized but not moved from main Resources.resx to more appropriate locations
+
+            InspectInconsistentSetting(root, results); // Look for conflicts between settings.settings and app.config
 
             var errorCounts = new Dictionary<PatternDetails, int>();
 

--- a/pwiz_tools/Skyline/app.config
+++ b/pwiz_tools/Skyline/app.config
@@ -690,7 +690,7 @@
             <setting name="MixedMoleculeSettingsTab" serializeAs="String">
                 <value>0</value>
             </setting>
-            <setting name="Prosit" serializeAs="String">
+            <setting name="Koina" serializeAs="String">
                 <value>False</value>
             </setting>
             <setting name="KoinaIntensityModel" serializeAs="String">
@@ -705,7 +705,7 @@
             <setting name="LibMatchMirror" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="PrositNCE" serializeAs="String">
+            <setting name="KoinaNCE" serializeAs="String">
                 <value>27</value>
             </setting>
             <setting name="ShowQcTraceName" serializeAs="String">
@@ -861,9 +861,6 @@
             <setting name="FullScanPropertySheetVisible" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="FeatureFindingMinIntensityPPM" serializeAs="String">
-                <value>100.0</value>
-            </setting>
             <setting name="FeatureFindingMinIdotP" serializeAs="String">
                 <value>0.9</value>
             </setting>
@@ -873,9 +870,15 @@
             <setting name="GroupComparisonAvoidLabelOverlap" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="GroupComparisonSuspendLabelLayout" serializeAs="String">
+                <value>False</value>
+            </setting>
             <setting name="RelativeAbundanceLogScale" serializeAs="String">
-                 <value>True</value>
-            </setting>			
+                <value>True</value>
+            </setting>
+            <setting name="FeatureFindingMinIntensityPPM" serializeAs="String">
+                <value>100</value>
+            </setting>
         </pwiz.Skyline.Properties.Settings>
     </userSettings>
     <applicationSettings>

--- a/pwiz_tools/Skyline/app.config
+++ b/pwiz_tools/Skyline/app.config
@@ -861,6 +861,9 @@
             <setting name="FullScanPropertySheetVisible" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="FeatureFindingMinIntensityPPM" serializeAs="String">
+                <value>100.0</value>
+            </setting>
             <setting name="FeatureFindingMinIdotP" serializeAs="String">
                 <value>0.9</value>
             </setting>
@@ -875,9 +878,6 @@
             </setting>
             <setting name="RelativeAbundanceLogScale" serializeAs="String">
                 <value>True</value>
-            </setting>
-            <setting name="FeatureFindingMinIntensityPPM" serializeAs="String">
-                <value>100</value>
             </setting>
         </pwiz.Skyline.Properties.Settings>
     </userSettings>


### PR DESCRIPTION
a little bit of voodoo around settings that are collections of strings - Settings Designer may not create an app.config entry if the collection is empty. On the other hand, if the collection is non-empty then edited to be empty, the app.config entry will exist, but with an empty string as its value.

also had to change "Prosit" to "Koina" in app.config