### PR TITLE
Tweaks to deal with new warnings from latest ReSharper.

### DIFF
--- a/pwiz_tools/Shared/Common/DataAnalysis/Matrices/QrFactorizationCache.cs
+++ b/pwiz_tools/Shared/Common/DataAnalysis/Matrices/QrFactorizationCache.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.LinearAlgebra.Double;
 
@@ -42,7 +43,7 @@ namespace pwiz.Common.DataAnalysis.Matrices
 
 
 
-        public struct Key
+        public struct Key : IEquatable<Key>
         {
             public Key(Matrix<double> matrix, double tolerance) : this()
             {
@@ -52,6 +53,25 @@ namespace pwiz.Common.DataAnalysis.Matrices
 
             public ImmutableMatrix Matrix { get; private set; }
             public double Tolerance { get; private set; }
+
+            public bool Equals(Key other)
+            {
+                return Equals(Matrix, other.Matrix) && Tolerance.Equals(other.Tolerance);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is Key other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((Matrix != null ? Matrix.GetHashCode() : 0) * 397) ^ Tolerance.GetHashCode();
+                }
+            }
+
         }
 
         public class CacheEntry

--- a/pwiz_tools/Shared/Common/DataAnalysis/PValues.cs
+++ b/pwiz_tools/Shared/Common/DataAnalysis/PValues.cs
@@ -33,14 +33,12 @@ namespace pwiz.Common.DataAnalysis
         {
             var entries = pValues.Select((pValue, index) => new Tuple<double, int>(pValue, index)).ToArray();
             Array.Sort(entries);
-            double[] cumulativeMins = new double[entries.Length];
             double currentMin = 1.0;
             var result = new double[entries.Length];
             for (int i = entries.Length - 1; i >= 0; i--)
             {
                 double value = entries[i].Item1*entries.Length/(i + 1);
                 currentMin = Math.Min(value, currentMin);
-                cumulativeMins[i] = currentMin;
                 result[entries[i].Item2] = currentMin;
             }
             return result;

--- a/pwiz_tools/Shared/Common/DataBinding/ViewGroup.cs
+++ b/pwiz_tools/Shared/Common/DataBinding/ViewGroup.cs
@@ -4,8 +4,9 @@ using pwiz.Common.SystemUtil;
 
 namespace pwiz.Common.DataBinding
 {
-    public struct ViewGroupId
+    public struct ViewGroupId : IEquatable<ViewGroupId>
     {
+
         private readonly string _name;
         public ViewGroupId(string name) : this()
         {
@@ -20,6 +21,21 @@ namespace pwiz.Common.DataBinding
         public ViewName ViewName(string viewName)
         {
             return new ViewName(this, viewName);
+        }
+
+        public bool Equals(ViewGroupId other)
+        {
+            return _name == other._name;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ViewGroupId other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return (_name != null ? _name.GetHashCode() : 0);
         }
     }
 
@@ -40,7 +56,7 @@ namespace pwiz.Common.DataBinding
         }
     }
 
-    public struct ViewName
+    public struct ViewName : IEquatable<ViewName>
     {
         public ViewName(ViewGroupId groupId, string name) : this()
         {
@@ -67,6 +83,24 @@ namespace pwiz.Common.DataBinding
                 return new ViewName(new ViewGroupId(str), null);
             }
             return new ViewName(new ViewGroupId(str.Substring(0, ichDot)), str.Substring(ichDot + 1));
+        }
+
+        public bool Equals(ViewName other)
+        {
+            return GroupId.Equals(other.GroupId) && Name == other.Name;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ViewName other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (GroupId.GetHashCode() * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+            }
         }
     }
 }

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
@@ -548,9 +548,7 @@ public class WebDavBrowser : PanoramaFolderBrowser
                     var files = json[@"files"];
                     foreach (var file in files)
                     {
-                        var listItem = new string[5];
                         var fileName = (string)file[@"text"];
-                        listItem[0] = fileName;
                         var isFile = (bool)file[@"leaf"];
                         if (!isFile)
                         {

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -5080,6 +5080,7 @@ namespace pwiz.Skyline
         {
             // Show progress at least every 2 seconds and at 100%, if any other percentage
             // output has been shown.
+            // ReSharper disable once InconsistentlySynchronizedField
             return (currentTime - _lastOutput).TotalSeconds < SecondsBetweenStatusUpdates && !status.IsError &&
                    (status.PercentComplete != 100 || _lastOutput == _waitStart);
         }

--- a/pwiz_tools/Skyline/Controls/Graphs/AlignmentForm.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AlignmentForm.cs
@@ -337,7 +337,7 @@ namespace pwiz.Skyline.Controls.Graphs
             return dataRows;
         }
 
-        internal struct DataRow
+        internal struct DataRow : IEquatable<DataRow>
         {
             public DataRow(SrmSettings settings, RetentionTimeSource target, RetentionTimeSource timesToAlign) : this()
             {
@@ -492,9 +492,36 @@ namespace pwiz.Skyline.Controls.Graphs
                 }
                 return libraryRetentionTimes.GetFirstRetentionTimes();
             }
+
+            public bool Equals(DataRow other)
+            {
+                return Equals(DocumentRetentionTimes, other.DocumentRetentionTimes) && Equals(Target, other.Target) &&
+                       Equals(Source, other.Source) && Equals(Alignment, other.Alignment) && Equals(TargetTimes, other.TargetTimes) &&
+                       Equals(SourceTimes, other.SourceTimes) && Equals(AlignedRetentionTimes, other.AlignedRetentionTimes);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is DataRow other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (DocumentRetentionTimes != null ? DocumentRetentionTimes.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Target != null ? Target.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Source != null ? Source.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Alignment != null ? Alignment.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (TargetTimes != null ? TargetTimes.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (SourceTimes != null ? SourceTimes.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (AlignedRetentionTimes != null ? AlignedRetentionTimes.GetHashCode() : 0);
+                    return hashCode;
+                }
+            }
         }
 
-        internal struct DataFileKey
+        internal struct DataFileKey : IEquatable<DataFileKey>
         {
             public DataFileKey(RetentionTimeSource retentionTimeSource) : this()
             {
@@ -505,6 +532,21 @@ namespace pwiz.Skyline.Controls.Graphs
             public override string ToString()
             {
                 return RetentionTimeSource.Name;
+            }
+
+            public bool Equals(DataFileKey other)
+            {
+                return Equals(RetentionTimeSource, other.RetentionTimeSource);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is DataFileKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return (RetentionTimeSource != null ? RetentionTimeSource.GetHashCode() : 0);
             }
         }
 

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -3830,7 +3830,7 @@ namespace pwiz.Skyline.Controls.Graphs
         public ZoomState ZoomState { get; private set; }
     }
 
-    public struct ScaledRetentionTime
+    public struct ScaledRetentionTime : IEquatable<ScaledRetentionTime>
     {
         public static readonly ScaledRetentionTime ZERO = default(ScaledRetentionTime);
         public ScaledRetentionTime(double measuredTime) : this(measuredTime, measuredTime)
@@ -3854,6 +3854,24 @@ namespace pwiz.Skyline.Controls.Graphs
                 return MeasuredTime.ToString(CultureInfo.InvariantCulture);
             }
             return string.Format(@"{0} ({1})", MeasuredTime, DisplayTime);
+        }
+
+        public bool Equals(ScaledRetentionTime other)
+        {
+            return MeasuredTime.Equals(other.MeasuredTime) && DisplayTime.Equals(other.DisplayTime);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ScaledRetentionTime other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (MeasuredTime.GetHashCode() * 397) ^ DisplayTime.GetHashCode();
+            }
         }
     }
 

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphHelper.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphHelper.cs
@@ -642,7 +642,7 @@ namespace pwiz.Skyline.Controls.Graphs
         }
     }
 
