### PR TITLE
Keep cookie token encrypted while stored, only decrypt when accessed for API call

### DIFF
--- a/pwiz_tools/Shared/CommonMsData/CommonMsData.csproj
+++ b/pwiz_tools/Shared/CommonMsData/CommonMsData.csproj
@@ -90,6 +90,7 @@
     <Compile Include="RemoteApi\Ardia\CompleteMultiPartUploadRequest.cs" />
     <Compile Include="RemoteApi\Ardia\CreateFolderRequest.cs" />
     <Compile Include="RemoteApi\Ardia\CreateDocumentRequest.cs" />
+    <Compile Include="RemoteApi\Ardia\EncryptedToken.cs" />
     <Compile Include="RemoteApi\Ardia\GetParentFolderResponse.cs" />
     <Compile Include="RemoteApi\Ardia\StageDocumentRequest.cs" />
     <Compile Include="RemoteApi\Ardia\StorageInfoResponse.cs" />

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
@@ -199,7 +199,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
 
         public bool HasToken()
         {
-            return !EncryptedToken.IsNullOrEmpty(Token);
+            return !Token.IsNullOrEmpty();
         }
 
         #region Implementation of IXmlSerializable
@@ -232,7 +232,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
             base.WriteXml(writer);
             writer.WriteAttributeString(ATTR.delete_after_import.ToString(), DeleteRawAfterImport.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
 
-            if (!EncryptedToken.IsNullOrEmpty(Token))
+            if (!Token.IsNullOrEmpty())
             {
                 writer.WriteAttributeString(ATTR.token.ToString(), Token.Encrypted);
             }

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
@@ -199,7 +199,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
 
         public bool HasToken()
         {
-            return !string.IsNullOrEmpty(Token.Encrypted);
+            return !EncryptedToken.IsNullOrEmpty(Token);
         }
 
         #region Implementation of IXmlSerializable

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
@@ -47,18 +47,18 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
     public class ArdiaAccount : RemoteAccount
     {
         // TEST ONLY
-        public static readonly ArdiaAccount DEFAULT = new ArdiaAccount(string.Empty, string.Empty, string.Empty, string.Empty);
+        public static readonly ArdiaAccount DEFAULT = new ArdiaAccount(string.Empty, string.Empty, string.Empty, EncryptedToken.Empty);
 
         public override RemoteAccountType AccountType => RemoteAccountType.ARDIA;
         public bool DeleteRawAfterImport { get; private set; }
-        public string Token { get; internal set; }
+        public EncryptedToken Token { get; internal set; }
 
         // TEST ONLY properties for supporting the automated tests in class ArdiaTest
         public string TestingOnly_NotSerialized_Role { get; private set; }
         public string TestingOnly_NotSerialized_Username { get; private set; }
         public string TestingOnly_NotSerialized_Password { get; private set; }
 
-        public ArdiaAccount(string serverUrl, string username, string password, string token)
+        public ArdiaAccount(string serverUrl, string username, string password, EncryptedToken token)
         {
             ServerUrl = serverUrl;
             Username = username;
@@ -161,7 +161,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
             return result;
         }
 
-        public ArdiaAccount ChangeToken(string token)
+        public ArdiaAccount ChangeToken(EncryptedToken token)
         {
             var result = ChangeProp(ImClone(this), im => im.Token = token);
             result._authenticatedHttpClientFactory = _authenticatedHttpClientFactory;
@@ -199,7 +199,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
 
         public bool HasToken()
         {
-            return !string.IsNullOrEmpty(Token);
+            return !string.IsNullOrEmpty(Token.Encrypted);
         }
 
         #region Implementation of IXmlSerializable
@@ -220,10 +220,10 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
             base.ReadXElement(xElement);
             DeleteRawAfterImport = Convert.ToBoolean((string)xElement.Attribute(ATTR.delete_after_import.ToString()));
 
-            var tokenString = (string)xElement.Attribute(ATTR.token.ToString());
-            if (!string.IsNullOrEmpty(tokenString))
+            var encryptedTokenString = (string)xElement.Attribute(ATTR.token.ToString());
+            if (!string.IsNullOrEmpty(encryptedTokenString))
             {
-                Token = tokenString;
+                Token = EncryptedToken.FromEncryptedString(encryptedTokenString);
             }
         }
 
@@ -232,9 +232,9 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
             base.WriteXml(writer);
             writer.WriteAttributeString(ATTR.delete_after_import.ToString(), DeleteRawAfterImport.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
 
-            if (!string.IsNullOrEmpty(Token))
+            if (!EncryptedToken.IsNullOrEmpty(Token))
             {
-                writer.WriteAttributeString(ATTR.token.ToString(), Token);
+                writer.WriteAttributeString(ATTR.token.ToString(), Token.Encrypted);
             }
         }
 
@@ -258,7 +258,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
                 return false;
             if (!Equals(DeleteRawAfterImport, obj.DeleteRawAfterImport))
                 return false;
-            if(!string.Equals(Token, obj.Token))
+            if(!string.Equals(Token.Encrypted, obj.Token.Encrypted))
                 return false;
 
             if (!Equals(TestingOnly_NotSerialized_Role, obj.TestingOnly_NotSerialized_Role))

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
@@ -224,7 +224,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
             var tokenString = (string)xElement.Attribute(ATTR.token.ToString());
             if (!string.IsNullOrEmpty(tokenString))
             {
-                Token = CommonTextUtil.DecryptString(tokenString);
+                Token = tokenString;
             }
         }
 
@@ -235,7 +235,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
 
             if (!string.IsNullOrEmpty(Token))
             {
-                writer.WriteAttributeString(ATTR.token.ToString(), CommonTextUtil.EncryptString(Token));
+                writer.WriteAttributeString(ATTR.token.ToString(), Token);
             }
         }
 

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaAccount.cs
@@ -23,7 +23,6 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Serialization;
 using pwiz.Common.Collections;
