### PR TITLE
Always set Console.OutputEncoding to UTF-8.

### DIFF
--- a/pwiz_tools/Skyline/TestRunner/Program.cs
+++ b/pwiz_tools/Skyline/TestRunner/Program.cs
@@ -267,6 +267,7 @@ namespace TestRunner
         [STAThread, MethodImpl(MethodImplOptions.NoOptimization)]
         static int Main(string[] args)
         {
+            Console.OutputEncoding = Encoding.UTF8;
             Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
             Application.ThreadException += ThreadExceptionEventHandler;
 
@@ -288,9 +289,6 @@ namespace TestRunner
                     Report(commandLineArgs.ArgAsString("report"));
                     return 0;
             }
-
-            if (commandLineArgs.ArgAsString("language") != "en" && commandLineArgs.ArgAsString("language") != "en-US")
-                Console.OutputEncoding = Encoding.UTF8;  // So we can send Japanese to SkylineTester, which monitors our stdout
 
             Console.WriteLine();
             if (!commandLineArgs.ArgAsBool("status") && !commandLineArgs.ArgAsBool("buildcheck") && !commandLineArgs.HasArg("listonly") && commandLineArgs.ArgAsBool("showheader"))
@@ -2095,7 +2093,6 @@ namespace TestRunner
         // Generate a summary report of errors and memory leaks from a log file.
         private static void Report(string logFile)
         {
-            Console.OutputEncoding = Encoding.UTF8;
             var logLines = File.ReadAllLines(logFile);
 
             var errorList = new List<string>();


### PR DESCRIPTION
Remove wine-related code which did not set the encoding when running tests only in English.