### PR TITLE
Add cache tracking to TestPeakAreaRelativeAbundanceGraph Test 4

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/PeakAreaRelativeAbundanceGraphTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/PeakAreaRelativeAbundanceGraphTest.cs
@@ -381,14 +381,14 @@ namespace pwiz.SkylineTestFunctional
                     "Should have cached at least one result during undo");
 
                 // Expect a single calculation. If multiple DocumentChanged events fired,
-                // there will be multiple results — fail with diagnostic info to investigate.
+                // there will be multiple results -- fail with diagnostic info to investigate.
                 var diagnosticInfo = string.Join("\n", cachedResults.Select((r, i) =>
                     $"  [{i}]: {r.GetDiagnosticInfo()}"));
                 Assert.AreEqual(1, cachedResults.Count,
                     $"Expected a single calculation during undo, but got {cachedResults.Count}. " +
                     $"Multiple DocumentChanged events may be causing parallel calculations:\n{diagnosticInfo}");
 
-                // Single calculation — verify incremental update
+                // Single calculation -- verify incremental update
                 var result = cachedResults.First();
                 Assert.AreEqual(originalPeptideCount - peptidesToDelete, result.CachedNodeCount,
                     $"After undo, existing peptides should be cached. " +


### PR DESCRIPTION
## Summary

* Added GraphDataCachingReceiver.TrackCaching to Test 4 (undo after multi-peptide delete)
* Asserts exactly 1 cached calculation result during undo, with diagnostic dump on failure
* Same pattern as Test 6 (PR #3830) to investigate intermittent CachedNodeCount=0 failures
* When the intermittent failure recurs on nightly, the assertion message will reveal whether
  multiple DocumentChanged events caused parallel calculations or something else

## Context

TestPeakAreaRelativeAbundanceGraph Test 4 has 22 intermittent failures since 2025-03-27.
The failure shows CachedNodeCount=0 (full recalculation) instead of the expected 121
(incremental). PR #3830 fixed the same class of issue in Test 6 by discovering that
OpenFile triggers multiple DocumentChanged events causing parallel calculations.

This change adds the same tracking infrastructure to Test 4 so the next failure provides
diagnostic data instead of an opaque count mismatch.

## Test plan

- [x] TestPeakAreaRelativeAbundanceGraph - passes locally

Co-Authored-By: Claude <noreply@anthropic.com>