### PR TITLE
Fixed AlertDlg.ShowDialog() to enforce test timeout

### DIFF
--- a/pwiz_tools/Skyline/Alerts/AlertDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/AlertDlg.cs
@@ -77,6 +77,25 @@ namespace pwiz.Skyline.Alerts
             }
         }
 
+        /// <summary>
+        /// Shadows Form.ShowDialog() to prevent parentless dialogs.
+        /// Use ShowDialog(IWin32Window) or ShowAndDispose(IWin32Window) instead.
+        /// </summary>
+        public new DialogResult ShowDialog()
+        {
+            // Parentless dialogs can leak handles. Use ShowDialog(parent) instead.
+            throw new InvalidOperationException(@"Not supported.");
+        }
+
+        /// <summary>
+        /// Shadows Form.ShowDialog(IWin32Window) to enforce test timeout behavior.
+        /// Use ShowAndDispose() for the common pattern of showing a dialog once and disposing it.
+        /// </summary>
+        public new DialogResult ShowDialog(IWin32Window parent)
+        {
+            return ShowWithTimeout(parent, GetTitleAndMessageDetail());
+        }
+
         public DialogResult ShowWithTimeout(IWin32Window parent, string message)
         {
             Assume.IsNotNull(parent);   // Problems if the parent is null
@@ -96,7 +115,7 @@ namespace pwiz.Skyline.Alerts
                 };
                 timeoutTimer.Start();
 
-                var result = ShowDialog(parent);
+                var result = base.ShowDialog(parent);
                 timeoutTimer.Stop();
                 if (timeout)
                     throw new TimeoutException(
@@ -107,7 +126,7 @@ namespace pwiz.Skyline.Alerts
                 return result;
             }
 
-            return ShowDialog(parent);
+            return base.ShowDialog(parent);
         }
         private const int TIMEOUT_SECONDS = 10;
 


### PR DESCRIPTION
## Summary
- Shadowed `Form.ShowDialog()` methods on `AlertDlg` with timeout-aware versions
- During functional tests, dialogs now throw `TimeoutException` after 10 seconds if not dismissed
- Prevents silent test hangs from unexpected `AlertDlg` dialogs (19 existing usages now protected)

## Background
Investigation of a test hang on KAIPOT-PC1 running `TestFilesTreeForm` revealed the issue. The `SkylineWindow.AskForLogEntry()` method shows an `AlertDlg` asking whether to add an audit log entry when the document hash doesn't match. On KAIPOT-PC1, a CRLF line-ending issue caused this dialog to appear unexpectedly during document loading.

The problem: `AlertDlg.ShowDialog()` bypassed the timeout mechanism used by `MessageDlg.Show()` and `MultiButtonMsgDlg.Show()`. The familiar pattern `using (var dlg = new AlertDlg()) { dlg.ShowDialog(...) }` had spread to 19 locations, all of which could cause silent test hangs.

By shadowing `ShowDialog()` with `new`, all existing and future usages automatically get timeout behavior in tests.

## Test plan
- [x] Build succeeds
- [ ] TeamCity build passes
- [ ] KAIPOT-PC1 `TestFilesTreeForm` now fails with TimeoutException instead of hanging silently

Co-Authored-By: Claude <noreply@anthropic.com>