-    public struct PaneKey : IComparable
+    public struct PaneKey : IComparable, IEquatable<PaneKey>
     {
         public static readonly PaneKey PRECURSORS = new PaneKey(Adduct.EMPTY, null, false);
         public static readonly PaneKey PRODUCTS = new PaneKey(Adduct.EMPTY, null, true);
@@ -702,6 +702,29 @@ namespace pwiz.Skyline.Controls.Graphs
                 return false;
             }
             return true;
+        }
+
+        public bool Equals(PaneKey other)
+        {
+            return Equals(PrecursorAdduct, other.PrecursorAdduct) && Equals(IsotopeLabelType, other.IsotopeLabelType) &&
+                   Nullable.Equals(SpectrumClassFilter, other.SpectrumClassFilter) && IsProducts == other.IsProducts;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PaneKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (PrecursorAdduct != null ? PrecursorAdduct.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (IsotopeLabelType != null ? IsotopeLabelType.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ SpectrumClassFilter.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsProducts.GetHashCode();
+                return hashCode;
+            }
         }
     }    
 }

--- a/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.cs
@@ -756,18 +756,16 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
             var backup = GroupComparisonDef.ColorRows.Select(r => r.Clone()).ToArray();
             using var form = new VolcanoPlotFormattingDlg(this, GroupComparisonDef.ColorRows, foldChangeRows, UpdateColorRows);
