### PR TITLE
* switched BiblioSpec usage of bfs::canonical to pwiz::util

### DIFF
--- a/pwiz/utility/misc/Filesystem.cpp
+++ b/pwiz/utility/misc/Filesystem.cpp
@@ -62,6 +62,7 @@
 //#include <boost/xpressive/xpressive.hpp>
 #include <iostream>
 #include <thread>
+#include <filesystem>
 
 using std::string;
 using std::vector;
@@ -523,6 +524,11 @@ PWIZ_API_DECL void copy_directory(const bfs::path& from, const bfs::path& to, bo
         else
             bfs::copy(from, to);
     }
+}
+
+PWIZ_API_DECL bfs::path canonical(const bfs::path from)
+{
+    return PWIZ_API_DECL bfs::path(std::filesystem::canonical(std::filesystem::u8path(from.string())).u8string());
 }
 
 

--- a/pwiz/utility/misc/Filesystem.hpp
+++ b/pwiz/utility/misc/Filesystem.hpp
@@ -122,6 +122,11 @@ PWIZ_API_DECL int expand_pathmask(const bfs::path& pathmask,
 /// - if "ec" is NULL, a boost::filesystem_error is thrown
 PWIZ_API_DECL void copy_directory(const bfs::path& from, const bfs::path& to, bool recursive = true, boost::system::error_code* ec = 0);
 
+
+/// wrapper for std::filesystem::canonical because boost::filesystem::canonical has an issue on Wine
+PWIZ_API_DECL bfs::path canonical(const bfs::path from);
+
+
 PWIZ_API_DECL enum ByteSizeAbbreviation
 {
     /// sizes are treated as multiples of 2;

--- a/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
+++ b/pwiz_aux/msrc/utility/vendor_api/ABI/WiffFile2.ipp
@@ -34,7 +34,6 @@ using namespace System::Collections::Generic;
 #include "WiffFile.hpp"
 #endif
 #include "pwiz/utility/misc/Filesystem.hpp"
-#include <filesystem>
 using namespace SCIEX::Apis::Data::v1;
 using namespace SCIEX::Apis::Data::v1::Contracts;
 
@@ -300,7 +299,7 @@ WiffFile2Impl::WiffFile2Impl(const string& wiffpath)
     try
     {
         auto sampleRequest = DataReader()->RequestFactory->CreateSamplesReadRequest();
-        sampleRequest->AbsolutePathToWiffFile = ToSystemString(std::filesystem::canonical(std::filesystem::u8path(wiffpath)).u8string());
+        sampleRequest->AbsolutePathToWiffFile = ToSystemString(pwiz::util::canonical(wiffpath).string());
 
         allSamples = gcnew List<ISample^>();
 

--- a/pwiz_tools/BiblioSpec/src/BuildParser.cpp
+++ b/pwiz_tools/BiblioSpec/src/BuildParser.cpp
@@ -248,10 +248,10 @@ string BuildParser::filesNotFoundMessage(
         messageString += "\n" + specfileroot;
 
     bfs::path deepestPath = filepath_.empty() ? bfs::current_path() : bfs::path(filepath_);
-    messageString += "\n\nIn any of the following directories:\n" + bfs::canonical(deepestPath).make_preferred().string();
+    messageString += "\n\nIn any of the following directories:\n" + pwiz::util::canonical(deepestPath).make_preferred().string();
     set<string> parentPaths;
     for (const auto& dir : directories)
-        parentPaths.insert((bfs::path(dir).is_absolute() ? dir : bfs::canonical(deepestPath / dir)).make_preferred().string());
+        parentPaths.insert((bfs::path(dir).is_absolute() ? dir : pwiz::util::canonical(deepestPath / dir)).make_preferred().string());
     for (const auto& dir : boost::make_iterator_range(parentPaths.rbegin(), parentPaths.rend()))
         messageString += "\n" + dir;
 

--- a/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/MaxQuantReader.cpp
@@ -228,7 +228,7 @@ void MaxQuantReader::initFixedModifications()
                 {
                     // Not there, error
                     Verbosity::error("mqpar.xml file not found. Please move it to the directory %s "
-                        "with the msms.txt file.", filesystem::canonical(tsvDir).string().c_str());
+                        "with the msms.txt file.", pwiz::util::canonical(tsvDir).string().c_str());
                 }
             }
         }


### PR DESCRIPTION
* wrapped std::filesystem::canonical in a pwiz::util function that returns bfs::path
* switched BiblioSpec usage of bfs::canonical to pwiz::util