### PR TITLE
Fix failing test FilesDirTest (fr)

### DIFF
--- a/pwiz_tools/Skyline/Test/UtilTest.cs
+++ b/pwiz_tools/Skyline/Test/UtilTest.cs
@@ -494,7 +494,7 @@ namespace pwiz.SkylineTest
         private static void VerifyDeleteDirectoryWithFileLockingDetails(string dirPath, string lockedFile)
         {
             AssertEx.ThrowsException<IOException>(() => FileLockingProcessFinder.DeleteDirectoryWithFileLockingDetails(dirPath),
-                x => AssertEx.Contains(x.Message, lockedFile, "this process"));
+                x => AssertEx.Contains(x.Message, dirPath, Path.GetFileName(lockedFile)));
         }
     }
 }


### PR DESCRIPTION
Test was failing in French.  This PR corrects the failure and verifies that the Exception message generated contains both the directory name (which can be levels above the actual directory name in the case of the recurring directory test) and the file name.