### PR TITLE
Fixed NullReferenceException in GraphFullScan.ZoomXAxis

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -1211,7 +1211,7 @@ namespace pwiz.Skyline.Controls.Graphs
                 xScale.Min = mz - 1.5;
                 xScale.Max = mz + 3.5;
             }
-            else
+            else if (_requestedRange != null)
             {
                 xScale.Min = _requestedRange.Min;
                 xScale.Max = _requestedRange.Max;


### PR DESCRIPTION
## Summary

* Added null check for `_requestedRange` in `ZoomXAxis()` before accessing `Min`/`Max` properties
* Field is null before scan data loads asynchronously in `SetSpectraUI()`, so clicking the zoom toolbar button before data loads triggered NullReferenceException
* 7 reports from 6 users since August 2025 (fingerprint `fceac746bf4b350b`)

Fixes #3888

## Test plan

- [ ] TeamCity CI passes

See ai/todos/active/TODO-20260130_graphfullscan_zoomxaxis_null.md

Co-Authored-By: Claude <noreply@anthropic.com>