### PR TITLE
Fix code inspection

### DIFF
--- a/pwiz_tools/Skyline/TestConnected/ArdiaFunctionalTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/ArdiaFunctionalTest.cs
@@ -27,7 +27,6 @@ using pwiz.Skyline.FileUI;
 using pwiz.Skyline.Model.ElementLocators;
 using pwiz.Skyline.Model.Results.RemoteApi;
 using pwiz.Skyline.Model.Results.RemoteApi.Ardia;
-using pwiz.Skyline.Properties;
 using pwiz.Skyline.ToolsUI;
 using pwiz.SkylineTestUtil;
 

--- a/scripts/misc/vcs_trigger_and_paths_config.py
+++ b/scripts/misc/vcs_trigger_and_paths_config.py
@@ -50,8 +50,8 @@ targets['SkylineWithTestConnected'] = \
 {
     'master':
     {
-        "ProteoWizard_SkylineMasterAndPRsTestConnectedTests": "Skyline master and PRs TestConnected tests" # depends on "bt209",
-        ,"ProteoWizard_WindowsX8664msvcProfessionalSkylineResharperChecks": "Skyline code inspection" # depends on "bt209",
+        "ProteoWizard_SkylineMasterAndPRsTestConnectedTests": "Skyline code inspection" # depends on "bt209",
+        ,"ProteoWizard_WindowsX8664msvcProfessionalSkylineResharperChecks": "Skyline master and PRs TestConnected tests" # depends on "bt209",
         ,"bt209": "Skyline master and PRs (Windows x86_64)"
     },
     'release':

--- a/scripts/misc/vcs_trigger_and_paths_config.py
+++ b/scripts/misc/vcs_trigger_and_paths_config.py
@@ -50,8 +50,8 @@ targets['SkylineWithTestConnected'] = \
 {
     'master':
     {
-        "ProteoWizard_SkylineMasterAndPRsTestConnectedTests": "Skyline code inspection" # depends on "bt209",
-        ,"ProteoWizard_WindowsX8664msvcProfessionalSkylineResharperChecks": "Skyline master and PRs TestConnected tests" # depends on "bt209",
+        "ProteoWizard_SkylineMasterAndPRsTestConnectedTests": "Skyline master and PRs TestConnected tests" # depends on "bt209",
+        ,"ProteoWizard_WindowsX8664msvcProfessionalSkylineResharperChecks": "Skyline code inspection" # depends on "bt209",
         ,"bt209": "Skyline master and PRs (Windows x86_64)"
     },
     'release':


### PR DESCRIPTION
* fixed code inspection (build failure from my last PR was hidden because the new TestConnected config had the wrong status report string copied from the code inspection config)