### PR TITLE
Added JAMDATE fallback to Skyline version date extraction

### DIFF
--- a/pwiz_tools/Skyline/Jamfile.jam
+++ b/pwiz_tools/Skyline/Jamfile.jam
@@ -51,6 +51,12 @@ if [ modules.peek : NT ] && --i-agree-to-the-vendor-licenses in [ modules.peek :
     # Use Git commit date for version day-of-year (reproducible versioning)
     local git_date = [ SHELL "git log -1 --format=%cs HEAD" ] ;
     local ymd = [ MATCH "([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])" : $(git_date) ] ;
+    if ! $(ymd)
+    {
+        # Fallback to build machine date if git date extraction fails
+        local utc = [ modules.peek : JAMDATE ] ;
+        ymd = [ MATCH "([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])" : $(utc) ] ;
+    }
     local year_2digit = [ MATCH "[0-9][0-9]([0-9][0-9])" : $(ymd) ] ;
 
     constant SKYLINE_YEAR : 26 ;


### PR DESCRIPTION
## Summary

Companion fix to PR #3773 (Jamroot.jam fallback cherry-pick).

Skyline's `Jamfile.jam` has its own git date extraction for versioning that also needs the JAMDATE fallback. On BOSS-PC with an older git version, `git log -1 --format=%cs HEAD` returns the literal string `%cs` instead of the date, causing the build to fail.

**Changes:**
* Added fallback to JAMDATE when git date extraction fails in `pwiz_tools/Skyline/Jamfile.jam`

**Tested on BOSS-PC** - build now succeeds.

Master PR: #3776