### PR TITLE
Add "Replicate" column to new Peptide Normalized Areas and Protein Abundances reports.

### DIFF
--- a/pwiz_tools/Skyline/Model/PersistedViews.cs
+++ b/pwiz_tools/Skyline/Model/PersistedViews.cs
@@ -521,12 +521,14 @@ namespace pwiz.Skyline.Model
     <column name='Protein.Name' />
     <column name='Protein.Description' />
     <column name='Protein.Accession' />
+    <column name='Results!*.Value.ResultFile.Replicate' />
     <column name='Results!*.Value.Quantification.NormalizedArea' />
   </view>
   <view name='Protein Abundances' rowsource='pwiz.Skyline.Model.Databinding.Entities.Protein' sublist='' uimode='proteomic'>
     <column name='' />
     <column name='Description' />
     <column name='Gene' />
+    <column name='Results!*.Value.Replicate' />
     <column name='Results!*.Value.Abundance' />
   </view>
 </views>";


### PR DESCRIPTION
Since there hasn't been a Skyline-daily release since when these reports were added, it is not necessary to increment the version number in PersistedViews.cs

Adding the "Replicate" column gives the user something to click on to navigate to the replicate.

<img width="947" height="462" alt="image" src="https://github.com/user-attachments/assets/f17bdb6b-a52a-4ad7-83d1-de129341c1d0" />
<img width="947" height="462" alt="image" src="https://github.com/user-attachments/assets/1caaa062-6feb-4b9a-9dcf-0d757cb26e30" />
