### PR TITLE
Fix "Argument Null Exception" in Library Explorer

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -340,7 +340,7 @@ namespace pwiz.Skyline.Model.Lib
                 {
                     foreach (var scoreTypeName in scoreTypes)
                     {
-                        if (scoreTypesByName.TryGetValue(scoreTypeName, out var scoreType))
+                        if (scoreTypeName != null && scoreTypesByName.TryGetValue(scoreTypeName, out var scoreType))
                         {
                             detailsByFileId[file.Id].ScoreThresholds.Add(scoreType, file.CutoffScore);
                         }


### PR DESCRIPTION
Fixed unhandled error viewing library details on Koina generated library (reported by Hui)