### PR TITLE
Skyline: More screenshot automation improvements

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/FormUtil.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/FormUtil.cs
@@ -214,6 +214,15 @@ namespace pwiz.Common.SystemUtil
         }
 
         [DllImport("user32.dll", SetLastError = true)]
+        private static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
+
+        public static void HideCaret(this ComboBox comboBox)
+        {
+            var handleEdit = FindWindowEx(comboBox.Handle, IntPtr.Zero, "Edit", null);
+            if (handleEdit != IntPtr.Zero)
+                HideCaret(handleEdit); }
+
+        [DllImport("user32.dll", SetLastError = true)]
         private static extern int SetScrollPos(IntPtr hWnd, int nBar, int nPos, bool bRedraw);
 
         public static void SetScrollPos(this Control control, Orientation sd, int pos)

--- a/pwiz_tools/Skyline/Executables/DevTools/ImageComparer/ImageComparerWindow.cs
+++ b/pwiz_tools/Skyline/Executables/DevTools/ImageComparer/ImageComparerWindow.cs
@@ -166,6 +166,7 @@ namespace ImageComparer
 
         private void ShowImageDiff()
         {
+            bool showOldPictureBox = true;
             if (_diff == null)
             {
                 pictureMatching.Visible = false;
@@ -194,11 +195,12 @@ namespace ImageComparer
                         _diff.ShowBinaryDiff(EnsureBinaryDiffControl());
                     }
 
-                    oldScreenshotPictureBox.Visible = !imagesMatch;
-                    if (_rtfDiff != null)
-                        _rtfDiff.Visible = imagesMatch;
+                    showOldPictureBox = !imagesMatch;
                 }
             }
+            oldScreenshotPictureBox.Visible = showOldPictureBox;
+            if (_rtfDiff != null)
+                _rtfDiff.Visible = !showOldPictureBox;
         }
 
         private RichTextBox EnsureBinaryDiffControl()

--- a/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
@@ -1080,7 +1080,7 @@ namespace pwiz.Skyline.SettingsUI
             {
                 var newRadioTimeAroundTop = workflow == ImportPeptideSearchDlg.Workflow.feature_detection ?
                     radioTimeAroundMs2Ids.Top :
-                    radioKeepAllTime.Top;
+                    radioUseSchedulingWindow.Top;
                 int radioTimeAroundTopDifference = radioKeepAllTime.Top - newRadioTimeAroundTop;
                 radioUseSchedulingWindow.Visible = false;
                 flowLayoutPanelUseSchedulingWindow.Visible = false;

--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
@@ -253,8 +253,15 @@ namespace pwiz.SkylineTestTutorial
 
             OkDialog(arrangeGraphsDlg, arrangeGraphsDlg.OkDialog);
 
+            var savedBounds = Rectangle.Empty;
             if (IsPauseForScreenShots)
-                RunUI(() => SkylineWindow.WindowState = FormWindowState.Maximized);
+                RunUI(() =>
+                {
+                    // Essentially maximize the window for a 1920x1080 monitor at 100%
+                    savedBounds = SkylineWindow.Bounds;
+                    SkylineWindow.Size = new Size(1934, 1047);
+                    SkylineWindow.Location = new Point(-7, 0);
+                });
 
             SelectNode(SrmDocument.Level.Molecules, 0);
 
@@ -272,7 +279,7 @@ namespace pwiz.SkylineTestTutorial
                 TestApplyToAll();
 
             if (IsPauseForScreenShots)
-                RunUI(() => SkylineWindow.WindowState = FormWindowState.Normal);
+                RunUI(() => SkylineWindow.Bounds = savedBounds);
         }
 
         private void PlaceTargetsAndGraph(Control graphForm)
@@ -1469,12 +1476,13 @@ namespace pwiz.SkylineTestTutorial
             RunUI(() => SkylineWindow.ShowGroupComparisonWindow(comparisonName));
             var foldChangeGrid = FindOpenForm<FoldChangeGrid>();
             var foldChangeGridControl = foldChangeGrid.DataboundGridControl;
