### PR TITLE
Fix inconsistent formatting of MS vs MS/MS resolution values in Transition Settings > Full Scan dialog

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
+++ b/pwiz_tools/Skyline/SettingsUI/FullScanSettingsControl.cs
@@ -191,7 +191,7 @@ namespace pwiz.Skyline.SettingsUI
                 double precursorRes;
                 return double.TryParse(textPrecursorRes.Text, out precursorRes) ? (double?)precursorRes : null;
             }
-            set { textPrecursorRes.Text = FormatPrecursorRes(value, PrecursorMassAnalyzer); }
+            set { textPrecursorRes.Text = FormatRes(value, PrecursorMassAnalyzer); }
         }
 
         public double? PrecursorResMz
@@ -211,7 +211,7 @@ namespace pwiz.Skyline.SettingsUI
                 double productRes;
                 return double.TryParse(textProductRes.Text, out productRes) ? (double?)productRes : null;
             }
-            set { textProductRes.Text = value.ToString(); }
+            set { textProductRes.Text = FormatRes(value, ProductMassAnalyzer); }
         }
 
         public double? ProductResMz
@@ -885,7 +885,7 @@ namespace pwiz.Skyline.SettingsUI
             get { return double.Parse(tbxTimeAroundPrediction.Text); }
         }
 
-        private static string FormatPrecursorRes(double? resolvingPower, FullScanMassAnalyzerType analyzerType)
+        private static string FormatRes(double? resolvingPower, FullScanMassAnalyzerType analyzerType)
         {
             if (!resolvingPower.HasValue)
                 return string.Empty;
@@ -921,7 +921,7 @@ namespace pwiz.Skyline.SettingsUI
                 labelTh.Visible = false;
                 textAt.Visible = false;
                 textRes.Enabled = true;
-                textRes.Text = FormatPrecursorRes(
+                textRes.Text = FormatRes(
                     resCurrent.HasValue && (analyzerTypeCurrent == analyzerTypeNew)
                         ? resCurrent
                         : TransitionFullScan.DEFAULT_CENTROIDED_PPM,
@@ -951,9 +951,9 @@ namespace pwiz.Skyline.SettingsUI
                 }
 
                 if (analyzerTypeNew == analyzerTypeCurrent && resCurrent.HasValue)
-                    textRes.Text = FormatPrecursorRes(resCurrent, analyzerTypeNew);
+                    textRes.Text = FormatRes(resCurrent, analyzerTypeNew);
                 else
-                    textRes.Text = FormatPrecursorRes(TransitionFullScan.DEFAULT_RES_VALUES[(int)analyzerTypeNew], analyzerTypeNew);
+                    textRes.Text = FormatRes(TransitionFullScan.DEFAULT_RES_VALUES[(int)analyzerTypeNew], analyzerTypeNew);
 
                 labelAt.Visible = variableRes;
                 textAt.Visible = variableRes;


### PR DESCRIPTION
It's actually not possible to enter this state (inconsistent use of thousands separator) as a user, but automated testing and tutorial screen capture could do so.

![image](https://github.com/user-attachments/assets/590df615-c644-4400-95e0-4ba5b4b05767)
vs
![image](https://github.com/user-attachments/assets/d4dede61-052b-46d8-9c72-61b02b6c0521)

