### PR TITLE
Update "View > Live Reports" and "View > Libraries" references in English tutorial HTML files.

### DIFF
--- a/pwiz_tools/Skyline/Documentation/Tutorials/AbsoluteQuant/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/AbsoluteQuant/en/index.html
@@ -427,7 +427,7 @@
     </ul>
     <h2>Specify the analyte concentrations of the external standards:</h2>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>In the top left of the <b>Document Grid</b>, click the <b>Reports</b> dropdown list and choose
             <b>Replicates</b>.</li>
         <li>Copy the following data and paste it into the <b>Document Grid</b> to set each of the “Standard_#” replicates <b>Sample

--- a/pwiz_tools/Skyline/Documentation/Tutorials/AuditLog/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/AuditLog/en/index.html
@@ -75,7 +75,7 @@
         Now open the audit log by doing the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Other Grids</b> and click <b>Audit Log</b> (Alt + 4)</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Audit Log</b> (Alt-4)</li>
     </ul>
     <p>
         This should bring up the <b>Audit Log</b> view in its default configuration as shown below:
@@ -336,7 +336,7 @@
         Next, specify the analyte concentration for each replicate using the <b>Document Grid</b> as follows:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>In the top left of the <b>Document Grid</b>, click the <b>Reports</b> dropdown list and choose
             <b>Replicates</b>.</li>
         <li>In the row for FOXN1-GST, set its <b>Sample Type</b> to “Unknown”.</li>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/CustomReports/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/CustomReports/en/index.html
@@ -536,7 +536,7 @@
         To view the data for key quality control metrics follow the steps below: 
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>At the top of the <b>Document Grid</b> form, click the <b>Reports</b> button. A dropdown list will appear.</li>
         <li>Choose <b>Manage Reports</b> from the dropdown list.</li>
         <li>Click the import button in the <b>Manage Reports</b> form.</li>
@@ -649,7 +649,7 @@
         To get started using the <b>Results Grid</b> view, do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Other Grids</b>, and click <b>Results Grid</b> (Alt-F2).</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Results Grid</b> (Alt-2).</li>
     </ul>
     <p class="keep-next">
         Skyline should now look something like this:

--- a/pwiz_tools/Skyline/Documentation/Tutorials/DDASearch/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/DDASearch/en/index.html
@@ -362,9 +362,9 @@
         <li>Click on that peptide’s first precursor 835.9140++ and the chromatogram for that precursor and the MS/MS spectrum for that peptide will
             appear. (Note that the bold, underlined residue “<b><u>C</u></b>” in the peptide sequence indicates a carbamidomethyl cysteine).
         </li>
-        <li>If you do not see the MS/MS spectrum, on the <b>View</b> menu, click <b>Library Match</b>.</li>
+        <li>If you do not see the MS/MS spectrum, on the <b>View</b> menu, choose <b>Libraries</b>, and click <b>Library Match</b> (Alt-1).</li>
         <li>If you do not see as many annotated peaks in the <b>Library Match</b> view as in the image below, on the <b>View</b>
-            menu, choose <b>Ion Types</b> and check <b>B</b> and <b>Y</b>.</li>
+            menu, choose <b>Libraries</b>, then <b>Ion Types</b>, and check <b>B</b> and <b>Y</b>.</li>
         <li>If you do not see the entire chromatogram for the peptide, on the <b>View</b> menu, choose <b>Auto-Zoom</b> and click
             <b>None</b> (Shift-F11).</li>
         <li>Right-click the chromatogram graph, choose <b>Peptide ID Times</b>, and click <b>Aligned</b> if it is unchecked.</li>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/DIA-PASEF/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/DIA-PASEF/en/index.html
@@ -438,7 +438,7 @@
         You are now ready to annotate the replicates you have imported:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Document Grid</b> (Alt-3).</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
     </ul>
     <p>
         This brings up the <b>Document Grid</b> window, which will show the <b>Proteins</b> report if you have never used it
@@ -673,7 +673,7 @@
         To perform a simple pairwise group comparison inside Skyline do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Other Grids</b>, then <b>Group Comparison</b>, and click <b>Add</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add...</b>.</li>
         <li>For the <b>Name</b> field, enter “By Condition”.</li>
         <li>For the <b>Control group annotation</b> field, choose “Condition”.</li>
         <li>For the <b>Control group value</b> field, choose “A”.</li>
