### PR TITLE
Pass correct value for "IgnoreZeroIntensityPoints" when opening MSDataFile

### DIFF
--- a/pwiz_tools/Shared/CommonMsData/OpenMsDataFileParams.cs
+++ b/pwiz_tools/Shared/CommonMsData/OpenMsDataFileParams.cs
@@ -41,7 +41,8 @@ namespace pwiz.CommonMsData
         {
             return new MsDataFileImpl(path, sampleIndex: Math.Max(sampleIndex, 0), lockmassParameters: lockMassParameters,
                 simAsSpectra: SimAsSpectra, requireVendorCentroidedMS1: CentroidMs1,
-                requireVendorCentroidedMS2: CentroidMs2, preferOnlyMsLevel: PreferOnlyMs1 ? 1 : 0);
+                requireVendorCentroidedMS2: CentroidMs2, preferOnlyMsLevel: PreferOnlyMs1 ? 1 : 0,
+                ignoreZeroIntensityPoints: IgnoreZeroIntensityPoints);
         }
     }
 }


### PR DESCRIPTION
Fixed "error reading spectrum" extracting chromatograms from certain data files (reported by Nikki) Skyline used to pass "true" for "IgnoreZeroIntensityPoints", and that got changed to "false" which exposes a "Index was outside the bounds of the array" error in "Agilent::FrameImpl::getCombinedSpectrumData". There might be a different bug in "getCombinedSpectrumData" which we should also fix.