### PR TITLE
Added a test to check if available disk space is less than 5% of total

### DIFF
--- a/pwiz_tools/Skyline/Test/DiskSpaceTest.cs
+++ b/pwiz_tools/Skyline/Test/DiskSpaceTest.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Original author: Aaron Banse <abanse .at. uw dot edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.Common.SystemUtil;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTest
+{
+    [TestClass]
+    // Test to ensure there is enough space on the disk before starting.
+    public class DiskSpaceTest : AbstractUnitTest
+    {
+        private const double MIN_SPACE_PERCENT = .05;
+
+        [TestMethod]
+        public void TestIsDiskFull()
+        {
+            DriveInfo drive = new DriveInfo(Path.GetPathRoot(TestContext.TestDir));
+            Assert.IsTrue((double)drive.TotalFreeSpace / drive.TotalSize > MIN_SPACE_PERCENT, 
+                $"The disk has less than {MIN_SPACE_PERCENT * 100}% of space remaining.");
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Test/DiskSpaceTest.cs
+++ b/pwiz_tools/Skyline/Test/DiskSpaceTest.cs
@@ -1,6 +1,8 @@
 ﻿/*
  * Original author: Aaron Banse <abanse .at. uw dot edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
+ *         
+ * Copyright 2025 University of Washington - Seattle, WA
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pwiz_tools/Skyline/Test/DiskSpaceTest.cs
+++ b/pwiz_tools/Skyline/Test/DiskSpaceTest.cs
@@ -24,7 +24,8 @@ using pwiz.SkylineTestUtil;
 namespace pwiz.SkylineTest
 {
     [TestClass]
-    // Test to ensure there is enough space on the disk before starting.
+    // Test to see if there is less than 5% of space left on disk.
+    // Necessary to prevent unrelated tests failing when an issue causes disk to fill up.
     public class DiskSpaceTest : AbstractUnitTest
     {
         private const double MIN_SPACE_PERCENT = .05;

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -278,6 +278,7 @@
     <Compile Include="SSRCalc3Test.cs" />
     <Compile Include="StatisticsTest.cs" />
     <Compile Include="StringHelpersTest.cs" />
+    <Compile Include="DiskSpaceTest.cs" />
     <Compile Include="TestSerializeIsolationScheme.cs" />
     <Compile Include="TextUtilTest.cs" />
     <Compile Include="TimeIntervalsTest.cs" />


### PR DESCRIPTION
Necessary to prevent unrelated tests failing inadvertently when an issue causes the disk to fill up.