### PR TITLE
Fix an apparent race condition in WatersLockmassPerfTest …

### DIFF
--- a/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
+++ b/pwiz_tools/Skyline/Model/Results/Chromatogram.cs
@@ -1145,6 +1145,11 @@ namespace pwiz.Skyline.Model.Results
             return ChangeProp(ImClone(this), im => im.ImportTime = importTime);
         }
 
+        public ChromFileInfo ChangeFileWriteTime(DateTime? fileWriteTime)
+        {
+            return ChangeProp(ImClone(this), im => im.FileWriteTime = fileWriteTime);
+        }
+
         public ChromFileInfo ChangeSampleId(string sampleId)
         {
             return ChangeProp(ImClone(this), im => im.SampleId = sampleId);

--- a/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
+++ b/pwiz_tools/Skyline/Model/Results/MeasuredResults.cs
@@ -787,6 +787,16 @@ namespace pwiz.Skyline.Model.Results
                 chrom.MSDataFileInfos.Select(info => info.ChangeImportTime(null)).ToList())).ToList());
         }
 
+        /// <summary>
+        /// Sets the FileWriteTimes on all of the ChromFileInfo's to null so that they will not
+        /// interfere with comparisons in tests.
+        /// </summary>
+        public MeasuredResults ClearFileWriteTimes()
+        {
+            return ChangeChromatograms(Chromatograms.Select(chrom => chrom.ChangeMSDataFileInfos(
+                chrom.MSDataFileInfos.Select(info => info.ChangeFileWriteTime(null)).ToList())).ToList());
+        }
+
         public IEnumerable<string> QcTraceNames
         {
             get

--- a/pwiz_tools/Skyline/TestPerf/PerfLockmassTest.cs
+++ b/pwiz_tools/Skyline/TestPerf/PerfLockmassTest.cs
@@ -94,7 +94,8 @@ namespace TestPerf // Note: tests in the "TestPerf" namespace only run when the 
 
                 if (testloop < 2)
                     DebugLog.Info("lockmass {0} load time = {1}", (testloop == 0) ? "corrected" : "uncorrected", loadStopwatch.ElapsedMilliseconds);
-                document = ResultsUtil.ClearFileImportTimes(document);
+                document = ResultsUtil.ClearFileImportTimes(document); // Ignore import time differences for comparisons
+                document = ResultsUtil.ClearFileWriteTimes(document); // Ignore write time differences for comparisons
                 if (testloop == 0)
                 {
                     corrected = document;

--- a/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
+++ b/pwiz_tools/Skyline/TestUtil/ResultsUtil.cs
@@ -135,6 +135,19 @@ namespace pwiz.SkylineTestUtil
             }
             return document.ChangeSettingsNoDiff(document.Settings.ChangeMeasuredResults(newMeasuredResults));
         }
+
+        /// <summary>
+        /// Set all of FileWriteTime values in all of the ChromFileInfos to null.
+        /// </summary>
+        public static SrmDocument ClearFileWriteTimes(SrmDocument document)
+        {
+            var newMeasuredResults = document.MeasuredResults?.ClearFileWriteTimes();
+            if (Equals(newMeasuredResults, document.MeasuredResults))
+            {
+                return document;
+            }
+            return document.ChangeSettingsNoDiff(document.Settings.ChangeMeasuredResults(newMeasuredResults));
+        }
     }
 
     public class DocResultsState


### PR DESCRIPTION
… by ignoring chromatogram file write time in document comparisons