### PR TITLE
Fix incorrectly disabled "Max LOQ CV" text box

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/Spectra/SpectrumMetadatas.cs
+++ b/pwiz_tools/Skyline/Model/Results/Spectra/SpectrumMetadatas.cs
@@ -281,7 +281,7 @@ namespace pwiz.Skyline.Model.Results.Spectra
             return CollectionUtil.GetHashCodeDeep(this);
         }
 
-        private struct PrecursorWithLevel
+        private readonly struct PrecursorWithLevel : IEquatable<PrecursorWithLevel>
         {
             public PrecursorWithLevel(int msLevel, SpectrumPrecursor spectrumPrecursor)
             {
@@ -291,6 +291,24 @@ namespace pwiz.Skyline.Model.Results.Spectra
 
             public int MsLevel { get; }
             public SpectrumPrecursor Precursor { get; }
+
+            public bool Equals(PrecursorWithLevel other)
+            {
+                return MsLevel == other.MsLevel && Precursor.Equals(other.Precursor);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is PrecursorWithLevel other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (MsLevel * 397) ^ Precursor.GetHashCode();
+                }
+            }
         }
 
         private struct ScanId

--- a/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.Designer.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.Designer.cs
@@ -445,7 +445,6 @@ namespace pwiz.Skyline.SettingsUI
             resources.ApplyResources(this.comboLodMethod, "comboLodMethod");
             this.comboLodMethod.Name = "comboLodMethod";
             this.helpTip.SetToolTip(this.comboLodMethod, resources.GetString("comboLodMethod.ToolTip"));
-            this.comboLodMethod.SelectedIndexChanged += new System.EventHandler(this.comboLodMethod_SelectedIndexChanged);
             // 
             // tbxMaxLoqCv
             // 

--- a/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/PeptideSettingsUI.cs
@@ -2115,11 +2115,6 @@ namespace pwiz.Skyline.SettingsUI
             ChangeTooltip(listLibraries, librarySpec?.ItemDescription?.ToString() ?? _librariesOriginalTooltip);
         }
 
-        private void comboLodMethod_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            tbxMaxLoqBias.Enabled = comboLodMethod.SelectedItem != LodCalculation.TURNING_POINT_STDERR;
-        }
-
         private void comboRegressionFit_SelectedIndexChanged(object sender, EventArgs e)
         {
             UpdateLodOptions(comboLodMethod.SelectedItem as LodCalculation);


### PR DESCRIPTION
Fixed "Max LOQ CV" text box incorrectly disabled when LOD calculation is "Bilinear turning point" (reported by Philip) The "Max LOQ CV" text box needed to be disabled when the limit of quantification was being calculated using bootstrap curves. Now that LOQ is no longer calculated with using bootstrap curves, the text box should always be enabled.

Also fix performance problem pasting a large number of values into Document Grid in very large document (not reported by anyone).
Also fix performance problem I introduced earlier this week reading ResultFileMetadata