### PR TITLE
Cherry-pick: Populated FileCount and File columns in localization CSV export

### DIFF
--- a/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/Jamfile.jam
+++ b/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/Jamfile.jam
@@ -102,5 +102,69 @@ make FinalizeResxFiles
 
 explicit FinalizeResxFiles ;
 
+##############
+# GenerateLocalizationCsvFiles
+# Should be run on the release branch after FinalizeResxFiles to generate CSV files for translators
+##############
+
+rule do_GenerateLocalizationCsvFiles ( targets + : sources * : properties * )
+{
+    return [ build-properties $(targets) : $(sources) : $(properties) ] ;
+}
+
+actions do_GenerateLocalizationCsvFiles
+{
+    echo Generating localization CSV files
+    call $(CURRENT_DIR)\scripts\GenerateLocalizationCsvFiles.bat
+    set status=%ERRORLEVEL%
+    exit %status%
+}
+
+
+make GenerateLocalizationCsvFiles
+    : # sources
+    : # actions
+        @do_GenerateLocalizationCsvFiles
+    : # requirements
+        <link>shared:<build>no
+        <conditional>@no-express-requirement
+        <conditional>@msvc-dotnet-requirement
+        <dependency>ResourcesOrganizer.exe
+    ;
+
+explicit GenerateLocalizationCsvFiles ;
+
+##############
+# ImportLocalizationCsvFiles
+# Should be run on the release branch after receiving translated CSV files from translators
+# Imports translations and updates the .resx files
+##############
+
+rule do_ImportLocalizationCsvFiles ( targets + : sources * : properties * )
+{
+    return [ build-properties $(targets) : $(sources) : $(properties) ] ;
+}
+
+actions do_ImportLocalizationCsvFiles
+{
+    echo Importing localization CSV files
+    call $(CURRENT_DIR)\scripts\ImportLocalizationCsvFiles.bat
+    set status=%ERRORLEVEL%
+    exit %status%
+}
+
+
+make ImportLocalizationCsvFiles
+    : # sources
+    : # actions
+        @do_ImportLocalizationCsvFiles
+    : # requirements
+        <link>shared:<build>no
+        <conditional>@no-express-requirement
+        <conditional>@msvc-dotnet-requirement
+        <dependency>ResourcesOrganizer.exe
+    ;
+
+explicit ImportLocalizationCsvFiles ;
 
 

--- a/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/README.md
+++ b/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/README.md
@@ -5,27 +5,69 @@ pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\ResourcesOrganizer.sl
 
 The project requires .Net 8 to build.
 
->The project has been published to the folder:
->
-> `pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\ResourcesOrganizer\scripts\exe`
+## Jamfile Targets (Recommended)
 
