### PR TITLE
Use ToLowerInvariant() instead of ToLower() when identifying small molecule column headers…

### DIFF
--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -1572,7 +1572,7 @@ namespace pwiz.Skyline.Model
 
             private static IsotopeLabelType GetLabelType(string typeId)
             {
-                typeId = typeId.ToLower();
+                typeId = typeId.ToLowerInvariant();
                 return ((Equals(typeId, IsotopeLabelType.HEAVY_NAME.Substring(0, 1)) || Equals(typeId, IsotopeLabelType.HEAVY_NAME)) ? IsotopeLabelType.heavy : IsotopeLabelType.light);
             }
 
@@ -1969,7 +1969,7 @@ namespace pwiz.Skyline.Model
             // Helper method for FindLabelType
             private static bool ContainsLabelType(string field)
             {
-                field = field.ToLower(); // Now our detection is case insensitive
+                field = field.ToLowerInvariant(); // Now our detection is case insensitive
                 if (Equals(field, IsotopeLabelType.LIGHT_NAME.Substring(0, 1)) || // Checks for "L"
                     (Equals(field, IsotopeLabelType.HEAVY_NAME.Substring(0, 1)) || // Checks for "H"
                     (Equals(field, IsotopeLabelType.LIGHT_NAME)) || // Checks for "light"
@@ -2563,11 +2563,11 @@ namespace pwiz.Skyline.Model
                     if (item.Value.Equals(key))
                     {
                         // Remove whitespace and make the strings lowercase for comparison
-                        var lowerValue = item.Key.ToLower();
+                        var lowerValue = item.Key.ToLowerInvariant();
                         lowerValue = lowerValue.Replace(@" ", string.Empty);
-                        var lowerHeader = header.ToLower();
+                        var lowerHeader = header.ToLowerInvariant();
                         lowerHeader = lowerHeader.Replace(@" ", string.Empty);
-                        var lowerKey = item.Value.ToLower();
+                        var lowerKey = item.Value.ToLowerInvariant();
                         lowerKey = lowerKey.Replace(@" ", string.Empty);
                         if (lowerValue.Equals(lowerHeader) || lowerKey.Equals(lowerHeader))
                         {


### PR DESCRIPTION
… (otherwise the "I" in "InChi" does not convert to "i" under language tr-TR)