### PR TITLE
Cherry-pick: Added fallback to JAMDATE when git date extraction fails

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -537,10 +537,17 @@ rule day_of_year ( Y M D )
 
 # YMMDD where Y is number of years since 2016
 # Uses git commit date for reproducible versioning (not build machine date)
+# Falls back to JAMDATE if git command fails (e.g., old git version, shallow clone)
 rule MAKE_BUILD_TIMESTAMP ( )
 {
     local git_date = [ SHELL "git log -1 --format=%cs HEAD" ] ;
     local ymd = [ MATCH "([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])" : $(git_date) ] ;
+    if ! $(ymd)
+    {
+        # Fallback to build machine date if git date extraction fails
+        local utc = [ modules.peek : JAMDATE ] ;
+        ymd = [ MATCH "([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])" : $(utc) ] ;
+    }
     local d = [ MATCH "[0-9][0-9]([0-9][0-9])" : $(ymd[0]) ] [ day_of_year $(ymd) ] ;
     return $(d:J=) ;
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #3769 to release branch `Skyline/skyline_26_1`.

The automatic cherry-pick failed due to merge commits in the PR history.

**Original fix:**
* Added fallback to JAMDATE-based timestamp when git date extraction fails
* Fixes build failure on BOSS-PC where `git log -1 --format=%cs HEAD` returned empty