### PR TITLE
Simplify HardklorReader explicit RT handling by moving logic into the  parent sslReader class

### DIFF
--- a/pwiz_tools/BiblioSpec/src/HardklorReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/HardklorReader.cpp
@@ -107,37 +107,6 @@ namespace BiblioSpec {
         SslReader::addDataLine(data);
     }
 
-    bool HardklorReader::getSpectrum(PSM* psm,
-        SPEC_ID_TYPE findBy,
-        SpecData& returnData,
-        bool getPeaks)
-    {
-        bool isMS1 = psm->isPrecursorOnly();
-        if (isMS1)
-        {
-            getPeaks = false;
-            if (psm->specKey < 0 && findBy == SPEC_ID_TYPE::SCAN_NUM_ID)
-            {
-                findBy = NAME_ID; // Look up by constructed ID since there's no actual spectrum associated
-            }
-        }
-        bool success = !getPeaks;
-        if (getPeaks)
-        {
-            switch (findBy) {
-            case NAME_ID:
-                success = SslReader::getSpectrum(psm->specName, returnData, getPeaks);
-                break;
-            case SCAN_NUM_ID:
-                success = SslReader::getSpectrum(psm->specKey, returnData, findBy, getPeaks);
-                break;
-            case INDEX_ID:
-                success = SslReader::getSpectrum(psm->specIndex, returnData, findBy, getPeaks);
-                break;
-            }
-        }
-        return success;
-    };
     
 } // namespace
 

--- a/pwiz_tools/BiblioSpec/src/HardklorReader.h
+++ b/pwiz_tools/BiblioSpec/src/HardklorReader.h
@@ -44,7 +44,6 @@ class HardklorReader : public SslReader {
     ~HardklorReader();
 
     virtual void setColumnsAndSeparators(DelimitedFileReader<sslPSM> &fileReader);
-    virtual bool getSpectrum(PSM* psm, SPEC_ID_TYPE findBy, SpecData& returnData, bool getPeaks);
     virtual void addDataLine(sslPSM& data); // from DelimitedFileConsumer
 
 private:

--- a/pwiz_tools/BiblioSpec/src/SslReader.cpp
+++ b/pwiz_tools/BiblioSpec/src/SslReader.cpp
@@ -104,16 +104,6 @@ SslReader::SslReader(BlibBuilder& maker,
           psms.push_back(curPSM);
       }
 
-      if (newPSM.rtInfo.retentionTime != 0 || newPSM.rtInfo.startTime != 0)
-      {
-          int identifier = newPSM.specKey;
-          if (newPSM.specIndex != -1) // not default value means scan id is index=<index>
-              identifier = newPSM.specIndex;
-          else if (newPSM.specKey == -1) // default value
-              identifier = std::hash<string>()(newPSM.specName);
-
-          overrideRt_[identifier] = newPSM.rtInfo;
-      }
   }
 
   void SslReader::setColumnsAndSeparators(DelimitedFileReader<sslPSM> &fileReader)
@@ -222,44 +212,44 @@ SslReader::SslReader(BlibBuilder& maker,
     }
     return vector<PSM_SCORE_TYPE>(allScoreTypes.begin(), allScoreTypes.end());
   }
