### PR TITLE
Move expected values for DiaSwathTutorialTest into separate text files

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/Irt/AddIrtPeptidesDlg.cs
@@ -286,5 +286,10 @@ namespace pwiz.Skyline.SettingsUI.Irt
         {
             return 0 <= rowIndex && rowIndex < dataGridView.RowCount ? dataGridView.Rows[rowIndex] : null;
         }
+
+        public IIrtRegression GetRegressionRefined(int rowIndex)
+        {
+            return (GetRow(rowIndex).Tag as RetentionTimeProviderData)?.RegressionRefined;
+        }
     }
 }

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.cs
@@ -410,7 +410,7 @@ namespace TestPerf
             Assert.IsNotNull(_expectedValuesFileName);
             using var streamWriter = new StreamWriter(Path.Combine(GetExpectedValuesFolder(), _expectedValuesFileName));
             using var jsonTextWriter = new JsonTextWriter(streamWriter);
-            JsonSerializer.Create(new JsonSerializerSettings()
+            JsonSerializer.Create(new JsonSerializerSettings
             {
                 Formatting = Formatting.Indented
             }).Serialize(jsonTextWriter, _expectedValues);
@@ -584,7 +584,7 @@ namespace TestPerf
         /// <summary>
         /// Change to true to write coefficient arrays.
         /// </summary>
-        protected override bool IsRecordMode => true;
+        protected override bool IsRecordMode => false;
 
         protected override void DoTest()
         {

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.cs
@@ -87,12 +87,7 @@ namespace TestPerf
             public int? MinPeptidesPerProtein;
             public bool RemoveDuplicates;
             //public int[] TargetCounts;
-            public string ScoringModelCoefficients;
             public PointF ChromatogramClickPoint;
-            public double[][] MassErrorStats;
-            public int[] DiffPeptideCounts;
-            public int UnpolishedProteins;
-            public int? PolishedProteins;
             public double? FoldChangeProteinsMax;
             public double? FoldChangeProteinsMin;
 
@@ -108,6 +103,11 @@ namespace TestPerf
             public double IrtSlope;
             public double IrtIntercept;
             public int[] FinalTargetCounts;
+            public double[][] MassErrorStats;
+            public int[] DiffPeptideCounts;
+            public int UnpolishedProteins;
+            public int? PolishedProteins;
+            public double?[] ScoringModelCoefficients;
         }
 
 
@@ -163,20 +163,6 @@ namespace TestPerf
                     RemoveDuplicates = true,
                     ChromatogramClickPoint = new PointF(34.18F, 108.0F),
                     //TargetCounts = new[] { 4700, 36628, 37960, 227760 },
-                    ScoringModelCoefficients = "-0.0842|-0.7447|4.2691|-0.2084|-0.2644|0.7594|0.3124|-0.0659",
-                    MassErrorStats = new[]
-                    {
-                        new[] {2.8, 4.6},
-                        new[] {2.4, 4.3},
-                        new[] {3.9, 4.2},
-                        new[] {5.2, 4.1},
-                        new[] {4.5, 4.2},
-                        new[] {-0.4, 3.9},
-                        new[] {1.0, 4.1},
-                    },
-                    DiffPeptideCounts = new[] { 12808, 7963, 2692, 2142 },
-                    UnpolishedProteins = 2207,
-                    PolishedProteins = 2207,
                 };
             }
             else
@@ -187,19 +173,6 @@ namespace TestPerf
                     IrtFilterText = "standard",
                     ChromatogramClickPoint = new PointF(34.18F, 108.0F),
                     //TargetCounts = new[] { 14, 279, 299, 1793 },
-                    ScoringModelCoefficients = "0.2674|-0.6467|3.4194|-0.0171|-0.4723|0.9270|0.0768|-0.0496",
-                    MassErrorStats = new[]
-                    {
-                        new[] {3.0, 4.4},
-                        new[] {2.8, 4.1},
-                        new[] {3.9, 4.3},
-                        new[] {5.9, 3.6},
-                        new[] {4.7, 4.2},
-                        new[] {-0.1, 3.4},
-                        new[] {1.0, 3.6},
-                    },
-                    DiffPeptideCounts = new[] { 142, 44, 30, 57 },
-                    UnpolishedProteins = 9,
                 };
             }
 
@@ -248,20 +221,6 @@ namespace TestPerf
                     RemoveDuplicates = true,
                     ChromatogramClickPoint = new PointF(32.05F, 268334.7F),
                     //TargetCounts = new[] { 3991, 30916, 33841, 203044 },
-                    ScoringModelCoefficients = "0.3173|-0.8915|3.7829|0.2263|-0.0825|0.7332|0.0012|-0.0606",
-                    MassErrorStats = new[]
-                    {
-                        new[] { 2.0, 4.7 },
-                        new[] { 1.5, 4.6 },
-                        new[] { 2.0, 4.7 },
-                        new[] { 2.1, 4.6 },
-                        new[] { 2.1, 4.8 },
-                        new[] { 2.2, 4.6 },
-                        new[] { 1.9, 4.7 },
-                    },
-                    DiffPeptideCounts = new[] { 10467, 6391, 2242, 1823 },
-                    UnpolishedProteins = 1653,
-                    PolishedProteins = 2031,
                 };
             }
             else
@@ -272,19 +231,6 @@ namespace TestPerf
                     IrtFilterText = "standard",
                     ChromatogramClickPoint = new PointF(31.98F, 285741.3F),
                     //TargetCounts = new[] { 14, 271, 331, 1985 },
