### PR TITLE
Reduce the burden imposed on Uniprot servers by these tests, by using revised protDB files where most (but not all) protein metadata is already resolved

### DIFF
--- a/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfUniquePeptidesTest.cs
@@ -56,7 +56,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
         void scenario(PeptideFilter.PeptideUniquenessConstraint cancellationCheckType, string initialBackgroundProteome, string newBackgroundProteome = null, bool verbose = false)
         {
             AllowInternetAccess = true; // Testing cancellation of web lookup is integral to this test
-            TestFilesZip = GetPerfTestDataURL(@"PerfUniquePeptidesTest.zip");
+            TestFilesZip = GetPerfTestDataURL(@"PerfUniquePeptidesTest_v2.zip"); // N.B. in V2 the protdb files metadata are mostly resolved so we don't abuse Uniprot servers  
             _skyfile = "lots_of_human_proteins.sky";
             _cancellationCheckType = cancellationCheckType;
             _initialBackgroundProteome = initialBackgroundProteome;


### PR DESCRIPTION
Should reduce any throttling that's causing test timeouts.

Internal test issue, not reported by any user