### PR TITLE
Skyline: Cleanup persistent folder before and after test runs

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -1959,6 +1959,7 @@ namespace SkylineTester
             else
             {
                 coverageCheckbox.Enabled = true;
+                runMode.SelectedItem = "Test";  // Only Test mode supported in parallel testing
             }
         }
 
@@ -1979,6 +1980,7 @@ namespace SkylineTester
         {
             // Adjust settings to match the mode
             var runModeTest = RunTestMode.SelectedItem.ToString();
+            bool offScreenEnabled = true;
             if (!Equals(runModeTest, "Test"))
             {
                 runSerial.Checked = true;
@@ -1992,9 +1994,10 @@ namespace SkylineTester
                     runLoops.Checked = true;
                     runLoopsCount.Text = 1.ToString();
                     Offscreen.Checked = false;  // Can't do screenshots offscreen
-                    Offscreen.Enabled = false;
+                    offScreenEnabled = false;
                 }
             }
+            Offscreen.Enabled = offScreenEnabled;
         }
 
         #endregion Control events

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -1991,6 +1991,8 @@ namespace SkylineTester
                 {
                     runLoops.Checked = true;
                     runLoopsCount.Text = 1.ToString();
+                    Offscreen.Checked = false;  // Can't do screenshots offscreen
+                    Offscreen.Enabled = false;
                 }
             }
         }

--- a/pwiz_tools/Skyline/Test/ErrorIfPersistentFilesDirModifiedTest.cs
+++ b/pwiz_tools/Skyline/Test/ErrorIfPersistentFilesDirModifiedTest.cs
@@ -32,6 +32,7 @@ namespace pwiz.SkylineTest
             TestFilesZip = "https://skyline.ms/tutorials/OptimizeCEMzml.zip";
             TestFilesPersistent = new[] { "CE_Vantage" };
             TestFilesDir = new TestFilesDir(TestContext, TestFilesZip, TestContext.TestName, TestFilesPersistent);
+            TestFilesDir.RecordMetrics();
             string persistentFile = TestFilesDir.GetTestPath("OptimizeCEMzml/CE_Vantage_15mTorr_0001.mzML");
             string persistentFileCopy = persistentFile + ".copy";
             try

--- a/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
@@ -407,7 +407,10 @@ namespace TestPerf
             }
 
             RunUI(() => SkylineWindow.SaveDocument());
+        }
 
+        protected override void CleanupPersistentDir()
+        {
             DirectoryEx.SafeDelete(Path.Combine(Path.GetDirectoryName(SearchFiles.First())!, "converted"));
             foreach (var searchFile in SearchFiles)
             {

--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
@@ -256,7 +256,20 @@ namespace pwiz.SkylineTestUtil
                     TestFilesDirs[i] = new TestFilesDir(TestContext, TestFilesZipPaths[i], TestDirectoryName,
                         TestFilesPersistent, IsExtractHere(i));
                 }
+                CleanupPersistentDir(); // Clean up before recording metrics
+                foreach (var dir in TestFilesDirs)
+                {
+                    dir.RecordMetrics();
+                }
             }
+        }
+
+        /// <summary>
+        /// Override this function with any specific file deletions that need to
+        /// happen to avoid leaving files in the PersistentFilesDir.
+        /// </summary>
+        protected virtual void CleanupPersistentDir()
+        {
         }
 
         private static string DownloadZipFile(string targetFolder, string zipPath, string zipFilePath)