-                    ScoringModelCoefficients = "0.3065|-0.7855|4.9580|-0.4976|-0.0812|0.7443|0.0988|-0.0542",
-                    MassErrorStats = new[]
-                    {
-                        new[] { 1.6, 4.2 },
-                        new[] { 1.3, 4.1 },
-                        new[] { 1.6, 4.4 },
-                        new[] { 1.8, 3.7 },
-                        new[] { 1.8, 4.4 },
-                        new[] { 1.8, 4.1 },
-                        new[] { 1.2, 4.3 },
-                    },
-                    DiffPeptideCounts = new[] { 139, 47, 29, 52 },
-                    UnpolishedProteins = 9,
                     FoldChangeProteinsMax = 2,
                 };
             }
@@ -337,19 +283,6 @@ namespace TestPerf
                     RemoveDuplicates = true,
                     ChromatogramClickPoint = new PointF(32.05F, 268334.7F),
                     //TargetCounts = new[] { 3991, 30916, 33841, 203044 },
-                    MassErrorStats = new[]
-                    {
-                        new[] {1.9, 4.3},
-                        new[] {1.4, 4.3},
-                        new[] {2.0, 4.3},
-                        new[] {2.0, 4.2},
-                        new[] {2.1, 4.2},
-                        new[] {2.1, 4.2},
-                        new[] {1.9, 4.2},
-                    },
-                    DiffPeptideCounts = new[] { 14479, 9877, 2828, 1756 },
-                    UnpolishedProteins = 1846,
-                    PolishedProteins = 1846
                 };
             }
             else
@@ -360,20 +293,6 @@ namespace TestPerf
                     IrtFilterText = "iRT",
                     ChromatogramClickPoint = new PointF(31.98F, 285741.3F),
                     //TargetCounts = new[] { 14, 271, 331, 1985 },
-
-                    MassErrorStats = new[]
-                    {
-                        new[] {1.8, 3.2},
-                        new[] {1.2, 3.0},
-                        new[] {1.8, 3.0},
-                        new[] {2.0, 3.2},
-                        new[] {2.1, 3.7},
-                        new[] {1.9, 3.2},
-                        new[] {1.6, 3.4},
-                    },
-                    DiffPeptideCounts = new[] { 125, 41, 28, 45 },
-                    UnpolishedProteins = 3,
-                    PolishedProteins = 11,
                     FoldChangeProteinsMax = 2,
                 };
             }
@@ -396,20 +315,6 @@ namespace TestPerf
                     RemoveDuplicates = true,
                     ChromatogramClickPoint = new PointF(10.79F, 3800.0F),
                     //TargetCounts = new[] { 4937, 37152, 38716, 232296 },
-                    ScoringModelCoefficients = "-0.3356|-0.9056|4.5024|3.5338|-0.1011|0.7388|0.4436|-0.1319",
-                    MassErrorStats = new[]
-                    {
-                        new[] { 3.6, 2.7 },
-                        new[] { 3.6, 2.6 },
-                        new[] { 3.5, 2.7 },
-                        new[] { 3.7, 2.6 },
-                        new[] { 3.6, 2.7 },
-                        new[] { 3.9, 2.6 },
-                        new[] { 3.6, 2.7 },
-                    },
-                    DiffPeptideCounts = new[] { 12621, 8498, 2254, 1854 },
-                    UnpolishedProteins = 2314,
-                    PolishedProteins = 2314,
                 };
 
                 SetInstrumentType(new InstrumentSpecificValues
@@ -447,19 +352,6 @@ namespace TestPerf
                     IrtFilterText = Resources.IrtDb_MakeDocumentXml_iRT_standards,
                     ChromatogramClickPoint = new PointF(10.79F, 3800.0F),
                     //TargetCounts = new[] { 14, 75, 83, 498 },
-                    ScoringModelCoefficients = "-0.5426|-2.3112|7.5216|6.0391|-0.1598|0.6420|0.8686|-0.3133",
-                    MassErrorStats = new[]
-                    {
-                        new[] {3.9, 1.9},
-                        new[] {3.8, 2.3},
-                        new[] {3.8, 1.8},
-                        new[] {3.6, 2.3},
-                        new[] {4.0, 1.7},
-                        new[] {4.4, 1.7},
-                        new[] {3.7, 1.8},
-                    },
-                    DiffPeptideCounts = new[] { 42, 7, 8, 12 },
-                    UnpolishedProteins = 9,
                 };
 
                 SetInstrumentType(new InstrumentSpecificValues
@@ -552,26 +444,17 @@ namespace TestPerf
             TestFilesPersistent = new[] { Path.Combine(ZipFileName, "DDA_search"), Path.Combine(ZipFileName, "DIA") };
         }
 
-        public void ValidateTargets(bool recordMode, int proteinCount, int peptideCount, int precursorCount, int transitionCount, string propName)
+        public void ValidateTargets(bool recordMode, ref int[] expected, int proteinCount, int peptideCount, int precursorCount, int transitionCount)
         {
+            var targetCountsActual = new[] { proteinCount, peptideCount, precursorCount, transitionCount };
             if (recordMode)
             {
-                Console.WriteLine(@"{0} = new[] {{ {1}, {2}, {3}, {4} }},", propName, proteinCount, peptideCount, precursorCount, transitionCount);
+                expected = targetCountsActual;
+                return;
             }
 
-            var targetCountsActual = new[] { proteinCount, peptideCount, precursorCount, transitionCount };
-            if (!ArrayUtil.EqualsDeep(_expectedValues.FinalTargetCounts, targetCountsActual))
-            {
-                if (recordMode)
-                {
-                    _expectedValues.FinalTargetCounts = targetCountsActual;
-                }
-                else
-                {
-                    Assert.Fail("Expected target counts <{0}> do not match actual <{1}>.",
-                        string.Join(", ", _expectedValues.FinalTargetCounts), string.Join(", ", targetCountsActual));
-                }
-            }
+            CollectionAssert.AreEqual(expected, targetCountsActual, "Expected target counts <{0}> do not match actual <{1}>.",
+                string.Join(", ", _expectedValues.FinalTargetCounts), string.Join(", ", targetCountsActual));
         }
     }
 
