### PR TITLE
Fix retention time alignment performance problem

### DIFF
--- a/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
+++ b/pwiz_tools/Skyline/Model/DocSettings/SrmSettings.cs
@@ -2874,7 +2874,7 @@ namespace pwiz.Skyline.Model.DocSettings
             // If the integration strategy has changed, then force a full update of all results
             if (newTran.Integration.IsIntegrateAll != oldTran.Integration.IsIntegrateAll
                 || !Equals(settingsNew.PeptideSettings.Imputation, settingsOld.PeptideSettings.Imputation)
-                || !Equals(settingsNew.DocumentRetentionTimes, settingsOld.DocumentRetentionTimes))
+                || !settingsNew.DocumentRetentionTimes.Equivalent(settingsOld.DocumentRetentionTimes))
             {
                 DiffResults = DiffResultsAll = true;
             }

--- a/pwiz_tools/Skyline/Model/RetentionTimes/DocumentRetentionTimes.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/DocumentRetentionTimes.cs
@@ -146,6 +146,33 @@ namespace pwiz.Skyline.Model.RetentionTimes
 
         public ResultFileAlignments ResultFileAlignments { get; private set; } = ResultFileAlignments.EMPTY;
 
+        public bool Equivalent(DocumentRetentionTimes other)
+        {
+            if (Equals(other))
+            {
+                return true;
+            }
+
+            var thisUnloaded = UnloadLibraries();
+            var otherUnloaded = other.UnloadLibraries();
+            if (Equals(thisUnloaded, otherUnloaded))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private DocumentRetentionTimes UnloadLibraries()
+        {
+            return ChangeProp(ImClone(this), im =>
+            {
+                im._libraryAlignments = _libraryAlignments.ToDictionary(kvp => kvp.Key,
+                    kvp => new LibraryAlignmentValue(null, kvp.Value.Alignments));
+                im._deserializedAlignmentFunctions ??= CollectionUtil.SafeToDictionary(im.ResultFileAlignments.GetAlignmentFunctions());
+                im.ResultFileAlignments = ResultFileAlignments.EMPTY;
+            });
+        }
         #region Object Overrides
         public bool Equals(DocumentRetentionTimes other)
         {
@@ -153,7 +180,8 @@ namespace pwiz.Skyline.Model.RetentionTimes
             if (ReferenceEquals(this, other)) return true;
             return CollectionUtil.EqualsDeep(_libraryAlignments, other._libraryAlignments)
                    && Equals(ResultFileAlignments, other.ResultFileAlignments)
-                   && Equals(MedianDocumentRetentionTimes, other.MedianDocumentRetentionTimes);
+                   && Equals(MedianDocumentRetentionTimes, other.MedianDocumentRetentionTimes)
+                   && CollectionUtil.EqualsDeep(_deserializedAlignmentFunctions, other._deserializedAlignmentFunctions);
 
         }
 

--- a/pwiz_tools/Skyline/Model/RetentionTimes/LibraryAlignment.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/LibraryAlignment.cs
@@ -1,4 +1,22 @@
-﻿using System.Collections.Generic;
+﻿/*
+ * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2025 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Generic;
 using pwiz.Skyline.Model.Lib;
 
 namespace pwiz.Skyline.Model.RetentionTimes
@@ -13,6 +31,39 @@ namespace pwiz.Skyline.Model.RetentionTimes
 
         public Library Library { get; private set; }
         public Alignments Alignments { get; private set; }
+
+        protected bool Equals(LibraryAlignment other)
+        {
+            return Equals(Library, other.Library) && Equals(Alignments, other.Alignments);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
+            return Equals((LibraryAlignment)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Library != null ? Library.GetHashCode() : 0) * 397) ^ (Alignments != null ? Alignments.GetHashCode() : 0);
+            }
+        }
 
         public IEnumerable<double> GetNormalizedRetentionTimes(ICollection<string> spectrumSourceFiles, IList<Target> targets)
         {

--- a/pwiz_tools/Skyline/Model/RetentionTimes/PeakImputation/PeakBoundaryImputer.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/PeakImputation/PeakBoundaryImputer.cs
@@ -304,7 +304,7 @@ namespace pwiz.Skyline.Model.RetentionTimes.PeakImputation
         private ImputedPeak GetImputedPeakFromLibraryPeak(CancellationToken cancellationToken, LibraryInfo libraryInfo, SourcedPeak exemplaryPeak,
             MsDataFileUri filePath)
         {
-            if (AlignmentTarget == null)
+            if (AlignmentTarget == null || filePath == null)
             {
                 return new ImputedPeak(exemplaryPeak.Peak.PeakBounds, exemplaryPeak);
             }

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeManager.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeManager.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using pwiz.Common.SystemUtil;
+using pwiz.Skyline.Model.DocSettings;
 using pwiz.Skyline.Util;
 
 namespace pwiz.Skyline.Model.RetentionTimes
@@ -130,8 +131,12 @@ namespace pwiz.Skyline.Model.RetentionTimes
                 {
                     return false;
                 }
+
+                using var settingsChangeMonitor =
+                    new SrmSettingsChangeMonitor(new LoadMonitor(this, container, docCurrent),
+                        "Updating retention time alignment");
                 docNew = docCurrent.ChangeSettings(
-                    docCurrent.Settings.ChangeDocumentRetentionTimes(newDocumentRetentionTimes));
+                    docCurrent.Settings.ChangeDocumentRetentionTimes(newDocumentRetentionTimes), settingsChangeMonitor);
             }
             while (!CompleteProcessing(container, docNew, docCurrent));
             return true;

--- a/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeManager.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/RetentionTimeManager.cs
@@ -132,11 +132,20 @@ namespace pwiz.Skyline.Model.RetentionTimes
                     return false;
                 }
 
-                using var settingsChangeMonitor =
-                    new SrmSettingsChangeMonitor(new LoadMonitor(this, container, docCurrent),
-                        RetentionTimesResources.RetentionTimeManager_PerformNextAlignment_Updating_retention_time_alignment);
-                docNew = docCurrent.ChangeSettings(
-                    docCurrent.Settings.ChangeDocumentRetentionTimes(newDocumentRetentionTimes), settingsChangeMonitor);
+                try
+                {
+                    using var settingsChangeMonitor =
+                        new SrmSettingsChangeMonitor(new LoadMonitor(this, container, docCurrent),
+                            RetentionTimesResources
+                                .RetentionTimeManager_PerformNextAlignment_Updating_retention_time_alignment);
+                    docNew = docCurrent.ChangeSettings(
+                        docCurrent.Settings.ChangeDocumentRetentionTimes(newDocumentRetentionTimes),
+                        settingsChangeMonitor);
+                }
+                catch (OperationCanceledException)
+                {
+                    return false;
+                }
             }
             while (!CompleteProcessing(container, docNew, docCurrent));
             return true;

--- a/pwiz_tools/Skyline/Skyline.cs
+++ b/pwiz_tools/Skyline/Skyline.cs
@@ -2609,7 +2609,7 @@ namespace pwiz.Skyline
                     {
                         throw;
                     }
-                    MessageDlg.ShowWithException(this, TextUtil.LineSeparate(Resources.ShareListDlg_OkDialog_An_error_occurred, exception.Message), exception);
+                    MessageDlg.ShowWithException(parent ?? this, TextUtil.LineSeparate(Resources.ShareListDlg_OkDialog_An_error_occurred, exception.Message), exception);
                     return false;
                 }
                 finally

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -827,7 +827,7 @@ namespace pwiz.Skyline
                 }
                 catch (Exception e)
                 {
-                    MessageDlg.ShowException(this, e);
+                    MessageDlg.ShowException(parent ?? this, e);
                 }
             }
             else if (!File.Exists(pathCache) &&

--- a/pwiz_tools/Skyline/Test/PeakShapeStatisticsTest.cs
+++ b/pwiz_tools/Skyline/Test/PeakShapeStatisticsTest.cs
@@ -127,15 +127,9 @@ namespace pwiz.SkylineTest
             var times = new double[] {0, 1};
             var intensities = new double[] {0, 1};
             var stats = PeakShapeStatistics.Calculate(times, intensities);
-
-            var samples = new List<double>();
-            for (int i = 0; i <= 10000; i++)
-            {
-                var time = i / 10000.0;
-                samples.AddRange(Enumerable.Repeat(time, i));
-            }
-
+            var samples = Enumerable.Range(0, 10001).SelectMany(i => Enumerable.Repeat(i / 10000.0, i));
             var runningStatistics = new RunningStatistics(samples);
+
             Assert.AreEqual(runningStatistics.Mean, stats.MeanTime, .001);
             Assert.AreEqual(runningStatistics.StandardDeviation, stats.StdDevTime, .001);
             Assert.AreEqual(runningStatistics.Skewness, stats.Skewness, .001);
@@ -156,19 +150,18 @@ namespace pwiz.SkylineTest
 
         private RunningStatistics GetRunningStatisticsBySampling(IList<double> times, IList<double> intensities)
         {
-            var samples = new List<double>();
             var maxIntensity = intensities.Max();
             var timeIntensities = new TimeIntensities(times.Select(t => (float) t), intensities.Select(i => (float) i),
                 null, null);
             const int nTimes = 1000;
-            for (int i = 0; i < nTimes; i++)
+            var samples = Enumerable.Range(0, nTimes).SelectMany(i =>
             {
                 var time = (times[0] + i * (times[times.Count - 1] - times[0]) / nTimes);
                 var interpolatedTimeIntensities = timeIntensities.InterpolateTime((float) time);
                 var intensity = interpolatedTimeIntensities.Intensities[interpolatedTimeIntensities.IndexOfNearestTime((float) time)];
                 int count = (int) Math.Round(intensity * 100 / maxIntensity);
-                samples.AddRange(Enumerable.Repeat(time, count));
-            }
+                return Enumerable.Repeat(time, count);
+            });
 
             return new RunningStatistics(samples);
         }


### PR DESCRIPTION
Fixed performance problem with peak imputation and large documents (not reported by anyone)
Fixed problem where Skyline would update results for entire tree even when the retention time alignment had not changed.