### PR TITLE
Skyline: First drafts of AuditLogTutorialTest and SmallMolLibrariesTutorialTest

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
@@ -342,10 +342,9 @@ namespace pwiz.Skyline.Controls.Graphs
 
         private void ZoomXAxis(Axis axis, double xMin, double xMax)
         {
+            axis.Scale.MinAuto = axis.Scale.MinAuto = false;
             axis.Scale.Min = xMin;
-            axis.Scale.MinAuto = false;
             axis.Scale.Max = xMax;
-            axis.Scale.MaxAuto = false;
         }
 
         public void ZoomXAxis(double xMin, double xMax)

--- a/pwiz_tools/Skyline/Controls/UndoRedoButtons.cs
+++ b/pwiz_tools/Skyline/Controls/UndoRedoButtons.cs
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using pwiz.Skyline.Model;
 
@@ -33,8 +34,10 @@ namespace pwiz.Skyline.Controls
         private readonly UndoManager _undoManager;
         private readonly ToolStripMenuItem _undoMenuItem;
         private readonly ToolStripSplitButton _undoButton;
+        private UndoRedoList _undoList;
         private readonly ToolStripMenuItem _redoMenuItem;
         private readonly ToolStripSplitButton _redoButton;
+        private UndoRedoList _redoList;
         private readonly Action<Action> _runUIAction;
 
         public UndoRedoButtons(UndoManager undoManager,
@@ -63,6 +66,36 @@ namespace pwiz.Skyline.Controls
                 _redoButton, false);
         }
 
+        public void ShowUndo(bool show)
+        {
+            ShowButtonDropdown(_undoButton, show, ref _undoList);
+        }
+
+        public void ShowRedo(bool show)
+        {
+            ShowButtonDropdown(_redoButton, show, ref _redoList);
+        }
+
+        private void ShowButtonDropdown(ToolStripDropDownItem button, bool show, ref UndoRedoList list)
+        {
+            if (show)
+            {
+                button.ShowDropDown();
+                if (list != null)
+                    list.Closing += DenyListClosing;
+            }
+            else if (list != null)
+            {
+                list.Closing -= DenyListClosing;
+                list.Close();
+            }
+        }
+
+        private void DenyListClosing(object sender, CancelEventArgs e)
+        {
+            e.Cancel = true;
+        }
+
         void undoManager_StacksChanged(object sender, EventArgs e)
         {
             _runUIAction(UpdateButtons);
@@ -78,9 +111,12 @@ namespace pwiz.Skyline.Controls
 
         void PopulateDropDownButton(ToolStripDropDownItem button, bool undo)
         {
-            UndoRedoList undoRedoList = new UndoRedoList();
+            var undoRedoList = new UndoRedoList();
             undoRedoList.ShowList(button, undo, _undoManager);
+            if (undo)
+                _undoList = undoRedoList;
+            else
+                _redoList = undoRedoList;
         }
-
     }
 }

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -111,6 +111,7 @@ namespace pwiz.Skyline
         private int _savedVersion;
         private bool _closing;
         private readonly UndoManager _undoManager;
+        private readonly UndoRedoButtons _undoRedoButtons;
         private readonly BackgroundProteomeManager _backgroundProteomeManager;
         private readonly ProteinMetadataManager _proteinMetadataManager;
         private readonly IrtDbManager _irtDbManager;
@@ -142,11 +143,11 @@ namespace pwiz.Skyline
             InitializeComponent();
             InitializeMenus();
             _undoManager = new UndoManager(this);
-            var undoRedoButtons = new UndoRedoButtons(_undoManager,
+            _undoRedoButtons = new UndoRedoButtons(_undoManager,
                 EditMenu.UndoMenuItem, undoToolBarButton,
                 EditMenu.RedoMenuItem, redoToolBarButton,
                 RunUIAction);
-            undoRedoButtons.AttachEventHandlers();
+            _undoRedoButtons.AttachEventHandlers();
 
             // Setup to manage and interact with mode selector buttons in UI
             SetModeUIToolStripButtons(modeUIToolBarDropDownButton);
@@ -900,6 +901,16 @@ namespace pwiz.Skyline
                     SetActiveFile(pathOnDisk);                    
                 }
             }
