### PR TITLE
Cherry-pick: Fixed CompletionListener double-Unlisten in ReplicateCachingReceiver (#3839)

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/ReplicateCachingReceiver.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ReplicateCachingReceiver.cs
@@ -393,6 +393,7 @@ namespace pwiz.Skyline.Controls.Graphs
             private readonly ReplicateCachingReceiver<TParam, TResult> _owner;
             private readonly int _cacheKey;
             private readonly WorkOrder _workOrder;
+            private int _isListening = 1;  // 1 = listening, 0 = unlistened
 
             public CompletionListener(ReplicateCachingReceiver<TParam, TResult> owner, int cacheKey, WorkOrder workOrder)
             {
@@ -429,6 +430,9 @@ namespace pwiz.Skyline.Controls.Graphs
 
             public void Unlisten()
             {
+                // Atomic check-and-set to prevent double Unlisten from concurrent threads
+                if (Interlocked.Exchange(ref _isListening, 0) == 0)
+                    return;
                 _owner._receiver.Cache.Unlisten(_workOrder, this);
             }
         }


### PR DESCRIPTION
## Summary

Cherry-pick of #3839 to release branch `Skyline/skyline_26_1`.

**Original changes:**
* Added `_isListening` flag to `CompletionListener` in `ReplicateCachingReceiver`
* Uses `Interlocked.Exchange` to prevent double-Unlisten when `OnProductAvailable` and `ClearCache` race

Fixes race condition where `ProductionFacility.Unlisten` throws `InvalidOperationException` when attempting to unlisten from a WorkOrder that was already removed.

Co-Authored-By: Claude <noreply@anthropic.com>