### PR TITLE
Skyline: Fixes for consistent screenshots on Windows 11

### DIFF
--- a/pwiz_tools/Skyline/Controls/SequenceTree.cs
+++ b/pwiz_tools/Skyline/Controls/SequenceTree.cs
@@ -142,44 +142,48 @@ namespace pwiz.Skyline.Controls
 
             ImageList = new ImageList
             {
-                TransparentColor = Color.Magenta
+                TransparentColor = Color.Magenta,
+                ColorDepth = ColorDepth.Depth24Bit
             };
-            ImageList.Images.Add(Resources.Blank);
-            ImageList.Images.Add(Resources.Protein);
-            ImageList.Images.Add(Resources.Peptide);
-            ImageList.Images.Add(Resources.TransitionGroup);
-            ImageList.Images.Add(Resources.Fragment);
-            ImageList.Images.Add(Resources.PeptideLib);
-            ImageList.Images.Add(Resources.PeptideIrt);
-            ImageList.Images.Add(Resources.PeptideIrtLib);
-            ImageList.Images.Add(Resources.PeptideStandard);
-            ImageList.Images.Add(Resources.PeptideStandardLib);
-            ImageList.Images.Add(Resources.PeptideQc);
-            ImageList.Images.Add(Resources.PeptideQcLib);
-            ImageList.Images.Add(Resources.TransitionGroupLib);
-            ImageList.Images.Add(Resources.FragmentLib);
-            ImageList.Images.Add(Resources.PeptideDecoy);
-            ImageList.Images.Add(Resources.TransitionGroupDecoy);
-            ImageList.Images.Add(Resources.FragmentDecoy);
-            ImageList.Images.Add(Resources.ProteinDecoy);
-            ImageList.Images.Add(Resources.PeptideDecoyLib);
-            ImageList.Images.Add(Resources.TransitionGroupLibDecoy);
-            ImageList.Images.Add(Resources.FragmentLibDecoy);
-            ImageList.Images.Add(Resources.Molecule);
-            ImageList.Images.Add(Resources.MoleculeLib);
-            ImageList.Images.Add(Resources.MoleculeIrt);
-            ImageList.Images.Add(Resources.MoleculeIrtLib);
-            ImageList.Images.Add(Resources.MoleculeStandard);
-            ImageList.Images.Add(Resources.MoleculeStandardLib);
-            ImageList.Images.Add(Resources.MoleculeList);
-            ImageList.Images.Add(Resources.PeptideList);
-            ImageList.Images.Add(Resources.EmptyList);
+            ImageList.Images.Add(Resources.Blank);      // 1bpp
+            ImageList.Images.Add(Resources.Protein);    // 16bpp
+            ImageList.Images.Add(Resources.Peptide);    // 4bpp
+            ImageList.Images.Add(Resources.TransitionGroup); // 8bpp
+            ImageList.Images.Add(Resources.Fragment);   // 8bpp
+            ImageList.Images.Add(Resources.PeptideLib); // 4bpp
+            ImageList.Images.Add(Resources.PeptideIrt); // 4bpp
+            ImageList.Images.Add(Resources.PeptideIrtLib); // 4bpp
+            ImageList.Images.Add(Resources.PeptideStandard); // 4bpp
+            ImageList.Images.Add(Resources.PeptideStandardLib); // 4bpp
+            ImageList.Images.Add(Resources.PeptideQc);  // 4bpp
+            ImageList.Images.Add(Resources.PeptideQcLib); // 4bpp
+            ImageList.Images.Add(Resources.TransitionGroupLib); // 8bpp
+            ImageList.Images.Add(Resources.FragmentLib); // 8bpp
+            ImageList.Images.Add(Resources.PeptideDecoy); // 4bpp
+            ImageList.Images.Add(Resources.TransitionGroupDecoy); // 8bpp
+            ImageList.Images.Add(Resources.FragmentDecoy); // 8bpp
+            ImageList.Images.Add(Resources.ProteinDecoy); // 24bpp
+            ImageList.Images.Add(Resources.PeptideDecoyLib); // 4bpp
+            ImageList.Images.Add(Resources.TransitionGroupLibDecoy); // 8bpp
+            ImageList.Images.Add(Resources.FragmentLibDecoy); // 8bpp
+            ImageList.Images.Add(Resources.Molecule);   // 24bpp
+            ImageList.Images.Add(Resources.MoleculeLib); // 24bpp
+            ImageList.Images.Add(Resources.MoleculeIrt); // 24bpp
+            ImageList.Images.Add(Resources.MoleculeIrtLib); // 24bpp
+            ImageList.Images.Add(Resources.MoleculeStandard); // 24bpp
+            ImageList.Images.Add(Resources.MoleculeStandardLib); // 24bpp
+            ImageList.Images.Add(Resources.MoleculeList); // 16bpp
+            ImageList.Images.Add(Resources.PeptideList); // 16bpp
+            ImageList.Images.Add(Resources.EmptyList);  // 16bpp
 