@@ -591,6 +474,7 @@ namespace TestPerf
         private bool IsDiaNN => _testInfo.IsDiaNN;
         private DiaSwathTestInfo.AnalysisValues _analysisValues => _testInfo._analysisValues;
         private DiaSwathTestInfo.InstrumentSpecificValues _instrumentValues => _testInfo._instrumentValues;
+        private DiaSwathTestInfo.ExpectedValues _expectedValues => _testInfo._expectedValues;
 
         [TestMethod]
         public void TestDiaTtofTutorial()
@@ -778,17 +662,17 @@ namespace TestPerf
                 var row = addIrtPeptidesDlg.GetRow(0);
                 if (IsRecordMode)
                 {
-                    _testInfo._expectedValues.LibraryPeptideCount = addIrtPeptidesDlg.PeptidesCount;
-                    _testInfo._expectedValues.ExpectedIrtPeptideCount = (int) row.Cells[1].Value;
+                    _expectedValues.LibraryPeptideCount = addIrtPeptidesDlg.PeptidesCount;
+                    _expectedValues.ExpectedIrtPeptideCount = (int) row.Cells[1].Value;
                     ParseIrtSlopeAndIntercept((string)row.Cells[2].Value, CultureInfo.CurrentCulture, out var slope, out var intercept);
-                    _testInfo._expectedValues.IrtSlope = slope;
-                    _testInfo._expectedValues.IrtIntercept = intercept;
+                    _expectedValues.IrtSlope = slope;
+                    _expectedValues.IrtIntercept = intercept;
                 }
                 else
                 {
-                    Assert.AreEqual(_testInfo._expectedValues.ExpectedIrtPeptideCount, row.Cells[1].Value);
-                    Assert.AreEqual(_testInfo._expectedValues.LibraryPeptideCount, addIrtPeptidesDlg.PeptidesCount);
-                    var regressionLine = new RegressionLine(_testInfo._expectedValues.IrtSlope, _testInfo._expectedValues.IrtIntercept);
+                    Assert.AreEqual(_expectedValues.ExpectedIrtPeptideCount, row.Cells[1].Value);
+                    Assert.AreEqual(_expectedValues.LibraryPeptideCount, addIrtPeptidesDlg.PeptidesCount);
+                    var regressionLine = new RegressionLine(_expectedValues.IrtSlope, _expectedValues.IrtIntercept);
                     Assert.AreEqual(regressionLine.DisplayEquation, row.Cells[2].Value);
                     //Assert.AreEqual(1.0, double.Parse(row.Cells[3].Value.ToString()));
                 }
@@ -991,13 +875,8 @@ namespace TestPerf
             });
             PauseForScreenShot<ImportPeptideSearchDlg.FastaPage>("Import Peptide Search - Import FASTA page");
 
-            if (IsRecordMode)
-                Console.WriteLine();
-
             var peptidesPerProteinDlg = ShowDialog<AssociateProteinsDlg>(() => importPeptideSearchDlg.ClickNextButton());
             WaitForCondition(() => peptidesPerProteinDlg.DocumentFinalCalculated);
-            if (IsRecordMode)
-                Console.WriteLine();    // Line break after test run information
             RunUI(() =>
             {
                 //int proteinCount, peptideCount, precursorCount, transitionCount;
@@ -1013,7 +892,8 @@ namespace TestPerf
             {
                 int proteinCount, peptideCount, precursorCount, transitionCount;
                 peptidesPerProteinDlg.NewTargetsFinal(out proteinCount, out peptideCount, out precursorCount, out transitionCount);
-                _testInfo.ValidateTargets(IsRecordMode, proteinCount, peptideCount, precursorCount, transitionCount, @"FinalTargetCounts");
+                _testInfo.ValidateTargets(IsRecordMode, ref _expectedValues.FinalTargetCounts, proteinCount,
+                    peptideCount, precursorCount, transitionCount);
             });
             PauseForScreenShot<AssociateProteinsDlg>("Import FASTA summary form");
 
@@ -1030,7 +910,7 @@ namespace TestPerf
             {
                 var peakScoringModelDlg = WaitForOpenForm<EditPeakScoringModelDlg>();
                 PauseForScreenShot<EditPeakScoringModelDlg>("mProphet model form");
-                ValidateCoefficients(peakScoringModelDlg, _analysisValues.ScoringModelCoefficients);
+                ValidateCoefficients(peakScoringModelDlg, ref _expectedValues.ScoringModelCoefficients);
 
                 OkDialog(peakScoringModelDlg, peakScoringModelDlg.OkDialog);
             }
@@ -1040,12 +920,12 @@ namespace TestPerf
             {
                 if (!IsRecordMode)
                 {
-                    Assert.AreEqual(_testInfo._expectedValues.LibraryPeptideCount + _testInfo._expectedValues.ExpectedIrtPeptideCount, docLibrary.LibraryDetails.UniquePeptideCount);
-                    Assert.AreEqual(_testInfo._expectedValues.ExpectedIrtPeptideCount, SkylineWindow.Document.PeptideGroups.First().PeptideCount);
+                    Assert.AreEqual(_expectedValues.LibraryPeptideCount + _expectedValues.ExpectedIrtPeptideCount, docLibrary.LibraryDetails.UniquePeptideCount);
+                    Assert.AreEqual(_expectedValues.ExpectedIrtPeptideCount, SkylineWindow.Document.PeptideGroups.First().PeptideCount);
                 }
                 else
                 {
-                    _testInfo._expectedValues.ExpectedIrtPeptideCount = SkylineWindow.Document.PeptideGroups.First().PeptideCount;
+                    _expectedValues.ExpectedIrtPeptideCount = SkylineWindow.Document.PeptideGroups.First().PeptideCount;
                 }
             });
 
