### PR TITLE
Fix invalid Ion Match Tolerance in Import Peptide Search wizard

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.cs
@@ -194,8 +194,8 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             }
             set
             {
-                IonMatchTolerance = value.Value;
                 IonMatchToleranceUnits = value.Unit;
+                IonMatchTolerance = value.Value;
             }
         }
 


### PR DESCRIPTION
Fixed "Ion match tolerance" sometimes multiplied or divided by 1000 in Import Peptide Search wizard (reported by Mike)