### PR TITLE
Hide the selection in the grid in AssociateProteinsDlg

### DIFF
--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
@@ -353,6 +353,7 @@ namespace pwiz.Skyline.EditUI
             {
                 dgvAssociateResults.Rows.Clear();
                 dgvAssociateResults.Rows.Add(3);
+                dgvAssociateResults.ClearSelection();
             }
 
             var proteinRow = dgvAssociateResults.Rows[0];


### PR DESCRIPTION
A "ClearSelection" call was incorrectly removed in PR #3401