### PR TITLE
Catch exceptions copying from AlertDlg

### DIFF
--- a/pwiz_tools/Skyline/Alerts/AlertDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/AlertDlg.cs
@@ -96,5 +96,9 @@ namespace pwiz.Skyline.Alerts
             base.OnLoad(e);
             GetModeUIHelper().OnLoad(this);
         }
+        public override void CopyMessage()
+        {
+            ClipboardHelper.SetSystemClipboardText(this, GetTitleAndMessageDetail());
+        }
     }
 }


### PR DESCRIPTION
Fixed unhandled error pressing copy button on message box when another application has the clipboard locked (reported by Brendan) AlertDlg now uses ClipboardHelper to catch clipboard locked exceptions. This got broken when CommonAlertDlg base class was created in CommonUtil. "CommonAlertDlg.CopyMessage" was supposed to be overridden for Skyline's extra error handling.