### PR TITLE
Mobilion reader uses HDF5 library, which isn't thread safe. Put a processwide lock in the ctor to ensure only one thread is in use at a time

### DIFF
--- a/pwiz/data/vendor_readers/Mobilion/ChromatogramList_Mobilion.cpp
+++ b/pwiz/data/vendor_readers/Mobilion/ChromatogramList_Mobilion.cpp
@@ -98,7 +98,6 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Mobilion::chromatogram(size_t ind
     if (!result.get())
         throw std::runtime_error("[ChromatogramList_Mobilion::chromatogram()] Allocation error.");
 
-    boost::lock_guard<boost::mutex> lock(processWideHdf5Mutex);  // lock_guard will unlock mutex when out of scope or when exception thrown (during destruction)
     result->index = index;
     result->id = ie.id;
     result->set(ie.chromatogramType);

--- a/pwiz/data/vendor_readers/Mobilion/Reader_Mobilion.cpp
+++ b/pwiz/data/vendor_readers/Mobilion/Reader_Mobilion.cpp
@@ -183,8 +183,6 @@ void Reader_Mobilion::read(const string& filename,
         throw ReaderFail(string("[Reader_Mobilion::read()] Mobilion API does not support Unicode in filepaths ('") + utf8CharAsString(unicodeCharItr, filename.end()) + "')");
     }
 
-    boost::lock_guard<boost::mutex> lock(processWideHdf5Mutex); // mutex unlocks when out of scope or when exception thrown (during destruction)
-
     MBIFilePtr rawdata(new MBIFileWrapper(filename.c_str()));
     result.run.spectrumListPtr = SpectrumListPtr(new SpectrumList_Mobilion(result, rawdata, config));
     result.run.chromatogramListPtr = ChromatogramListPtr(new ChromatogramList_Mobilion(rawdata, config));

--- a/pwiz/data/vendor_readers/Mobilion/Reader_Mobilion_Detail.hpp
+++ b/pwiz/data/vendor_readers/Mobilion/Reader_Mobilion_Detail.hpp
@@ -36,18 +36,23 @@ namespace pwiz {
 namespace msdata {
 namespace detail {
 namespace Mobilion {
+
+extern boost::mutex processWideHdf5Mutex; // HDF5 library isn't thread-safe: allow just one at a time
+
 PWIZ_API_DECL class MBIFileWrapper
 {
     public:
     MBIFileWrapper(const std::string& filepath)
     : file(filepath.c_str())
     {
+        processWideHdf5Mutex.lock(); // HDF5 library isn't thread-safe: allow just one at a time
         file.Init();
     }
 
     ~MBIFileWrapper()
     {
         file.Close();
+        processWideHdf5Mutex.unlock(); // HDF5 library isn't thread-safe: allow just one at a time
     }
 
     MBIFile file;
@@ -65,7 +70,6 @@ PWIZ_API_DECL CVID translatePolarity(const std::string& polarity);
 PWIZ_API_DECL CVID translateAsInletType(IonizationType ionizationType);
 PWIZ_API_DECL CVID translate(ActivationType activationType);*/
 
-extern boost::mutex processWideHdf5Mutex; // HDF5 library isn't thread-safe
 } // Mobilion
 
 using namespace Mobilion;

--- a/pwiz/data/vendor_readers/Mobilion/SpectrumList_Mobilion.cpp
+++ b/pwiz/data/vendor_readers/Mobilion/SpectrumList_Mobilion.cpp
@@ -76,7 +76,6 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Mobilion::spectrum(size_t index, bool get
 
 PWIZ_API_DECL SpectrumPtr SpectrumList_Mobilion::spectrum(size_t index, DetailLevel detailLevel) const
 {
-    boost::lock_guard<boost::mutex> lock(processWideHdf5Mutex);  // lock_guard will unlock mutex when out of scope or when exception thrown (during destruction)
     if (index >= size_)
         throw runtime_error("[SpectrumList_Mobilion::spectrum()] Bad index: "
                             + lexical_cast<string>(index));


### PR DESCRIPTION
Looks a bit funny when parallel processing multiple .mbi files in Skyline and MSConvertGUI, as only one proceeds at a time, but it does complete