### PR TITLE
Skyline: Final fix for MS1 and ImageComparerWindow fixes

### DIFF
--- a/pwiz_tools/Skyline/Executables/DevTools/ImageComparer/GitFileHelper.cs
+++ b/pwiz_tools/Skyline/Executables/DevTools/ImageComparer/GitFileHelper.cs
@@ -65,10 +65,12 @@ namespace ImageComparer
             using var reader = new StringReader(output);
             while (reader.ReadLine() is { } line)
             {
-                if (!line.StartsWith(" M "))
-                    continue;
                 // 'git status --porcelain' format: XY path/to/file
-                var filePath = line.Substring(3).Replace('/', Path.DirectorySeparatorChar);
+                // For modified have seen " M " and "M  "
+                line = line.Trim();
+                if (!line.StartsWith("M"))
+                    continue;
+                var filePath = line.Substring(1).Trim().Replace('/', Path.DirectorySeparatorChar);
                 yield return Path.Combine(GetPathInfo(directoryPath).Root, filePath);
             }
         }

--- a/pwiz_tools/Skyline/Executables/DevTools/ImageComparer/ImageComparerWindow.cs
+++ b/pwiz_tools/Skyline/Executables/DevTools/ImageComparer/ImageComparerWindow.cs
@@ -506,14 +506,21 @@ namespace ImageComparer
                 toolStripFileList.Enabled = true;
                 if (toolStripFileList.SelectedIndex != 0)
                     toolStripFileList.SelectedIndex = 0;
+                FormStateChanged();
             }
             else
             {
                 toolStripFileList.Enabled = false;
+                lock (_lock)
+                {
+                    _fileToShow = null;
+                    _oldScreenshot = new OldScreenshot();
+                    _newScreenshot = new OldScreenshot();
+                    _diff = null;
+                }
+                FormStateChanged();
                 ShowMessage(string.Format("No changed PNG files found in {0}", folderPath));
             }
-            
-            FormStateChanged();
         }
 
         private void Previous()

--- a/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
+++ b/pwiz_tools/Skyline/TestTutorial/Ms1FullScanFilteringTutorial.cs
@@ -621,6 +621,8 @@ namespace pwiz.SkylineTestTutorial
 
             int[] m1Thru5 = { 1, 2, 3, 4, 5, 6 };
             PickTransitions(pepIndex, m1Thru5); // turn on M+3 M+4 and M+5
+            if (Equals("ja", CultureInfo.CurrentCulture.TwoLetterISOLanguageName))
+                RunUIForScreenShot(() => SkylineWindow.Width += 12);    // Japanese needs to be a bit wider for the next 4 screenshots
             PauseForChromGraphScreenShot("upper - Chromatogram graph metafile with M+3, M+4 and M+5 added", TIP_NAME, tutorialPage++);
             PauseForChromGraphScreenShot("lower - Chromatogram graph metafile with M+3, M+4 and M+5 added", TIB_NAME, tutorialPage);
             CheckAnnotations(TIB_L, pepIndex, atest++);

--- a/pwiz_tools/Skyline/TestUtil/GitFileHelper.cs
+++ b/pwiz_tools/Skyline/TestUtil/GitFileHelper.cs
@@ -66,10 +66,12 @@ namespace pwiz.SkylineTestUtil
             using var reader = new StringReader(output);
             while (reader.ReadLine() is { } line)
             {
-                if (!line.StartsWith(" M "))
-                    continue;
+                // For modified have seen " M " and "M  "
                 // 'git status --porcelain' format: XY path/to/file
-                var filePath = line.Substring(3).Replace('/', Path.DirectorySeparatorChar);
+                line = line.Trim();
+                if (!line.StartsWith("M"))
+                    continue;
+                var filePath = line.Substring(1).Trim().Replace('/', Path.DirectorySeparatorChar);
                 yield return Path.Combine(GetPathInfo(directoryPath).Root, filePath);
             }
         }


### PR DESCRIPTION
- Made several MS1 graph screenshots slightly wider in Japanese
- Fixed detection of modified files in Git for new output format
- Fixed ImageComparerWindow behavior when no modified files are found