### PR TITLE
Fix NRE in GroupComparisonDef.GetCaseGroupIdentifier

### DIFF
--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonDef.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonDef.cs
@@ -74,7 +74,7 @@ namespace pwiz.Skyline.Model.GroupComparison
             {
                 return null;
             }
-            return controlReplicateValue.Parse(CaseValue);
+            return controlReplicateValue?.Parse(CaseValue);
         }
         
         public GroupComparisonDef ChangeControlAnnotation(string value)
@@ -211,7 +211,7 @@ namespace pwiz.Skyline.Model.GroupComparison
                 return default;
             }
 
-            return GetControlReplicateValue(settings).Parse(ControlValue);
+            return GetControlReplicateValue(settings)?.Parse(ControlValue) ?? default;
         }
 
         [TrackChildren]


### PR DESCRIPTION
Fixed error when group comparison has not specified a control group (reported on exception web)
Skyline-daily only bug; introduced by PR #3642