### PR TITLE
Fix exception in AxisLabelScaler

### DIFF
--- a/pwiz_tools/Shared/zedgraph/ZedGraph/FontSpec.cs
+++ b/pwiz_tools/Shared/zedgraph/ZedGraph/FontSpec.cs
@@ -360,27 +360,10 @@ namespace ZedGraph
 			get { return _size; }
 			set
 			{
-				if ( value != _size )
+				if (value != _size)
 				{
-					try
-					{
-						if (_size == 0)
-						{
-							Font newFont = null;
-							Remake(value, 1, ref _scaledSize, ref newFont);
-							_font = newFont; 
-						}
-						else
-						{
-							Remake(_scaledSize / _size * value, _size, 
-								ref _scaledSize, ref _font);
-						}
-						_size = value;
-					}
-					catch (Exception e)
-					{
-						throw new Exception(string.Format(@"Unable to set FontSpec.Size to {0} for _size {1} _scaledSize {2}", value, _size, _scaledSize), e);
-					}
+					Remake(_scaledSize / _size, value, ref _scaledSize, ref _font);
+					_size = value;
 				}
 			}
 		}

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -292,6 +292,7 @@
     <Compile Include="UtilTest.cs" />
     <Compile Include="VariableModTest.cs" />
     <Compile Include="WebEnabledFastaImporterTest.cs" />
+    <Compile Include="ZedGraphTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Shared\Common\Common.csproj">

--- a/pwiz_tools/Skyline/Test/ZedGraphTest.cs
+++ b/pwiz_tools/Skyline/Test/ZedGraphTest.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2025 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ZedGraph;
+
+namespace pwiz.SkylineTest
+{
+    [TestClass]
+    public class ZedGraphTest
+    {
+        /// <summary>
+        /// Verifies that changing <see cref="FontSpec.Size"/> can be done repeatedly without exception.
+        /// There used to be a bug that <see cref="FontSpec._scaledSize"/> would be a nonsensical value
+        /// and eventually overflow.
+        /// </summary>
+        [TestMethod]
+        public void TestFontSpecSize()
+        {
+            var fontSpec = new FontSpec();
+            for (int i = 0; i < 1000; i++)
+            {
+                fontSpec.Size = 10;
+                Assert.AreEqual(10, fontSpec.Size);
+                fontSpec.Size = 100;
+                Assert.AreEqual(100, fontSpec.Size);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed error sometimes trying to draw text on graphs.

There was a bug in the implementation of the setter for FontSpec.Size where "_scaledSize" would be a nonsensical number which grew larger every time the size was changed and would eventually overflow.