### PR TITLE
Handle empty chromatograms in Waters data

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
@@ -569,7 +569,15 @@ struct PWIZ_API_DECL RawData
 
         for (int ch = 0; ch < channels; ch++)
         {
-            AnalogChromatogramReader.ReadChannel(ch, analogTimes[ch], analogIntensities[ch]);
+            try
+            {
+                AnalogChromatogramReader.ReadChannel(ch, analogTimes[ch], analogIntensities[ch]);
+            }
+            catch(MassLynxRawException const& ex)
+            {
+                // Likely just an empty channel - if there's a real problem the folllowing calls will probably throw too
+                std::cout << ex.what() << std::endl;
+            }
             analogChannelNames[ch] = AnalogChromatogramReader.GetChannelDescription(ch);
             analogChannelUnits[ch] = AnalogChromatogramReader.GetChannelUnits(ch);
         }

--- a/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
@@ -576,7 +576,6 @@ struct PWIZ_API_DECL RawData
             catch(MassLynxRawException const& ex)
             {
                 // Likely just an empty channel - if there's a real problem the folllowing calls will probably throw too
-                std::cout << ex.what() << std::endl;
             }
             analogChannelNames[ch] = AnalogChromatogramReader.GetChannelDescription(ch);
             analogChannelUnits[ch] = AnalogChromatogramReader.GetChannelUnits(ch);

--- a/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Waters/WatersRawFile.hpp
@@ -573,7 +573,7 @@ struct PWIZ_API_DECL RawData
             {
                 AnalogChromatogramReader.ReadChannel(ch, analogTimes[ch], analogIntensities[ch]);
             }
-            catch(MassLynxRawException const& ex)
+            catch (MassLynxRawException&)
             {
                 // Likely just an empty channel - if there's a real problem the folllowing calls will probably throw too
             }


### PR DESCRIPTION
per https://skyline.ms/announcements/home/support/thread.view?rowId=40366 it appears that the MassLynx reader DLL throws an exception when it encounters an empty chromatogram (or "channel", in API-speak). With this change we catch and ignore the exception, with the assumption that if there's an actual problem then attempts to get channel name etc with throw too, and we'll let that one pass through.

reported by user Warham