### PR TITLE
Add Mobilion header files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,6 +399,7 @@ Version.cpp
 /pwiz_aux/msrc/utility/vendor_api/Bruker/x64/
 /pwiz_aux/msrc/utility/vendor_api/Bruker/x86/
 /pwiz_aux/msrc/utility/vendor_api/Bruker/**/*.h
+/pwiz_aux/msrc/utility/vendor_api/Mobilion/*.h
 /pwiz_aux/msrc/utility/vendor_api/Shimadzu/*.xml
 /pwiz_aux/msrc/utility/vendor_api/Shimadzu/*.txt
 /pwiz_aux/msrc/utility/vendor_api/Waters/MassLynx*.h*


### PR DESCRIPTION
Add /pwiz_aux/msrc/utility/vendor_api/Mobilion/*.h to .gitignore file