+            if (form.ShowDialog(FormEx.GetParentForm(this)) == DialogResult.OK)
             {
-                if (form.ShowDialog(FormEx.GetParentForm(this)) == DialogResult.OK)
-                {
-                    EditGroupComparisonDlg.ChangeGroupComparisonDef(true, GroupComparisonModel, GroupComparisonDef);
-                }
-                else
-                {
-                    EditGroupComparisonDlg.ChangeGroupComparisonDef(false, GroupComparisonModel, GroupComparisonDef.ChangeColorRows(backup));
-                }
+                EditGroupComparisonDlg.ChangeGroupComparisonDef(true, GroupComparisonModel, GroupComparisonDef);
+            }
+            else
+            {
+                EditGroupComparisonDlg.ChangeGroupComparisonDef(false, GroupComparisonModel, GroupComparisonDef.ChangeColorRows(backup));
+            }
 
-                UpdateGraph();
-            }     
+            UpdateGraph();
         }
 
         private void UpdateColorRows(IEnumerable<MatchRgbHexColor> colorRows)

--- a/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportTransitionListColumnSelectDlg.cs
@@ -73,7 +73,7 @@ namespace pwiz.Skyline.FileUI
         // Stores the position of proteins for _proteinTip
         private List<Protein> _proteinList;
 
-        public struct HeaderDocType
+        public struct HeaderDocType : IEquatable<HeaderDocType>
         {
             public HeaderDocType(string name, SrmDocument.DOCUMENT_TYPE docType)
             {
@@ -83,6 +83,24 @@ namespace pwiz.Skyline.FileUI
 
             public string Name;
             public SrmDocument.DOCUMENT_TYPE DocType;
+
+            public bool Equals(HeaderDocType other)
+            {
+                return Name == other.Name && DocType == other.DocType;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is HeaderDocType other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ (int)DocType;
+                }
+            }
         }
 
         // This list stores headers in the order we want to present them to the user along with an identifier denoting which mode they are associated with

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/MatchModificationsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/MatchModificationsControl.cs
@@ -34,7 +34,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
     {
         public enum ModType { structural, heavy };
 
-        public struct ListBoxModification
+        public struct ListBoxModification : IEquatable<ListBoxModification>
         {
             public StaticMod Mod { get; private set; }
             public ModType? ModificationType { get; private set; }
@@ -64,6 +64,24 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                         sb.Append(PeptideSearchResources.ListBoxModification_ToString__fixed_);
                 }
                 return string.Format(Resources.AbstractModificationMatcherFoundMatches__0__equals__1__, Mod.Name, sb);
+            }
+
+            public bool Equals(ListBoxModification other)
+            {
+                return Equals(Mod, other.Mod) && ModificationType == other.ModificationType;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is ListBoxModification other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((Mod != null ? Mod.GetHashCode() : 0) * 397) ^ ModificationType.GetHashCode();
+                }
             }
         }
 

--- a/pwiz_tools/Skyline/Menus/ViewMenu.cs
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.cs
@@ -555,15 +555,9 @@ namespace pwiz.Skyline.Menus
                 if (qcTraceNames.Count > 0)
                 {
                     var qcTraceItems = new ToolStripItem[qcTraceNames.Count];
-                    var qcContextTraceItems = new ToolStripItem[qcTraceNames.Count];
                     for (int i = 0; i < qcTraceNames.Count; i++)
                     {
                         qcTraceItems[i] = new ToolStripMenuItem(qcTraceNames[i], null, qcMenuItem_Click)
-                        {
-                            Checked = displayType == DisplayTypeChrom.qc &&
-                                      Settings.Default.ShowQcTraceName == qcTraceNames[i]
-                        };
-                        qcContextTraceItems[i] = new ToolStripMenuItem(qcTraceNames[i], null, qcMenuItem_Click)
                         {
                             Checked = displayType == DisplayTypeChrom.qc &&
                                       Settings.Default.ShowQcTraceName == qcTraceNames[i]

--- a/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
@@ -1198,7 +1198,7 @@ namespace pwiz.Skyline.Model
             }
         }
 
-        public struct AAModKey
+        public struct AAModKey : IEquatable<AAModKey>
         {
             public char AA { get; set; }
             private ModTerminus? _terminus;
@@ -1225,6 +1225,35 @@ namespace pwiz.Skyline.Model
             }
 
             public string TerminusText => Terminus.HasValue ? @"-" + Terminus.Value : string.Empty;
+
+            public bool Equals(AAModKey other)
+            {
+                return _terminus == other._terminus && AA == other.AA && Nullable.Equals(Mass, other.Mass) && Name == other.Name &&
+                       UniModId == other.UniModId && RoundedTo == other.RoundedTo && AppearsToBeSpecificMod == other.AppearsToBeSpecificMod &&
+                       UserIndicatedHeavy == other.UserIndicatedHeavy && IsCrosslinker == other.IsCrosslinker;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is AAModKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = _terminus.GetHashCode();
+                    hashCode = (hashCode * 397) ^ AA.GetHashCode();
+                    hashCode = (hashCode * 397) ^ Mass.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ UniModId.GetHashCode();
+                    hashCode = (hashCode * 397) ^ RoundedTo;
+                    hashCode = (hashCode * 397) ^ AppearsToBeSpecificMod.GetHashCode();
+                    hashCode = (hashCode * 397) ^ UserIndicatedHeavy.GetHashCode();
+                    hashCode = (hashCode * 397) ^ IsCrosslinker.GetHashCode();
+                    return hashCode;
+                }
+            }
         }
 
         public struct AAModMatch