@@ -694,7 +694,7 @@
         To see the group comparison you have just created:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Other Grids</b>, then <b>Group Comparison</b>, and click <b>By
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>By
                 Condition</b>.</li>
     </ul>
     <p>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/DIA-PASEF/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/DIA-PASEF/en/index.html
@@ -673,7 +673,7 @@
         To perform a simple pairwise group comparison inside Skyline do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add...</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add</b>.</li>
         <li>For the <b>Name</b> field, enter “By Condition”.</li>
         <li>For the <b>Control group annotation</b> field, choose “Condition”.</li>
         <li>For the <b>Control group value</b> field, choose “A”.</li>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/DIA-QE/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/DIA-QE/en/index.html
@@ -443,7 +443,7 @@
         You are now ready to annotate the replicates you have imported:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Document Grid</b> (Alt-3).</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
     </ul>
     <p>
         This brings up the <b>Document Grid</b> window, which will show the <b>Proteins</b> report if you have never used it
@@ -668,7 +668,7 @@
         To perform a simple pairwise group comparison inside Skyline do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Other Grids</b>, then <b>Group Comparison</b>, and click <b>Add</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add...</b>.</li>
         <li>For the <b>Name</b> field, enter “By Condition”.</li>
         <li>For the <b>Control group annotation</b> field, choose “Condition”.</li>
         <li>For the <b>Control group value</b> field, choose “A”.</li>
@@ -689,7 +689,7 @@
         To see the group comparison you have just created:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Other Grids</b>, then <b>Group Comparison</b>, and click <b>By
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparison</b>, and click <b>By
                 Condition</b>.</li>
     </ul>
     <p>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/DIA-QE/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/DIA-QE/en/index.html
@@ -668,7 +668,7 @@
         To perform a simple pairwise group comparison inside Skyline do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add...</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add</b>.</li>
         <li>For the <b>Name</b> field, enter “By Condition”.</li>
         <li>For the <b>Control group annotation</b> field, choose “Condition”.</li>
         <li>For the <b>Control group value</b> field, choose “A”.</li>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/DIA-TTOF/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/DIA-TTOF/en/index.html
@@ -441,7 +441,7 @@
         You are now ready to annotate the replicates you have imported:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Document Grid</b> (Alt-3).</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
     </ul>
     <p>
         This brings up the <b>Document Grid</b> window, which will show the <b>Proteins</b> report if you have never used it
@@ -666,7 +666,7 @@
         To perform a simple pairwise group comparison inside Skyline do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Other Grids</b>, then <b>Group Comparison</b>, and click <b>Add</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add...</b>.</li>
         <li>For the <b>Name</b> field, enter “By Condition”.</li>
         <li>For the <b>Control group annotation</b> field, choose “Condition”.</li>
         <li>For the <b>Control group value</b> field, choose “A”.</li>
@@ -687,7 +687,7 @@
         To see the group comparison you have just created:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Other Grids</b>, then <b>Group Comparison</b>, and click <b>By
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>By
                 Condition</b>.</li>
     </ul>
     <p>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/DIA-TTOF/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/DIA-TTOF/en/index.html
@@ -666,7 +666,7 @@
         To perform a simple pairwise group comparison inside Skyline do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add...</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Add</b>.</li>
         <li>For the <b>Name</b> field, enter “By Condition”.</li>
         <li>For the <b>Control group annotation</b> field, choose “Condition”.</li>
         <li>For the <b>Control group value</b> field, choose “A”.</li>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/ExistingQuant/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/ExistingQuant/en/index.html
@@ -310,8 +310,8 @@
         selections:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Ion Types</b> and click <b>B</b>.</li>
-        <li>On the <b>View</b> menu, choose <b>Charges</b> and click <b>2</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Libraries</b>, then <b>Ion Types</b>, and click <b>B</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Libraries</b>, then <b>Charges</b> and click <b>2</b>.</li>
     </ul>
     <p>
         You may have noticed that Skyline shows the same spectrum for both the light and heavy precursors. This spectral library may contain only
