### PR TITLE
- fixed MSFragger download to use new verification code scheme (#3469)

### DIFF
--- a/pwiz_tools/Skyline/Alerts/AlertsResources.designer.cs
+++ b/pwiz_tools/Skyline/Alerts/AlertsResources.designer.cs
@@ -483,6 +483,15 @@ namespace pwiz.Skyline.Alerts {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Check your email for the verification code and copy it into the box..
+        /// </summary>
+        public static string MsFraggerDownloadDlg_btnRequestVerificationCode_Click_Check_your_email {
+            get {
+                return ResourceManager.GetString("MsFraggerDownloadDlg_btnRequestVerificationCode_Click_Check_your_email", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Downloading MSFragger {0}.
         /// </summary>
         public static string MsFraggerDownloadDlg_Download_Downloading_MSFragger__0_ {

--- a/pwiz_tools/Skyline/Alerts/AlertsResources.resx
+++ b/pwiz_tools/Skyline/Alerts/AlertsResources.resx
@@ -324,4 +324,7 @@
   <data name="ArdiaLoginDlg_CoreWebView2OnNavigationCompleted_AfterNavigateToLoginURL_Load_Login_page_failed_with_HTTP_status_code__0__Login_Page_URL___1_" xml:space="preserve">
     <value>Load Login page failed with HTTP status code {0}. It is likely that the Client Registration Code is invalid. A new Client Registration Code was just received from the server so this is probably a bug. Login Page URL: {1}</value>
   </data>
+  <data name="MsFraggerDownloadDlg_btnRequestVerificationCode_Click_Check_your_email" xml:space="preserve">
+      <value>Check your email for the verification code and copy it into the box.</value>
+  </data>
 </root>

--- a/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.Designer.cs
+++ b/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.Designer.cs
@@ -29,29 +29,25 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MsFraggerDownloadDlg));
-            this.tbUsageConditions = new System.Windows.Forms.TextBox();
             this.cbAgreeToLicense = new System.Windows.Forms.CheckBox();
             this.rtbAgreeToLicense = new System.Windows.Forms.RichTextBox();
-            this.tbName = new System.Windows.Forms.TextBox();
-            this.lblName = new System.Windows.Forms.Label();
+            this.tbFirstName = new System.Windows.Forms.TextBox();
+            this.lblFirstName = new System.Windows.Forms.Label();
             this.lblEmail = new System.Windows.Forms.Label();
             this.tbEmail = new System.Windows.Forms.TextBox();
             this.lblInstitution = new System.Windows.Forms.Label();
             this.tbInstitution = new System.Windows.Forms.TextBox();
-            this.cbReceiveUpdateEmails = new System.Windows.Forms.CheckBox();
             this.btnAccept = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.tbLastName = new System.Windows.Forms.TextBox();
+            this.lblLastName = new System.Windows.Forms.Label();
+            this.tbVerificationCode = new System.Windows.Forms.TextBox();
+            this.lblVerificationCode = new System.Windows.Forms.Label();
+            this.btnRequestVerificationCode = new System.Windows.Forms.Button();
+            this.rtbUsageConditions = new System.Windows.Forms.RichTextBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // tbUsageConditions
-            // 
-            resources.ApplyResources(this.tbUsageConditions, "tbUsageConditions");
-            this.tbUsageConditions.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.tbUsageConditions.Name = "tbUsageConditions";
-            this.tbUsageConditions.ReadOnly = true;
-            this.tbUsageConditions.TabStop = false;
             // 
             // cbAgreeToLicense
             // 
@@ -65,19 +61,21 @@
             resources.ApplyResources(this.rtbAgreeToLicense, "rtbAgreeToLicense");
             this.rtbAgreeToLicense.BackColor = System.Drawing.SystemColors.Control;
             this.rtbAgreeToLicense.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.rtbAgreeToLicense.Cursor = System.Windows.Forms.Cursors.Arrow;
             this.rtbAgreeToLicense.Name = "rtbAgreeToLicense";
             this.rtbAgreeToLicense.ReadOnly = true;
             this.rtbAgreeToLicense.TabStop = false;
             // 
-            // tbName
+            // tbFirstName
             // 
-            resources.ApplyResources(this.tbName, "tbName");
-            this.tbName.Name = "tbName";
+            resources.ApplyResources(this.tbFirstName, "tbFirstName");
+            this.tbFirstName.Name = "tbFirstName";
+            this.tbFirstName.TextChanged += new System.EventHandler(this.tbTextChanged);
             // 
-            // lblName
+            // lblFirstName
             // 
-            resources.ApplyResources(this.lblName, "lblName");
-            this.lblName.Name = "lblName";
+            resources.ApplyResources(this.lblFirstName, "lblFirstName");
+            this.lblFirstName.Name = "lblFirstName";
             // 
             // lblEmail
             // 
@@ -88,6 +86,7 @@
             // 
             resources.ApplyResources(this.tbEmail, "tbEmail");
             this.tbEmail.Name = "tbEmail";
+            this.tbEmail.TextChanged += new System.EventHandler(this.tbTextChanged);
             // 
             // lblInstitution
             // 
@@ -98,12 +97,7 @@
             // 
             resources.ApplyResources(this.tbInstitution, "tbInstitution");
             this.tbInstitution.Name = "tbInstitution";
-            // 
-            // cbReceiveUpdateEmails
-            // 
-            resources.ApplyResources(this.cbReceiveUpdateEmails, "cbReceiveUpdateEmails");
-            this.cbReceiveUpdateEmails.Name = "cbReceiveUpdateEmails";
-            this.cbReceiveUpdateEmails.UseVisualStyleBackColor = true;
+            this.tbInstitution.TextChanged += new System.EventHandler(this.tbTextChanged);
             // 
             // btnAccept
             // 
@@ -122,13 +116,54 @@
             // tableLayoutPanel1
             // 
             resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
-            this.tableLayoutPanel1.Controls.Add(this.lblName, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.lblEmail, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.lblInstitution, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.tbName, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.tbInstitution, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.tbEmail, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.tbLastName, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.lblLastName, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.lblFirstName, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lblEmail, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.lblInstitution, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.tbFirstName, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.tbInstitution, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.tbEmail, 1, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            // 
+            // tbLastName
+            // 
+            resources.ApplyResources(this.tbLastName, "tbLastName");
+            this.tbLastName.Name = "tbLastName";
+            this.tbLastName.TextChanged += new System.EventHandler(this.tbTextChanged);
+            // 
+            // lblLastName
+            // 
+            resources.ApplyResources(this.lblLastName, "lblLastName");
+            this.lblLastName.Name = "lblLastName";
+            // 
+            // tbVerificationCode
+            // 
+            resources.ApplyResources(this.tbVerificationCode, "tbVerificationCode");
+            this.tbVerificationCode.Name = "tbVerificationCode";
+            this.tbVerificationCode.TextChanged += new System.EventHandler(this.tbVerificationCodeChanged);
+            // 
+            // lblVerificationCode
+            // 
+            resources.ApplyResources(this.lblVerificationCode, "lblVerificationCode");
+            this.lblVerificationCode.Name = "lblVerificationCode";
+            // 
+            // btnRequestVerificationCode
+            // 
+            resources.ApplyResources(this.btnRequestVerificationCode, "btnRequestVerificationCode");
+            this.btnRequestVerificationCode.Name = "btnRequestVerificationCode";
+            this.btnRequestVerificationCode.UseVisualStyleBackColor = true;
+            this.btnRequestVerificationCode.Click += new System.EventHandler(this.btnRequestVerificationCode_Click);
+            // 
+            // rtbUsageConditions
+            // 
+            resources.ApplyResources(this.rtbUsageConditions, "rtbUsageConditions");
+            this.rtbUsageConditions.BackColor = System.Drawing.SystemColors.Control;
+            this.rtbUsageConditions.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.rtbUsageConditions.Cursor = System.Windows.Forms.Cursors.Arrow;
+            this.rtbUsageConditions.Name = "rtbUsageConditions";
+            this.rtbUsageConditions.ReadOnly = true;
+            this.rtbUsageConditions.TabStop = false;
             // 
             // MsFraggerDownloadDlg
             // 
@@ -136,13 +171,15 @@
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
+            this.Controls.Add(this.btnRequestVerificationCode);
+            this.Controls.Add(this.lblVerificationCode);
+            this.Controls.Add(this.tbVerificationCode);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnAccept);
-            this.Controls.Add(this.cbReceiveUpdateEmails);
             this.Controls.Add(this.rtbAgreeToLicense);
             this.Controls.Add(this.cbAgreeToLicense);
-            this.Controls.Add(this.tbUsageConditions);
+            this.Controls.Add(this.rtbUsageConditions);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "MsFraggerDownloadDlg";
@@ -156,19 +193,22 @@
         }
 
         #endregion
-
-        private System.Windows.Forms.TextBox tbUsageConditions;
         private System.Windows.Forms.CheckBox cbAgreeToLicense;
         private System.Windows.Forms.RichTextBox rtbAgreeToLicense;
-        private System.Windows.Forms.TextBox tbName;
-        private System.Windows.Forms.Label lblName;
+        private System.Windows.Forms.TextBox tbFirstName;
+        private System.Windows.Forms.Label lblFirstName;
         private System.Windows.Forms.Label lblEmail;
         private System.Windows.Forms.TextBox tbEmail;
         private System.Windows.Forms.Label lblInstitution;
         private System.Windows.Forms.TextBox tbInstitution;
-        private System.Windows.Forms.CheckBox cbReceiveUpdateEmails;
         private System.Windows.Forms.Button btnAccept;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label lblLastName;
+        private System.Windows.Forms.TextBox tbLastName;
+        private System.Windows.Forms.TextBox tbVerificationCode;
+        private System.Windows.Forms.Label lblVerificationCode;
+        private System.Windows.Forms.Button btnRequestVerificationCode;
+        private System.Windows.Forms.RichTextBox rtbUsageConditions;
     }
 }

--- a/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.cs
@@ -17,28 +17,41 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Ionic.Zip;
+using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Controls;
 using pwiz.Skyline.Model.DdaSearch;
 using pwiz.Skyline.Util;
 using pwiz.Skyline.Util.Extensions;
+using pwiz.Skyline.Properties;
 
 namespace pwiz.Skyline.Alerts
 {
     public partial class MsFraggerDownloadDlg : FormEx
     {
-        private const string LICENSE_URL = @"https://msfragger.arsci.com/upgrader/MSFragger-LICENSE.pdf";
-        private const string DOWNLOAD_URL = @"http://msfragger-upgrader.nesvilab.org/upgrader/upgrade_download.php";
-        private const string DOWNLOAD_METHOD = @"POST";
-        private readonly Uri DOWNLOAD_URL_FOR_FUNCTIONAL_TESTS = new Uri($@"https://example.com/MSFragger-{MsFraggerSearchEngine.MSFRAGGER_VERSION}.zip");
+        private static readonly string LICENSE_URL = Settings.Default.MsFraggerLicenseUrl;
+        private static readonly string VERIFY_URL = Settings.Default.MsFraggerVerifyUrl;
+        private const string VERIFY_SUCCESS = @"download link has been sent";
+        private static readonly string DOWNLOAD_URL_WITH_TOKEN = $@"{Settings.Default.MsFraggerDownloadUrl}?token={{0}}&download=Release%20{MsFraggerSearchEngine.MSFRAGGER_VERSION}%24zip";
+        private const string VERIFY_METHOD = @"POST";
+        private static readonly Uri DOWNLOAD_URL_FOR_FUNCTIONAL_TESTS = new Uri($@"https://ci.skyline.ms/skyline_tool_testing_mirror/MSFragger-{MsFraggerSearchEngine.MSFRAGGER_VERSION}.zip");
 
-        private Tuple<int, int> licenseLinkStartEnd;
+        public class LinkInfo
+        {
+            public object Source;
+            public int Start, End;
+            public string Target;
+        }
+        private List<LinkInfo> linkInfos;
 
         public MsFraggerDownloadDlg()
         {
@@ -49,96 +62,142 @@ namespace pwiz.Skyline.Alerts
         {
             base.OnLoad(e);
 
+            linkInfos = new List<LinkInfo>();
+            formatRichTextMarkup(rtbAgreeToLicense);
+            formatRichTextMarkup(rtbUsageConditions);
+        }
+
+        private void formatRichTextMarkup(RichTextBox rtb)
+        {
             const string BOLD_PATTERN = "<b>(.*?)</b>";
-            var academicBoldMatch = Regex.Match(rtbAgreeToLicense.Text, BOLD_PATTERN);
-            rtbAgreeToLicense.Select(academicBoldMatch.Index, academicBoldMatch.Length);
+            var boldMatch = Regex.Match(rtb.Text, BOLD_PATTERN);
+            rtb.Select(boldMatch.Index, boldMatch.Length);
             try
             {
-                rtbAgreeToLicense.SelectionFont = new Font(rtbAgreeToLicense.SelectionFont, FontStyle.Bold);
+                rtb.SelectionFont = new Font(rtb.SelectionFont, FontStyle.Bold);
             }
             catch (Exception)
             {
                 // Ignore failed attempt to set text to bold
             }
-            rtbAgreeToLicense.SelectedText = Regex.Replace(rtbAgreeToLicense.SelectedText, BOLD_PATTERN, "$1");
+            rtb.SelectedText = Regex.Replace(rtb.SelectedText, BOLD_PATTERN, "$1");
 
-            const string LINK_PATTERN = "<link>(.*?)</link>";
-            var licenseLinkMatch = Regex.Match(rtbAgreeToLicense.Text, LINK_PATTERN);
-            rtbAgreeToLicense.Select(licenseLinkMatch.Index, licenseLinkMatch.Length);
-            try
+            const string LINK_PATTERN = "<link(?:\\s*target=\"(.*?)\")?>(.*?)</link>";
+            for (int i=0; i < 100; ++i)
             {
-                rtbAgreeToLicense.SelectionFont = new Font(rtbAgreeToLicense.SelectionFont, FontStyle.Underline);
+                var match = Regex.Match(rtb.Text, LINK_PATTERN);
+                if (!match.Success)
+                    break;
+
+                rtb.Select(match.Index, match.Length); // select the match
+                try
+                {
+                    rtb.SelectionFont = new Font(rtb.SelectionFont, FontStyle.Underline);
+                }
+                catch (Exception)
+                {
+                    // Ignore failed attempt to set text to underline
+                }
+
+                rtb.SelectionColor = SystemColors.HotTrack;
+                rtb.SelectedText = Regex.Replace(rtb.SelectedText, LINK_PATTERN, "$2");
+                linkInfos.Add(new LinkInfo
+                {
+                    Source = rtb,
+                    Start = match.Index,
+                    End = match.Index + match.Groups[2].Length,
+                    Target = match.Groups[1].Success ? match.Groups[1].Value : match.Groups[2].Value
+                });
             }
-            catch (Exception)
-            {
-                // Ignore failed attempt to set text to underline
-            }
-            rtbAgreeToLicense.SelectionColor = SystemColors.HotTrack;
-            rtbAgreeToLicense.SelectedText = Regex.Replace(rtbAgreeToLicense.SelectedText, LINK_PATTERN, "$1");
-            licenseLinkStartEnd = new Tuple<int, int>(licenseLinkMatch.Index, licenseLinkMatch.Index + licenseLinkMatch.Length - 13);
 
-            rtbAgreeToLicense.Select(0, 0);
-            tbUsageConditions.Select(0, 0);
-
-            rtbAgreeToLicense.MouseMove += RtbAgreeToLicense_MouseMove;
-            rtbAgreeToLicense.MouseClick += RtbAgreeToLicense_MouseClick;
-
-            tbName.TextChanged += tbTextChanged;
-            tbEmail.TextChanged += tbTextChanged;
-            tbInstitution.TextChanged += tbTextChanged;
+            rtb.Select(0, 0);
 
             // do not allow focusing on the text boxes (so caret stays hidden)
-            rtbAgreeToLicense.GotFocus += (sender, args) => cbAgreeToLicense.Focus();
-            tbUsageConditions.GotFocus += (sender, args) => tbName.Focus();
+            rtb.GotFocus += (sender, args) => cbAgreeToLicense.Focus();
+
+            // listen for click and move to handle links and cursor changing
+            rtb.MouseMove += RtbAgreeToLicense_MouseMove;
+            rtb.MouseClick += RtbAgreeToLicense_MouseClick;
         }
 
-        public void SetValues(string name, string email, string institution)
+        public void SetValues(string firstName, string lastName, string email, string institution)
         {
-            tbName.Text = name;
+            tbFirstName.Text = firstName;
+            tbLastName.Text = lastName;
             tbEmail.Text = email;
             tbInstitution.Text = institution;
             cbAgreeToLicense.Checked = true;
+            tbVerificationCode.Text = @"1234";
+            // now clicking "Accept" button should start download
         }
 
-        public void Download()
+        private void RequestVerificationCode()
+        {
+            if (Program.FunctionalTest)
+                return;
+
+            using var downloadProgressDlg = new LongWaitDlg();
+            using var client = new WebClient();
+
+            var postData = new NameValueCollection();
+            postData[@"transfer"] = @"academic";
+            postData[@"agreement1"] = @"on";
+            postData[@"agreement2"] = @"on";
+            postData[@"agreement3"] = @"on";
+            postData[@"first_name"] = tbFirstName.Text;
+            postData[@"last_name"] = tbLastName.Text;
+            postData[@"email"] = tbEmail.Text;
+            postData[@"organization"] = tbInstitution.Text;
+            postData[@"download"] = $@"Release {MsFraggerSearchEngine.MSFRAGGER_VERSION}$zip";
+            postData[@"is_fragpipe"] = @"true";
+
+            downloadProgressDlg.PerformWork(this, 50, broker =>
+            {
+                var uploadTask = client.UploadValuesTaskAsync(VERIFY_URL, VERIFY_METHOD, postData);
+                uploadTask.Wait(broker.CancellationToken);
+                if (uploadTask.Exception != null)
+                    throw uploadTask.Exception;
+
+                var resultBytes = uploadTask.Result;
+                var resultString = Encoding.UTF8.GetString(resultBytes);
+
+                if (!resultString.Contains(VERIFY_SUCCESS))
+                    throw new InvalidOperationException(resultString);
+            });
+        }
+
+        private bool Download()
         {
             using (var downloadProgressDlg = new LongWaitDlg())
             {
                 downloadProgressDlg.Message = string.Format(AlertsResources.MsFraggerDownloadDlg_Download_Downloading_MSFragger__0_, MsFraggerSearchEngine.MSFRAGGER_VERSION);
-                if (Program.FunctionalTest && !Program.UseOriginalURLs)
+                if (Program.FunctionalTest) // original URLs not possible with "verification code" system
                 {
                     var msFraggerDownloadInfo = MsFraggerSearchEngine.MsFraggerDownloadInfo;
                     msFraggerDownloadInfo.DownloadUrl = DOWNLOAD_URL_FOR_FUNCTIONAL_TESTS;
                     downloadProgressDlg.PerformWork(this, 50, pm => SimpleFileDownloader.DownloadRequiredFiles(new[] { msFraggerDownloadInfo }, pm));
-                    return;
+                    return true;
                 }
 
                 using (var client = new WebClient())
                 {
-                    client.UploadProgressChanged += (o, args) => downloadProgressDlg.ProgressValue = Math.Max(0, Math.Min(100, (args.ProgressPercentage - 50) * 2)); // ignore the upload part of the progress calculation
-
-                    downloadProgressDlg.PerformWork(this, 50, () =>
+                    var status = downloadProgressDlg.PerformWork(this, 50, broker =>
                     {
-                        var postData = new NameValueCollection();
-                        postData[@"transfer"] = @"academic";
-                        postData[@"agreement1"] = @"on";
-                        postData[@"agreement2"] = @"on";
-                        postData[@"agreement3"] = @"on";
-                        postData[@"name"] = tbName.Text;
-                        postData[@"email"] = tbEmail.Text;
-                        postData[@"organization"] = tbInstitution.Text;
-                        postData[@"download"] = $@"Release {MsFraggerSearchEngine.MSFRAGGER_VERSION}$zip";
-                        if (cbReceiveUpdateEmails.Checked)
-                            postData[@"receive_email"] = @"on";
+                        client.DownloadProgressChanged += (sender, args) => broker.UpdateProgress(new ProgressStatus().ChangePercentComplete(args.ProgressPercentage));
 
-                        // temporarily disable Expect100Continue to avoid (417) Expectation Failed
-                        bool lastExpect100ContinueValue = ServicePointManager.Expect100Continue;
-                        ServicePointManager.Expect100Continue = false;
+                        string downloadUrl = string.Format(DOWNLOAD_URL_WITH_TOKEN, tbVerificationCode.Text);
+                        var msFraggerZipBytes = client.DownloadData(downloadUrl);
 
-                        var uploadTask = client.UploadValuesTaskAsync(DOWNLOAD_URL, DOWNLOAD_METHOD, postData);
-                        var msFraggerZipBytes = uploadTask.Result;
-
-                        ServicePointManager.Expect100Continue = lastExpect100ContinueValue;
+                        // check if downloaded bytes are actually a zip file
+                        if (!ZipFile.IsZipFile(new MemoryStream(msFraggerZipBytes), false))
+                        {
+                            var resultString = Encoding.UTF8.GetString(msFraggerZipBytes);
+                            broker.UpdateProgress(new ProgressStatus().ChangeErrorException(
+                                new InvalidOperationException(string.Format(@"{0}{1}{1}{2}",
+                                    Resources.TestToolStoreClient_GetToolZipFile_Error_downloading_tool,
+                                    Environment.NewLine, resultString))));
+                            return;
+                        }
 
                         var installPath = MsFraggerSearchEngine.MsFraggerDirectory;
                         var downloadFilename = Path.Combine(installPath, MsFraggerSearchEngine.MSFRAGGER_FILENAME + @".zip");
@@ -155,52 +214,99 @@ namespace pwiz.Skyline.Alerts
                         }
                         FileEx.SafeDelete(downloadFilename);
                     });
+
+                    if (status.IsError)
+                    {
+                        MessageDlg.Show(this, status.ErrorException.Message);
+                        return false;
+                    }
+                    return true;
                 }
             }
         }
 
         public void ClickAccept() { btnAccept.PerformClick(); }
 
-        private bool IsReadyToDownload => cbAgreeToLicense.Checked && tbName.TextLength > 0 && tbEmail.Text.IsValidEmail() && tbInstitution.TextLength > 0;
+        private bool IsReadyToVerify => cbAgreeToLicense.Checked && tbFirstName.TextLength > 0 &&
+                                        tbLastName.TextLength > 0 && tbEmail.Text.IsValidEmail() &&
+                                        tbInstitution.TextLength > 0;
 
         private void btnAccept_Click(object sender, EventArgs e)
         {
-            Download();
+            if (!Download())
+                return;
 
             DialogResult = DialogResult.OK;
         }
 
-        public bool CheckCursorWithinRange(MouseEventArgs e, Tuple<int, int> range)
+        private void btnRequestVerificationCode_Click(object sender, EventArgs e)
         {
-            int charIndex = rtbAgreeToLicense.GetCharIndexFromPosition(e.Location);
-            return range.Item1 <= charIndex && range.Item2 >= charIndex;
+            RequestVerificationCode();
+            lblVerificationCode.Enabled = tbVerificationCode.Enabled = true;
+            MessageDlg.Show(this, AlertsResources.MsFraggerDownloadDlg_btnRequestVerificationCode_Click_Check_your_email);
+        }
+
+        private bool CheckCursorWithinRange(RichTextBox rtb, MouseEventArgs e, LinkInfo linkInfo)
+        {
+            if (linkInfo.Source != rtb)
+                return false;
+
+            int charIndex = rtb.GetCharIndexFromPosition(e.Location);
+            return linkInfo.Start <= charIndex && linkInfo.End >= charIndex;
         }
 
         private void RtbAgreeToLicense_MouseMove(object sender, MouseEventArgs e)
         {
-            if (CheckCursorWithinRange(e, licenseLinkStartEnd))
-                Cursor = Cursors.Hand;
+            var rtb = sender as RichTextBox;
+            if (rtb == null) return;
+
+            if (linkInfos.Any(p => CheckCursorWithinRange(rtb, e, p)))
+            {
+                if (Cursor != Cursors.Hand)
+                    Cursor = rtb.Cursor = Cursors.Hand;
+            }
+            else if (Cursor == Cursors.Hand)
+                Cursor = rtb.Cursor = Cursors.Default;
             else
-                ResetCursor();
-            base.OnMouseMove(e);
+                base.OnMouseMove(e);
         }
 
         private void RtbAgreeToLicense_MouseClick(object sender, MouseEventArgs e)
         {
-            if (CheckCursorWithinRange(e, licenseLinkStartEnd))
-                WebHelpers.OpenLink(this, LICENSE_URL);
-            else
+            foreach (var linkInfo in linkInfos)
+            {
+                if (CheckCursorWithinRange(sender as RichTextBox, e, linkInfo))
+                {
+                    var target = linkInfo.Target;
+                    if (target == @"lic")
+                        target = LICENSE_URL;
+                    WebHelpers.OpenLink(this, target);
+                    return;
+                }
+            }
+
+            if (sender == rtbAgreeToLicense)
                 cbAgreeToLicense.Checked = !cbAgreeToLicense.Checked;
+        }
+
+        private void CheckVerificationReady()
+        {
+            btnRequestVerificationCode.Enabled = IsReadyToVerify;
         }
 
         private void tbTextChanged(object sender, EventArgs e)
         {
-            btnAccept.Enabled = IsReadyToDownload;
+            CheckVerificationReady();
         }
 
         private void cbAgreeToLicense_CheckedChanged(object sender, EventArgs e)
         {
-            btnAccept.Enabled = IsReadyToDownload;
+            CheckVerificationReady();
+        }
+
+        private void tbVerificationCodeChanged(object sender, EventArgs e)
+        {
+            btnAccept.Enabled = tbVerificationCode.TextLength > 0;
         }
     }
 }

--- a/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.ja.resx
+++ b/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.ja.resx
@@ -121,39 +121,11 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tbUsageConditions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="tbUsageConditions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tbUsageConditions.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tbUsageConditions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>375, 100</value>
-  </data>
-  <data name="tbUsageConditions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tbUsageConditions.Text" xml:space="preserve">
+  <data name="rtbUsageConditions.Text" xml:space="preserve">
     <value>MSFraggerは、学術ライセンスで学術研究、非営利目的や教育目的で自由に利用できます。その他の使用には、60日間の評価期間後に、ミシガン大学オフィスの技術移転担当のDrew Bennett(andbenne@umich.edu)にお問い合わせいただくと取得できる商用ライセンスが必要です。
 
 ご質問は、Alexey Nesvizhskii教授(nesvi@med.umich.edu)までお問い合わせください。</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Name" xml:space="preserve">
-    <value>tbUsageConditions</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="cbAgreeToLicense.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.resx
+++ b/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.resx
@@ -120,52 +120,19 @@
   <metadata name="modeUIHandler.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tbUsageConditions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="tbUsageConditions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tbUsageConditions.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tbUsageConditions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>375, 100</value>
-  </data>
-  <data name="tbUsageConditions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tbUsageConditions.Text" xml:space="preserve">
-    <value>MSFragger is available freely for academic research, non-commercial or educational purposes under academic license. Other uses require a commercial license after the initial 60-day evaluation period that can be obtained by contacting Drew Bennett (andbenne@umich.edu) at the University of Michigan Office of Tech Transfer.
-
-For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Name" xml:space="preserve">
-    <value>tbUsageConditions</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
   <data name="cbAgreeToLicense.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="cbAgreeToLicense.Location" type="System.Drawing.Point, System.Drawing">
-    <value>32, 250</value>
+    <value>23, 244</value>
   </data>
   <data name="cbAgreeToLicense.Size" type="System.Drawing.Size, System.Drawing">
     <value>15, 14</value>
   </data>
   <data name="cbAgreeToLicense.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>9</value>
   </data>
   <data name="&gt;&gt;cbAgreeToLicense.Name" xml:space="preserve">
     <value>cbAgreeToLicense</value>
@@ -177,13 +144,14 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbAgreeToLicense.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="rtbAgreeToLicense.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
   <data name="rtbAgreeToLicense.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 227</value>
+    <value>44, 221</value>
   </data>
   <data name="rtbAgreeToLicense.ScrollBars" type="System.Windows.Forms.RichTextBoxScrollBars, System.Windows.Forms">
     <value>None</value>
@@ -195,7 +163,7 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>2</value>
   </data>
   <data name="rtbAgreeToLicense.Text" xml:space="preserve">
-    <value>I have read the &lt;b&gt;academic&lt;/b&gt; &lt;link&gt;license&lt;/link&gt;. I understand that this license provides a non-exclusive, non-transferable right to use MSFragger solely for academic research, non-commercial or educational purposes within the licensee’s department.</value>
+    <value>I have read the &lt;link target="lic"&gt;academic license&lt;/link&gt;. I understand that this license provides a non-exclusive, non-transferable right to use MSFragger solely for academic research, non-commercial or educational purposes within the licensee’s department.</value>
   </data>
   <data name="&gt;&gt;rtbAgreeToLicense.Name" xml:space="preserve">
     <value>rtbAgreeToLicense</value>
@@ -207,67 +175,70 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>$this</value>
   </data>
   <data name="&gt;&gt;rtbAgreeToLicense.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
-  <data name="tbName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+  <data name="tbFirstName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
-  <data name="tbName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>64, 6</value>
+  <data name="tbFirstName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>70, 3</value>
   </data>
-  <data name="tbName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="tbFirstName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
   </data>
-  <data name="tbName.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tbFirstName.Size" type="System.Drawing.Size, System.Drawing">
     <value>275, 20</value>
   </data>
-  <data name="tbName.TabIndex" type="System.Int32, mscorlib">
+  <data name="tbFirstName.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;tbName.Name" xml:space="preserve">
-    <value>tbName</value>
+  <data name="&gt;&gt;tbFirstName.Name" xml:space="preserve">
+    <value>tbFirstName</value>
   </data>
-  <data name="&gt;&gt;tbName.Type" xml:space="preserve">
+  <data name="&gt;&gt;tbFirstName.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;tbName.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tbFirstName.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;tbName.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;tbFirstName.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="lblName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+  <data name="lblFirstName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
   </data>
-  <data name="lblName.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblFirstName.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="lblName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 10</value>
+  <data name="lblFirstName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="lblName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+  <data name="lblFirstName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 6</value>
   </data>
-  <data name="lblName.TabIndex" type="System.Int32, mscorlib">
+  <data name="lblFirstName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 13</value>
+  </data>
+  <data name="lblFirstName.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="lblName.Text" xml:space="preserve">
-    <value>&amp;Name:</value>
+  <data name="lblFirstName.Text" xml:space="preserve">
+    <value>&amp;First Name:</value>
   </data>
-  <data name="lblName.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+  <data name="lblFirstName.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>TopRight</value>
   </data>
-  <data name="&gt;&gt;lblName.Name" xml:space="preserve">
-    <value>lblName</value>
+  <data name="&gt;&gt;lblFirstName.Name" xml:space="preserve">
+    <value>lblFirstName</value>
   </data>
-  <data name="&gt;&gt;lblName.Type" xml:space="preserve">
+  <data name="&gt;&gt;lblFirstName.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;lblName.Parent" xml:space="preserve">
+  <data name="&gt;&gt;lblFirstName.Parent" xml:space="preserve">
     <value>tableLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;lblName.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;lblFirstName.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="lblEmail.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
@@ -279,13 +250,13 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>NoControl</value>
   </data>
   <data name="lblEmail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 43</value>
+    <value>29, 52</value>
   </data>
   <data name="lblEmail.Size" type="System.Drawing.Size, System.Drawing">
     <value>35, 13</value>
   </data>
   <data name="lblEmail.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="lblEmail.Text" xml:space="preserve">
     <value>&amp;Email:</value>
@@ -303,13 +274,13 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblEmail.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="tbEmail.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="tbEmail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>64, 39</value>
+    <value>70, 49</value>
   </data>
   <data name="tbEmail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
@@ -318,7 +289,7 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>275, 20</value>
   </data>
   <data name="tbEmail.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;tbEmail.Name" xml:space="preserve">
     <value>tbEmail</value>
@@ -330,7 +301,7 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tbEmail.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="lblInstitution.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
@@ -342,13 +313,13 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>NoControl</value>
   </data>
   <data name="lblInstitution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 76</value>
+    <value>9, 79</value>
   </data>
   <data name="lblInstitution.Size" type="System.Drawing.Size, System.Drawing">
     <value>55, 13</value>
   </data>
   <data name="lblInstitution.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="lblInstitution.Text" xml:space="preserve">
     <value>&amp;Institution:</value>
@@ -366,13 +337,13 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;lblInstitution.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="tbInstitution.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left, Right</value>
   </data>
   <data name="tbInstitution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>64, 73</value>
+    <value>70, 76</value>
   </data>
   <data name="tbInstitution.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
@@ -381,7 +352,7 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>275, 20</value>
   </data>
   <data name="tbInstitution.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;tbInstitution.Name" xml:space="preserve">
     <value>tbInstitution</value>
@@ -393,31 +364,7 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;tbInstitution.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="cbReceiveUpdateEmails.Location" type="System.Drawing.Point, System.Drawing">
-    <value>32, 293</value>
-  </data>
-  <data name="cbReceiveUpdateEmails.Size" type="System.Drawing.Size, System.Drawing">
-    <value>355, 26</value>
-  </data>
-  <data name="cbReceiveUpdateEmails.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="cbReceiveUpdateEmails.Text" xml:space="preserve">
-    <value>I would like to receive emails with updates in the future.</value>
-  </data>
-  <data name="&gt;&gt;cbReceiveUpdateEmails.Name" xml:space="preserve">
-    <value>cbReceiveUpdateEmails</value>
-  </data>
-  <data name="&gt;&gt;cbReceiveUpdateEmails.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbReceiveUpdateEmails.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;cbReceiveUpdateEmails.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="btnAccept.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -426,13 +373,13 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>False</value>
   </data>
   <data name="btnAccept.Location" type="System.Drawing.Point, System.Drawing">
-    <value>181, 325</value>
+    <value>181, 318</value>
   </data>
   <data name="btnAccept.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 23</value>
   </data>
   <data name="btnAccept.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>13</value>
   </data>
   <data name="btnAccept.Text" xml:space="preserve">
     <value>&amp;Accept and Download</value>
@@ -447,19 +394,19 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnAccept.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
   <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 325</value>
+    <value>312, 318</value>
   </data>
   <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
   </data>
   <data name="btnCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>14</value>
   </data>
   <data name="btnCancel.Text" xml:space="preserve">
     <value>&amp;Cancel</value>
@@ -474,7 +421,7 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -485,11 +432,74 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <data name="tbLastName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="tbLastName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>70, 29</value>
+  </data>
+  <data name="tbLastName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 10, 3</value>
+  </data>
+  <data name="tbLastName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>275, 20</value>
+  </data>
+  <data name="tbLastName.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;tbLastName.Name" xml:space="preserve">
+    <value>tbLastName</value>
+  </data>
+  <data name="&gt;&gt;tbLastName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbLastName.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tbLastName.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblLastName.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="lblLastName.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblLastName.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblLastName.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 29</value>
+  </data>
+  <data name="lblLastName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 13</value>
+  </data>
+  <data name="lblLastName.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="lblLastName.Text" xml:space="preserve">
+    <value>&amp;Last Name:</value>
+  </data>
+  <data name="lblLastName.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopRight</value>
+  </data>
+  <data name="&gt;&gt;lblLastName.Name" xml:space="preserve">
+    <value>lblLastName</value>
+  </data>
+  <data name="&gt;&gt;lblLastName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblLastName.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;lblLastName.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>24, 118</value>
+    <value>23, 105</value>
   </data>
   <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>344, 100</value>
@@ -507,10 +517,142 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>$this</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="lblName" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblEmail" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblInstitution" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tbName" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tbInstitution" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tbEmail" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="tbLastName" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblLastName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblFirstName" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblEmail" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblInstitution" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tbFirstName" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tbInstitution" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="tbEmail" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="Percent,33.33333,Absolute,20,Percent,33.33333,Percent,33.33333,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="tbVerificationCode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="tbVerificationCode.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="tbVerificationCode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>115, 287</value>
+  </data>
+  <data name="tbVerificationCode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 20</value>
+  </data>
+  <data name="tbVerificationCode.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;tbVerificationCode.Name" xml:space="preserve">
+    <value>tbVerificationCode</value>
+  </data>
+  <data name="&gt;&gt;tbVerificationCode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbVerificationCode.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tbVerificationCode.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblVerificationCode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="lblVerificationCode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblVerificationCode.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="lblVerificationCode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblVerificationCode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 291</value>
+  </data>
+  <data name="lblVerificationCode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 13</value>
+  </data>
+  <data name="lblVerificationCode.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="lblVerificationCode.Text" xml:space="preserve">
+    <value>&amp;Verification code:</value>
+  </data>
+  <data name="lblVerificationCode.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopRight</value>
+  </data>
+  <data name="&gt;&gt;lblVerificationCode.Name" xml:space="preserve">
+    <value>lblVerificationCode</value>
+  </data>
+  <data name="&gt;&gt;lblVerificationCode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblVerificationCode.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblVerificationCode.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnRequestVerificationCode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="btnRequestVerificationCode.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnRequestVerificationCode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnRequestVerificationCode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>221, 285</value>
+  </data>
+  <data name="btnRequestVerificationCode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>166, 23</value>
+  </data>
+  <data name="btnRequestVerificationCode.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="btnRequestVerificationCode.Text" xml:space="preserve">
+    <value>&amp;Request Verification Code</value>
+  </data>
+  <data name="&gt;&gt;btnRequestVerificationCode.Name" xml:space="preserve">
+    <value>btnRequestVerificationCode</value>
+  </data>
+  <data name="&gt;&gt;btnRequestVerificationCode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRequestVerificationCode.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnRequestVerificationCode.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="rtbUsageConditions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="rtbUsageConditions.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 12</value>
+  </data>
+  <data name="rtbUsageConditions.ScrollBars" type="System.Windows.Forms.RichTextBoxScrollBars, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="rtbUsageConditions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>378, 87</value>
+  </data>
+  <data name="rtbUsageConditions.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="rtbUsageConditions.Text" xml:space="preserve">
+    <value>MSFragger is available freely for academic research, non-commercial or educational purposes under academic license. Non-academic users must visit Fragmatics at &lt;link&gt;www.fragmatics.com&lt;/link&gt; or email info@fragmatics.com to purchase a license and access the tools.
+
+Read the &lt;link target="lic"&gt;academic license&lt;/link&gt; for MSFragger.
+</value>
+  </data>
+  <data name="&gt;&gt;rtbUsageConditions.Name" xml:space="preserve">
+    <value>rtbUsageConditions</value>
+  </data>
+  <data name="&gt;&gt;rtbUsageConditions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RichTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rtbUsageConditions.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;rtbUsageConditions.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -519,7 +661,7 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>399, 360</value>
+    <value>399, 353</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
@@ -531,12 +673,12 @@ For questions, please contact Prof. Alexey Nesvizhskii (nesvi@med.umich.edu).</v
     <value>modeUIHandler</value>
   </data>
   <data name="&gt;&gt;modeUIHandler.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.Helpers+ModeUIExtender, Skyline-daily, Version=24.1.1.492, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>MsFraggerDownloadDlg</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>pwiz.Skyline.Util.FormEx, Skyline, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>pwiz.Skyline.Util.FormEx, Skyline-daily, Version=24.1.1.492, Culture=neutral, PublicKeyToken=null</value>
   </data>
 </root>

--- a/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Alerts/MsFraggerDownloadDlg.zh-CHS.resx
@@ -121,39 +121,12 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tbUsageConditions.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="tbUsageConditions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tbUsageConditions.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tbUsageConditions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>375, 100</value>
-  </data>
-  <data name="tbUsageConditions.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tbUsageConditions.Text" xml:space="preserve">
+  <data name="rtbUsageConditions.Text" xml:space="preserve">
     <value>根据学术许可，MSFragger 可免费用于学术研究、非商业或教育目的。用于其他用途时，需要在最初的 60 天评估期过后联系密歇根大学技术转让办公室的 Drew Bennett (andbenne@umich.edu) 获取商业许可。
 
 如有疑问，请联系 Alexey Nesvizhskii 教授 (nesvi@med.umich.edu)。</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Name" xml:space="preserve">
-    <value>tbUsageConditions</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tbUsageConditions.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="cbAgreeToLicense.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/ImportPeptideSearchDlg.cs
@@ -1531,7 +1531,7 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
         private bool CanWizardClose()
         {
             var wizardPageControl = GetPageControl(wizardPagesImportPeptideSearch.SelectedTab) as WizardPageControl;
-            return wizardPageControl == null || wizardPageControl.CanWizardClose();
+            return wizardPageControl == null || Program.ClosingForms || wizardPageControl.CanWizardClose();
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)

--- a/pwiz_tools/Skyline/Model/DdaSearch/MsFraggerSearchEngine.cs
+++ b/pwiz_tools/Skyline/Model/DdaSearch/MsFraggerSearchEngine.cs
@@ -175,7 +175,7 @@ namespace pwiz.Skyline.Model.DdaSearch
             @"c,z",
         };
 
-        public static string MSFRAGGER_VERSION = @"4.1";
+        public static string MSFRAGGER_VERSION = @"4.1"; // TODO: after next release and daily, remove outdated rtbUsageConditions.Text translations for ja/zh
         public static string MSFRAGGER_FILENAME = @"MSFragger-4.1";
         public static string MsFraggerDirectory => Path.Combine(ToolDescriptionHelpers.GetToolsDirectory(), MSFRAGGER_FILENAME);
         public static string MsFraggerBinary => Path.Combine(MsFraggerDirectory, MSFRAGGER_FILENAME, MSFRAGGER_FILENAME + @".jar");

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -80,6 +80,7 @@ namespace pwiz.Skyline
             }
         }
         public static string TestName { get; set; }                 // Set during unit and functional tests
