### PR TITLE
Moved ApplyPeak try-catch outside the document lock

### DIFF
--- a/pwiz_tools/Skyline/Menus/EditMenu.cs
+++ b/pwiz_tools/Skyline/Menus/EditMenu.cs
@@ -795,16 +795,16 @@ namespace pwiz.Skyline.Menus
             if (!canApply)
                 return;
 
-            lock (SkylineWindow.GetDocumentChangeLock())
+            try
             {
-                try
+                lock (SkylineWindow.GetDocumentChangeLock())
                 {
                     ApplyPeakWithLongWait(subsequent, group);
                 }
-                catch (Exception e)
-                {
-                    ExceptionUtil.DisplayOrReportException(SkylineWindow, e);
-                }
+            }
+            catch (Exception e)
+            {
+                ExceptionUtil.DisplayOrReportException(SkylineWindow, e);
             }
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #3812 per Nick's review comment.

- Moved try-catch outside the `lock (SkylineWindow.GetDocumentChangeLock())` block
- Error dialog no longer holds document lock while displayed

See ai/todos/active/TODO-20260116_apply_peak_ioexception.md

Co-Authored-By: Claude <noreply@anthropic.com>