### PR TITLE
Cherry-pick: Fixed PanoramaImportErrorException treated as programming defect

### DIFF
--- a/pwiz_tools/Shared/PanoramaClient/PanoramaUtil.cs
+++ b/pwiz_tools/Shared/PanoramaClient/PanoramaUtil.cs
@@ -450,7 +450,18 @@ namespace pwiz.PanoramaClient
         }
     }
 
-    public class PanoramaServerException : IOException
+    /// <summary>
+    /// Base class for all Panorama-specific exceptions.
+    /// Inherits from IOException so that these exceptions are recognized as user-actionable
+    /// rather than programming defects by ExceptionUtil.IsProgrammingDefect().
+    /// </summary>
+    public class PanoramaException : IOException
+    {
+        public PanoramaException(string message) : base(message) { }
+        public PanoramaException(string message, Exception innerException) : base(message, innerException) { }
+    }
+
+    public class PanoramaServerException : PanoramaException
     {
         public HttpStatusCode? HttpStatus { get; }
 
@@ -473,7 +484,7 @@ namespace pwiz.PanoramaClient
             if (labKeyError != null)
             {
                 errorMessageBuilder.LabKeyError(labKeyError);
-                
+
                 // Don't include the NetworkRequestException message when we have a LabKey error
                 // The LabKey error is the server's specific error message and is what users need
                 // The exception message would be technical details (e.g., "Response status code does not indicate success: 500...")
@@ -577,9 +588,10 @@ namespace pwiz.PanoramaClient
         }
     }
 
-    public class PanoramaImportErrorException : Exception
+    public class PanoramaImportErrorException : PanoramaException
     {
         public PanoramaImportErrorException(Uri serverUrl, Uri jobUrl, string error, bool jobCancelled = false)
+            : base(error)
         {
             ServerUrl = serverUrl;
             JobUrl = jobUrl;


### PR DESCRIPTION
## Summary

Cherry-pick of #3809 to release branch `Skyline/skyline_26_1`.

**Original changes:**
* Added `PanoramaException` base class inheriting from `IOException`
* Changed `PanoramaServerException` to inherit from `PanoramaException`
* Changed `PanoramaImportErrorException` to inherit from `PanoramaException`
* Added `TestPanoramaExceptionsUserActionable` unit test

This fixes a bug where users see a crash dialog instead of a friendly error message when Panorama document import fails on the server.

Co-Authored-By: Claude <noreply@anthropic.com>