### PR TITLE
Fixes for Comet search issues (reported by Mike)

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ConverterSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ConverterSettingsControl.cs
@@ -266,9 +266,10 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
             stringToValueIfNonDefault(EstimateBackground.ToString(), defaultDiaUmpireSettings[ESTIMATEBG]);
 
-            KeyValueGridDlg.Show(PeptideSearchResources.SearchSettingsControl_Additional_Settings,
+            KeyValueGridDlg.Show(this, PeptideSearchResources.SearchSettingsControl_Additional_Settings,
                 allDiaUmpireSettings, valueToString, stringToValueIfNonDefault,
-                (value, setting) => setting.Validate(value));
+                (value, setting) => setting.Validate(value),
+                setting => setting.ValidValues);
         }
 
         private void UpdateSettingIfNonDefault<T>(IDictionary<string, AbstractDdaSearchEngine.Setting> settingStore,

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/EncyclopeDiaSearchDlg.cs
@@ -542,7 +542,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         private void btnAdditionalSettings_Click(object sender, EventArgs e)
         {
-            KeyValueGridDlg.Show(PeptideSearchResources.SearchSettingsControl_Additional_Settings,
+            KeyValueGridDlg.Show(this, PeptideSearchResources.SearchSettingsControl_Additional_Settings,
                 EncyclopeDiaConfig.Parameters,
                 setting => setting.Value.ToString(),
                 (value, setting) => setting.Value = value,

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -183,8 +183,6 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                 if (isFeatureDetection)
                 {
                     this.Text = PeptideSearchResources.ImportPeptideSearchDlg_ImportPeptideSearchDlg_Feature_Detection;
-                    label14.Text =
-                        PeptideSearchResources.BuildPeptideSearchLibraryControl_btnAddFile_Click_Select_Files_to_Search; // Was "Spectral Library"
                     lblDDASearch.Text = PeptideSearchResources.ImportPeptideSearchDlg_ImportPeptideSearchDlg_Feature_Detection; // Was "DDA Search"
                     // Set some defaults
                     SearchSettingsControl.HardklorSignalToNoise = Settings.Default.FeatureFindingSignalToNoise;
@@ -198,6 +196,11 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                 {
                     Height = BuildPepSearchLibControl.Bottom;
                 }
+            }
+
+            if (isFeatureDetection || isRunPeptideSearch)
+            {
+                label14.Text = PeptideSearchResources.BuildPeptideSearchLibraryControl_btnAddFile_Click_Select_Files_to_Search; // Was "Spectral Library"
             }
         }
 

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/SearchSettingsControl.cs
@@ -377,6 +377,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             {
                 return;
             }
+            LoadMassUnitEntries();
             LoadFragmentIonEntries();
             LoadMs2AnalyzerEntries();
 
@@ -393,8 +394,6 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
 
         private void LoadMassUnitEntries()
         {
-            string[] entries = { @"Da", @"ppm" };
-
             void ClearAndRestoreComboBoxItems(ComboBox cb, string[] newEntries)
             {
                 string oldSelection = cb.SelectedItem as string;
@@ -404,10 +403,10 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
                     cb.SelectedIndex = newEntries.ToList().IndexOf(oldSelection);
             }
 
-            var ms1Entries = ImportPeptideSearch.SearchEngine.PrecursorIonToleranceUnitTypes.Select(t => entries[(int) t]).ToArray();
+            var ms1Entries = ImportPeptideSearch.SearchEngine.PrecursorIonToleranceUnitTypes.Select(t => t.Name).ToArray();
             ClearAndRestoreComboBoxItems(cbMS1TolUnit, ms1Entries);
 
-            var ms2Entries = ImportPeptideSearch.SearchEngine.FragmentIonToleranceUnitTypes.Select(t => entries[(int) t]).ToArray();
+            var ms2Entries = ImportPeptideSearch.SearchEngine.FragmentIonToleranceUnitTypes.Select(t => t.Name).ToArray();
             ClearAndRestoreComboBoxItems(cbMS2TolUnit, ms2Entries);
         }
 
@@ -670,11 +669,14 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             Assume.IsNotNull(ImportPeptideSearch.SearchEngine.AdditionalSettings);
 
-            KeyValueGridDlg.Show(PeptideSearchResources.SearchSettingsControl_Additional_Settings,
+            KeyValueGridDlg.Show(this, PeptideSearchResources.SearchSettingsControl_Additional_Settings,
                 ImportPeptideSearch.SearchEngine.AdditionalSettings,
                 (setting) => setting.Value.ToString(),
                 (value, setting) => setting.Value = value,
-                (value, setting) => setting.Validate(value));
+                (value, setting) => setting.Validate(value),
+                setting => setting.ValidValues);
+
+            InitializeControls();
         }
     }
 

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.cs
@@ -320,7 +320,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         {
             // Reset control locations, in case this isn't the first call to Initialize.
             foreach (var kvp in _originalLocations)
-                kvp.Key.Location = kvp.Value;
+                kvp.Key.Location = new Point(kvp.Key.Location.X, kvp.Value.Y);
 
             if (workflow != ImportPeptideSearchDlg.Workflow.dia)
             {

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.resx
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.resx
@@ -829,10 +829,10 @@
     <value>66, 23</value>
   </data>
   <data name="btnEditSpectrumFilter.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
+    <value>19</value>
   </data>
   <data name="btnEditSpectrumFilter.Text" xml:space="preserve">
-    <value>Edit...</value>
+    <value>&amp;Edit...</value>
   </data>
   <data name="&gt;&gt;btnEditSpectrumFilter.Name" xml:space="preserve">
     <value>btnEditSpectrumFilter</value>
@@ -859,7 +859,7 @@
     <value>250, 23</value>
   </data>
   <data name="tbxSpectrumFilter.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
+    <value>18</value>
   </data>
   <data name="&gt;&gt;tbxSpectrumFilter.Name" xml:space="preserve">
     <value>tbxSpectrumFilter</value>
@@ -886,10 +886,10 @@
     <value>95, 13</value>
   </data>
   <data name="label13.TabIndex" type="System.Int32, mscorlib">
-    <value>27</value>
+    <value>17</value>
   </data>
   <data name="label13.Text" xml:space="preserve">
-    <value>Advanced filtering:</value>
+    <value>Ad&amp;vanced filtering:</value>
   </data>
   <data name="&gt;&gt;label13.Name" xml:space="preserve">
     <value>label13</value>

--- a/pwiz_tools/Skyline/Model/AbstractDdaSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/AbstractDdaSearchEngine.cs
@@ -34,10 +34,22 @@ namespace pwiz.Skyline.Model
 {
     public abstract class AbstractDdaSearchEngine : IDisposable
     {
+        public class MzToleranceUnits
+        {
+            public MzToleranceUnits(string name, MzTolerance.Units unit)
+            {
+                Name = name;
+                Unit = unit;
+            }
+
+            public string Name { get; }
+            public MzTolerance.Units Unit { get; }
+        }
+
         public abstract string[] FragmentIons { get; }
         public abstract string[] Ms2Analyzers { get; }
-        public virtual MzTolerance.Units[] PrecursorIonToleranceUnitTypes { get; } = { MzTolerance.Units.mz, MzTolerance.Units.ppm };
-        public virtual MzTolerance.Units[] FragmentIonToleranceUnitTypes { get; } = { MzTolerance.Units.mz, MzTolerance.Units.ppm };
+        public virtual MzToleranceUnits[] PrecursorIonToleranceUnitTypes { get; } = { new MzToleranceUnits(@"Da", MzTolerance.Units.mz), new MzToleranceUnits(@"ppm", MzTolerance.Units.ppm) };
+        public virtual MzToleranceUnits[] FragmentIonToleranceUnitTypes { get; } = { new MzToleranceUnits(@"Da", MzTolerance.Units.mz), new MzToleranceUnits(@"ppm", MzTolerance.Units.ppm) };
         public abstract string EngineName { get; }
         public abstract string CutoffScoreName { get; }
         public abstract string CutoffScoreLabel { get; }
@@ -123,8 +135,8 @@ namespace pwiz.Skyline.Model
                     case string s:
                         if (ValidValues?.Any(o => o.Equals(value)) == false)
                             throw new ArgumentOutOfRangeException(string.Format(
-                                "The value {0} is not valid for the argument {1} which must one of: {2}",
-                                s, Name, string.Join(@", ", ValidValues)));
+                                Resources.CommandArgs_ParseArgsInternal_Error____0___is_not_a_valid_value_for__1___It_must_be_one_of_the_following___2_,
+                                value, Name, string.Join(@", ", ValidValues)));
                         return value;
 
                     case bool b:

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -87,9 +87,11 @@ namespace pwiz.SkylineTestFunctional
             public string Ms2Analyzer { get; set; }
             public MzTolerance PrecursorTolerance { get; set; }
             public MzTolerance FragmentTolerance { get; set; }
-            public List<KeyValuePair<string, string>> AdditionalSettings { get; set; }
+            public Dictionary<string, string> AdditionalSettings { get; set; }
             public ExpectedResults ExpectedResults { get; set; }
             public ExpectedResults ExpectedResultsFinal { get; set; }
+            public Action BeforeSettingsAction { get; set; }
+            public Action ExpectedErrorAction { get; set; }
             public bool HasMissingDependencies { get; private set; }
         }
 
@@ -112,7 +114,7 @@ namespace pwiz.SkylineTestFunctional
                 Ms2Analyzer = "Default",
                 PrecursorTolerance = new MzTolerance(15, MzTolerance.Units.ppm),
                 FragmentTolerance = new MzTolerance(25, MzTolerance.Units.ppm),
-                AdditionalSettings = new List<KeyValuePair<string, string>>(),
+                AdditionalSettings = new Dictionary<string, string>(),
                 ExpectedResultsFinal = new ExpectedResults(133, 332, 394, 1182, 163)
             };
 
@@ -140,7 +142,7 @@ namespace pwiz.SkylineTestFunctional
                 Ms2Analyzer = "Orbitrap/FTICR/Lumos",
                 PrecursorTolerance = new MzTolerance(15, MzTolerance.Units.ppm),
                 FragmentTolerance = new MzTolerance(25, MzTolerance.Units.ppm),
-                AdditionalSettings = new List<KeyValuePair<string, string>>(),
+                AdditionalSettings = new Dictionary<string, string>(),
                 ExpectedResultsFinal = new ExpectedResults(104, 256, 317, 951, 124)
             };
 