@@ -1216,11 +1096,6 @@ namespace TestPerf
             WaitForGraphs();
             Assert.IsTrue(SkylineWindow.GraphMassError.TryGetGraphPane(out MassErrorHistogramGraphPane massErrorPane));
             int massErrorStatsIndex = 0;
-            if (IsRecordMode)
-            {
-                Console.WriteLine(@"MassErrorStats = new[]");
-                Console.WriteLine(@"{");
-            }
             ValidateMassErrors(massErrorPane, massErrorStatsIndex++);
 
             PauseForScreenShot(SkylineWindow.GraphMassError,"Mass errors histogram graph window");
@@ -1233,11 +1108,6 @@ namespace TestPerf
                 WaitForGraphs();
                 ValidateMassErrors(massErrorPane, massErrorStatsIndex++);
             }
-            if (IsRecordMode)
-            {
-                Console.WriteLine(@"},");
-            }
-
             RunUI(() =>
             {
                 SkylineWindow.ShowPointsTypeMassError(PointsTypeMassError.decoys);
@@ -1306,9 +1176,13 @@ namespace TestPerf
                 {
                     int actualPoints = volcanoPlot.CurveList[4].Points.Count;
                     if (IsRecordMode)
-                        Console.Write(@"DiffPeptideCounts = new[] { " + actualPoints);
+                    {
+                        _expectedValues.DiffPeptideCounts = new[] { actualPoints };
+                    }
                     else
-                        Assert.AreEqual(_analysisValues.DiffPeptideCounts[0], actualPoints);
+                    {
+                        Assert.AreEqual(_expectedValues.DiffPeptideCounts[0], actualPoints);
+                    }
                 });
                 var formattingDlg = ShowDialog<VolcanoPlotFormattingDlg>(volcanoPlot.ShowFormattingDialog);
                 ApplyFormatting(formattingDlg, "ECOLI", "128, 0, 255");
@@ -1330,13 +1204,14 @@ namespace TestPerf
                     {
                         int actualPoints = volcanoPlot.CurveList[7 - i].Points.Count;
                         if (IsRecordMode)
-                            Console.Write(@", " + actualPoints);
+                        {
+                            _expectedValues.DiffPeptideCounts =
+                                _expectedValues.DiffPeptideCounts.Append(actualPoints).ToArray();
+                        }
                         else
-                            Assert.AreEqual(_analysisValues.DiffPeptideCounts[i], actualPoints);
+                            Assert.AreEqual(_expectedValues.DiffPeptideCounts[i], actualPoints);
                     });
                 }
-                if (IsRecordMode)
-                    Console.WriteLine(@" },");
                 PauseForGraphScreenShot("By Condition:Volcano Plot - fully formatted", volcanoPlot);
             }
 
@@ -1357,12 +1232,12 @@ namespace TestPerf
                 if (!IsRecordMode)
                 {
                     for (int i = 1; i < 4; i++)
-                        RunUI(() => Assert.AreEqual(_analysisValues.DiffPeptideCounts[i], volcanoPlot.CurveList[7 - i].Points.Count));
+                        RunUI(() => Assert.AreEqual(_expectedValues.DiffPeptideCounts[i], volcanoPlot.CurveList[7 - i].Points.Count));
                 }
                 var barGraph = WaitForOpenForm<FoldChangeBarGraph>();
                 int volcanoBarDelta = _instrumentValues.DesiredIrtPeptideCount - 1; // iRTs - selected peptide
                 if (!IsRecordMode)
-                    WaitForBarGraphPoints(barGraph, _analysisValues.DiffPeptideCounts[0] - volcanoBarDelta, _analysisValues.DiffPeptideCounts[0] - volcanoBarDelta * 2);
+                    WaitForBarGraphPoints(barGraph, _expectedValues.DiffPeptideCounts[0] - volcanoBarDelta, _expectedValues.DiffPeptideCounts[0] - volcanoBarDelta * 2);
 
                 SortByFoldChange(fcGridControl, _resultProperty);
                 PauseForScreenShot<FoldChangeBarGraph>("By Condition:Bar Graph - peptides");
@@ -1371,14 +1246,12 @@ namespace TestPerf
                 RunUI(() => changeGroupComparisonSettings.RadioScopePerProtein.Checked = true);
 
                 int targetProteinCount = SkylineWindow.Document.MoleculeGroupCount - 2; // minus iRTs and decoys
-                int unpolishedCount = _analysisValues.UnpolishedProteins;
                 if (!IsRecordMode)
