### PR TITLE
Skyline: Attempt a fix for the deadlock in TestMs1Tutorial

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -134,7 +134,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
         private void SetSpectra(MsDataSpectrum[] spectra)
         {
-            Invoke(new Action(() => SetSpectraUI(spectra)));
+            BeginInvoke(new Action(() => SetSpectraUI(spectra)));
         }
 
         private void SetSpectraUI(MsDataSpectrum[] spectra)
@@ -199,7 +199,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
         private void HandleLoadScanException(Exception ex)
         {
-            Invoke(new Action(() => HandleLoadScanExceptionUI(ex)));
+            BeginInvoke(new Action(() => HandleLoadScanExceptionUI(ex)));
         }
 
         private void HandleLoadScanExceptionUI(Exception ex)


### PR DESCRIPTION
Make BackgroundScanProvider communicate with GraphFullScan through BeginInvoke instead of Invoke to avoid the case where GraphFullScan tries to Join the background thread just as it is trying to Invoke to the UI thread.