### PR TITLE
Fixed CV Histogram graph titles and histogram co-location

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/GraphSummary.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphSummary.cs
@@ -167,7 +167,7 @@ namespace pwiz.Skyline.Controls.Graphs
                              new DefaultStateProvider();
 
             Type = type;
-            Text = Controller.Text + @" - " + Type.CustomToString();
+            Text = Controller.Text + @" - " + Type.CustomToString(Controller);
             Helpers.PeptideToMoleculeTextMapper.TranslateForm(this, _documentContainer.Document.DocumentType); // Use terminology like "Molecule Comparison" instead of "Peptide Comparison" as appropriate
 
             // Clear ZedGraph's default pane so the control paints blank until
@@ -606,7 +606,7 @@ namespace pwiz.Skyline.Controls.Graphs
 
     public static class Extensions
     {
-        public static string CustomToString(this GraphTypeSummary type)
+        public static string CustomToString(this GraphTypeSummary type, GraphSummary.IController controller = null)
         {
             switch (type)
             {
@@ -627,9 +627,13 @@ namespace pwiz.Skyline.Controls.Graphs
                 case GraphTypeSummary.run_to_run_regression:
                     return GraphsResources.Extensions_CustomToString_Run_To_Run_Regression;
                 case GraphTypeSummary.histogram:
-                    return GraphsResources.Extensions_CustomToString_Histogram;
+                    return controller is AreaGraphController
+                        ? GraphsResources.Extensions_CustomToString_CV_Histogram
+                        : GraphsResources.Extensions_CustomToString_Histogram;
                 case GraphTypeSummary.histogram2d:
-                    return GraphsResources.Extensions_CustomToString__2D_Histogram;
+                    return controller is AreaGraphController
+                        ? GraphsResources.Extensions_CustomToString_CV_2D_Histogram
+                        : GraphsResources.Extensions_CustomToString__2D_Histogram;
                 case GraphTypeSummary.detections:
                     return GraphsResources.Extensions_CustomToString_Detections_Replicates;
                 case GraphTypeSummary.detections_histogram:

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.designer.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.designer.cs
@@ -881,6 +881,24 @@ namespace pwiz.Skyline.Controls.Graphs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CV 2D Histogram.
+        /// </summary>
+        public static string Extensions_CustomToString_CV_2D_Histogram {
+            get {
+                return ResourceManager.GetString("Extensions_CustomToString_CV_2D_Histogram", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to CV Histogram.
+        /// </summary>
+        public static string Extensions_CustomToString_CV_Histogram {
+            get {
+                return ResourceManager.GetString("Extensions_CustomToString_CV_Histogram", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Histogram.
         /// </summary>
         public static string Extensions_CustomToString_Detections_Histogram {

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.ja.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.ja.resx
@@ -380,6 +380,12 @@
   <data name="Extensions_CustomToString__2D_Histogram" xml:space="preserve">
     <value>2Dヒストグラム</value>
   </data>
+  <data name="Extensions_CustomToString_CV_2D_Histogram" xml:space="preserve">
+    <value>CV 2Dヒストグラム</value>
+  </data>
+  <data name="Extensions_CustomToString_CV_Histogram" xml:space="preserve">
+    <value>CVヒストグラム</value>
+  </data>
   <data name="Extensions_CustomToString_Detections_Histogram" xml:space="preserve">
     <value>ヒストグラム</value>
   </data>

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.resx
@@ -380,6 +380,12 @@
   <data name="Extensions_CustomToString__2D_Histogram" xml:space="preserve">
     <value>2D Histogram</value>
   </data>
+  <data name="Extensions_CustomToString_CV_2D_Histogram" xml:space="preserve">
+    <value>CV 2D Histogram</value>
+  </data>
+  <data name="Extensions_CustomToString_CV_Histogram" xml:space="preserve">
+    <value>CV Histogram</value>
+  </data>
   <data name="Extensions_CustomToString_Detections_Histogram" xml:space="preserve">
     <value>Histogram</value>
   </data>

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.zh-CHS.resx
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphsResources.zh-CHS.resx
@@ -380,6 +380,12 @@
   <data name="Extensions_CustomToString__2D_Histogram" xml:space="preserve">
     <value>2D 直方图</value>
   </data>
+  <data name="Extensions_CustomToString_CV_2D_Histogram" xml:space="preserve">
+    <value>CV 2D 直方图</value>
+  </data>
+  <data name="Extensions_CustomToString_CV_Histogram" xml:space="preserve">
+    <value>CV 直方图</value>
+  </data>
   <data name="Extensions_CustomToString_Detections_Histogram" xml:space="preserve">
     <value>直方图</value>
   </data>

--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -2690,6 +2690,10 @@ namespace pwiz.Skyline
                     return GraphTypeSummary.abundance_comparison;
                 case GraphTypeSummary.abundance_comparison:
                     return GraphTypeSummary.abundance;
+                case GraphTypeSummary.histogram:
+                    return GraphTypeSummary.histogram2d;
+                case GraphTypeSummary.histogram2d:
+                    return GraphTypeSummary.histogram;
                 default:
                     return GraphTypeSummary.invalid;
             }


### PR DESCRIPTION
## Summary
- Peak area histogram titles showed "Histogram" / "2D Histogram" instead of "CV Histogram" / "CV 2D Histogram" — added controller-aware `CustomToString` with localized resource strings (en, ja, zh-CHS) matching menu text
- Made `histogram` and `histogram2d` sibling graph types so they co-locate when separated from their primary graph (same pattern as `abundance` / `abundance_comparison`)

Fixes #4064

## Test plan
- [x] AreaCVHistogramTest passes
- [x] Build succeeds with zero warnings

See ai/todos/active/TODO-20260330_cv_histogram_titles.md

Co-Authored-By: Claude <noreply@anthropic.com>