-                    WaitForBarGraphPoints(barGraph, unpolishedCount);
+                    WaitForBarGraphPoints(barGraph, _expectedValues.UnpolishedProteins);
                 else
                 {
                     WaitForBarGraphPoints(barGraph, targetProteinCount, 1);
-                    unpolishedCount = GetBarCount(barGraph);
-                    Console.WriteLine(@"UnpolishedProteins = {0},", unpolishedCount);
+                    _expectedValues.UnpolishedProteins = GetBarCount(barGraph);
                 }
 
                 RunUI(() => changeGroupComparisonSettings.ComboSummaryMethod.SelectedItem =
@@ -1388,12 +1261,11 @@ namespace TestPerf
                     return; // fold change bar graphs don't behave the same way for DIA-NN results as for iProphet, so exit early
 
                 if (!IsRecordMode)
-                    WaitForBarGraphPoints(barGraph, _analysisValues.PolishedProteins ?? targetProteinCount);
+                    WaitForBarGraphPoints(barGraph, _expectedValues.PolishedProteins ?? targetProteinCount);
                 else
                 {
-                    WaitForBarGraphPoints(barGraph, targetProteinCount, unpolishedCount);
-                    if (GetBarCount(barGraph) != targetProteinCount)
-                        Console.WriteLine(@"PolishedProteins = {0},", GetBarCount(barGraph));
+                    WaitForBarGraphPoints(barGraph, targetProteinCount, _expectedValues.UnpolishedProteins);
+                    _expectedValues.PolishedProteins = GetBarCount(barGraph);
                 }
 
                 fcGrid = WaitForOpenForm<FoldChangeGrid>();
@@ -1403,9 +1275,9 @@ namespace TestPerf
                 RestoreViewOnScreen(31);
                 barGraph = WaitForOpenForm<FoldChangeBarGraph>();
                 if (!IsRecordMode)
-                    WaitForBarGraphPoints(barGraph, _analysisValues.PolishedProteins ?? targetProteinCount);
+                    WaitForBarGraphPoints(barGraph, _expectedValues.PolishedProteins ?? targetProteinCount);
                 else
-                    WaitForBarGraphPoints(barGraph, targetProteinCount, unpolishedCount);
+                    WaitForBarGraphPoints(barGraph, targetProteinCount, _expectedValues.UnpolishedProteins);
                 RunUIForScreenShot(() =>
                 {
                     var yScale = barGraph.ZedGraphControl.GraphPane.YAxis.Scale;
@@ -1588,22 +1460,16 @@ namespace TestPerf
             });
         }
 
-        private void ValidateCoefficients(EditPeakScoringModelDlg editDlgFromSrm, string expectedCoefficients)
+        private void ValidateCoefficients(EditPeakScoringModelDlg editDlgFromSrm, ref double?[] expectedCoefficients)
         {
-            string coefficients = string.Join(@"|", GetCoefficientStrings(editDlgFromSrm));
-            try
+            var actualCoefficients = GetCoefficients(editDlgFromSrm).ToArray();
+            if (IsRecordMode)
             {
-                AssertEx.AreEqualLines(expectedCoefficients, coefficients);
+                expectedCoefficients = actualCoefficients;
             }
-            catch (AssertFailedException e)
+            else
             {
-                if (IsRecordMode)
-                {
-                    Console.WriteLine(@"ScoringModelCoefficients = ""{0}"",", coefficients); // Not L10N
-                    Console.Error.WriteLine("ScoringModelCoefficients: " + e.Message);
-                }
-                else
-                    throw;
+                AssertEx.AreEqual(string.Join("|", expectedCoefficients), string.Join("|", actualCoefficients));
             }
         }
 
@@ -1611,11 +1477,19 @@ namespace TestPerf
         {
             double mean = massErrorPane.Mean, stdDev = massErrorPane.StdDev;
             if (IsRecordMode)
-                Console.WriteLine(@"new[] {{{0:0.0}, {1:0.0}}},", mean, stdDev);  // Not L10N
+            {
+                _expectedValues.MassErrorStats ??= Array.Empty<double[]>();
+                while (_expectedValues.MassErrorStats.Length <= index)
+                {
+                    _expectedValues.MassErrorStats =
+                        _expectedValues.MassErrorStats.Append(Array.Empty<double>()).ToArray();
+                }
+                _expectedValues.MassErrorStats[index] = new []{ Math.Round(mean, 2), Math.Round(stdDev, 2) };
+            }
             else
             {
-                Assert.AreEqual(_analysisValues.MassErrorStats[index][0], mean, 0.05);
-                Assert.AreEqual(_analysisValues.MassErrorStats[index][1], stdDev, 0.05);
+                Assert.AreEqual(_expectedValues.MassErrorStats[index][0], mean, 0.05);
+                Assert.AreEqual(_expectedValues.MassErrorStats[index][1], stdDev, 0.05);
             }
         }
 
@@ -1861,8 +1735,9 @@ namespace TestPerf
 
                     //Assert.AreEqual(0.95, importPeptideSearchDlg.BuildPepSearchLibControl.Grid.Files.First().ScoreThreshold);
 
-                    _testInfo.ValidateTargets(false, doc.PeptideGroupCount, doc.PeptideCount,
-                        doc.PeptideTransitionGroupCount, doc.PeptideTransitionCount, @"FinalTargetCounts");
+                    _testInfo.ValidateTargets(false, ref _testInfo._expectedValues.FinalTargetCounts,
+                        doc.PeptideGroupCount, doc.PeptideCount, doc.PeptideTransitionGroupCount,
+                        doc.PeptideTransitionCount);
                     //ValidateCoefficients(peakScoringModelDlg, _analysisValues.ScoringModelCoefficients);
                     docContainer.AssertComplete();
                 }

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.cs
@@ -144,6 +144,7 @@ namespace TestPerf
                 {
                     "DDA_search\\interact.pep.xml"
                 },
