### PR TITLE
Fix bug with modified sequence containing "F[+10]"

### DIFF
--- a/pwiz_tools/Skyline/EditUI/PasteDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/PasteDlg.cs
@@ -296,12 +296,11 @@ namespace pwiz.Skyline.EditUI
                                       Settings.Default.HeavyModList);
             }
             catch (FormatException e)
-            {
-                MessageDlg.ShowException(this, e);
+            { 
                 ShowPeptideError(new PasteError
                                      {
                                          Column = colPeptideSequence.Index,
-                                         Message = EditUIResources.PasteDlg_AddPeptides_Unable_to_interpret_peptide_modifications
+                                         Message = e.Message
                                      });
                 return null;
             }

--- a/pwiz_tools/Skyline/Model/Import.cs
+++ b/pwiz_tools/Skyline/Model/Import.cs
@@ -630,10 +630,18 @@ namespace pwiz.Skyline.Model
             for (var index = 0; index < lines.Count; index++)
             {
                 string row = lines[index];
-                var errorInfo = RowReader.NextRow(row, ++_linesSeen);
-                if (errorInfo != null)
+                try
                 {
-                    errorList.Add(errorInfo);
+                    var errorInfo = RowReader.NextRow(row, ++_linesSeen);
+                    if (errorInfo != null)
+                    {
+                        errorList.Add(errorInfo);
+                        continue;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    errorList.Add(new TransitionImportErrorInfo(exception.Message, null, _linesSeen, row));
                     continue;
                 }
 

--- a/pwiz_tools/Skyline/Model/ModificationMatcher.cs
+++ b/pwiz_tools/Skyline/Model/ModificationMatcher.cs
@@ -469,6 +469,11 @@ namespace pwiz.Skyline.Model
                    throw new ArgumentException(ModelResources.ModificationMatcher_GetStaticMod_no_UniMod_match);
         }
 
+        /// <summary>
+        /// Replaces the brackets around unimod modification identifiers (e.g. "unimod:4")
+        /// and SCIEX short names (e.g. "CAM") with square brackets or curly braces to indicate
+        /// whether the modification is light or heavy.
+        /// </summary>
         public string SimplifyUnimodSequence(string seq)
         {
             var sb = new StringBuilder(seq);
@@ -497,15 +502,13 @@ namespace pwiz.Skyline.Model
                     if (TryGetIdFromUnimod(mod, out uniModId))
                     {
                         var staticMod = GetStaticMod(uniModId, aa, modTerminus);
-                        if (staticMod == null)
+                        if (staticMod != null)
                         {
-                            ThrowUnimodException(seq, uniModId, indexAA, indexBracket, indexClose);
-                            return null;    // Keep ReSharper happy
+                            string name = staticMod.Name;
+                            bool isHeavy = !UniMod.DictStructuralModNames.ContainsKey(name);
+                            sb[indexBracket] = isHeavy ? '{' : '[';
+                            sb[indexClose] = isHeavy ? '}' : ']';
                         }
-                        string name = staticMod.Name;
-                        bool isHeavy = !UniMod.DictStructuralModNames.ContainsKey(name);
-                        sb[indexBracket] = isHeavy ? '{' : '[';
-                        sb[indexClose] = isHeavy ? '}' : ']';
                     }
                 }
                 // If the next character is a bracket, continue using the same amino


### PR DESCRIPTION
Fixed bug where "+10" was incorrectly interpreted as "Label:13C(6)15N(4) (R)" regardless of which amino acid it was applied to (reported by Philip)

Changed "SimplifyUnimodSequence" to ignore mismatches between unimod modification symbols and the amino acid they could be applied to. Changed to catch exceptions in MassListImporter.DoImport and display an error with line number.