--- a/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkSite.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/CrosslinkSite.cs
@@ -30,7 +30,7 @@ namespace pwiz.Skyline.Model.Crosslinking
     /// Crosslink sites are identified by a 0-based peptide index and a 0-based amino
     /// acid index.
     /// </summary>
-    public struct CrosslinkSite : IComparable<CrosslinkSite>
+    public struct CrosslinkSite : IComparable<CrosslinkSite>, IEquatable<CrosslinkSite>
     {
         public CrosslinkSite(int peptideIndex, int aaIndex) : this()
         {
@@ -65,9 +65,27 @@ namespace pwiz.Skyline.Model.Crosslinking
 
             return result;
         }
+
+        public bool Equals(CrosslinkSite other)
+        {
+            return PeptideIndex == other.PeptideIndex && AaIndex == other.AaIndex;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is CrosslinkSite other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (PeptideIndex * 397) ^ AaIndex;
+            }
+        }
     }
 
-    public struct CrosslinkSites : IEnumerable<CrosslinkSite>
+    public struct CrosslinkSites : IEnumerable<CrosslinkSite>, IEquatable<CrosslinkSites>
     {
         private ImmutableList<CrosslinkSite> _sites;
 
@@ -145,6 +163,21 @@ namespace pwiz.Skyline.Model.Crosslinking
             }
 
             return stringBuilder.ToString();
+        }
+
+        public bool Equals(CrosslinkSites other)
+        {
+            return Equals(_sites, other._sites);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is CrosslinkSites other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return (_sites != null ? _sites.GetHashCode() : 0);
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/Crosslinking/IonOrdinal.cs
+++ b/pwiz_tools/Skyline/Model/Crosslinking/IonOrdinal.cs
@@ -28,7 +28,7 @@ namespace pwiz.Skyline.Model.Crosslinking
     /// This object can also represent an empty ion, which the transition fragment includes zero atoms from one
     /// of the crosslinked peptides.
     /// </summary>
-    public struct IonOrdinal : IComparable<IonOrdinal>
+    public struct IonOrdinal : IComparable<IonOrdinal>, IEquatable<IonOrdinal>
     {
         private IonType _ionType;
 
@@ -174,6 +174,24 @@ namespace pwiz.Skyline.Model.Crosslinking
             }
 
             return Ordinal.CompareTo(ionFragment.Ordinal);
+        }
+
+        public bool Equals(IonOrdinal other)
+        {
+            return _ionType == other._ionType && Ordinal == other.Ordinal;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is IonOrdinal other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((int)_ionType * 397) ^ Ordinal;
+            }
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/PeakGroupScore.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/PeakGroupScore.cs
@@ -157,7 +157,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         }
     }
 
-    public struct FeatureKey : IComparable<FeatureKey>
+    public struct FeatureKey : IComparable<FeatureKey>, IEquatable<FeatureKey>
     {
         private string _calculatorName;
         public static FeatureKey FromCalculator(IPeakFeatureCalculator calculator)
@@ -179,6 +179,21 @@ namespace pwiz.Skyline.Model.Databinding.Entities
         public int CompareTo(FeatureKey other)
         {
             return StringComparer.OrdinalIgnoreCase.Compare(ToString(), other.ToString());
+        }
+
+        public bool Equals(FeatureKey other)
+        {
+            return _calculatorName == other._calculatorName;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is FeatureKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return (_calculatorName != null ? _calculatorName.GetHashCode() : 0);
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/CalibrationCurveFitter.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/AbsoluteQuantification/CalibrationCurveFitter.cs
@@ -831,7 +831,7 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         }
     }
 
