### PR TITLE
- fixed crash for timsTOF data that have empty spectra

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Bruker/TimsData.cpp
@@ -235,6 +235,11 @@ TimsDataImpl::TimsDataImpl(const string& rawpath, bool combineIonMobilitySpectra
         double bpi = row.get<double>(++idx);
         double tic = row.get<double>(++idx);
 
+        int numScans = row.get<int>(++idx);
+        int numPeaks = row.get<int>(++idx);
+        if (numPeaks == 0)
+            continue;
+
         tic_->times.push_back(rt);
         bpc_->times.push_back(rt);
         tic_->intensities.push_back(tic);
@@ -247,11 +252,6 @@ TimsDataImpl::TimsDataImpl(const string& rawpath, bool combineIonMobilitySpectra
             ticMs1_->intensities.push_back(tic);
             bpcMs1_->intensities.push_back(bpi);
         }
-
-        int numScans = row.get<int>(++idx);
-        int numPeaks = row.get<int>(++idx);
-        if (numPeaks == 0)
-            continue;
 
         maxNumScans = max(maxNumScans, numScans);
 


### PR DESCRIPTION
- fixed crash when creating chromatograms for timsTOF data that have empty spectra (reported by Chris)

It's amazing it took this long to trigger. It must be very rare for a timsTOF frame to have 0 peaks.