@@ -166,9 +168,49 @@ namespace pwiz.SkylineTestFunctional
                 FragmentIons = "b,y",
                 Ms2Analyzer = "Default",
                 PrecursorTolerance = new MzTolerance(15, MzTolerance.Units.ppm),
+                FragmentTolerance = new MzTolerance(1.0005),
+                AdditionalSettings = new Dictionary<string, string>(),
+                ExpectedResultsFinal = new ExpectedResults(123, 297, 358, 1074, 144)
+            };
+
+            RunFunctionalTest();
+            Assert.IsFalse(IsRecordMode);
+        }
+
+        [TestMethod, NoParallelTesting(TestExclusionReason.RESOURCE_INTENSIVE), NoUnicodeTesting(TestExclusionReason.COMET_UNICODE_ISSUES)]
+        public void TestDdaSearchCometAutoTolerance()
+        {
+            // Check that the error from having not enough spectra to do auto-tolerance calculation is report properly.
+
+            TestFilesZip = @"TestFunctional\DdaSearchTest.zip";
+
+            if (RedownloadTools)
+                foreach (var requiredFile in CometSearchEngine.FilesToDownload)
+                    if (requiredFile.Unzip)
+                        DirectoryEx.SafeDelete(requiredFile.InstallPath);
+                    else
+                        FileEx.SafeDelete(Path.Combine(requiredFile.InstallPath, requiredFile.Filename));
+
+            TestSettings = new DdaTestSettings
+            {
+                SearchEngine = SearchSettingsControl.SearchEngine.Comet,
+                FragmentIons = "b,y",
+                Ms2Analyzer = "Default",
+                PrecursorTolerance = new MzTolerance(25, MzTolerance.Units.ppm),
                 FragmentTolerance = new MzTolerance(0.5),
-                AdditionalSettings = new List<KeyValuePair<string, string>>(),
-                ExpectedResultsFinal = new ExpectedResults(133, 316, 375, 1123, 157)
+                AdditionalSettings = new Dictionary<string, string>
+                {
+                    { "auto_fragment_bin_tol", "fail" },
+                    { "auto_peptide_mass_tolerance", "fail" }
+                },
+                ExpectedResultsFinal = new ExpectedResults(new IOException()),
+                ExpectedErrorAction = () =>
+                {
+                    var errorCalculationFailedDlg = WaitForOpenForm<MessageDlg>();
+                    StringAssert.Contains(errorCalculationFailedDlg.Message, "Precursor error calculation failed");
+                    StringAssert.Contains(errorCalculationFailedDlg.Message, "Fragment error calculation failed");
+                    OkDialog(errorCalculationFailedDlg, errorCalculationFailedDlg.ClickOk);
+                }
             };
 
             RunFunctionalTest();
@@ -194,12 +236,12 @@ namespace pwiz.SkylineTestFunctional
                 Ms2Analyzer = "Default",
                 PrecursorTolerance = new MzTolerance(50, MzTolerance.Units.ppm),
                 FragmentTolerance = new MzTolerance(50, MzTolerance.Units.ppm),
-                AdditionalSettings = new List<KeyValuePair<string, string>>
+                AdditionalSettings = new Dictionary<string, string>
                 {
-                    new KeyValuePair<string, string>("check_spectral_files", "0"),
-                    new KeyValuePair<string, string>("calibrate_mass", "0"),
-                    //new KeyValuePair<string, string>("output_report_topN", "5"),
-                    new KeyValuePair<string, string>("train-fdr", Convert.ToString(0.1, CultureInfo.CurrentCulture))
+                    { "check_spectral_files", "0" },
+                    { "calibrate_mass", "0" },
+                    //{ "output_report_topN", "5" },
+                    { "train-fdr", Convert.ToString(0.1, CultureInfo.CurrentCulture) }
                 },
                 ExpectedResultsFinal = new ExpectedResults(143, 340, 428, 1284, 166)
             };