+            var foldChangePath = PropertyPath.Root.Property("FoldChangeResult");
             WaitForConditionUI(() => foldChangeGridControl.IsComplete &&
-                foldChangeGridControl.FindColumn(PropertyPath.Root.Property("FoldChangeResult")) != null);
+                                     foldChangeGridControl.FindColumn(foldChangePath) != null &&
+                                     foldChangeGridControl.RowCount == 48);
             RunUI(() =>
             {
-                var foldChangeResultColumn =
-                    foldChangeGridControl.FindColumn(PropertyPath.Root.Property("FoldChangeResult"));
+                var foldChangeResultColumn = foldChangeGridControl.FindColumn(foldChangePath);
                 foldChangeGridControl.DataGridView.AutoResizeColumn(foldChangeResultColumn.Index);
                 foldChangeGrid.Parent.Parent.Height = 278;
             });
@@ -1500,8 +1508,7 @@ namespace pwiz.SkylineTestTutorial
             WaitForConditionUI(() => foldChangeGrid.DataboundGridControl.IsComplete);
             RunUI(() =>
             {
-                var foldChangeResultColumn =
-                    foldChangeGrid.DataboundGridControl.FindColumn(PropertyPath.Root.Property("FoldChangeResult"));
+                var foldChangeResultColumn = foldChangeGrid.DataboundGridControl.FindColumn(foldChangePath);
                 Assert.IsNotNull(foldChangeResultColumn);
                 foldChangeGrid.DataboundGridControl.DataGridView.Sort(foldChangeResultColumn, ListSortDirection.Ascending);
             });

--- a/pwiz_tools/Skyline/TestTutorial/MethodRefinementTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/MethodRefinementTutorialTest.cs
@@ -98,7 +98,7 @@ namespace pwiz.SkylineTestTutorial
                 SkylineWindow.SequenceTree.SelectedNode = SkylineWindow.SequenceTree.Nodes[0].Nodes[0];
                 SkylineWindow.AutoZoomBestPeak();
                 SkylineWindow.GraphSpectrumSettings.ShowBIons = true;
-                SkylineWindow.Size = new Size(1278, 736);
+                SkylineWindow.Size = new Size(1266, 736);
 
                 Assert.AreEqual(SkylineWindow.SequenceTree.SelectedNode.Text, "YLGAYLLATLGGNASPSAQDVLK"); // Not L10N
             });
@@ -149,9 +149,11 @@ namespace pwiz.SkylineTestTutorial
                     new[] {new KeyValuePair<string, MsDataFileUri[]>(replicateName, namedPathSets[0].Value.Take(15).ToArray())};
                 importResultsDlg.OkDialog();
             });
-            var allChromGraph = WaitForOpenForm<AllChromatogramsGraph>();   // To make the AllChromatogramsGraph form accessible to the SkylineTester forms tab
-            WaitForConditionUI(() => allChromGraph.ProgressTotalPercent >= 20);
+            var allChrom = WaitForOpenForm<AllChromatogramsGraph>();   // To make the AllChromatogramsGraph form accessible to the SkylineTester forms tab
+            allChrom.SetFreezeProgressPercent(98, @"00:00:01");
+            WaitForConditionUI(() => allChrom.IsProgressFrozen());
             PauseForScreenShot<AllChromatogramsGraph>("Loading Chromatograms: Take screenshot at about 25% loaded...", 7);
+            allChrom.SetFreezeProgressPercent(null, null);
             WaitForCondition(15*60*1000, () => SkylineWindow.Document.Settings.MeasuredResults.IsLoaded);  // 15 minutes
 
             Assert.IsTrue(SkylineWindow.Document.Settings.HasResults);
@@ -475,6 +477,7 @@ namespace pwiz.SkylineTestTutorial
 
             RunUI(() => SkylineWindow.Size = new Size(1060, 550));
             RestoreViewOnScreen(21);
+            FocusDocument();
             PauseForScreenShot("Main window", 21); // Not L10N
 
             RTScheduleGraphPane pane = null;
@@ -570,6 +573,7 @@ namespace pwiz.SkylineTestTutorial
             });
             RestoreViewOnScreen(26);
             WaitForGraphs();
