### PR TITLE
Fix "Score types not loaded" error building library with invalid .tsv file

### DIFF
--- a/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.cs
+++ b/pwiz_tools/Skyline/SettingsUI/BuildLibraryDlg.cs
@@ -139,7 +139,10 @@ namespace pwiz.Skyline.SettingsUI
             Grid = gridInputFiles;
             Grid.FilesChanged += (sender, e) =>
             {
-                btnNext.Enabled = tabControlMain.SelectedIndex == (int)Pages.files || Grid.IsReady;
+                if (tabControlMain.SelectedIndex == (int)Pages.files)
+                {
+                    btnNext.Enabled = Grid.IsReady;
+                }
             };
 
             // If we're not using dataSourceGroupBox (because we're in small molecule mode) shift other controls over where it was


### PR DESCRIPTION
Fixed unhandled error trying to build library from invalid TSV file (reported by Eileen)