### PR TITLE
Cherry-pick: Fix VS 2026 (msvc-14.5) build toolset detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -428,8 +428,10 @@ Version.cpp
 /pwiz_tools/Skyline/SkylineTester test list.txt
 /pwiz_tools/Skyline/SkylineTester.log
 SkylineTester Results
+/b.bat
 /b64.bat
 /b32.bat
+/bs.bat
 /bs64.bat
 /bs32.bat
 /bso64.bat

--- a/libraries/boost-build/src/tools/msvc.jam
+++ b/libraries/boost-build/src/tools/msvc.jam
@@ -2593,8 +2593,10 @@ for local arch in [ MATCH "^\\.cpus-on-(.*)" : [ VARNAMES $(__name__) ] ]
     ;
 .version-14.3-env = VS170COMNTOOLS ProgramFiles ProgramFiles(x86) ;
 .version-14.5-path =
-    "../../VC/Tools/MSVC/*/bin/Host*/*"
-    "Microsoft Visual Studio/18/*/VC/Tools/MSVC/*/bin/Host*/*"
+    "../../VC/Tools/MSVC/*/bin/Hostx64/x64"
+    "../../VC/Tools/MSVC/*/bin/Hostx86/x86"
+    "Microsoft Visual Studio/18/*/VC/Tools/MSVC/*/bin/Hostx64/x64"
+    "Microsoft Visual Studio/18/*/VC/Tools/MSVC/*/bin/Hostx86/x86"
     ;
 .version-14.5-env = VS180COMNTOOLS ProgramFiles ProgramFiles(x86) ;
 

--- a/pwiz_tools/build-apps.bat
+++ b/pwiz_tools/build-apps.bat
@@ -102,6 +102,7 @@ findstr /c:"Could not resolve reference" %QUICKBUILDLOG%
 findstr /b /c:"Unable to load" %QUICKBUILDLOG%
 findstr /b /c:"error:" %QUICKBUILDLOG%
 findstr /c:"test(s) Passed" %QUICKBUILDLOG%
+findstr /c:"Elapsed time:" %QUICKBUILDLOG%
 
 :BUILD_DONE
 echo.


### PR DESCRIPTION
## Summary

Cherry-pick of #3774 to release branch `Skyline/skyline_26_1`.

**Original fix:**
* Fixed msvc.jam toolset 14.5 path patterns to use explicit Hostx64/x64 and Hostx86/x86 instead of Host*/* glob
* VS 2026 added ARM64 host compilers (HostArm64) which sorted alphabetically before Hostx64, causing cl.exe not to be found on x64 machines
* Added b.bat and bs.bat to .gitignore
* Surface elapsed time in build-apps.bat output