### PR TITLE
Fix unhandled error in Edit Linked Peptide dialog

### DIFF
--- a/pwiz_tools/Skyline/EditUI/EditLinkedPeptidesDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/EditLinkedPeptidesDlg.cs
@@ -590,8 +590,11 @@ namespace pwiz.Skyline.EditUI
         {
             if (IsHandleCreated)
             {
-                dataGridView.CurrentCell = dataGridView.Rows[rowIndex].Cells[column.Index];
-                dataGridView.Focus();
+                if (column.Visible)
+                {
+                    dataGridView.CurrentCell = dataGridView.Rows[rowIndex].Cells[column.Index];
+                    dataGridView.Focus();
+                }
             }
             else
             {


### PR DESCRIPTION
Fixed unhandled error on Edit Linked Peptides dialog (reported by Caroline)