### PR TITLE
Force GC collection after closing Agilent MIDAC IMS reader to release file locks

### DIFF
--- a/pwiz_aux/msrc/utility/vendor_api/Agilent/MidacData.cpp
+++ b/pwiz_aux/msrc/utility/vendor_api/Agilent/MidacData.cpp
@@ -184,6 +184,10 @@ MidacDataImpl::MidacDataImpl(const std::string& path)
 MidacDataImpl::~MidacDataImpl() noexcept(false)
 {
     try {imsReader_->Close();} CATCH_AND_FORWARD
+    imsReader_ = nullptr;
+    imsCcsReader_ = nullptr;
+    System::GC::Collect();
+    System::GC::WaitForPendingFinalizers();
 }
 
 std::string MidacDataImpl::getVersion() const


### PR DESCRIPTION
## Summary

* `MidacDataImpl::~MidacDataImpl()` called `imsReader_->Close()` but did not force .NET GC
  finalization, leaving native file handles open until the GC finalizer thread ran
  non-deterministically
* Null out `imsReader_` and `imsCcsReader_` gcroots before `GC::Collect()` so those managed
  objects are eligible for collection in the same GC cycle
* Added `GC::Collect()` + `WaitForPendingFinalizers()` to ensure all handles are released
  synchronously, matching the existing pattern in `MassHunterDataImpl::~MassHunterDataImpl()`
  for DAD files

Fixes #4057

## Test plan

- [x] Reader_Agilent_Test - the specific test that was failing intermittently on AWS agents
  with "Cannot rename ImsSynth_Chrom.d: there are unreleased file locks!"

Co-Authored-By: Claude <noreply@anthropic.com>