### PR TITLE
Fix NRE in PeakBoundaryImputer.GetMedianPeak

### DIFF
--- a/pwiz_tools/Skyline/Model/RetentionTimes/PeakImputation/PeakBoundaryImputer.cs
+++ b/pwiz_tools/Skyline/Model/RetentionTimes/PeakImputation/PeakBoundaryImputer.cs
@@ -371,7 +371,8 @@ namespace pwiz.Skyline.Model.RetentionTimes.PeakImputation
 
         private ImputedPeak GetMedianPeak(IEnumerable<ImputedPeak> imputedPeaks)
         {
-            var orderedPeaks = imputedPeaks.OrderBy(peak => peak.PeakBounds.StartTime + peak.PeakBounds.EndTime).ToList();
+            var orderedPeaks = imputedPeaks.Where(peak => null != peak)
+                .OrderBy(peak => peak.PeakBounds.StartTime + peak.PeakBounds.EndTime).ToList();
             if (orderedPeaks.Count == 0)
             {
                 return null;


### PR DESCRIPTION
Fixed error removing replicates while doing peak imputation (reported on Exception Web)