### PR TITLE
Enable using the clipboard when paused in a test

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/PauseAndContinueForm.cs
+++ b/pwiz_tools/Skyline/TestUtil/PauseAndContinueForm.cs
@@ -117,7 +117,7 @@ namespace pwiz.SkylineTestUtil
                 RunUI(_ownerForm, RefreshAndShow);
                 Monitor.Wait(_pauseLock, timeout ?? -1);
             }
-            ClipboardEx.UseInternalClipboard(true);
+            ClipboardEx.UseInternalClipboard();
             RunUI(Program.MainWindow, () => Program.MainWindow.UseKeysOverride = true);
 
             // Record that the screenshot happened in the console output to make

--- a/pwiz_tools/Skyline/TestUtil/PauseAndContinueForm.cs
+++ b/pwiz_tools/Skyline/TestUtil/PauseAndContinueForm.cs
@@ -111,11 +111,13 @@ namespace pwiz.SkylineTestUtil
             // Testing will have UseKeysOverride set to true to prevent accidental
             // keyboard interaction with the running test.
             RunUI(Program.MainWindow, () => Program.MainWindow.UseKeysOverride = false);
+            ClipboardEx.UseInternalClipboard(false);
             lock (_pauseLock)
             {
                 RunUI(_ownerForm, RefreshAndShow);
                 Monitor.Wait(_pauseLock, timeout ?? -1);
             }
+            ClipboardEx.UseInternalClipboard(true);
             RunUI(Program.MainWindow, () => Program.MainWindow.UseKeysOverride = true);
 
             // Record that the screenshot happened in the console output to make


### PR DESCRIPTION
When tests are running, they use the "internal" clipboard instead of the system clipboard. There used to be code in PauseAndContinueForm to switch to using the system clipboard when the test is paused. That code got removed in PR #3153