### PR TITLE
Skyline: More fixes for screenshot consistency

### DIFF
--- a/pwiz_tools/Skyline/Executables/DevTools/ImageComparer/ScreenshotInfo.cs
+++ b/pwiz_tools/Skyline/Executables/DevTools/ImageComparer/ScreenshotInfo.cs
@@ -85,7 +85,7 @@ namespace ImageComparer
 
     internal class ScreenshotFile
     {
-        private static readonly Regex PATTERN = new Regex(@"\\([a-zA-Z\-]+)\\(\w\w-?[A-Z]*)\\s-(\d\d)\.png");
+        private static readonly Regex PATTERN = new Regex(@"\\([a-zA-Z0-9\-]+)\\(\w\w-?[A-Z]*)\\s-(\d\d)\.png");
 
         public static bool IsMatch(string filePath)
         {

--- a/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/GroupedStudies1TutorialTest.cs
@@ -255,10 +255,10 @@ namespace pwiz.SkylineTestTutorial
             if (IsPauseForScreenShots)
                 RunUI(() =>
                 {
-                    // Essentially maximize the window for a 1920x1080 monitor at 100%
+                    // Essentially maximize the window
                     savedBounds = SkylineWindow.Bounds;
-                    SkylineWindow.Size = new Size(1934, 1047);
-                    SkylineWindow.Location = new Point(-7, 0);
+                    SkylineWindow.Size = Screen.FromControl(SkylineWindow).WorkingArea.Size;
+                    SkylineWindow.Location = new Point(0, 0);
                 });
 
             SelectNode(SrmDocument.Level.Molecules, 0);
@@ -1098,7 +1098,7 @@ namespace pwiz.SkylineTestTutorial
                 var documentSettingsDlg = ShowDialog<DocumentSettingsDlg>(SkylineWindow.ShowDocumentSettingsDialog);
 
                 AddAnnotation(documentSettingsDlg, "MissingData", AnnotationDef.AnnotationType.true_false, null,
-                    AnnotationDef.AnnotationTargetSet.Singleton(AnnotationDef.AnnotationTarget.peptide));
+                    AnnotationDef.AnnotationTargetSet.Singleton(AnnotationDef.AnnotationTarget.peptide), true);
 
                 RunUI(() => documentSettingsDlg.AnnotationsCheckedListBox.SetItemChecked(3, true));
 


### PR DESCRIPTION
- Add back annotation screenshot in TestGroupedStudies1Tutorial removed with page number refactoring
- Reduce the size of the maximized Skyline window in TestGroupedStudies1Tutorial to work for both Windows 10 and 11
- Fix Regex for screenshot naming in ImageComparer/ScreenshotInfo.cs