### PR TITLE
Skyline: Fixed over multiplying match tolerance m/z

### DIFF
--- a/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.cs
+++ b/pwiz_tools/Skyline/FileUI/PeptideSearch/TransitionSettingsControl.cs
@@ -521,15 +521,24 @@ namespace pwiz.Skyline.FileUI.PeptideSearch
             return new TransitionSettings(settings.Prediction, filter, libraries, settings.Integration, instrument, fullScan, settings.IonMobilityFiltering);
         }
 
+        private MzTolerance.Units? _mzMatchToleranceUnitsCurrent;
+
         private void comboMatchToleranceUnit_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (double.TryParse(txtTolerance.Text, out var matchTolerance))
+            // Only perform tolerance scaling when the units are known, and
+            // they are being changed.
+            if (_mzMatchToleranceUnitsCurrent.HasValue &&
+                _mzMatchToleranceUnitsCurrent.Value != IonMatchToleranceUnits)
             {
-                if (IonMatchToleranceUnits == MzTolerance.Units.mz)
-                    IonMatchTolerance = matchTolerance / 1000;
-                else
-                    IonMatchTolerance = matchTolerance * 1000;
+                if (double.TryParse(txtTolerance.Text, out var matchTolerance))
+                {
+                    if (IonMatchToleranceUnits == MzTolerance.Units.mz)
+                        IonMatchTolerance = matchTolerance / 1000;
+                    else
+                        IonMatchTolerance = matchTolerance * 1000;
+                }
             }
+            _mzMatchToleranceUnitsCurrent = IonMatchToleranceUnits;
         }
     }
 }

--- a/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.cs
+++ b/pwiz_tools/Skyline/SettingsUI/TransitionSettingsUI.cs
@@ -1330,16 +1330,26 @@ namespace pwiz.Skyline.SettingsUI
             }
         }
 
+        private MzTolerance.Units? _mzMatchToleranceUnitsCurrent;
+
         private void comboToleranceUnits_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (double.TryParse(textTolerance.Text, out var matchTolerance))
+            // Only perform tolerance scaling when the units are known, and
+            // they are being changed.
+            if (_mzMatchToleranceUnitsCurrent.HasValue &&
+                _mzMatchToleranceUnitsCurrent.Value != IonMatchToleranceUnits)
             {
-                if (IonMatchToleranceUnits == MzTolerance.Units.mz)
-                    IonMatchTolerance = matchTolerance / 1000;
-                else
-                    IonMatchTolerance = matchTolerance * 1000;
+                if (double.TryParse(textTolerance.Text, out var matchTolerance))
+                {
+                    if (IonMatchToleranceUnits == MzTolerance.Units.mz)
+                        IonMatchTolerance = matchTolerance / 1000;
+                    else
+                        IonMatchTolerance = matchTolerance * 1000;
+                }
             }
+            _mzMatchToleranceUnitsCurrent = IonMatchToleranceUnits;
         }
+
         private void btnEditSpectrumFilter_Click(object sender, EventArgs e)
         {
             EditSpectrumFilter();


### PR DESCRIPTION
- TransitionSettingsControl and TransitionSettingsUI both had combo_SelectedIndexChanged methods that multiplied the match tolerance by 1000 when the choice was not m/z.
- Code needed to be added to keep from doing this when it was not actually changing from m/z to PPM or vise versa for division.