### PR TITLE
Fix intermittent failure in TestMultiInjectRescore

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/MultiInjectRescoreTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MultiInjectRescoreTest.cs
@@ -82,7 +82,6 @@ namespace pwiz.SkylineTestFunctional
                 Assert.IsNotNull(fileStatuses[0].Error);
                 Assert.IsNull(fileStatuses[1].Error);
             });
-            OkDialog(allChromatogramsGraph, allChromatogramsGraph.Close);
             RunDlg<MultiButtonMsgDlg>(()=>SkylineWindow.NewDocument(), messageDlg=>messageDlg.ClickNo());
         }
     }


### PR DESCRIPTION
The test called "Close" on the AllChromatogramsGraph The AllChromatogramsGraph does not have a close button, and if it is closed in this way SkylineWindow will not know that it has been closed and will throw exceptions if it tries to send it update that window. Changed the test to not close that window.