### PR TITLE
Cherry-pick: Fixed intermittent TestPeakAreaRelativeAbundanceGraph failure

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/ReplicateCachingReceiver.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ReplicateCachingReceiver.cs
@@ -156,6 +156,7 @@ namespace pwiz.Skyline.Controls.Graphs
             var cachedDocuments = new ReadOnlyDictionary<int, SrmDocument>(
                 _localCache.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Document));
             var keysToRemove = _cleanCache(document, cachedDocuments);
+
             foreach (var key in keysToRemove)
             {
                 _localCache.TryRemove(key, out _);
@@ -315,6 +316,7 @@ namespace pwiz.Skyline.Controls.Graphs
             {
                 // Store in local cache with the document the result was computed from
                 _localCache[cacheKey] = new CacheEntry(result, result.Document);
+                TrackCachedResult(result);
                 return true;
             }
 
@@ -410,6 +412,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 {
                     // Store successful result in cache with its source document
                     _owner._localCache[_cacheKey] = new CacheEntry(typedResult, typedResult.Document);
+                    TrackCachedResult(typedResult);
                 }
 
                 // Clean up: unlisten and remove from pending
@@ -429,5 +432,44 @@ namespace pwiz.Skyline.Controls.Graphs
                 _owner._receiver.Cache.Unlisten(_workOrder, this);
             }
         }
+
+        #region Cache tracking for tests
+
+        /// <summary>
+        /// When true, records all cached results for later inspection by tests.
+        /// Use ScopedAction to enable/disable around test code.
+        /// Setting to true clears any previously tracked results.
+        /// </summary>
+        public static bool TrackCaching
+        {
+            get => _trackCaching;
+            set
+            {
+                _trackCaching = value;
+                if (value)
+                    _cachedSinceTracked = new List<TResult>();
+                // Don't clear on false - test needs to read the results
+            }
+        }
+
+        // ReSharper disable once StaticMemberInGenericType
+        private static bool _trackCaching;
+        private static List<TResult> _cachedSinceTracked;
+
+        /// <summary>
+        /// Returns all results cached since TrackCaching was enabled.
+        /// Use First() to get the initial (full) calculation after document reopen.
+        /// Subsequent entries should be incremental updates with zero recalculation.
+        /// </summary>
+        public static IEnumerable<TResult> CachedSinceTracked =>
+            _cachedSinceTracked ?? Enumerable.Empty<TResult>();
+
+        private static void TrackCachedResult(TResult result)
+        {
+            if (_trackCaching && _cachedSinceTracked != null)
+                _cachedSinceTracked.Add(result);
+        }
+
+        #endregion
     }
 }

--- a/pwiz_tools/Skyline/Controls/Graphs/SummaryRelativeAbundanceGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SummaryRelativeAbundanceGraphPane.cs
@@ -789,11 +789,13 @@ namespace pwiz.Skyline.Controls.Graphs
                     // The caller (CleanCacheForIncrementalUpdates) has already validated that the
                     // prior data is from the same document identity with compatible settings
                     CalcDataPositionsIncremental(parameters.PriorGraphData, productionMonitor);
+                    WasFullCalculation = false;
                 }
                 else
                 {
                     // Full calculation
                     CalcDataPositionsFull(productionMonitor);
+                    WasFullCalculation = true;
                 }
             }
 
@@ -1258,6 +1260,21 @@ namespace pwiz.Skyline.Controls.Graphs
             /// Equals total node count when full calculation was performed.
             /// </summary>
             public int RecalculatedNodeCount { get; private set; }
+
+            /// <summary>
+            /// True if this data was calculated from scratch (CalcDataPositionsFull),
+            /// false if it was an incremental update using prior cached data.
+            /// </summary>
+            public bool WasFullCalculation { get; private set; }
+
+            /// <summary>
+            /// Returns diagnostic information for debugging test failures.
+            /// </summary>
+            public string GetDiagnosticInfo()
+            {
+                return $@"Full={WasFullCalculation}, Cached={CachedNodeCount}, Recalc={RecalculatedNodeCount}, " +
+                       $@"DocId={Document.Id.GlobalIndex}, DocRev={Document.RevisionIndex}";
+            }
 
             public virtual double MaxValueSetting { get { return 0; } }
             public virtual double MinValueSetting { get { return 0; } }


### PR DESCRIPTION
## Summary

Cherry-pick of #3825 and #3830 to release branch `Skyline/skyline_26_1`.

**Original changes:**
* Fixed IsComplete race condition in SummaryRelativeAbundanceGraphPane (#3825)
* Added cache tracking to ReplicateCachingReceiver for test inspection (#3830)
* Updated test to check first cached result instead of final pane state
* Test now handles parallel calculations during document reopen

Fixes #3824

See ai/todos/active/TODO-20260116_relative_abundance_race_fix.md

Co-Authored-By: Claude <noreply@anthropic.com>