### PR TITLE
* updated cherrypick-pr-to-release.yml action to use v1.1

### DIFF
--- a/.github/workflows/cherrypick-pr-to-release.yml
+++ b/.github/workflows/cherrypick-pr-to-release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v1
     - name: Cherry pick PR to release
-      uses: chambm/gh-backport-action@master
+      uses: chambm/gh-backport-action@v1.1
       with:
         pr_branch: 'Skyline/skyline_25_1'
         pr_title: 'Automatic cherry pick of #{pr_number} from {base_branch} to {pr_branch}'


### PR DESCRIPTION
* updated cherrypick-pr-to-release.yml action to use v1.1, hopefully fixing issue with cherry picking PRs with merge commits in them