+            FocusDocument();
             PauseForScreenShot("Main window", 26); // Not L10N
 
             // Show the RefineDlg.ConsistencyTab for localization text review

--- a/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
@@ -469,6 +469,8 @@ namespace pwiz.SkylineTestTutorial
                 SkylineWindow.ArrangeGraphsTiled();
                 SkylineWindow.ShowChromatogramLegends(false);
             });
+            FocusDocument();
+            JiggleSelection();
             PauseForScreenShot("Main window layout", tutorialPage++);
 
             int atest = 0;

--- a/pwiz_tools/Skyline/TestUtil/MultiFormActivator.cs
+++ b/pwiz_tools/Skyline/TestUtil/MultiFormActivator.cs
@@ -94,6 +94,10 @@ namespace pwiz.SkylineTestUtil
         private void FormActivated(object sender, EventArgs e)
         {
             var activatedForm = (Form)sender;
+            // DockableForms can get activated during DockableForm.Dispose()
+            if (!activatedForm.IsHandleCreated)
+                return;
+
             var activatedFormHandle = activatedForm.Handle;
 
             lock (_formsToActivate)
@@ -107,6 +111,9 @@ namespace pwiz.SkylineTestUtil
 
         private void ShowForm(Form form, IntPtr referenceFormHandle)
         {
+            if (!form.IsHandleCreated)
+                return;
+
             // Must be done on the form's thread
             form.Invoke((Action)(() =>
             {

--- a/pwiz_tools/Skyline/TestUtil/ScreenshotManager.cs
+++ b/pwiz_tools/Skyline/TestUtil/ScreenshotManager.cs
@@ -416,10 +416,10 @@ namespace pwiz.SkylineTestUtil
                 focusText.Select(focusText.Text.Length, 0);
                 focusText.HideCaret();
             }
-            else if (focusControl is ComboBox { CanSelect: true } focusCombo)
+            else if (focusControl is ComboBox { DropDownStyle: ComboBoxStyle.DropDown } focusCombo)
             {
                 focusCombo.Select(0, 0);
-                focusCombo.HideCaret(); // CONSIDER: This does not seem to work
+                focusCombo.HideCaret();
             }
             else if (focusControl is TabControl focusTabControl)
             {

--- a/pwiz_tools/Skyline/TestUtil/ScreenshotPreviewForm.Designer.cs
+++ b/pwiz_tools/Skyline/TestUtil/ScreenshotPreviewForm.Designer.cs
@@ -31,7 +31,6 @@ namespace pwiz.SkylineTestUtil
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ScreenshotPreviewForm));
             this.oldScreenshotPictureBox = new System.Windows.Forms.PictureBox();
             this.newScreenshotPictureBox = new System.Windows.Forms.PictureBox();
             this.previewSplitContainer = new System.Windows.Forms.SplitContainer();
@@ -55,10 +54,10 @@ namespace pwiz.SkylineTestUtil
             this.toolStripRevert = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripAutoSize = new System.Windows.Forms.ToolStripButton();
+            this.toolStripPickColorButton = new pwiz.SkylineTestUtil.AlphaColorPickerButton();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripGotoWeb = new System.Windows.Forms.ToolStripButton();
             this.toolStripDescription = new System.Windows.Forms.ToolStripLabel();
-            this.toolStripPickColorButton = new pwiz.SkylineTestUtil.AlphaColorPickerButton();
             ((System.ComponentModel.ISupportInitialize)(this.oldScreenshotPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.newScreenshotPictureBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.previewSplitContainer)).BeginInit();
@@ -307,6 +306,7 @@ namespace pwiz.SkylineTestUtil
             this.toolStripRevert.Name = "toolStripRevert";
             this.toolStripRevert.Size = new System.Drawing.Size(23, 22);
             this.toolStripRevert.ToolTipText = "Revert (Ctrl-Z)";
+            this.toolStripRevert.Click += new System.EventHandler(this.toolStripRevert_Click);
             // 
             // toolStripSeparator1
             // 
@@ -325,6 +325,17 @@ namespace pwiz.SkylineTestUtil
             this.toolStripAutoSize.Size = new System.Drawing.Size(23, 22);
             this.toolStripAutoSize.ToolTipText = "Auto-Size";
             this.toolStripAutoSize.CheckedChanged += new System.EventHandler(this.toolStripAutoSize_CheckedChanged);
+            // 
+            // toolStripPickColorButton
+            // 
+            this.toolStripPickColorButton.BackColor = System.Drawing.SystemColors.Control;
+            this.toolStripPickColorButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolStripPickColorButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripPickColorButton.Name = "toolStripPickColorButton";
+            this.toolStripPickColorButton.SelectedColor = System.Drawing.Color.FromArgb(((int)(((byte)(127)))), ((int)(((byte)(255)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.toolStripPickColorButton.Size = new System.Drawing.Size(13, 22);
+            this.toolStripPickColorButton.ToolTipText = "Selected Color: Color [A=128, R=255, G=0, B=0] (Alpha: 128)";
+            this.toolStripPickColorButton.ColorChanged += new System.EventHandler(this.toolStripPickColorButton_ColorChanged);
             // 
             // toolStripSeparator2
             // 
@@ -346,18 +357,6 @@ namespace pwiz.SkylineTestUtil
             this.toolStripDescription.Name = "toolStripDescription";
             this.toolStripDescription.Size = new System.Drawing.Size(38, 22);
             this.toolStripDescription.Text = "s-1: ...";
-            // 
-            // toolStripPickColorButton
-            // 
-            this.toolStripPickColorButton.BackColor = System.Drawing.SystemColors.Control;
-            this.toolStripPickColorButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripPickColorButton.Image = ((System.Drawing.Image)(resources.GetObject("toolStripPickColorButton.Image")));
-            this.toolStripPickColorButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripPickColorButton.Name = "toolStripPickColorButton";
-            this.toolStripPickColorButton.SelectedColor = System.Drawing.Color.FromArgb(((int)(((byte)(127)))), ((int)(((byte)(255)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.toolStripPickColorButton.Size = new System.Drawing.Size(29, 22);
-            this.toolStripPickColorButton.ToolTipText = "Selected Color: Color [A=128, R=255, G=0, B=0] (Alpha: 128)";
-            this.toolStripPickColorButton.ColorChanged += new System.EventHandler(this.toolStripPickColorButton_ColorChanged);
             // 
             // ScreenshotPreviewForm
             // 

--- a/pwiz_tools/Skyline/TestUtil/ScreenshotPreviewForm.cs
+++ b/pwiz_tools/Skyline/TestUtil/ScreenshotPreviewForm.cs
@@ -306,6 +306,7 @@ namespace pwiz.SkylineTestUtil
 
         private void ShowImageDiff()
         {
+            bool showOldPictureBox = true;
             if (_diff == null)
             {
                 pictureMatching.Visible = false;
@@ -334,11 +335,12 @@ namespace pwiz.SkylineTestUtil
                         _diff.ShowBinaryDiff(EnsureBinaryDiffControl());
                     }
 
-                    oldScreenshotPictureBox.Visible = !imagesMatch;
-                    if (_rtfDiff != null)
-                        _rtfDiff.Visible = imagesMatch;
+                    showOldPictureBox = !imagesMatch;
                 }
             }
+            oldScreenshotPictureBox.Visible = showOldPictureBox;
+            if (_rtfDiff != null)
+                _rtfDiff.Visible = !showOldPictureBox;
         }
 
         private RichTextBox EnsureBinaryDiffControl()
@@ -860,6 +862,7 @@ namespace pwiz.SkylineTestUtil
                 _fileToShow = new ScreenshotFile(_screenshotManager.ScreenshotSourceFile(_screenshotNum));
                 _fileToSave = _screenshotManager.ScreenshotDestFile(_screenshotNum);
                 _newScreenshot.IsTaken = false;
+                _diff = null;
             }
         }
 
@@ -874,6 +877,9 @@ namespace pwiz.SkylineTestUtil
                 FormStateChanged();
             }
 
+            // The MultiFormActivator can change test behavior. So, it needs to be cleared
+            // before continuing the test.
+            _activator.Clear();
             _pauseTestController.Continue();
         }
 

--- a/pwiz_tools/Skyline/TestUtil/ScreenshotProcessingExtensions.cs
+++ b/pwiz_tools/Skyline/TestUtil/ScreenshotProcessingExtensions.cs
@@ -38,6 +38,10 @@ namespace pwiz.SkylineTestUtil
         /// On a red background this becomes #FF68251F
         /// </summary>
         private static readonly Color STANDARD_BORDER_COLOR = Color.FromArgb(0x70, 0x70, 0x70);
+        /// <summary>
+        /// The interior border color for a docked dockable form.
+        /// </summary>
+        private static readonly Color INTERIOR_BORDER_COLOR = Color.FromArgb(0xA0, 0xA0, 0xA0);
 
         public static Bitmap CleanupBorder(this Bitmap bmp, bool toolWindow = false)
         {
@@ -82,6 +86,15 @@ namespace pwiz.SkylineTestUtil
             // drawing a curved corner on top of the otherwise rectangular border.
             if (cornerRadius != 0 && colorCounts.Count == 1)
                 return bmp;
+            // If the proposed color is the standard border color and the best color is the
+            // interior boarder color, then use the interior color. This is the case for
+            // docked DockableForms.
+            if (color.HasValue &&
+                color.Value == STANDARD_BORDER_COLOR &&
+                bestBorderColor == INTERIOR_BORDER_COLOR)
+            {
+                color = bestBorderColor;
+            }
             return bmp.CleanupBorderInternal(color ?? bestBorderColor, rect, cornerRadius);
         }
 

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -290,15 +290,13 @@ namespace pwiz.SkylineTestUtil
 
         private static void EnsureScreenshotIcon(Form dlg)
         {
-            // Making sure if the form has a visible icon it's Skyline release icon, not daily one.
             if (IsRecordingScreenShots && dlg.ShowIcon && !ReferenceEquals(dlg, SkylineWindow))
             {
-                if (dlg.FormBorderStyle != FormBorderStyle.FixedDialog ||
-                    AreIconsEqual(dlg.Icon, Resources.Skyline))    // Normally a fixed dialog will not have the Skyline icon
-                {
-                    if (!AreIconsEqual(dlg.Icon, SkylineWindow.Icon))
-                        RunUI(() => dlg.Icon = SkylineWindow.Icon);
-                }
+                // If the form has the current Skyline resource Icon, but it is not the same
+                // as the Skyline window icon, use the Skyline window icon to avoid recording
+                // screenshots of the Skyline-daily icon
+                if (AreIconsEqual(dlg.Icon, Resources.Skyline) && !AreIconsEqual(dlg.Icon, SkylineWindow.Icon))
+                    RunUI(() => dlg.Icon = SkylineWindow.Icon);
             }
         }
 


### PR DESCRIPTION
- Hide blinking caret in ComboBoxes with an edit control
- Hide RTF control in ScreenshotPreviewForm and ImageComparerWindow as soon as it is not appropriate
- Fixed FullScanSettingsControl radio button layout from bug introduced with feature finding
- Fixed GroupedStudies1TutorialTest to not maximize the SkylineWindow which produces a monitor dependent screenshot
- Fixed GroupedStudies1TutorialTest to reliably AutoResize the FoldChangeResult column
- Tweaked MethodRefinementTutorialTest with FocusDocument and some sizing fixes
- Tweaked Ms1FullScanFilteringTutorial with FocusDocument and JiggleSelection
- Fixed MultiFormActivator to check for IsHandleCreated before Handle which can cause HWND creation, and clear MultiFormActivator before restarting a test.
- Connected Revert toolstrip button in ScreenshotPreviewForm to its event handler
- Tweaked ScreenshotProcessingExtensions.CleanupBorder to use lighter gray for interior borders of docked DockableForms
- Fixed AbstractFunctionalTest to only change a window icon when it has Resources.Skyline but that does not match SkylineWindow.Icon.