### PR TITLE
Hang detection captures ThreadExceptionDialog text (#3957)

### DIFF
--- a/pwiz_tools/Skyline/TestUtil/HangDetection.cs
+++ b/pwiz_tools/Skyline/TestUtil/HangDetection.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using pwiz.Common.SystemUtil;
 
 namespace pwiz.SkylineTestUtil
 {
@@ -83,6 +84,17 @@ namespace pwiz.SkylineTestUtil
                     Console.Out.WriteLine("Unable to get thread dump: {0}", ex);
                 }
 
+                try
+                {
+                    foreach (var form in FormUtil.OpenForms)
+                    {
+                        Console.Out.WriteLine("Open Form: {0}", AbstractFunctionalTest.GetTextForForm(form));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Out.WriteLine("Unable to get open forms string: {0}", ex);
+                }
                 throw;
             }
             finally

--- a/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
+++ b/pwiz_tools/Skyline/TestUtil/TestFunctional.cs
@@ -965,7 +965,7 @@ namespace pwiz.SkylineTestUtil
             });
         }
 
-        private static string GetTextForForm(Control form)
+        public static string GetTextForForm(Control form)
         {
             var result = form.Text;
             var threadExceptionDialog = form as ThreadExceptionDialog;
@@ -1193,17 +1193,9 @@ namespace pwiz.SkylineTestUtil
                     Assert.IsFalse(Program.TestExceptions.Any(), "Exception while running test");
 
                 bool isCondition = false;
-                try
-                {
-                    hangDetection.InterruptAfter(
-                        () => Program.MainWindow.Invoke(new Action(() => isCondition = func())),
-                        maxInvokeDuration);
-                }
-                catch (ThreadInterruptedException)
-                {
-                    Console.Out.WriteLine("Open forms: {0}", GetOpenFormsString());
-                    throw;
-                }
+                hangDetection.InterruptAfter(
+                    () => Program.MainWindow.Invoke(new Action(() => isCondition = func())),
+                    maxInvokeDuration);
 
                 if (isCondition)
                     return true;


### PR DESCRIPTION
Refactored HangDetection from a static class to an instance-based IDisposable that reuses a single watchdog thread across calls
WaitForConditionUI now creates one HangDetection instance for the entire loop, and writes GetOpenFormsString() to the console when a hang is detected — this captures ThreadExceptionDialog text in test output Thread dump logic moved into InterruptAfter so all callers benefit Fixes #3955

(cherry picked from commit 5df762e55ae6fb212f72f053b3797d57ae7a5e40)