### PR TITLE
Skyline: Final improvements for phase 1 of screenshot updates

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/FileProgressControl.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/FileProgressControl.cs
@@ -29,6 +29,13 @@ namespace pwiz.Skyline.Controls.Graphs
 {
     public partial class FileProgressControl : UserControl
     {
+        public interface IStateProvider
+        {
+            DateTime Time { get; }
+            string PrepareErrorText(string errorText);
+        }
+
+        private readonly IStateProvider _stateProvider;
         private int _number;
         private MsDataFileUri _filePath;
         private bool _selected;
@@ -47,8 +54,9 @@ namespace pwiz.Skyline.Controls.Graphs
         public event EventHandler ShowGraph;
         public event EventHandler ShowLog;
 
-        public FileProgressControl()
+        public FileProgressControl(IStateProvider stateProvider)
         {
+            _stateProvider = stateProvider;
             InitializeComponent();
             labelPercent.Text = string.Empty;
             TabStop = false;
@@ -132,8 +140,8 @@ namespace pwiz.Skyline.Controls.Graphs
                 {
                     if (Error == null)
                     {
-                        Error = string.Format(GraphsResources.FileProgressControl_SetStatus_, DateTime.Now.ToShortTimeString(),
-                            ExceptionUtil.GetMessage(status.ErrorException));
+                        Error = string.Format(GraphsResources.FileProgressControl_SetStatus_, _stateProvider.Time.ToShortTimeString(),
+                            _stateProvider.PrepareErrorText(ExceptionUtil.GetMessage(status.ErrorException)));
                         _errorCount++;
                         if (_errorLog.Count == 3)
                         {

--- a/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/AuditLogTutorialTest.cs
@@ -73,6 +73,10 @@ namespace pwiz.SkylineTestTutorial
         [TestMethod]
         public void TestAuditLogTutorial()
         {
+            // Not yet translated
+            if (IsTranslationRequired)
+                return;
+
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
 //            PauseStartingPage = 16;

--- a/pwiz_tools/Skyline/TestTutorial/CEOptimizationTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/CEOptimizationTutorialTest.cs
@@ -49,6 +49,10 @@ namespace pwiz.SkylineTestTutorial
         [TestMethod]
         public void TestCEOptimizationTutorial()
         {
+            // Not yet translated
+            if (IsTranslationRequired)
+                return;
+
             AsSmallMolecules = false;
             RunCEOptimizationTutorialTest();
         }

--- a/pwiz_tools/Skyline/TestTutorial/LibraryExplorerTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/LibraryExplorerTutorialTest.cs
@@ -44,6 +44,9 @@ namespace pwiz.SkylineTestTutorial
         [TestMethod]
         public void TestLibraryExplorerTutorial()
         {
+            // Not yet translated
+            if (IsTranslationRequired)
+                return;
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
 //            IsCoverShotMode = true;
@@ -337,12 +340,15 @@ namespace pwiz.SkylineTestTutorial
                 Assert.AreEqual(2, viewLibraryDlg1.PeptideDisplayCount);
                 Assert.AreEqual(countLabels1, viewLibraryDlg1.GraphItem.IonLabels.Count());
             });
+            RunUIForScreenShot(() => viewLibraryDlg1.Width -= 185);
+            LimitXAxis(viewLibraryDlg1);
             PauseForGraphScreenShot("Spectrum graph metafile", viewLibraryDlg1.GraphExtensionControl, 16);   // p. 16, figure 1a
             RunUI(() =>
             {
                 viewLibraryDlg1.SelectedIndex = 1;
                 Assert.AreEqual(countLabels2, viewLibraryDlg1.GraphItem.IonLabels.Count());
             });
+            LimitXAxis(viewLibraryDlg1);
             PauseForGraphScreenShot("Spectrum graph metafile", viewLibraryDlg1.GraphExtensionControl, 16);   // p. 16, figure 1b
 
             docInitial = SkylineWindow.Document;
@@ -380,6 +386,7 @@ namespace pwiz.SkylineTestTutorial
                 Assert.IsTrue(labelsPhospho.Contains(label => label.Contains(string.Format("{0} {1}", IonType.precursor.GetLocalizedString(), lossText)))); 
                 Assert.AreEqual(countLabels1 + countLossLabels1 + countPrecursors1, labelsPhospho.Count);
             });
+            LimitXAxis(viewLibraryDlg1);
             PauseForGraphScreenShot("Spectrum graph metafile", viewLibraryDlg1.GraphExtensionControl, 18);   // p. 18, figure 1a.
 
             RunUI(() =>
@@ -390,6 +397,7 @@ namespace pwiz.SkylineTestTutorial
                 Assert.IsTrue(labelsPhospho.Contains(label => label.Contains(string.Format("{0} {1}", IonType.precursor.GetLocalizedString(), lossText))));
                 Assert.AreEqual(countLabels2 + countLossLabels2 + countPrecursors2, labelsPhospho.Count);
             });
+            LimitXAxis(viewLibraryDlg1);
             PauseForGraphScreenShot("Spectrum graph metafile", viewLibraryDlg1.GraphExtensionControl, 18);   // p. 18, figure 1b.
 
             // Matching Library Peptides to Proteins p. 18
@@ -400,6 +408,7 @@ namespace pwiz.SkylineTestTutorial
             {
                 buildBackgroundProteomeDlg.BackgroundProteomePath = GetTestPath(@"human.protdb");
                 buildBackgroundProteomeDlg.BackgroundProteomeName = "Human (mini)";
+                buildBackgroundProteomeDlg.SelToEndBackgroundProteomePath();
             });
             PauseForScreenShot<BuildBackgroundProteomeDlg>("Edit Background Proteome", 19);   // p. 19
 
@@ -463,6 +472,11 @@ namespace pwiz.SkylineTestTutorial
             PauseForScreenShot("Main window", 21);
 
             OkDialog(viewLibraryDlg, viewLibraryDlg.Close);
+        }
+
+        private void LimitXAxis(ViewLibraryDlg viewLibraryDlg)
+        {
+            viewLibraryDlg.GraphExtensionControl.Graph.GraphPane.XAxis.Scale.Max = 1225;
         }
     }
 }