@@ -227,11 +269,19 @@ namespace pwiz.SkylineTestFunctional
                 Ms2Analyzer = "Default",
                 PrecursorTolerance = new MzTolerance(50, MzTolerance.Units.ppm),
                 FragmentTolerance = new MzTolerance(50, MzTolerance.Units.ppm),
-                AdditionalSettings = new List<KeyValuePair<string, string>>
+                AdditionalSettings = new Dictionary<string, string>
                 {
-                    new KeyValuePair<string, string>("check_spectral_files", "0")
+                    { "check_spectral_files", "0" }
                 },
-                ExpectedResultsFinal = new ExpectedResults(new FileNotFoundException())
+                BeforeSettingsAction = () => File.Delete(GetTestPath(TestSettings.FastaFilename)),
+                ExpectedResultsFinal = new ExpectedResults(new FileNotFoundException()),
+                ExpectedErrorAction = () =>
+                {
+                    var fastaFileNotFoundDlg = WaitForOpenForm<MessageDlg>();
+                    var expectedMsg = new FileNotFoundException(GetSystemResourceString("IO.FileNotFound_FileName", GetTestPath(TestSettings.FastaFilename))).Message;
+                    Assert.AreEqual(expectedMsg, fastaFileNotFoundDlg.Message);
+                    OkDialog(fastaFileNotFoundDlg, fastaFileNotFoundDlg.ClickOk);
+                }
             };
 
             RunFunctionalTest();
