### PR TITLE
Gracefully handle adduct/molecule combinations that make no sense (e.g. removing more atoms than are in the molecule) in libraries by ignoring them

### DIFF
--- a/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/AbstractModificationMatcher.cs
@@ -474,8 +474,16 @@ namespace pwiz.Skyline.Model
                     if (nodePep != null && Settings.PeptideSettings.Libraries.TryGetLibInfo(key, out libInfo))
                     {
                         var isotopeLabelType = key.Adduct.HasIsotopeLabels ? IsotopeLabelType.heavy : IsotopeLabelType.light;
-                        var group = new TransitionGroup(peptide, key.Adduct, isotopeLabelType);
-                        nodeGroupMatched = new TransitionGroupDocNode(group, Annotations.EMPTY, Settings, null, libInfo, ExplicitTransitionGroupValues.EMPTY, null, null, false);
+                        try
+                        {
+                            // Not all combinations of molecule and adduct that users provide are valid
+                            var group = new TransitionGroup(peptide, key.Adduct, isotopeLabelType);
+                            nodeGroupMatched = new TransitionGroupDocNode(group, Annotations.EMPTY, Settings, null, libInfo, ExplicitTransitionGroupValues.EMPTY, null, null, false);
+                        }
+                        catch (InvalidDataException)
+                        {
+                            continue;  // Probably something like "Adduct [M-2H2O+Na] calls for removing more O atoms than are found in the molecule C16H22ClN3O"
+                        }
                         SpectrumPeaksInfo spectrum;
                         if (Settings.PeptideSettings.Libraries.TryLoadSpectrum(key, out spectrum))
                         {


### PR DESCRIPTION
per https://skyline.ms/announcements/home/issues/exceptions/thread.view?entityId=201cbf53-9ef6-103d-b4e5-22f535560118&_anchor=67193#row:67193