### PR TITLE
- added isolation width to Shimadzu spectra, if present

### DIFF
--- a/pwiz/data/vendor_readers/Shimadzu/SpectrumList_Shimadzu.cpp
+++ b/pwiz/data/vendor_readers/Shimadzu/SpectrumList_Shimadzu.cpp
@@ -176,16 +176,17 @@ PWIZ_API_DECL SpectrumPtr SpectrumList_Shimadzu::spectrum(size_t index, DetailLe
             spectrum->getPrecursorInfo(selectedMz, intensity, charge);
 
             Precursor precursor;
-            /*if (spectrum->getHasIsolationInfo())
+            if (spectrum->getHasIsolationInfo())
             {
                 double centerMz, lowerLimit, upperLimit;
                 spectrum->getIsolationInfo(centerMz, lowerLimit, upperLimit);
                 precursor.isolationWindow.set(MS_isolation_window_target_m_z, centerMz, MS_m_z);
-                precursor.isolationWindow.set(MS_isolation_window_lower_offset, centerMz - lowerLimit, MS_m_z);
-                precursor.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit - centerMz, MS_m_z);
-				selectedMz = centerMz;
-            }*/
-            precursor.isolationWindow.set(MS_isolation_window_target_m_z, selectedMz, MS_m_z);
+                precursor.isolationWindow.set(MS_isolation_window_lower_offset, lowerLimit, MS_m_z);
+                precursor.isolationWindow.set(MS_isolation_window_upper_offset, upperLimit, MS_m_z);
+                selectedMz = centerMz;
+            }
+            else
+                precursor.isolationWindow.set(MS_isolation_window_target_m_z, selectedMz, MS_m_z);
 
             SelectedIon selectedIon;
 

--- a/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Shimadzu/ShimadzuReader.cpp
@@ -119,7 +119,10 @@ public:
             precursorCharge_ = precursorInfo->second;
         }
         else
-            precursorMz_ = (double) spectrum_->AcqModeMz * MASS_MULTIPLIER;
+            precursorMz_ = (double)spectrum_->AcqModeMz * MASS_MULTIPLIER;
+
+        if (((ShimadzuGeneric::Param::MS::MassEventInfo^) eventInfo_) != nullptr)
+            qTransmissionMzWidth_ = (double)eventInfo_->QTransmissionMzWidthNmzManual * PRECURSOR_MZ_MULTIPLIER / 2;
     }
 
     virtual double getScanTime() const { return spectrum_->RetentionTime; }
@@ -132,8 +135,16 @@ public:
     virtual double getMinX() const { return ((ShimadzuGeneric::Param::MS::MassEventInfo^) eventInfo_) == nullptr ? 0 : (double) eventInfo_->StartMz * MASS_MULTIPLIER; }
     virtual double getMaxX() const { return ((ShimadzuGeneric::Param::MS::MassEventInfo^) eventInfo_) == nullptr ? 0 : (double) eventInfo_->EndMz * MASS_MULTIPLIER; }
 
-    virtual bool getHasIsolationInfo() const { return false; }
-    virtual void getIsolationInfo(double& centerMz, double& lowerLimit, double& upperLimit) const { }
+    virtual bool getHasIsolationInfo() const { return qTransmissionMzWidth_ > 0; }
+    virtual void getIsolationInfo(double& centerMz, double& lowerLimit, double& upperLimit) const
+    {
+        if (!getHasIsolationInfo())
+            return;
+
+        centerMz = precursorMz_;
+        lowerLimit = qTransmissionMzWidth_;
+        upperLimit = qTransmissionMzWidth_;
+    }
 
     virtual bool getHasPrecursorInfo() const { return precursorMz_ > 0; }
     virtual void getPrecursorInfo(double& selectedMz, double& intensity, int& charge) const
@@ -184,6 +195,7 @@ public:
     gcroot<ShimadzuGeneric::Param::MS::MassEventInfo^> eventInfo_;
     double precursorMz_;
     int precursorCharge_;
+    double qTransmissionMzWidth_;
 };
 
 


### PR DESCRIPTION
- added isolation width to Shimadzu spectra, if present; current Reader_Shimadzu_Test files do not have it, but I have manually tested on DIA files that do