### PR TITLE
Add progress bar to peak area relative abundance plot

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AreaRelativeAbundanceGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AreaRelativeAbundanceGraphPane.cs
@@ -44,8 +44,8 @@ namespace pwiz.Skyline.Controls.Graphs
 
         internal class AreaGraphData : GraphData
         {
-            public AreaGraphData(SrmDocument document, GraphSettings graphSettings, CancellationToken cancellationToken)
-                : base(document, graphSettings, cancellationToken)
+            public AreaGraphData(SrmDocument document, GraphSettings graphSettings, ProductionMonitor productionMonitor)
+                : base(document, graphSettings, productionMonitor)
             {
             }
 
@@ -58,7 +58,7 @@ namespace pwiz.Skyline.Controls.Graphs
         {
             public override GraphData ProduceResult(ProductionMonitor productionMonitor, GraphDataParameters parameter, IDictionary<WorkOrder, object> inputs)
             {
-                return new AreaGraphData(parameter.Document, parameter.GraphSettings, productionMonitor.CancellationToken);
+                return new AreaGraphData(parameter.Document, parameter.GraphSettings, productionMonitor);
             }
         }
     }

--- a/pwiz_tools/Skyline/Controls/Graphs/AreaRelativeAbundanceGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AreaRelativeAbundanceGraphPane.cs
@@ -18,7 +18,6 @@
  */
 
 using System.Collections.Generic;
-using System.Threading;
 using pwiz.Common.SystemUtil.Caching;
 using pwiz.Skyline.Model;
 using pwiz.Skyline.Properties;

--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -4494,7 +4494,6 @@ namespace pwiz.Skyline
 
         public void ShowPeakAreaRelativeAbundanceGraph()
         {
-            ShowTotalTransitions();
             Settings.Default.AreaGraphTypes.Insert(0, GraphTypeSummary.abundance);
             ShowGraphPeakArea(true, GraphTypeSummary.abundance);
             UpdatePeakAreaGraph();


### PR DESCRIPTION
Added progress bar to Peak Area Relative Abundance plot (requested by Mike)
Fixed bug where "View > Transitions" would change to "Total" when Peak Area Relative Abundance plot is shown (reported by Mike)