### PR TITLE
Fixed ArgumentOutOfRangeException in PlacePane during graph arrangement

### DIFF
--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -5923,9 +5923,16 @@ namespace pwiz.Skyline
         private void PlacePane(int row, int col, int count,
             DockPaneAlignment alignment, IList<List<List<DockableForm>>> listTiles)
         {
+            if (row >= listTiles.Count || col >= listTiles[row].Count)
+                return;
+            int previousIndex = alignment == DockPaneAlignment.Bottom ? row - 1 : col - 1;
+            if (previousIndex < 0)
+                return;
+            if (alignment == DockPaneAlignment.Bottom && col >= listTiles[previousIndex].Count)
+                return;
             DockableForm previousForm = alignment == DockPaneAlignment.Bottom
-                                            ? listTiles[row - 1][col][0]
-                                            : listTiles[row][col - 1][0];
+                                            ? listTiles[previousIndex][col][0]
+                                            : listTiles[row][previousIndex][0];
             DockPane previousPane = FindPane(previousForm);
             var groupForms = listTiles[row][col];
             var dockableForm = groupForms[0];


### PR DESCRIPTION
## Summary

* Added defensive bounds checks for all `listTiles` accesses in `PlacePane`
* Guarded `previousIndex` (`row-1` or `col-1`) against negative values
* Guarded cross-row column access for Bottom alignment (previous row may have fewer columns)
* 10 reports from 8 users across versions 21.2 through 26.0.9 (fingerprints `d1b83c9a97a288fe`, `2b5b2a631cfc87a1`)

Fixes #3910

## Test plan

- [x] ArrangeGraphsTest passes
- [ ] TeamCity CI passes

See ai/todos/active/TODO-20260130_placepane_bounds_check.md

Co-Authored-By: Claude <noreply@anthropic.com>