-using pwiz.Common.SystemUtil;
 
 // BUG: now that access tokens are stored across sessions Skyline sessions, a new bug is exposed where EditRemoteAccountDlg shows
 //      the Ardia account as "not logged in" if it has not already talked with the remote API during the Skyline session.

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaClient.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaClient.cs
@@ -81,7 +81,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
             }
 
             var token = ArdiaCredentialHelper.GetToken(account);
-            if (EncryptedToken.IsNullOrEmpty(token))
+            if (token.IsNullOrEmpty())
             {
                 throw new IOException(ArdiaResources.Error_InvalidToken);
             }
@@ -121,7 +121,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
             return partSizeMBs >= 5 && partSizeMBs < 2048;
         }
 
-        public bool HasCredentials => !string.IsNullOrWhiteSpace(ApplicationCode) && !EncryptedToken.IsNullOrEmpty(Token);
+        public bool HasCredentials => !string.IsNullOrWhiteSpace(ApplicationCode) && !Token.IsNullOrEmpty();
         private ArdiaAccount Account { get; }
         private string ApplicationCode { get; }
         private EncryptedToken Token { get; }

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaClient.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaClient.cs
@@ -124,8 +124,8 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
         public bool HasCredentials => !string.IsNullOrWhiteSpace(ApplicationCode) && !string.IsNullOrWhiteSpace(Token);
         private ArdiaAccount Account { get; }
         private string ApplicationCode { get; }
-        private string _encryptedToken;
-        public string Token => !_encryptedToken.IsNullOrEmpty() ? CommonTextUtil.DecryptString(_encryptedToken) : null;
+        private readonly string _encryptedToken;
+        private string Token => !_encryptedToken.IsNullOrEmpty() ? CommonTextUtil.DecryptString(_encryptedToken) : null;
         private Uri ServerUri { get; }
 
         /// <summary>

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaClient.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaClient.cs
@@ -69,7 +69,6 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
         private const string PATH_STORAGE_INFO               = @"/session-management/bff/raw-data/api/v1/rawdata/storageInfo";
         private const string PATH_SESSION_COOKIE             = @"/session-management/bff/session-management/api/v1/SessionManagement/sessioncookie";
         private const string PATH_GET_PARENT_BY_PATH         = @"/session-management/bff/navigation/api/v1/navigation/path";
-        private const string PATH_DATA_EXPLORER              = @"/app/data-explorer";
 
         // CONSIDER: throw IOException as a placeholder for improving the experience of editing Remote Account settings. It should
         //           not be possible to exit the settings editor when the account is invalid.

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaClient.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaClient.cs
@@ -97,7 +97,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
             Account = account;
             ServerUri = new Uri(serverUrl);
             ApplicationCode = applicationCode;
-            Token = token;
+            _encryptedToken = token;
             UploadPartSizeMBs = DEFAULT_PART_SIZE_MB;
         }
 
@@ -124,7 +124,8 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
         public bool HasCredentials => !string.IsNullOrWhiteSpace(ApplicationCode) && !string.IsNullOrWhiteSpace(Token);
         private ArdiaAccount Account { get; }
         private string ApplicationCode { get; }
