### PR TITLE
Fix PInvoke's Dwmapi

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/WindowThumbnail.cs
+++ b/pwiz_tools/Skyline/SkylineTester/WindowThumbnail.cs
@@ -56,7 +56,7 @@ namespace SkylineTester
         {
             if (_thumb != IntPtr.Zero)
             {
-                DwmapiTest.UnregisterThumbnail(_thumb);
+                DwmapiTest.DwmUnregisterThumbnail(_thumb);
                 _thumb = IntPtr.Zero;
             }
         }
@@ -71,7 +71,7 @@ namespace SkylineTester
             }
 
             IntPtr newThumb;
-            DwmapiTest.RegisterThumbnail(MainWindow.Handle, window, out newThumb);
+            DwmapiTest.DwmRegisterThumbnail(MainWindow.Handle, window, out newThumb);
             if (newThumb == IntPtr.Zero)
             {
                 UnregisterThumb();
@@ -86,7 +86,7 @@ namespace SkylineTester
             Point locationOnForm = MainWindow.PointToClient(Parent.PointToScreen(Location));
 
             PInvokeCommon.SIZE size;
-            DwmapiTest.QueryThumbnailSourceSize(_thumb, out size);
+            DwmapiTest.DwmQueryThumbnailSourceSize(_thumb, out size);
 
             var props = new DwmapiTest.THUMBNAIL_PROPERTIES
             {
@@ -105,7 +105,7 @@ namespace SkylineTester
             if (size.cy < Height)
                 props.rcDestination.bottom = props.rcDestination.top + size.cy;
 
-            DwmapiTest.UpdateThumbnailProperties(_thumb, ref props);
+            DwmapiTest.DwmUpdateThumbnailProperties(_thumb, ref props);
         }
 
         private IntPtr FindWindow(int processId)

--- a/pwiz_tools/Skyline/TestRunnerLib/PInvoke/DwmapiTest.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/PInvoke/DwmapiTest.cs
@@ -48,18 +48,18 @@ namespace TestRunnerLib.PInvoke
 
         // ReSharper disable once StringLiteralTypo
         [DllImport("dwmapi.dll")]
-        public static extern int RegisterThumbnail(IntPtr dest, IntPtr src, out IntPtr thumb);
+        public static extern int DwmRegisterThumbnail(IntPtr dest, IntPtr src, out IntPtr thumb);
 
         // ReSharper disable once StringLiteralTypo
         [DllImport("dwmapi.dll")]
-        public static extern int UnregisterThumbnail(IntPtr thumb);
+        public static extern int DwmUnregisterThumbnail(IntPtr thumb);
 
         // ReSharper disable once StringLiteralTypo
         [DllImport("dwmapi.dll")]
-        public static extern int QueryThumbnailSourceSize(IntPtr thumb, out PInvokeCommon.SIZE size);
+        public static extern int DwmQueryThumbnailSourceSize(IntPtr thumb, out PInvokeCommon.SIZE size);
 
         // ReSharper disable once StringLiteralTypo
         [DllImport("dwmapi.dll")]
-        public static extern int UpdateThumbnailProperties(IntPtr hThumb, ref THUMBNAIL_PROPERTIES props);
+        public static extern int DwmUpdateThumbnailProperties(IntPtr hThumb, ref THUMBNAIL_PROPERTIES props);
     }
 }


### PR DESCRIPTION
Fix a naming issue in DwmapiTest that caused EntryPointNotFound exceptions and broke screenshots in SkylineTester's Quality tab.