+        public static bool ClosingForms { get; set; }               // Set to true during AbstractFunctionalTest.CloseOpenForm (all forms should check this before cancelling a Close request)
         public static string DefaultUiMode { get; set; }            // Set to avoid seeing NoModeUiDlg at the start of a test
 
         public static bool SkylineOffscreen

--- a/pwiz_tools/Skyline/Properties/Settings.Designer.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.Designer.cs
@@ -3533,5 +3533,32 @@ namespace pwiz.Skyline.Properties {
                 return ((int)(this["KoinaRetryCount"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://msfragger-upgrader.nesvilab.org/upgrader/LICENSE-ACADEMIC.pdf")]
+        public string MsFraggerLicenseUrl {
+            get {
+                return ((string)(this["MsFraggerLicenseUrl"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("http://msfragger-upgrader.nesvilab.org/upgrader/upgrade_download.php")]
+        public string MsFraggerVerifyUrl {
+            get {
+                return ((string)(this["MsFraggerVerifyUrl"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://msfragger-upgrader.nesvilab.org/upgrader/download.php")]
+        public string MsFraggerDownloadUrl {
+            get {
+                return ((string)(this["MsFraggerDownloadUrl"]));
+            }
+        }
     }
 }

--- a/pwiz_tools/Skyline/Properties/Settings.settings
+++ b/pwiz_tools/Skyline/Properties/Settings.settings
@@ -884,5 +884,14 @@
     <Setting Name="KoinaRetryCount" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">10</Value>
     </Setting>
+    <Setting Name="MsFraggerLicenseUrl" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://msfragger-upgrader.nesvilab.org/upgrader/LICENSE-ACADEMIC.pdf</Value>
+    </Setting>
+    <Setting Name="MsFraggerVerifyUrl" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">http://msfragger-upgrader.nesvilab.org/upgrader/upgrade_download.php</Value>
+    </Setting>
+    <Setting Name="MsFraggerDownloadUrl" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://msfragger-upgrader.nesvilab.org/upgrader/download.php</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DdaSearchTest.cs
@@ -456,7 +456,7 @@ namespace pwiz.SkylineTestFunctional
                     var msfraggerDownloaderDlg = TryWaitForOpenForm<MsFraggerDownloadDlg>(2000);
                     if (msfraggerDownloaderDlg != null)
                     {
-                        RunUI(() => msfraggerDownloaderDlg.SetValues("Matt Chambers (testing download from Skyline)", "matt.chambers42@gmail.com", "UW"));
+                        RunUI(() => msfraggerDownloaderDlg.SetValues("Matt (testing download from Skyline)", "Chambers", "chambem2@uw.edu", "UW"));
                         OkDialog(msfraggerDownloaderDlg, msfraggerDownloaderDlg.ClickAccept);
                     }
                 }

--- a/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/DiaSearchTest.cs
@@ -474,7 +474,7 @@ namespace pwiz.SkylineTestFunctional
                     var msfraggerDownloaderDlg = TryWaitForOpenForm<MsFraggerDownloadDlg>(2000);
                     if (msfraggerDownloaderDlg != null)
                     {
-                        RunUI(() => msfraggerDownloaderDlg.SetValues("Matt Chambers (testing download from Skyline)", "matt.chambers42@gmail.com", "UW"));
+                        RunUI(() => msfraggerDownloaderDlg.SetValues("Matt (testing download from Skyline)", "Chambers", "chambem2@uw.edu", "UW"));
                         OkDialog(msfraggerDownloaderDlg, msfraggerDownloaderDlg.ClickAccept);
                     }
                 }
@@ -766,7 +766,7 @@ namespace pwiz.SkylineTestFunctional
                     var msfraggerDownloaderDlg = TryWaitForOpenForm<MsFraggerDownloadDlg>(2000);
                     if (msfraggerDownloaderDlg != null)
                     {
-                        RunUI(() => msfraggerDownloaderDlg.SetValues("Matt Chambers (testing download from Skyline)", "matt.chambers42@gmail.com", "UW"));
+                        RunUI(() => msfraggerDownloaderDlg.SetValues("Matt (testing download from Skyline)", "Chambers", "chambem2@uw.edu", "UW"));
                         OkDialog(msfraggerDownloaderDlg, msfraggerDownloaderDlg.ClickAccept);
                     }
                 }

--- a/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DdaTutorialTest.cs
@@ -275,7 +275,7 @@ namespace TestPerf
                     if (msfraggerDownloaderDlg != null)
                     {
                         PauseForScreenShot<MsFraggerDownloadDlg>("Import Peptide Search - Download MSFragger"); // Maybe someday
-                        RunUI(() => msfraggerDownloaderDlg.SetValues("Matt Chambers (testing download from Skyline)", "matt.chambers42@gmail.com", "UW"));
+                        RunUI(() => msfraggerDownloaderDlg.SetValues("Matt (testing download from Skyline)", "Chambers", "chambem2@uw.edu", "UW"));
                         OkDialog(msfraggerDownloaderDlg, msfraggerDownloaderDlg.ClickAccept);
                     }
                 }

--- a/pwiz_tools/Skyline/TestPerf/DiaSearchTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaSearchTutorialTest.cs
@@ -463,8 +463,7 @@ namespace TestPerf
                 if (msfraggerDownloaderDlg != null)
                 {
                     PauseForScreenShot<MsFraggerDownloadDlg>("Import Peptide Search - Download MSFragger"); // Maybe someday
-                    RunUI(() => msfraggerDownloaderDlg.SetValues("Matt Chambers (testing download from Skyline)",
-                        "matt.chambers42@gmail.com", "UW"));
+                    RunUI(() => msfraggerDownloaderDlg.SetValues("Matt (testing download from Skyline)", "Chambers", "chambem2@uw.edu", "UW"));
                     OkDialog(msfraggerDownloaderDlg, msfraggerDownloaderDlg.ClickAccept);
                 }
 

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2602,33 +2602,42 @@ namespace pwiz.SkylineTestUtil
 
         private void CloseOpenForm(Form formToClose, List<Form> openForms)
         {
-            openForms.Remove(formToClose);
-            // Close any owned forms, since they may be pushing message loops that would keep this form
-            // from closing.
-            foreach (var ownedForm in formToClose.OwnedForms)
+            try
             {
-                CloseOpenForm(ownedForm, openForms);
-            }
+                Program.ClosingForms = true;
 
-            var messageDlg = formToClose as CommonAlertDlg;
-            // ReSharper disable LocalizableElement
-            if (messageDlg == null)
-                Console.WriteLine("\n\nClosing open form of type {0}\n", formToClose.GetType()); // Not L10N
-            else
+                openForms.Remove(formToClose);
+                // Close any owned forms, since they may be pushing message loops that would keep this form
+                // from closing.
+                foreach (var ownedForm in formToClose.OwnedForms)
+                {
+                    CloseOpenForm(ownedForm, openForms);
+                }
+
+                var messageDlg = formToClose as CommonAlertDlg;
+                // ReSharper disable LocalizableElement
+                if (messageDlg == null)
+                    Console.WriteLine("\n\nClosing open form of type {0}\n", formToClose.GetType()); // Not L10N
+                else
                 Console.WriteLine("\n\nClosing open MessageDlg: {0}\n", TextUtil.LineSeparate(messageDlg.Message, messageDlg.DetailMessage)); // Not L10N
-            // ReSharper restore LocalizableElement
+                // ReSharper restore LocalizableElement
 
-            RunUI(() =>
+                RunUI(() =>
+                {
+                    try
+                    {
+                        formToClose.Close();
+                    }
+                    catch
+                    {
+                        // Ignore exceptions
+                    }
+                });
+            }
+            finally
             {
-                try
-                {
-                    formToClose.Close();
-                }
-                catch
-                {
-                    // Ignore exceptions
-                }
-            });
+                Program.ClosingForms = false;
+            }
         }
 
 

--- a/pwiz_tools/Skyline/app.config
+++ b/pwiz_tools/Skyline/app.config
@@ -893,6 +893,15 @@
             <setting name="KoinaRetryCount" serializeAs="String">
                 <value>10</value>
             </setting>
+            <setting name="MsFraggerLicenseUrl" serializeAs="String">
+                <value>https://msfragger-upgrader.nesvilab.org/upgrader/LICENSE-ACADEMIC.pdf</value>
+            </setting>
+            <setting name="MsFraggerVerifyUrl" serializeAs="String">
+                <value>http://msfragger-upgrader.nesvilab.org/upgrader/upgrade_download.php</value>
+            </setting>
+            <setting name="MsFraggerDownloadUrl" serializeAs="String">
+                <value>https://msfragger-upgrader.nesvilab.org/upgrader/download.php</value>
+            </setting>
         </pwiz.Skyline.Properties.Settings>
     </applicationSettings>
   <system.data>


### PR DESCRIPTION
- fixed MSFragger download to use new verification code scheme
* fixed "Do you want to cancel search?" popup in peptide search wizard from preventing forms cleanup
* removed Expect100Continue manipulation since new scheme doesn't need it, and moved TextChanged handlers to designer code
* added message box to check email after clicking Request Verification Code
* fixed reporting of error message if download MSFragger fails (e.g. expired/invalid verification code)