--- a/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
@@ -63,6 +63,10 @@ namespace pwiz.SkylineTestTutorial
         [TestMethod]
         public void TestPeakPickingTutorial()
         {
+            // Not yet translated
+            if (IsTranslationRequired)
+                return;
+
             // Set true to look at tutorial screenshots.
 //            IsPauseForScreenShots = true;
 //            IsCoverShotMode = true;

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -722,9 +722,16 @@ namespace pwiz.SkylineTestTutorial
 
             // Try to import a file to show it fails.
             ImportResultsDlg importResultsDlg3 = ShowDialog<ImportResultsDlg>(SkylineWindow.ImportResults);
+            var uri500fmol = MsDataFileUri.Parse(GetTestPath(@"TOF\6-BSA-500fmol" + ExtAgilentRaw));
             RunUI(() => importResultsDlg3.NamedPathSets = importResultsDlg3.GetDataSourcePathsFileReplicates(
-                new[] { MsDataFileUri.Parse(GetTestPath(@"TOF\6-BSA-500fmol" + ExtAgilentRaw)) }));
+                new[] { uri500fmol }));
             var importProgress = ShowDialog<AllChromatogramsGraph>(importResultsDlg3.OkDialog);
+            // Set a consistent time for a screenshot
+            var dateTimeCurrent = DateTime.Now;
+            var dateTimeError = new DateTime(dateTimeCurrent.Year, dateTimeCurrent.Month, dateTimeCurrent.Day, 12, 35, 0);
+            importProgress.SetFreezeTimeForError(dateTimeError);
+            // Remove the full path for the error in a screenshot
+            importProgress.SetReplacementForError(Path.GetDirectoryName(uri500fmol.GetFilePath()) + Path.DirectorySeparatorChar, string.Empty);
             var docFullScanError = WaitForDocumentChangeLoaded(docCalibrate1);
 //            WaitForConditionUI(() => importProgress.Files.Any());
             WaitForConditionUI(() => importProgress.Finished);

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1306,6 +1306,8 @@ namespace pwiz.SkylineTestUtil
             }
         }
 
+        public static bool IsTranslationRequired => IsAutoScreenShotMode && !Equals("en", GetFolderNameForLanguage(CultureInfo.CurrentCulture));
+
         private static bool _isCoverShotMode;
 
         public static bool IsCoverShotMode


### PR DESCRIPTION
- Fixed ability to use a screenshot of an error message in AllChromatogramsGraph (TargetedMsmsTutorialTest)
- Added short-circuit for auto-screenshot mode in non-en languages to untranslated tutorials
- Final tweaks to LibraryExplorerTutorialTest for auto-screenshot update