### PR TITLE
Added exception handling to IrtDbManager.LoadBackground()

### DIFF
--- a/pwiz_tools/Skyline/CommandLine.cs
+++ b/pwiz_tools/Skyline/CommandLine.cs
@@ -3012,7 +3012,7 @@ namespace pwiz.Skyline
                         prediction.ChangeRetentionTime(retentionTimeRegression)));
                 }
                 string dbPath = calcIrt.DatabasePath;
-                IrtDb db = IrtDb.GetIrtDb(dbPath, null);
+                IrtDb db = IrtDb.GetIrtDb(dbPath);
                 if (checkPeptides)
                 {
                     var standards = docNew.Molecules.Where(m => db.IsStandard(m.ModifiedTarget)).ToArray();

--- a/pwiz_tools/Skyline/FileUI/CreateIrtCalculatorDlg.cs
+++ b/pwiz_tools/Skyline/FileUI/CreateIrtCalculatorDlg.cs
@@ -123,7 +123,7 @@ namespace pwiz.Skyline.FileUI
                         textOpenDatabase.Focus();
                         return;
                     }
-                    var db = IrtDb.GetIrtDb(textOpenDatabase.Text, null);
+                    var db = IrtDb.GetIrtDb(textOpenDatabase.Text);
                     if (db == null)
                     {
                         throw new DatabaseOpeningException(string.Format(FileUIResources.CreateIrtCalculatorDlg_OkDialog_Cannot_read_the_database_file__0_, textOpenDatabase.Text));

--- a/pwiz_tools/Skyline/Model/Irt/RCalcIrt.cs
+++ b/pwiz_tools/Skyline/Model/Irt/RCalcIrt.cs
@@ -70,10 +70,16 @@ namespace pwiz.Skyline.Model.Irt
 
         public override RetentionScoreCalculatorSpec Initialize(IProgressMonitor loadMonitor)
         {
+            IProgressStatus status = new ProgressStatus();
+            return Initialize(loadMonitor, ref status);
+        }
+
+        public RCalcIrt Initialize(IProgressMonitor progressMonitor, ref IProgressStatus status)
+        {
             if (_database != null)
                 return this;
 
-            var database = IrtDb.GetIrtDb(DatabasePath, loadMonitor);
+            var database = IrtDb.GetIrtDb(DatabasePath, progressMonitor, ref status);
             // Check for the case where an exception was handled by the progress monitor
             if (database == null)
                 return null;
@@ -563,7 +569,7 @@ namespace pwiz.Skyline.Model.Irt
 
         public static string PersistAsSmallMolecules(string currentPersistencePath, string pathDestDir = null, IrtDb database = null)
         {
-            database ??= IrtDb.GetIrtDb(currentPersistencePath, null);
+            database ??= IrtDb.GetIrtDb(currentPersistencePath);
             pathDestDir ??= Path.GetDirectoryName(currentPersistencePath) ?? string.Empty;
 
             var persistPath = Path.Combine(pathDestDir, Path.GetFileName(currentPersistencePath) ?? string.Empty);  // ReSharper

--- a/pwiz_tools/Skyline/Model/SrmDocument.cs
+++ b/pwiz_tools/Skyline/Model/SrmDocument.cs
@@ -1597,7 +1597,7 @@ namespace pwiz.Skyline.Model
                 throw new InvalidDataException(ModelResources.SrmDocument_AddIrtPeptides_Must_have_an_active_iRT_calculator_to_add_iRT_peptides);
             }
             var dbPath = calculator.DatabasePath;
-            var db = File.Exists(dbPath) ? IrtDb.GetIrtDb(dbPath, null) : IrtDb.CreateIrtDb(dbPath);
+            var db = File.Exists(dbPath) ? IrtDb.GetIrtDb(dbPath) : IrtDb.CreateIrtDb(dbPath);
             var oldPeptides = db.ReadPeptides().Select(p => new DbIrtPeptide(p)).ToList();
             var peptidesCombined = DbIrtPeptide.FindNonConflicts(oldPeptides, irtPeptides, progressMonitor, out var conflicts);
             if (peptidesCombined == null)

--- a/pwiz_tools/Skyline/SkylineFiles.cs
+++ b/pwiz_tools/Skyline/SkylineFiles.cs
@@ -2427,7 +2427,7 @@ namespace pwiz.Skyline
                     }
                 }
                 var dbPath = calcIrt.DatabasePath;
-                db = File.Exists(dbPath) ? IrtDb.GetIrtDb(dbPath, null) : IrtDb.CreateIrtDb(dbPath);
+                db = File.Exists(dbPath) ? IrtDb.GetIrtDb(dbPath) : IrtDb.CreateIrtDb(dbPath);
             }
             else
             {

--- a/pwiz_tools/Skyline/TestData/CommandLineImportTest.cs
+++ b/pwiz_tools/Skyline/TestData/CommandLineImportTest.cs
@@ -185,7 +185,7 @@ namespace pwiz.SkylineTestData
                 "--import-search-file=" + searchFilePath,
                 "--import-search-irts=CiRT (iRT-C18)",
                 "--import-search-num-cirts=10");
-            var libIrts = IrtDb.GetIrtDb(TestFilesDir.GetTestPath("blank.blib"), null).StandardPeptides.ToArray();
+            var libIrts = IrtDb.GetIrtDb(TestFilesDir.GetTestPath("blank.blib")).StandardPeptides.ToArray();
             AssertEx.AreEqual(10, libIrts.Length);
             foreach (var libIrt in libIrts)
                 AssertEx.IsTrue(IrtStandard.CIRT.Contains(libIrt));