+        }
+
+        public void ShowUndo(bool show = true)
+        {
+            _undoRedoButtons.ShowUndo(show);
+        }
+
+        public void ShowRedo(bool show = true)
+        {
+            _undoRedoButtons.ShowRedo(show);
         }
 
         public IUndoTransaction BeginUndo(IUndoState undoState = null)

--- a/pwiz_tools/Skyline/TestPerf/SmallMolLibrariesTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/SmallMolLibrariesTutorialTest.cs
@@ -53,7 +53,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
         {
 //            IsPauseForScreenShots = true;
 //            IsCoverShotMode = true;
-            CoverShotName = "SmallMolLibraries";
+            CoverShotName = "SmallMoleculeIMSLibraries";
 
             LinkPdf = "https://skyline.ms/_webdav/home/software/Skyline/%40files/tutorials/SmallMoleculeIMSLibraries-20_2.pdf";
 
@@ -172,14 +172,16 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             //   To open the library explorer and view the contents of the library you just added, do the following: 
             //   • From the View menu, click Spectral Libraries.
             var viewLibUI = ShowDialog<ViewLibraryDlg>(SkylineWindow.ViewSpectralLibraries);
-            RunUI(() =>
+            RunUIForScreenShot(() =>
             {
                 viewLibUI.Left = SkylineWindow.Right + 20;
                 viewLibUI.Top = SkylineWindow.Top;
+                viewLibUI.Width = 775;
+                viewLibUI.Height = 463;
             });
 
             //   The library explorer should now resemble the image below:
-            PauseForScreenShot("Library Explorer (probably need to resize wider)", 7);
+            PauseForScreenShot<ViewLibraryDlg>("Library Explorer", 7);
 
             //  To add all the molecules in the library to your target list:
             //   • Click the Add All button.
@@ -196,6 +198,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
 
             //   Your Skyline window should now resemble:
             RunUI(() => SkylineWindow.Size = new Size(951, 607));
+            FocusDocument();
             PauseForScreenShot("Populated Skyline window", 8);
 
             //Importing Results Chromatogram.Data
@@ -245,6 +248,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                     allChromatograms.Top = SkylineWindow.Top;
                     allChromatograms.Left = SkylineWindow.Right + 20;
                 });
+                WaitForConditionUI(() => allChromatograms.ProgressTotalPercent > 40);
                 PauseForScreenShot<AllChromatogramsGraph>("Importing results form", 11);
             }
 
@@ -276,12 +280,13 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             });
             //  • Select the molecule PC(16:0_18:1) and your spectra should appear as: 
             FindNode("PC(16:0_18:1)");
-            PauseForScreenShot("Chromatograms - prtsc-paste-edit", 12);
+            PauseForScreenShot("Chromatograms", 12, null, ClipChromatograms);
 
             RestoreViewOnScreen(13);
+            WaitForGraphs();
             var libraryMatchView = WaitForOpenForm<GraphSpectrum>();
             RunUI(() => libraryMatchView.ZoomXAxis(100, 400));
-            PauseForScreenShot("Library Match", 13);
+            PauseForScreenShot<GraphSpectrum>("Library Match", 13);
 
             //Since there are only 38 precursors in this document, you may want to review all 38 to get an overall feel for how the XIC look prior to IMS filtering.Before starting this review, do the following:
             //   • On the View menu, choose Retention Times and click Replicate Comparison (F8).
@@ -332,22 +337,31 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 propDlg.OkDialog();
             });
             WaitForGraphs();
-            PauseForScreenShot("Chromatogram", 15);
+            var firstReplicateName = SkylineWindow.Document.Settings.MeasuredResults.Chromatograms.First().Name;
+            var clickPoint = new PointF(14.81F, 162.1E3F);
+            if (IsPauseForScreenShots)
+            {
+                MouseOverChromatogram(firstReplicateName, clickPoint.X, clickPoint.Y, PaneKey.PRECURSORS);
+            }
+            var graphChrom = SkylineWindow.GetGraphChrom(firstReplicateName);
+            PauseForScreenShot(graphChrom,"Chromatogram", 15, null, bmp =>
+                ClipBitmap(DrawHandCursorOnChromBitmap(bmp, graphChrom, true, clickPoint.X, clickPoint.Y, PaneKey.PRECURSORS),
+                    new Rectangle(0, 0, bmp.Width, (int)(bmp.Height * 0.515))));
 
             //   • Hover the mouse cursor over the precursor chromatogram peak apex until a blue circle appears that tracks the mouse movement, and click on it.
