### PR TITLE
Skyline: Various fixes and improvements for tutorial screenshots

### DIFF
--- a/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/FilterTab.resx
+++ b/pwiz_tools/Shared/Common/DataBinding/Controls/Editor/FilterTab.resx
@@ -139,7 +139,7 @@
     <value>0</value>
   </data>
   <data name="availableFieldsTreeFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>314, 307</value>
+    <value>313, 307</value>
   </data>
   <data name="availableFieldsTreeFilter.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -155,6 +155,12 @@
   </data>
   <data name="&gt;&gt;availableFieldsTreeFilter.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="panel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
   <data name="btnAddFilter.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -190,10 +196,10 @@
     <value>Right</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>314, 0</value>
+    <value>313, 0</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 307</value>
+    <value>57, 307</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -247,7 +253,7 @@
     <value>0, 0</value>
   </data>
   <data name="dataGridViewFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>475, 307</value>
+    <value>483, 307</value>
   </data>
   <data name="dataGridViewFilter.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -256,7 +262,7 @@
     <value>dataGridViewFilter</value>
   </data>
   <data name="&gt;&gt;dataGridViewFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>pwiz.Common.Controls.CommonDataGridView, pwiz.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridViewFilter.Parent" xml:space="preserve">
     <value>splitContainerFilter.Panel2</value>
@@ -274,16 +280,16 @@
     <value>Magenta</value>
   </data>
   <data name="btnDeleteFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>29, 20</value>
+    <value>21, 20</value>
   </data>
   <data name="btnDeleteFilter.Text" xml:space="preserve">
     <value>Delete</value>
   </data>
   <data name="toolStripFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>475, 0</value>
+    <value>483, 0</value>
   </data>
   <data name="toolStripFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 307</value>
+    <value>24, 307</value>
   </data>
   <data name="toolStripFilter.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>

--- a/pwiz_tools/Skyline/Controls/Databinding/PivotReplicateAndIsotopeLabelWidget.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Databinding/PivotReplicateAndIsotopeLabelWidget.ja.resx
@@ -127,7 +127,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cbxPivotIsotopeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>138, 3</value>
+    <value>157, 3</value>
   </data>
   <data name="cbxPivotIsotopeLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>117, 17</value>
@@ -186,8 +186,14 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+      <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+      <value>GrowAndShrink</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 22</value>
+    <value>277, 23</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PivotReplicateAndIsotopeLabelWidget</value>

--- a/pwiz_tools/Skyline/Controls/Databinding/PivotReplicateAndIsotopeLabelWidget.resx
+++ b/pwiz_tools/Skyline/Controls/Databinding/PivotReplicateAndIsotopeLabelWidget.resx
@@ -127,7 +127,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cbxPivotIsotopeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>138, 3</value>
+    <value>157, 3</value>
   </data>
   <data name="cbxPivotIsotopeLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>117, 17</value>
@@ -186,8 +186,14 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 22</value>
+    <value>277, 23</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PivotReplicateAndIsotopeLabelWidget</value>

--- a/pwiz_tools/Skyline/Controls/Databinding/PivotReplicateAndIsotopeLabelWidget.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Databinding/PivotReplicateAndIsotopeLabelWidget.zh-CHS.resx
@@ -127,7 +127,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cbxPivotIsotopeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>138, 3</value>
+    <value>157, 3</value>
   </data>
   <data name="cbxPivotIsotopeLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>117, 17</value>
@@ -186,8 +186,14 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+      <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+      <value>GrowAndShrink</value>
+  </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>259, 22</value>
+    <value>277, 23</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PivotReplicateAndIsotopeLabelWidget</value>

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.cs
@@ -390,7 +390,52 @@ namespace pwiz.Skyline.Controls.GroupComparison
             return column;
         }
 
