### PR TITLE
Fix memory leak in TestIrtTutorial

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/Caching/Receiver.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/Caching/Receiver.cs
@@ -74,7 +74,11 @@ namespace pwiz.Common.SystemUtil.Caching
 
         private void BeginInvoke(Action action)
         {
-            _synchronizationContext?.Post(_ => action(), null);
+            _synchronizationContext?.Post(_ =>
+            {
+                if (OwnerControl != null)
+                    action();
+            }, null);
         }
 
         private void OnProductStatusChanged()


### PR DESCRIPTION
Fixed memory leak in TestIrtTutorial
The switch to using "TaskScheduler" instead of "SafeBeginInvoke" enabled a notification to be sent after the graph window had been disposed. The graph window would end up asking for more data that would never get released.
Also, this change switches to just using "SynchronizationContext" instead of "TaskScheduler.FromCurrentSynchronizationContext" because that makes the code a little simpler, but the actual memory leak fix is not notifying after OwnerControl has been set to null in Receiver.cs.

Fixes #3980