### PR TITLE
Fix ArgumentOutOfRangeException in ProgressBar.set_Value

### DIFF
--- a/pwiz_tools/Skyline/Controls/LongWaitDlg.cs
+++ b/pwiz_tools/Skyline/Controls/LongWaitDlg.cs
@@ -125,7 +125,7 @@ namespace pwiz.Skyline.Controls
         {
             if (IsCanceled)
                 throw new OperationCanceledException();
-            ProgressValue = 100 * step / totalSteps;
+            ProgressValue = (int)(step * 100.0 / totalSteps);
         }
 
         public void PerformWork(Control parent, int delayMillis, Action performWork)


### PR DESCRIPTION
Fixed error saving document with more than 20 million precursor results (reported anonymously on Exception web)