@@ -1001,7 +1001,7 @@
         following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b> (Alt-3).</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>On the <b>Reports</b> menu in the upper left corner of the <b>Document Grid</b>, click <b>Replicates</b>.
         </li>
     </ul>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/GroupedStudies/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/GroupedStudies/en/index.html
@@ -128,7 +128,7 @@
         Proteome Machine (GPM). You can explore their coverage by doing the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>On the <b>Reports</b> menu in the upper-left corner of the <b>Document Grid</b> form, click
             <b>Precursors</b>.</li>
         <li>Scroll to the right in the <b>Document Grid</b> to find the “Library Name” column, click it and click <b>Sort
@@ -361,7 +361,7 @@
         You can also use the <b>Document Grid</b> to create a list of all precursors with any peak truncation by doing the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>On the <b>Reports</b> menu in the <b>Document Grid</b> view, click <b>Precursors</b>.</li>
         <li>On the <b>Reports</b> menu in the <b>Document Grid</b> view, click <b>Customize Report</b>.</li>
         <li>In the <b>Report name</b> field, enter “Truncated Precursors”.</li>
@@ -677,7 +677,7 @@
     <p>
         Now you can see that the peak area for peptide HLNGFSVPR decreases dramatically from the results acquired for the first sample to the last. The
         total peak area goes from roughly 6,000,000 to 30,000, spanning a 200-fold difference. See if you able to use the <b>Results
-            Grid</b> (under <b>View</b> &gt; <b>Other Grids</b> &gt; <b>Results Grid</b>) with the HLNGFSVPR
+            Grid</b> (under <b>View</b> &gt; <b>Live Reports</b> &gt; <b>Results Grid</b>) with the HLNGFSVPR
         peptide precursor 513.7776++ selected to determine the exact maximum and minimum total peak areas. Looking at the other two standard peptides,
         you will see that they too decrease over time (VVLSGSDATLAYSAFK 2.3 to 1.1 million and AFGLSSPR 23 to 1 million). All 42 runs are supposed to
         be essentially technical replicates for these three peptides. While there is clearly systematic signal degradation for all peptides over time
@@ -1122,7 +1122,7 @@
         To set the annotations you have added to the document, do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>On the <b>Reports</b> menu, in the upper left corner of the <b>Document Grid</b>, click <b>Replicates</b>.
         </li>
     </ul>
@@ -1500,7 +1500,7 @@
         To inspect the group comparison you just defined do the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Group Comparisons</b> and click <b>Health v. Diseased</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, then <b>Group Comparisons</b>, and click <b>Health v. Diseased</b>.</li>
     </ul>
     <p class="keep-next">
         Skyline will show a grid view that looks like this:

--- a/pwiz_tools/Skyline/Documentation/Tutorials/HiResMetabolomics/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/HiResMetabolomics/en/index.html
@@ -310,7 +310,7 @@
         <li>On the <b>View</b> menu, choose <b>Peak Areas</b> and click <b>Replicate Comparison</b>.</li>
         <li>On the <b>View</b> menu, choose <b>Retention Times</b> and click <b>Replicate Comparison</b>.</li>
         <li>Click and drag these views to dock them above the chromatogram graphs.</li>
-        <li>On the <b>View</b> menu, choose <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>In the <b>Document Grid</b> view, click the <b>Reports</b> menu, and then click <b>Molecule
                 Quantification</b>.</li>
         <li>Click and drag the <b>Document Grid</b> view and dock it next to the chromatogram graphs.</li>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/ImportingAssayLibraries/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/ImportingAssayLibraries/en/index.html
@@ -226,7 +226,7 @@
         You can also browse this newly generated spectral library in the Spectral Library Explorer by doing the following:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Spectral Libraries</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Libraries</b>, and click <b>Library Explorer</b>.</li>
     </ul>
     <p>
         The spectral library was named the same as your current Skyline document, “AQUA4_Human_Blank-assay”. 

--- a/pwiz_tools/Skyline/Documentation/Tutorials/LibraryExplorer/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/LibraryExplorer/en/index.html
@@ -112,7 +112,7 @@
         To open the library explorer and view the contents of the library you just added, do the following: 
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Spectral Libraries</b>. </li>
+        <li>On the <b>View</b> menu, choose <b>Libraries</b>, and click <b>Library Explorer</b>.</li>
     </ul>
     <p>
         A message is presented about the modifications Skyline has detected in the Experiment 15N library. In your own work, you will often want to

