### PR TITLE
Skyline: Fix minor issues found testing APD changes

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSpectrum.cs
@@ -454,9 +454,7 @@ namespace pwiz.Skyline.Controls.Graphs
                     {
                         comboSpectrum.Items.Clear();
                         comboMirrorSpectrum.Items.Clear();
-                        selectedSpectrum = null;
                         selectedSpectrumIndex = -1;
-                        selectedMirror = null;
                     }
                 }
 

--- a/pwiz_tools/Skyline/Controls/ImmediateWindow.Designer.cs
+++ b/pwiz_tools/Skyline/Controls/ImmediateWindow.Designer.cs
@@ -42,6 +42,7 @@
             this.textImWindow.DragDrop += new System.Windows.Forms.DragEventHandler(this.textImWindow_DragDrop);
             this.textImWindow.DragEnter += new System.Windows.Forms.DragEventHandler(this.textImWindow_DragEnter);
             this.textImWindow.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textImWindow_KeyPress);
+            this.textImWindow.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textImWindow_KeyDown);
             // 
             // contextMenuStrip1
             // 

--- a/pwiz_tools/Skyline/Controls/ImmediateWindow.cs
+++ b/pwiz_tools/Skyline/Controls/ImmediateWindow.cs
@@ -75,6 +75,16 @@ namespace pwiz.Skyline.Controls
             }
         }
 
+        private void textImWindow_KeyDown(object sender, KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Escape:
+                    _parent.FocusDocument();
+                    break;
+            }
+        }
+
         /// <summary>
         /// Call before closing to stop the TextboxStreamWriter from writing to a disposed textbox.
         /// </summary>
@@ -209,7 +219,7 @@ namespace pwiz.Skyline.Controls
             var skylineWindow = _parent;
             if (skylineWindow != null)
             {
-                skylineWindow.ClipboardControlLostFocus(skylineWindow);
+                skylineWindow.ClipboardControlLostFocus(this);
             }
         }
     }


### PR DESCRIPTION
- Fixed mirror plots resetting mirror combos with every selection change (also complained about at courses)
- Fixed ImmediateWindow to restore disabled cut-copy-paste-delete menu items when losing focus
- Fixed ImmediateWindow to set focus to Targets view when Esc is pressed