-  
-  bool SslReader::getSpectrum(int identifier,
-                              SpecData& returnData,
-                              SPEC_ID_TYPE type,
-                              bool getPeaks) {
-    if (PwizReader::getSpectrum(identifier, returnData, type, getPeaks))
-    {
-      map<int, RTINFO>::const_iterator i = overrideRt_.find(identifier);
-      if (i != overrideRt_.end()) {
-          setRtInfo(returnData, i->second);
+
+  bool SslReader::getSpectrum(PSM* psm,
+      SPEC_ID_TYPE findBy,
+      SpecData& returnData,
+      bool getPeaks)
+  {
+      bool isMS1 = psm->isPrecursorOnly();
+      if (isMS1)
+      {
+          getPeaks = false;
+          if (psm->specKey < 0 && findBy == SPEC_ID_TYPE::SCAN_NUM_ID)
+          {
+              findBy = NAME_ID; // Look up by constructed ID since there's no actual spectrum associated
+          }
       }
-      return true;
-    }
-    return false;
-  }
-
-  void SslReader::setRtInfo(SpecData& returnData, const RTINFO &rtInfo) {
-    if (rtInfo.retentionTime != 0)
-        returnData.retentionTime = rtInfo.retentionTime;
-    if (rtInfo.startTime != 0)
-        returnData.startTime = rtInfo.startTime;
-    if (rtInfo.endTime != 0)
-        returnData.endTime = rtInfo.endTime;
-}
-
-  bool SslReader::getSpectrum(string identifier,
-                              SpecData& returnData,
-                              bool getPeaks) {
-    if (PwizReader::getSpectrum(identifier, returnData, getPeaks))
-    {
-        map<int, RTINFO>::const_iterator i = overrideRt_.find(std::hash<string>()(identifier));
-        if (i != overrideRt_.end()) {
-            setRtInfo(returnData, i->second);
-        }
-        return true;
-    }
-    return false;
-  }
+      bool success = true;
+      if (getPeaks)
+      {
+          switch (findBy) {
+          case NAME_ID:
+              success = PwizReader::getSpectrum(psm->specName, returnData, getPeaks);
+              break;
+          case SCAN_NUM_ID:
+              success = PwizReader::getSpectrum(psm->specKey, returnData, findBy, getPeaks);
+              break;
+          case INDEX_ID:
+              success = PwizReader::getSpectrum(psm->specIndex, returnData, findBy, getPeaks);
+              break;
+          }
+      }
+      if (dynamic_cast<sslPSM*>(psm)->rtInfo.retentionTime != 0)
+      {
+          returnData.retentionTime = dynamic_cast<sslPSM*>(psm)->rtInfo.retentionTime;
+          returnData.startTime = dynamic_cast<sslPSM*>(psm)->rtInfo.startTime;
+          returnData.endTime = dynamic_cast<sslPSM*>(psm)->rtInfo.endTime;
+      }
+      return success;
+  };
 
   /**
    * Finds modifications of the form [+/-float] and for each for each inserts

--- a/pwiz_tools/BiblioSpec/src/SslReader.h
+++ b/pwiz_tools/BiblioSpec/src/SslReader.h
@@ -29,6 +29,7 @@ namespace BiblioSpec {
 // classes and functions to use with the DelimitedFileReader
 struct RTINFO
 {
+    // Parsed RT info - overrides anythng you'd look up in scan data
     // All times in minutes
     double retentionTime;
     double startTime;
@@ -39,7 +40,7 @@ class sslPSM : public PSM {
   public:
     std::string filename; 
     PSM_SCORE_TYPE scoreType;
-    RTINFO rtInfo; // RT, startT, endT in minutes
+    RTINFO rtInfo; // Parsed RT info, overrides anything that might be looked up in scans
 
     sslPSM() : PSM(), scoreType(UNKNOWN_SCORE_TYPE)
     {
@@ -252,15 +253,10 @@ class SslReader : public BuildParser, DelimitedFileConsumer<sslPSM>, public Pwiz
     vector<PSM_SCORE_TYPE> getScoreTypes(); // inherited from BuildParser
     virtual void addDataLine(sslPSM& data); // from DelimitedFileConsumer
     virtual void setColumnsAndSeparators(DelimitedFileReader<sslPSM> &fileReader);
-
-    virtual bool getSpectrum(int identifier,
-                             SpecData& returnData,
-                             SPEC_ID_TYPE type,
-                             bool getPeaks);
-
-    virtual bool getSpectrum(string specName,
-                             SpecData& returnData,
-                             bool getPeaks);
+    virtual bool getSpectrum(PSM* psm,
+        SPEC_ID_TYPE findBy,
+        SpecData& returnData,
+        bool getPeaks);
 
   protected:
     string sslName_;
@@ -269,12 +265,9 @@ class SslReader : public BuildParser, DelimitedFileConsumer<sslPSM>, public Pwiz
     map<string, vector<PSM*> > fileMap_; // vector of PSMs for each spec file
     map<string, PSM_SCORE_TYPE> fileScoreTypes_; // score type for each file
 
-    map<int, RTINFO> overrideRt_; // forced retention times (key is scan number)
-
     void parseModSeq(vector<SeqMod>& mods, string& modSeq);
     void unmodifySequence(string& seq);
     string parseCrosslinkedSequence(vector<SeqMod>& mods, const string& modSeq);
-    static void setRtInfo(SpecData& returnData, const RTINFO& rtInfo);
   };
 
 } // namespace


### PR DESCRIPTION
Solves an issue with reading SSL files with explicit retention times and scan IDs duplicated across multiple files, as well as simplifying unnecessarily complicated (and faulty) logic