### PR TITLE
Skyline: Fix a common IndexOutOfRangeException

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -1154,10 +1154,10 @@ namespace pwiz.Skyline.Controls.Graphs
         public void FireSelectedScanChanged(double retentionTime)
         {
             IsLoaded = true;
+            var transitionId = _msDataFileScanHelper.CurrentTransition?.Id;
             SelectedScanChanged?.Invoke(this,
-                _msDataFileScanHelper.MsDataSpectra != null
-                    ? new SelectedScanEventArgs(_msDataFileScanHelper.ScanProvider.DataFilePath, retentionTime,
-                        _msDataFileScanHelper.ScanProvider.Transitions[_msDataFileScanHelper.TransitionIndex].Id,
+                _msDataFileScanHelper.MsDataSpectra != null && transitionId != null
+                    ? new SelectedScanEventArgs(_msDataFileScanHelper.ScanProvider.DataFilePath, retentionTime, transitionId,
                         _msDataFileScanHelper.OptStep)
                     : new SelectedScanEventArgs(null, 0, null, null));
         }


### PR DESCRIPTION
- GraphFullScan.FireSelectedScanChanged has reported IndexOutOfRangeExceptions since it was released
- This change should get rid of those exceptions with the possible downside that the user will not get a selected scan in the Full-Scan view when they expect one.
- They can always click again. It has been a very long time without any progress on this issue.