--- a/pwiz_tools/Skyline/Documentation/Tutorials/MS1Filtering/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/MS1Filtering/en/index.html
@@ -312,7 +312,7 @@
         the following steps:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Spectral Libraries</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Libraries</b>, and click <b>Library Explorer</b>.</li>
     </ul>
     <p class="keep-next">
         Skyline will again offer to use the modifications it detects in the library which you chose not to add to your document
@@ -367,8 +367,8 @@
     <ul>
         <li>Click on the sequence of the first phosphopeptide K.DIDIS<b><u>S</u></b>PEFK.I and the MS/MS spectrum will appear. (Note that
             the bold, underlined residue “<b><u>S</u></b>” in the peptide sequence indicates a serine phosphorylation). </li>
-        <li>If you do not see the MS/MS spectrum, on the <b>View</b> menu, click <b>Library Match</b>.</li>
-        <li>If you do not see as many annotated peaks as in the image below, on the <b>View</b> menu, choose <b>Ion Types</b> and
+        <li>If you do not see the MS/MS spectrum, on the <b>View</b> menu, choose <b>Libraries</b>, and click <b>Library Match</b> (Alt-1).</li>
+        <li>If you do not see as many annotated peaks as in the image below, on the <b>View</b> menu, choose <b>Libraries</b>, then <b>Ion Types</b> and
             check <b>A</b>, <b>B</b>, <b>Y</b> and <b>Precursor</b>.</li>
         <li>If you do not see the entire chromatogram for the peptide, on the <b>View</b> menu, choose <b>Auto-Zoom</b> and click
             <b>None</b> (Shift-F11).</li>

--- a/pwiz_tools/Skyline/Documentation/Tutorials/MethodEdit/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/MethodEdit/en/index.html
@@ -227,7 +227,7 @@
         <img src="s-04.png" />
     </p>
     <ul>
-        <li>On the <b>View</b> menu, choose <b>Ion Types</b>, and then click <b>B</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Libraries</b>, then <b>Ion Types</b>, and click <b>B</b>.</li>
     </ul>
     <p>
         This makes Skyline highlight the b-ions for this peptide in purple in the spectrum graph. Here are the steps to show precursor <i>m/z</i> and

--- a/pwiz_tools/Skyline/Documentation/Tutorials/MethodRefine/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/MethodRefine/en/index.html
@@ -97,7 +97,7 @@
     <ul>
         <li>Select the first peptide (YLGAYLLATLGGNASPSAQDVLK) in the <b>Targets</b> view.</li>
         <li>On the <b>View</b> menu, choose <b>Auto-Zoom</b>, and click <b>Best Peak</b>.</li>
-        <li>On the <b>View</b> menu, choose <b>Ion Types</b>, and click <b>B</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Libraries</b>, then <b>Ion Types</b>, and click <b>B</b>.</li>
     </ul>
     <p>
         Skyline should present graphs showing both a corresponding MS/MS spectrum from a library and time-intensity chromatogram data measured for

--- a/pwiz_tools/Skyline/Documentation/Tutorials/PRMOrbitrap-PRBB/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/PRMOrbitrap-PRBB/en/index.html
@@ -579,7 +579,7 @@
     </p>
     <p>
         <b>Tip!</b> For each target peptide you can view the corresponding MS2 spectrum of the library via the MS/MS Spectrum tab (usually by
-        default visible, if not, go to View🡪Library Match). To select the ion type that you want to label in the MS2 spectrum right-click on the
+        default visible, if not, go to View🡪Libraries🡪Library Match). To select the ion type that you want to label in the MS2 spectrum right-click on the
         spectrum and select any additional ion types you are interested in.
     </p>
     <p>
@@ -963,7 +963,7 @@
         Once all the data has been reviewed and properly refined, we will use Skyline to quantify the proteins of interest in our samples.
     </p>
     <ul>
-        <li><b>Go</b> to “View” → “Document Grid”. </li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>In the Document Grid window: <b>Go</b> to “Reports” → “Peptide Ratio Results”.</li>
     </ul>
     <p>