@@ -454,6 +467,8 @@ namespace pwiz.SkylineTestUtil
             // mask the original error.
             if (TestFilesDirs != null && TestContext.CurrentTestOutcome == UnitTestOutcome.Passed)
             {
+                CleanupPersistentDir();
+
                 foreach (var dir in TestFilesDirs.Where(d => d != null))
                 {
                     dir.Cleanup();

--- a/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFilesDir.cs
@@ -82,8 +82,8 @@ namespace pwiz.SkylineTestUtil
             string zipBaseName = Path.GetFileNameWithoutExtension(relativePathZip);
             if (zipBaseName == null)
                 Assert.Fail("Null zip base name");  // Resharper
-            directoryName = GetExtractDir(directoryName, zipBaseName, false);   // Only persistent files can be extract here
-            FullPath = TestContext.GetTestPath(directoryName);
+            DirectoryName = GetExtractDir(directoryName, zipBaseName, false);   // Only persistent files can be extract here
+            FullPath = TestContext.GetTestPath(DirectoryName);
             if (Directory.Exists(FullPath))
             {
                 Helpers.TryTwice(() => Directory.Delete(FullPath, true));
@@ -95,9 +95,12 @@ namespace pwiz.SkylineTestUtil
                 PersistentFilesDir = GetExtractDir(Path.GetDirectoryName(relativePathZip), zipBaseName, isExtractHere);
 
             TestContext.ExtractTestFiles(relativePathZip, FullPath, PersistentFiles, PersistentFilesDir);
+        }
 
+        public void RecordMetrics()
+        {
             // record the size of the persistent directory after extracting
-            var targetDir = isExtractHere ? Path.Combine(PersistentFilesDir ?? "", directoryName) : PersistentFilesDir;
+            var targetDir = IsExtractHere ? Path.Combine(PersistentFilesDir ?? string.Empty, DirectoryName) : PersistentFilesDir;
             var persistentDirInfo = string.IsNullOrEmpty(PersistentFilesDir) ? null : new DirectoryInfo(targetDir);
             if (persistentDirInfo != null && Directory.Exists(PersistentFilesDir))
             {
@@ -118,6 +121,7 @@ namespace pwiz.SkylineTestUtil
             return directoryName;
         }
 
+        public string DirectoryName { get; private set; }
         public string FullPath { get; private set; }
 
         public string PersistentFilesDir { get; private set; }

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2011,73 +2011,74 @@ namespace pwiz.SkylineTestUtil
                 return; // Don't want to run this lengthy test right now
             }
 
-            bool firstTry = true;
-            // Be prepared to re-run test in the event that a previously downloaded data file is damaged or stale
-            for (;;)
+            RunFunctionalTestAttempt(defaultUiMode);
+
+            if (Program.TestExceptions.Count > 0 && RetryDataDownloads)
             {
                 try
                 {
-                    RunFunctionalTestOrThrow(defaultUiMode);
+                    if (FreshenTestDataDownloads())
+                    {
+                        // Clear exceptions and run tests again with the fresh downloads
+                        Program.TestExceptions.Clear();
+
+                        RunFunctionalTestAttempt(defaultUiMode);
+                    }
                 }
                 catch (Exception x)
                 {
-                    Program.AddTestException(x);
+                    Program.AddTestException(x); // Some trouble with data download, make a note of it
                 }
+            }
 
-                Settings.Default.SrmSettingsList[0] = SrmSettingsList.GetDefault(); // Release memory held in settings
-
-                // Delete unzipped test files.
-                if (TestFilesDirs != null)
-                {
-                    foreach (TestFilesDir dir in TestFilesDirs)
-                    {
-                        try
-                        {
-                            dir?.Cleanup();
-                        }
-                        catch (Exception x)
-                        {
-                            Program.AddTestException(x);
-                            FileStreamManager.Default.CloseAllStreams();
-                        }
-                    }
-                }
-
-                if (firstTry && Program.TestExceptions.Count > 0 && RetryDataDownloads)
-                {
-                    try
-                    {
-                        if (FreshenTestDataDownloads())
-                        {
-                            firstTry = false;
-                            Program.TestExceptions.Clear();
-                            continue;
-                        }
-                    }
-                    catch (Exception xx)
-                    {
-                        Program.AddTestException(xx); // Some trouble with data download, make a note of it
-                    }
-                }
-
-
-                if (Program.TestExceptions.Count > 0)
-                {
-                    //Log<AbstractFunctionalTest>.Exception(@"Functional test exception", Program.TestExceptions[0]);
-                    const string errorSeparator = "------------------------------------------------------";
-                    Assert.Fail("{0}{1}{2}{3}",
-                        Environment.NewLine + Environment.NewLine,
-                        errorSeparator + Environment.NewLine,
-                        Program.TestExceptions[0],
-                        Environment.NewLine + errorSeparator + Environment.NewLine);
-                }
-                break;
+            if (Program.TestExceptions.Count > 0)
+            {
+                //Log<AbstractFunctionalTest>.Exception(@"Functional test exception", Program.TestExceptions[0]);
+                const string errorSeparator = "------------------------------------------------------";
+                Assert.Fail("{0}{1}{2}{3}",
+                    Environment.NewLine + Environment.NewLine,
+                    errorSeparator + Environment.NewLine,
+                    Program.TestExceptions[0],
+                    Environment.NewLine + errorSeparator + Environment.NewLine);
             }
 
             if (!_testCompleted)
             {
                 //Log<AbstractFunctionalTest>.Fail(@"Functional test did not complete");
                 Assert.Fail("Functional test did not complete");
+            }
+        }
+
+        private void RunFunctionalTestAttempt(string defaultUiMode)
+        {
+            try
+            {
+                RunFunctionalTestOrThrow(defaultUiMode);
+            }
+            catch (Exception x)
+            {
+                Program.AddTestException(x);
+            }
+
+            Settings.Default.SrmSettingsList[0] = SrmSettingsList.GetDefault(); // Release memory held in settings
+
+            // Delete unzipped test files.
+            if (TestFilesDirs != null)
+            {
+                CleanupPersistentDir(); // Clean before checking for modifications
+
+                foreach (var dir in TestFilesDirs.Where(d => d != null))
+                {
+                    try
+                    {
+                        dir.Cleanup();
+                    }
+                    catch (Exception x)
+                    {
+                        Program.AddTestException(x);
+                        FileStreamManager.Default.CloseAllStreams();
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
- Helps avoid the case where a prior failure causes an echo failure in the next run because cleanup deletes left over files in the persistent folder