### PR TITLE
Avoid a null reference in graph update in a race condition with an action that removes all chromatograms

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -614,7 +614,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
                 if (_documentContainer is SkylineWindow stateProvider)
                 {
-                    var chromSet = stateProvider.DocumentUI.Settings.MeasuredResults.Chromatograms.FirstOrDefault(
+                    var chromSet = stateProvider.DocumentUI.Settings.MeasuredResults?.Chromatograms.FirstOrDefault(
                         chrom => chrom.ContainsFile(_msDataFileScanHelper.ScanProvider.DataFilePath));
                     spectrumProperties.ReplicateName = chromSet?.Name;
                     if (_peaks?.Length > 0)


### PR DESCRIPTION
bumped into this while working on something else

not reported by any user