### PR TITLE
* disabled TestKoinaBuildLibrary as it's too unreliable now

### DIFF
--- a/pwiz_tools/Skyline/TestConnected/KoinaBuildLibraryTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/KoinaBuildLibraryTest.cs
@@ -32,7 +32,7 @@ namespace pwiz.SkylineTestConnected
     [TestClass]
     public class KoinaBuildLibraryTest : AbstractFunctionalTest
     {
-        [TestMethod, NoParallelTesting(TestExclusionReason.DOCKER_ROOT_CERTS)]
+        //[TestMethod, NoParallelTesting(TestExclusionReason.DOCKER_ROOT_CERTS)]
         public void TestKoinaBuildLibrary()
         {
             if (!HasKoinaServer())


### PR DESCRIPTION
* disabled TestKoinaBuildLibrary as it's too unreliable now (although I'm not sure it's actually the remote API causing the unreliability)