### PR TITLE
Fix Apply Peak to All crash when replicates lack chromatogram data

### DIFF
--- a/pwiz_tools/Skyline/Model/PeakMatcher.cs
+++ b/pwiz_tools/Skyline/Model/PeakMatcher.cs
@@ -434,9 +434,18 @@ namespace pwiz.Skyline.Model
 
                 var groupPath = new IdentityPath(peptideGroup, peptideDocNode.Peptide, nodeTranGroup.Id);
 
-                doc = _retentionTime.HasValue
-                    ? doc.ChangePeak(groupPath, nameSet, filePath, null, _retentionTime.Value, UserSet.TRUE)
-                    : doc.ChangePeak(groupPath, nameSet, filePath, null, StartTime, EndTime, UserSet.TRUE, null, false);
+                try
+                {
+                    doc = _retentionTime.HasValue
+                        ? doc.ChangePeak(groupPath, nameSet, filePath, null, _retentionTime.Value, UserSet.TRUE)
+                        : doc.ChangePeak(groupPath, nameSet, filePath, null, StartTime, EndTime, UserSet.TRUE, null, false);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Skip replicates without chromatogram data at the target RT.
+                    // This is normal when Apply Peak to All iterates across all replicates.
+                    return doc;
+                }
 
                 var activeTransitionGroup = (TransitionGroupDocNode) doc.FindNode(groupPath);
                 if (activeTransitionGroup.RelativeRT != RelativeRT.Matching)


### PR DESCRIPTION
## Summary

* Fixed crash in "Apply Peak to All" when some replicates don't have chromatogram data at the target retention time (30 reports from 21 users)
* Wrapped `doc.ChangePeak()` call in `PeakMatch.ChangePeak` with try-catch for `ArgumentOutOfRangeException`, returning `doc` unchanged to skip replicates without data
* Left the throws in `TransitionGroupDocNode.ChangePeak` and `SrmDocument.ChangePeak` intact — they correctly catch programming errors in the single-replicate UI path

Fixes #3983

## Test plan

- [x] ApplyPeakToAllTest - existing test passes with fix applied

See ai/todos/active/TODO-20260215_apply-peak-crash.md

Co-Authored-By: Claude <noreply@anthropic.com>