-### The "scripts" folder contains the following scripts which are intended to be run from the root of the project:
+The simplest way to use ResourcesOrganizer is via Jamfile targets. Run from the project root:
+
+### Generate Localization CSV Files
+
+```cmd
+b.bat pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer//GenerateLocalizationCsvFiles
+```
+
+Creates `localization.ja.csv` and `localization.zh-CHS.csv` in `pwiz_tools\Skyline\Translation\Scratch\` containing strings needing translation. The CSV includes columns for:
+- **Name**: Resource key (empty for consolidated entries)
+- **English**: Text to translate
+- **Translation**: Empty column for translators
+- **Issue**: Localization issues (e.g., "English text changed")
+- **FileCount/File**: Source .resx file(s) for context
+
+### Import Localization CSV Files
+
+```cmd
+b.bat pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer//ImportLocalizationCsvFiles
+```
+
+Place translated CSV files in `pwiz_tools\Skyline\Translation\Scratch\` (keeping filenames `localization.ja.csv` and `localization.zh-CHS.csv`), then run this target to:
+1. Import translations into the database
+2. Export updated .resx files
+3. Extract them to the project
+
+Verify success by checking build output shows "changed X/Y matching records" and ends with "SUCCESS".
+
+### Finalize Resx Files (Pre-Release)
+
+```cmd
+b.bat pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer//FinalizeResxFiles
+```
+
+Run before creating a release branch to update .ja and .zh-CHS .resx files with comments for strings added since the last release.
+
+## Manual Scripts
+
+The "scripts" folder contains batch files for manual operation:
 
 >`pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\readResxFiles.bat`
 >
->creates a file called "resources.db" which contains information from all of the .resx files
+>Creates "resources.db" containing information from all .resx files
 
-> `pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\generateLocalizationCsvFiles.bat`
+>`pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\GenerateLocalizationCsvFiles.bat`
 >
-> *creates files "localization.ja.csv" and "localization.zh-CHS.csv" containing strings that have "NeedsReview:" comments in them*
+>Creates localization CSV files for translation
 
-### Additionally, the following commands will be useful after getting updated copies of these .csv files back from the localizers:
-
->  `pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\exe\ResourcesOrganizer.exe importLocalizationCsv`
+>`pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\ImportLocalizationCsvFiles.bat`
 >
-> *Imports the contents of "localization.ja.csv" and "localization.zh-CHS.csv" back into resources.db*
+>Imports translated CSV files and updates .resx files
 
-> `pwiz_tools\Skyline\Executables\DevTools\ResourcesOrganizer\scripts\exe\ResourcesOrganizer.exe exportResx resxFiles.zip`
+## Command-Line Tool
+
+The ResourcesOrganizer executable supports additional commands:
+
+>`ResourcesOrganizer.exe importLocalizationCsv --db <database> --input <csv> --language <lang>`
 >
-> *Outputs the contents of `resources.db` into zipfiles in "resxFiles.zip". You can then extract the contents of that zip file to the root of the project and normalize the resx files, making sure that the contents of the resx files are in the same order across the languages.*
+>Imports a single CSV file into the database
+
+>`ResourcesOrganizer.exe exportResx --db <database> <output.zip>`
+>
+>Exports database contents to a zip of .resx files
 

--- a/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/ResourcesOrganizer/Program.cs
+++ b/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/ResourcesOrganizer/Program.cs
@@ -238,6 +238,7 @@ namespace ResourcesOrganizer
             if (languages.Count == 1)
             {
                 yield return new LanguageFilePath(languages[0], fullPath);
+                yield break;
             }
 
             foreach (var language in languages)

--- a/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/ResourcesOrganizer/ResourcesModel/ResourcesDatabase.cs
+++ b/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/ResourcesOrganizer/ResourcesModel/ResourcesDatabase.cs
@@ -471,28 +471,48 @@ namespace ResourcesOrganizer.ResourcesModel
         public void ExportLocalizationCsv(string path, string language, out int entryCount)
         {
             var records = new List<LocalizationCsvRecord>();
-            foreach (var textGroup in GetInvariantResources().Values.SelectMany(list=>list)
-                         .Where(resourceEntry=>resourceEntry.Invariant.IsLocalizableText && NeedsLocalizationHelp(resourceEntry, language))
-                         .GroupBy(resourceEntry=>resourceEntry.Invariant with {File = string.Empty, Name = string.Empty}))
-            {
-                var individualRecords =
-                    textGroup.Select(resourceEntry => MakeLocalizationCsvRecord(resourceEntry, language)).ToList();
 
-                if (individualRecords.Count > 1)
+            // Iterate over ResourcesFiles directly to preserve file path information
+            var entriesWithFiles = ResourcesFiles
+                .SelectMany(kvp => kvp.Value.Entries
+                    .Where(entry => entry.Invariant.IsLocalizableText && NeedsLocalizationHelp(entry, language))
+                    .Select(entry => (FilePath: kvp.Key, Entry: entry)))
+                .GroupBy(x => x.Entry.Invariant with { File = string.Empty, Name = string.Empty });
+
+            foreach (var textGroup in entriesWithFiles)
+            {
+                var groupList = textGroup.ToList();
+                var uniqueFiles = groupList.Select(x => x.FilePath).Distinct().OrderBy(f => f).ToList();
+                var fileCount = uniqueFiles.Count;
+
+                // Create records with file path association preserved
+                var recordsWithFiles = groupList
+                    .Select(x => (FilePath: x.FilePath, Record: MakeLocalizationCsvRecord(x.Entry, language)))
+                    .ToList();
+
+                if (recordsWithFiles.Count > 1)
                 {
-                    var uniqueIssues = textGroup.Select(entry => entry.GetTranslation(language)?.Issue)
+                    var uniqueIssues = groupList.Select(x => x.Entry.GetTranslation(language)?.Issue)
                         .OfType<LocalizationIssue>()
                         .Where(issue => issue != LocalizationIssue.MissingTranslation).Distinct()
                         .ToList();
                     if (uniqueIssues.Count == 1)
                     {
-                        individualRecords = individualRecords.Select(record => uniqueIssues[0].StoreInCsvRecord(record))
+                        recordsWithFiles = recordsWithFiles
+                            .Select(x => (x.FilePath, Record: uniqueIssues[0].StoreInCsvRecord(x.Record)))
                             .Distinct().ToList();
                     }
-                    var unqualifiedRecords = individualRecords.Select(record => record with
+
+                    // Build a file list for context (show up to 3 files, with "..." if more)
+                    var fileList = uniqueFiles.Count <= 3
+                        ? string.Join("; ", uniqueFiles)
+                        : string.Join("; ", uniqueFiles.Take(3)) + "; ...";
+
+                    var unqualifiedRecords = recordsWithFiles.Select(x => x.Record with
                     {
-                        File = string.Empty,
-                        Name = string.Empty
+                        File = fileList,
+                        Name = string.Empty,
+                        FileCount = fileCount
                     }).Distinct().ToList();
                     if (unqualifiedRecords.Count == 1)
                     {
@@ -500,7 +520,9 @@ namespace ResourcesOrganizer.ResourcesModel
                         continue;
                     }
                 }
-                records.AddRange(individualRecords);
+
+                // For non-consolidated entries, each record keeps its own file path with FileCount=1
+                records.AddRange(recordsWithFiles.Select(x => x.Record with { FileCount = 1, File = x.FilePath }));
             }
             using var stream = new FileStream(path, FileMode.Create);
             using var writer = new StreamWriter(stream, new UTF8Encoding(false));

--- a/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/ResourcesOrganizer/ResourcesModel/ResourcesFile.cs
+++ b/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/ResourcesOrganizer/ResourcesModel/ResourcesFile.cs
@@ -314,7 +314,7 @@ namespace ResourcesOrganizer.ResourcesModel
                 var entry = entries[i];
                 foreach (var record in records[entry.Invariant.Name!].Concat(records[string.Empty]))
                 {
-                    if (!string.IsNullOrEmpty(record.File) && record.File != RelativePath)
+                    if (!string.IsNullOrEmpty(record.File) && !FileMatchesRecord(record.File, RelativePath))
                     {
                         continue;
                     }
@@ -346,6 +346,29 @@ namespace ResourcesOrganizer.ResourcesModel
             }
 
             return this with { Entries = entries.ToImmutableList() };
+        }
+
+        /// <summary>
+        /// Check if a file path matches the record's File field.
+        /// The File field may contain a single path or a semicolon-separated list of paths
+        /// (e.g., "FileA.resx; FileB.resx; FileC.resx" or "FileA.resx; FileB.resx; ...").
+        /// </summary>
+        private static bool FileMatchesRecord(string recordFile, string filePath)
+        {
+            // Check for exact match first (most common case)
+            if (recordFile == filePath)
+                return true;
+
+            // Check if it's a semicolon-separated list
+            if (recordFile.Contains("; "))
+            {
+                // Split and check if filePath is in the list
+                // Handle trailing "; ..." for truncated lists
+                var files = recordFile.Split(new[] { "; " }, StringSplitOptions.RemoveEmptyEntries);
+                return files.Any(f => f == filePath || f == "...");
+            }
+
+            return false;
         }
     }
 }

--- a/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/scripts/ImportLocalizationCsvFiles.bat
+++ b/pwiz_tools/Skyline/Executables/DevTools/ResourcesOrganizer/scripts/ImportLocalizationCsvFiles.bat
@@ -1,0 +1,56 @@
+@setlocal
+echo on
+call %~dp0SetVariables.bat
+if %ERRORLEVEL% neq 0 (
+    goto end
+)
+
+pushd %PWIZ_ROOT%
+call %~dp0MakeResourcesDb.bat %WORKDIR%\ForImportLocalizationCsv.db
+popd
+pushd %WORKDIR%
+
+REM Import Japanese translations
+if exist localization.ja.csv (
+    echo Importing Japanese translations from localization.ja.csv
+    %RESORGANIZER% importLocalizationCsv --db ForImportLocalizationCsv.db --input localization.ja.csv --language ja
+    if %ERRORLEVEL% neq 0 (
+        goto error
+    )
+) else (
+    echo localization.ja.csv not found, skipping Japanese
+)
+
+REM Import Chinese translations
+if exist localization.zh-CHS.csv (
+    echo Importing Chinese translations from localization.zh-CHS.csv
+    %RESORGANIZER% importLocalizationCsv --db ForImportLocalizationCsv.db --input localization.zh-CHS.csv --language zh-CHS
+    if %ERRORLEVEL% neq 0 (
+        goto error
+    )
+) else (
+    echo localization.zh-CHS.csv not found, skipping Chinese
+)
+
+REM Export updated resx files
+echo Exporting updated resx files
+%RESORGANIZER% exportResx --db ForImportLocalizationCsv.db ImportedResxFiles.zip
+if %ERRORLEVEL% neq 0 (
+    goto error
+)
+popd
+
+REM Extract the updated resx files
+pushd %PWIZ_ROOT%
+echo Extracting updated resx files
+libraries\7za.exe x -y %WORKDIR%\ImportedResxFiles.zip
+if %ERRORLEVEL% neq 0 (
+    goto error
+)
+popd
+
+echo SUCCESS
+goto end
+:error
+echo ERROR
+:end


### PR DESCRIPTION
## Summary

Cherry-pick of #3766 to release branch `Skyline/skyline_26_1`.

The original PR was merged to master but the automatic cherry-pick failed because the source branch was deleted before the cherry-pick bot could run.

**Original changes:**
* Added `FileCount` and `File` columns to localization CSV export for translator context
* Fixed non-consolidated entries to retain original file paths with FileCount=1
* Updated README with Jamfile targets documentation
* Added ImportLocalizationCsvFiles.bat script