+                DesiredIrtPeptideCount = 11,
                 IrtStandard = IrtStandard.BIOGNOSYS_11,
                 HasAmbiguousMatches = true,
                 IsolationSchemeName = "ETH TTOF (64 variable)",
@@ -203,6 +204,7 @@ namespace TestPerf
                     "DDA_search\\interact.pep.xml"
                 },
                 IrtStandard = IrtStandard.BIOGNOSYS_11,
+                DesiredIrtPeptideCount = 11,
                 HasAmbiguousMatches = false,
                 IsolationSchemeName = "ETH QE (18 variable)",
                 IsolationSchemeFile = "QE_DIA_18var.tsv",
@@ -261,6 +263,7 @@ namespace TestPerf
                 },
                 HasRedundantLibrary = false,
                 IrtStandard = IrtStandard.AUTO,
+                DesiredIrtPeptideCount = 11,
                 HasAmbiguousMatches = false,
                 IsolationSchemeName = "ETH QE (18 variable)",
                 IsolationSchemeFile = "QE_DIA_18var.tsv",
@@ -1235,9 +1238,12 @@ namespace TestPerf
                         RunUI(() => Assert.AreEqual(_expectedValues.DiffPeptideCounts[i], volcanoPlot.CurveList[7 - i].Points.Count));
                 }
                 var barGraph = WaitForOpenForm<FoldChangeBarGraph>();
-                int volcanoBarDelta = _instrumentValues.DesiredIrtPeptideCount - 1; // iRTs - selected peptide
+                
                 if (!IsRecordMode)
+                {
+                    int volcanoBarDelta = _expectedValues.ExpectedIrtPeptideCount - 1; // iRTs - selected peptide
                     WaitForBarGraphPoints(barGraph, _expectedValues.DiffPeptideCounts[0] - volcanoBarDelta, _expectedValues.DiffPeptideCounts[0] - volcanoBarDelta * 2);
+                }
 
                 SortByFoldChange(fcGridControl, _resultProperty);
                 PauseForScreenShot<FoldChangeBarGraph>("By Condition:Bar Graph - peptides");
@@ -1265,7 +1271,10 @@ namespace TestPerf
                 else
                 {
                     WaitForBarGraphPoints(barGraph, targetProteinCount, _expectedValues.UnpolishedProteins);
-                    _expectedValues.PolishedProteins = GetBarCount(barGraph);
+                    if (_expectedValues.PolishedProteins.HasValue || GetBarCount(barGraph) != targetProteinCount)
+                    {
+                        _expectedValues.PolishedProteins = GetBarCount(barGraph);
+                    }
                 }
 
                 fcGrid = WaitForOpenForm<FoldChangeGrid>();

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestPasefData.json
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestPasefData.json
@@ -1,0 +1,60 @@
+{
+  "LibraryPeptideCount": 6028,
+  "ExpectedIrtPeptideCount": 15,
+  "IrtSlope": 8.765,
+  "IrtIntercept": -54.858,
+  "FinalTargetCounts": [
+    12,
+    75,
+    83,
+    498
+  ],
+  "MassErrorStats": [
+    [
+      3.9,
+      1.94
+    ],
+    [
+      3.76,
+      2.25
+    ],
+    [
+      3.8,
+      1.76
+    ],
+    [
+      3.62,
+      2.34
+    ],
+    [
+      4.05,
+      1.65
+    ],
+    [
+      4.44,
+      1.71
+    ],
+    [
+      3.74,
+      1.83
+    ]
+  ],
+  "DiffPeptideCounts": [
+    42,
+    7,
+    8,
+    12
+  ],
+  "UnpolishedProteins": 9,
+  "PolishedProteins": 9,
+  "ScoringModelCoefficients": [
+    -0.5426,
+    -2.3112,
+    7.5216,
+    6.0391,
+    -0.1598,
+    0.642,
+    0.8686,
+    -0.3133
+  ]
+}

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestPasefData_full.json
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestPasefData_full.json
@@ -1,0 +1,60 @@
+{
+  "LibraryPeptideCount": 22111,
+  "ExpectedIrtPeptideCount": 15,
+  "IrtSlope": 8.621,
+  "IrtIntercept": -51.543,
+  "FinalTargetCounts": [
+    2697,
+    27225,
+    28373,
+    170238
+  ],
+  "MassErrorStats": [
+    [
+      3.64,
+      2.66
+    ],
+    [
+      3.58,
+      2.56
+    ],
+    [
+      3.53,
+      2.71
+    ],
+    [
+      3.66,
+      2.6
+    ],
+    [
+      3.56,
+      2.7
+    ],
+    [
+      3.88,
+      2.61
+    ],
+    [
+      3.61,
+      2.75
+    ]
+  ],
+  "DiffPeptideCounts": [
+    12621,
+    8498,
+    2254,
+    1854
+  ],
+  "UnpolishedProteins": 2314,
+  "PolishedProteins": 2314,
+  "ScoringModelCoefficients": [
+    -0.3356,
+    -0.9056,
+    4.5024,
+    3.5338,
+    -0.1011,
+    0.7388,
+    0.4436,
+    -0.1319
+  ]
+}

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestQeData.json
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestQeData.json
@@ -1,0 +1,60 @@
+{
+  "LibraryPeptideCount": 15855,
+  "ExpectedIrtPeptideCount": 11,
+  "IrtSlope": 2.624,
+  "IrtIntercept": -48.003,
+  "FinalTargetCounts": [
+    13,
+    271,
+    331,
+    1985
+  ],
+  "MassErrorStats": [
+    [
+      1.61,
+      4.18
+    ],
+    [
+      1.35,
+      4.12
+    ],
+    [
+      1.61,
+      4.43
+    ],
+    [
+      1.83,
+      3.7
+    ],
+    [
+      1.84,
+      4.37
+    ],
+    [
+      1.82,
+      4.13
+    ],
+    [
+      1.23,
+      4.34
+    ]
+  ],
+  "DiffPeptideCounts": [
+    139,
+    47,
+    29,
+    52
+  ],
+  "UnpolishedProteins": 9,
+  "PolishedProteins": 9,
+  "ScoringModelCoefficients": [
+    0.3065,
+    -0.7855,
+    4.958,
+    -0.4976,
+    -0.0812,
+    0.7443,
+    0.0988,
+    -0.0542
+  ]
+}

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestQeDataDiaNN.json
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestQeDataDiaNN.json
@@ -1,0 +1,51 @@
+{
+  "LibraryPeptideCount": 21695,
+  "ExpectedIrtPeptideCount": 11,
+  "IrtSlope": 2.6,
+  "IrtIntercept": -44.875,
+  "FinalTargetCounts": [
+    13,
+    275,
+    306,
+    1836
+  ],
+  "MassErrorStats": [
+    [
+      1.78,
+      3.24
+    ],
+    [
+      1.22,
+      3.01
+    ],
+    [
+      1.77,
+      3.02
+    ],
+    [
+      2.05,
+      3.16
+    ],
+    [
+      2.06,
+      3.66
+    ],
+    [
+      1.94,
+      3.17
+    ],
+    [
+      1.63,
+      3.36
+    ]
+  ],
+  "DiffPeptideCounts": [
+    125,
+    41,
+    28,
+    45
+  ],
+  "UnpolishedProteins": 3,
+  "PolishedProteins": 3,
+  "ScoringModelCoefficients": null
+}

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestQeData_full.json
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestQeData_full.json
@@ -1,0 +1,6 @@
+{
+  "LibraryPeptideCount": 15855,
+  "ExpectedIrtPeptideCount": 11,
+  "IrtSlope": 2.624,
+  "IrtIntercept": -48.003
+}

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestQeData_full.json
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestQeData_full.json
@@ -2,5 +2,59 @@
   "LibraryPeptideCount": 15855,
   "ExpectedIrtPeptideCount": 11,
   "IrtSlope": 2.624,
