### PR TITLE
Thermo Stellar SRM spectra improvements

### DIFF
--- a/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.cpp
+++ b/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.cpp
@@ -26,6 +26,8 @@
 
 #include "ChromatogramList_Thermo.hpp"
 
+#include <boost/range/algorithm/find.hpp>
+
 
 #ifdef PWIZ_READER_THERMO
 #include "Reader_Thermo_Detail.hpp"
@@ -193,10 +195,9 @@ PWIZ_API_DECL ChromatogramPtr ChromatogramList_Thermo::chromatogram(size_t index
 
                 string q1 = (format("%.10g", std::locale::classic()) % ci.q1).str();
                 string q3Range = (format("%.10g-%.10g", std::locale::classic())
-                                  % (ci.q3 - ci.q3Offset)
-                                  % (ci.q3 + ci.q3Offset)
+                                  % (ci.filterQ3 - ci.filterOffset) // offset must match filter
+                                  % (ci.filterQ3 + ci.filterOffset)
                                  ).str();
-
                 ChromatogramDataPtr cd = rawfile_->getChromatogramData(Type_MassRange,
                     polarity + "SRM ms2 " + q1 + " [" + q3Range + "]", ci.q3 - ci.q3Offset, ci.q3 + ci.q3Offset, 0,
                     rawfile_->getFirstScanTime(), rawfile_->getLastScanTime());
@@ -330,9 +331,45 @@ PWIZ_API_DECL ChromatogramList_Thermo::IndexEntry& ChromatogramList_Thermo::addC
     return ci;
 }
 
+template<typename MapT>
+typename MapT::const_iterator find_nearest(MapT const& m, typename MapT::key_type const& query, typename MapT::key_type const& tolerance)
+{
+    typename MapT::const_iterator cur, min, max, best;
+
+    min = m.lower_bound(query - tolerance);
+    max = m.lower_bound(query + tolerance);
+
+    if (min == m.end() || fabs(query - min->first) > tolerance)
+        return m.end();
+    else if (min == max)
+        return min;
+    else
+        best = min;
+
+    double minDiff = fabs(query - best->first);
+    for (cur = min; cur != max; ++cur)
+    {
+        double curDiff = fabs(query - cur->first);
+        if (curDiff < minDiff)
+        {
+            minDiff = curDiff;
+            best = cur;
+        }
+    }
+    return best;
+}
 
 PWIZ_API_DECL void ChromatogramList_Thermo::createIndex() const
 {
+    /*MassListTable massListTable;
+    for(const auto& method : rawfile_->getInstrumentMethods())
+    {
+        massListTable = parseMassListTables(method);
+        if (!massListTable.empty())
+            break;
+    }*/
+
+
     for (int controllerType = Controller_MS;
          controllerType < Controller_Count;
          ++controllerType)
@@ -390,22 +427,53 @@ PWIZ_API_DECL void ChromatogramList_Thermo::createIndex() const
                                 ci.q1 = filterParser.precursorMZs_[0];
                                 idMap_[ci.id] = ci.index;*/
 
+                                double q1 = scanInfo->precursorMZ(0);
+
                                 for (size_t j=0, jc=scanInfo->scanRangeCount(); j < jc; ++j)
                                 {
-                                    double q1 = scanInfo->precursorMZ(0);
-                                    double q3 = (scanInfo->scanRange(j).first + scanInfo->scanRange(j).second) / 2.0;
+                                    double scanRange = scanInfo->scanRange(j).second - scanInfo->scanRange(j).first;
+                                    double filterQ3 = (scanInfo->scanRange(j).first + scanInfo->scanRange(j).second) / 2.0;
                                     auto polarityType = translate(scanInfo->polarityType());
                                     string polarity = polarityStringForFilter(polarityType);
+
+                                    // if there's a mass list table entry for this q1/q3, use it instead of the scan range
+                                    /*auto findPrecursorItr = find_nearest(massListTable, q1, 0.001);
+                                    if (findPrecursorItr != massListTable.end())
+                                    {
+                                        auto findProductStartItr = findPrecursorItr->second.lower_bound(scanInfo->scanRange(j).first);
+                                        auto findProductEndItr = findPrecursorItr->second.lower_bound(scanInfo->scanRange(j).second);
+                                        for(const auto& itr : boost::iterator_range<MassListTable::mapped_type::const_iterator>(findProductStartItr, findProductEndItr))
+                                        {
+                                            double q3 = itr.second.product_mz;
+                                            string id = (format("%sSRM SIC %s,%.10g", std::locale::classic())
+                                                % polarity
+                                                % precursorMZ
+                                                % q3
+                                                ).str();
+                                            IndexEntry& ci = addChromatogram(id, (ControllerType)controllerType, n, MS_SRM_chromatogram, filterString);
+                                            ci.q1 = q1;
+                                            ci.q3 = q3;
+                                            ci.polarityType = polarityType;
+                                            ci.q3Offset = 0.35;
+                                            ci.filterQ3 = filterQ3;
+                                            ci.filterOffset = scanRange / 2.0;
+                                        }
+                                        continue;
+                                    }*/
+
+                                    if (scanRange > MAX_SRM_SCAN_RANGE)
+                                        continue; // skip this one, it's too wide
+
                                     string id = (format("%sSRM SIC %s,%.10g", std::locale::classic())
                                              % polarity
                                              % precursorMZ
-                                             % q3
+                                             % filterQ3
                                             ).str();
                                     IndexEntry& ci = addChromatogram(id, (ControllerType)controllerType, n, MS_SRM_chromatogram, filterString);
                                     ci.q1 = q1;
-                                    ci.q3 = q3;
+                                    ci.q3 = ci.filterQ3 = filterQ3;
                                     ci.polarityType = polarityType;
-                                    ci.q3Offset = (scanInfo->scanRange(j).second - scanInfo->scanRange(j).first) / 2.0;
+                                    ci.filterOffset = ci.q3Offset = scanRange / 2.0;
                                 }
                             }
                             break; // case ScanType_SRM

