### PR TITLE
Explore challenging intermittent nightly test failures - decrufted

### DIFF
--- a/pwiz_tools/Skyline/TestConnected/ArdiaFunctionalTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/ArdiaFunctionalTest.cs
@@ -162,7 +162,7 @@ namespace pwiz.SkylineTestConnected
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("small.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("small.sky"));
             var importResultsDlg = ShowDialog<ImportResultsDlg>(SkylineWindow.ImportResults);
             var openDataSourceDialog = ShowDialog<OpenDataSourceDialog>(importResultsDlg.OkDialog);
             var editAccountDlg = ShowDialog<EditRemoteAccountDlg>(() => openDataSourceDialog.CurrentDirectory = RemoteUrl.EMPTY);
@@ -193,7 +193,7 @@ namespace pwiz.SkylineTestConnected
             }
 
             RunUI(() => SkylineWindow.SaveDocument());
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("small.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("small.sky"));
 
             if (!_account.DeleteRawAfterImport)
             {

--- a/pwiz_tools/Skyline/TestFunctional/AgilentCeOptimizationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AgilentCeOptimizationTest.cs
@@ -27,7 +27,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class AgilentCeOptimizationTest : AbstractFunctionalTest
+    public class AgilentCeOptimizationTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestAgilentCeOptimization()
@@ -38,10 +38,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() =>
-            { 
-                SkylineWindow.OpenFile(TestFilesDir.GetTestPath("AgilentCeTest.sky"));
-            });
+            OpenDocument(TestFilesDir.GetTestPath("AgilentCeTest.sky"));
             RunDlg<ImportResultsDlg>(SkylineWindow.ImportResults, importResults=>{
                 importResults.OptimizationName = ExportOptimize.CE;
                 importResults.NamedPathSets = new[]

--- a/pwiz_tools/Skyline/TestFunctional/AlertDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AlertDlgTest.cs
@@ -30,7 +30,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class AlertDlgTest : AbstractFunctionalTest
+    public class AlertDlgTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestAlertDlg()
@@ -41,9 +41,9 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
+            OpenDocument(TestFilesDir.GetTestPath("SmallMoleculePredictedRetentionTime.sky"));
             RunUI(()=>
             {
-                SkylineWindow.OpenFile(TestFilesDir.GetTestPath("SmallMoleculePredictedRetentionTime.sky"));
                 Assert.AreEqual(SrmDocument.DOCUMENT_TYPE.small_molecules, SkylineWindow.Document.DocumentType);
                 Assert.AreEqual(SrmDocument.DOCUMENT_TYPE.small_molecules, SkylineWindow.ModeUI);
             });

--- a/pwiz_tools/Skyline/TestFunctional/AnnotationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AnnotationTest.cs
@@ -43,7 +43,7 @@ namespace pwiz.SkylineTestFunctional
     /// </summary>
     // ReSharper disable LocalizableElement
     [TestClass]
-    public class AnnotationTest : AbstractFunctionalTest
+    public class AnnotationTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestAnnotations()
@@ -105,7 +105,7 @@ namespace pwiz.SkylineTestFunctional
             OkDialog(editListDlg, () => editListDlg.DialogResult = DialogResult.OK);
             OkDialog(chooseAnnotationsDlg, chooseAnnotationsDlg.Close);
             // Open the .sky file
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini_missing_results.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini_missing_results.sky"));
             // Turn on the annotations
             chooseAnnotationsDlg = ShowDialog<DocumentSettingsDlg>(SkylineWindow.ShowDocumentSettingsDialog);
             RunUI(() =>

--- a/pwiz_tools/Skyline/TestFunctional/ArrangeGraphsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ArrangeGraphsTest.cs
@@ -28,7 +28,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class ArrangeGraphsTest : AbstractFunctionalTest
+    public class ArrangeGraphsTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestArrangeGraphs()
@@ -40,7 +40,7 @@ namespace pwiz.SkylineTestFunctional
         protected override void DoTest()
         {
             string documentPath = TestFilesDir.GetTestPath("11-16-10mz_manual.sky");
-            RunUI(() => SkylineWindow.OpenFile(documentPath));
+            OpenDocument(documentPath);
 
             // Tests that elements show up in correct groups and order as type "tiled" in grouped window.
             RunGroupDlg(9, DisplayGraphsType.Tiled, GroupGraphsType.separated, GroupGraphsOrder.Acquired_Time);

--- a/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
@@ -858,7 +858,7 @@ importIrt => importIrt.Btn1Click());
             var documentInterleaved = TestFilesDir.GetTestPath("Consensus_Dario_iRT_new_blank.sky");
             var textInterleaved = TestFilesDir.GetTestPath("Interleaved.csv");
             RemoveColumn(textInterleaved, 22);
-            RunUI(() => SkylineWindow.OpenFile(documentInterleaved));
+            OpenDocument(documentInterleaved);
             ImportTransitionListSkipColumnSelectWithMessage(textInterleaved,
                 Resources.SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_library_values___Add_these_iRT_values_to_the_iRT_calculator_,
                 addIrtDlg => addIrtDlg.Btn0Click());
@@ -901,7 +901,7 @@ importIrt => importIrt.Btn1Click());
             var documentInterleavedIrt = TestFilesDir.GetTestPath("Consensus_Dario_iRT_new_blank.sky");
             var textInterleavedIrt = TestFilesDir.GetTestPath("InterleavedDiffIrt.csv");
             RemoveColumn(textInterleavedIrt, 22);
-            RunUI(() => SkylineWindow.OpenFile(documentInterleavedIrt));
+            OpenDocument(documentInterleavedIrt);
             ImportTransitionListSkipColumnSelectWithMessage(textInterleavedIrt,
                 Resources.SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_iRT_library_values___Add_these_iRT_values_to_the_iRT_calculator_,
                 addIrtDlg => addIrtDlg.Btn0Click());
@@ -926,7 +926,7 @@ importIrt => importIrt.Btn1Click());
             // Make sure all the iRT magic works even when no spectral library info is present
             // (regression test in response to crash when libraries not present)
             var textInterleavedIrtNoLib = TestFilesDir.GetTestPath("InterleavedDiffIrt.csv");
-            RunUI(() => SkylineWindow.OpenFile(documentInterleavedIrt));
+            OpenDocument(documentInterleavedIrt);
             ImportTransitionListSkipColumnSelectWithMessage(textInterleavedIrtNoLib,
                 Resources.SkylineWindow_ImportMassList_The_transition_list_appears_to_contain_spectral_library_intensities___Create_a_document_library_from_these_intensities_,
                 addIrtDlg => addIrtDlg.Btn0Click());

--- a/pwiz_tools/Skyline/TestFunctional/AssociateProteinsDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AssociateProteinsDlgTest.cs
@@ -40,7 +40,7 @@ namespace pwiz.SkylineTestFunctional
 {
     
     [TestClass]
-    public class AssociateProteinsDlgTest : AbstractFunctionalTest
+    public class AssociateProteinsDlgTest : AbstractFunctionalTestEx
     {
         private enum ImportType { FASTA, BGPROTEOME, OVERRIDE }
         private String _fastaFile;
@@ -66,7 +66,7 @@ namespace pwiz.SkylineTestFunctional
 
         private void TestInvalidFasta()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("AssociateProteinsTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("AssociateProteinsTest.sky"));
 
             AssociateProteinsDlg associateProteinsDlg = ShowDialog<AssociateProteinsDlg>(SkylineWindow.ShowAssociateProteinsDlg);
 
@@ -92,11 +92,11 @@ namespace pwiz.SkylineTestFunctional
         private void TestUseFasta()
 
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("AssociateProteinsTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("AssociateProteinsTest.sky"));
             TestDialog(ImportType.FASTA);
 
             // test again without needing to set the FASTA
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("AssociateProteinsTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("AssociateProteinsTest.sky"));
             TestDialog(ImportType.FASTA);
         }
 
@@ -105,7 +105,7 @@ namespace pwiz.SkylineTestFunctional
         /// </summary>
         private void TestUseBackgroundProteome()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("AssociateProteinsTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("AssociateProteinsTest.sky"));
             TestDialog(ImportType.BGPROTEOME);
         }
 
@@ -114,7 +114,7 @@ namespace pwiz.SkylineTestFunctional
         /// </summary>
         private void TestFastaOverride()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("AssociateProteinsTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("AssociateProteinsTest.sky"));
             TestDialog(ImportType.OVERRIDE);
 
             // test again with existing associations

--- a/pwiz_tools/Skyline/TestFunctional/AuditLogValidationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AuditLogValidationTest.cs
@@ -46,7 +46,7 @@ namespace pwiz.SkylineTestFunctional
             var documentFile = TestFilesDir.GetTestPath(@"AuditLogValidationTest/MethodEditClean.sky");
             WaitForCondition(() => File.Exists(documentFile));
 
-            RunUI(() => SkylineWindow.OpenFile(documentFile)); // Should execute without any problems
+            OpenDocument(documentFile); // Should execute without any problems
 
             // - audit log with modified content - expect message dialog to appear
             // - audit log with modified entry hashes - expect exception

--- a/pwiz_tools/Skyline/TestFunctional/BatchCalibrationGroupComparisonTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/BatchCalibrationGroupComparisonTest.cs
@@ -40,7 +40,7 @@ namespace pwiz.SkylineTestFunctional
     /// yields the correct fold change numbers.
     /// </summary>
     [TestClass]
-    public class BatchCalibrationGroupComparisonTest : AbstractFunctionalTest
+    public class BatchCalibrationGroupComparisonTest : AbstractFunctionalTestEx
     {
         private const string GROUP_COMPARISON_NAME = "AD vs HC";
         [TestMethod]
@@ -52,7 +52,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("BatchCalibrationGroupComparisonTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("BatchCalibrationGroupComparisonTest.sky"));
             AnnotationDef conditionAnnotation =
                 SkylineWindow.Document.Settings.DataSettings.AnnotationDefs.FirstOrDefault(def =>
                     def.Name == "Condition");

--- a/pwiz_tools/Skyline/TestFunctional/ClusteredHeatMapTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ClusteredHeatMapTest.cs
@@ -32,7 +32,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class ClusteredHeatMapTest : AbstractFunctionalTest
+    public class ClusteredHeatMapTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestClusteredHeatMap()
@@ -114,7 +114,7 @@ namespace pwiz.SkylineTestFunctional
                 heatMap.Close();
             });
             Assert.IsNull(FindOpenForm<HeatMapGraph>());
-            RunUI(() => SkylineWindow.OpenFile(filePath));
+            OpenDocument(filePath);
             heatMap = FindOpenForm<HeatMapGraph>();
             Assert.IsNotNull(heatMap);
             WaitForConditionUI(() => heatMap.IsComplete && heatMap.TabText == expectedHeatMapTitle);
@@ -143,7 +143,7 @@ namespace pwiz.SkylineTestFunctional
                 pcaPlot.Close();
             });
             Assert.IsNull(FindOpenForm<PcaPlot>());
-            RunUI(() => SkylineWindow.OpenFile(filePath));
+            OpenDocument(filePath);
             pcaPlot = FindOpenForm<PcaPlot>();
             WaitForConditionUI(() => pcaPlot.IsComplete && pcaPlot.TabText == expectedPcaPlotTitle);
             Assert.AreEqual(curveCount, pcaPlot.GraphControl.GraphPane.CurveList.Count);

--- a/pwiz_tools/Skyline/TestFunctional/CopyPasteTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/CopyPasteTest.cs
@@ -39,7 +39,7 @@ namespace pwiz.SkylineTestFunctional
     /// Functional test for CopyPaste.
     /// </summary>
     [TestClass]
-    public class CopyPasteTest : AbstractFunctionalTest
+    public class CopyPasteTest : AbstractFunctionalTestEx
     {
         private const string TEXT_INDENT = "    ";
         private const string TEXT_LINE_BREAK = "\r\n";
@@ -56,7 +56,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini_withMod.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini_withMod.sky"));
             WaitForGraphs();
 
             RunUI(() =>

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -95,7 +95,7 @@ namespace pwiz.SkylineTestFunctional
 
         DdaTestSettings TestSettings;
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoNightlyTestingAttribute(TestExclusionReason.MSAMANDA_MEMORY_ISSUES)]
         public void TestDdaSearch()
         {
             TestFilesZip = @"TestFunctional\DdaSearchTest.zip";

--- a/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
@@ -103,7 +103,8 @@ namespace pwiz.SkylineTestFunctional
             };
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoUnicodeTesting(TestExclusionReason.MSGFPLUS_UNICODE_ISSUES)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoUnicodeTesting(TestExclusionReason.MSGFPLUS_UNICODE_ISSUES),
+         NoNightlyTestingAttribute(TestExclusionReason.MSAMANDA_MEMORY_ISSUES)]
         public void TestDiaSearchVariableWindows()
         {
             TestFilesZip = @"TestFunctional\DiaSearchTest.zip";
@@ -157,7 +158,8 @@ namespace pwiz.SkylineTestFunctional
             RunFunctionalTest();
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoUnicodeTesting(TestExclusionReason.MSFRAGGER_UNICODE_ISSUES)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoUnicodeTesting(TestExclusionReason.MSFRAGGER_UNICODE_ISSUES),
+         NoNightlyTestingAttribute(TestExclusionReason.MSAMANDA_MEMORY_ISSUES)]
         public void TestDiaSearchFixedWindows()
         {
             TestFilesZip = @"TestFunctional\DiaSearchTest.zip";

--- a/pwiz_tools/Skyline/TestFunctional/DocumentSizeErrorTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DocumentSizeErrorTest.cs
@@ -31,7 +31,7 @@ namespace pwiz.SkylineTestFunctional
     /// Summary description for DocumentSizeErrorTest
     /// </summary>
     [TestClass]
-    public class DocumentSizeErrorTest : AbstractFunctionalTest
+    public class DocumentSizeErrorTest : AbstractFunctionalTestEx
     {
         [TestMethod, MinidumpLeakThreshold(15)]
         public void TestDocumentSizeError()

--- a/pwiz_tools/Skyline/TestFunctional/DuplicateSmallMoleculePrecursorTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DuplicateSmallMoleculePrecursorTest.cs
@@ -62,7 +62,7 @@ namespace pwiz.SkylineTestFunctional
 
             // Now test fix for "an item with the same key has already been added" as in https://skyline.ms/announcements/home/support/thread.view?rowId=51494
             LoadNewDocument(true);
-            RunUI(() => { SkylineWindow.OpenFile(TestFilesDir.GetTestPath("402.sky")); });
+            OpenDocument(TestFilesDir.GetTestPath("402.sky"));
             var mzML = TestFilesDir.GetTestPath("402.mzML");
             ImportResultsFile(mzML);
             WaitForDocumentLoaded(240000);

--- a/pwiz_tools/Skyline/TestFunctional/EditDialogsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditDialogsTest.cs
@@ -29,7 +29,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class EditDialogsTest : AbstractFunctionalTest
+    public class EditDialogsTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestEditDialogs()
@@ -43,7 +43,7 @@ namespace pwiz.SkylineTestFunctional
             RunEditDialogs(); // no data needed to test these
 
             // Open a .sky file
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini.sky"));
             RunOtherDialogs();
         }
 

--- a/pwiz_tools/Skyline/TestFunctional/EditNoteTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/EditNoteTest.cs
@@ -32,7 +32,7 @@ namespace pwiz.SkylineTestFunctional
     /// Summary description for EditNoteTest
     /// </summary>
     [TestClass]
-    public class EditNoteTest : AbstractFunctionalTest
+    public class EditNoteTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestEditNote()
@@ -47,7 +47,7 @@ namespace pwiz.SkylineTestFunctional
         {
 
             // Open the .sky file
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini.sky"));
 
             // Select the first transition group.
             RunUI(() =>

--- a/pwiz_tools/Skyline/TestFunctional/ExplicitAnalyteConcentrationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExplicitAnalyteConcentrationTest.cs
@@ -36,7 +36,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class ExplicitAnalyteConcentrationTest : AbstractFunctionalTest
+    public class ExplicitAnalyteConcentrationTest : AbstractFunctionalTestEx
     {
         private const string ExplictionConcentrationsReportName = "ExplicitConcentrations";
         [TestMethod]
@@ -49,7 +49,7 @@ namespace pwiz.SkylineTestFunctional
         protected override void DoTest()
         {
             string skylinePath = TestFilesDir.GetTestPath("ExplicitAnalyteConcentrationTest.sky");
-            RunUI(() => SkylineWindow.OpenFile(skylinePath));
+            OpenDocument(skylinePath);
             SetSampleTypes();
             CreatExplicitConcentrationReport();
             FillInExplicitConcentrations();

--- a/pwiz_tools/Skyline/TestFunctional/ExportMethodDialogTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExportMethodDialogTest.cs
@@ -40,7 +40,7 @@ namespace pwiz.SkylineTestFunctional
     /// Tests ExportMethodDlg 
     /// </summary>
     [TestClass]
-    public class ExportMethodDlgTest : AbstractFunctionalTest
+    public class ExportMethodDlgTest : AbstractFunctionalTestEx
     {
 
         [TestMethod]
@@ -443,7 +443,7 @@ namespace pwiz.SkylineTestFunctional
 
             // Success cases exporting for document with both results on some peptides and a library match on
             // a peptide without results
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("Bovine_std_curated_seq_small2-trigger.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("Bovine_std_curated_seq_small2-trigger.sky"));
             string agilentExpected = TestFilesDir.GetTestPath("TranListTriggered.csv");
             string agilentActual = IsTriggeredRecordMode ? agilentExpected : TestFilesDir.GetTestPath("TranListTriggered-actual.csv");
             string thermoExpected = TestFilesDir.GetTestPath("TranListIsrm.csv");
@@ -782,7 +782,7 @@ namespace pwiz.SkylineTestFunctional
         private void ABSciexShortNameTest()
         {
             // Failure trying to export to file with a peptide lacking results or library match 
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("mods_shortNameTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("mods_shortNameTest.sky"));
             string modsShortNameExpected = TestFilesDir.GetTestPath("ModShortName.csv");
             string modsShortNameActual = TestFilesDir.GetTestPath("ModShortName-Actual.csv");
 
@@ -794,7 +794,7 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("shortnames_4peptide.sky")));
             string modsShortNameExplicit = TestFilesDir.GetTestPath("ModShortName-Explicit.csv");
             ExportAbTransitionList(modsShortNameExplicit);
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("shortnames_4peptide-var.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("shortnames_4peptide-var.sky"));
             string modsShortNameVariable = TestFilesDir.GetTestPath("ModShortName-Variable.csv");
             ExportAbTransitionList(modsShortNameVariable);
             AssertEx.NoDiff(File.ReadAllText(modsShortNameExplicit), File.ReadAllText(modsShortNameVariable));

--- a/pwiz_tools/Skyline/TestFunctional/ExpressionAnnotationsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ExpressionAnnotationsTest.cs
@@ -32,7 +32,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class ExpressionAnnotationsTest : AbstractFunctionalTest
+    public class ExpressionAnnotationsTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestExpressionAnnotations()
@@ -44,7 +44,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("ExpressionAnnotationsTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("ExpressionAnnotationsTest.sky"));
             var documentSettingsDlg = ShowDialog<DocumentSettingsDlg>(SkylineWindow.ShowDocumentSettingsDialog);
             RunDlg<DefineAnnotationDlg>(documentSettingsDlg.AddAnnotation, defineAnnotationDlg=>
             {

--- a/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
@@ -70,7 +70,7 @@ namespace pwiz.SkylineTestFunctional
             string databasePath = testFilesDir.GetTestPath("irt-c18.irtdb");
 
             string documentPath = testFilesDir.GetTestPath("iRT Test.sky");
-            RunUI(() => SkylineWindow.OpenFile(documentPath));
+            OpenDocument(documentPath);
 
             var peptideSettingsDlg1 = ShowDialog<PeptideSettingsUI>(
                 () => SkylineWindow.ShowPeptideSettingsUI(PeptideSettingsUI.TABS.Prediction));
@@ -733,7 +733,7 @@ namespace pwiz.SkylineTestFunctional
         {
             var testFilesDir = new TestFilesDir(TestContext, TestFilesZip);
 
-            RunUI(() => SkylineWindow.OpenFile(testFilesDir.GetTestPath("RePLiCal data for Skyline team - Pierce.sky")));
+            OpenDocument(testFilesDir.GetTestPath("RePLiCal data for Skyline team - Pierce.sky"));
             var peptideSettingsDlg = ShowDialog<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI);
             var editIrtCalcDlg = ShowDialog<EditIrtCalcDlg>(peptideSettingsDlg.AddCalculator);
 
@@ -824,7 +824,7 @@ namespace pwiz.SkylineTestFunctional
             Assert.IsTrue(SkylineWindow.Document.Peptides.All(pep => standardPeptides.Contains(pep.Target)));
 
             // CiRT calibration test (use predefined values)
-            RunUI(() => SkylineWindow.OpenFile(testFilesDir.GetTestPath("Bruker_diaPASEF_HYE-cirtonly.sky")));
+            OpenDocument(testFilesDir.GetTestPath("Bruker_diaPASEF_HYE-cirtonly.sky"));
             var peptideSettingsDlg3 = ShowDialog<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI);
             var editIrtCalcDlg2 = ShowDialog<EditIrtCalcDlg>(peptideSettingsDlg3.AddCalculator);
             var calibrateIrtDlg2 = ShowDialog<CalibrateIrtDlg>(editIrtCalcDlg2.Calibrate);

--- a/pwiz_tools/Skyline/TestFunctional/LibraryMatchViewTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryMatchViewTest.cs
@@ -31,7 +31,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class LibraryMatchViewTest : AbstractFunctionalTest
+    public class LibraryMatchViewTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestLibraryMatchView()
@@ -48,7 +48,7 @@ namespace pwiz.SkylineTestFunctional
             var docPath = testFilesDir.GetTestPath("MPDS.sky");
 
             // Open document
-            RunUI(() => SkylineWindow.OpenFile(docPath));
+            OpenDocument(docPath);
 
             // Add spectral library
             var peptideSettingsDlg = ShowDialog<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI);

--- a/pwiz_tools/Skyline/TestFunctional/ManageResultsTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ManageResultsTest.cs
@@ -39,7 +39,7 @@ namespace pwiz.SkylineTestFunctional
     /// Functional test for CE Optimization.
     /// </summary>
     [TestClass]
-    public class ManageResultsTest : AbstractFunctionalTest
+    public class ManageResultsTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestManageResults()
@@ -57,7 +57,7 @@ namespace pwiz.SkylineTestFunctional
         {
             // Open the .sky file
             string documentPath = TestFilesDir.GetTestPath("160109_Mix1_calcurve.sky");
-            RunUI(() => SkylineWindow.OpenFile(documentPath));
+            OpenDocument(documentPath);
 
             var listGraphChroms = new List<GraphChromatogram>(SkylineWindow.GraphChromatograms);
             Assert.AreEqual(4, listGraphChroms.Count);

--- a/pwiz_tools/Skyline/TestFunctional/MultiSelectPeakAreaGraphTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MultiSelectPeakAreaGraphTest.cs
@@ -53,7 +53,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("ABSciex4000_Study9-1_Site19_CalCurves only.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("ABSciex4000_Study9-1_Site19_CalCurves only.sky"));
             if (_asSmallMolecules)
             {
                 ConvertDocumentToSmallMolecules(RefinementSettings.ConvertToSmallMoleculesMode.formulas,

--- a/pwiz_tools/Skyline/TestFunctional/MultiSelectRetentionTimeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MultiSelectRetentionTimeTest.cs
@@ -27,7 +27,7 @@ using ZedGraph;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class MultiSelectRetentionTimeTest : AbstractFunctionalTest
+    public class MultiSelectRetentionTimeTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestMultiSelectRetentionTime()
@@ -38,7 +38,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("MultiSelectRetentionTimeTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("MultiSelectRetentionTimeTest.sky"));
             Assert.AreEqual(BarType.Cluster, SkylineWindow.GraphRetentionTime.GraphControl.GraphPane.BarSettings.Type);
             // Test select all
             RunUI(() =>

--- a/pwiz_tools/Skyline/TestFunctional/MultiSelectTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MultiSelectTest.cs
@@ -30,7 +30,7 @@ namespace pwiz.SkylineTestFunctional
     /// Functional test for MultiSelect.
     /// </summary>
     [TestClass]
-    public class MultiSelectTest : AbstractFunctionalTest
+    public class MultiSelectTest : AbstractFunctionalTestEx
     {
         private IList<Identity> _expectedSelNodes;
         private Identity _expectedSelNode;
@@ -47,7 +47,7 @@ namespace pwiz.SkylineTestFunctional
         /// </summary>
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini.sky"));
             
             _expectedSelNodes = new List<Identity>();
 

--- a/pwiz_tools/Skyline/TestFunctional/OptimizeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/OptimizeTest.cs
@@ -96,7 +96,7 @@ namespace pwiz.SkylineTestFunctional
 
             // Open the .sky file
             string documentPath = TestFilesDir.GetTestPath("CE_Vantage_15mTorr_scheduled_mini.sky");
-            RunUI(() => SkylineWindow.OpenFile(documentPath));
+            OpenDocument(documentPath);
             if (AsSmallMolecules)
             {
                 ConvertDocumentToSmallMolecules();
@@ -427,7 +427,7 @@ namespace pwiz.SkylineTestFunctional
 
             // Open the .sky file
             string documentPath = TestFilesDir.GetTestPath("test_opt_nl.sky");
-            RunUI(() => SkylineWindow.OpenFile(documentPath));
+            OpenDocument(documentPath);
 
             var docCurrent = SkylineWindow.Document;
 
@@ -464,7 +464,7 @@ namespace pwiz.SkylineTestFunctional
             // Open the .sky file
             string documentPath = TestFilesDir.GetTestPath(@"covdata\cov_optimization_part.sky");
             string wiffFile = TestFilesDir.GetTestPath(@"covdata\wiff\041115 BG_sky Test Round 1.wiff");
-            RunUI(() => SkylineWindow.OpenFile(documentPath));
+            OpenDocument(documentPath);
             if (AsSmallMolecules)
             {
                 ConvertDocumentToSmallMolecules();

--- a/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PasteMoleculesTest.cs
@@ -363,7 +363,7 @@ namespace pwiz.SkylineTestFunctional
             var docEmpty = NewDocument();
 
             // Load a document whose settings understand heavy labeling
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("heavy.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("heavy.sky"));
 
             var fullColumnOrder = new[]
             {
@@ -1125,7 +1125,7 @@ namespace pwiz.SkylineTestFunctional
             }
 
             // Load a document whose settings call for different mass type for precursors and fragments
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("mixed_mass_types.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("mixed_mass_types.sky"));
             docOrig = SkylineWindow.Document;
 
             const string precursorOnly = "15xT\tC150H197N30O103P14\t-3";

--- a/pwiz_tools/Skyline/TestFunctional/PivotEditorTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PivotEditorTest.cs
@@ -38,7 +38,7 @@ namespace pwiz.SkylineTestFunctional
 {
     // ReSharper disable LocalizableElement
     [TestClass]
-    public class PivotEditorTest : AbstractFunctionalTest
+    public class PivotEditorTest : AbstractFunctionalTestEx
     {
         private const string pivotTestViewName = "PivotTest";
         private const string meanCvByConditionNumber = "meanCvByConditionNumber";
@@ -54,7 +54,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("Rat_plasma.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("Rat_plasma.sky"));
             RunUI(() => SkylineWindow.ShowDocumentGrid(true));
             var documentGrid = FindOpenForm<DocumentGridForm>();
             CreateBaseView(documentGrid);

--- a/pwiz_tools/Skyline/TestFunctional/PrmCeOptimizationTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PrmCeOptimizationTest.cs
@@ -32,7 +32,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class PrmCeOptimizationTest : AbstractFunctionalTest
+    public class PrmCeOptimizationTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestPrmCeOptimization()
@@ -45,7 +45,7 @@ namespace pwiz.SkylineTestFunctional
             var dir = TestFilesDir.GetTestPath(".");
 
             // Open the document.
-            RunUI(() => SkylineWindow.OpenFile(Path.Combine(dir, "doc.sky")));
+            OpenDocument(Path.Combine(dir, "doc.sky"));
 
             var doc = SkylineWindow.Document;
 

--- a/pwiz_tools/Skyline/TestFunctional/ProfileImport.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ProfileImport.cs
@@ -27,7 +27,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class ProfileImport : AbstractFunctionalTest
+    public class ProfileImport : AbstractFunctionalTestEx
     {
         private string _skyFile;
         private object _dataFile;
@@ -86,7 +86,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(_skyFile));
+            OpenDocument(_skyFile);
 
             RunDlg<ManageResultsDlg>(SkylineWindow.ManageResults, dlg =>
             {

--- a/pwiz_tools/Skyline/TestFunctional/ReplicateNameMetadataRuleTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ReplicateNameMetadataRuleTest.cs
@@ -29,7 +29,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class ReplicateNameMetadataRuleTest : AbstractFunctionalTest
+    public class ReplicateNameMetadataRuleTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestReplicateNameMetadataRule()
@@ -46,7 +46,7 @@ namespace pwiz.SkylineTestFunctional
             var replicateRule = new MetadataRule().ChangeSource(PropertyPath.Root.Property(nameof(ResultFile.FileName)))
                 .ChangeTarget(PropertyPath.Root.Property(nameof(ResultFile.Replicate))
                     .Property(nameof(Replicate.Name)));
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("Rat_plasma.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("Rat_plasma.sky"));
 
             ImportResultsFile(TestFilesDir.GetTestPath("D_102_REP1.mzML"));
             ImportResultsFile(TestFilesDir.GetTestPath("H_146_REP1.mzML"));

--- a/pwiz_tools/Skyline/TestFunctional/ReportSummaryTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ReportSummaryTest.cs
@@ -36,7 +36,7 @@ namespace pwiz.SkylineTestFunctional
     /// Functional test of summary reports.
     /// </summary>
     [TestClass]
-    public class ReportSummaryTest : AbstractFunctionalTest
+    public class ReportSummaryTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestReportSummary()
@@ -66,7 +66,7 @@ namespace pwiz.SkylineTestFunctional
         {
             // Open the .sky file
             string documentPath = TestFilesDir.GetTestPath(DOCUMENT_NAME);
-            RunUI(() => SkylineWindow.OpenFile(documentPath));
+            OpenDocument(documentPath);
 
             var exportLiveReportDlg = ShowDialog<ExportLiveReportDlg>(SkylineWindow.ShowExportReportDialog);
             RunUI(() => exportLiveReportDlg.SetUseInvariantLanguage(true));

--- a/pwiz_tools/Skyline/TestFunctional/ScheduleMethodDlgTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ScheduleMethodDlgTest.cs
@@ -46,7 +46,7 @@ namespace pwiz.SkylineTestFunctional
     ///     and Replicate combobox is disabled.
     /// </summary>
     [TestClass]
-    public class ScheduleMethodDlgTest : AbstractFunctionalTest
+    public class ScheduleMethodDlgTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestScheduleMethodDlg()
@@ -59,7 +59,7 @@ namespace pwiz.SkylineTestFunctional
         {
             // Open 160109_Mix1_calcurve.sky under TestFunctional\ManageResultsTest.zip
             string documentPath = TestFilesDir.GetTestPath("160109_Mix1_calcurve.sky");
-            RunUI(() => SkylineWindow.OpenFile(documentPath));
+            OpenDocument(documentPath);
 
             // Make sure collision energy equation matches with instrument type to be used
             RunUI(() => SkylineWindow.ModifyDocument("Change settings", doc =>

--- a/pwiz_tools/Skyline/TestFunctional/SettingsChangeReimportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SettingsChangeReimportTest.cs
@@ -33,7 +33,7 @@ namespace pwiz.SkylineTestFunctional
     /// peaks are integrated using the new settings.
     /// </summary>
     [TestClass]
-    public class SettingsChangeReimportTest : AbstractFunctionalTest
+    public class SettingsChangeReimportTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestSettingsChangeReimport()
@@ -44,7 +44,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("SettingsChangeReimportTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("SettingsChangeReimportTest.sky"));
             var idPath = SkylineWindow.Document.GetPathTo((int)SrmDocument.Level.TransitionGroups, 0);
             var transitionGroup = (TransitionGroupDocNode)SkylineWindow.Document.FindNode(idPath);
             Assert.IsNull(transitionGroup.Results);

--- a/pwiz_tools/Skyline/TestFunctional/SrmSmMolChromTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SrmSmMolChromTest.cs
@@ -28,7 +28,7 @@ namespace pwiz.SkylineTestFunctional
     /// matched up to a chromatogram in the SRM result files.
     /// </summary>
     [TestClass]
-    public class SrmSmMolChromTest : AbstractFunctionalTest
+    public class SrmSmMolChromTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestSrmSmallMoleculeChromatograms()
@@ -40,7 +40,7 @@ namespace pwiz.SkylineTestFunctional
         protected override void DoTest()
         {
             var testPath = TestFilesDir.GetTestPath("SrmSmMolChromTest.sky");
-            RunUI(() => SkylineWindow.OpenFile(testPath));
+            OpenDocument(testPath);
             ImportResultsFiles(new[]
             {
                 new MsDataFilePath(TestFilesDir.GetTestPath("ID36310_01_WAA263_3771_030118" + ExtensionTestContext.ExtMz5)),
@@ -60,7 +60,7 @@ namespace pwiz.SkylineTestFunctional
             // That info should survive serialization round trip
             RunUI(() => SkylineWindow.SaveDocument(testPath));
             RunUI(() => SkylineWindow.NewDocument());
-            RunUI(() => SkylineWindow.OpenFile(testPath));
+            OpenDocument(testPath);
             VerifyAllTransitionsHaveChromatograms();
         }
 

--- a/pwiz_tools/Skyline/TestFunctional/SurrogateStandardTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/SurrogateStandardTest.cs
@@ -33,7 +33,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestFunctional
 {
     [TestClass]
-    public class SurrogateStandardTest : AbstractFunctionalTest
+    public class SurrogateStandardTest : AbstractFunctionalTestEx
     {
         [TestMethod]
         public void TestSurrogateStandards()
@@ -44,7 +44,7 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("p180test_calibration_DukeApril2016.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("p180test_calibration_DukeApril2016.sky"));
             var surrogateStandards = new Dictionary<string, string>
             {
                 {"Leu","Ile" },

--- a/pwiz_tools/Skyline/TestFunctional/TargetRatiosTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/TargetRatiosTest.cs
@@ -37,7 +37,7 @@ namespace pwiz.SkylineTestFunctional
     /// menu item so that the ratios on TransitionTreeNodes can be verified.
     /// </summary>
     [TestClass]
-    public class TargetRatiosTest : AbstractFunctionalTest
+    public class TargetRatiosTest : AbstractFunctionalTestEx
     {
         private bool _testingTransitions;
         /// <summary>
@@ -74,7 +74,7 @@ namespace pwiz.SkylineTestFunctional
             VerifyNormalizationMethodDisplayed(ratioToHeavy);
             RunUI(()=>SkylineWindow.AreaNormalizeOption = NormalizeOption.GLOBAL_STANDARDS);
             VerifyNormalizationMethodDisplayed(NormalizationMethod.GLOBAL_STANDARDS);
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("Human_plasma.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("Human_plasma.sky"));
             VerifyNormalizationMethodDisplayed(ratioToHeavy);
             RunUI(()=>
             {

--- a/pwiz_tools/Skyline/TestFunctional/TestPeakAreaDotpGraph.cs
+++ b/pwiz_tools/Skyline/TestFunctional/TestPeakAreaDotpGraph.cs
@@ -28,8 +28,8 @@ namespace pwiz.SkylineTestFunctional
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(
-                TestFilesDir.GetTestPath("ABSciex4000_Study9-1_Site19_CalCurves only.sky")));
+            OpenDocument(
+                TestFilesDir.GetTestPath("ABSciex4000_Study9-1_Site19_CalCurves only.sky"));
             var replicates = new[]
             {
                 "A1_CalCurve_run_063", "J1_CalCurve_run_074", "9-1_Site19_B2_CalCurve_run_106",
@@ -82,8 +82,8 @@ namespace pwiz.SkylineTestFunctional
             RunUI(() => AssertNoDotp());
 
 
-            RunUI(() => SkylineWindow.OpenFile(
-                TestFilesDir.GetTestPath("DIA-QE-tutorial.sky")));
+            OpenDocument(
+                TestFilesDir.GetTestPath("DIA-QE-tutorial.sky"));
             SkylineWindow.ShowSplitChromatogramGraph(true);
             replicates = new[]{"1-A", "2-B", "3-A","4-B", "5-A", "6-B"};
             var expectedIDotp = new[] {0.93, 0.82, 0.95, 0.92, 0.95, 0.74};

--- a/pwiz_tools/Skyline/TestFunctional/UIModeTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/UIModeTest.cs
@@ -36,7 +36,7 @@ namespace pwiz.SkylineTestFunctional
     /// Functional test for UI Mode handling.
     /// </summary>
     [TestClass]
-    public class UIModeTest : AbstractFunctionalTest
+    public class UIModeTest : AbstractFunctionalTestEx
     {
 
         private bool _showStartPage;
@@ -97,7 +97,7 @@ namespace pwiz.SkylineTestFunctional
             });
 
             // Verify handling of start page invoked from Skyline menu with a populated document
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("Proteomic.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("Proteomic.sky"));
             Assert.IsTrue(SkylineWindow.HasProteomicMenuItems);
             startPage = ShowDialog<StartPage>(SkylineWindow.OpenStartPage);
             RunDlg<AlertDlg>(() => startPage.SetUIMode(SrmDocument.DOCUMENT_TYPE.small_molecules), alertDlg => alertDlg.ClickYes());

--- a/pwiz_tools/Skyline/TestPerf/DriftTimePredictorTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DriftTimePredictorTutorialTest.cs
@@ -90,7 +90,7 @@ namespace TestPerf // This would be in tutorial tests if it didn't take about 10
         {
             // Check backward compatibility with 19.1.9.338 and 350 when combined IMS got written to MsDataFilePath
             string legacyFile_19_1_9 = TestFilesDirs[1].GetTestPath(@"BSA-Training.sky");
-            RunUI(() => SkylineWindow.OpenFile(legacyFile_19_1_9));
+            OpenDocument(legacyFile_19_1_9);
             VerifyCombinedIonMobility(WaitForDocumentLoaded());
             RunUI(() =>
             {

--- a/pwiz_tools/Skyline/TestPerf/FeatureDetectionTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/FeatureDetectionTest.cs
@@ -180,7 +180,7 @@ namespace TestPerf
             if (pass != SMALL_MOL_ONLY_PASS) 
             {
                 // Load a data set that was processed by MaxQuant
-                RunUI(() => SkylineWindow.OpenFile(GetDataPath("Label-free.sky")));
+                OpenDocument(GetDataPath("Label-free.sky"));
                 AssertEx.IsDocumentState(SkylineWindow.Document, null, expectedPeptideGroups, expectedPeptides, expectedPeptideTransitionGroups, expectedPeptideTransitions);
             }
             else

--- a/pwiz_tools/Skyline/TestPerf/PerfAssociateProteinsHugeTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfAssociateProteinsHugeTest.cs
@@ -29,7 +29,7 @@ using Resources = pwiz.Skyline.Properties.Resources;
 namespace TestPerf
 {
     [TestClass]
-    public class PerfAssociateProteinsHugeTest : AbstractFunctionalTest
+    public class PerfAssociateProteinsHugeTest : AbstractFunctionalTestEx
     {
         private enum ImportType { FASTA, BGPROTEOME }
         private String _fastaFile;
@@ -54,7 +54,7 @@ namespace TestPerf
         private void TestUseFasta()
 
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("PerfAssociateProteinsHugeTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("PerfAssociateProteinsHugeTest.sky"));
             //PauseTest();
             TestDialog(ImportType.FASTA);
         }
@@ -64,7 +64,7 @@ namespace TestPerf
         /// </summary>
         private void TestUseBackgroundProteome()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("AssociateProteinsTest-NoBg.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("AssociateProteinsTest-NoBg.sky"));
             var associateProteinsDlg = ShowDialog<AssociateProteinsDlg>(SkylineWindow.ShowAssociateProteinsDlg);
             RunDlg<MessageDlg>(associateProteinsDlg.UseBackgroundProteome, messageDlg =>
             {
@@ -72,7 +72,7 @@ namespace TestPerf
                 messageDlg.OkDialog();
             });
             OkDialog(associateProteinsDlg, associateProteinsDlg.CancelDialog);
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("AssociateProteinsTest.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("AssociateProteinsTest.sky"));
             var proteinsDlg = ShowDialog<AssociateProteinsDlg>(SkylineWindow.ShowAssociateProteinsDlg);
             RunUI(proteinsDlg.UseBackgroundProteome);
             TestDialog(ImportType.BGPROTEOME);

--- a/pwiz_tools/Skyline/TestPerf/PerfImportBrukerPasefBbCIDTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportBrukerPasefBbCIDTest.cs
@@ -58,7 +58,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             // Load a .sky with mising .skyd, forcing re-import with existing parameters
             // This simplifies the test code since we have six different PASEF modes to deal with here
             string skyfile = TestFilesDir.GetTestPath("timsTOF_Lipidomics_test.sky");
-            RunUI(() => SkylineWindow.OpenFile(skyfile));
+            OpenDocument(skyfile);
             ImportResults(TestFilesDir.GetTestPath("HESI_Celegans_MTBE-2_150ul_bbCID_4ul_neg_19_1_3206.d"));
             var doc1 = WaitForDocumentLoaded();
             AssertEx.IsDocumentState(doc1, null, 1, 1, 1, 10);

--- a/pwiz_tools/Skyline/TestPerf/PerfImportHundredsOfReplicatesTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfImportHundredsOfReplicatesTest.cs
@@ -25,7 +25,7 @@ using pwiz.SkylineTestUtil;
 namespace TestPerf
 {
     [TestClass]
-    public class PerfImportHundredsOfReplicatesTest : AbstractFunctionalTest
+    public class PerfImportHundredsOfReplicatesTest : AbstractFunctionalTestEx
     {
         const int REPLICATE_COUNT_TO_TEST = 1500;
         [TestMethod]
@@ -37,7 +37,7 @@ namespace TestPerf
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath("test_b.sky")));
+            OpenDocument(TestFilesDir.GetTestPath("test_b.sky"));
             string templateFile = TestFilesDir.GetTestPath("mzmlfile.template");
             for (int i = 0; i < REPLICATE_COUNT_TO_TEST; i++)
             {

--- a/pwiz_tools/Skyline/TestPerf/PerfOptimizeCEImportResultsNativeVsMz5Test.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfOptimizeCEImportResultsNativeVsMz5Test.cs
@@ -33,7 +33,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
     /// Compare performance of vendor readers vs mz5 for results import.
     /// </summary>
     [TestClass]
-    public class PerformanceOptimizeCeImportVsMz5Test : AbstractFunctionalTest
+    public class PerformanceOptimizeCeImportVsMz5Test : AbstractFunctionalTestEx
     {
 
         // Note to developers considering this as a template for new tests:
@@ -126,7 +126,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
 
         protected override void DoTest()
         {
-            RunUI(() => SkylineWindow.OpenFile(_skyFile));
+            OpenDocument(_skyFile);
 
             Stopwatch loadStopwatch = new Stopwatch();
             loadStopwatch.Start();

--- a/pwiz_tools/Skyline/TestPerf/SmallMolDriftTimePredictorTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/SmallMolDriftTimePredictorTest.cs
@@ -60,8 +60,8 @@ namespace TestPerf
         protected override void DoTest()
         {
             // Empty doc with suitable full scan settings
-            RunUI(() => SkylineWindow.OpenFile(
-                TestFilesDirs[0].GetTestPath(@"DriftTimePredictorSmallMoleculesTest.sky")));
+            OpenDocument(
+                TestFilesDirs[0].GetTestPath(@"DriftTimePredictorSmallMoleculesTest.sky"));
 
             var docCurrent = SkylineWindow.Document;
             var transitionList = TestFilesDirs[0].GetTestPath(@"Skyline Transition List wo CCS.csv");

--- a/pwiz_tools/Skyline/TestTutorial/CEOptimizationTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/CEOptimizationTutorialTest.cs
@@ -98,7 +98,7 @@ namespace pwiz.SkylineTestTutorial
         protected override void DoTest()
         {
             // Skyline Collision Energy Optimization
-            RunUI(() => SkylineWindow.OpenFile(GetTestPath("CE_Vantage_15mTorr.sky"))); // Not L10N
+            OpenDocument(GetTestPath("CE_Vantage_15mTorr.sky")); // Not L10N
 
             if (AsSmallMolecules)
             {

--- a/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/CustomReportsTutorialTest.cs
@@ -48,7 +48,7 @@ namespace pwiz.SkylineTestTutorial
     /// </summary>
     // ReSharper disable LocalizableElement
     [TestClass]
-    public class CustomReportsTutorialTest : AbstractFunctionalTest
+    public class CustomReportsTutorialTest : AbstractFunctionalTestEx
     {
         const string customReportName = "Overview";
 
@@ -78,7 +78,7 @@ namespace pwiz.SkylineTestTutorial
         protected override void DoTest()
         {
             // Data Overview, p. 2
-            RunUI(() => SkylineWindow.OpenFile(TestFilesDir.GetTestPath(@"CustomReports\Study7_example.sky")));
+            OpenDocument(TestFilesDir.GetTestPath(@"CustomReports\Study7_example.sky"));
                 // Not L10N
             RunDlg<FindNodeDlg>(SkylineWindow.ShowFindNodeDlg, findPeptideDlg =>
             {

--- a/pwiz_tools/Skyline/TestTutorial/DiaTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/DiaTutorialTest.cs
@@ -292,7 +292,7 @@ namespace pwiz.SkylineTestTutorial
             }
             else
             {
-                RunUI(() => SkylineWindow.OpenFile(GetTestPath(DIA_IMPORTED_CHECKPOINT)));
+                OpenDocument(GetTestPath(DIA_IMPORTED_CHECKPOINT));
             }
 
             if (IsRecordMode)

--- a/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/IrtTutorialTest.cs
@@ -476,7 +476,7 @@ namespace pwiz.SkylineTestTutorial
                       });
 
             // Recalibrate method to 90-minute gradient, p. 20
-            RunUI(() => SkylineWindow.OpenFile(GetTestPath("iRT Human+Standard.sky"))); // Not L10N
+            OpenDocument(GetTestPath("iRT Human+Standard.sky")); // Not L10N
             RunDlg<FindNodeDlg>(SkylineWindow.ShowFindNodeDlg, findDlg =>
                     {
                         findDlg.FindOptions = new FindOptions().ChangeText("NSAQ"); // Not L10N

--- a/pwiz_tools/Skyline/TestTutorial/QuasarTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/QuasarTutorialTest.cs
@@ -36,7 +36,7 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTestTutorial
 {
     [TestClass]
-    public class QuasarTutorialTest : AbstractFunctionalTest
+    public class QuasarTutorialTest : AbstractFunctionalTestEx
     {
         [TestMethod, NoLocalization]
         public void TestQuasarTutorialLegacy()
@@ -59,7 +59,7 @@ namespace pwiz.SkylineTestTutorial
             // p. 1 open the file
             string documentFile = GetTestPath(@"QuaSAR_Tutorial.sky"); // Not L10N
             WaitForCondition(() => File.Exists(documentFile));
-            RunUI(() => SkylineWindow.OpenFile(documentFile));
+            OpenDocument(documentFile);
 
             var document = SkylineWindow.Document;
             AssertEx.IsDocumentState(document, null, 34, 125, 250, 750);

--- a/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/TargetedMSMSTutorialTest.cs
@@ -583,7 +583,7 @@ namespace pwiz.SkylineTestTutorial
                 RunUI(() => SkylineWindow.SaveDocument());
 
                 var fiveRunFile = TestFilesDirs[2].GetTestPath(@"BSA_Protea_label_free_20100323_meth3_long_all.sky");
-                RunUI(() => SkylineWindow.OpenFile(fiveRunFile));
+                OpenDocument(fiveRunFile);
                 FindNode("K.LVNELTEFAK.T [66, 75]");
 
                 RunUI(() =>
@@ -708,7 +708,7 @@ namespace pwiz.SkylineTestTutorial
             // Import a new Document. High-Resolution Mass Spectra, working with TOF p27.
             string newDocumentFile = GetTestPath(@"TOF\BSA_Agilent.sky");
             WaitForCondition(() => File.Exists(newDocumentFile));
-            RunUI(() => SkylineWindow.OpenFile(newDocumentFile));
+            OpenDocument(newDocumentFile);
 
             bool asSmallMolecules = AsSmallMoleculesTestMode != RefinementSettings.ConvertToSmallMoleculesMode.none;
             if (asSmallMolecules)

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -156,6 +156,7 @@ namespace pwiz.SkylineTestUtil
         public const string HARDKLOR_UNICODE_ISSUES = "Hardklor doesn't handle unicode paths";
         public const string ZIP_INSIDE_ZIP = "ZIP inside ZIP does not seem to work on MACS2";
         public const string DOCKER_ROOT_CERTS = "Docker runners do not yet have access to the root certificates needed for Koina";
+        public const string MSAMANDA_MEMORY_ISSUES = "In-process MSAmanda causes memory corruption on some test machines";
     }
 
     /// <summary>


### PR DESCRIPTION
Swapping this in as Integration test branch as hopefully miminal change set for calming nightlies. Most significantly, it omits tests using MSAmanda as that seems to have effects on C++ memory stability.