### PR TITLE
Simplified handling of bogus lockmass correction requests

### DIFF
--- a/pwiz/analysis/chromatogram_processing/ChromatogramList_LockmassRefiner.cpp
+++ b/pwiz/analysis/chromatogram_processing/ChromatogramList_LockmassRefiner.cpp
@@ -41,29 +41,30 @@ ChromatogramList_LockmassRefiner::ChromatogramList_LockmassRefiner(const msdata:
 : ChromatogramListWrapper(inner), mzPositiveScans_(lockmassMzPosScans), mzNegativeScans_(lockmassMzNegScans), tolerance_(lockmassTolerance)
 {
 
-    // add processing methods to the copy of the inner ChromatogramList's data processing
-    ProcessingMethod method;
-    method.order = dp_->processingMethods.size();
-    method.set(MS_m_z_calibration);
-    
-    if (!dp_->processingMethods.empty())
-        method.softwarePtr = dp_->processingMethods[0].softwarePtr;
-
     detail::ChromatogramList_Waters* waters = dynamic_cast<detail::ChromatogramList_Waters*>(&*inner);
     if (waters)
     {
+        // add processing methods to the copy of the inner ChromatogramList's data processing
+        ProcessingMethod method;
+        method.order = dp_->processingMethods.size();
+        method.set(MS_m_z_calibration);
+
+        if (!dp_->processingMethods.empty())
+            method.softwarePtr = dp_->processingMethods[0].softwarePtr;
+
         method.userParams.push_back(UserParam("Waters lockmass correction"));
+        dp_->processingMethods.push_back(method);
     }
     else
     {
-        cerr << "Warning: lockmass refinement was requested, but is unavailable";
+        cerr << "Warning: lockmass refinement for chromatogram data was requested, but is unavailable";
 #ifdef WIN32
         cerr << " for non-Waters input data. ";
 #else
         cerr << " as it depends on Windows DLLs.  ";
 #endif
+        cerr << endl;
     }
-    dp_->processingMethods.push_back(method);
 }
 
 

--- a/pwiz/analysis/spectrum_processing/SpectrumList_LockmassRefiner.cpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_LockmassRefiner.cpp
@@ -41,31 +41,30 @@ PWIZ_API_DECL
 SpectrumList_LockmassRefiner::SpectrumList_LockmassRefiner(const msdata::SpectrumListPtr& inner, double lockmassMzPosScans, double lockmassMzNegScans, double lockmassTolerance)
 : SpectrumListWrapper(inner), mzPositiveScans_(lockmassMzPosScans), mzNegativeScans_(lockmassMzNegScans), tolerance_(lockmassTolerance)
 {
-
-    // add processing methods to the copy of the inner SpectrumList's data processing
-    ProcessingMethod method;
-    method.order = dp_->processingMethods.size();
-    method.set(MS_m_z_calibration);
-    
-    if (!dp_->processingMethods.empty())
-        method.softwarePtr = dp_->processingMethods[0].softwarePtr;
-
-    SpectrumList_PeakPicker* peakPicker = dynamic_cast<SpectrumList_PeakPicker*>(&*inner);
+    SpectrumList_PeakPicker* peakPicker = dynamic_cast<SpectrumList_PeakPicker*>(&*inner); // If there's a peak picker, it will be outermost
     detail::SpectrumList_Waters* waters = dynamic_cast<detail::SpectrumList_Waters*>(peakPicker ? &*peakPicker->inner() : &*inner);
     if (waters)
     {
+        // add processing methods to the copy of the inner SpectrumList's data processing
+        ProcessingMethod method;
+        method.order = dp_->processingMethods.size();
+        method.set(MS_m_z_calibration);
+
+        if (!dp_->processingMethods.empty())
+            method.softwarePtr = dp_->processingMethods[0].softwarePtr;
         method.userParams.push_back(UserParam("Waters lockmass correction"));
+        dp_->processingMethods.push_back(method);
     }
     else
     {
-        cerr << "Warning: lockmass refinement was requested, but is unavailable";
+        cerr << "Warning: lockmass refinement for spectrum data was requested, but is unavailable";
 #ifdef WIN32
         cerr << " for non-Waters input data. ";
 #else
         cerr << " as it depends on Windows DLLs.  ";
 #endif
+        cerr << endl;
     }
-    dp_->processingMethods.push_back(method);
 }
 
 


### PR DESCRIPTION
While chasing down memory issues, I noticed that there seemed to be some proximity to tests that involved asking for lockmass correction on data that isn't actual Waters raw. I'm not 100%% convinced that this is the issue, but it does seem just as well to simplify this code so that the data processing chain is left completely untouched when spurious requests are made. If nothing else it makes for a more accurate set of CVParams.