### PR TITLE
Fix error when .blib file has unrecognized score type

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -367,7 +367,7 @@ namespace pwiz.Skyline.Model.Lib
                                     ? Convert.ToDouble(reader.GetValue(icolCutoffScore))
                                     : (double?)null;
 
-                                if (!string.IsNullOrEmpty(scoreName))
+                                if (!string.IsNullOrEmpty(scoreName) && ScoreType.INVARIANT_NAMES.Contains(scoreName))
                                 {
                                     var scoreType = new ScoreType(scoreName, probabilityType);
                                     sourceFileDetails.ScoreThresholds[scoreType] = cutoffScore;


### PR DESCRIPTION
Fixed "Invalid Score Type" sharing minimized library when .blib file came from EncyclopeDIA conversion (reported by Rich)