-  "IrtIntercept": -48.003
+  "IrtIntercept": -48.003,
+  "FinalTargetCounts": [
+    2038,
+    21960,
+    24013,
+    144076
+  ],
+  "MassErrorStats": [
+    [
+      1.96,
+      4.7
+    ],
+    [
+      1.46,
+      4.61
+    ],
+    [
+      1.98,
+      4.73
+    ],
+    [
+      2.14,
+      4.63
+    ],
+    [
+      2.1,
+      4.78
+    ],
+    [
+      2.17,
+      4.63
+    ],
+    [
+      1.93,
+      4.75
+    ]
+  ],
+  "DiffPeptideCounts": [
+    10467,
+    6391,
+    2242,
+    1823
+  ],
+  "UnpolishedProteins": 1653,
+  "PolishedProteins": 1653,
+  "ScoringModelCoefficients": [
+    0.3173,
+    -0.8915,
+    3.7829,
+    0.2263,
+    -0.0825,
+    0.7332,
+    0.0012,
+    -0.0606
+  ]
 }

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestTtofData.json
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestTtofData.json
@@ -1,0 +1,60 @@
+{
+  "LibraryPeptideCount": 18600,
+  "ExpectedIrtPeptideCount": 11,
+  "IrtSlope": 2.926,
+  "IrtIntercept": -68.85,
+  "FinalTargetCounts": [
+    13,
+    279,
+    299,
+    1793
+  ],
+  "MassErrorStats": [
+    [
+      3.03,
+      4.37
+    ],
+    [
+      2.78,
+      4.1
+    ],
+    [
+      3.88,
+      4.25
+    ],
+    [
+      5.87,
+      3.58
+    ],
+    [
+      4.69,
+      4.17
+    ],
+    [
+      -0.07,
+      3.42
+    ],
+    [
+      1.01,
+      3.63
+    ]
+  ],
+  "DiffPeptideCounts": [
+    142,
+    44,
+    30,
+    57
+  ],
+  "UnpolishedProteins": 9,
+  "PolishedProteins": 9,
+  "ScoringModelCoefficients": [
+    0.2674,
+    -0.6467,
+    3.4194,
+    -0.0171,
+    -0.4723,
+    0.927,
+    0.0768,
+    -0.0496
+  ]
+}

--- a/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestTtofData_full.json
+++ b/pwiz_tools/Skyline/TestPerf/DiaSwathTutorialTest.data/TestTtofData_full.json
@@ -1,0 +1,60 @@
+{
+  "LibraryPeptideCount": 18600,
+  "ExpectedIrtPeptideCount": 11,
+  "IrtSlope": 2.926,
+  "IrtIntercept": -68.85,
+  "FinalTargetCounts": [
+    2399,
+    26144,
+    27078,
+    162468
+  ],
+  "MassErrorStats": [
+    [
+      2.78,
+      4.56
+    ],
+    [
+      2.43,
+      4.29
+    ],
+    [
+      3.92,
+      4.19
+    ],
+    [
+      5.16,
+      4.08
+    ],
+    [
+      4.48,
+      4.2
+    ],
+    [
+      -0.35,
+      3.93
+    ],
+    [
+      1.03,
+      4.06
+    ]
+  ],
+  "DiffPeptideCounts": [
+    12808,
+    7963,
+    2692,
+    2142
+  ],
+  "UnpolishedProteins": 2207,
+  "PolishedProteins": 2207,
+  "ScoringModelCoefficients": [
+    -0.0842,
+    -0.7447,
+    4.2691,
+    -0.2084,
+    -0.2644,
+    0.7594,
+    0.3124,
+    -0.0659
+  ]
+}

