### PR TITLE
Fix find() for Bruker TSF

### DIFF
--- a/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpire.hpp
+++ b/pwiz/analysis/spectrum_processing/SpectrumList_DiaUmpire.hpp
@@ -43,6 +43,11 @@ namespace analysis {
         msdata::SpectrumPtr spectrum(size_t index, msdata::DetailLevel detailLevel) const;
         size_t size() const;
         const msdata::SpectrumIdentity& spectrumIdentity(size_t index) const;
+        virtual size_t find(const std::string& id) const { return SpectrumList::find(id); }
+        virtual size_t findAbbreviated(const std::string& abbreviatedId, char delimiter = '.') const { return SpectrumList::findAbbreviated(abbreviatedId, delimiter); }
+        virtual msdata::IndexList findNameValue(const std::string& name, const std::string& value) const { return SpectrumList::findNameValue(name, value); }
+        virtual msdata::IndexList findSpotID(const std::string& spotID) const { return SpectrumList::findSpotID(spotID); }
+
         ///@}
 
         private:

--- a/pwiz/data/msdata/SpectrumListWrapper.hpp
+++ b/pwiz/data/msdata/SpectrumListWrapper.hpp
@@ -49,7 +49,11 @@ class PWIZ_API_DECL SpectrumListWrapper : public SpectrumListBase
 
     virtual size_t size() const {return inner_->size();}
     virtual bool empty() const {return size() == 0;}
-    virtual const SpectrumIdentity& spectrumIdentity(size_t index) const {return inner_->spectrumIdentity(index);} 
+    virtual const SpectrumIdentity& spectrumIdentity(size_t index) const {return inner_->spectrumIdentity(index);}
+    virtual size_t find(const std::string& id) const {return size() == inner_->size() ? inner_->find(id) : SpectrumList::find(id);}
+    virtual size_t findAbbreviated(const std::string& abbreviatedId, char delimiter = '.') const {return size() == inner_->size() ? inner_->findAbbreviated(abbreviatedId, delimiter) : SpectrumList::findAbbreviated(abbreviatedId, delimiter);}
+    virtual IndexList findNameValue(const std::string& name, const std::string& value) const {return size() == inner_->size() ? inner_->findNameValue(name, value) : SpectrumList::findNameValue(name, value);}
+    virtual IndexList findSpotID(const std::string& spotID) const {return size() == inner_->size() ? inner_->findSpotID(spotID) : SpectrumList::findSpotID(spotID);}
 
     // no default implementation, because otherwise subclasses could override the DetailLevel overload and the getBinaryData overload would be inconsistent
     virtual SpectrumPtr spectrum(size_t index, bool getBinaryData = false) const = 0;

--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/TsfData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/TsfData.cpp
@@ -293,7 +293,7 @@ size_t TsfDataImpl::getSpectrumIndex(int frame, int scan) const
     auto findItr = frames_.find(frame);
     if (findItr == frames_.end())
         throw out_of_range("[TsfData::getSpectrumIndex] invalid frame index");
-    return findItr->second->frameId() - 1;
+    return findItr - frames_.begin();
 }
 
 


### PR DESCRIPTION
* fixed underlying SpectrumList::find() overrides not being used for SpectrumListWrapper, so accessing profile vendor spectra would use the vendor's find() override, but accessing centroid vendor spectra would use the fallback linear search of SpectrumList::find()
- fixed incorrect find() result for Bruker TSF data with skipped frames (reported by Agnes)