-            ClickChromatogram(F_A_018, 14.81, 162.1E3, PaneKey.PRECURSORS);
+            ClickChromatogram(F_A_018, clickPoint.X, clickPoint.Y, PaneKey.PRECURSORS);
             //   This should bring up the Full-Scan view showing a familiar two-dimensional spectrum in profile mode:
             RunUI(() => SkylineWindow.GraphFullScan.SetSpectrum(true));
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
-            PauseForScreenShot("2D plot", 16);
+            PauseForFullScanGraphScreenShot("2D plot", 16);
 
             //   • Click the Show 2D Spectrum button  to change the plot to a three-dimensional spectrum with drift time.
             RunUI(() => SkylineWindow.GraphFullScan.SetSpectrum(false));
-            PauseForScreenShot("3D plot", 16);
+            PauseForFullScanGraphScreenShot("3D plot", 16);
 
             //   • Click the Zoom to Selection button to see the entire 3D MS1 spectrum at the selected retention time.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(false));
-            PauseForScreenShot("3D plot full range", 17);
+            PauseForFullScanGraphScreenShot("3D plot full range", 17);
 
             //    This is a fairly typical MS1 spectrum for IMS-MS lipidomics data.You can get a better sense of the data by zooming into multiple areas on this plot.You can also select other lipids and click on the blue circle at the apex of each precursor chromatogram peak to see how this plot can differ with retention time. An interesting example is PE(O-18:0/16:1), which has distinct ion distributions showing correlations between m/z and drift time for different lipid classes.
             //    To inspect a relevant MS/MS spectrum:
@@ -360,13 +374,13 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
             ClickChromatogram(F_A_018, 14.83, 120.5E3, PaneKey.PRODUCTS);
             //   The Full-Scan graph should change to:
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(true));
-            PauseForScreenShot("3D plot MSMS zoomed", 18);
+            PauseForFullScanGraphScreenShot("3D plot MSMS zoomed", 18);
 
 
             //You can see that at least three visible ions are contributing to the extracted intensities at 33, 37, and 44 ms.This goes back to the nature of lipid fragmentation as previously discussed, where most lipids with an 18:3 fatty acyl chain will share this fragment.The complexity is increased for fatty acyl chains fragments with fewer double bonds, such as 18:2 at m/z 279, which may have multiple ions as well as isotopic overlap from the abundant 18:3 fragment at m/z 277 contributing to the extracted intensity.A similar observation can be made with the FA 16:1(+O) fragment.
             //   • Click the Zoom to Selection button again to see the entire 3D MS/MS spectrum.
             RunUI(() => SkylineWindow.GraphFullScan.ZoomToSelection(false));
-            PauseForScreenShot("3D plot MSMS full range", 18);
+            PauseForFullScanGraphScreenShot("3D plot MSMS full range", 18);
 
 
             //    Reimporting Data with Drift Time Filtering
@@ -439,7 +453,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                 return;
             }
 
-            PauseForScreenShot("Full scan graph with IM filtering", 21);
+            PauseForFullScanGraphScreenShot("Full scan graph with IM filtering", 21);
 
             // Note that if you were interested in lipids that are not present in the current spectral library, you can add to it manually or using LipidCreator. To access the LipidCreator plugin, do the following:
             //   • From the Tools menu, click Tool Store.
@@ -458,7 +472,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't require a mas
                     pick.SelectTool("LipidCreator");
                     pick.Left = SkylineWindow.Right + 20;
                 });
-                PauseForScreenShot("LipidCreator in tool store", 22);
+                PauseForScreenShot<ToolStoreDlg>("LipidCreator in tool store", 22);
                 OkDialog(pick, pick.CancelDialog);
                 OkDialog(configureToolsDlg, configureToolsDlg.Cancel);
                 //   • Click the Install button.

