### PR TITLE
Fix DecoysMatchTest

### DIFF
--- a/pwiz_tools/Skyline/TestPerf/PerfDecoysMatchTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfDecoysMatchTest.cs
@@ -144,10 +144,10 @@ namespace TestPerf
                     foreach (var graphChromatogram in SkylineWindow.GraphChromatograms)
                     {
                         Assert.IsNull(graphChromatogram.RetentionMsMs);
-                        // There are no aligned retention times because the graph has only been asked to show unaligned retention times
                         Assert.IsNull(graphChromatogram.AlignedRetentionMsMs);
-                        // There are no unaligned retention times because all runs have been successfully aligned to each other
-                        Assert.IsNull(graphChromatogram.UnalignedRetentionMsMs);
+                        Assert.IsNotNull(graphChromatogram.UnalignedRetentionMsMs);
+                        Assert.AreNotEqual(0, graphChromatogram.UnalignedRetentionMsMs.Length);
+                        ValidateTimeRange(graphChromatogram, graphChromatogram.UnalignedRetentionMsMs, 8, 120);
                     }
 
                     SkylineWindow.SequenceTree.SelectedNode = SkipInvalidNodes(SkylineWindow.SequenceTree.SelectedNode.NextNode);


### PR DESCRIPTION
PerfDecoysMatchTest got changed with the initial Peak Imputation commit in PR #3428 on Aug 26. Later, on Sept 17, with PR #3594, the way that unaligned retention times was fixed, and PerfDecoysMatchTest should have been reverted back to its earlier version. This change reverts PerfDecoysMatchTest back to its old version from earlier this summer.