-        public BindingList<MatchRgbHexColor> GetCurrentBindingList()
+        public MatchRgbHexColor AddRow(MatchRgbHexColor match = null)
+        {
+            if (IsLastRowEmpty)
+            {
+                // Testing for screenshots needs to be able to activate
+                // the form which puts to focus on the grid and adds an
+                // empty row to the binding list. This was causing tests
+                // to fail when they tried to change the binding list
+                // with a dirty row. Silently removing the row below fixes
+                // the issue.
+                _bindingList.RaiseListChangedEvents = false;
+                try
+                {
+                    regexColorRowGrid1.DataGridView.CancelEdit();
+                    _bindingList.RemoveAt(_bindingList.Count - 1);
+                }
+                finally
+                {
+                    _bindingList.RaiseListChangedEvents = true;
+                }
+            }
+
+            if (match == null)
+                return _bindingList.AddNew();
+
+            _bindingList.Add(match);
+            return match;
+        }
+
+        private bool IsLastRowEmpty => Equals(_bindingList.LastOrDefault(), MatchRgbHexColor.EMPTY);
+
+        public PointSymbol GetRowPointSymbol(int rowIndex)
+        {
+            return _bindingList[rowIndex].PointSymbol;
+        }
+
+        public void SetRowPointSymbol(int rowIndex, PointSymbol pointSymbol)
+        {
+            _bindingList[rowIndex].PointSymbol = pointSymbol;
+        }
+
+        /// <summary>
+        /// Used by the <see cref="ColorGrid{T}"/> but not for general use.
+        /// Extend the testing interface if you need more.
+        /// </summary>
+        BindingList<MatchRgbHexColor> ColorGrid<MatchRgbHexColor>.IColorGridOwner.GetCurrentBindingList()
         {
             return _bindingList;
         }

--- a/pwiz_tools/Skyline/Model/GroupComparison/MatchRgbHexColor.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/MatchRgbHexColor.cs
@@ -50,6 +50,8 @@ namespace pwiz.Skyline.Model.GroupComparison
     [XmlRoot(XML_ROOT)]
     public class MatchRgbHexColor : RgbHexColor, ICloneable
     {
+        public static readonly MatchRgbHexColor EMPTY = new MatchRgbHexColor();
+
         public const string XML_ROOT = "format_detail";
         private string _expression;
         private bool _labeled;

--- a/pwiz_tools/Skyline/SkylineTester/TabTutorials.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabTutorials.cs
@@ -18,7 +18,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text;
 using System.Windows.Forms;
 
@@ -66,10 +65,8 @@ namespace SkylineTester
                     pauseSeconds = 0;
                 args.Append(" pause=").Append(pauseSeconds);
             }
-            args.Append(" screenshotlist=\"");
-            args.Append(Path.Combine(MainWindow.RootDir, "ScreenShotForms.txt"));
-            args.Append("\" test=");
-            args.Append(String.Join(",", testList));
+            args.Append(" test=");
+            args.Append(string.Join(",", testList));
 
             MainWindow.AddTestRunner(args.ToString());
             MainWindow.RunCommands();

--- a/pwiz_tools/Skyline/TestFunctional/PeakAreaRelativeAbundanceGraphTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PeakAreaRelativeAbundanceGraphTest.cs
@@ -90,12 +90,12 @@ namespace pwiz.SkylineTestFunctional
                 Assert.AreEqual(Skyline.Controls.GroupComparison.GroupComparisonResources
                         .VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Protein_Expression_Formatting,
                     formattingDlg.Text);
-                var row = formattingDlg.GetCurrentBindingList().AddNew();
+                var row = formattingDlg.AddRow();
                 Assert.IsNotNull(row);
                 row.Expression = new MatchExpression("QE", new[] { MatchOption.PeptideSequence }).ToString();
                 row.PointSymbol = PointSymbol.Diamond;
                 row.Color = Color.FromArgb(Color.Indigo.ToArgb());
-                row = formattingDlg.GetCurrentBindingList().AddNew();
+                row = formattingDlg.AddRow();
                 Assert.IsNotNull(row);
                 row.Expression = new MatchExpression("GQ", new[] { MatchOption.PeptideSequence }).ToString();
                 row.PointSymbol = PointSymbol.Triangle;
