### PR TITLE
Fix for feature finding

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -909,7 +909,10 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             // Add the library molecules to the document, in natural sort order
             var status = new ProgressStatus(PeptideSearchResources.ImportPeptideSearchDlg_NextPage_Adding_detected_features_to_document);
             progressMonitor.UpdateProgress(status);
-            Assume.AreNotEqual(Document.Settings.PeptideSettings.Libraries.LibrarySpecs, _existingLibraries.LibrarySpecs);
+            if (Equals(Document.Settings.PeptideSettings.Libraries.LibrarySpecs, _existingLibraries.LibrarySpecs))
+            {
+                MessageDlg.Show(this, PeptideSearchResources.ImportPeptideSearchDlg_AddDetectedFeaturesToDocument_Did_not_detect_any_features___check_your_settings_and_try_again);
+            }
             var docNew = Document;
             foreach (var lib in Document.Settings.PeptideSettings.Libraries.Libraries.Where(l =>
                          !_existingLibraries.Libraries.Contains(l)))

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.designer.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.designer.cs
@@ -533,6 +533,16 @@ namespace pwiz.Skyline.FileUI.PeptideSearch {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Did not detect any features - check your settings and try again.
+        /// </summary>
+        public static string ImportPeptideSearchDlg_AddDetectedFeaturesToDocument_Did_not_detect_any_features___check_your_settings_and_try_again {
+            get {
+                return ResourceManager.GetString("ImportPeptideSearchDlg_AddDetectedFeaturesToDocument_Did_not_detect_any_features_" +
+                        "__check_your_settings_and_try_again", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Feature Detection.
         /// </summary>
         public static string ImportPeptideSearchDlg_ImportPeptideSearchDlg_Feature_Detection {

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/PeptideSearchResources.resx
@@ -365,4 +365,7 @@ Click 'Retry' to try building again after placing the original spectrum files in
   <data name="SearchControl_CanWizardClose_Cannot_close_wizard_while_the_search_is_running_" xml:space="preserve">
       <value>Cannot close wizard while the search is running. Do you want to cancel the search?</value>
   </data>
+  <data name="ImportPeptideSearchDlg_AddDetectedFeaturesToDocument_Did_not_detect_any_features___check_your_settings_and_try_again" xml:space="preserve">
+      <value>Did not detect any features - check your settings and try again</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Model/DocSettings/TransitionSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/TransitionSettings.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using pwiz.BiblioSpec;
 using pwiz.Common.Chemistry;
 using pwiz.Common.Collections;
 using pwiz.Common.DataBinding;
@@ -1686,7 +1687,18 @@ namespace pwiz.Skyline.Model.DocSettings
             // CONSIDER: Maybe we should be storing a ChromSource on the transition at the time it is created, which
             // seems to be the only time we really know that a precursor ion is being created for MS1 filtering
             // or not.
-            return nodeGroup.Transitions.Count(nodeTran => !nodeTran.IsMs1 || nodeTran.HasLibInfo) >= MinIonCount;
+            if (nodeGroup.Transitions.Count(nodeTran => !nodeTran.IsMs1 || nodeTran.HasLibInfo) >= MinIonCount)
+            {
+                return true;
+            }
+
+            // Special case with feature finding where libraries don't have fragment info, just precursors
+            if (nodeGroup.HasLibInfo && nodeGroup.LibInfo.ScoreType.Equals(ScoreType.HARDKLOR_IDOTP) && nodeGroup.Transitions.All(nodeTran => nodeTran.IsMs1))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         #region Property change methods

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -2772,6 +2772,11 @@ namespace pwiz.Skyline.Model
             }
         }
 
+        public override string ToString()
+        {
+            return $@"{MoleculeGroupCount},{MoleculeCount},{MoleculeTransitionGroupCount},{MoleculeTransitionCount}"; // For debugging convenience, not user-facing
+        }
+
         #endregion
     }
 


### PR DESCRIPTION
The feature finding code uses spectral libraries in an unconventional manner - entries don't have any fragments, just the precursor info. This tripped up the AutoManage code, specifically the use of TransitionSettings.Libraries.MinIonCount. Now we treat libraries with score type ScoreType.HARDKLOR_IDOTP as being immune to that particular filter.

I can't help but wonder if there isn't a more general way to deal with this, though