### PR TITLE
Fixed handle leak in ProducerConsumerWorker thread transitions

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/ProducerConsumerWorker.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/ProducerConsumerWorker.cs
@@ -100,7 +100,7 @@ namespace pwiz.Common.SystemUtil
                         ((produceThreads == 0 && _produceThreads == null) || (produceThreads > 0 && _produceThreads != null && produceThreads == _produceThreads.Length)) &&
                         _queue.BoundedCapacity == maxQueueSize)
                         return;
-                    Abort();
+                    Abort(true);  // Wait for old threads to exit before creating new ones
                 }
                 _queue = new BlockingCollection<TItem>(new TProducerConsumerCollection(), maxQueueSize);
             }


### PR DESCRIPTION
## Summary
- Changed `Abort()` to `Abort(true)` in `RunAsync()` to wait for old threads to exit before creating new ones
- Prevents race condition when thread count changes during file loading
- Fixes handle leaks in multiple tutorials (TestSmallMolMethodDevCEOptTutorial, TestMethodRefinementTutorial)

## Root Cause
When `ProducerConsumerWorker.RunAsync()` is called with a different thread count than currently running (e.g., during import when thread count scales), it calls `Abort()` without waiting for old threads to complete. This race condition causes GDI handles from the old thread contexts to leak.

## Test plan
- [x] Ran TestSmallMolMethodDevCEOptTutorial and TestMethodRefinementTutorial together 70+ times with -ReportHandles
- [x] No handle growth observed (previously both showed obvious handle growth)

Fixes #3833

See ai/todos/active/TODO-20260118_SmallMolMethodDevCEOptTutorial_HandleLeak.md

Co-Authored-By: Claude <noreply@anthropic.com>