### PR TITLE
* switched to std::filesystem instead of boost::filesystem for canonical() call for WIFF2 files

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -34,7 +34,7 @@ using namespace System::Collections::Generic;
 #include "WiffFile.hpp"
 #endif
 #include "pwiz/utility/misc/Filesystem.hpp"
-
+#include <filesystem>
 using namespace SCIEX::Apis::Data::v1;
 using namespace SCIEX::Apis::Data::v1::Contracts;
 
@@ -300,7 +300,7 @@ WiffFile2Impl::WiffFile2Impl(const string& wiffpath)
     try
     {
         auto sampleRequest = DataReader()->RequestFactory->CreateSamplesReadRequest();
-        sampleRequest->AbsolutePathToWiffFile = ToSystemString(bfs::canonical(wiffpath, bfs::current_path()).string());
+        sampleRequest->AbsolutePathToWiffFile = ToSystemString(std::filesystem::canonical(std::filesystem::u8path(wiffpath)).u8string());
 
         allSamples = gcnew List<ISample^>();
 


### PR DESCRIPTION
* switched to std::filesystem instead of boost::filesystem for canonical() call for WIFF2 files: Wine 10.6-staging has some issue with the symbolic link code used by boost's implementation