### PR TITLE
- fixed error when clicking "Open" for waters_connect sample set folder

### DIFF
--- a/pwiz_tools/Skyline/FileUI/BaseFileDialogNE.cs
+++ b/pwiz_tools/Skyline/FileUI/BaseFileDialogNE.cs
@@ -788,7 +788,7 @@ namespace pwiz.Skyline.FileUI
             }
         }
 
-        private bool TreatAsFolder(string itemText)
+        protected static bool TreatAsFolder(string itemText)
         {
             return DataSourceUtil.IsFolderType(itemText) || DataSourceUtil.IsSampleSetType(itemText);
         }
@@ -811,8 +811,7 @@ namespace pwiz.Skyline.FileUI
             else
             {
                 FileNames = new[] { ((SourceInfo) item.Tag).MsDataFileUri,  };
-                DialogResult = DialogResult.OK;
-                Close();
+                DoMainAction();
             }
         }
 

--- a/pwiz_tools/Skyline/FileUI/OpenFileDialogNE.cs
+++ b/pwiz_tools/Skyline/FileUI/OpenFileDialogNE.cs
@@ -48,7 +48,7 @@ namespace pwiz.Skyline.FileUI
             List<MsDataFileUri> dataSourceList = new List<MsDataFileUri>();
             foreach (ListViewItem item in listView.SelectedItems)
             {
-                if (!DataSourceUtil.IsFolderType(item.SubItems[1].Text))
+                if (!TreatAsFolder(item.SubItems[1].Text))
                 {
                     dataSourceList.Add(((SourceInfo)item.Tag).MsDataFileUri);
                 }
@@ -65,7 +65,7 @@ namespace pwiz.Skyline.FileUI
             // should navigate to
             foreach (ListViewItem item in listView.SelectedItems)
             {
-                if (DataSourceUtil.IsFolderType(item.SubItems[1].Text))
+                if (TreatAsFolder(item.SubItems[1].Text))
                 {
                     OpenFolderItem(item);
                     return;


### PR DESCRIPTION
I forgot to update the Open action in OpenFileDialogNE to use TreatAsFolder instead of IsFolder.