### PR TITLE
Allow .ssl files to use folders

### DIFF
--- a/pwiz_tools/BiblioSpec/src/BuildParser.cpp
+++ b/pwiz_tools/BiblioSpec/src/BuildParser.cpp
@@ -195,8 +195,7 @@ void BuildParser::setSpecFileName
 {
     curSpecFileName_.clear();
     if( checkFile ){
-        ifstream file(specfile.c_str());
-        if(!file.good()) {
+        if(!boost::filesystem::exists(specfile)) {
             throw BlibException(true, "Could not open spectrum file '%s' for search results file '%s'.", 
                                 specfile.c_str(), fullFilename_.c_str());
         }


### PR DESCRIPTION
Fixed to allow BiblioSpec .ssl files to use .raw or .d folders (reported by Fengchao)