### PR TITLE
* added preliminary support for Timeout attribute

### DIFF
--- a/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
@@ -77,7 +77,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             }
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), Timeout(180000)]
         public void UniquePeptides0PerfTest()
         {
             // Scenarios to test:
@@ -85,35 +85,35 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             scenario(PeptideFilter.PeptideUniquenessConstraint.none, "human_and_yeast.protdb");
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), Timeout(180000)]
         public void UniquePeptides1PerfTest()
         {
             // 1)  No current background proteome
             scenario(PeptideFilter.PeptideUniquenessConstraint.gene, null, "human_and_yeast_no_metadata.protdb", true);
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), Timeout(180000)]
         public void UniquePeptides2PerfTest()
         {
             // 2)  Current background proteome same as in new settings, needs digest and protein metadata search
             scenario(PeptideFilter.PeptideUniquenessConstraint.protein, "human_and_yeast_no_digest.protdb");
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), Timeout(180000)]
         public void UniquePeptides3PerfTest()
         {
             // 3)  Current background proteome same as in new settings, needs protein metadata search
             scenario(PeptideFilter.PeptideUniquenessConstraint.gene, "human_and_yeast_no_metadata_too.protdb");
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), Timeout(180000)]
         public void UniquePeptides4PerfTest()
         {
             // 4)  Current background proteome not same as in new settings
             scenario(PeptideFilter.PeptideUniquenessConstraint.species, "human_and_yeast.protdb", "human_and_yeast_no_metadata.protdb");
         }
 
-        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE)]
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), Timeout(180000)]
         public void UniquePeptides5PerfTest()
         {
             // Just verify that we've fixed a problem with opening files with uniqueness mode already turned on


### PR DESCRIPTION
* added preliminary support for Timeout attribute when running tests under TestRunner; doesn't always work right now, it may need additional thread cleanup other than just the one thread launched to run the TestMethod

I'm making a draft PR for this to get it out there. It would be really nice to have Timeout support like the Visual Studio test runner has.