@@ -1143,7 +1143,7 @@
         To inspect the group comparison you just defined do the following:
     </p>
     <ul>
-        <li><b>“View”</b> → “Other Grids” → “Group Comparisons” → “G2M-vs-G1” or “S-vs-G1”.</li>
+        <li><b>“View”</b> → “Live Reports” → “Group Comparisons” → “G2M-vs-G1” or “S-vs-G1”.</li>
     </ul>
     <p class="keep-next">
         Skyline will show a grid view that looks like this:

--- a/pwiz_tools/Skyline/Documentation/Tutorials/PRMOrbitrap/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/PRMOrbitrap/en/index.html
@@ -269,7 +269,7 @@
     </ul>
     <p>
         <b><span class="green">Tip!</span></b> You can visualize and browse all peptides of your library in the Spectral Library Explorer
-        under <br /><b>View</b> → <b>Spectral Libraries</b>.
+        under <br /><b>View</b> → <b>Libraries</b> → <b>Library Explorer</b>.
     </p>
     <p>
         <b><span class="green">Tip!</span></b> Skyline supports building libraries from many peptide spectrum matching pipeline outputs. The

--- a/pwiz_tools/Skyline/Documentation/Tutorials/SmallMoleculeIMSLibraries/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/SmallMoleculeIMSLibraries/en/index.html
@@ -196,7 +196,7 @@
         To open the library explorer and view the contents of the library you just added, do the following: 
     </p>
     <ul>
-        <li>From the <b>View</b> menu, click <b>Spectral Libraries</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Libraries</b>, and click <b>Library Explorer</b>.</li>
     </ul>
     <p class="keep-next">
         The library explorer should now look like this:

--- a/pwiz_tools/Skyline/Documentation/Tutorials/SmallMoleculeMethodDevCEOpt/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/SmallMoleculeMethodDevCEOpt/en/index.html
@@ -503,7 +503,7 @@
         calibration function.
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b> (Alt-3).</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>In the <b>Document Grid</b>, click the <b>Reports</b> menu, and then click <b>Replicates</b>.</li>
         <li>Set the <b>Sample Type</b> to in each row to <b>Standard</b></li>
         <li>Set the <b>Analyte Concentration</b> as the appropriate decimal number for the ratio preceding the underscore in the replicate

--- a/pwiz_tools/Skyline/Documentation/Tutorials/SmallMoleculeQuantification/en/index.html
+++ b/pwiz_tools/Skyline/Documentation/Tutorials/SmallMoleculeQuantification/en/index.html
@@ -411,7 +411,7 @@
         In this case, you need to supply details for the various replicates as follows:
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>Click <b>Reports</b> in the upper left corner of the grid, and choose <b>Replicates</b>.</li>
     </ul>
     <p class="keep-next">
@@ -654,7 +654,7 @@
         do that, follow these steps: 
     </p>
     <ul>
-        <li>On the <b>View</b> menu, click <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>Click on <b>Reports</b> in the upper left corner of the grid, and then click <b>Replicates</b>.</li>
         <li>Click again on <b>Reports</b> in the upper left corner of the grid, and then click <b>Customize Report</b>.</li>
         <li>Click on the search button <img src="../../shared/black-binocular-button.png" /> and enter “accuracy” into the <b>Find what</b> field.</li>
@@ -713,7 +713,7 @@
             Results</b> view.
     </p>
     <ul>
-        <li>In the <b>View</b> menu, click <b>Document Grid</b>.</li>
+        <li>On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).</li>
         <li>In the <b>Reports</b> dropdown list, click <b>Molecule Ratio Results</b>.</li>
         <li>Click the <b>Replicate</b> column header and select <b>Sort Ascending</b>.</li>
     </ul>


### PR DESCRIPTION
I found and fixed all the places in the "index.html" tutorial HTML files that mentioned menu items that have been moved to the "View > Live Reports" or "View > Libraries" sub-menus.
I also changed it so that they all mention the accelerator if it exists for example:
`On the <b>View</b> menu, choose <b>Live Reports</b>, and click <b>Document Grid</b> (Alt-3).`

I wonder why we have standardized on using a hyphen in "Alt-3" instead of a plus sign "Alt+3".
The text in the menus always has a "+".