### PR TITLE
Revert recent changes to RescoreInPlaceTest

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/RescoreInPlaceTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/RescoreInPlaceTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Original author: Nicholas Shulman <nicksh .at. u.washington.edu>,
  *                  MacCoss Lab, Department of Genome Sciences, UW
  *


### PR DESCRIPTION
Recent changes seem to have introduced a hang caused by an AlertDlg being shown and not being dismissed.