### PR TITLE
Fix Japanese ConsoleImportPeptideSearchTest and TestCommandLineExportThermoMethod (#3468)

### DIFF
--- a/pwiz_tools/Skyline/Model/Koina/KoinaResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/Koina/KoinaResources.ja.resx
@@ -161,6 +161,6 @@
     <value>スペクトルライブラリの一致がありません</value>
   </data>
   <data name="KoinaModel_PredictBatches_Error___0__retrying__1_____2__" xml:space="preserve">
-    <value>エラー: {0} 再試行回数{1}/{2}。</value>
+    <value>エラー： {0} 再試行回数{1}/{2}。</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Model/ModelResources.ja.resx
+++ b/pwiz_tools/Skyline/Model/ModelResources.ja.resx
@@ -825,7 +825,7 @@
     <value>インストールされたThermo装置タイプ「{0}」は、リクエストされた出力メソッドタイプ「 {1}」と一致しません。</value>
   </data>
   <data name="CommandLine_ExportInstrumentFile_Error__The_specified_instrument_type___0___does_not_match_the_installed_software___1___" xml:space="preserve">
-    <value>エラー: 指定された装置タイプ「{0}」はインストールされたソフトウェア「{1}」に一致しません。</value>
+    <value>エラー： 指定された装置タイプ「{0}」はインストールされたソフトウェア「{1}」に一致しません。</value>
   </data>
   <data name="CommandLine_ExportInstrumentFile_Use_the_instrument_type__Thermo__to_export_a_method_with_the_installed_software_" xml:space="preserve">
     <value>装置タイプ「Thermo」を使用して、インストールされたソフトウェアでメソッドをエクスポートします。</value>

--- a/pwiz_tools/Skyline/SkylineResources.ja.resx
+++ b/pwiz_tools/Skyline/SkylineResources.ja.resx
@@ -386,7 +386,7 @@
     <value>警告： 結果ファイル'{0}'を特定できません</value>
   </data>
   <data name="CommandLine_ImportSearchInternal_Error__iRT_standard_set_to__0___but_multiple_iRT_standards_were_found__iRT_standard_must_be_set_explicitly_" xml:space="preserve">
-    <value>エラー: iRT標準が{0}に設定されましたが、複数のiRT標準が検出されました。iRT標準は明示的に設定する必要があります。</value>
+    <value>エラー： iRT標準が{0}に設定されましたが、複数のiRT標準が検出されました。iRT標準は明示的に設定する必要があります。</value>
   </data>
   <data name="CommandLine_ImportSearchInternal_The_iRT_standard_name___0___is_invalid_" xml:space="preserve">
     <value>iRT標準名「{0}」は無効です。</value>
@@ -1187,7 +1187,7 @@
     <value>ファイル「{0}」を更新中にエラーが発生しました。</value>
   </data>
   <data name="CommandLine_ImportSearchInternal_Error__Failed_to_build_the_spectral_library_" xml:space="preserve">
-    <value>エラー: スペクトルライブラリを構築できませんでした。</value>
+    <value>エラー： スペクトルライブラリを構築できませんでした。</value>
   </data>
   <data name="SkylineWindow_ImportAnnotations_Reading_annotations" xml:space="preserve">
     <value>注釈を読み取り中</value>

--- a/pwiz_tools/Skyline/TestData/TestData.csproj
+++ b/pwiz_tools/Skyline/TestData/TestData.csproj
@@ -162,6 +162,7 @@
     <Compile Include="ExportMethodShimadzuTest.cs" />
     <Compile Include="FullScanAcquisitionMethodTest.cs" />
     <Compile Include="InstrumentInfoUtilTest.cs" />
+    <Compile Include="LocalizedResourcesTest.cs" />
     <Compile Include="OptimizationSpacingTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PwizFileInfoTest.cs" />

--- a/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
+++ b/pwiz_tools/Skyline/TestFunctional/TestFunctional.csproj
@@ -202,7 +202,6 @@
     <Compile Include="LegacyScoringModelTest.cs" />
     <Compile Include="LibraryMatchViewTest.cs" />
     <Compile Include="LiteDropdownListTest.cs" />
-    <Compile Include="LocalizedResourcesTest.cs" />
     <Compile Include="LogScaleAxisTest.cs" />
     <Compile Include="MedianNormalizationTest.cs" />
     <Compile Include="MessageBoxHelperTest.cs" />

--- a/pwiz_tools/Skyline/ToolsUI/ToolsUIResources.ja.resx
+++ b/pwiz_tools/Skyline/ToolsUI/ToolsUIResources.ja.resx
@@ -360,10 +360,10 @@
     <value>接続</value>
   </data>
   <data name="EditRemoteAccountDlg_GetBrowserLogoutUrl_Error__no_Ardia_registration_code_for_URL" xml:space="preserve">
-    <value>エラー: URLのArdia登録コードがありません</value>
+    <value>エラー： URLのArdia登録コードがありません</value>
   </data>
   <data name="EditRemoteAccountDlg_GetBrowserLogoutUrl_Error__unable_to_compute_URL_for_logout" xml:space="preserve">
-    <value>エラー: URL for ArdiaログアウトのURLを演算できません</value>
+    <value>エラー： URL for ArdiaログアウトのURLを演算できません</value>
   </data>
   <data name="EditRemoteAccountDlg_TestArdiaAccount_Login_was_canceled" xml:space="preserve">
     <value>ログインがキャンセルされました</value>

--- a/pwiz_tools/Skyline/Util/Extensions/ExtensionsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Util/Extensions/ExtensionsResources.zh-CHS.resx
@@ -119,10 +119,10 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ColonEndOfLine" xml:space="preserve">
-    <value>:</value>
+    <value>：</value>
   </data>
   <data name="ColonSeparator" xml:space="preserve">
-    <value>{0}: {1}</value>
+    <value>{0}：{1}</value>
   </data>
   <data name="ExportStrategyExtension_LOCALIZED_VALUES_Average" xml:space="preserve">
     <value>平均</value>


### PR DESCRIPTION
Move "LocalizedResourcesTest" from "TestFunctional" into "TestData" so that it can use "ErrorChecker.cs". Add assert to LocalizedResourcesTest that if English text starts with "Error:", localized text starts with localized version of that.

Change Chinese colon used by "TextUtil.AppendColon" and "TextUtil.ColonSeparate".