### PR TITLE
Fixed BackgroundActionService.AddTask NullReferenceException race condition

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/ProducerConsumerWorker.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/ProducerConsumerWorker.cs
@@ -244,7 +244,7 @@ namespace pwiz.Common.SystemUtil
             else
             {
                 Interlocked.Increment(ref _itemsWaiting);
-                _queue.Add(item);
+                _queue?.Add(item);
             }
         }
 

--- a/pwiz_tools/Skyline/Controls/FilesTree/BackgroundActionService.cs
+++ b/pwiz_tools/Skyline/Controls/FilesTree/BackgroundActionService.cs
@@ -59,7 +59,7 @@ namespace pwiz.Skyline.Controls.FilesTree
             {
                 queue.Add(action);
             }
-            catch (Exception ex) when (ex is ObjectDisposedException || ex is NullReferenceException)
+            catch (ObjectDisposedException)
             {
                 // Race condition: queue was disposed between our null check and Add call
                 _pendingActionCount = 0;


### PR DESCRIPTION
## Summary

- Fixed race condition between `AddTask` and `Dispose` in `BackgroundActionService`
- Captured `_workQueue` reference in local variable before null check
- Added exception handling for disposal race windows

## Root Cause

FileSystemWatcher events can call `AddTask` while another thread is disposing the service:
1. Thread A (FSW callback): `AddTask` increments `_pendingActionCount`
2. Thread B: `Dispose()` calls `DoneAdding`, sets `_workQueue = null`
3. Thread A: tries `_workQueue.Add()` → **NullReferenceException**

## Test plan

- [x] Build succeeded
- [x] TestFilesModel - Pass
- [x] TestFilesTreeFileSystem - Pass
- [x] TestFilesTreeForm - Pass
- [x] TestSkylineWindowEvents - Pass

Fixes #3864
See ai/todos/active/TODO-20260125_addtask_nullref.md

Co-Authored-By: Claude <noreply@anthropic.com>