### PR TITLE
* changed Run Peptide Search to keep wizard form close button visible

### DIFF
--- a/pwiz_tools/Skyline/Controls/WizardPages.cs
+++ b/pwiz_tools/Skyline/Controls/WizardPages.cs
@@ -50,6 +50,17 @@ namespace pwiz.Skyline.Controls
             return base.ProcessCmdKey(ref msg, keyData);
         }
     }
+
+    public class WizardPageControl : UserControl
+    {
+        /// <summary>
+        /// Allow controls in a wizard to preempt close requests by the wizard's form. Returns true iff the close request should continue, false if it should be canceled.
+        /// </summary>
+        public virtual bool CanWizardClose()
+        {
+            return true;
+        }
+    }
 }
 
 

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -229,7 +229,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         private UserControl GetPageControl(TabPage tabPage)
         {
             // Assume each tabPage only has a single UserControl; if that changes this function will need to be updated
-            return tabPage.Controls.OfType<UserControl>().Single();
+            return tabPage.Controls.OfType<UserControl>().SingleOrDefault();
         }
 
         public SrmDocument Document
@@ -1491,13 +1491,13 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         private bool CanWizardClose()
         {
             var wizardPageControl = GetPageControl(wizardPagesImportPeptideSearch.SelectedTab) as WizardPageControl;
-            return wizardPageControl?.CanWizardClose() == false;
+            return wizardPageControl == null || wizardPageControl.CanWizardClose();
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
             // Ask current WizardPageControl if wizard is in a good state to close
-            if (CanWizardClose())
+            if (!CanWizardClose())
             {
                 e.Cancel = true;
                 return;

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -226,6 +226,13 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             tabPage.Controls.Add(pageControl);
         }
 
+        private UserControl GetPageControl(TabPage tabPage)
+        {
+            var wizardPageControls = tabPage.Controls.OfType<UserControl>().ToArray();
+            Assume.AreEqual(1, wizardPageControls.Length);
+            return wizardPageControls[0];
+        }
+
         public SrmDocument Document
         {
             get
@@ -998,7 +1005,6 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             btnNext.Enabled = false;
             btnCancel.Enabled = false;
             btnBack.Enabled = false;
-            ControlBox = false;
 
             AbstractDdaConverter.MsdataFileFormat requiredFormat =
                 IsFeatureDetectionWorkflow
@@ -1085,7 +1091,6 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             btnCancel.Enabled = true;
             btnBack.Enabled = true;
-            ControlBox = true;
             btnNext.Enabled = success;
         }
 
@@ -1486,6 +1491,13 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
+            // Ask current WizardPageControl if wizard is in a good state to close
+            if ((GetPageControl(wizardPagesImportPeptideSearch.SelectedTab) as WizardPageControl)?.CanWizardClose() == false)
+            {
+                e.Cancel = true;
+                return;
+            }
+
             // Close file handles to the peptide search library
             ImportPeptideSearch.ClosePeptideSearchLibraryStreams(Document);
 

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -228,9 +228,8 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         private UserControl GetPageControl(TabPage tabPage)
         {
-            var wizardPageControls = tabPage.Controls.OfType<UserControl>().ToArray();
-            Assume.AreEqual(1, wizardPageControls.Length);
-            return wizardPageControls[0];
+            // Assume each tabPage only has a single UserControl; if that changes this function will need to be updated
+            return tabPage.Controls.OfType<UserControl>().Single();
         }
 
         public SrmDocument Document
@@ -1489,10 +1488,16 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             DialogResult = result;
         }
 
+        private bool CanWizardClose()
+        {
+            var wizardPageControl = GetPageControl(wizardPagesImportPeptideSearch.SelectedTab) as WizardPageControl;
+            return wizardPageControl?.CanWizardClose() == false;
+        }
+
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
             // Ask current WizardPageControl if wizard is in a good state to close
-            if ((GetPageControl(wizardPagesImportPeptideSearch.SelectedTab) as WizardPageControl)?.CanWizardClose() == false)
+            if (CanWizardClose())
             {
                 e.Cancel = true;
                 return;

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.designer.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.designer.cs
@@ -776,6 +776,15 @@ namespace pwiz.Skyline.FileUI.PeptideSearch {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot close wizard while the search is running. Press the Cancel Search button first..
+        /// </summary>
+        public static string SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_ {
+            get {
+                return ResourceManager.GetString("SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Additional Settings.
         /// </summary>
         public static string SearchSettingsControl_Additional_Settings {

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.designer.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.designer.cs
@@ -776,7 +776,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot close wizard while the search is running. Press the Cancel Search button first..
+        ///   Looks up a localized string similar to Cannot close wizard while the search is running. Do you want to cancel the search?.
         /// </summary>
         public static string SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_ {
             get {

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.resx
@@ -363,6 +363,6 @@ Click 'Retry' to try building again after placing the original spectrum files in
     <value>Adding detected features to document</value>
   </data>
   <data name="SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_" xml:space="preserve">
-      <value>Cannot close wizard while the search is running. Press the Cancel Search button first.</value>
+      <value>Cannot close wizard while the search is running. Do you want to cancel the search?</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.resx
@@ -362,4 +362,7 @@ Click 'Retry' to try building again after placing the original spectrum files in
   <data name="ImportPeptideSearchDlg_NextPage_Adding_detected_features_to_document" xml:space="preserve">
     <value>Adding detected features to document</value>
   </data>
+  <data name="SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_" xml:space="preserve">
+      <value>Cannot close wizard while the search is running. Press the Cancel Search button first.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.cs
@@ -27,12 +27,13 @@ using pwiz.Common.Collections;
 using pwiz.Common.Controls;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Alerts;
+using pwiz.Skyline.Controls;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
 
 namespace pwiz.Skyline.FileUI.PeptideSearch
 {
-    public abstract partial class SearchControl : UserControl, IProgressMonitor
+    public abstract partial class SearchControl : WizardPageControl, IProgressMonitor
     {
         public Action<IProgressStatus> UpdateUI;
 
@@ -264,6 +265,16 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             _cancelToken?.Cancel();
             btnCancel.Enabled = false;
+        }
+
+        public override bool CanWizardClose()
+        {
+            if (btnCancel.Enabled)
+            {
+                MessageDlg.Show(Parent, PeptideSearchResources.SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_);
+                return false;
+            }
+            return base.CanWizardClose();
         }
 
         private void btnCancel_Click(object sender, EventArgs e)

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchControl.cs
@@ -271,7 +271,13 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             if (btnCancel.Enabled)
             {
-                MessageDlg.Show(Parent, PeptideSearchResources.SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_);
+                if (DialogResult.Yes == MessageDlg.Show(Parent,
+                        PeptideSearchResources.SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_, false,
+                        MessageBoxButtons.YesNo))
+                {
+                    Cancel();
+                    SearchFinished += _ => ParentForm?.Close();
+                }
                 return false;
             }
             return base.CanWizardClose();


### PR DESCRIPTION
* changed Run Peptide Search to keep wizard form close button visible, but intercept it while search is running and display an explanation message to click cancel search button

![image](https://github.com/user-attachments/assets/6c37b767-fb26-48d5-9c3f-b1835c47d14a)

