### PR TITLE
Remove logging statements

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -2567,17 +2567,8 @@ namespace pwiz.SkylineTestUtil
                 // Release all resources by setting the document to something that
                 // holds no file handles.
                 var docNew = new SrmDocument(SrmSettingsList.GetDefault());
-                bool verboseLogging = Program.IsVerboseLogging(GetType().FullName);
-                if (verboseLogging)
-                {
-                    Console.Out.WriteLine("Before switch to blank document");
-                }
                 // Try twice, because this operation can fail due to active background processing
                 RunUI(() => TryHelper.TryTwice(() => SkylineWindow.SwitchDocument(docNew, null)));
-                if (verboseLogging)
-                {
-                    Console.Out.WriteLine("After switch to blank document");
-                }
 
                 WaitForCondition(1000, () => !FileStreamManager.Default.HasPooledStreams, string.Empty, false);
                 if (FileStreamManager.Default.HasPooledStreams)

--- a/pwiz_tools/Skyline/Util/PooledSqliteConnection.cs
+++ b/pwiz_tools/Skyline/Util/PooledSqliteConnection.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Data.SQLite;
 using System.IO;
-using System.Runtime.CompilerServices;
 using pwiz.Common.Database;
 using pwiz.Common.SystemUtil;
 using pwiz.Skyline.Properties;
@@ -39,7 +38,6 @@ namespace pwiz.Skyline.Util
 
         protected override IDisposable Connect()
         {
-            LogEvent(@"Connect");
             return SqliteOperations.OpenConnection(FilePath);
         }
 
@@ -97,14 +95,6 @@ namespace pwiz.Skyline.Util
                     throw new IOException(string.Format(Resources.BiblioSpecLiteLibrary_ReadSpectrum_Unexpected_SQLite_failure_reading__0__,
                         FilePath), x);
                 }
-            }
-        }
-
-        public void LogEvent(string eventName)
-        {
-            if (Program.IsVerboseLogging(FilePath))
-            {
-                Console.Out.WriteLine(@"{0}: ID:{1} Path:{2}", eventName, RuntimeHelpers.GetHashCode(this), FilePath);
             }
         }
     }

--- a/pwiz_tools/Skyline/Util/UtilIO.cs
+++ b/pwiz_tools/Skyline/Util/UtilIO.cs
@@ -244,7 +244,6 @@ namespace pwiz.Skyline.Util
                 IDisposable connection;
                 if (!_connections.TryGetValue(id.GlobalIndex, out connection))
                     return;
-                (id as PooledSqliteConnection)?.LogEvent(@"Disconnect");
                 _connections.Remove(id.GlobalIndex);
                 // Disconnect inside lock, since a new attempt to connect
                 // may fail if the old connection is not fully disconnected.


### PR DESCRIPTION
Remove logging statements that had been added to track down TestInternationalFilenames intermittent failure.