### PR TITLE
Fix parent of MessageDlg in "CheckResults"

### DIFF
--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -2609,7 +2609,7 @@ namespace pwiz.Skyline
                     {
                         throw;
                     }
-                    MessageDlg.ShowWithException(this, TextUtil.LineSeparate(Resources.ShareListDlg_OkDialog_An_error_occurred, exception.Message), exception);
+                    MessageDlg.ShowWithException(parent ?? this, TextUtil.LineSeparate(Resources.ShareListDlg_OkDialog_An_error_occurred, exception.Message), exception);
                     return false;
                 }
                 finally

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -827,7 +827,7 @@ namespace pwiz.Skyline
                 }
                 catch (Exception e)
                 {
-                    MessageDlg.ShowException(this, e);
+                    MessageDlg.ShowException(parent ?? this, e);
                 }
             }
             else if (!File.Exists(pathCache) &&


### PR DESCRIPTION
Fixed error message appears behind Start Page if opening document with no results but .skyd file could not be deleted (not reported by anyone)