### PR TITLE
Fix iRT alignment in older documents

### DIFF
--- a/pwiz_tools/Skyline/Model/RetentionTimes/AlignmentTarget.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/AlignmentTarget.cs
@@ -60,9 +60,23 @@ namespace pwiz.Skyline.Model.RetentionTimes
             return (int)RegressionMethod;
         }
 
+        public double? ScoreTargets(IEnumerable<Target> candidateTargets)
+        {
+            return candidateTargets.Select(ScoreSequence).OfType<double>().FirstOrDefault();
+        }
         protected abstract double? ScoreSequence(Target target);
         public abstract string DisplayName { get; }
         public abstract double ChooseUnknownScore();
+
+        /// <summary>
+        /// Whether run-to-run retention time alignment should be performed using the current peaks that may have been adjusted by
+        /// the user, or the original peaks that Skyline chose.
+        /// When all peptides are used in the alignment, the original peaks are used for alignment, because otherwise any change to
+        /// peak boundaries will change the alignment.
+        /// However, when the alignment only uses iRT standards, the current peak boundaries should be used.
+        /// </summary>
+        public virtual bool UseCurrentPeaks { get { return false; } }
+
         public virtual RetentionScoreCalculatorSpec AsRetentionScoreCalculator()
         {
             return new RetentionScoreCalculatorImpl(this);
@@ -423,6 +437,18 @@ namespace pwiz.Skyline.Model.RetentionTimes
 
                 return RegressionMethodRT.kde;
             }
+
+            public override bool UseCurrentPeaks
+            {
+                get
+                {
+                    if (Calculator is RCalcIrt rCalcIrt)
+                    {
+                        return rCalcIrt.GetStandardPeptides().Any();
+                    }
+                    return false;
+                }
+            }
         }
 
         public class LibraryTarget : AlignmentTarget
@@ -513,7 +539,7 @@ namespace pwiz.Skyline.Model.RetentionTimes
             }
 
             public MedianDocumentRetentionTimes(SrmDocument document)
-                : this(ResultFileAlignments.GetAlignmentSources(document, null).Values)
+                : this(ResultFileAlignments.GetAlignmentSources(document, null, null).Values)
             {
             }
 


### PR DESCRIPTION
Fixed iRT alignment in Skyline 25.1 documents (reported by Will)