### PR TITLE
Cherry-pick: Fix VS 2026 detection and improve build script process blocking

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/Main.cs
+++ b/pwiz_tools/Skyline/SkylineTester/Main.cs
@@ -632,6 +632,24 @@ namespace SkylineTester
         }
 
         public const int MINIMUM_VISUAL_STUDIO = 2017;
+
+        // Map internal VS version numbers to marketing years
+        private static int GetVsYear(int version)
+        {
+            // Year-based folders (2017+) are already the year
+            if (version >= MINIMUM_VISUAL_STUDIO)
+                return version;
+            // Internal version mapping: 15=2017, 16=2019, 17=2022, 18=2026, ...
+            switch (version)
+            {
+                case 15: return 2017;
+                case 16: return 2019;
+                case 17: return 2022;
+                case 18: return 2026;
+                default: return 2026 + (version - 18) * 2; // Estimate future versions
+            }
+        }
+
         public static string GetExistingVsIdeFilePath(string relativePath)
         {
             var programFiles = new[]
@@ -639,13 +657,25 @@ namespace SkylineTester
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)
             };
-            string[] pathTrials = 
+            string[] pathTrials =
             {
-                @"Microsoft Visual Studio\{0}\Enterprise\Common7\IDE",  
+                @"Microsoft Visual Studio\{0}\Enterprise\Common7\IDE",
                 @"Microsoft Visual Studio\{0}\Professional\Common7\IDE",
-                @"Microsoft Visual Studio\{0}\Community\Common7\IDE",   
+                @"Microsoft Visual Studio\{0}\Community\Common7\IDE",
             };
-            for (var version = 2040; version >= MINIMUM_VISUAL_STUDIO; version--) // 2040 is completely arbitrary
+            // Check both marketing years (2017-2040) and internal version numbers (15-30)
+            // VS 2017-2022 use year-based folders (2017, 2019, 2022)
+            // VS 2026+ may use internal version numbers (18 for VS 2026)
+            // Find all matches and return the most recent VS version
+            var candidates = new List<Tuple<int, string>>(); // (year, path)
+
+            var versionsToCheck = new List<int>();
+            for (var year = 2040; year >= MINIMUM_VISUAL_STUDIO; year--)
+                versionsToCheck.Add(year);
+            for (var version = 30; version >= 15; version--)
+                versionsToCheck.Add(version);
+
+            foreach (var version in versionsToCheck)
             {
                 foreach (var pathTrial in pathTrials)
                 {
@@ -653,12 +683,13 @@ namespace SkylineTester
                     {
                         var path = Path.Combine(Path.Combine(programFilesDir, string.Format(pathTrial, version)), relativePath);
                         if (File.Exists(path))
-                            return path;
+                            candidates.Add(Tuple.Create(GetVsYear(version), path));
                     }
                 }
             }
 
-            return null;
+            // Return the path from the most recent VS version
+            return candidates.OrderByDescending(c => c.Item1).FirstOrDefault()?.Item2;
         }
 
         public void RunUI(Action action, int delayMsec = 0)


### PR DESCRIPTION
## Summary

Cherry-pick of #3780 to release branch `Skyline/skyline_26_1`.

**Original changes:**

SkylineTester VS detection:
- VS 2026 uses folder name '18' (internal version) instead of '2026'
- Now checks both marketing years (2017-2040) and internal versions (15-30)

Build-Skyline.ps1:
- Process blocking now checks executable path, not just process name
- Only blocks on processes from current build directory
- Allows builds when SkylineTester/TestRunner running from other installations