### PR TITLE
Skyline: Fix FilesDirTest FileLockingProcessFinder test on French language system

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/FileLockingProcessFinder.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/FileLockingProcessFinder.cs
@@ -218,7 +218,7 @@ namespace pwiz.Common.SystemUtil
             // If it's a file locking issue, wrap the exception to report the locking process
             if (x is IOException { HResult: ERROR_SHARING_VIOLATION } ioException)
             {
-                var match = Regex.Match(ioException.Message, "'(.*)'");
+                var match = Regex.Match(ioException.Message, "'([^']+)'");
                 if (match.Success)
                 {
                     string lockedFileName = match.Captures[0].Value.Trim('\'');

--- a/pwiz_tools/Skyline/Test/UtilTest.cs
+++ b/pwiz_tools/Skyline/Test/UtilTest.cs
@@ -493,6 +493,8 @@ namespace pwiz.SkylineTest
 
         private static void VerifyDeleteDirectoryWithFileLockingDetails(string dirPath, string lockedFile)
         {
+            // NB: We really do not want to see the error "was locked but has since been deleted"
+            //     since we know the file is locked and cannot have been deleted.
             AssertEx.ThrowsException<IOException>(() => FileLockingProcessFinder.DeleteDirectoryWithFileLockingDetails(dirPath),
                 x => AssertEx.Contains(x.Message, lockedFile, "this process"));
         }

--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -1138,7 +1138,7 @@ namespace TestRunner
                                     if (testInfo.Pass == 2)
                                         testInfo.IncrementLoopCount();
                                     if (loop == 0)
-                                        testQueue.Enqueue(testInfo);
+                                        (testInfo.TestInfo.DoNotRunInParallel ? nonParallelTestQueue : testQueue).Enqueue(testInfo);
                                 }
                                 finally
                                 {
@@ -1147,7 +1147,7 @@ namespace TestRunner
                                         //if (testInfo.TestMethod.Name == "TestSwathIsolationLists")
                                         //    testRequeue = false;
                                         Console.Error.WriteLine($"No result for test {workerInfo.CurrentTest}; requeuing...");
-                                        testQueue.Enqueue(testInfo);
+                                        (testInfo.TestInfo.DoNotRunInParallel ? nonParallelTestQueue : testQueue).Enqueue(testInfo);
                                     }
                                 }
                             }


### PR DESCRIPTION
- existing code failed when IOException text contained an extra apostrophe due to RegEx bug
- fixed "Run indefinitely" in parallel test mode with non-parallel tests to keep them from running on Docker agents