### PR TITLE
Add diagnostic assertions in AssociateProteinsDlg.NewTargetsFinalSync

### DIFF
--- a/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
+++ b/pwiz_tools/Skyline/EditUI/AssociateProteinsDlg.cs
@@ -860,7 +860,10 @@ namespace pwiz.Skyline.EditUI
 
         public void NewTargetsFinalSync(out int proteins, out int peptides, out int precursors, out int transitions, out int unmappedOrRemoved)
         {
+            Assume.IsTrue(IsComplete, @"NewTargetsFinalSync: IsComplete");
             var doc = DocumentFinal;
+            Assume.IsNotNull(doc, @"NewTargetsFinalSync: DocumentFinal");
+            Assume.IsNotNull(_proteinAssociation, @"NewTargetsFinalSync: _proteinAssociation");
             var unmappedPeptideGroup = doc.PeptideGroups.FirstOrDefault(pg => pg.Name == Resources.ProteinAssociation_CreateDocTree_Unmapped_Peptides);
             unmappedOrRemoved = _proteinAssociation.PeptidesRemovedByFiltersCount + (unmappedPeptideGroup?.PeptideCount ?? 0);
             proteins = doc.PeptideGroupCount;


### PR DESCRIPTION
## Summary

* Added `Assume.IsTrue(IsComplete)` to detect premature calls before processing finishes
* Added `Assume.IsNotNull` for `DocumentFinal` and `_proteinAssociation`
* Converts cryptic `NullReferenceException` into clear diagnostic identifying which invariant failed

The NullRef on `_proteinAssociation` was observed once in nightly testing (run 80277, same run where TestDdaSearchTide also timed out). Rather than silently masking with null-coalescing, these assertions will provide clear diagnostic data on next occurrence.

Fixes #3878

## Test plan

- [ ] TeamCity CI passes

Co-Authored-By: Claude <noreply@anthropic.com>