### PR TITLE
Fixed ProductionFacility.Unlisten race condition

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/ReplicateCachingReceiver.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ReplicateCachingReceiver.cs
@@ -393,6 +393,7 @@ namespace pwiz.Skyline.Controls.Graphs
             private readonly ReplicateCachingReceiver<TParam, TResult> _owner;
             private readonly int _cacheKey;
             private readonly WorkOrder _workOrder;
+            private int _isListening = 1;  // 1 = listening, 0 = unlistened
 
             public CompletionListener(ReplicateCachingReceiver<TParam, TResult> owner, int cacheKey, WorkOrder workOrder)
             {
@@ -429,6 +430,9 @@ namespace pwiz.Skyline.Controls.Graphs
 
             public void Unlisten()
             {
+                // Atomic check-and-set to prevent double Unlisten from concurrent threads
+                if (Interlocked.Exchange(ref _isListening, 0) == 0)
+                    return;
                 _owner._receiver.Cache.Unlisten(_workOrder, this);
             }
         }


### PR DESCRIPTION
## Summary

* Added `_isListening` flag to `CompletionListener` in `ReplicateCachingReceiver`
* Uses `Interlocked.Exchange` to prevent double-Unlisten when `OnProductAvailable` and `ClearCache` race

Per Nick's review: the fix belongs in `ReplicateCachingReceiver.CompletionListener` which should track its listening state, not in `ProductionFacility` which should be able to assume balanced Listen/Unlisten calls.

Fixes #3832

## Test plan

- [x] Build succeeds
- [x] TestPeakPickingTutorial passes (50+ runs, original failure scenario)

See ai/todos/active/TODO-20260120_ProductionFacility_Unlisten.md

Co-Authored-By: Claude <noreply@anthropic.com>