### PR TITLE
Small fix for the sequence tree expand/collapse logic

### DIFF
--- a/pwiz_tools/Skyline/Controls/SequenceTree.cs
+++ b/pwiz_tools/Skyline/Controls/SequenceTree.cs
@@ -1651,6 +1651,8 @@ namespace pwiz.Skyline.Controls
             node.Nodes.OfType<TreeNodeMS>().ForEach(childNode => SelectNode(childNode, select));
             if (GetNodeLevel(node) < level)
                 node.Nodes.OfType<TreeNodeMS>().ForEach(childNode => ExpandRecursive(childNode, level, select));
+            else
+                node.Nodes.OfType<TreeNodeMS>().ForEach(childNode => childNode.Collapse());     // collapse all children below the level
         }
     }
 

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -1782,7 +1782,6 @@ namespace pwiz.Skyline
             copyContextMenuItem.Enabled = enabled;
             cutContextMenuItem.Enabled = enabled;
             deleteContextMenuItem.Enabled = enabled;
-
             if (SequenceTree.SelectedNodes.Count > 0)
             {
                 expandSelectionContextMenuItem.Enabled = true;
@@ -1792,6 +1791,16 @@ namespace pwiz.Skyline
             {
                 expandSelectionContextMenuItem.Enabled = false;
                 expandSelectionContextMenuItem.Visible = false;
+            }
+            if (Settings.Default.UIMode == UiModes.PROTEOMIC)
+            {
+                expandSelectionProteinsContextMenuItem.Text = SeqNodeResources.PeptideGroupTreeNode_Heading_Protein;
+                expandSelectionPeptidesContextMenuItem.Text = SeqNodeResources.PeptideTreeNode_Heading_Title;
+            }
+            else
+            {
+                expandSelectionProteinsContextMenuItem.Text = SeqNodeResources.PeptideGroupTreeNode_Heading_Molecule_List;
+                expandSelectionPeptidesContextMenuItem.Text = SeqNodeResources.PeptideTreeNode_Heading_Title_Molecule;
             }
             pickChildrenContextMenuItem.Enabled = SequenceTree.CanPickChildren(SequenceTree.SelectedNode) && enabled;
             editNoteContextMenuItem.Enabled = (SequenceTree.SelectedNode is SrmTreeNode && enabled);

--- a/pwiz_tools/Skyline/Skyline.resx
+++ b/pwiz_tools/Skyline/Skyline.resx
@@ -273,7 +273,7 @@
     <value>228, 22</value>
   </data>
   <data name="expandSelectionPrecursorsContextMenuItem.Text" xml:space="preserve">
-    <value>Precursors</value>
+    <value>Precursor</value>
   </data>
   <data name="toggleQuantitativeContextMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>228, 22</value>


### PR DESCRIPTION
The tree did not collapse properly when only a protein node is selected.