### PR TITLE
MsDataFilePath performance improvements

### DIFF
--- a/pwiz_tools/Shared/CommonMsData/RemoteApi/RemoteUrl.cs
+++ b/pwiz_tools/Shared/CommonMsData/RemoteApi/RemoteUrl.cs
@@ -72,16 +72,16 @@ namespace pwiz.CommonMsData.RemoteApi
 
         protected virtual void Init(NameValueParameters nameValueParameters)
         {
-            LegacyCentroidMs1 = nameValueParameters.GetBoolValue(Attr.centroid_ms1.ToString());
-            LegacyCentroidMs2 = nameValueParameters.GetBoolValue(Attr.centroid_ms2.ToString());
-            LockMassParameters = new LockMassParameters(
-                nameValueParameters.GetDoubleValue(Attr.lockmass_pos.ToString()),
-                nameValueParameters.GetDoubleValue(Attr.lockmass_neg.ToString()),
-                nameValueParameters.GetDoubleValue(Attr.lockmass_tol.ToString()));
-            ServerUrl = nameValueParameters.GetValue(Attr.server.ToString());
-            Username = nameValueParameters.GetValue(Attr.username.ToString());
-            EncodedPath = nameValueParameters.GetValue(Attr.path.ToString());
-            ModifiedTime = nameValueParameters.GetDateValue(Attr.modified_time.ToString());
+            LegacyCentroidMs1 = nameValueParameters.GetBoolValue(nameof(Attr.centroid_ms1));
+            LegacyCentroidMs2 = nameValueParameters.GetBoolValue(nameof(Attr.centroid_ms2));
+            LockMassParameters = LockMassParameters.Create(
+                nameValueParameters.GetDoubleValue(nameof(Attr.lockmass_pos)),
+                nameValueParameters.GetDoubleValue(nameof(Attr.lockmass_neg)),
+                nameValueParameters.GetDoubleValue(nameof(Attr.lockmass_tol)));
+            ServerUrl = nameValueParameters.GetValue(nameof(Attr.server));
+            Username = nameValueParameters.GetValue(nameof(Attr.username));
+            EncodedPath = nameValueParameters.GetValue(nameof(Attr.path));
+            ModifiedTime = nameValueParameters.GetDateValue(nameof(Attr.modified_time));
         }
 
         public override MsDataFileUri ChangeLockMassParameters(LockMassParameters lockMassParameters)

--- a/pwiz_tools/Shared/CommonMsData/SampleHelp.cs
+++ b/pwiz_tools/Shared/CommonMsData/SampleHelp.cs
@@ -233,9 +233,9 @@ namespace pwiz.CommonMsData
 
         public static LockMassParameters GetLockmassParameters(string url)
         {
-            if (url == null || string.IsNullOrEmpty(url))
+            if (string.IsNullOrEmpty(url))
                 return LockMassParameters.EMPTY;
-            return new LockMassParameters(ParseParameterDouble(TAG_LOCKMASS_POS, url), ParseParameterDouble(TAG_LOCKMASS_NEG, url), ParseParameterDouble(TAG_LOCKMASS_TOL, url));
+            return LockMassParameters.Create(ParseParameterDouble(TAG_LOCKMASS_POS, url), ParseParameterDouble(TAG_LOCKMASS_NEG, url), ParseParameterDouble(TAG_LOCKMASS_TOL, url));
         }
     }
 }