@@ -158,11 +158,11 @@ namespace pwiz.SkylineTestFunctional
             formattingDlg = ShowDialog<VolcanoPlotFormattingDlg>(pane.ShowFormattingDialog);
             RunUI(() =>
             {
-                Assert.AreEqual(PointSymbol.Diamond, formattingDlg.GetCurrentBindingList()[0].PointSymbol);
-                formattingDlg.GetCurrentBindingList()[0].PointSymbol = PointSymbol.Plus;
+                Assert.AreEqual(PointSymbol.Diamond, formattingDlg.GetRowPointSymbol(0));
+                formattingDlg.SetRowPointSymbol(0, PointSymbol.Plus);
             });
             WaitForGraphs();
-            RunUI(() => formattingDlg.GetCurrentBindingList()[0].PointSymbol =PointSymbol.Diamond);
+            RunUI(() => formattingDlg.SetRowPointSymbol(0, PointSymbol.Diamond));
             WaitForGraphs();
             OkDialog(formattingDlg, formattingDlg.OkDialog);
         }

--- a/pwiz_tools/Skyline/TestFunctional/VolcanoPlotFormattingTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/VolcanoPlotFormattingTest.cs
@@ -314,13 +314,13 @@ namespace pwiz.SkylineTestFunctional
 
                 var createExprDlg = ShowDialog<CreateMatchExpressionDlg>(() =>
                 {
-                    var bindingList = formattingDlg.GetCurrentBindingList();
-                    Assert.AreEqual(initialRowCount + index, bindingList.Count);
+                    int rows = formattingDlg.ResultList.Count;
+                    Assert.AreEqual(initialRowCount + index, rows);
 
-                    bindingList.Add(new MatchRgbHexColor(string.Empty, exprInfo.ExpectedPointsInfo.Labeled,
+                    formattingDlg.AddRow(new MatchRgbHexColor(string.Empty, exprInfo.ExpectedPointsInfo.Labeled,
                         exprInfo.ExpectedPointsInfo.Color, exprInfo.ExpectedPointsInfo.PointSymbol,
                         exprInfo.ExpectedPointsInfo.PointSize));
-                    formattingDlg.ClickCreateExpression(bindingList.Count - 1);
+                    formattingDlg.ClickCreateExpression(rows);
                 });
 
                 RunUI(() =>
@@ -456,11 +456,10 @@ namespace pwiz.SkylineTestFunctional
             var formattingDlg = ShowDialog<VolcanoPlotFormattingDlg>(volcanoPlot.ShowFormattingDialog);
             var createExprDlg = ShowDialog<CreateMatchExpressionDlg>(() =>
             {
-                var bindingList = formattingDlg.GetCurrentBindingList();
-                bindingList.Add(new MatchRgbHexColor(string.Empty, exprInfo.ExpectedPointsInfo.Labeled,
+                formattingDlg.AddRow(new MatchRgbHexColor(string.Empty, exprInfo.ExpectedPointsInfo.Labeled,
                     exprInfo.ExpectedPointsInfo.Color, exprInfo.ExpectedPointsInfo.PointSymbol,
                     exprInfo.ExpectedPointsInfo.PointSize));
-                formattingDlg.ClickCreateExpression(bindingList.Count - 1);
+                formattingDlg.ClickCreateExpression(formattingDlg.ResultList.Count - 1);
             });
             var matchExprListDlg = ShowDialog<MatchExpressionListDlg>(createExprDlg.ClickEnterList);
             RunUI(() =>

--- a/pwiz_tools/Skyline/TestPerf/DiaUmpireTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaUmpireTutorialTest.cs
@@ -854,16 +854,6 @@ namespace TestPerf
             }
         }
 
-        private void ApplyFormatting(VolcanoPlotFormattingDlg formattingDlg, string matchText, string rgbText)
-        {
-            RunUI(() =>
-            {
-                var bindingList = formattingDlg.GetCurrentBindingList();
-                var color = RgbHexColor.ParseRgb(rgbText).Value;
-                bindingList.Add(new MatchRgbHexColor("ProteinName: " + matchText, false, color, PointSymbol.Circle, PointSize.normal));
-            });
-        }
-
         private void ValidateTargets(ref int[] targetCounts, int proteinCount, int peptideCount, int precursorCount, int transitionCount, string propName)
         {
             if (IsRecordMode)

--- a/pwiz_tools/Skyline/TestPerf/DiaUmpireTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaUmpireTutorialTest.cs
@@ -40,7 +40,6 @@ using pwiz.Skyline.FileUI.PeptideSearch;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Model.AuditLog;
 using pwiz.Skyline.Model.DocSettings;
-using pwiz.Skyline.Model.GroupComparison;
 using pwiz.Skyline.Model.Irt;
 using pwiz.Skyline.Model.Results;
 using pwiz.Skyline.Properties;

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -250,7 +250,7 @@ namespace TestRunner
             "parallelmode=off;workercount=0;waitforworkers=off;keepworkerlogs=off;checkdocker=on;workername;queuehost;workerport;workertimeout;alwaysupcltpassword;" +
             "coverage=off;dotcoverexe=jetbrains.dotcover.commandlinetools\\2023.3.3\\tools\\dotCover.exe;" +
             "maxsecondspertest=-1;" +
-            "demo=off;showformnames=off;showpages=off;status=off;buildcheck=0;screenshotlist;" +
+            "demo=off;showformnames=off;showpages=off;status=off;buildcheck=0;" +
             "quality=off;pass0=off;pass1=off;pass2=on;" +
             "perftests=off;" +
             "retrydatadownloads=off;" +

--- a/pwiz_tools/Skyline/TestUtil/ScreenshotPreviewForm.cs
+++ b/pwiz_tools/Skyline/TestUtil/ScreenshotPreviewForm.cs
@@ -43,6 +43,7 @@ namespace pwiz.SkylineTestUtil
         string Description { get; }
         string LinkUrl { get; }
         string ImageUrl { get; }
+        string FileToShow { get; }
         string FileToSave { get; }
         Control ScreenshotControl { get; }
         bool FullScreen { get; }
@@ -71,6 +72,7 @@ namespace pwiz.SkylineTestUtil
         private string _description;
         private string _linkUrl;
         private string _imageUrl;
+        private string _fileToShow;
         private string _fileToSave;
         private ScreenshotValues _screenshotValues;
         private Bitmap _oldScreenshot;
@@ -99,7 +101,6 @@ namespace pwiz.SkylineTestUtil
 
         public ScreenshotPreviewForm(IPauseTestController pauseTestController, ScreenshotManager screenshotManager)
         {
-
             _pauseTestController = pauseTestController;
             _screenshotManager = screenshotManager;
 
@@ -119,13 +120,14 @@ namespace pwiz.SkylineTestUtil
                 splitBar.Visible = false;
 
             // Unfortunately there is not enough information about the image sizes to
-            // the the starting location right here, but this is better than using the Windows default
+            // the starting location right here, but this is better than using the Windows default
             StartPosition = FormStartPosition.Manual;
             var savedLocation = TestUtilSettings.Default.PreviewFormLocation;
             if (!TestUtilSettings.Default.ManualSizePreview)
             {
-                // CONSIDER: Only do this if the stored location is on the same screen as Skyline
-                Location = GetBestLocation();
+                Location = Equals(_screenshotManager.GetScreenshotScreen(), Screen.FromPoint(savedLocation))
+                    ? GetBestLocation()
+                    : savedLocation;
             }
             else
             {
@@ -147,8 +149,7 @@ namespace pwiz.SkylineTestUtil
         /// <summary>
         /// To be called by the <see cref="IPauseTestController"/> when switching modes or entering new pause.
         /// </summary>
-        /// <param name="delayForScreenshot">True when test UI may need time to stabilize before a screenshot</param>
-        public void Show(bool delayForScreenshot)
+        public void ShowOrUpdate()
         {
             lock (_lock)
             {
@@ -156,11 +157,12 @@ namespace pwiz.SkylineTestUtil
                 _description = _pauseTestController.Description;
                 _linkUrl = _pauseTestController.LinkUrl;
                 _imageUrl = _pauseTestController.ImageUrl;
+                _fileToSave = _pauseTestController.FileToSave;
                 _screenshotValues = new ScreenshotValues(_pauseTestController.ScreenshotControl,
-                    _pauseTestController.FullScreen, _pauseTestController.ProcessShot, delayForScreenshot);
-                if (!Equals(_fileToSave, _pauseTestController.FileToSave))
+                    _pauseTestController.FullScreen, _pauseTestController.ProcessShot);
+                if (!Equals(_fileToShow, _pauseTestController.FileToShow))
                 {
-                    _fileToSave = _pauseTestController.FileToSave;
+                    _fileToShow = _pauseTestController.FileToShow;
                     _fileLoaded = null;
                 }
 
@@ -224,7 +226,7 @@ namespace pwiz.SkylineTestUtil
         private bool HasBackgroundWork { get { lock(_lock) { return !IsLoaded || (!IsWaiting && !IsScreenshotTaken); } } }
         private bool IsComplete { get { lock (_lock) { return IsLoaded && !IsWaiting && IsScreenshotTaken; } } }
         // CONSIDER: This doesn't really cover the case where the current thing is loaded but not from the current source
-        private bool IsLoaded { get { lock (_lock) { return Equals(_fileLoaded, _fileToSave) || Equals(_fileLoaded, _imageUrl); } } }
+        private bool IsLoaded { get { lock (_lock) { return Equals(_fileLoaded, _fileToShow) || Equals(_fileLoaded, _imageUrl); } } }
         private bool IsWaiting { get { lock (_lock) { return _nextScreenshotProgress is { IsReadyForScreenshot: false }; } } }
         private bool IsScreenshotTaken { get { lock (_lock) { return _screenshotTaken; } } }
 
@@ -376,7 +378,7 @@ namespace pwiz.SkylineTestUtil
             else
             {
                 int nextScreenshot = _screenshotNum + 1;
-                bool nextExists = File.Exists(_screenshotManager.ScreenshotFile(nextScreenshot));
+                bool nextExists = File.Exists(_screenshotManager.ScreenshotSourceFile(nextScreenshot));
 
                 textBox.Text = nextExists ? nextScreenshot.ToString() : END_TEST_TEXT;
                 textBox.Enabled = nextExists;
@@ -484,20 +486,20 @@ namespace pwiz.SkylineTestUtil
             Assume.IsTrue(InvokeRequired);  // Expecting this to run on a background thread. Use ActionUtil.RunAsync()
 
             Bitmap oldScreenshot;
-            string fileToSave, imageUrl, fileLoaded;
+            string fileToShow, imageUrl, fileLoaded;
 
             lock (_lock)
             {
-                fileToSave = _fileToSave;
+                fileToShow = _fileToShow;
                 fileLoaded = _fileLoaded;
                 imageUrl = showWebImage ? _imageUrl : null;
                 oldScreenshot = _oldScreenshot;
             }
 
-            string fileToLoad = imageUrl ?? fileToSave;
+            string fileToLoad = imageUrl ?? fileToShow;
             if (!Equals(fileLoaded, fileToLoad))
             {
-                oldScreenshot = LoadScreenshot(fileToSave, imageUrl);
+                oldScreenshot = LoadScreenshot(fileToShow, imageUrl);
                 fileLoaded = fileToLoad;
             }
 
@@ -546,20 +548,18 @@ namespace pwiz.SkylineTestUtil
 
         private struct ScreenshotValues
         {
-            public static readonly ScreenshotValues Empty = new ScreenshotValues(null, false, null, false);
+            public static readonly ScreenshotValues Empty = new ScreenshotValues(null, false, null);
 
-            public ScreenshotValues(Control control, bool fullScreen, Func<Bitmap, Bitmap> processShot, bool delay)
+            public ScreenshotValues(Control control, bool fullScreen, Func<Bitmap, Bitmap> processShot)
             {
                 Control = control;
                 FullScreen = fullScreen;
                 ProcessShot = processShot;
-                Delay = delay;
             }
 
             public Control Control { get; }
             public bool FullScreen { get; }
             public Func<Bitmap, Bitmap> ProcessShot { get; }
-            public bool Delay { get; }
         }
 
         private Bitmap TakeScreenshot(ScreenshotValues values)
@@ -568,9 +568,6 @@ namespace pwiz.SkylineTestUtil
             {
                 return Resources.noscreenshot;
             }
-            // TODO: Is this value necessary anymore.
-            if (values.Delay)
-                Thread.Sleep(1000);
 
             var control = values.Control;
             try
@@ -783,7 +780,7 @@ namespace pwiz.SkylineTestUtil
                     return;
                 }
 
-                string nextScreenshotFile = _screenshotManager.ScreenshotFile(nextShot);
+                string nextScreenshotFile = _screenshotManager.ScreenshotSourceFile(nextShot);
                 if (!File.Exists(nextScreenshotFile))
                 {
                     helper.ShowTextBoxError(textBoxNext, "Invalid {0} value {1}. Screenshot file {2} does not exist.", null, nextShot, nextScreenshotFile);
@@ -823,7 +820,7 @@ namespace pwiz.SkylineTestUtil
         /// <returns>The last number found to exist without interruption in the series</returns>
         int FindLastShot(int startFrom)
         {
-            while (File.Exists(_screenshotManager.ScreenshotFile(startFrom + 1)))
+            while (File.Exists(_screenshotManager.ScreenshotSourceFile(startFrom + 1)))
                 startFrom++;
             return startFrom;
         }
@@ -836,7 +833,8 @@ namespace pwiz.SkylineTestUtil
                 // Since it is not yet known what the description will be use ... and the link to the next screenshot
                 // CONSIDER: Make this a ScreenShotInfo class?
                 _description = _screenshotManager.ScreenshotDescription(_screenshotNum, "...");
-                _fileToSave = _screenshotManager.ScreenshotFile(_screenshotNum);
+                _fileToShow = _screenshotManager.ScreenshotSourceFile(_screenshotNum);
+                _fileToSave = _screenshotManager.ScreenshotDestFile(_screenshotNum);
                 _imageUrl = _screenshotManager.ScreenshotImgUrl(_screenshotNum);
                 _linkUrl = _screenshotManager.ScreenshotUrl(_screenshotNum);
                 _screenshotTaken = false;
@@ -849,7 +847,7 @@ namespace pwiz.SkylineTestUtil
             {
                 Hide();
             }
-            else if(File.Exists(_screenshotManager.ScreenshotFile(_screenshotNum)))
+            else if(File.Exists(_screenshotManager.ScreenshotSourceFile(_screenshotNum)))
             {
                 FormStateChanged();
             }
@@ -877,7 +875,7 @@ namespace pwiz.SkylineTestUtil
 
         private bool SaveScreenshot()
         {
-            if (!FileEx.IsWritable(_fileToSave))
+            if (File.Exists(_fileToSave) && !FileEx.IsWritable(_fileToSave))
             {
                 PreviewMessageDlg.Show(this, TextUtil.LineSeparate(string.Format("The file {0} is locked.", _fileToSave),
                     "Check that it is not open in another program such as TortoiseIDiff."));
@@ -885,6 +883,10 @@ namespace pwiz.SkylineTestUtil
             }
             try
             {
+                string screenshotDir = Path.GetDirectoryName(_fileToSave) ?? string.Empty;
+                Assume.IsFalse(string.IsNullOrEmpty(screenshotDir));    // Because ReSharper complains about possible null
+                Directory.CreateDirectory(screenshotDir);
+
                 _newScreenshot.Save(_fileToSave);
                 return true;
             }
@@ -1178,6 +1180,28 @@ namespace pwiz.SkylineTestUtil
                         e.Handled = true;
                     }
                     break;
+                case Keys.C:
+                    if (e.Control)
+                    {
+                        if (e.Shift)
+                            CopyBitmap(_oldScreenshot);
+                        else
+                            CopyBitmap(_newScreenshot);
+                        e.Handled = true;
+                    }
+                    break;
+            }
+        }
+
+        private void CopyBitmap(Bitmap bitmap)
+        {
+            try
+            {
+                Clipboard.SetImage(bitmap);
+            }
+            catch (Exception e)
+            {
+                PreviewMessageDlg.ShowWithException(this, "Failed clipboard operation.", e);
             }
         }
 

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1338,14 +1338,6 @@ namespace pwiz.SkylineTestUtil
 
         private PauseAndContinueForm _pauseAndContinueForm;
 
-        private PauseAndContinueForm PauseAndContinueFormInstance
-        {
-            get
-            {
-                return _pauseAndContinueForm ??= new PauseAndContinueForm(ScreenshotManager);
-            }
-        }
-
         public void BeginDragDisplay(Control dockableForm, double xProportion, double yProportion)
         {
             if (!IsPauseForScreenShots)
@@ -1755,7 +1747,9 @@ namespace pwiz.SkylineTestUtil
         }
 
         /// <summary>
-        /// Type that indicates a full-screen screenshot should be taken
+        /// Type that indicates a full-screen screenshot should be taken.
+        /// A null Type and a null Control were already reserved for a
+        /// screenshot of the Skyline form.
         /// </summary>
         public class ScreenForm : IFormView
         {
@@ -1795,15 +1789,16 @@ namespace pwiz.SkylineTestUtil
 
                 if (IsAutoScreenShotMode)
                 {
-                    Thread.Sleep(1000); // Wait for UI to settle down - Necessary?
+                    // Thread.Sleep(500); // Wait for UI to settle down - Necessary?
                     ScreenshotManager.ActivateScreenshotForm(screenshotForm);
-                    var fileToSave = _shotManager.ScreenshotFile(ScreenshotCounter);
+                    var fileToSave = _shotManager.ScreenshotDestFile(ScreenshotCounter);
                     _shotManager.TakeShot(screenshotForm, fullScreen, fileToSave, processShot);
                 }
                 else
                 {
                     bool showMatchingPages = IsShowMatchingTutorialPages || Program.ShowMatchingPages;
-                    PauseAndContinueFormInstance.Show(description, ScreenshotCounter, showMatchingPages, timeout, screenshotForm, fullScreen, processShot);
+                    _pauseAndContinueForm ??= new PauseAndContinueForm(ScreenshotManager);
+                    _pauseAndContinueForm.Show(description, ScreenshotCounter, showMatchingPages, timeout, screenshotForm, fullScreen, processShot);
                 }
             }
             else


### PR DESCRIPTION
- Fixed layout in ViewEditor for Japanese and Chinese
- Fixed to VolcanoPlotFormattingDlg for failure in IsPauseForScreenShots mode
- Removed screenshotlist argument from TestRunner and SkylineTester
- Fixed issue with auto-screenshot mode not saving to non-existent language folders
- Fixed ScreenshotPreviewForm startup placement in auto-size mode on 2nd monitor
- Added console output for each screenshot
- Cleaned up unnecessary Thread.Sleep() code in ScreenshotPreviewForm
- Cleaned up a bit inside ScreenshotManager and add code to ForceOnScreen() the frame to be screenshot
- Added keyboard commands (Ctrl-C and Ctrl-Shift-C) to copy new and old bitmaps respectively.
- Removed Thread.Sleep() in auto-screenshot mode for more testing
- Improved commenting in several places