### PR TITLE
Fix path to SortRESX.exe in "PreBuildEvents.bat"

### DIFF
--- a/pwiz_tools/Skyline/PreBuildEvents.bat
+++ b/pwiz_tools/Skyline/PreBuildEvents.bat
@@ -2,12 +2,12 @@ REM folders where the .resx files get processed by SortRESX.exe so that all of t
 REM paths are relative to pwiz_tools\Skyline
 for %%f in ( 
 "%~dp0Controls\AuditLog"
-"%~dp0Executables\SortRESX
+"%~dp0Executables\DevTools\SortRESX
 "%~dp0Model\Databinding\Entities"
 "%~dp0Properties"
 ) do (
-echo "%~dp0Executables\SortRESX\SortRESX.exe" %%~f 
-"%~dp0Executables\SortRESX\SortRESX.exe" --preserveOrderInResourcesResx %%~f
+echo "%~dp0Executables\DevTools\SortRESX\SortRESX.exe" --preserveOrderInResourcesResx %%~f 
+"%~dp0Executables\DevTools\SortRESX\SortRESX.exe" --preserveOrderInResourcesResx %%~f
 )
 
 echo "%~dp0ProtocolBuffers\generatecode.bat"


### PR DESCRIPTION
SortRESX.exe was moved into "DevTools" subfolder. This tool is responsible for keeping the entries in ColumnCaptions.resx and ColumnTooltips.resx sorted alphabetically.