--- a/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
+++ b/pwiz_tools/Skyline/TestPerf/TestPerf.csproj
@@ -264,7 +264,6 @@
     <None Include="FeatureDetectionTest.zip" />
     <None Include="OrbiPrmViews.zip" />
     <None Include="PerfImportHundredsOfReplicatesTest.zip" />
-    <None Include="HiResMetabolomicsViews.zip" />
     <None Include="PerfMs3ChromatogramTest.zip" />
     <None Include="SmallMolLibrariesTutorialViews.zip" />
   </ItemGroup>

--- a/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
@@ -143,11 +143,17 @@ namespace pwiz.SkylineTestTutorial
                 SkylineWindow.Width = 1010;
             });
 
-            PauseForScreenShot("Undo list expanded. (manual)", 4);
+            RunUIForScreenShot(() => SkylineWindow.ShowUndo());
+            PauseForScreenShot("Undo list expanded.", 4, null, bmp => 
+                ClipBitmap(bmp, new Rectangle(0, 0, 713, 131)));
+            RunUIForScreenShot(() => SkylineWindow.ShowUndo(false));
 
             RunUI(SkylineWindow.Undo);
 
-            PauseForScreenShot("Redo list expanded. (manual)", 5);
+            RunUIForScreenShot(() => SkylineWindow.ShowRedo());
+            PauseForScreenShot("Redo list expanded.", 5, null, bmp =>
+                ClipBitmap(bmp, new Rectangle(0, 0, 743, 127)));
+            RunUIForScreenShot(() => SkylineWindow.ShowRedo(false));
 
             RunUI(SkylineWindow.Redo);
 
@@ -180,7 +186,7 @@ namespace pwiz.SkylineTestTutorial
                 SkylineWindow.Height = 390;
             });
 
-            PauseForScreenShot("Main window with Targets view", 6);
+            PauseForScreenShot<SequenceTreeForm>("Targets view", 6);
 
             ShowAndPositionAuditLog(true);
             PauseForScreenShot<AuditLogForm>("Audit Log form with inserted peptide.", 7);
@@ -354,6 +360,7 @@ namespace pwiz.SkylineTestTutorial
                 VerifyCalibrationCurve(calibrationForm, 5.4065E-1, -2.9539E-1, 0.999);
             });
 
+            JiggleSelection();
             PauseForScreenShot<CalibrationForm>("Calibration curve zoomed", 15);
             RunUI(() =>
             {
@@ -376,7 +383,11 @@ namespace pwiz.SkylineTestTutorial
 
             PauseForScreenShot<AuditLogForm>("Audit Log with excluded standard records", 16);
 
-            PauseForScreenShot<AuditLogForm>("Audit Log Reports menu (manual)", 16);
+            RunUIForScreenShot(() => SkylineWindow.AuditLogForm.Parent.Parent.Width += 100);    // Wider to remove the horizontal scrollbar
+            ShowReportsDropdown(AuditLogStrings.AuditLogForm_AuditLogForm_All_Info);
+            PauseForScreenShot<AuditLogForm>("Audit Log Reports menu", 16, null, bmp =>
+                ClipBitmap(bmp, new Rectangle(0, 0, 503, bmp.Height)));
+            HideReportsDropdown();
 
             // TODO(nicksh): Audit log reason field does not currently support fill down
 //            RunUI(() =>
@@ -396,7 +407,7 @@ namespace pwiz.SkylineTestTutorial
                 SkylineWindow.AuditLogForm.ChooseView(AuditLogStrings.AuditLogForm_MakeAuditLogForm_Undo_Redo);
             });
             SetGridFormToFullWidth(SkylineWindow.AuditLogForm);
