### PR TITLE
Fix intermittent failure in TestRetentionTimeManager

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/RetentionTimeManagerTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/RetentionTimeManagerTest.cs
@@ -114,6 +114,9 @@ namespace pwiz.SkylineTestFunctional
                 SkylineWindow.OpenFile(SkylineWindow.DocumentFilePath);
             });
             Assert.IsTrue(SkylineWindow.Document.Settings.DocumentRetentionTimes.ResultFileAlignments.IsEmpty);
+
+            // Wait for the document to be loaded so that it does not get switched out during a ReadPeaks call which might reopen a file stream
+            WaitForDocumentLoaded();
         }
 
         private void OnDocumentChanged(object sender, DocumentChangedEventArgs args)


### PR DESCRIPTION
Wait for the document to be loaded before the test ends so that ChangeSettings is not happening while the test is ending. The real fix would involve something similar to what is in PR #3763: any time that you interact with a SrmDocument you have to close all the streams if it's no longer the current document. Also, the only reason that ChangeSettings is doing any work is that he document was just renamed and the settings have not yet been updated with the new library name which is also something that should be fixed