### PR TITLE
Change ZedGraphTest to inherit from AbstractUnitTest

### DIFF
--- a/pwiz_tools/Skyline/Test/ZedGraphTest.cs
+++ b/pwiz_tools/Skyline/Test/ZedGraphTest.cs
@@ -18,12 +18,13 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.SkylineTestUtil;
 using ZedGraph;
 
 namespace pwiz.SkylineTest
 {
     [TestClass]
-    public class ZedGraphTest
+    public class ZedGraphTest : AbstractUnitTest
     {
         /// <summary>
         /// Verifies that changing <see cref="FontSpec.Size"/> can be done repeatedly without exception.


### PR DESCRIPTION
Newly added test "ZedGraphTest" was causing warnings in TestRunner because it did not inherit from AbstractUnitTest