### PR TITLE
Fix TestFeatureDetectionTutorialFuture

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/NonLinearRegressionTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NonLinearRegressionTest.cs
@@ -78,8 +78,8 @@ namespace pwiz.SkylineTestFunctional
 
             var kdeFunction = (PiecewiseLinearRegressionFunction) graphPane.RegressionRefined.Conversion;
 
-            Assert.AreEqual(5.7326, kdeFunction.RMSD, 0.0001);
-            Assert.AreEqual(22, kdeFunction.LinearFunctionsCount);
+            Assert.AreEqual(8.7415, kdeFunction.RMSD, 0.0001);
+            Assert.AreEqual(21, kdeFunction.LinearFunctionsCount);
 
             //Check for Loess
 
@@ -92,8 +92,8 @@ namespace pwiz.SkylineTestFunctional
             // ReSharper disable once PossibleInvalidCastException
             var loessFunction = (LoessRegression) graphPane.RegressionRefined.Conversion;
 
-            Assert.AreEqual(4.0552, loessFunction.Rmsd, 0.0001);
-            Assert.AreEqual(22, kdeFunction.LinearFunctionsCount);
+            Assert.AreEqual(3.2781, loessFunction.Rmsd, 0.0001);
+            Assert.AreEqual(21, kdeFunction.LinearFunctionsCount);
         }
 
         void TestRunToRunRegression()

--- a/pwiz_tools/Skyline/TestFunctional/NonLinearRegressionTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NonLinearRegressionTest.cs
@@ -78,8 +78,8 @@ namespace pwiz.SkylineTestFunctional
 
             var kdeFunction = (PiecewiseLinearRegressionFunction) graphPane.RegressionRefined.Conversion;
 
-            Assert.AreEqual(8.7539, kdeFunction.RMSD, 0.0001);
-            Assert.AreEqual(21, kdeFunction.LinearFunctionsCount);
+            Assert.AreEqual(5.7326, kdeFunction.RMSD, 0.0001);
+            Assert.AreEqual(22, kdeFunction.LinearFunctionsCount);
 
             //Check for Loess
 
@@ -92,7 +92,8 @@ namespace pwiz.SkylineTestFunctional
             // ReSharper disable once PossibleInvalidCastException
             var loessFunction = (LoessRegression) graphPane.RegressionRefined.Conversion;
 
-            Assert.AreEqual(3.2781, loessFunction.Rmsd, 0.0001);
+            Assert.AreEqual(4.0552, loessFunction.Rmsd, 0.0001);
+            Assert.AreEqual(22, kdeFunction.LinearFunctionsCount);
         }
 
         void TestRunToRunRegression()

--- a/pwiz_tools/Skyline/TestPerf/DiaNnPeakImputationTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/DiaNnPeakImputationTest.cs
@@ -100,7 +100,7 @@ namespace TestPerf
                 WaitForConditionUI(() => associateProteinsDlg.IsOkEnabled);
             }, associateProteinsDlg=>associateProteinsDlg.OkDialog());
 
-            WaitForDocumentLoaded();
+            WaitForDocumentLoaded(WAIT_TIME * 4);
             var imputedPeptidesWithMissingResults = SkylineWindow.Document.Molecules.Where(AnyMissingResults).ToList();
             Assert.AreEqual(0, imputedPeptidesWithMissingResults.Count);
             RunDlg<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI, peptideSettingsUi =>


### PR DESCRIPTION
The Peak Imputation commit (PR #3428) included some changes to KdeAligner which did not need to be made.
Revert those changes to KdeAligner.