### PR TITLE
Fix ArgumentNullException in EncyclopeDiaLibrary.GetRetentionTimesWithSequences

### DIFF
--- a/pwiz_tools/Skyline/Model/Lib/EncylopeDiaLibrary.cs
+++ b/pwiz_tools/Skyline/Model/Lib/EncylopeDiaLibrary.cs
@@ -970,7 +970,8 @@ namespace pwiz.Skyline.Model.Lib
 
         public override IList<double>[] GetRetentionTimesWithSequences(IEnumerable<string> spectrumSourceFiles, ICollection<Target> targets)
         {
-            var fileIndexes = spectrumSourceFiles.Select(file => LibraryFiles.IndexOfFilePath(file)).ToList();
+            var fileIndexes = spectrumSourceFiles?.Select(file => LibraryFiles.IndexOfFilePath(file)).ToList()
+                              ?? Enumerable.Range(0, LibraryFiles.Count).ToList();
             var lists = new IList<double>[LibraryFiles.Count];
             foreach (var fileIndex in fileIndexes)
             {


### PR DESCRIPTION
Fixed showing Peptide ID Times "From other runs" on chromatogram graph with EncyclopeDIA library (reported by Mike)

Fix ArgumentNullException in EncyclopeDiaLibrary.GetRetentionTimesWithSequences (introduced last August, did not happen in Skyline 25.1)