--- a/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/AssayLibraryImportTest.cs
@@ -663,7 +663,7 @@ namespace pwiz.SkylineTestFunctional
             var calcTemp = SkylineWindow.Document.Settings.PeptideSettings.Prediction.RetentionTime.Calculator as RCalcIrt;
             Assert.IsNotNull(calcTemp);
             string dbPath = calcTemp.DatabasePath;
-            IrtDb db = IrtDb.GetIrtDb(dbPath, null);
+            IrtDb db = IrtDb.GetIrtDb(dbPath);
             var oldPeptides = db.ReadPeptides().ToList();
             var standardSeq = from peptide in oldPeptides where peptide.Standard select peptide.Target;
             standardSeq = standardSeq.ToList();

--- a/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/IrtTest.cs
@@ -298,7 +298,7 @@ namespace pwiz.SkylineTestFunctional
              * Check that the database was created successfully
              * Check that it has the correct numbers of standard and library peptides
              */
-            IrtDb db = IrtDb.GetIrtDb(databasePath, null);
+            IrtDb db = IrtDb.GetIrtDb(databasePath);
 
             Assert.AreEqual(numStandardPeps, db.StandardPeptideCount);
             Assert.AreEqual(numLibraryPeps, db.LibraryPeptideCount);
@@ -812,7 +812,7 @@ namespace pwiz.SkylineTestFunctional
                 SkylineWindow.NewDocument();
             });
             // The created irtdb should have document XML for the standard peptides
-            var irtDb = IrtDb.GetIrtDb(calcPath, null);
+            var irtDb = IrtDb.GetIrtDb(calcPath);
             Assert.IsFalse(string.IsNullOrEmpty(irtDb.DocumentXml));
             // Set RT regression to None
             RunDlg<PeptideSettingsUI>(() => SkylineWindow.ShowPeptideSettingsUI(), dlg =>
@@ -1168,7 +1168,7 @@ namespace pwiz.SkylineTestFunctional
 
             void CheckIrtDbFile(bool expectDuplicates, out DbIrtPeptide[] arrStandards, out DbIrtPeptide[] arrLibrary, out Target[] arrOverlap)
             {
-                IrtDb.GetIrtDb(dbPath, null, out var dbPeptides);
+                IrtDb.GetIrtDb(dbPath, out var dbPeptides);
                 arrStandards = dbPeptides.Where(pep => pep.Standard).ToArray();
                 arrLibrary = dbPeptides.Where(pep => !pep.Standard).ToArray();
                 arrOverlap = arrStandards.Select(pep => pep.ModifiedTarget).Intersect(arrLibrary.Select(pep => pep.ModifiedTarget)).ToArray();
@@ -1394,7 +1394,7 @@ namespace pwiz.SkylineTestFunctional
 
         private void CheckIrtDbFile()
         {
-            var db = IrtDb.GetIrtDb(_dbPath, null, out var dbPeptides);
+            var db = IrtDb.GetIrtDb(_dbPath, out var dbPeptides);
             Assert.AreEqual(_redundant, db.Redundant);
 
             var dbHistories = new Dictionary<long, List<double>>();

--- a/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/LibraryBuildTest.cs
@@ -480,7 +480,7 @@ namespace pwiz.SkylineTestFunctional
             var recalibrateDlg = ShowDialog<MultiButtonMsgDlg>(addIrtDlg.OkDialog);
             var addPredictorDlg = ShowDialog<AddRetentionTimePredictorDlg>(recalibrateDlg.BtnCancelClick);
             OkDialog(addPredictorDlg, addPredictorDlg.NoDialog);
-            var twoStandardDb = IrtDb.GetIrtDb(TestFilesDir.GetTestPath(_libraryName) + ".blib", null);
+            var twoStandardDb = IrtDb.GetIrtDb(TestFilesDir.GetTestPath(_libraryName) + ".blib");
             var dbStandards = twoStandardDb.StandardPeptides.ToArray();
             // Check that the created blib has the chosen standards.
             Assert.AreEqual(dbStandards.Length, IrtStandard.BIOGNOSYS_11.Peptides.Count);

--- a/pwiz_tools/Skyline/TestFunctional/MinimizeIrtTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/MinimizeIrtTest.cs
@@ -97,7 +97,7 @@ namespace pwiz.SkylineTestFunctional
             // Note that this iRT db file is not actually being used by the current Skyline document. Because
             // of IrtDbManager._loadedCalculators, it is required that you exit Skyline if you want to change
             // the file location of a particular irt database.
-            var minimizedIrtDb = IrtDb.GetIrtDb(minimizedIrtPath, null);
+            var minimizedIrtDb = IrtDb.GetIrtDb(minimizedIrtPath);
             irtPeptideSequences = minimizedIrtDb.ReadPeptides()
                 .Select(peptide => FastaSequence.StripModifications(peptide.ModifiedTarget.Sequence)).ToHashSet();
             // Verify that a peptide sequence can be found in the iRT database if and only if the peptide had not


### PR DESCRIPTION
## Summary

* Wrapped `LoadBackground()` in try-catch with `IsProgrammingDefect()` pattern following `LibraryManager` model
* Pass `LoadMonitor` to `IrtDb.GetIrtDb()` instead of `null` for proper error reporting
* Consolidated duplicate database loading into single load operation
* User-actionable errors (corrupt/incompatible iRT database) now reported through progress monitor instead of crash dialog

Fixes #3856

## Test plan

- [x] IrtTest - passes
- [x] IrtCalibrationTest - passes
- [x] AddIrtStandardsTest - passes

Co-Authored-By: Claude <noreply@anthropic.com>