### PR TITLE
Set Console.OutputEncoding in TestRunner Report.

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -2095,6 +2095,7 @@ namespace TestRunner
         // Generate a summary report of errors and memory leaks from a log file.
         private static void Report(string logFile)
         {
+            Console.OutputEncoding = Encoding.UTF8;
             var logLines = File.ReadAllLines(logFile);
 
             var errorList = new List<string>();


### PR DESCRIPTION
Fix character encoding problem running TestRunner.exe with "report" argument.