### PR TITLE
Display "No quantitative chromatograms found" instead of "Chromatogram information unavailable" if only showing quantitative chromatograms

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphChromatogram.cs
@@ -1150,6 +1150,12 @@ namespace pwiz.Skyline.Controls.Graphs
                         case DisplayTypeChrom.qc:
                             message = GraphsResources.GraphChromatogram_UpdateUI_No_QC_chromatogram_found;
                             break;
+                        default:
+                            if (Settings.Default.ShowQuantitativeOnly)
+                            {
+                                message = GraphsResources.GraphChromatogram_UpdateUI_No_quantitative_chromatograms_found;
+                            }
+                            break;
                     }
                     SetErrorGraphItem(new UnavailableChromGraphItem(Helpers.PeptideToMoleculeTextMapper.Translate(message, DocumentUI.DocumentType)));
                 }

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.designer.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.designer.cs
@@ -1210,6 +1210,15 @@ namespace pwiz.Skyline.Controls.Graphs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No quantitative chromatograms found.
+        /// </summary>
+        public static string GraphChromatogram_UpdateUI_No_quantitative_chromatograms_found {
+            get {
+                return ResourceManager.GetString("GraphChromatogram_UpdateUI_No_quantitative_chromatograms_found", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No TIC chromatogram found.
         /// </summary>
         public static string GraphChromatogram_UpdateUI_No_TIC_chromatogram_found {

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.resx
@@ -748,4 +748,7 @@ Here are the last 3 errors:
   <data name="RelativeAbundanceGraph_ToolTip_Rank" xml:space="preserve">
     <value>Rank</value>
   </data>
+  <data name="GraphChromatogram_UpdateUI_No_quantitative_chromatograms_found" xml:space="preserve">
+	  <value>No quantitative chromatograms found</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.resx
@@ -749,6 +749,6 @@ Here are the last 3 errors:
     <value>Rank</value>
   </data>
   <data name="GraphChromatogram_UpdateUI_No_quantitative_chromatograms_found" xml:space="preserve">
-	  <value>No quantitative chromatograms found</value>
+    <value>No quantitative chromatograms found</value>
   </data>
 </root>


### PR DESCRIPTION
Changed to display "No quantitative chromatograms" instead of "Chromatogram information unavailable" when displaying only quantitative transitions and no chromatograms found (reported by Vicky).