-            RunUI(() =>
+            RunUIForScreenShot(() =>
             {
                 var floatingWindow = SkylineWindow.AuditLogForm.Parent.Parent;
                 floatingWindow.Height = 334;
@@ -450,7 +461,12 @@ namespace pwiz.SkylineTestTutorial
             PauseForScreenShot<ViewEditor.ChooseColumnsView>("Custom Columns report template", 17);
             OkDialog(customizeDialog, customizeDialog.OkDialog);
             SetGridFormToFullWidth(SkylineWindow.AuditLogForm);
-            RunUI(() => SkylineWindow.AuditLogForm.Parent.Parent.Height += 10); // Extra for 2-line headers
+            RunUIForScreenShot(() =>
+            {
+                var floatingForm = SkylineWindow.AuditLogForm.Parent.Parent;
+                floatingForm.Width = 1130; // Wider for Skyline Version and User columns
+                floatingForm.Height += 10; // Extra for 2-line headers
+            }); 
             PauseForScreenShot<AuditLogForm>("Audit Log with custom view.", 18);
 
             var registrationDialog = ShowDialog<MultiButtonMsgDlg>(() => SkylineWindow.ShowPublishDlg(null));
@@ -465,7 +481,7 @@ namespace pwiz.SkylineTestTutorial
                 loginDialog.Username = PANORAMA_USER_NAME;
             });
 
-            if (!IsPauseForScreenShots)
+            if (!IsPauseForScreenShots || IsAutoScreenShotMode) // Skip manual screenshots if in auto-screenshot mode
                 OkDialog(loginDialog, loginDialog.CancelButton.PerformClick);
             else
             {

--- a/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
@@ -339,36 +339,12 @@ namespace pwiz.SkylineTestTutorial
             );
             PauseForScreenShot<ManageViewsForm>("Manage Reports form", 20);
             OkDialog(manageViewsForm, manageViewsForm.Close);
-            Size originalSize = Size.Empty;
-            Point formLocation = Point.Empty;
+            var formRectNext = Rectangle.Empty;
             if (IsPauseForScreenShots)
             {
-                // CONSIDER: The ShowDropDown() use below causes User+GDI handle leaks
-                RunUI(() =>
-                {
-                    documentGridForm.NavBar.ReportsButton.ShowDropDown();   //we need to expand it to determine its full size
-                    int ddHeight = documentGridForm.NavBar.ReportsButton.DropDown.Height;
-                    formLocation = new Point(SkylineWindow.DesktopBounds.Left + 200, SkylineWindow.DesktopBounds.Top + 200);
-                    documentGridForm.NavBar.ReportsButton.HideDropDown();
-                    originalSize = documentGridForm.Size;
-                    //make sure the dropdown fits into the window with some margin.
-                    documentGridForm.FloatingPane.FloatAt(new Rectangle(formLocation, new Size(documentGridForm.Width, ddHeight + 75)));
-                    documentGridForm.NavBar.ReportsButton.ShowDropDown();
-
-                    var i = 0;      //find and select the Summary Statistics item.
-                    var items = documentGridForm.NavBar.ReportsButton.DropDown.Items;
-                    while (i < items.Count && items[i].Text != "Summary Statistics")
-                    {
-                        i++;
-                    }
-                    if (i < items.Count)
-                        items[i].Select();
-                    else
-                    {
-                        Assert.Fail("Summary Statistics not found in Reports menu");
-                    }
-                });
-                PauseForScreenShot<DocumentGridForm>("Click the Reports dropdown and highlight 'Summary_stats'", 21);
+                formRectNext = ShowReportsDropdown("Summary Statistics");
+                PauseForScreenShot<DocumentGridForm>("Click the Reports dropdown and highlight 'Summary Statistics'", 21);
+                HideReportsDropdown();
 
                 RunUI(() => documentGridForm.NavBar.ReportsButton.HideDropDown());
             }
@@ -376,14 +352,13 @@ namespace pwiz.SkylineTestTutorial
             WaitForConditionUI(() => documentGridForm.IsComplete);
             RunUI(() => documentGridForm.ExpandColumns());
             
-            if (IsPauseForScreenShots)
-                RunUI(() =>
-                {
-                    documentGridForm.FloatingPane.FloatAt(new Rectangle(formLocation, originalSize));
-                    // nudge data grid to resize columns, especially forcing column 0's header to wrap into 2 lines of text
-                    documentGridForm.DataGridView.Columns[0].Width = 45;
-                    documentGridForm.DataGridView.AutoResizeColumns();
-                });
+            RunUIForScreenShot(() =>
+            {
+                documentGridForm.FloatingPane.FloatAt(formRectNext);
+                // nudge data grid to resize columns, especially forcing column 0's header to wrap into 2 lines of text
+                documentGridForm.DataGridView.Columns[0].Width = 45;
+                documentGridForm.DataGridView.AutoResizeColumns();
+            });
 
             PauseForScreenShot<DocumentGridForm>("Document Grid with summary statistics", 21, processShot: (bmp) =>
             {

--- a/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
@@ -444,8 +444,8 @@ namespace pwiz.SkylineTestTutorial
 
                     menuStrip = peakAreasControl.ContextMenuStrip;
                     subMenuStrip = showDotProductItem.DropDown;
-                    menuStrip.Closing += DenyMenuClose;
-                    subMenuStrip.Closing += DenyMenuClose;
+                    menuStrip.Closing += DenyMenuClosing;
+                    subMenuStrip.Closing += DenyMenuClosing;
                 });
 
                 PauseForScreenShot<ScreenForm>("Peak Areas view (show context menu)", tutorialPage++, null,
@@ -455,8 +455,8 @@ namespace pwiz.SkylineTestTutorial
 
                 RunUI(() =>
                 {
-                    menuStrip.Closing -= DenyMenuClose;
-                    subMenuStrip.Closing -= DenyMenuClose;
+                    menuStrip.Closing -= DenyMenuClosing;
+                    subMenuStrip.Closing -= DenyMenuClosing;
                     menuStrip.Close();
                 });
             }
@@ -771,11 +771,6 @@ namespace pwiz.SkylineTestTutorial
 
             RunUI(() => SkylineWindow.SaveDocument());
             RunUI(SkylineWindow.NewDocument);
-        }
-
-        private void DenyMenuClose(object sender, ToolStripDropDownClosingEventArgs e)
-        {
-            e.Cancel = true;
         }
 
         private int GetTotalPointCount(GraphPane msGraphPane)

