### PR TITLE
Fix intermittent failure in TestShareDocument

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/ShareDocumentTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ShareDocumentTest.cs
@@ -412,82 +412,82 @@ namespace pwiz.SkylineTestFunctional
             var totalFilesCount = doc.MeasuredResults.Chromatograms.Count;
 
             string shareCompletePath = testFilesDir.GetTestPath($"{Path.GetFileName(directoryElsewhere)}{testFolder}.sky.zip");
-            var shareDlg = ShowDialog<ShareTypeDlg>(() => SkylineWindow.ShareDocument(shareCompletePath));
-            RunUI(() => Assert.IsNull(shareDlg.SelectedSkylineVersion));    // Expect using the currently saved format
-            // Check box must be checked in order for files to be zipped
-            int missingFilesCount = directoryElsewhere != null ? 1 : 0;
-            if (testFolder)
-                missingFilesCount++;
-            RunUI(() =>
+            RunLongDlg<ShareTypeDlg>(() => SkylineWindow.ShareDocument(shareCompletePath), shareDlg =>
             {
-                shareDlg.IncludeReplicateFiles = true;
-                VerifyFileStatus(shareDlg, totalFilesCount, missingFilesCount);
-            });
-            var replicatePickDlg = ShowDialog<ShareResultsFilesDlg>(() => shareDlg.ShowSelectReplicatesDialog());
-            if (missingFilesCount == totalFilesCount)
-            {
-                // No checkboxes to test
-                RunUI(() => VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, missingFilesCount));
-            }
-            else
-            {
-                // Turn a checkbox off and on and verify UI updates appropriately
+                RunUI(() => Assert.IsNull(shareDlg.SelectedSkylineVersion)); // Expect using the currently saved format
+                // Check box must be checked in order for files to be zipped
+                int missingFilesCount = directoryElsewhere != null ? 1 : 0;
+                if (testFolder)
+                    missingFilesCount++;
                 RunUI(() =>
                 {
-                    VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, missingFilesCount);
-                    replicatePickDlg.SetFileChecked(0, false);
-                    VerifyCheckedState(replicatePickDlg, totalFilesCount, 1, missingFilesCount);
-                    replicatePickDlg.SetFileChecked(0, true);
-                    VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, missingFilesCount);
-                    replicatePickDlg.IsSelectAll = false;
-                    VerifyCheckedState(replicatePickDlg, totalFilesCount, totalFilesCount-missingFilesCount, missingFilesCount);
-                    replicatePickDlg.IsSelectAll = true;
-                    VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, missingFilesCount);
+                    shareDlg.IncludeReplicateFiles = true;
+                    VerifyFileStatus(shareDlg, totalFilesCount, missingFilesCount);
                 });
-            }
-            if (directoryElsewhere != null)
-            {
-                if (testFolder)
+                var replicatePickDlg = ShowDialog<ShareResultsFilesDlg>(() => shareDlg.ShowSelectReplicatesDialog());
+                if (missingFilesCount == totalFilesCount)
                 {
-                    // Test folder selector
-                    RunUI(() =>
-                        replicatePickDlg.SearchDirectoryForMissingFiles(directoryElsewhere)); // Exercise folder select
+                    // No checkboxes to test
+                    RunUI(() => VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, missingFilesCount));
                 }
                 else
                 {
-                    // Test file selector
-                    var fileFinderDlg = ShowDialog<OpenDataSourceDialog>(() => replicatePickDlg.LocateMissingFiles());
+                    // Turn a checkbox off and on and verify UI updates appropriately
                     RunUI(() =>
                     {
-                        fileFinderDlg.SelectFile(directoryElsewhere); // Select sub folder
-                        fileFinderDlg.Open(); // Open folder
-                        string selectName = Path.GetFileName(filename);
-                        fileFinderDlg.SelectFile(selectName); // Select file
-                        Assert.AreEqual(selectName, fileFinderDlg.SelectedFiles.FirstOrDefault());
+                        VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, missingFilesCount);
+                        replicatePickDlg.SetFileChecked(0, false);
+                        VerifyCheckedState(replicatePickDlg, totalFilesCount, 1, missingFilesCount);
+                        replicatePickDlg.SetFileChecked(0, true);
+                        VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, missingFilesCount);
+                        replicatePickDlg.IsSelectAll = false;
+                        VerifyCheckedState(replicatePickDlg, totalFilesCount, totalFilesCount-missingFilesCount, missingFilesCount);
+                        replicatePickDlg.IsSelectAll = true;
+                        VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, missingFilesCount);
                     });
