### PR TITLE
UniCode file handling tweak for Waters and Mobilion…

### DIFF
--- a/pwiz/data/vendor_readers/Mobilion/Reader_Mobilion.cpp
+++ b/pwiz/data/vendor_readers/Mobilion/Reader_Mobilion.cpp
@@ -189,7 +189,7 @@ void Reader_Mobilion::read(const string& filenameIn,
     result.run.spectrumListPtr = SpectrumListPtr(new SpectrumList_Mobilion(result, rawdata, config));
     result.run.chromatogramListPtr = ChromatogramListPtr(new ChromatogramList_Mobilion(rawdata, config));
 
-    fillInMetadata(filename, &rawdata->file, result);
+    fillInMetadata(filenameIn, &rawdata->file, result);
 }
 
 

--- a/pwiz/data/vendor_readers/Waters/Reader_Waters.cpp
+++ b/pwiz/data/vendor_readers/Waters/Reader_Waters.cpp
@@ -210,7 +210,7 @@ void Reader_Waters::read(const string& filenameIn,
         result.run.spectrumListPtr = SpectrumListPtr(new SpectrumList_Waters(result, rawdata, config));
         result.run.chromatogramListPtr = ChromatogramListPtr(new ChromatogramList_Waters(rawdata, config));
 
-        fillInMetadata(filename, rawdata, result);
+        fillInMetadata(filenameIn, rawdata, result);
     }
     catch (exception&)
     {


### PR DESCRIPTION
… (whose reader DLLs do not handle UniCode filenames), msconvert was using the 8.3 version of UniCode-containing filenames for output filename and for run id in the mzML file.

e.g. 091204_NFDM_008-试验.raw should produce 091204_NFDM_008-试验.mzML but was creating 091204\~1.mzML instead, and within the file where it should read id="091204_NFDM_008-试验.raw" it used id="091204\~1.raw"