--- a/pwiz_tools/Skyline/TestTutorial/TestTutorial.csproj
+++ b/pwiz_tools/Skyline/TestTutorial/TestTutorial.csproj
@@ -212,22 +212,15 @@
     <None Include="AbsoluteQuantViews.zip" />
     <None Include="AuditLogViews.zip" />
     <None Include="CEOptimizationViews.zip" />
-    <None Include="CustomReportsViews.zip" />
     <None Include="DiaViews.zip" />
-    <None Include="ExistingExperimentsViews.zip" />
-    <None Include="GroupedStudies1Views.zip" />
     <None Include="IrtViews.zip" />
     <None Include="LibraryExplorerViews.zip" />
     <None Include="MethodEditCSVs.zip" />
-    <None Include="MethodEditViews.zip" />
-    <None Include="MethodRefinementViews.zip" />
-    <None Include="Ms1FullScanFilteringViews.zip" />
     <None Include="PeakPickingViews.zip" />
     <None Include="SmallMolMethodDevCEOptViews.zip" />
     <None Include="SmallMoleculesQuantificationViews.zip" />
     <None Include="SmallMoleculeViews.zip" />
     <None Include="SRMViews.zip" />
-    <None Include="TargetedMSMSViews.zip" />
     <None Include="GroupedStudiesViews.zip" />
   </ItemGroup>
   <ItemGroup>

--- a/pwiz_tools/Skyline/TestUtil/ScreenshotPreviewForm.cs
+++ b/pwiz_tools/Skyline/TestUtil/ScreenshotPreviewForm.cs
@@ -572,7 +572,7 @@ namespace pwiz.SkylineTestUtil
             var control = values.Control;
             try
             {
-                ScreenshotManager.ActivateScreenshotForm(control);
+                _screenshotManager.ActivateScreenshotForm(control);
                 return _screenshotManager.TakeShot(control, values.FullScreen, null, values.ProcessShot);
             }
             catch (Exception e)


### PR DESCRIPTION
- Moved ScreenshotManager instantiation to where SkylineWindow is not null
- Added support for showing Undo and Redo dropdowns
- Improved and centralized support for showing Reports dropdown
- Removed left over ZIP files from .csproj files
- Improved and centralized code to keep screenshot forms on screen