-                    OkDialog(fileFinderDlg, fileFinderDlg.Open); // Accept selected files and close dialog
                 }
-            }
-
-            // Close and confirm results
-            RunUI(() => VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, 0));
-            OkDialog(replicatePickDlg, replicatePickDlg.OkDialog);
-            RunUI(() => VerifyFileStatus(shareDlg, totalFilesCount, 0));
-            // If the format is older and any directory is being added, Skyline should show an error.
-            if (SkylineWindow.SavedDocumentFormat.CompareTo(DocumentFormat.SHARE_DATA_FOLDERS) < 0 &&
-                shareDlg.GetIncludedAuxiliaryFiles().Any(Directory.Exists))
-            {
-                RunDlg<MessageDlg>(shareDlg.OkDialog, dlg =>
+                if (directoryElsewhere != null)
                 {
-                    Assert.AreEqual(Resources.ShareTypeDlg_OkDialog_Including_data_folders_is_not_supported_by_the_currently_selected_version_, dlg.Message);
-                    dlg.OkDialog();
-                });
-                RunUI(() => shareDlg.SelectedSkylineVersion = SkylineVersion.CURRENT);
-            }
-            OkDialog(shareDlg, shareDlg.OkDialog);
+                    if (testFolder)
+                    {
+                        // Test folder selector
+                        RunUI(() =>
+                            replicatePickDlg.SearchDirectoryForMissingFiles(directoryElsewhere)); // Exercise folder select
+                    }
+                    else
+                    {
+                        // Test file selector
+                        var fileFinderDlg = ShowDialog<OpenDataSourceDialog>(() => replicatePickDlg.LocateMissingFiles());
+                        RunUI(() =>
+                        {
+                            fileFinderDlg.SelectFile(directoryElsewhere); // Select sub folder
+                            fileFinderDlg.Open(); // Open folder
+                            string selectName = Path.GetFileName(filename);
+                            fileFinderDlg.SelectFile(selectName); // Select file
+                            Assert.AreEqual(selectName, fileFinderDlg.SelectedFiles.FirstOrDefault());
+                        });
+                        OkDialog(fileFinderDlg, fileFinderDlg.Open); // Accept selected files and close dialog
+                    }
+                }
 
-            WaitForCondition(() => File.Exists(shareCompletePath));
+                // Close and confirm results
+                RunUI(() => VerifyCheckedState(replicatePickDlg, totalFilesCount, 0, 0));
+                OkDialog(replicatePickDlg, replicatePickDlg.OkDialog);
+                RunUI(() => VerifyFileStatus(shareDlg, totalFilesCount, 0));
+                // If the format is older and any directory is being added, Skyline should show an error.
+                if (SkylineWindow.SavedDocumentFormat.CompareTo(DocumentFormat.SHARE_DATA_FOLDERS) < 0 &&
+                    shareDlg.GetIncludedAuxiliaryFiles().Any(Directory.Exists))
+                {
+                    RunDlg<MessageDlg>(shareDlg.OkDialog, dlg =>
+                    {
+                        Assert.AreEqual(Resources.ShareTypeDlg_OkDialog_Including_data_folders_is_not_supported_by_the_currently_selected_version_, dlg.Message);
+                        dlg.OkDialog();
+                    });
+                    RunUI(() => shareDlg.SelectedSkylineVersion = SkylineVersion.CURRENT);
+                }
+            }, shareDlg => shareDlg.OkDialog());
 
+            AssertEx.FileExists(shareCompletePath);
             return shareCompletePath;
         }
 


### PR DESCRIPTION
Change "ShowDialog" call to "RunLongDlg" so that the subsequent code does not execute until the method which brought up the dialog has returned. Subsequent test code had been trying to interact with .zip file while it was still locked.