--- a/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.hpp
+++ b/pwiz/data/vendor_readers/Thermo/ChromatogramList_Thermo.hpp
@@ -81,6 +81,7 @@ public:
         string filter;
         double q1, q3;
         double q3Offset;
+        double filterQ3, filterOffset; // SRM Q3 and its range must match scan filter, even if we use mass table to get actual Q3
         CVID polarityType;
     };
 

--- a/pwiz/data/vendor_readers/Thermo/Jamfile.jam
+++ b/pwiz/data/vendor_readers/Thermo/Jamfile.jam
@@ -119,7 +119,8 @@ lib pwiz_reader_thermo
         <conditional>@vendor-api-usage-requirements
     ;
 
-doctest SpectrumList_ThermoTest : SpectrumList_Thermo.cpp : <library>$(PWIZ_ROOT_PATH)/pwiz/data/msdata//pwiz_data_msdata <conditional>@vendor-api-requirements ;
+doctest SpectrumList_ThermoTest : SpectrumList_Thermo.cpp : <library>pwiz_reader_thermo ;
+doctest Reader_Thermo_DetailTest : Reader_Thermo_Detail.cpp : <library>pwiz_reader_thermo ;
 
 
 rule warn-once ( message )

--- a/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Detail.hpp
+++ b/pwiz/data/vendor_readers/Thermo/Reader_Thermo_Detail.hpp
@@ -54,6 +54,23 @@ PWIZ_API_DECL CVID translateAsInletType(IonizationType ionizationType);
 PWIZ_API_DECL CVID translate(PolarityType polarityType);
 PWIZ_API_DECL void setActivationType(ActivationType activationType, ActivationType supplementalActivationType, Activation& activation);
 
+constexpr double MAX_SRM_SCAN_RANGE = 1.0; // if Q3 m/z range is larger than this, don't produce SRM chromatogram
+
+
+PWIZ_API_DECL struct MassListTableEntry
+{
+    std::string compound;
+    double precursor_mz;
+    double product_mz;
+    double collision_energy;
+    std::string polarity;
+};
+
+typedef std::map<double, std::map<double, MassListTableEntry>> MassListTable; /// keyed by precursor m/z, then product m/z
+
+PWIZ_API_DECL MassListTable parseMassListTables(const std::string& instrumentMethod);
+
+
 } // Thermo
 } // detail
 } // msdata

--- a/pwiz_tools/Skyline/Model/Results/SpectrumFilterPair.cs
+++ b/pwiz_tools/Skyline/Model/Results/SpectrumFilterPair.cs
@@ -237,6 +237,18 @@ namespace pwiz.Skyline.Model.Results
                 if (imRangeHelper.IsBeyondRange(spectrum))
                     break;
 
+                if (ReferenceEquals(productFilters, Ms2ProductFilters) &&
+                    spectrum.Metadata != null &&
+                    spectrum.Metadata.ScanWindowLowerLimit.HasValue &&
+                    spectrum.Metadata.ScanWindowUpperLimit.HasValue &&
+                    productFilters.All(f =>
+                        spectrum.Metadata.ScanWindowLowerLimit > f.TargetMz ||
+                        spectrum.Metadata.ScanWindowUpperLimit < f.TargetMz))
+                {
+                    // No overlap of any target with this spectrum's scan window
+                    continue;
+                }
+
                 // If these are spectra from distinct retention times, average them.
                 // Note that for ion mobility data we will see fewer retention time changes 
                 // than the total spectra count - ascending DT (or descending 1/K0) within each RT.  Within a


### PR DESCRIPTION
- changed Thermo processing of SRM spectra to only create chromatograms for them if the scan range is less than 1 m/z
- fixed spiky chromatograms in Skyline when processing SRM spectra (Skyline had not been checking whether the target Q3 m/z was within the scan window)
* fixed HasSrmSpectraInList to check fileDescription for "SRM spectrum" term
* added MS_raw_ion_mobility_drift_time_array variant for reading combined ion mobility spectra

@nickshulman @brendanx67 if you could review the Skyline changes I'd appreciate it. I originally made the filter step in `FilterQ3SpectrumList`, but that required allocating new lists and Brendan suggested that might be a performance issue. So I moved it into the spectrum processing loop. It has to check the ReferenceEquals(Ms2ProductIons,) bit so it only applies to calls from `FilterQ3SpectrumList`. 