### PR TITLE
Fix typo in column tool tip.

### DIFF
--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.Designer.cs
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.Designer.cs
@@ -1467,7 +1467,7 @@ namespace pwiz.Skyline.Model.Databinding.Entities {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to With of the m/z window in which the precursor was isolated. 
+        ///   Looks up a localized string similar to Width of the m/z window in which the precursor was isolated. 
         ///If more than one precursor was isolated then the Isolation Window Width is the sum of the windows around each precursor..
         /// </summary>
         public static string IsolationWindowWidth {

--- a/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.resx
+++ b/pwiz_tools/Skyline/Model/Databinding/Entities/ColumnToolTips.resx
@@ -587,7 +587,7 @@ between the peak integration boundaries.</value>
     <value>True if this is a decoy precursor.</value>
   </data>
   <data name="IsolationWindowWidth">
-    <value>With of the m/z window in which the precursor was isolated. 
+    <value>Width of the m/z window in which the precursor was isolated. 
 If more than one precursor was isolated then the Isolation Window Width is the sum of the windows around each precursor.</value>
   </data>
   <data name="IsotopeDistIndex">


### PR DESCRIPTION
Fixed typo in "Isolation Window Width" tooltip (reported by localization team)