### PR TITLE
Fix NullReferenceException in NistLibraryBase.GetHashCode

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
+++ b/pwiz_tools/Skyline/Model/Lib/NistLibSpec.cs
@@ -2090,9 +2090,9 @@ namespace pwiz.Skyline.Model.Lib
             unchecked
             {
                 int result = base.GetHashCode();
-                result = (result * 397) ^ Id.GetHashCode();
-                result = (result * 397) ^ Revision.GetHashCode();
-                result = (result * 397) ^ (FilePath != null ? FilePath.GetHashCode() : 0);
+                result = (result * 397) ^ (Id?.GetHashCode() ?? 0);
+                result = (result * 397) ^ (Revision?.GetHashCode() ?? 0);
+                result = (result * 397) ^ (FilePath?.GetHashCode() ?? 0);
                 return result;
             }
         }


### PR DESCRIPTION
## Summary

* Fixed `NullReferenceException` in `NistLibraryBase.GetHashCode()` when `Id` or `Revision` properties are null
* Added null-conditional operators consistent with existing `FilePath` null check

Fixes #3879

## Test plan

- [ ] TeamCity CI passes

Co-Authored-By: Claude <noreply@anthropic.com>