### PR TITLE
Cherry-pick: Fixed TestPeakPickingTutorial race condition in RT regression graph

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/RTLinearRegressionGraphPane.cs
@@ -506,6 +506,28 @@ namespace pwiz.Skyline.Controls.Graphs
             }
         }
 
+        /// <summary>
+        /// Returns true when the graph data is fully loaded and ready to be accessed.
+        /// Use this in tests instead of just IsCalculating to avoid race conditions
+        /// where the background calculation is done but the data hasn't been set yet.
+        /// </summary>
+        public bool IsComplete
+        {
+            get
+            {
+                // Error means we're "done" (no further processing will help)
+                if (_graphDataReceiver.HasError)
+                    return true;
+
+                // Not complete if still calculating
+                if (IsCalculating)
+                    return false;
+
+                // Data must be populated (ProductAvailableAction callback has run)
+                return StatisticsRefined != null;
+            }
+        }
+
         private RetentionTimeRegressionSettings GetRegressionSettings()
         {
             var targetIndex = ShowReplicate == ReplicateDisplay.single || RunToRun

--- a/pwiz_tools/Skyline/TestFunctional/NonLinearRegressionTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/NonLinearRegressionTest.cs
@@ -68,7 +68,7 @@ namespace pwiz.SkylineTestFunctional
         {
             //Check rmsd and number of linear functions for KDE
             RunUI(() => SkylineWindow.ShowRegressionMethod(RegressionMethodRT.kde));
-            WaitForPaneCondition<RTLinearRegressionGraphPane>(summary, pane => !pane.IsCalculating);
+            WaitForPaneCondition<RTLinearRegressionGraphPane>(summary, pane => pane.IsComplete);
 
             RTLinearRegressionGraphPane graphPane;
             summary.TryGetGraphPane(out graphPane);
@@ -84,7 +84,7 @@ namespace pwiz.SkylineTestFunctional
             //Check for Loess
 
             RunUI(() => SkylineWindow.ShowRegressionMethod(RegressionMethodRT.loess));
-            WaitForPaneCondition<RTLinearRegressionGraphPane>(summary, pane => !pane.IsCalculating);
+            WaitForPaneCondition<RTLinearRegressionGraphPane>(summary, pane => pane.IsComplete);
 
             //Make sure Loess is not refined. Too slow
             Assert.IsTrue(graphPane.RegressionRefinedNull);

--- a/pwiz_tools/Skyline/TestFunctional/RunToRunAlignmentTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/RunToRunAlignmentTest.cs
@@ -92,12 +92,12 @@ namespace pwiz.SkylineTestFunctional
             WaitForGraphs();
             var scoreToRunGraphPane = GetScoreToRunGraphPane();
             Assert.IsNotNull(scoreToRunGraphPane);
-            WaitForCondition(() => !scoreToRunGraphPane.IsCalculating);
+            WaitForCondition(() => scoreToRunGraphPane.IsComplete);
             foreach (var rtOption in RtCalculatorOption.GetOptions(SkylineWindow.Document))
             {
                 RunUI(() => SkylineWindow.ChooseCalculator(rtOption));
                 WaitForGraphs();
-                WaitForCondition(() => !scoreToRunGraphPane.IsCalculating);
+                WaitForCondition(() => scoreToRunGraphPane.IsComplete);
             }
 
             RunDlg<PeptideSettingsUI>(SkylineWindow.ShowPeptideSettingsUI, peptideSettingsUi =>

--- a/pwiz_tools/Skyline/TestPerf/PeakBoundaryImputationDiaTutorial.cs
+++ b/pwiz_tools/Skyline/TestPerf/PeakBoundaryImputationDiaTutorial.cs
@@ -226,7 +226,7 @@ namespace TestPerf
         {
             var scoreToRunGraphPane = GetScoreToRunGraphPane();
             Assert.IsNotNull(scoreToRunGraphPane);
-            WaitForConditionUI(() => !scoreToRunGraphPane.IsCalculating);
+            WaitForConditionUI(() => scoreToRunGraphPane.IsComplete);
         }
 
         public static RTLinearRegressionGraphPane GetScoreToRunGraphPane()

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -1236,7 +1236,7 @@ namespace pwiz.SkylineTestUtil
         {
             WaitForGraphs();
             WaitForConditionUI(() => SkylineWindow.RTGraphController != null);
-            WaitForPaneCondition<RTLinearRegressionGraphPane>(SkylineWindow.RTGraphController.GraphSummary, pane => !pane.IsCalculating);
+            WaitForPaneCondition<RTLinearRegressionGraphPane>(SkylineWindow.RTGraphController.GraphSummary, pane => pane.IsComplete);
         }
 
         private static void WaitForBackgroundLoaders()


### PR DESCRIPTION
## Summary

Cherry-pick of #3822 to release branch `Skyline/skyline_26_1`.

**Original changes:**
* Fixed race condition in TestPeakPickingTutorial where RTGraphController.GraphSummary could be null
* Added null checks and WaitForConditionUI to ensure graph is ready before accessing it