### PR TITLE
Fix scrollbar display after paste into Document Grid

### DIFF
--- a/pwiz_tools/Skyline/Util/DataGridViewPasteHandler.cs
+++ b/pwiz_tools/Skyline/Util/DataGridViewPasteHandler.cs
@@ -157,6 +157,9 @@ namespace pwiz.Skyline.Util
                 }
                 Settings.Default.ResultsGridSynchSelection = resultsGridSynchSelectionOld;
                 skylineDataSchema.RollbackBatchModifyDocument();
+
+                // Call "PerformLayout" so that the scrollbar displays the correct scroll position
+                DataGridView.PerformLayout();
             }
         }
 


### PR DESCRIPTION
Fixed scrollbar thumb position after pasting into Document Grid (reported by Brendan)