### PR TITLE
Fixed NullReferenceException in AlignmentForm when RetentionTimeSource is null

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/AlignmentForm.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/AlignmentForm.cs
@@ -328,15 +328,18 @@ namespace pwiz.Skyline.Controls.Graphs
             {
                 return new DataRow[0];
             }
+            var target = targetKey.Value.RetentionTimeSource;
+            if (target == null)
+                return new DataRow[0];
             var documentRetentionTimes = Document.Settings.DocumentRetentionTimes;
             var dataRows = new List<DataRow>();
             foreach (var retentionTimeSource in GetRetentionTimeSources())
             {
-                if (targetKey.Value.RetentionTimeSource.Name == retentionTimeSource.Name)
+                if (target.Name == retentionTimeSource.Name)
                 {
                     continue;
                 }
-                dataRows.Add(new DataRow(Document.Settings, targetKey.Value.RetentionTimeSource, retentionTimeSource));
+                dataRows.Add(new DataRow(Document.Settings, target, retentionTimeSource));
             }
             return dataRows;
         }


### PR DESCRIPTION
## Summary

* Added null check for RetentionTimeSource in AlignmentForm.GetRows()
* Returns empty array when target source is null (library unloaded while form open)
* Exception ID 73754, version 26.0.9.004

Fixes #3827

## Test plan

- [ ] TeamCity CI passes

Co-Authored-By: Claude <noreply@anthropic.com>