### PR TITLE
Fix intermittent failure in PeakBoundaryImputationDiaTutorial

### DIFF
--- a/pwiz_tools/Skyline/TestPerf/PeakBoundaryImputationDiaTutorial.cs
+++ b/pwiz_tools/Skyline/TestPerf/PeakBoundaryImputationDiaTutorial.cs
@@ -226,16 +226,7 @@ namespace TestPerf
         {
             var scoreToRunGraphPane = GetScoreToRunGraphPane();
             Assert.IsNotNull(scoreToRunGraphPane);
-            // WARNING: Using WaitForConditionUI here causes an unexplained deadlock.
-            //          The call to Program.MainWindow.Invoke blocks waiting for the UI thread,
-            //          while the Skyline window remains responsive to mouse and keyboard input.
-            //          The UI thread is actively pumping messages, yet the Invoke message is
-            //          never dispatched. This occurs after ProductAvailableAction runs via
-            //          BeginInvoke from the caching system. Using WaitForCondition works because
-            //          IsCalculating is thread-safe (reads _graphDataReceiver.IsProcessing()).
-            //          This pattern was previously established in RunToRunAlignmentTest.
-            // WaitForConditionUI(() => !scoreToRunGraphPane.IsCalculating);
-            WaitForCondition(() => !scoreToRunGraphPane.IsCalculating);
+            WaitForConditionUI(() => !scoreToRunGraphPane.IsCalculating);
         }
 
         public static RTLinearRegressionGraphPane GetScoreToRunGraphPane()


### PR DESCRIPTION
Claude came up with the idea that Receiver.OnProductStatusChanged was getting called a lot and all of its calls to BeginInvoke seems to maybe have been the cause of the eventual hang in WaitForConditionUI. Changed that function so that it does not fire off the notification if it's still waiting for the previous notification to be dequeued.