-    public struct CalibrationPoint
+    public struct CalibrationPoint : IEquatable<CalibrationPoint>
     {
         public CalibrationPoint(int replicateIndex, IsotopeLabelType labelType) : this()
         {
@@ -840,5 +840,23 @@ namespace pwiz.Skyline.Model.DocSettings.AbsoluteQuantification
         }
         public int ReplicateIndex { get; private set; }
         public IsotopeLabelType LabelType { get; private set; }
+
+        public bool Equals(CalibrationPoint other)
+        {
+            return ReplicateIndex == other.ReplicateIndex && Equals(LabelType, other.LabelType);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is CalibrationPoint other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (ReplicateIndex * 397) ^ (LabelType != null ? LabelType.GetHashCode() : 0);
+            }
+        }
     }
 }

--- a/pwiz_tools/Skyline/Model/DocSettings/UniMod.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/UniMod.cs
@@ -276,12 +276,34 @@ namespace pwiz.Skyline.Model.DocSettings
                 && mod.Equivalent(unimod);
         }
 
-        public struct UniModIdKey
+        public struct UniModIdKey : IEquatable<UniModIdKey>
         {
             public int Id { get; set; }
             public char Aa { get; set; }
             public bool AllAas { get; set; }
             public ModTerminus? Terminus { get; set; }
+
+            public bool Equals(UniModIdKey other)
+            {
+                return Id == other.Id && Aa == other.Aa && AllAas == other.AllAas && Terminus == other.Terminus;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is UniModIdKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = Id;
+                    hashCode = (hashCode * 397) ^ Aa.GetHashCode();
+                    hashCode = (hashCode * 397) ^ AllAas.GetHashCode();
+                    hashCode = (hashCode * 397) ^ Terminus.GetHashCode();
+                    return hashCode;
+                }
+            }
         }
     }
 

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupIdentifier.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupIdentifier.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace pwiz.Skyline.Model.GroupComparison
 {
-    public struct GroupIdentifier : IComparable
+    public struct GroupIdentifier : IComparable, IEquatable<GroupIdentifier>
     {
         private readonly object _value;
 
@@ -102,6 +102,21 @@ namespace pwiz.Skyline.Model.GroupComparison
                 return new GroupIdentifier((double) value);
             }
             return new GroupIdentifier(value as string ?? value.ToString());
+        }
+
+        public bool Equals(GroupIdentifier other)
+        {
+            return Equals(_value, other._value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is GroupIdentifier other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return (_value != null ? _value.GetHashCode() : 0);
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -56,7 +56,7 @@ namespace pwiz.Skyline.Model
             UnrecognizedChargeStates = new HashSet<UnrecognizedChargeState>();
         }
 
-        public struct UnrecognizedChargeState
+        public struct UnrecognizedChargeState : IEquatable<UnrecognizedChargeState>
         {
             public string Peptide;
             public string File;
@@ -83,6 +83,27 @@ namespace pwiz.Skyline.Model
             public override string ToString()
             {
                 return PrintLine(' ');
+            }
+
+            public bool Equals(UnrecognizedChargeState other)
+            {
+                return Peptide == other.Peptide && File == other.File && Equals(Charge, other.Charge);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is UnrecognizedChargeState other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (Peptide != null ? Peptide.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (File != null ? File.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Charge != null ? Charge.GetHashCode() : 0);
+                    return hashCode;
+                }
             }
         }
 

--- a/pwiz_tools/Skyline/Model/LibKeyModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/LibKeyModificationMatcher.cs
@@ -624,7 +624,7 @@ namespace pwiz.Skyline.Model
             }
         }
 
-        private struct AATermKey
+        private struct AATermKey : IEquatable<AATermKey>
         {
             public AATermKey(char? aa, ModTerminus? terminus)
             {
@@ -637,7 +637,7 @@ namespace pwiz.Skyline.Model
 
             #region object overrides
 
-            private bool Equals(AATermKey other)
+            public bool Equals(AATermKey other)
             {
                 return other._aa.Equals(_aa) &&
                     other._terminus.Equals(_terminus);
@@ -658,6 +658,8 @@ namespace pwiz.Skyline.Model
                         (_terminus.HasValue ? _terminus.Value.GetHashCode() : 0);
                 }
             }
+
+
 
             #endregion
         }

