### PR TITLE
Add some different logging statements to track down .blib locking problem

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
+++ b/pwiz_tools/Skyline/Model/Lib/BiblioSpecLite.cs
@@ -725,7 +725,6 @@ namespace pwiz.Skyline.Model.Lib
                         rowsRead++;
                         if (loader.IsCanceled)
                         {
-                            LogForFuncTest(@"Cancelled during RefSpectra", TraceLevel.Info);
                             return;
                         }
 
@@ -834,7 +833,6 @@ namespace pwiz.Skyline.Model.Lib
             if (loader.IsCanceled)
             {
                 loader.UpdateProgress(status.Cancel());
-                LogForFuncTest(@"Cancelled after RefSpectra", TraceLevel.Info);
                 return false;
             }
 
@@ -847,7 +845,6 @@ namespace pwiz.Skyline.Model.Lib
                 if (loader.IsCanceled)
                 {
                     loader.UpdateProgress(status.Cancel());
-                    LogForFuncTest(@"Cancelled during RetentionTime", TraceLevel.Info);
                     return false;
                 }
                 var retentionTimesBySpectraId = retentionTimeReader.GetRetentionTimes();
@@ -881,7 +878,6 @@ namespace pwiz.Skyline.Model.Lib
             SetLibraryEntries(FilterInvalidLibraryEntries(ref status, libraryEntries.OrderBy(spec=>spec.Id)));
             EnsureConnections(sm);
             loader.UpdateProgress(status.ChangeSegments(segmentCount - 1, segmentCount).Complete());
-            LogForFuncTest(@"Finished Load", TraceLevel.Verbose);
             return true;
         }
 
@@ -926,7 +922,6 @@ namespace pwiz.Skyline.Model.Lib
             }
             catch (Exception x)
             {
-                LogForFuncTest(x.Message, TraceLevel.Warning);
                 // SQLiteExceptions are not considered programming defects and should be shown to the user
                 // as an ordinary error message
                 if (x is SQLiteException || x is TargetInvocationException && x.InnerException is SQLiteException || !ExceptionUtil.IsProgrammingDefect(x))
@@ -941,7 +936,6 @@ namespace pwiz.Skyline.Model.Lib
                     throw new Exception(FormatErrorMessage(x), x);
                 }
             }
-            LogForFuncTest(@"Load Failed", TraceLevel.Warning);
             // Close any streams that got opened
             foreach (var pooledStream in ReadStreams)
                 pooledStream.CloseStream();
@@ -2443,14 +2437,6 @@ namespace pwiz.Skyline.Model.Lib
                 im.FilePath = newSpec.FilePath;
                 _sqliteConnection = new PooledSqliteConnection(connectionPool, newSpec.FilePath);
             });
-        }
-
-        private void LogForFuncTest(string eventName, TraceLevel traceLevel)
-        {
-            if (Program.FunctionalTest && traceLevel < TraceLevel.Verbose)
-            {
-                Console.Out.WriteLine(@"Event: {0} File: {1}", eventName, FilePath);
-            }
         }
     }
 

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -80,6 +80,15 @@ namespace pwiz.Skyline
                 CommonApplicationSettings.FunctionalTest = value;
             }
         }
+
+        // TODO(nicksh): Remove this once intermittent failures in these tests are fixed
+        public static bool IsVerboseLogging(string name)
+        {
+            return FunctionalTest && new[]
+            {
+                @"ShareDocumentTest", @"InternationalFilenamesTest"
+            }.Any(folder => name.IndexOf(folder, StringComparison.Ordinal) >= 0);
+        }
         public static string TestName { get; set; }                 // Set during unit and functional tests
         public static bool ClosingForms { get; set; }               // Set to true during AbstractFunctionalTest.CloseOpenForm (all forms should check this before cancelling a Close request)
         public static string DefaultUiMode { get; set; }            // Set to avoid seeing NoModeUiDlg at the start of a test

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2567,8 +2567,17 @@ namespace pwiz.SkylineTestUtil
                 // Release all resources by setting the document to something that
                 // holds no file handles.
                 var docNew = new SrmDocument(SrmSettingsList.GetDefault());
+                bool verboseLogging = Program.IsVerboseLogging(GetType().FullName);
+                if (verboseLogging)
+                {
+                    Console.Out.WriteLine("Before switch to blank document");
+                }
                 // Try twice, because this operation can fail due to active background processing
                 RunUI(() => TryHelper.TryTwice(() => SkylineWindow.SwitchDocument(docNew, null)));
+                if (verboseLogging)
+                {
+                    Console.Out.WriteLine("After switch to blank document");
+                }
 
                 WaitForCondition(1000, () => !FileStreamManager.Default.HasPooledStreams, string.Empty, false);
                 if (FileStreamManager.Default.HasPooledStreams)

--- a/pwiz_tools/Skyline/Util/PooledSqliteConnection.cs
+++ b/pwiz_tools/Skyline/Util/PooledSqliteConnection.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Data.SQLite;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using pwiz.Common.Database;
 using pwiz.Common.SystemUtil;

--- a/pwiz_tools/Skyline/Util/PooledSqliteConnection.cs
+++ b/pwiz_tools/Skyline/Util/PooledSqliteConnection.cs
@@ -19,6 +19,8 @@
 using System;
 using System.Data.SQLite;
 using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using pwiz.Common.Database;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Properties;
@@ -38,6 +40,7 @@ namespace pwiz.Skyline.Util
 
         protected override IDisposable Connect()
         {
+            LogEvent(@"Connect");
             return SqliteOperations.OpenConnection(FilePath);
         }
 
@@ -95,6 +98,14 @@ namespace pwiz.Skyline.Util
                     throw new IOException(string.Format(Resources.BiblioSpecLiteLibrary_ReadSpectrum_Unexpected_SQLite_failure_reading__0__,
                         FilePath), x);
                 }
+            }
+        }
+
+        public void LogEvent(string eventName)
+        {
+            if (Program.IsVerboseLogging(FilePath))
+            {
+                Console.Out.WriteLine(@"{0}: ID:{1} Path:{2}", eventName, RuntimeHelpers.GetHashCode(this), FilePath);
             }
         }
     }

--- a/pwiz_tools/Skyline/Util/UtilIO.cs
+++ b/pwiz_tools/Skyline/Util/UtilIO.cs
@@ -244,6 +244,7 @@ namespace pwiz.Skyline.Util
                 IDisposable connection;
                 if (!_connections.TryGetValue(id.GlobalIndex, out connection))
                     return;
+                (id as PooledSqliteConnection)?.LogEvent(@"Disconnect");
                 _connections.Remove(id.GlobalIndex);
                 // Disconnect inside lock, since a new attempt to connect
                 // may fail if the old connection is not fully disconnected.
@@ -474,7 +475,14 @@ namespace pwiz.Skyline.Util
             {
                 if (!IsModified)
                     return @"Unmodified";
-                return FileEx.GetElapsedTimeExplanation(FileTime, File.GetLastWriteTime(FilePath));
+                try
+                {
+                    return FileEx.GetElapsedTimeExplanation(FileTime, File.GetLastWriteTime(FilePath));
+                }
+                catch (Exception exception)
+                {
+                    return string.Format(@"Unable to read file time: {0}", exception.Message);
+                }
             }
         }
 


### PR DESCRIPTION
Add logging statements to track down intermittent failures in TestDocumentSharing and TestInternationalFilenames