### PR TITLE
Fix InvalidOperationException in CommandShell.cs

### DIFF
--- a/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
+++ b/pwiz_tools/Skyline/SkylineTester/CommandShell.cs
@@ -397,10 +397,12 @@ namespace SkylineTester
                 _process.ErrorDataReceived += HandleOutput;
                 _process.Exited += ProcessExit;
             }
+
+            _processName = Path.GetFileNameWithoutExtension(exe);
+            var process = _process;
             _process.Start();
-            _processName = _process.ProcessName;
-            _process.BeginOutputReadLine();
-            _process.BeginErrorReadLine();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
             ResetLastOutputTime();
         }
 
@@ -507,7 +509,6 @@ namespace SkylineTester
                 return;
 
             var exitCode = _process.ExitCode; // That's all the info you can get from a process that has exited - no name etc
-            var processName = _process.ToString();
             _process = null;
             bool processKilled = _processKilled;
             _processKilled = false;


### PR DESCRIPTION
Fix InvalidOperationException using SkylineTester to run a very fast test (e.g. "TestFastaImport") I am finding that SkylineTester crashes if I run a test which does not take very long. It seems that the problem is that it runs TestRunner to read the log file and TestRunner is able to exit before SkylineTester is able to initialize a few variables. One problem is that line 510:
var processName = _process.ToString();
is not supposed to be there at all. That line was removed on 8/31/2018, but got added back on Sept 7th as part of a complicated commit with several parts that seems to have restored the line in a bad merge.

But, it also seemed to run into a problem trying to get the process name on line 401 if the process exited really quickly, so I changed the code to assume that the name of the process is the same as the name of the executable.