### PR TITLE
Fix for https://github.com/ProteoWizard/pwiz/issues/3868 - Unicode path test support should not be a process-level static.…

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/ProcessEx.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/ProcessEx.cs
@@ -35,35 +35,29 @@ namespace pwiz.Common.SystemUtil
         /// <summary>
         /// Returns true iff the process is running under an OS and on volume(s) that support windows 8.3 format conversion
         /// </summary>
-        private static bool? _canConvertUnicodePaths;
         private static Dictionary<string, bool> _volumesTested = new Dictionary<string, bool>();
 
-        public static bool? CanConvertUnicodePaths
+        public static bool CanConvertUnicodePaths
         {
-            set => _canConvertUnicodePaths = value;
             get
             {
-                if (!_canConvertUnicodePaths.HasValue)
+                if (IsRunningOnWine)
                 {
-                    if (IsRunningOnWine)
-                    {
-                        _canConvertUnicodePaths = false;
-                    }
-                    else
-                    {
-                        // Systems may have 8.3 conversion enabled on some volumes but not others
-                        // So don't assume we can convert unicode paths unless we can actually do it everywhere we might need to
-                        _canConvertUnicodePaths =
-                            CanConvertUnicodePathsInDirectory(Path.GetTempPath()) &&
-                            CanConvertUnicodePathsInDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) &&
-                            CanConvertUnicodePathsInDirectory(Directory.GetCurrentDirectory()) &&
-                            CanConvertUnicodePathsInDirectory(PathEx.GetDownloadsPath());
-                    }
+                    return false; // Never supported on Wine
                 }
-                return _canConvertUnicodePaths;
+                else
+                {
+                    // Systems may have 8.3 conversion enabled on some volumes but not others
+                    // So don't assume we can convert Unicode paths unless we can actually do it everywhere we might need to
+                    return
+                        CanConvertUnicodePathsInDirectory(Path.GetTempPath()) &&
+                        CanConvertUnicodePathsInDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)) &&
+                        CanConvertUnicodePathsInDirectory(Directory.GetCurrentDirectory()) &&
+                        CanConvertUnicodePathsInDirectory(PathEx.GetDownloadsPath());
+                }
             }
         }
-        static public bool CanConvertUnicodePathsInDirectory(string baseDir)
+        private static bool CanConvertUnicodePathsInDirectory(string baseDir)
         {
             var volume = Path.GetPathRoot(baseDir);
             if (_volumesTested.TryGetValue(volume, out var result))

--- a/pwiz_tools/Skyline/Model/Tools/ToolDescription.cs
+++ b/pwiz_tools/Skyline/Model/Tools/ToolDescription.cs
@@ -486,7 +486,7 @@ namespace pwiz.Skyline.Model.Tools
 
         public static string GetToolsDirectoryBasis()
         {
-            return (Program.UnitTest && ProcessEx.CanConvertUnicodePaths.Value) ? @"Tööls" : @"Tools"; // Helps catch Unicode path issues on Windows
+            return (Program.UnitTest && !Program.DoNotTestUnicodeHandling) ? @"Tööls" : @"Tools"; // Helps catch Unicode path issues on Windows
         }
 
         /// <summary>

--- a/pwiz_tools/Skyline/Program.cs
+++ b/pwiz_tools/Skyline/Program.cs
@@ -96,9 +96,10 @@ namespace pwiz.Skyline
             }.Any(folder => name.IndexOf(folder, StringComparison.Ordinal) >= 0);
         }
         public static string TestName { get; set; }                 // Set during unit and functional tests
+        public static bool DoNotTestUnicodeHandling { get; set; }   // Set true to skip unicode handling tests, either because the platform doesn't support it or test attribute forbids it
         public static bool ClosingForms { get; set; }               // Set to true during AbstractFunctionalTest.CloseOpenForm (all forms should check this before cancelling a Close request)
         public static string DefaultUiMode { get; set; }            // Set to avoid seeing NoModeUiDlg at the start of a test
-        public static bool IsPaused => FormUtil.OpenForms.Any(form => form.GetType().Name == "PauseAndContinueForm");
+        public static bool IsPaused => FormUtil.OpenForms.Any(form => form.GetType().Name == @"PauseAndContinueForm");
 
         public static bool SkylineOffscreen
         {

--- a/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
+++ b/pwiz_tools/Skyline/TestRunnerLib/RunTests.cs
@@ -52,7 +52,7 @@ namespace TestRunnerLib
         public readonly bool DoNotRunInParallel;
         public readonly bool DoNotRunInNightly;
         public bool DoNotLeakTest; // If true, test is too lengthy to run multiple iterations for leak checks (we invert this in perftest runs)
-        public readonly bool DoNotUseUnicode; // If true, test is known to have trouble with unicode (3rd party tool, mz5, etc)
+        public readonly bool DoNotUseUnicode; // If true, test is known to have trouble with Unicode (3rd party tool, mz5, etc), or the system does not support it
         public readonly DateTime? SkipTestUntil; // If set, test will be skipped if the current (UTC) date is before the SkipTestUntil date
 
         public TestInfo(Type testClass, MethodInfo testMethod, MethodInfo testInitializeMethod, MethodInfo testCleanupMethod)
@@ -64,10 +64,9 @@ namespace TestRunnerLib
             TestCleanup = testCleanupMethod;
             IsPerfTest = (testClass.Namespace ?? String.Empty).Equals("TestPerf");
 
-            // Explicitly disable unicode path conversion for tests marked with NoUnicodeTestingAttribute
-            ProcessEx.CanConvertUnicodePaths = (RunTests.GetAttribute(testMethod, "NoUnicodeTestingAttribute") != null) ? false : (bool?)null;
-            DoNotUseUnicode = !ProcessEx.CanConvertUnicodePaths.Value; // If true, don't add unicode to TMP environment variable etc
-            
+            // If true, don't add Unicode characters to TMP environment variable etc
+            DoNotUseUnicode = !ProcessEx.CanConvertUnicodePaths || 
+                              (RunTests.GetAttribute(testMethod, "NoUnicodeTestingAttribute") != null); 
             var noParallelTestAttr = RunTests.GetAttribute(testMethod, "NoParallelTestingAttribute");
             DoNotRunInParallel = noParallelTestAttr != null;
 

--- a/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
+++ b/pwiz_tools/Skyline/TestUtil/AbstractUnitTest.cs
@@ -421,6 +421,7 @@ namespace pwiz.SkylineTestUtil
         {
             Program.UnitTest = true;
             Program.TestName = TestContext.TestName;
+            Program.DoNotTestUnicodeHandling = TestContext.Properties["UnicodeDecoration"]==null;
 
             // Stop profiler if we are profiling.  The unit test will start profiling explicitly when it wants to.
             DotTraceProfile.Stop(true);


### PR DESCRIPTION
… Cached information about which system volumes can support 8.3 conversion is still suitable as a process-level static but how that information is used depends on test attributes.