--- a/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
+++ b/pwiz_tools/Skyline/TestTutorial/PeakPickingTutorialTest.cs
@@ -534,7 +534,8 @@ namespace pwiz.SkylineTestTutorial
 
         private void ValidateCoefficients(EditPeakScoringModelDlg editDlgFromSrm, int coeffIndex)
         {
-            string coefficients = string.Join(@"|", GetCoefficientStrings(editDlgFromSrm));
+            string coefficients = string.Join(@"|",
+                GetCoefficients(editDlgFromSrm).Select(v => v?.ToString(CultureInfo.InvariantCulture) ?? " null "));
             if (IsRecordMode)
                 Console.WriteLine(@"""{0}"",", coefficients);
             else

--- a/pwiz_tools/Skyline/TestUtil/AbstractFunctionalTestEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractFunctionalTestEx.cs
@@ -705,16 +705,21 @@ namespace pwiz.SkylineTestUtil
             OkDialog(annotationsListDlg, annotationsListDlg.OkDialog);
         }
 
-        protected IEnumerable<string> GetCoefficientStrings(EditPeakScoringModelDlg editDlg)
+        protected IEnumerable<double?> GetCoefficients(EditPeakScoringModelDlg editDlg)
         {
             for (int i = 0; i < editDlg.PeakCalculatorsGrid.Items.Count; i++)
             {
                 double? weight = editDlg.PeakCalculatorsGrid.Items[i].Weight;
                 if (weight.HasValue)
-                    yield return string.Format(CultureInfo.InvariantCulture, "{0:F04}", weight.Value);
+                    yield return Math.Round(weight.Value, 4);
                 else
-                    yield return " null ";  // To help values line up
+                    yield return null;
             }
+        }
+
+        protected IEnumerable<string> GetCoefficientStrings(EditPeakScoringModelDlg editDlg)
+        {
+            return GetCoefficients(editDlg).Select(v=>v?.ToString(CultureInfo.InvariantCulture) ?? " null ");
         }
 
         public static int CheckDocumentResultsGridValuesRecordedCount;

--- a/pwiz_tools/Skyline/TestUtil/AbstractFunctionalTestEx.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractFunctionalTestEx.cs
@@ -705,21 +705,16 @@ namespace pwiz.SkylineTestUtil
             OkDialog(annotationsListDlg, annotationsListDlg.OkDialog);
         }
 
-        protected IEnumerable<double?> GetCoefficients(EditPeakScoringModelDlg editDlg)
+        protected IEnumerable<string> GetCoefficientStrings(EditPeakScoringModelDlg editDlg)
         {
             for (int i = 0; i < editDlg.PeakCalculatorsGrid.Items.Count; i++)
             {
                 double? weight = editDlg.PeakCalculatorsGrid.Items[i].Weight;
                 if (weight.HasValue)
-                    yield return Math.Round(weight.Value, 4);
+                    yield return string.Format(CultureInfo.InvariantCulture, "{0:F04}", weight.Value);
                 else
-                    yield return null;
+                    yield return " null ";  // To help values line up
             }
-        }
-
-        protected IEnumerable<string> GetCoefficientStrings(EditPeakScoringModelDlg editDlg)
-        {
-            return GetCoefficients(editDlg).Select(v=>v?.ToString(CultureInfo.InvariantCulture) ?? " null ");
         }
 
         public static int CheckDocumentResultsGridValuesRecordedCount;

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2975,12 +2975,21 @@ namespace pwiz.SkylineTestUtil
 
         public static string ParseIrtProperties(string irtFormula, CultureInfo cultureInfo = null)
         {
+            ParseIrtSlopeAndIntercept(irtFormula, cultureInfo??CultureInfo.CurrentCulture, out var slope, out var intercept);
+            return $"IrtSlope = {slope},\r\nIrtIntercept = {intercept},\r\n";
+        }
+
+        public static void ParseIrtSlopeAndIntercept(string irtFormula, CultureInfo cultureInfo, out double slope, out double intercept)
+        {
             var decimalSeparator = (cultureInfo ?? CultureInfo.CurrentCulture).NumberFormat.NumberDecimalSeparator;
             var match = Regex.Match(irtFormula, $@"iRT = (?<slope>\d+{decimalSeparator}\d+) \* [^+-]+? (?<sign>[+-]) (?<intercept>\d+{decimalSeparator}\d+)");
             Assert.IsTrue(match.Success);
-            string slope = match.Groups["slope"].Value, intercept = match.Groups["intercept"].Value, sign = match.Groups["sign"].Value;
-            if (sign == "+") sign = string.Empty;
-            return $"IrtSlope = {slope},\r\nIrtIntercept = {sign}{intercept},\r\n";
+            slope = double.Parse(match.Groups["slope"].Value, cultureInfo);
+            intercept = double.Parse(match.Groups["intercept"].Value);
+            if (match.Groups["sign"].Value == "-")
+            {
+                intercept = -intercept;
+            }
         }
 
         #region Modification helpers


### PR DESCRIPTION
This change moves the expected values out of the code in DiaSwathTutorialTest and puts them in individual text files in the "TestPerf\DiaSwathTutorialTest.data" folder.
