### PR TITLE
Fixed intermittent failure in ConstrainNormalizationMethodTest

### DIFF
--- a/pwiz_tools/Skyline/TestFunctional/ConstrainNormalizationMethodTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/ConstrainNormalizationMethodTest.cs
@@ -61,6 +61,10 @@ namespace pwiz.SkylineTestFunctional
             });
             Assert.IsFalse(SkylineWindow.Document.Settings.HasGlobalStandardArea);
             string pathNoGlobalStandardsNoHeavy = TestFilesDir.GetTestPath("NoGlobalStandards.sky");
+            // Wait for results to load before saving: OptimizeCache in SaveDocument only creates
+            // the .skyd at the new path when results are fully loaded. On slower machines running
+            // parallel tests, loading may not finish in time, causing a missing-data dialog on reopen.
+            WaitForDocumentLoaded();
             RunUI(()=>SkylineWindow.SaveDocument(pathNoGlobalStandardsNoHeavy));
 
             // Open a document which has heavy standards and choose "Normalize To Heavy"


### PR DESCRIPTION
## Summary

* `ConstrainNormalizationMethodTest` was failing intermittently on nightly parallel test machines
* Root cause: `SaveDocument` calls `OptimizeCache`, which only creates `NoGlobalStandards.skyd` when `results.IsLoaded` is true; on slower/parallel machines, background results loading from `Rat_plasma.skyd` may not finish before `SaveDocument` is called
* Without the `.skyd`, reopening `NoGlobalStandards.sky` triggers a `MultiButtonMsgDlg` about missing data; that dialog fires inside a synchronous `RunUI()` call, blocking the test thread until the 10-second hang-detection timeout aborts it
* Fix: add `WaitForDocumentLoaded()` before `SaveDocument` to guarantee results are loaded first

## Test plan

- [x] TestConstrainNormalizationMethod - passes locally

Co-Authored-By: Claude <noreply@anthropic.com>