### PR TITLE
* added README.md at Skyline source root

### DIFF
--- a/pwiz_tools/Skyline/README.md
+++ b/pwiz_tools/Skyline/README.md
@@ -1,0 +1,10 @@
+![Skyline Logo](https://skyline.ms/labkey/_webdav/home/%40files/skyline.jpg "Skyline")
+
+[Skyline](https://skyline.ms/project/home/software/Skyline/begin.view) is a freely-available and open-source Windows client application for building Selected Reaction Monitoring (SRM) / Multiple Reaction Monitoring (MRM), 
+Parallel Reaction Monitoring (PRM), Data Independent Acquisition (DIA/SWATH) and DDA with MS1 quantitative methods and analyzing the resulting mass spectrometer data. 
+Its flexible configuration supports All Molecules. It aims to employ cutting-edge technologies for creating and iteratively refining targeted methods for large-scale 
+quantitative mass spectrometry studies in life sciences.
+
+Core code and libraries are under the Apache open source license; the vendor libraries fall under various vendor-specific licenses.
+
+Click [here](https://skyline.ms/skyline64.url) to visit the official download page.


### PR DESCRIPTION
I did find it odd that we didn't have one, but I'm mainly doing this to test my fix for cherry picking since that fix PR itself couldn't be cherry picked because it modified workflow files and apparently that's a no-no (which makes sense, you generally don't want automated workflows to be able to modify themselves!). I could fix that by changing the actions to use a personal token with more permission, but I don't think the security risk is justified.