### PR TITLE
- fixed KeyValueGridDlg showing blank contents

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/GUI/CommonAlertDlg.Designer.cs
+++ b/pwiz_tools/Shared/CommonUtil/GUI/CommonAlertDlg.Designer.cs
@@ -198,7 +198,7 @@ namespace pwiz.Common.GUI
         private System.Windows.Forms.Label labelMessage;
         private System.Windows.Forms.ToolStrip toolStrip1;
         private System.Windows.Forms.ToolStripButton toolStripButtonCopy;
-        private System.Windows.Forms.SplitContainer iconAndMessageSplitContainer;
+        protected System.Windows.Forms.SplitContainer iconAndMessageSplitContainer;
         private System.Windows.Forms.PictureBox iconPictureBox;
     }
 }

--- a/pwiz_tools/Skyline/Alerts/KeyValueGridDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/KeyValueGridDlg.cs
@@ -45,6 +45,8 @@ namespace pwiz.Skyline.Alerts
             };
             layout.RowCount = gridValues.Count + 2; // empty first and last row
             layout.ColumnCount = 2; // key and value
+            layout.ColumnStyles.Add(new ColumnStyle());
+            layout.ColumnStyles.Add(new ColumnStyle());
             foreach (ColumnStyle style in layout.ColumnStyles)
             {
                 style.Width = 50;

--- a/pwiz_tools/Skyline/Alerts/MultiButtonMsgDlg.cs
+++ b/pwiz_tools/Skyline/Alerts/MultiButtonMsgDlg.cs
@@ -79,7 +79,7 @@ namespace pwiz.Skyline.Alerts
         public MultiButtonMsgDlg(Control ctl, string btnText, string ctlContentAsText) : this(ctlContentAsText, btnText)
         {
             messageScrollPanel.Hide();
-            splitContainer.Panel1.Controls.Add(ctl);
+            iconAndMessageSplitContainer.Panel2.Controls.Add(ctl);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace pwiz.Skyline.Alerts
         : this(ctlContentAsText, btnYesText, btnNoText, allowCancel)
         {
             messageScrollPanel.Hide();
-            splitContainer.Panel1.Controls.Add(ctl);
+            iconAndMessageSplitContainer.Panel2.Controls.Add(ctl);
         }
 
         /// <summary>


### PR DESCRIPTION
- fixed KeyValueGridDlg (used by Additional Settings and DDA search file downloader) showing blank contents since icon+message split container was introduced in CommonAlertDlg