### PR TITLE
Disable "TestKeyboardShortcutsHelpDocumentation" until memory leaks are fixed

### DIFF
--- a/pwiz_tools/Skyline/Test/HelpDocumentationContentTest.cs
+++ b/pwiz_tools/Skyline/Test/HelpDocumentationContentTest.cs
@@ -43,7 +43,8 @@ namespace pwiz.SkylineTest
     {
         protected override bool IsRecordMode => false;
 
-        [TestMethod]
+        // TODO(nicksh): Re-enable this test after memory leaks are fixed
+        //[TestMethod]
         public void TestKeyboardShortcutsHelpDocumentation()
         {
             if (ProcessEx.IsRunningOnWine)


### PR DESCRIPTION
The test needs to construct a SkylineWindow in order to walk the menu items, so it will probably need to be rewritten as a class that inherits from AbstractFunctionalTest