### PR TITLE
Tweaks to quiet the latest ReSharper version's code inspection.

### DIFF
--- a/pwiz_tools/Shared/Common/DataAnalysis/PValues.cs
+++ b/pwiz_tools/Shared/Common/DataAnalysis/PValues.cs
@@ -33,14 +33,12 @@ namespace pwiz.Common.DataAnalysis
         {
             var entries = pValues.Select((pValue, index) => new Tuple<double, int>(pValue, index)).ToArray();
             Array.Sort(entries);
-            double[] cumulativeMins = new double[entries.Length];
             double currentMin = 1.0;
             var result = new double[entries.Length];
             for (int i = entries.Length - 1; i >= 0; i--)
             {
                 double value = entries[i].Item1*entries.Length/(i + 1);
                 currentMin = Math.Min(value, currentMin);
-                cumulativeMins[i] = currentMin;
                 result[entries[i].Item2] = currentMin;
             }
             return result;

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
@@ -548,9 +548,7 @@ public class WebDavBrowser : PanoramaFolderBrowser
                     var files = json[@"files"];
                     foreach (var file in files)
                     {
-                        var listItem = new string[5];
                         var fileName = (string)file[@"text"];
-                        listItem[0] = fileName;
                         var isFile = (bool)file[@"leaf"];
                         if (!isFile)
                         {

--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -5080,6 +5080,7 @@ namespace pwiz.Skyline
         {
             // Show progress at least every 2 seconds and at 100%, if any other percentage
             // output has been shown.
+            // ReSharper disable once InconsistentlySynchronizedField
             return (currentTime - _lastOutput).TotalSeconds < SecondsBetweenStatusUpdates && !status.IsError &&
                    (status.PercentComplete != 100 || _lastOutput == _waitStart);
         }

--- a/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.cs
@@ -756,18 +756,16 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
             var backup = GroupComparisonDef.ColorRows.Select(r => r.Clone()).ToArray();
             using var form = new VolcanoPlotFormattingDlg(this, GroupComparisonDef.ColorRows, foldChangeRows, UpdateColorRows);
+            if (form.ShowDialog(FormEx.GetParentForm(this)) == DialogResult.OK)
             {
-                if (form.ShowDialog(FormEx.GetParentForm(this)) == DialogResult.OK)
-                {
-                    EditGroupComparisonDlg.ChangeGroupComparisonDef(true, GroupComparisonModel, GroupComparisonDef);
-                }
-                else
-                {
-                    EditGroupComparisonDlg.ChangeGroupComparisonDef(false, GroupComparisonModel, GroupComparisonDef.ChangeColorRows(backup));
-                }
+                EditGroupComparisonDlg.ChangeGroupComparisonDef(true, GroupComparisonModel, GroupComparisonDef);
+            }
+            else
+            {
+                EditGroupComparisonDlg.ChangeGroupComparisonDef(false, GroupComparisonModel, GroupComparisonDef.ChangeColorRows(backup));
+            }
 
-                UpdateGraph();
-            }     
+            UpdateGraph();
         }
 
         private void UpdateColorRows(IEnumerable<MatchRgbHexColor> colorRows)

--- a/pwiz_tools/Skyline/Menus/ViewMenu.cs
+++ b/pwiz_tools/Skyline/Menus/ViewMenu.cs
@@ -555,15 +555,9 @@ namespace pwiz.Skyline.Menus
                 if (qcTraceNames.Count > 0)
                 {
                     var qcTraceItems = new ToolStripItem[qcTraceNames.Count];
-                    var qcContextTraceItems = new ToolStripItem[qcTraceNames.Count];
                     for (int i = 0; i < qcTraceNames.Count; i++)
                     {
                         qcTraceItems[i] = new ToolStripMenuItem(qcTraceNames[i], null, qcMenuItem_Click)
-                        {
-                            Checked = displayType == DisplayTypeChrom.qc &&
-                                      Settings.Default.ShowQcTraceName == qcTraceNames[i]
-                        };
-                        qcContextTraceItems[i] = new ToolStripMenuItem(qcTraceNames[i], null, qcMenuItem_Click)
                         {
                             Checked = displayType == DisplayTypeChrom.qc &&
                                       Settings.Default.ShowQcTraceName == qcTraceNames[i]

--- a/pwiz_tools/Skyline/Model/ProgressMonitor.cs
+++ b/pwiz_tools/Skyline/Model/ProgressMonitor.cs
@@ -15,6 +15,7 @@ namespace pwiz.Skyline.Model
 
     public class ProgressMonitor
     {
+        // ReSharper disable once InconsistentlySynchronizedField
         public int ProgressRaw => _progressRaw;
         public int MaxProgressRaw { get; private set; }
         public int ReportingStep { get; private set; }

--- a/pwiz_tools/Skyline/Model/Results/ChromCacheMinimizer.cs
+++ b/pwiz_tools/Skyline/Model/Results/ChromCacheMinimizer.cs
@@ -246,6 +246,7 @@ namespace pwiz.Skyline.Model.Results
             public Settings Settings { get; private set; }
             public ChromatogramGroupInfo ChromGroupInfo { get; private set; }
             public IList<TransitionGroupDocNode> TransitionGroupDocNodes { get; private set; }
+            // ReSharper disable once MemberHidesStaticFromOuterClass
             private ProgressCallback ProgressCallback { get; set; }
             private MinStatisticsCollector StatisticsCollector { get; set; }
 

--- a/pwiz_tools/Skyline/Skyline.sln.DotSettings
+++ b/pwiz_tools/Skyline/Skyline.sln.DotSettings
@@ -109,6 +109,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedVariable/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedVariable_002ECompiler/@EntryIndexedValue"></s:String>
 	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedVariable_002ECompiler/@EntryIndexRemoved">True</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UsageOfDefaultStructEquality/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseCollectionCountProperty/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseFormatSpecifierInFormatString/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNullPropagation/@EntryIndexedValue">HINT</s:String>
@@ -119,6 +120,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VirtualMemberNeverOverridden_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VirtualMemberNeverOverriden_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=WrongIndentSize/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/UsageOfDefaultStructEquality/CheckNonUserTypes/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AA/@EntryIndexedValue">AA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ATTR/@EntryIndexedValue">ATTR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CE/@EntryIndexedValue">CE</s:String>

--- a/pwiz_tools/Skyline/TestFunctional/ShareDocumentTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ShareDocumentTest.cs
@@ -351,13 +351,11 @@ namespace pwiz.SkylineTestFunctional
             void VerifyContents(string s)
             {
                 using var zipFile = ZipFile.Read(s);
-                {
-                    // Confirm files have been correctly found
-                    Assert.IsTrue(zipFile.EntryFileNames.Contains(S1_RAW),
-                        $@"expected to find (fake!) raw data file {S1_RAW} in zip file");
-                    Assert.IsTrue(zipFile.EntryFileNames.Contains(S5_RAW),
-                        $@"expected to find (fake!) raw data file {S5_RAW} in zip file");
-                }
+                // Confirm files have been correctly found
+                Assert.IsTrue(zipFile.EntryFileNames.Contains(S1_RAW),
+                    $@"expected to find (fake!) raw data file {S1_RAW} in zip file");
+                Assert.IsTrue(zipFile.EntryFileNames.Contains(S5_RAW),
+                    $@"expected to find (fake!) raw data file {S5_RAW} in zip file");
             }
 
             var shareCompletePath = DoShareWithRawFiles(TestFilesDirs[1], null, S1_RAW);
@@ -395,13 +393,11 @@ namespace pwiz.SkylineTestFunctional
 
             var shareCompletePathWiff = DoShareWithRawFiles(TestFilesDirs[4]);
             using var zipFile = ZipFile.Read(shareCompletePathWiff);
-            {
-                // Confirm files have been correctly found
-                Assert.IsTrue(zipFile.EntryFileNames.Contains(dataNameWiff),
-                    $@"expected to find data file {dataNameWiff} in zip file");
-                Assert.IsTrue(zipFile.EntryFileNames.Contains(dataNameWiffScan),
-                    $@"expected to find data file {dataNameWiffScan} in zip file");
-            }
+            // Confirm files have been correctly found
+            Assert.IsTrue(zipFile.EntryFileNames.Contains(dataNameWiff),
+                $@"expected to find data file {dataNameWiff} in zip file");
+            Assert.IsTrue(zipFile.EntryFileNames.Contains(dataNameWiffScan),
+                $@"expected to find data file {dataNameWiffScan} in zip file");
         }
 
         private void SafeFileCopy(string sourceFileName, string destFileName)

--- a/pwiz_tools/Skyline/TestRunner/UnusedPortFinder.cs
+++ b/pwiz_tools/Skyline/TestRunner/UnusedPortFinder.cs
@@ -176,6 +176,7 @@ namespace TestRunner
         {
             public uint dwNumEntries;
             [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.Struct, SizeConst = 1)]
+            // ReSharper disable once CollectionNeverQueried.Local
             public MIB_TCPROW_OWNER_PID[] table;
         }
 
@@ -241,6 +242,7 @@ namespace TestRunner
         {
             public uint dwNumEntries;
             [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.Struct, SizeConst = 1)]
+            // ReSharper disable once CollectionNeverQueried.Local
             public MIB_TCP6ROW_OWNER_PID[] table;
         }
 


### PR DESCRIPTION
Note in particular the new "UsageOfDefaultStructEquality" warning has been reduced to a suggestion - it wants equality members for structs, because the ones generated automatically are probably inefficient. Worth thinking about when looking at performance issues but not worth a general change to many dozens of files.