@@ -383,11 +433,7 @@ namespace pwiz.SkylineTestFunctional
                 Assert.IsTrue(importPeptideSearchDlg.CurrentPage == ImportPeptideSearchDlg.Pages.dda_search_settings_page);
             });
 
-
-
-            // delete the FASTA to cause the error
-            if (errorExpected)
-                File.Delete(GetTestPath(TestSettings.FastaFilename));
+            TestSettings.BeforeSettingsAction?.Invoke();
 
             RunUI(() =>
             {
@@ -449,10 +495,7 @@ namespace pwiz.SkylineTestFunctional
             }
             else // errorExpected
             {
-                var fastaFileNotFoundDlg = WaitForOpenForm<MessageDlg>();
-                var expectedMsg = new FileNotFoundException(GetSystemResourceString("IO.FileNotFound_FileName", GetTestPath(TestSettings.FastaFilename))).Message;
-                Assert.AreEqual(expectedMsg, fastaFileNotFoundDlg.Message);
-                OkDialog(fastaFileNotFoundDlg, fastaFileNotFoundDlg.ClickOk);
+                TestSettings.ExpectedErrorAction?.Invoke();
                 WaitForConditionUI(60000, () => searchSucceeded.HasValue);
                 OkDialog(importPeptideSearchDlg, importPeptideSearchDlg.ClickCancelButton);
                 return;

--- a/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
@@ -84,7 +84,10 @@ namespace TestPerf
 
         protected override void DoTest()
         {
-            TestMsFraggerSearch();
+            var searchEngine = IsRecordingScreenShots
+                ? SearchSettingsControl.SearchEngine.MSAmanda
+                : SearchSettingsControl.SearchEngine.MSFragger;
+            TestSearch(searchEngine);
         }
 
         /// <summary>
@@ -107,7 +110,7 @@ namespace TestPerf
         /// <summary>
         /// Test that the "Match Modifications" page of the Import Peptide Search wizard gets skipped.
         /// </summary>
-        private void TestMsFraggerSearch()
+        private void TestSearch(SearchSettingsControl.SearchEngine searchEngine)
         {
             PrepareDocument("TestDdaTutorial.sky");
 
@@ -214,22 +217,33 @@ namespace TestPerf
             bool? searchSucceeded = null;
             RunUI(() => Assert.IsTrue(importPeptideSearchDlg.CurrentPage == ImportPeptideSearchDlg.Pages.dda_search_settings_page));
 
-            bool useMsFragger = !IsPauseForScreenShots; // Tutorial still uses MSAmanda
+            bool useMsAmanda = IsPauseForScreenShots; // Tutorial still uses MSAmanda
 
             // Switch search engine
-            if (useMsFragger)
-                SkylineWindow.BeginInvoke(new Action(() => importPeptideSearchDlg.SearchSettingsControl.SelectedSearchEngine = SearchSettingsControl.SearchEngine.MSFragger));
+            if (!useMsAmanda)
+                SkylineWindow.BeginInvoke(new Action(() => importPeptideSearchDlg.SearchSettingsControl.SelectedSearchEngine = searchEngine));
 
             RunUI(() =>
             {
                 importPeptideSearchDlg.SearchSettingsControl.PrecursorTolerance = new MzTolerance(5, MzTolerance.Units.ppm);
-                importPeptideSearchDlg.SearchSettingsControl.FragmentTolerance = new MzTolerance(10, MzTolerance.Units.ppm);
                 // Using the default q value of 0.01 (FDR 1%) is best for teaching and requires less explaining
                 // importPeptideSearchDlg.SearchSettingsControl.CutoffScore = 0.05;
-                if (useMsFragger)
+                if (searchEngine == SearchSettingsControl.SearchEngine.MSFragger)
                 {
+                    importPeptideSearchDlg.SearchSettingsControl.FragmentTolerance = new MzTolerance(10, MzTolerance.Units.ppm);
                     importPeptideSearchDlg.SearchSettingsControl.SetAdditionalSetting("check_spectral_files", "0");
                     //importPeptideSearchDlg.SearchSettingsControl.SetAdditionalSetting("keep-intermediate-files", "True");
+                }
+                else if (searchEngine == SearchSettingsControl.SearchEngine.Comet)
+                {
+                    importPeptideSearchDlg.SearchSettingsControl.FragmentTolerance = new MzTolerance(0.02);
+                    importPeptideSearchDlg.SearchSettingsControl.SetAdditionalSetting("auto_peptide_mass_tolerance", "fail");
+                    importPeptideSearchDlg.SearchSettingsControl.SetAdditionalSetting("auto_fragment_bin_tol", "fail");
+                    //importPeptideSearchDlg.SearchSettingsControl.SetAdditionalSetting("keep-intermediate-files", "True");
+                }
+                else
+                {
+                    importPeptideSearchDlg.SearchSettingsControl.FragmentTolerance = new MzTolerance(10, MzTolerance.Units.ppm);
                 }
 
                 importPeptideSearchDlg.SearchControl.SearchFinished += (success) => searchSucceeded = success;
@@ -253,9 +267,9 @@ namespace TestPerf
             SkylineWindow.BeginInvoke(new Action(() => Assert.IsTrue(importPeptideSearchDlg.ClickNextButton())));
 
             // Handle download dialogs if necessary
-            if (useMsFragger)
+            if (RedownloadTools || HasMissingDependencies)
             {
-                if (RedownloadTools || HasMissingDependencies)
+                if (searchEngine == SearchSettingsControl.SearchEngine.MSFragger)
                 {
                     var msfraggerDownloaderDlg = TryWaitForOpenForm<MsFraggerDownloadDlg>(2000);
                     if (msfraggerDownloaderDlg != null)
@@ -264,7 +278,10 @@ namespace TestPerf
                         RunUI(() => msfraggerDownloaderDlg.SetValues("Matt Chambers (testing download from Skyline)", "matt.chambers42@gmail.com", "UW"));
                         OkDialog(msfraggerDownloaderDlg, msfraggerDownloaderDlg.ClickAccept);
                     }
+                }
 
+                if (searchEngine != SearchSettingsControl.SearchEngine.MSAmanda)
+                {
                     var downloaderDlg = TryWaitForOpenForm<MultiButtonMsgDlg>(2000);
                     if (downloaderDlg != null)
                     {


### PR DESCRIPTION
- changed Comet's default precursor_tolerance_type to 1 (m/z tolerance) and made tolerance units name responsive to that setting (m/z vs. Da)
- fixed Comet search with a single file
- fixed Additional Settings dialog not working properly if value set contains true or false string
- relabeled first tab of Run Peptide Search
* removed Comet's `use_*_ions` and `variable_mod*` parameters from Additional Settings (they are controlled by fragment ions and document mods)
* removed parentless KeyValueGridDlg overload
* fixed spectrum filter Edit button location and mnemonics