### PR TITLE
Fix "Open from Panorama" with anonymous server

### DIFF
--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFilePicker.cs
@@ -123,8 +123,7 @@ namespace pwiz.PanoramaClient
         /// </summary>
         private JToken GetJson(Uri queryUri)
         {
-            using (var requestHelper = new PanoramaRequestHelper(new WebClientWithCredentials(queryUri, FolderBrowser.GetActiveServer().Username,
-                       FolderBrowser.GetActiveServer().Password)))
+            using (var requestHelper = new PanoramaRequestHelper(new LabkeySessionWebClient(FolderBrowser.GetActiveServer())))
             {
                 JToken json = requestHelper.Get(queryUri);
                 return json;

--- a/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaFolderBrowser.cs
@@ -541,7 +541,7 @@ public class WebDavBrowser : PanoramaFolderBrowser
             try
             {
                 query = new Uri(string.Concat(folderInfo.Server.URI, PanoramaUtil.WEBDAV, folderInfo.FolderPath, "?method=json"));
-                using var requestHelper = new PanoramaRequestHelper(new WebClientWithCredentials(query, folderInfo.Server.Username, folderInfo.Server.Password));
+                using var requestHelper = new PanoramaRequestHelper(new LabkeySessionWebClient(folderInfo.Server));
                 JToken json = requestHelper.Get(query);
                 if ((int)json[@"fileCount"] != 0)
                 {

--- a/pwiz_tools/Shared/PanoramaClient/RequestHelper.cs
+++ b/pwiz_tools/Shared/PanoramaClient/RequestHelper.cs
@@ -195,9 +195,9 @@ namespace pwiz.PanoramaClient
 
     public class PanoramaRequestHelper : AbstractRequestHelper
     {
-        private readonly WebClientWithCredentials _client;
+        private readonly LabkeySessionWebClient _client;
         
-        public PanoramaRequestHelper(WebClientWithCredentials webClient)
+        public PanoramaRequestHelper(LabkeySessionWebClient webClient)
         {
             _client = webClient;
         }

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/PanoramaSettings.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQC/PanoramaSettings.cs
@@ -329,8 +329,8 @@ namespace AutoQC
 
         public void Init()
         {
-            _requestHelper = new PanoramaRequestHelper(new WebClientWithCredentials(_panoramaSettings.PanoramaServerUri,
-                _panoramaSettings.PanoramaUserEmail, _panoramaSettings.PanoramaPassword));
+            _requestHelper = new PanoramaRequestHelper(new LabkeySessionWebClient(new PanoramaServer(_panoramaSettings.PanoramaServerUri,
+                _panoramaSettings.PanoramaUserEmail, _panoramaSettings.PanoramaPassword)));
             _timer = new Timer(e => { PingPanoramaServer(); });
             _timer.Change(TimeSpan.FromSeconds(10), TimeSpan.FromMinutes(5)); // Ping Panorama every 5 minutes.
         }

--- a/pwiz_tools/Skyline/Executables/AutoQC/AutoQCTest/PanoramaTest.cs
+++ b/pwiz_tools/Skyline/Executables/AutoQC/AutoQCTest/PanoramaTest.cs
@@ -113,8 +113,8 @@ namespace AutoQCTest
             var labKeyQuery = PanoramaUtil.CallNewInterface(panoramaServerUri, "query", $"{uniqueFolder}",
                 "selectRows", "schemaName=targetedms&queryName=runs", true);
             var requestHelper =
-                new PanoramaRequestHelper(new WebClientWithCredentials(panoramaServerUri, TestUtils.PANORAMAWEB_USER,
-                    TestUtils.GetPanoramaWebPassword()));
+                new PanoramaRequestHelper(new LabkeySessionWebClient(new PanoramaServer(panoramaServerUri, TestUtils.PANORAMAWEB_USER,
+                    TestUtils.GetPanoramaWebPassword())));
             var startTime = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
             var x = startTime;
             while (x < startTime + TIMEOUT_80SEC)

--- a/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/PanoramaClientDownloadTest.cs
@@ -26,6 +26,7 @@ using pwiz.Common.SystemUtil;
 using pwiz.PanoramaClient;
 using pwiz.Skyline.Alerts;
 using pwiz.Skyline.Properties;
+using pwiz.Skyline.SettingsUI;
 using pwiz.Skyline.ToolsUI;
 using pwiz.Skyline.Util;
 using pwiz.SkylineTestUtil;
@@ -74,8 +75,11 @@ namespace pwiz.SkylineTestConnected
             // Test viewing webDav browser
             TestWebDav();
 
-            // Test adding a new server to Panorama - Test with and without username and password
+            // Test adding a new server to Panorama
             TestAddServer();
+
+            // Test adding PanoramaWeb as an anonymous server, and downloading a document from Panorama Public.
+            TestWithAnonymousServer();
         }
 
         private void AddPanoramaServers()
@@ -239,7 +243,7 @@ namespace pwiz.SkylineTestConnected
             Assert.IsFalse(File.Exists(path));
         }
 
-        //TODO: Test adding a new server to Panorama - Test with and without username and password 
+        //Test adding a new Panorama server.
         private void TestAddServer()
         {
             var path = TEST_FOLDER;
@@ -258,8 +262,66 @@ namespace pwiz.SkylineTestConnected
             var remoteDlg = ShowDialog<PanoramaFilePicker>(editItem.OkDialog);
             if (Settings.Default.ServerList != null)
                 Assert.AreEqual(1, Settings.Default.ServerList.Count);
-            RunUI(() => Assert.IsTrue(remoteDlg.IsLoaded));
+            RunUI(() =>
+            {
+                Assert.IsTrue(remoteDlg.IsLoaded);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(TEST_FOLDER), "Unable to select folder '{0}'", TEST_FOLDER);
+                Assert.IsTrue(remoteDlg.FolderBrowser.SelectNode(PANORAMA_FOLDER), "Unable to select folder '{0}'", PANORAMA_FOLDER);
+            });
+            
             OkDialog(remoteDlg, remoteDlg.Close);
+        }
+
+        private void TestWithAnonymousServer()
+        {
+            var toolsOptionsDlg = ShowDialog<ToolOptionsUI>(() => SkylineWindow.ShowToolOptionsUI(ToolOptionsUI.TABS.Panorama));
+
+            // Clear the Panorama server list
+            var editServerListDlg = ShowDialog<EditListDlg<SettingsListBase<Server>, Server>>(toolsOptionsDlg.EditServers);
+            RunUI(editServerListDlg.ResetList);
+
+            // Add PanoramaWeb as an anonymous server
+            var editServerDlg = ShowDialog<EditServerDlg>(editServerListDlg.AddItem);
+            RunUI(() =>
+            {
+                editServerDlg.URL = PANORAMA_WEB;
+                editServerDlg.AnonymousServer = true;
+            });
+            OkDialog(editServerDlg, editServerDlg.OkDialog);
+            OkDialog(editServerListDlg, editServerListDlg.OkDialog);
+            OkDialog(toolsOptionsDlg, toolsOptionsDlg.OkDialog);
+
+            Assert.IsNotNull(Settings.Default.ServerList);
+            Assert.AreEqual(1, Settings.Default.ServerList.Count);
+
+            const string panoramaPublicFolderPath = "Panorama Public/2018/MacLean - Baker IMS";
+            // Document in the "Panorama Public/2018/MacLean - Baker IMS" folder on https://panoramaweb.org that we will download.
+            const string skyDocName = "BSA-Training_2017-09-21_17-59-13.sky.zip";
+            var downloadFilePath = TestContext.GetTestResultsPath(skyDocName);
+            FileEx.SafeDelete(downloadFilePath, true);
+            Assert.IsFalse(File.Exists(downloadFilePath));
+
+            var panoramaFilePickerDlg = ShowDialog<PanoramaFilePicker>(() => SkylineWindow.OpenFromPanorama(downloadFilePath));
+            RunUI(() =>
+            {
+                Assert.IsTrue(panoramaFilePickerDlg.IsLoaded);
+                Assert.IsFalse(panoramaFilePickerDlg.FolderBrowser.SelectNode(TEST_FOLDER),
+                    "Guest user should not be able to see the private folder '{0}'.", TEST_FOLDER);
+
+                foreach (var folder in panoramaPublicFolderPath.Split('/'))
+                {
+                    Assert.IsTrue(panoramaFilePickerDlg.FolderBrowser.SelectNode(folder),
+                        "Guest user should be able to see folder '{0}' in the folder path '{1}'.", folder, panoramaPublicFolderPath);
+                }
+            });
+
+            var doc = SkylineWindow.Document;
+            OkDialog(panoramaFilePickerDlg, () => Assert.IsTrue(panoramaFilePickerDlg.ClickFile(skyDocName), "Unable to select Skyline document {0}", skyDocName));
+            WaitForCondition(() => File.Exists(downloadFilePath));
+            var docLoaded = WaitForDocumentChangeLoaded(doc);
+            AssertEx.IsDocumentState(docLoaded, null, 1, 34, 38, 404);
+            FileEx.SafeDelete(downloadFilePath, true);
+            Assert.IsFalse(File.Exists(downloadFilePath));
         }
 
         // Test viewing webDav browser


### PR DESCRIPTION
Request with an "anonymous" Panorama server fails because an Authorization header, with blank username and password, is added to the request which fails on the server with a 401 Unauthorized response.  This worked with previous LabKey releases because requests that failed authentication continued as an unauthenticated user.  This is no longer the case with LK 24.11.  
- Renamed WebClientWithCredentials to LabkeySessionWebClient
- Add the Authorization header in LabkeySessionWebClient only if a username and password is provided.
- Added test in PanoramaClientDownloadTest.cs