--- a/pwiz_tools/Skyline/Model/Lists/ListItemId.cs
+++ b/pwiz_tools/Skyline/Model/Lists/ListItemId.cs
@@ -23,7 +23,7 @@ namespace pwiz.Skyline.Model.Lists
     /// <summary>
     /// Identifies a row in a <see cref="ListData"/>, and enables following the row when other rows are added and removed.
     /// </summary>
-    public struct ListItemId : IComparable<ListItemId>, IComparable
+    public struct ListItemId : IComparable<ListItemId>, IComparable, IEquatable<ListItemId>
     {
         public ListItemId(int intValue) : this()
         {
@@ -47,6 +47,21 @@ namespace pwiz.Skyline.Model.Lists
         public override string ToString()
         {
             return @"#Row " + IntValue + @"#";
+        }
+
+        public bool Equals(ListItemId other)
+        {
+            return IntValue == other.IntValue;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ListItemId other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return IntValue;
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/ProgressMonitor.cs
+++ b/pwiz_tools/Skyline/Model/ProgressMonitor.cs
@@ -15,6 +15,7 @@ namespace pwiz.Skyline.Model
 
     public class ProgressMonitor
     {
+        // ReSharper disable once InconsistentlySynchronizedField
         public int ProgressRaw => _progressRaw;
         public int MaxProgressRaw { get; private set; }
         public int ReportingStep { get; private set; }

--- a/pwiz_tools/Skyline/Model/Results/ChromCacheMinimizer.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromCacheMinimizer.cs
@@ -246,6 +246,7 @@ namespace pwiz.Skyline.Model.Results
             public Settings Settings { get; private set; }
             public ChromatogramGroupInfo ChromGroupInfo { get; private set; }
             public IList<TransitionGroupDocNode> TransitionGroupDocNodes { get; private set; }
+            // ReSharper disable once MemberHidesStaticFromOuterClass
             private ProgressCallback ProgressCallback { get; set; }
             private MinStatisticsCollector StatisticsCollector { get; set; }
 

--- a/pwiz_tools/Skyline/Model/Results/PeakShapeValues.cs
+++ b/pwiz_tools/Skyline/Model/Results/PeakShapeValues.cs
@@ -1,6 +1,8 @@
-﻿namespace pwiz.Skyline.Model.Results
+﻿using System;
+
+namespace pwiz.Skyline.Model.Results
 {
-    public struct PeakShapeValues
+    public struct PeakShapeValues : IEquatable<PeakShapeValues>
     {
         public PeakShapeValues(float stdDev, float skewness, float kurtosis, float shapeCorrelation)
         {
@@ -14,5 +16,27 @@
         public float Skewness { get; }
         public float Kurtosis { get; }
         public float ShapeCorrelation { get; }
+
+        public bool Equals(PeakShapeValues other)
+        {
+            return StdDev.Equals(other.StdDev) && Skewness.Equals(other.Skewness) && Kurtosis.Equals(other.Kurtosis) && ShapeCorrelation.Equals(other.ShapeCorrelation);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PeakShapeValues other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = StdDev.GetHashCode();
+                hashCode = (hashCode * 397) ^ Skewness.GetHashCode();
+                hashCode = (hashCode * 397) ^ Kurtosis.GetHashCode();
+                hashCode = (hashCode * 397) ^ ShapeCorrelation.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 }

--- a/pwiz_tools/Skyline/Model/Results/RemoteApi/RemoteSession.cs
+++ b/pwiz_tools/Skyline/Model/Results/RemoteApi/RemoteSession.cs
@@ -197,7 +197,7 @@ namespace pwiz.Skyline.Model.Results.RemoteApi
             public RemoteServerException Exception { get; private set; }
         }
 
-        private struct RequestKey
+        private struct RequestKey : IEquatable<RequestKey>
         {
             public RequestKey(Type type, Uri uri) : this()
             {
@@ -207,6 +207,24 @@ namespace pwiz.Skyline.Model.Results.RemoteApi
 
             public Type Type { get; private set; }
             public Uri Uri { get; private set; }
+
+            public bool Equals(RequestKey other)
+            {
+                return Type == other.Type && Equals(Uri, other.Uri);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is RequestKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((Type != null ? Type.GetHashCode() : 0) * 397) ^ (Uri != null ? Uri.GetHashCode() : 0);
+                }
+            }
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilter.cs
@@ -1077,7 +1077,7 @@ namespace pwiz.Skyline.Model.Results
             }
         }
 
-        private struct IsolationWindowFilter
+        private struct IsolationWindowFilter : IEquatable<IsolationWindowFilter>
         {
             public IsolationWindowFilter(SignedMz? isolationMz, double? isolationWidth) : this()
             {
@@ -1090,7 +1090,7 @@ namespace pwiz.Skyline.Model.Results
 
             #region object overrides
 
-            private bool Equals(IsolationWindowFilter other)
+            public bool Equals(IsolationWindowFilter other)
             {
                 return other.IsolationMz.Equals(IsolationMz) &&
                     other.IsolationWidth.Equals(IsolationWidth);

--- a/pwiz_tools/Skyline/Model/Serialization/DocumentFormat.cs
+++ b/pwiz_tools/Skyline/Model/Serialization/DocumentFormat.cs
@@ -37,7 +37,7 @@ namespace pwiz.Skyline.Model.Serialization
     /// When changing the current version number, you should copy "Skyline_Current.xsd" to "Skyline_###.xsd" representing
     /// the old version number.</para>
     /// </summary>
-    public struct DocumentFormat : IComparable<DocumentFormat>
+    public struct DocumentFormat : IComparable<DocumentFormat>, IEquatable<DocumentFormat>
     {
         public static readonly DocumentFormat VERSION_0_1 = new DocumentFormat(0.1);
         public static readonly DocumentFormat VERSION_0_2 = new DocumentFormat(0.2);
@@ -179,6 +179,21 @@ namespace pwiz.Skyline.Model.Serialization
             }
 
             return string.Format(Resources.SpectrumLibraryInfoDlg_SetDetailsText_Version__0__, ToString());
+        }
+
+        public bool Equals(DocumentFormat other)
+        {
+            return _versionNumber.Equals(other._versionNumber);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is DocumentFormat other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return _versionNumber.GetHashCode();
         }
     }
 }

--- a/pwiz_tools/Skyline/Model/TransitionGroup.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroup.cs
@@ -777,7 +777,7 @@ namespace pwiz.Skyline.Model
             }
         }
 
-        private readonly struct LossId : IComparable
+        private readonly struct LossId : IComparable, IEquatable<LossId>
         {
             public LossId(IonType ionType, double mass, int charge)
             {
@@ -786,7 +786,7 @@ namespace pwiz.Skyline.Model
                 Charge = charge;
             }
 
-            public IonType IonType { get; }
+            public IonType IonType { get; }  // CONSIDER: why is this not part of equality check?
             public double Mass { get; }
             public int Charge { get; }
 
@@ -818,7 +818,7 @@ namespace pwiz.Skyline.Model
             {
                 unchecked
                 {
-                    return (Mass.GetHashCode() * 397) ^ ComparableCharge;
+                    return (Mass.GetHashCode() * 397) ^ ComparableCharge; // CONSIDER: why is IonType not included here?
                 }
             }
 

--- a/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
+++ b/pwiz_tools/Skyline/Model/TransitionGroupDocNode.cs
@@ -2291,7 +2291,7 @@ namespace pwiz.Skyline.Model
                 public List<IList<TransitionChromInfo>> ChromInfoLists { get; private set; }
             }
 
-            private struct FileStep
+            private struct FileStep : IEquatable<FileStep>
             {
                 public FileStep(ChromFileInfoId fileId, int optimizationStep) : this()
                 {
@@ -2303,8 +2303,8 @@ namespace pwiz.Skyline.Model
                 public int OptimizationStep { get; private set; }
 
                 #region object overrides
-                
-                private bool Equals(FileStep other)
+
+                public bool Equals(FileStep other)
                 {
                     return ReferenceEquals(other.FileId, FileId) &&
                         other.OptimizationStep == OptimizationStep;

--- a/pwiz_tools/Skyline/Test/MSstats/Normalization/MsStatsNormalizationTest.cs
+++ b/pwiz_tools/Skyline/Test/MSstats/Normalization/MsStatsNormalizationTest.cs
@@ -344,12 +344,34 @@ namespace pwiz.SkylineTest.MSstats.Normalization
             return rows;
         }
 
-        struct DataProcessedRowKey
+        struct DataProcessedRowKey : IEquatable<DataProcessedRowKey>
         {
             public String Protein { get; set; }
             public String Peptide { get; set; }
             public String Transition { get; set; }
             public int Run { get; set; }
+
+            public bool Equals(DataProcessedRowKey other)
+            {
+                return Protein == other.Protein && Peptide == other.Peptide && Transition == other.Transition && Run == other.Run;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is DataProcessedRowKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (Protein != null ? Protein.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Peptide != null ? Peptide.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Transition != null ? Transition.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ Run;
+                    return hashCode;
+                }
+            }
         }
     }
 }

--- a/pwiz_tools/Skyline/TestFunctional/ManageResultsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ManageResultsTest.cs
@@ -454,7 +454,7 @@ namespace pwiz.SkylineTestFunctional
             }
         }
 
-        private struct Point
+        private struct Point : IEquatable<Point>
         {
             private readonly int _x;
             private readonly int _y;
@@ -472,7 +472,7 @@ namespace pwiz.SkylineTestFunctional
 
             #region object overrides
 
-            private bool Equals(Point other)
+            public bool Equals(Point other)
             {
                 return other._x == _x && other._y == _y;
             }

--- a/pwiz_tools/Skyline/TestFunctional/ShareDocumentTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ShareDocumentTest.cs
@@ -351,13 +351,11 @@ namespace pwiz.SkylineTestFunctional
             void VerifyContents(string s)
             {
                 using var zipFile = ZipFile.Read(s);
-                {
-                    // Confirm files have been correctly found
-                    Assert.IsTrue(zipFile.EntryFileNames.Contains(S1_RAW),
-                        $@"expected to find (fake!) raw data file {S1_RAW} in zip file");
-                    Assert.IsTrue(zipFile.EntryFileNames.Contains(S5_RAW),
-                        $@"expected to find (fake!) raw data file {S5_RAW} in zip file");
-                }
+                // Confirm files have been correctly found
+                Assert.IsTrue(zipFile.EntryFileNames.Contains(S1_RAW),
+                    $@"expected to find (fake!) raw data file {S1_RAW} in zip file");
+                Assert.IsTrue(zipFile.EntryFileNames.Contains(S5_RAW),
+                    $@"expected to find (fake!) raw data file {S5_RAW} in zip file");
             }
 
             var shareCompletePath = DoShareWithRawFiles(TestFilesDirs[1], null, S1_RAW);
@@ -395,13 +393,11 @@ namespace pwiz.SkylineTestFunctional
 
             var shareCompletePathWiff = DoShareWithRawFiles(TestFilesDirs[4]);
             using var zipFile = ZipFile.Read(shareCompletePathWiff);
-            {
-                // Confirm files have been correctly found
-                Assert.IsTrue(zipFile.EntryFileNames.Contains(dataNameWiff),
-                    $@"expected to find data file {dataNameWiff} in zip file");
-                Assert.IsTrue(zipFile.EntryFileNames.Contains(dataNameWiffScan),
-                    $@"expected to find data file {dataNameWiffScan} in zip file");
-            }
+            // Confirm files have been correctly found
+            Assert.IsTrue(zipFile.EntryFileNames.Contains(dataNameWiff),
+                $@"expected to find data file {dataNameWiff} in zip file");
+            Assert.IsTrue(zipFile.EntryFileNames.Contains(dataNameWiffScan),
+                $@"expected to find data file {dataNameWiffScan} in zip file");
         }
 
         private void SafeFileCopy(string sourceFileName, string destFileName)

--- a/pwiz_tools/Skyline/TestRunner/UnusedPortFinder.cs
+++ b/pwiz_tools/Skyline/TestRunner/UnusedPortFinder.cs
@@ -176,6 +176,7 @@ namespace TestRunner
         {
             public uint dwNumEntries;
             [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.Struct, SizeConst = 1)]
+            // ReSharper disable once CollectionNeverQueried.Local
             public MIB_TCPROW_OWNER_PID[] table;
         }
 
@@ -241,6 +242,7 @@ namespace TestRunner
         {
             public uint dwNumEntries;
             [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.Struct, SizeConst = 1)]
+            // ReSharper disable once CollectionNeverQueried.Local
             public MIB_TCP6ROW_OWNER_PID[] table;
         }
 


### PR DESCRIPTION
This one is very popular:
[https://www.jetbrains.com/help/resharper/UsageOfDefaultStructEquality.html](https://www.jetbrains.com/help/resharper/UsageOfDefaultStructEquality.html) 
It suggests that default generated runtime comparisons for structs are usually slow, and we should use our own code for equality checks. I've done so, but I worry a bit that we now have more code to maintain in the event that a member is added to a struct. (Interestingly in the act of doing this, I noticed that Model.TransitionGroup.LossId already has its own equality comparer, but doesn't include all its members in that - I've left a CONSIDER comment there)