-        private string Token { get; }
+        private string _encryptedToken;
+        public string Token => !_encryptedToken.IsNullOrEmpty() ? CommonTextUtil.DecryptString(_encryptedToken) : null;
         private Uri ServerUri { get; }
 
         /// <summary>

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaCredentialHelper.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaCredentialHelper.cs
@@ -35,7 +35,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
         {
             Assume.IsNotNull(account);
 
-            account.Token = token;
+            account.Token = CommonTextUtil.EncryptString(token);
         }
 
         public static string GetApplicationCode(ArdiaAccount account)

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaCredentialHelper.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/ArdiaCredentialHelper.cs
@@ -24,7 +24,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
     {
         private static readonly IDictionary<string, string> CACHE = new Dictionary<string, string>();
 
-        public static string GetToken(ArdiaAccount account)
+        public static EncryptedToken GetToken(ArdiaAccount account)
         {
             Assume.IsNotNull(account);
 
@@ -35,7 +35,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
         {
             Assume.IsNotNull(account);
 
-            account.Token = CommonTextUtil.EncryptString(token);
+            account.Token = EncryptedToken.FromString(token);
         }
 
         public static string GetApplicationCode(ArdiaAccount account)

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/EncryptedToken.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/EncryptedToken.cs
@@ -1,30 +1,39 @@
-﻿using pwiz.Common.Collections;
+﻿/*
+ * Copyright 2025 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using pwiz.Common.Collections;
 using pwiz.Common.SystemUtil;
 
 namespace pwiz.CommonMsData.RemoteApi.Ardia
 {
     public class EncryptedToken
     {
-        public string Encrypted { get; private set; }
-        public string Decrypted => !IsNullOrEmpty(this) ? CommonTextUtil.DecryptString(Encrypted) : "";
+        public string Encrypted { get; }
+        public string Decrypted => !IsNullOrEmpty(this) ? CommonTextUtil.DecryptString(Encrypted) : string.Empty;
         public static bool IsNullOrEmpty(EncryptedToken token) => token == null || token.Encrypted.IsNullOrEmpty();
 
-        private EncryptedToken(string token)
+        private EncryptedToken(string encryptedToken)
         {
-            Encrypted = CommonTextUtil.EncryptString(token);
+            Encrypted = encryptedToken;
         }
 
-        public static EncryptedToken FromString(string token) => new EncryptedToken(token);
+        public static EncryptedToken FromString(string token) => new EncryptedToken(CommonTextUtil.EncryptString(token));
 
-        public static EncryptedToken FromEncryptedString(string encryptedToken)
-        {
-            var token = new EncryptedToken("");
-            {
-                token.Encrypted = encryptedToken;
-            };
-            return token;
-        }
+        public static EncryptedToken FromEncryptedString(string encryptedToken) => new EncryptedToken(encryptedToken);
 
-        public static EncryptedToken Empty => new EncryptedToken("");
+        public static EncryptedToken Empty => new EncryptedToken(string.Empty);
     }
 }

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/EncryptedToken.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/EncryptedToken.cs
@@ -22,8 +22,7 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
     public class EncryptedToken
     {
         public string Encrypted { get; }
-        public string Decrypted => !IsNullOrEmpty(this) ? CommonTextUtil.DecryptString(Encrypted) : string.Empty;
-        public static bool IsNullOrEmpty(EncryptedToken token) => token == null || token.Encrypted.IsNullOrEmpty();
+        public string Decrypted => !this.IsNullOrEmpty() ? CommonTextUtil.DecryptString(Encrypted) : string.Empty;
 
         private EncryptedToken(string encryptedToken)
         {
@@ -35,5 +34,13 @@ namespace pwiz.CommonMsData.RemoteApi.Ardia
         public static EncryptedToken FromEncryptedString(string encryptedToken) => new EncryptedToken(encryptedToken);
 
         public static EncryptedToken Empty => new EncryptedToken(string.Empty);
+    }
+
+    public static class Extensions
+    {
+        public static bool IsNullOrEmpty(this EncryptedToken token)
+        {
+            return token == null || token.Encrypted.IsNullOrEmpty();
+        }
     }
 }

--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/EncryptedToken.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/Ardia/EncryptedToken.cs
@@ -1,0 +1,30 @@
+﻿using pwiz.Common.Collections;
+using pwiz.Common.SystemUtil;
+
+namespace pwiz.CommonMsData.RemoteApi.Ardia
+{
+    public class EncryptedToken
+    {
+        public string Encrypted { get; private set; }
+        public string Decrypted => !IsNullOrEmpty(this) ? CommonTextUtil.DecryptString(Encrypted) : "";
+        public static bool IsNullOrEmpty(EncryptedToken token) => token == null || token.Encrypted.IsNullOrEmpty();
+
+        private EncryptedToken(string token)
+        {
+            Encrypted = CommonTextUtil.EncryptString(token);
+        }
+
+        public static EncryptedToken FromString(string token) => new EncryptedToken(token);
+
+        public static EncryptedToken FromEncryptedString(string encryptedToken)
+        {
+            var token = new EncryptedToken("");
+            {
+                token.Encrypted = encryptedToken;
+            };
+            return token;
+        }
+
+        public static EncryptedToken Empty => new EncryptedToken("");
+    }
+}

--- a/pwiz_tools/Skyline/Alerts/ArdiaLoginDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/ArdiaLoginDlg.cs
@@ -292,11 +292,11 @@ namespace pwiz.Skyline.Alerts
         {
             try
             {
-                var sessionCookieString = ArdiaCredentialHelper.GetToken(Account);
+                var sessionCookie = ArdiaCredentialHelper.GetToken(Account);
 
-                if (!string.IsNullOrEmpty(sessionCookieString))
+                if (!EncryptedToken.IsNullOrEmpty(sessionCookie))
                 {
-                    _bffCookie = new Cookie(@"Bff-Host", sessionCookieString);
+                    _bffCookie = new Cookie(@"Bff-Host", sessionCookie.Decrypted);
                     AuthenticatedHttpClientFactory = GetFactory();
 
                     // Check that cookie is still valid by calling the remote API and checking for a successful response

--- a/pwiz_tools/Skyline/Alerts/ArdiaLoginDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/ArdiaLoginDlg.cs
@@ -294,7 +294,7 @@ namespace pwiz.Skyline.Alerts
             {
                 var sessionCookie = ArdiaCredentialHelper.GetToken(Account);
 
-                if (!EncryptedToken.IsNullOrEmpty(sessionCookie))
+                if (!sessionCookie.IsNullOrEmpty())
                 {
                     _bffCookie = new Cookie(@"Bff-Host", sessionCookie.Decrypted);
                     AuthenticatedHttpClientFactory = GetFactory();

--- a/pwiz_tools/Skyline/Test/ArdiaMarshalingTest.cs
+++ b/pwiz_tools/Skyline/Test/ArdiaMarshalingTest.cs
@@ -30,7 +30,7 @@ namespace pwiz.SkylineTest
         [TestMethod]
         public void TestArdiaAccountUserConfigSettings()
         {
-            var ardiaAccount = new ArdiaAccount("https://ardiaserver.example.com", "ardia_username", "ardia password", "ardia token value");
+            var ardiaAccount = new ArdiaAccount("https://ardiaserver.example.com", "ardia_username", "ardia password", EncryptedToken.FromString("ardia token value"));
 
             var remoteAccountList = new RemoteAccountList { ardiaAccount };
 
@@ -40,12 +40,12 @@ namespace pwiz.SkylineTest
             var accountListXml = stringWriter.ToString();
 
             // token's plaintext value should not be in serialized XML
-            Assert.AreEqual(-1, accountListXml.IndexOf(ardiaAccount.Token, StringComparison.Ordinal));
+            Assert.AreEqual(-1, accountListXml.IndexOf(ardiaAccount.Token.Decrypted, StringComparison.Ordinal), $"{accountListXml}");
 
             var deserializedAccountList = (RemoteAccountList)xmlSerializer.Deserialize(new StringReader(accountListXml));
             Assert.AreEqual(remoteAccountList.Count, deserializedAccountList.Count);
             Assert.AreEqual(ardiaAccount, deserializedAccountList[0]);
-            Assert.AreEqual(ardiaAccount.Token, ((ArdiaAccount)deserializedAccountList[0]).Token);
+            Assert.AreEqual(ardiaAccount.Token.Encrypted, ((ArdiaAccount)deserializedAccountList[0]).Token.Encrypted);
         }
     }
 }

--- a/pwiz_tools/Skyline/Test/EncryptedTokenTest.cs
+++ b/pwiz_tools/Skyline/Test/EncryptedTokenTest.cs
@@ -15,17 +15,29 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.CommonMsData.RemoteApi.Ardia;
 using pwiz.SkylineTestUtil;
 
 namespace pwiz.SkylineTest
 {
     [TestClass]
-    public class EncryptedTokenTest : AbstractUnitTestEx
+    public class EncryptedTokenTest : AbstractUnitTest
     {
         [TestMethod]
         public void TestEncryptedToken()
         {
+            const string tokenString = "token value";
+            var tokenFromDecrypted = EncryptedToken.FromString(tokenString);
+            Assert.AreEqual(tokenString, tokenFromDecrypted.Decrypted);
+            Assert.IsFalse(tokenFromDecrypted.IsNullOrEmpty());
 
+            var tokenFromEncrypted = EncryptedToken.FromEncryptedString(tokenFromDecrypted.Encrypted);
+            Assert.AreEqual(tokenString, tokenFromEncrypted.Decrypted);
+            Assert.IsFalse(tokenFromEncrypted.IsNullOrEmpty());
+            
+            EncryptedToken nullToken = null;
+            Assert.IsTrue(nullToken.IsNullOrEmpty());
+            Assert.IsTrue(EncryptedToken.Empty.IsNullOrEmpty());
         }
     }
 }

--- a/pwiz_tools/Skyline/Test/EncryptedTokenTest.cs
+++ b/pwiz_tools/Skyline/Test/EncryptedTokenTest.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * Copyright 2025 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.SkylineTestUtil;
+
+namespace pwiz.SkylineTest
+{
+    [TestClass]
+    public class EncryptedTokenTest : AbstractUnitTestEx
+    {
+        [TestMethod]
+        public void TestEncryptedToken()
+        {
+
+        }
+    }
+}

--- a/pwiz_tools/Skyline/Test/Test.csproj
+++ b/pwiz_tools/Skyline/Test/Test.csproj
@@ -174,6 +174,7 @@
     <Compile Include="CmdLineAssociateProteinsTest.cs" />
     <Compile Include="CommandLineThermoMethodTest.cs" />
     <Compile Include="ElibQuantifiableTransitionTest.cs" />
+    <Compile Include="EncryptedTokenTest.cs" />
     <Compile Include="ErrorIfPersistentFilesDirModifiedTest.cs" />
     <Compile Include="FastaSequenceTest.cs" />
     <Compile Include="FilteredMessageWriterTest.cs" />

--- a/pwiz_tools/Skyline/TestConnected/ArdiaFileUploadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/ArdiaFileUploadTest.cs
@@ -71,7 +71,7 @@ namespace pwiz.SkylineTestConnected
             Assert.AreEqual(1, Settings.Default.RemoteAccountList.Count);
 
             account = (ArdiaAccount)Settings.Default.RemoteAccountList[0];
-            AssertEx.IsTrue(!string.IsNullOrEmpty(account.Token), "Ardia account does not have a token.");
+            AssertEx.IsTrue(!EncryptedToken.IsNullOrEmpty(account.Token), "Ardia account does not have a token.");
 
             // Test scenarios 
             TestGetFolderPath();

--- a/pwiz_tools/Skyline/TestConnected/ArdiaFileUploadTest.cs
+++ b/pwiz_tools/Skyline/TestConnected/ArdiaFileUploadTest.cs
@@ -71,7 +71,7 @@ namespace pwiz.SkylineTestConnected
             Assert.AreEqual(1, Settings.Default.RemoteAccountList.Count);
 
             account = (ArdiaAccount)Settings.Default.RemoteAccountList[0];
-            AssertEx.IsTrue(!EncryptedToken.IsNullOrEmpty(account.Token), "Ardia account does not have a token.");
+            AssertEx.IsTrue(!account.Token.IsNullOrEmpty(), "Ardia account does not have a token.");
 
             // Test scenarios 
             TestGetFolderPath();

--- a/pwiz_tools/Skyline/ToolsUI/EditRemoteAccountDlg.cs
+++ b/pwiz_tools/Skyline/ToolsUI/EditRemoteAccountDlg.cs
@@ -271,7 +271,7 @@ namespace pwiz.Skyline.ToolsUI
             using var httpClient = new HttpClient(handler);
             httpClient.BaseAddress = baseUri;
             // Add the Bff-Host cookie to the cookie container
-            cookieContainer.Add(apiBaseUri, new Cookie(@"Bff-Host", ArdiaCredentialHelper.GetToken(_ardiaAccount_CurrentlyLoggedIn)));
+            cookieContainer.Add(apiBaseUri, new Cookie(@"Bff-Host", ArdiaCredentialHelper.GetToken(_ardiaAccount_CurrentlyLoggedIn).Decrypted));
             // Add the required headers to the request
             httpClient.DefaultRequestHeaders.Add(@"Accept", @"application/json");
             httpClient.DefaultRequestHeaders.Add(@"applicationCode", applicationCode);


### PR DESCRIPTION
ArdiaAccount now stores encrypted Token. SetToken method encrypts token. ArdiaClient now stores private encrypted token, Token property returns decrypted token when accessed.