### PR TITLE
Fix intermittent failure in TestMinimizeWithEmptyFiles

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/MinimizeWithEmptyFilesTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MinimizeWithEmptyFilesTest.cs
@@ -57,6 +57,7 @@ namespace pwiz.SkylineTestFunctional
                     minimizeResultsDlg.Minimize(false);
                 });
             }, manageResultsDlg => { });
+            WaitForDocumentLoaded();
             var cachedFiles = SkylineWindow.Document.MeasuredResults.CachedFilePaths.ToHashSet();
             foreach (var filePath in SkylineWindow.Document.MeasuredResults.MSDataFilePaths)
             {


### PR DESCRIPTION
Add "WaitForDocumentLoaded" after OKing Manage Results dialog.