-            StateImageList = new ImageList();
-            StateImageList.Images.Add(Resources.Peak);
-            StateImageList.Images.Add(Resources.Keep);
-            StateImageList.Images.Add(Resources.NoPeak);
-            StateImageList.Images.Add(Resources.PeakBlank);
+            StateImageList = new ImageList
+            {
+                ColorDepth = ColorDepth.Depth24Bit
+            };
+            StateImageList.Images.Add(Resources.Peak);  // 8bpp
+            StateImageList.Images.Add(Resources.Keep);  // 24bpp
+            StateImageList.Images.Add(Resources.NoPeak); // 24bpp
+            StateImageList.Images.Add(Resources.PeakBlank); // 8bpp
 
             // Add the editable node at the end
             Nodes.Add(new EmptyNode());

--- a/pwiz_tools/Skyline/Controls/StatementCompletionTextBox.cs
+++ b/pwiz_tools/Skyline/Controls/StatementCompletionTextBox.cs
@@ -44,7 +44,11 @@ namespace pwiz.Skyline.Controls
         private ProteinMatchQuery _proteinMatcher;
         private CancellationTokenSource _cancellationTokenSource;
         private readonly IDocumentUIContainer _documentUiContainer;
-        private readonly ImageList _imageList = new ImageList() {TransparentColor = Color.Magenta};
+        private readonly ImageList _imageList = new ImageList
+        {
+            TransparentColor = Color.Magenta,
+            ColorDepth = ColorDepth.Depth16Bit
+        };
         private ProteomeDb _proteomeDb;
         private bool _hideOnLoseFocus;
 
@@ -55,8 +59,8 @@ namespace pwiz.Skyline.Controls
         {
             MatchTypes = ProteinMatchTypes.ALL;
             _documentUiContainer = documentUiContainer;
-            _imageList.Images.Add(Resources.Protein);
-            _imageList.Images.Add(Resources.Peptide);
+            _imageList.Images.Add(Resources.Protein);   // 16bpp
+            _imageList.Images.Add(Resources.Peptide);   // 4bpp
             _hideOnLoseFocus = hideOnLoseFocus;
         }
 
@@ -426,7 +430,7 @@ namespace pwiz.Skyline.Controls
                 _cancellationTokenSource = null;
             }
         }
-        public static readonly ImageList IMAGE_LIST = new ImageList();
+        // public static readonly ImageList IMAGE_LIST = new ImageList();
         private enum ImageId
         {
             protein,

--- a/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PublishDocumentDlg.cs
@@ -67,12 +67,12 @@ namespace pwiz.Skyline.FileUI
 
             _panoramaServers = servers;
             tbFilePath.Text = FileEx.GetTimeStampedFileName(fileName);
-            
-            treeViewFolders.ImageList = new ImageList();
-            treeViewFolders.ImageList.Images.Add(Resources.Panorama);
-            treeViewFolders.ImageList.Images.Add(Resources.LabKey);
-            treeViewFolders.ImageList.Images.Add(Resources.ChromLib);
-            treeViewFolders.ImageList.Images.Add(Resources.Folder);
+
+            treeViewFolders.ImageList = new ImageList { ColorDepth = ColorDepth.Depth32Bit };
+            treeViewFolders.ImageList.Images.Add(Resources.Panorama);   // 24bpp
+            treeViewFolders.ImageList.Images.Add(Resources.LabKey);     // 8bpp
+            treeViewFolders.ImageList.Images.Add(Resources.ChromLib);   // 8bpp
+            treeViewFolders.ImageList.Images.Add(Resources.Folder);     // 32bpp
 
             ServerTreeStateRestorer = new TreeViewStateRestorer(treeViewFolders);
 

--- a/pwiz_tools/Skyline/TestUtil/ScreenshotProcessingExtensions.cs
+++ b/pwiz_tools/Skyline/TestUtil/ScreenshotProcessingExtensions.cs
@@ -100,6 +100,7 @@ namespace pwiz.SkylineTestUtil
                 bestBorderColor == INTERIOR_BORDER_COLOR)
             {
                 color = bestBorderColor;
+                cornerRadius = 0;   // No arched corners on interior borders
             }
             return bmp.CleanupBorderInternal(color ?? bestBorderColor, rect, cornerRadius, excludeRect);
         }
@@ -107,7 +108,7 @@ namespace pwiz.SkylineTestUtil
         private static Bitmap CleanupBorderInternal(this Bitmap bmp, Color color, Rectangle rect, int cornerRadius,
             Rectangle? excludeRect)
         {
-            return IsWindows11()
+            return IsWindows11() && cornerRadius != 0
                 ? bmp.CleanupBorder11(color, rect, cornerRadius, excludeRect)
                 : bmp.CleanupBorder10(color, rect, excludeRect);
         }


### PR DESCRIPTION
- Fixed ColorDepth on ImageLists to match the files they include.
- Fixed CleanupBorder to set corner radius to zero for interior docked DockableForms.