### PR TITLE
Fix tri-state visual feedback on 'Select failed tests' button

### DIFF
--- a/ai/WORKFLOW.md
+++ b/ai/WORKFLOW.md
@@ -119,6 +119,37 @@ git pull origin master
 git branch -d Skyline/work/YYYYMMDD_feature  # Delete local branch
 ```
 
+### Workflow 3a: Bug Fix for Completed Work
+
+When fixing bugs in recently completed features (still in `ai/todos/completed/`):
+
+**Create bug-fix branch:**
+```bash
+git checkout master
+git pull origin master
+git checkout -b Skyline/work/YYYYMMDD_original-feature-name-fix
+```
+
+**Branch naming pattern:** Use original feature name + `-fix` suffix with today's date
+
+**Update the original TODO (don't create new one):**
+```bash
+# Add "Bug Fixes" section at end of ai/todos/completed/TODO-YYYYMMDD_original.md
+# Document: issue found, root cause, fix applied, testing notes
+git add ai/todos/completed/TODO-YYYYMMDD_original.md
+git commit -m "Document bug fix for original feature"
+```
+
+**After PR merge:**
+- Original TODO stays in `completed/` with bug fix documented
+- Delete bug-fix branch as usual
+- Bug fix becomes part of original feature's history
+
+**Use this workflow when:**
+- Bug is discovered shortly after feature completion
+- Fix is small and clearly related to original feature
+- Original TODO is still in `completed/` (not yet archived)
+
 ### Workflow 4: Create Backlog TODO During Active Work
 
 When inspiration strikes during development:

--- a/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
+++ b/pwiz_tools/Skyline/SkylineTester/SkylineTesterWindow.cs
@@ -1551,7 +1551,7 @@ namespace SkylineTester
         /// Updates all parent nodes in a tree to reflect their children's check states.
         /// Call this after programmatically checking/unchecking child nodes.
         /// </summary>
-        private void UpdateAllParentNodeCheckStates(TreeView treeView)
+        public void UpdateAllParentNodeCheckStates(TreeView treeView)
         {
             foreach (TreeNode rootNode in treeView.Nodes)
             {

--- a/pwiz_tools/Skyline/SkylineTester/TabTests.cs
+++ b/pwiz_tools/Skyline/SkylineTester/TabTests.cs
@@ -194,7 +194,9 @@ namespace SkylineTester
                 {
                     childNode.Checked = testSet.Contains(childNode.Text);
                 }
-            }            
+            }
+            // Update parent node tri-state visual feedback (gray text for partial selection)
+            MainWindow.UpdateAllParentNodeCheckStates(MainWindow.TestsTree);
             GetTestList(); // Updates the test list file contents
         }
 


### PR DESCRIPTION
## Summary
Fixed bug where parent nodes in Tests tab didn't immediately show gray text (tri-state indicator) when clicking "Select failed tests" button. The fix improves discoverability of selected tests by updating parent node visual state immediately.

## Changes
- Made `UpdateAllParentNodeCheckStates()` public in SkylineTesterWindow
- Called it in `TabTests.SetTests()` after programmatically checking nodes
- Documented bug fix workflow pattern in WORKFLOW.md
- Added bug fix section to TODO-20251116_skyline_tester_auto_restore.md

## Test Plan
1. Run some tests in SkylineTester (ensure at least one fails)
2. Click "Select failed tests" button on Output tab
3. Switch to Tests tab
4. Verify parent nodes immediately show gray text for partial selection
5. Close and restart SkylineTester
6. Verify visual state remains consistent

## Related Work
- Original feature: PR #3680 (SkylineTester auto-restore checked tests)
- Follows new bug-fix workflow documented in this PR's WORKFLOW.md changes

Co-Authored-By: Claude <noreply@anthropic.com>