### PR TITLE
Fix intermittent failure in TestIrtTutorial

### DIFF
--- a/pwiz_tools/Shared/CommonUtil/SystemUtil/Caching/ProductionFacility.cs
+++ b/pwiz_tools/Shared/CommonUtil/SystemUtil/Caching/ProductionFacility.cs
@@ -234,9 +234,6 @@ namespace pwiz.Common.SystemUtil.Caching
                         try
                         {
                             Cache.IncrementWaitingCount();
-                            // TEMPORARY: Delay so IsProcessing() returns true when
-                            // the UI thread switches replicates.
-                            Thread.Sleep(2000);
                             object value = Key.Producer.ProduceResult(progressCallback, Key.WorkParameter,
                                 _dependencyResultValues);
                             NotifyResultAvailable(ProductionResult.Success(value));

--- a/pwiz_tools/Skyline/Controls/Graphs/ReplicateCachingReceiver.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/ReplicateCachingReceiver.cs
@@ -337,9 +337,6 @@ namespace pwiz.Skyline.Controls.Graphs
             var listener = new CompletionListener(this, cacheKey, workOrder);
             if (_pendingListeners.TryAdd(cacheKey, listener))
             {
-                // TEMPORARY: Widen the race window so the background calculation
-                // completes before Cache.Listen adds the CompletionListener.
-                Thread.Sleep(3000);
                 _receiver.Cache.Listen(workOrder, listener);
 
                 // If the result became available between the IsProcessing() check


### PR DESCRIPTION
Fixes Issue #4055

Claude figured out that if the background work finishes right before the _receiver.Cache.Listen call in ReplicateCachingReceiver.KeepCalculationAlive, then ReplicateCachingReceiver will never notice that the calculation is finished and will never tell the ProductionFacility that it is no longer interested in the result.