--- a/pwiz_tools/Shared/ProteowizardWrapper/LockMassParameters.cs
+++ b/pwiz_tools/Shared/ProteowizardWrapper/LockMassParameters.cs
@@ -24,9 +24,9 @@ namespace pwiz.ProteowizardWrapper
     /// </summary>
     public class LockMassParameters : IComparable
     {
-        public LockMassParameters(double? lockmassPositve, double? lockmassNegative, double? lockmassTolerance)
+        private LockMassParameters(double? lockmassPositive, double? lockmassNegative, double? lockmassTolerance)
         {
-            LockmassPositive = lockmassPositve;
+            LockmassPositive = lockmassPositive;
             LockmassNegative = lockmassNegative;
             if (LockmassPositive.HasValue || LockmassNegative.HasValue)
             {
@@ -36,6 +36,16 @@ namespace pwiz.ProteowizardWrapper
             {
                 LockmassTolerance = null;  // Means nothing when no mz is given
             }
+        }
+
+        public static LockMassParameters Create(double? positive, double? negative, double? tolerance)
+        {
+            if (positive.HasValue || negative.HasValue || tolerance.HasValue)
+            {
+                return new LockMassParameters(positive, negative, tolerance);
+            }
+
+            return EMPTY;
         }
 
         public double? LockmassPositive { get; private set; }

--- a/pwiz_tools/Skyline/CommandArgs.cs
+++ b/pwiz_tools/Skyline/CommandArgs.cs
@@ -455,7 +455,7 @@ namespace pwiz.Skyline
         public double? LockmassPositive { get; private set; }
         public double? LockmassNegative { get; private set; }
         public double? LockmassTolerance { get; private set; }
-        public LockMassParameters LockMassParameters { get { return new LockMassParameters(LockmassPositive, LockmassNegative, LockmassTolerance); } }
+        public LockMassParameters LockMassParameters { get { return LockMassParameters.Create(LockmassPositive, LockmassNegative, LockmassTolerance); } }
 
         private void ParseImportFile(NameValuePair pair)
         {

--- a/pwiz_tools/Skyline/FileUI/ImportResultsLockMassDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/ImportResultsLockMassDlg.cs
@@ -128,7 +128,7 @@ namespace pwiz.Skyline.FileUI
             else if (!helper.ValidateDecimalTextBox(textLockmassTolerance, LockMassParameters.LOCKMASS_TOLERANCE_MIN, LockMassParameters.LOCKMASS_TOLERANCE_MAX, out lockmassTolerance))
                 return;
 
-            Settings.Default.LockmassParameters = LockMassParameters = new LockMassParameters(lockmassPositive, lockmassNegative, lockmassTolerance);
+            Settings.Default.LockmassParameters = LockMassParameters = LockMassParameters.Create(lockmassPositive, lockmassNegative, lockmassTolerance);
             DialogResult = DialogResult.OK;
         }
 

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -479,7 +479,7 @@ namespace pwiz.Skyline.Model
                     var dataFileUri = MsDataFileUri.Parse(fileName);
                     if (sampleName != null && dataFileUri is MsDataFilePath msDataFilePath)
                     {
-                        var uriWithSample = new MsDataFilePath(msDataFilePath.FilePath, sampleName, msDataFilePath.SampleIndex, msDataFilePath.LockMassParameters);
+                        var uriWithSample = msDataFilePath.ChangeSample(sampleName);
                         fileMatch = Document.Settings.MeasuredResults.FindMatchingMSDataFile(uriWithSample);
                         if (fileMatch == null)
                         {

--- a/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
+++ b/pwiz_tools/Skyline/Model/ImportPeakBoundaries.cs
@@ -479,7 +479,7 @@ namespace pwiz.Skyline.Model
                     var dataFileUri = MsDataFileUri.Parse(fileName);
                     if (sampleName != null && dataFileUri is MsDataFilePath msDataFilePath)
                     {
-                        var uriWithSample = msDataFilePath.ChangeSample(sampleName);
+                        var uriWithSample = new MsDataFilePath(msDataFilePath.FilePath, sampleName, msDataFilePath.SampleIndex, msDataFilePath.LockMassParameters);
                         fileMatch = Document.Settings.MeasuredResults.FindMatchingMSDataFile(uriWithSample);
                         if (fileMatch == null)
                         {

--- a/pwiz_tools/Skyline/Properties/Settings.cs
+++ b/pwiz_tools/Skyline/Properties/Settings.cs
@@ -195,7 +195,7 @@ namespace pwiz.Skyline.Properties
         {
             get
             {
-                return new LockMassParameters(
+                return LockMassParameters.Create(
                     LockMassPositive == 0 ? (double?) null : LockMassPositive,
                     LockMassNegative == 0 ? (double?) null : LockMassNegative,
                     LockMassTolerance == 0 ? (double?) null : LockMassTolerance);

--- a/pwiz_tools/Skyline/TestData/Results/SmallWiffTest.cs
+++ b/pwiz_tools/Skyline/TestData/Results/SmallWiffTest.cs
@@ -116,13 +116,13 @@ namespace pwiz.SkylineTestData.Results
         {
             var fname = "test.mzML";
             var pathSample = SampleHelp.LegacyEncodePath(fname, null, -1, null, true, false, false);
-            var lockmassParametersA = new LockMassParameters(1.23, 3.45, 4.56);
-            var lockmassParametersB = new LockMassParameters(1.23, null, 4.56);
+            var lockmassParametersA = LockMassParameters.Create(1.23, 3.45, 4.56);
+            var lockmassParametersB = LockMassParameters.Create(1.23, null, 4.56);
 
             Assert.IsTrue(lockmassParametersA.CompareTo(LockMassParameters.EMPTY) > 0);
             Assert.IsTrue(lockmassParametersA.CompareTo(null) < 0);
             Assert.IsTrue(lockmassParametersB.CompareTo(lockmassParametersA) < 0);
-            Assert.IsTrue(lockmassParametersA.CompareTo(new LockMassParameters(1.23, 3.45, 4.56)) == 0);
+            Assert.IsTrue(lockmassParametersA.CompareTo(LockMassParameters.Create(1.23, 3.45, 4.56)) == 0);
             
 
             var c = new ChromatogramSet("test", new[] { MsDataFileUri.Parse(pathSample) });

--- a/pwiz_tools/Skyline/TestData/XmlValidationTest.cs
+++ b/pwiz_tools/Skyline/TestData/XmlValidationTest.cs
@@ -75,7 +75,7 @@ namespace pwiz.SkylineTestData
             using (var docContainer = new ResultsTestDocumentContainer(docCurrent, docCurrentPath))
             {
                 string replicateName = Path.GetFileNameWithoutExtension(resultsPath);
-                var lockMassParameters = new LockMassParameters(456.78, 567.89, 12.34);
+                var lockMassParameters = LockMassParameters.Create(456.78, 567.89, 12.34);
                 var listChromatograms = new List<ChromatogramSet> { new ChromatogramSet(replicateName, new[] { new MsDataFilePath(resultsPath, lockMassParameters) }) };
 
                 // Lockmass values are Waters only so don't expect them to be saved to the doc which has no Waters results

--- a/pwiz_tools/Skyline/TestPerf/PerfDetectLockmassFunctionTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfDetectLockmassFunctionTest.cs
@@ -67,7 +67,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
             AssertEx.IsDocumentState(doc0, null, 24, 24, 24, 24);
 
             ImportResults(GetTestPath(TestFilesPersistent[0]),
-                new LockMassParameters(lockmassPositive, lockmassNegative, lockmassToler));
+                LockMassParameters.Create(lockmassPositive, lockmassNegative, lockmassToler));
 
             var document = WaitForDocumentLoaded(400000);
 

--- a/pwiz_tools/Skyline/TestPerf/PerfLockmassTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfLockmassTest.cs
@@ -85,7 +85,7 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
                 loadStopwatch.Start();
                 ImportResults(GetTestPath(TestFilesPersistent[0]),
                     (testloop == 0)
-                        ? new LockMassParameters(0, lockmassNegative, lockmassToler) // ESI- data
+                        ? LockMassParameters.Create(0, lockmassNegative, lockmassToler) // ESI- data
                         : LockMassParameters.EMPTY);
 
                 var document = WaitForDocumentLoaded(400000);


### PR DESCRIPTION
1. Make LockMassParameters constructor private and replace calls with LockMassParameters.Create which returns constant "Empty" instead of creating new one which makes "Equals" faster
2. Short circuit parsing parameters in MsDataFilePath constructor if there are no parameters.