### PR TITLE
Revert PR #4110: Volcano/RelAbundance per-trait formatting rules

### DIFF
--- a/pwiz_tools/Skyline/Controls/Graphs/DotPlotUtil.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/DotPlotUtil.cs
@@ -26,7 +26,6 @@ using pwiz.Skyline.Model.Databinding.Entities;
 using pwiz.Skyline.Model.GroupComparison;
 using ZedGraph;
 using Peptide = pwiz.Skyline.Model.Databinding.Entities.Peptide;
-// ReSharper disable PossibleMultipleEnumeration
 
 namespace pwiz.Skyline.Controls.Graphs
 {
@@ -73,16 +72,6 @@ namespace pwiz.Skyline.Controls.Graphs
                     return SymbolType.Plus;
                 case PointSymbol.Star:
                     return SymbolType.Star;
-                case PointSymbol.OutlineCircle:
-                    return SymbolType.Circle;
-                case PointSymbol.OutlineSquare:
-                    return SymbolType.Square;
-                case PointSymbol.OutlineTriangle:
-                    return SymbolType.Triangle;
-                case PointSymbol.OutlineTriangleDown:
-                    return SymbolType.TriangleDown;
-                case PointSymbol.OutlineDiamond:
-                    return SymbolType.Diamond;
                 default:
                     return SymbolType.Circle;
             }
@@ -93,13 +82,6 @@ namespace pwiz.Skyline.Controls.Graphs
             return pointSymbol == PointSymbol.Circle || pointSymbol == PointSymbol.Square ||
                    pointSymbol == PointSymbol.Triangle || pointSymbol == PointSymbol.TriangleDown ||
                    pointSymbol == PointSymbol.Diamond;
-        }
-
-        public static bool IsOutlineVariant(PointSymbol pointSymbol)
-        {
-            return pointSymbol == PointSymbol.OutlineCircle || pointSymbol == PointSymbol.OutlineSquare ||
-                   pointSymbol == PointSymbol.OutlineTriangle || pointSymbol == PointSymbol.OutlineTriangleDown ||
-                   pointSymbol == PointSymbol.OutlineDiamond;
         }
 
         public static float PointSizeToFloat(PointSize pointSize)
@@ -224,52 +206,6 @@ namespace pwiz.Skyline.Controls.Graphs
         {
             var docNode = peptide ?? (SkylineDocNode)protein;
             return skylineWindow != null && GetSelectedPath(skylineWindow, docNode.IdentityPath) != null;
-        }
-
-        /// <summary>
-        /// Resolves per-trait formatting for a single data point by scanning the ordered rule list.
-        /// Each trait (color, symbol, size, labeled=true) is set by the first matching rule that
-        /// explicitly provides that trait. <c>Labeled=false</c> is treated as "not set" so a later
-        /// rule can still enable labeling.
-        /// Returns <c>null</c> when no rule contributes any trait — the caller should add the point
-        /// to the default "other" collection rather than a matched curve.
-        /// </summary>
-        public static (Color? color, PointSymbol? symbol, PointSize? size, bool labeled, int firstRuleIndex)?
-            ResolvePointFormat(IList<MatchRgbHexColor> colorRows, Func<MatchRgbHexColor, bool> matches)
-        {
-            Color? resolvedColor = null;
-            PointSymbol? resolvedSymbol = null;
-            PointSize? resolvedSize = null;
-            var resolvedLabeled = false;
-            var firstRuleIndex = -1;
-
-            for (var i = 0; i < colorRows.Count; i++)
-            {
-                var rule = colorRows[i];
-                if (!matches(rule))
-                    continue;
-
-                var contributed = false;
-                if (resolvedColor == null && rule.Color != Color.Empty)
-                    { resolvedColor = rule.Color; contributed = true; }
-                if (resolvedSymbol == null && rule.PointSymbol.HasValue)
-                    { resolvedSymbol = rule.PointSymbol; contributed = true; }
-                if (resolvedSize == null && rule.PointSize.HasValue)
-                    { resolvedSize = rule.PointSize; contributed = true; }
-                if (!resolvedLabeled && rule.Labeled)
-                    { resolvedLabeled = true; contributed = true; }
-
-                if (contributed && firstRuleIndex < 0)
-                    firstRuleIndex = i;
-
-                if (resolvedColor != null && resolvedSymbol != null && resolvedSize != null && resolvedLabeled)
-                    break;
-            }
-
-            if (firstRuleIndex < 0)
-                return null;
-
-            return (resolvedColor, resolvedSymbol, resolvedSize, resolvedLabeled, firstRuleIndex);
         }
     }
 }

--- a/pwiz_tools/Skyline/Controls/Graphs/SummaryRelativeAbundanceGraphPane.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/SummaryRelativeAbundanceGraphPane.cs
@@ -505,10 +505,6 @@ namespace pwiz.Skyline.Controls.Graphs
             bool dataChanged = _graphData.MinY != oldGraphData?.MinY || _graphData.MaxY != oldGraphData?.MaxY;
 
             // For proper z-order, add the selected points, then the matched points, then the unmatched points
-            // Resolve formatting traits per-point independently: for each trait (color, symbol, size,
-            // labeled), the first matching rule that has that trait set (non-null / non-Empty) wins.
-            var colorRows = (_formattingOverride ?? document.Settings.DataSettings.RelativeAbundanceFormatting).ColorRows
-                .Where(r => r.MatchExpression != null).ToList();
             var selectedPoints = new PointPairList();
             var unmatchedPoints = new List<PointPair>();
             if (ShowSelection)
@@ -517,7 +513,7 @@ namespace pwiz.Skyline.Controls.Graphs
                     _graphData.PointPairList.Select(point => point.Tag).OfType<GraphPointData>()
                         .Select(graphPointData => graphPointData.IdentityPath)).ToHashSet();
 
-                foreach (var point in _graphData.PointPairList)
+                foreach (var point in _graphData.PointPairList) 
                 {
                     var pointData = (GraphPointData)point.Tag;
                     if (selectedPaths.Contains(pointData.IdentityPath) && selectedPoints.Count < MAX_SELECTED)
@@ -529,51 +525,34 @@ namespace pwiz.Skyline.Controls.Graphs
                         unmatchedPoints.Add(point);
                     }
                 }
-                // Selected points keep the selection color but preserve the marker shape from the matching rule
-                foreach (var symbolGroup in selectedPoints.GroupBy(point =>
-                {
-                    var pointData = (GraphPointData)point.Tag;
-                    return DotPlotUtil.ResolvePointFormat(colorRows,
-                        rule => rule.MatchExpression.Matches(document, pointData.Protein, pointData.Peptide, null, null))
-                        ?.symbol ?? PointSymbol.Circle;
-                }))
-                {
-                    AddPoints(new PointPairList(symbolGroup.ToList()), GraphSummary.ColorSelected,
-                        DotPlotUtil.PointSizeToFloat(PointSize.large), true, symbolGroup.Key, true);
-                }
+                AddPoints(new PointPairList(selectedPoints), GraphSummary.ColorSelected, DotPlotUtil.PointSizeToFloat(PointSize.large), true, PointSymbol.Circle, true);
             }
             else
             {
                 unmatchedPoints.AddRange(_graphData.PointPairList);
             }
-            var unmatchedOtherPoints = new PointPairList(); // points that matched no rule
-            var pointFormats = new List<(PointPair point, Color color, PointSymbol symbol, PointSize size, bool labeled, int firstRuleIndex)>();
-            foreach (var point in unmatchedPoints)
-            {
-                var pointData = (GraphPointData)point.Tag;
-                var resolved = DotPlotUtil.ResolvePointFormat(colorRows,
-                    rule => rule.MatchExpression.Matches(document, pointData.Protein, pointData.Peptide, null, null));
-                if (resolved == null)
-                    unmatchedOtherPoints.Add(point);
-                else
-                    pointFormats.Add((point,
-                        resolved.Value.color ?? Color.Gray,
-                        resolved.Value.symbol ?? PointSymbol.Circle,
-                        resolved.Value.size ?? PointSize.normal,
-                        resolved.Value.labeled,
-                        resolved.Value.firstRuleIndex));
-            }
 
-            foreach (var group in pointFormats
-                .GroupBy(pf => (pf.color, pf.symbol, pf.size, pf.labeled))
-                .OrderBy(g => g.Min(pf => pf.firstRuleIndex)))
+            // For each valid match expression specified by the user
+            var colorRows = (_formattingOverride ?? document.Settings.DataSettings.RelativeAbundanceFormatting).ColorRows;
+            foreach (var colorRow in colorRows.Where(r => r.MatchExpression != null))
             {
-                var fmt = group.Key;
-                AddPoints(new PointPairList(group.Select(pf => pf.point).ToList()),
-                    fmt.color, DotPlotUtil.PointSizeToFloat(fmt.size), fmt.labeled, fmt.symbol);
-            }
+                var matchedPoints = new List<PointPair>();
+                foreach (var point in unmatchedPoints)
+                {
+                    var pointData = (GraphPointData)point.Tag;
+                    if (colorRow.MatchExpression.Matches(document, pointData.Protein, pointData.Peptide, null, null))
+                    {
+                        matchedPoints.Add(point);
+                    }
+                }
 
-            AddPoints(unmatchedOtherPoints, Color.Gray, DotPlotUtil.PointSizeToFloat(PointSize.normal), false, PointSymbol.Circle);
+                if (matchedPoints.Any())
+                {
+                    AddPoints(new PointPairList(matchedPoints), colorRow.Color, DotPlotUtil.PointSizeToFloat(colorRow.PointSize), colorRow.Labeled, colorRow.PointSymbol);
+                    unmatchedPoints = unmatchedPoints.Except(matchedPoints).ToList();
+                }
+            }
+            AddPoints(new PointPairList(unmatchedPoints), Color.Gray, DotPlotUtil.PointSizeToFloat(PointSize.normal), false, PointSymbol.Circle);
             if(dataChanged || Settings.Default.RelativeAbundanceLogScale != YAxis.Scale.IsLog)
                 UpdateAxes();
             if (Settings.Default.GroupComparisonAvoidLabelOverlap)
@@ -662,15 +641,7 @@ namespace pwiz.Skyline.Controls.Graphs
             var symbolType = DotPlotUtil.PointSymbolToSymbolType(pointSymbol);
 
             LineItem lineItem;
-            if (DotPlotUtil.IsOutlineVariant(pointSymbol))
-            {
-                lineItem = new LineItem(null, points, Color.Black, symbolType)
-                {
-                    Line = { IsVisible = false },
-                    Symbol = { Border = { IsVisible = true, Color = color }, Fill = new Fill(Color.Transparent), Size = size, IsAntiAlias = true }
-                };
-            }
-            else if (DotPlotUtil.HasOutline(pointSymbol))
+            if (DotPlotUtil.HasOutline(pointSymbol))
             {
                 lineItem = new LineItem(null, points, Color.Black, symbolType)
                 {

--- a/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/FoldChangeVolcanoPlot.cs
@@ -352,52 +352,26 @@ namespace pwiz.Skyline.Controls.GroupComparison
             }
 
             // The order matters here, selected points should be highest in the zorder, followed by matched points and other(unmatched) points
-            // Resolve formatting traits per-point independently using DotPlotUtil.ResolvePointFormat.
-            // Each trait (color, symbol, size, labeled=true) is set by the first matching rule that
-            // explicitly provides it — separate rules can control different traits independently.
-            var colorRows = GroupComparisonDef.ColorRows.Where(r => r.MatchExpression != null).ToList();
+            AddPoints(selectedPoints, Color.Red, DotPlotUtil.PointSizeToFloat(PointSize.large), true, PointSymbol.Circle, true);
 
-            // Selected points keep the selection color but preserve the marker shape from the first
-            // selected point's matching rule. Exactly one selected curve must always be added at
-            // index 0 so that the cutoff-line insertion indices and MatchedPointsStartIndex stay valid.
-            var selectedSymbol = PointSymbol.Circle;
-            if (selectedPoints.Count > 0)
+            foreach (var colorRow in GroupComparisonDef.ColorRows.Where(r => r.MatchExpression != null))
             {
-                var firstRow = (FoldChangeRow)(selectedPoints[0]).Tag;
-                selectedSymbol = DotPlotUtil.ResolvePointFormat(colorRows,
-                    rule => rule.MatchExpression.Matches(Document, firstRow.Protein, firstRow.Peptide,
-                        firstRow.FoldChangeResult, CutoffSettings))?.symbol ?? PointSymbol.Circle;
-            }
-            AddPoints(selectedPoints, Color.Red, DotPlotUtil.PointSizeToFloat(PointSize.large), true, selectedSymbol, true);
-            var unmatchedOtherPoints = new PointPairList();
-            var pointFormats = new List<(PointPair point, Color color, PointSymbol symbol, PointSize size, bool labeled, int firstRuleIndex)>();
-            foreach (var point in otherPoints)
-            {
-                var foldChangeRow = (FoldChangeRow)point.Tag;
-                var resolved = DotPlotUtil.ResolvePointFormat(colorRows,
-                    rule => rule.MatchExpression.Matches(Document, foldChangeRow.Protein,
-                        foldChangeRow.Peptide, foldChangeRow.FoldChangeResult, CutoffSettings));
-                if (resolved == null)
-                    unmatchedOtherPoints.Add(point);
-                else
-                    pointFormats.Add((point,
-                        resolved.Value.color ?? Color.Gray,
-                        resolved.Value.symbol ?? PointSymbol.Circle,
-                        resolved.Value.size ?? PointSize.small,
-                        resolved.Value.labeled,
-                        resolved.Value.firstRuleIndex));
+                var row = colorRow;
+                var matchedPoints = otherPoints.Where(p =>
+                {
+                    var foldChangeRow = (FoldChangeRow) p.Tag;
+                    return row.MatchExpression.Matches(Document, foldChangeRow.Protein, foldChangeRow.Peptide,
+                        foldChangeRow.FoldChangeResult, CutoffSettings);
+                }).ToArray();
+
+                if (matchedPoints.Any())
+                {
+                    AddPoints(new PointPairList(matchedPoints), colorRow.Color, DotPlotUtil.PointSizeToFloat(row.PointSize), row.Labeled, row.PointSymbol);
+                    otherPoints = new PointPairList(otherPoints.Except(matchedPoints).ToArray());
+                }
             }
 
-            foreach (var group in pointFormats
-                .GroupBy(pf => (pf.color, pf.symbol, pf.size, pf.labeled))
-                .OrderBy(g => g.Min(pf => pf.firstRuleIndex)))
-            {
-                var fmt = group.Key;
-                AddPoints(new PointPairList(group.Select(pf => pf.point).ToList()),
-                    fmt.color, DotPlotUtil.PointSizeToFloat(fmt.size), fmt.labeled, fmt.symbol);
-            }
-
-            AddPoints(unmatchedOtherPoints, Color.Gray, DotPlotUtil.PointSizeToFloat(PointSize.small), false, PointSymbol.Circle);
+            AddPoints(otherPoints, Color.Gray, DotPlotUtil.PointSizeToFloat(PointSize.small), false, PointSymbol.Circle);
 
             // The coordinates that depend on the axis scale don't matter here, the AxisChangeEvent will fix those
             // Insert after selected items, but before all other items
@@ -467,15 +441,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
             var symbolType = DotPlotUtil.PointSymbolToSymbolType(pointSymbol);
 
             LineItem lineItem;
-            if (DotPlotUtil.IsOutlineVariant(pointSymbol))
-            {
-                lineItem = new LineItem(null, points, Color.Black, symbolType)
-                {
-                    Line = { IsVisible = false },
-                    Symbol = { Border = { IsVisible = true, Color = color }, Fill = new Fill(Color.Transparent), Size = size, IsAntiAlias = true }
-                };
-            }
-            else if (DotPlotUtil.HasOutline(pointSymbol))
+            if (DotPlotUtil.HasOutline(pointSymbol))
             {
                 lineItem = new LineItem(null, points, Color.Black, symbolType)
                 {
@@ -1054,23 +1020,18 @@ namespace pwiz.Skyline.Controls.GroupComparison
             var outCount = 0;
             var inCount = 0;
 
-            // Iterate all non-selected, non-cutoff-line curves (formatted groups + unmatched "other").
-            // Formatted rule curves occupy MatchedPointsStartIndex..Count-2; the unmatched curve is last.
-            for (var curveIndex = MatchedPointsStartIndex; curveIndex < curveList.Count; curveIndex++)
+            var otherPoints = curveList[MatchedPointsStartIndex].Points;
+            for (var i = 0; i < otherPoints.Count; ++i)
             {
-                var points = curveList[curveIndex].Points;
-                for (var i = 0; i < points.Count; ++i)
-                {
-                    var pair = points[i];
-                    var row = (FoldChangeRow) pair.Tag;
-                    var pvalue = -Math.Log10(Math.Max(MIN_PVALUE, row.FoldChangeResult.AdjustedPValue));
+                var pair = otherPoints[i];
+                var row = (FoldChangeRow) pair.Tag;
+                var pvalue = -Math.Log10(Math.Max(MIN_PVALUE, row.FoldChangeResult.AdjustedPValue));
 
-                    if ((!CutoffSettings.FoldChangeCutoffValid || row.FoldChangeResult.AbsLog2FoldChange > CutoffSettings.Log2FoldChangeCutoff) &&
-                        (!CutoffSettings.PValueCutoffValid || pvalue > CutoffSettings.PValueCutoff))
-                        ++outCount;
-                    else
-                        ++inCount;
-                }
+                if ((!CutoffSettings.FoldChangeCutoffValid || row.FoldChangeResult.AbsLog2FoldChange > CutoffSettings.Log2FoldChangeCutoff) &&
+                    (!CutoffSettings.PValueCutoffValid || pvalue > CutoffSettings.PValueCutoff))
+                    ++outCount;
+                else
+                    ++inCount;
             }
 
             return new CurveCounts(curveList.Count, selectedCount,

--- a/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.cs
+++ b/pwiz_tools/Skyline/Controls/GroupComparison/VolcanoPlotFormattingDlg.cs
@@ -44,7 +44,6 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
         private readonly DataGridViewComboBoxColumn _symbolCombo;
         private readonly DataGridViewComboBoxColumn _pointSizeCombo;
-        private readonly Font _symbolDropdownFont = new Font(SystemFonts.DefaultFont.FontFamily, 16f);
 
         public VolcanoPlotFormattingDlg(FoldChangeVolcanoPlot volcanoPlot, IList<MatchRgbHexColor> colorRows,
             FoldChangeRow[] foldChangeRows, Action<IEnumerable<MatchRgbHexColor>> updateGraph) : 
@@ -106,8 +105,6 @@ namespace pwiz.Skyline.Controls.GroupComparison
             _symbolCombo.DisplayMember = @"DisplayString";
             _symbolCombo.ValueMember = @"PointSymbol";
             _symbolCombo.Items.AddRange(
-                new PointSymbolStringPair(null,
-                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_None),
                 new PointSymbolStringPair(PointSymbol.Circle,
                     GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Circle),
                 new PointSymbolStringPair(PointSymbol.Square,
@@ -123,17 +120,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
                 new PointSymbolStringPair(PointSymbol.Plus,
                     GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Plus),
                 new PointSymbolStringPair(PointSymbol.Star,
-                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Star),
-                new PointSymbolStringPair(PointSymbol.OutlineCircle,
-                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineCircle),
-                new PointSymbolStringPair(PointSymbol.OutlineSquare,
-                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineSquare),
-                new PointSymbolStringPair(PointSymbol.OutlineTriangle,
-                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineTriangle),
-                new PointSymbolStringPair(PointSymbol.OutlineTriangleDown,
-                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineTriangleDown),
-                new PointSymbolStringPair(PointSymbol.OutlineDiamond,
-                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineDiamond)
+                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Star)
             );
             regexColorRowGrid1.Columns.Insert(6, _symbolCombo);
 
@@ -144,8 +131,6 @@ namespace pwiz.Skyline.Controls.GroupComparison
             _pointSizeCombo.DisplayMember = @"DisplayString";
             _pointSizeCombo.ValueMember = @"PointSize";
             _pointSizeCombo.Items.AddRange(
-                new PointSizeStringPair(null,
-                    GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_None),
                 new PointSizeStringPair(PointSize.x_small,
                     GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_X_Small),
                 new PointSizeStringPair(PointSize.small,
@@ -168,9 +153,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
             advancedCheckBox.Checked = Settings.Default.ShowAdvancedVolcanoPlotFormatting;
             UpdateAdvancedColumns();
 
-            regexColorRowGrid1.AddUseColorColumn(GroupComparisonStrings.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Color);
             regexColorRowGrid1.Owner = this;
-            regexColorRowGrid1.DataGridView.EditingControlShowing += DataGridView_EditingControlShowing;
             if (!hasFoldChangeResults)
             {
                 Text = GroupComparisonResources.VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Protein_Expression_Formatting;
@@ -181,7 +164,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
         public class PointSizeStringPair
         {
-            public PointSizeStringPair(PointSize? pointSize, string displayString)
+            public PointSizeStringPair(PointSize pointSize, string displayString)
             {
                 PointSize = pointSize;
                 DisplayString = displayString;
@@ -189,7 +172,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
             // These are actually used by the combo box
             // ReSharper disable once MemberCanBePrivate.Local
-            public PointSize? PointSize { get; set; }
+            public PointSize PointSize { get; set; }
 
             // ReSharper disable once UnusedAutoPropertyAccessor.Local
             // ReSharper disable once MemberCanBePrivate.Local
@@ -198,7 +181,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
         public class PointSymbolStringPair
         {
-            public PointSymbolStringPair(PointSymbol? pointSymbol, string displayString)
+            public PointSymbolStringPair(PointSymbol pointSymbol, string displayString)
             {
                 PointSymbol = pointSymbol;
                 DisplayString = displayString;
@@ -206,7 +189,7 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
             // These are actually used by the combo box
             // ReSharper disable once MemberCanBePrivate.Local
-            public PointSymbol? PointSymbol { get; set; }
+            public PointSymbol PointSymbol { get; set; }
 
             // ReSharper disable once UnusedAutoPropertyAccessor.Local
             // ReSharper disable once MemberCanBePrivate.Local
@@ -216,35 +199,8 @@ namespace pwiz.Skyline.Controls.GroupComparison
         protected override void OnHandleDestroyed(EventArgs e)
         {
             _bindingList.ListChanged -= _bindingList_ListChanged;
-            _symbolDropdownFont.Dispose();
+
             base.OnHandleDestroyed(e);
-        }
-
-        private void DataGridView_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
-        {
-            if (((DataGridView)sender).CurrentCell?.ColumnIndex != _symbolCombo.Index)
-                return;
-            if (e.Control is ComboBox cb)
-            {
-                cb.DrawMode = DrawMode.OwnerDrawFixed;
-                cb.ItemHeight = _symbolDropdownFont.Height + 4;
-                cb.DrawItem -= SymbolCombo_DrawItem;
-                cb.DrawItem += SymbolCombo_DrawItem;
-            }
-        }
-
-        private void SymbolCombo_DrawItem(object sender, DrawItemEventArgs e)
-        {
-            if (e.Index < 0)
-                return;
-            e.DrawBackground();
-            var cb = (ComboBox)sender;
-            var text = cb.GetItemText(cb.Items[e.Index]);
-            // Use normal font for the closed-state display (edit portion); large font for dropdown items.
-            var isEditPortion = (e.State & DrawItemState.ComboBoxEdit) != 0;
-            var font = isEditPortion ? cb.Font : _symbolDropdownFont;
-            TextRenderer.DrawText(e.Graphics, text, font, e.Bounds, SystemColors.WindowText,
-                TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
         }
 
         public void Select(IdentityPath identityPath)
@@ -465,12 +421,12 @@ namespace pwiz.Skyline.Controls.GroupComparison
 
         private bool IsLastRowEmpty => Equals(_bindingList.LastOrDefault(), MatchRgbHexColor.EMPTY);
 
-        public PointSymbol? GetRowPointSymbol(int rowIndex)
+        public PointSymbol GetRowPointSymbol(int rowIndex)
         {
             return _bindingList[rowIndex].PointSymbol;
         }
 
-        public void SetRowPointSymbol(int rowIndex, PointSymbol? pointSymbol)
+        public void SetRowPointSymbol(int rowIndex, PointSymbol pointSymbol)
         {
             _bindingList[rowIndex].PointSymbol = pointSymbol;
         }

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.Designer.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.Designer.cs
@@ -652,25 +652,7 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to None.
-        /// </summary>
-        internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_None {
-            get {
-                return ResourceManager.GetString("VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_None", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Color.
-        /// </summary>
-        internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Color {
-            get {
-                return ResourceManager.GetString("VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Color", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to ●.
+        ///   Looks up a localized string similar to Circle.
         /// </summary>
         internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Circle {
             get {
@@ -679,7 +661,7 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ◆.
+        ///   Looks up a localized string similar to Diamond.
         /// </summary>
         internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Diamond {
             get {
@@ -724,7 +706,7 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to +.
+        ///   Looks up a localized string similar to Plus.
         /// </summary>
         internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Plus {
             get {
@@ -751,7 +733,7 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ■.
+        ///   Looks up a localized string similar to Square.
         /// </summary>
         internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Square {
             get {
@@ -760,7 +742,7 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ★.
+        ///   Looks up a localized string similar to Star.
         /// </summary>
         internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Star {
             get {
@@ -778,7 +760,7 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ▲.
+        ///   Looks up a localized string similar to Triangle.
         /// </summary>
         internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Triangle {
             get {
@@ -787,7 +769,7 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ▼.
+        ///   Looks up a localized string similar to Triangle Down.
         /// </summary>
         internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_TriangleDown {
             get {
@@ -796,59 +778,14 @@ namespace pwiz.Skyline.Model.GroupComparison {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ×.
+        ///   Looks up a localized string similar to X Cross.
         /// </summary>
         internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_X_Cross {
             get {
                 return ResourceManager.GetString("VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_X_Cross", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to ○.
-        /// </summary>
-        internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineCircle {
-            get {
-                return ResourceManager.GetString("VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineCircle", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to □.
-        /// </summary>
-        internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineSquare {
-            get {
-                return ResourceManager.GetString("VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineSquare", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to △.
-        /// </summary>
-        internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineTriangle {
-            get {
-                return ResourceManager.GetString("VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineTriangle", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to ▽.
-        /// </summary>
-        internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineTriangleDown {
-            get {
-                return ResourceManager.GetString("VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineTriangleDown", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to ◇.
-        /// </summary>
-        internal static string VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineDiamond {
-            get {
-                return ResourceManager.GetString("VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineDiamond", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to X-Large.
         /// </summary>

--- a/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.resx
+++ b/pwiz_tools/Skyline/Model/GroupComparison/GroupComparisonStrings.resx
@@ -324,49 +324,28 @@
     <value>X-Large</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Square" xml:space="preserve">
-    <value>&#x25A0;</value>
+    <value>Square</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Diamond" xml:space="preserve">
-    <value>&#x25C6;</value>
+    <value>Diamond</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Triangle" xml:space="preserve">
-    <value>&#x25B2;</value>
-  </data>
-  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_None" xml:space="preserve">
-    <value>None</value>
-  </data>
-  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Color" xml:space="preserve">
-    <value>Color</value>
+    <value>Triangle</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Circle" xml:space="preserve">
-    <value>&#x25CF;</value>
+    <value>Circle</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_TriangleDown" xml:space="preserve">
-    <value>&#x25BC;</value>
+    <value>Triangle Down</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_X_Cross" xml:space="preserve">
-    <value>&#x00D7;</value>
+    <value>X Cross</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Plus" xml:space="preserve">
-    <value>+</value>
+    <value>Plus</value>
   </data>
   <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_Star" xml:space="preserve">
-    <value>&#x2605;</value>
-  </data>
-  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineCircle" xml:space="preserve">
-    <value>&#x25CB;</value>
-  </data>
-  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineSquare" xml:space="preserve">
-    <value>&#x25A1;</value>
-  </data>
-  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineTriangle" xml:space="preserve">
-    <value>&#x25B3;</value>
-  </data>
-  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineTriangleDown" xml:space="preserve">
-    <value>&#x25BD;</value>
-  </data>
-  <data name="VolcanoPlotFormattingDlg_VolcanoPlotFormattingDlg_OutlineDiamond" xml:space="preserve">
-    <value>&#x25C7;</value>
+    <value>Star</value>
   </data>
   <data name="NormalizationMethod_TIC_Total_Ion_Current" xml:space="preserve">
     <value>Total Ion Current</value>

--- a/pwiz_tools/Skyline/Model/GroupComparison/MatchRgbHexColor.cs
+++ b/pwiz_tools/Skyline/Model/GroupComparison/MatchRgbHexColor.cs
@@ -44,12 +44,7 @@ namespace pwiz.Skyline.Model.GroupComparison
         Diamond,
         XCross,
         Plus,
-        Star,
-        OutlineCircle,
-        OutlineSquare,
-        OutlineTriangle,
-        OutlineTriangleDown,
-        OutlineDiamond
+        Star
     }
 
     [XmlRoot(XML_ROOT)]
@@ -60,16 +55,10 @@ namespace pwiz.Skyline.Model.GroupComparison
         public const string XML_ROOT = "format_detail";
         private string _expression;
         private bool _labeled;
-        private PointSymbol? _pointSymbol;
-        private PointSize? _pointSize;
+        private PointSymbol _pointSymbol;
+        private PointSize _pointSize;
 
-        /// <summary>
-        /// Creates a formatting rule. Pass null for <paramref name="pointSymbol"/> or
-        /// <paramref name="pointSize"/> to leave that trait unset so a later matching rule
-        /// can supply it independently.  Pass <see cref="Color.Empty"/> for
-        /// <paramref name="color"/> to leave the color unset.
-        /// </summary>
-        public MatchRgbHexColor(string expression, bool labeled, Color color, PointSymbol? pointSymbol = null, PointSize? pointSize = null)
+        public MatchRgbHexColor(string expression, bool labeled, Color color, PointSymbol pointSymbol, PointSize pointSize)
             : base(color)
         {
             Expression = expression;
@@ -79,8 +68,10 @@ namespace pwiz.Skyline.Model.GroupComparison
         }
 
         public MatchRgbHexColor()
-            : this(string.Empty, false, Color.Empty)
+            // ReSharper disable once LocalizableElement
+            : this("", false, Color.Gray, PointSymbol.Circle, PointSize.normal)
         {
+
         }
 
         public MatchExpression MatchExpression { get; private set; }
@@ -124,7 +115,7 @@ namespace pwiz.Skyline.Model.GroupComparison
         }
 
         [Track]
-        public PointSize? PointSize
+        public PointSize PointSize
         {
             get { return _pointSize; }
             set
@@ -135,37 +126,13 @@ namespace pwiz.Skyline.Model.GroupComparison
         }
 
         [Track]
-        public PointSymbol? PointSymbol
+        public PointSymbol PointSymbol
         {
             get { return _pointSymbol; }
             set
             {
                 _pointSymbol = value;
                 NotifyPropertyChanged();
-            }
-        }
-
-        /// <summary>
-        /// Computed binding helper: true when a color is set, false when Color.Empty (no color override).
-        /// Setting to false clears the color. Setting to true when color is already set is a no-op;
-        /// ColorGrid opens the picker when checked with an empty color.
-        /// </summary>
-        public bool UseColor
-        {
-            get { return Color != Color.Empty; }
-            set { if (!value) Color = Color.Empty; }
-        }
-
-        // Shadow the base Color property to also notify UseColor when the empty/non-empty state changes.
-        public new Color Color
-        {
-            get { return base.Color; }
-            set
-            {
-                var wasUseColor = base.Color != Color.Empty;
-                base.Color = value;
-                if (wasUseColor != (value != Color.Empty))
-                    NotifyPropertyChanged(nameof(UseColor));
             }
         }
 
@@ -182,7 +149,7 @@ namespace pwiz.Skyline.Model.GroupComparison
         protected bool Equals(MatchRgbHexColor other)
         {
             return base.Equals(other) && string.Equals(_expression, other._expression) && _labeled == other._labeled &&
-                   Nullable.Equals(_pointSymbol, other._pointSymbol) && Nullable.Equals(_pointSize, other._pointSize);
+                   _pointSymbol == other._pointSymbol && _pointSize == other._pointSize;
         }
 
         public override bool Equals(object obj)
@@ -200,8 +167,8 @@ namespace pwiz.Skyline.Model.GroupComparison
                 int hashCode = base.GetHashCode();
                 hashCode = (hashCode * 397) ^ (_expression != null ? _expression.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ _labeled.GetHashCode();
-                hashCode = (hashCode * 397) ^ _pointSymbol.GetHashCode();
-                hashCode = (hashCode * 397) ^ _pointSize.GetHashCode();
+                hashCode = (hashCode * 397) ^ (int) _pointSymbol;
+                hashCode = (hashCode * 397) ^ (int) _pointSize;
                 return hashCode;
             }
         }
@@ -228,10 +195,10 @@ namespace pwiz.Skyline.Model.GroupComparison
             Labeled = reader.GetBoolAttribute(ATTR.labeled);
 
             var symbol = reader.GetAttribute(ATTR.symbol_type);
-            PointSymbol = symbol == null ? (PointSymbol?)null : Helpers.ParseEnum(symbol, Model.GroupComparison.PointSymbol.Circle);
+            PointSymbol = symbol == null ? PointSymbol.Circle : Helpers.ParseEnum(symbol, PointSymbol.Circle);
 
             var pointSize = reader.GetAttribute(ATTR.point_size);
-            PointSize = pointSize == null ? (PointSize?)null : Helpers.ParseEnum(pointSize, Model.GroupComparison.PointSize.normal);
+            PointSize = pointSize == null ? PointSize.normal : Helpers.ParseEnum(pointSize, PointSize.normal);
 
             reader.Read();
         }
@@ -241,10 +208,8 @@ namespace pwiz.Skyline.Model.GroupComparison
             base.WriteXml(writer);
             writer.WriteAttribute(ATTR.expr, Expression);
             writer.WriteAttribute(ATTR.labeled, Labeled);
-            if (PointSymbol.HasValue)
-                writer.WriteAttribute(ATTR.symbol_type, PointSymbol.Value.ToString());
-            if (PointSize.HasValue)
-                writer.WriteAttribute(ATTR.point_size, PointSize.Value.ToString());
+            writer.WriteAttribute(ATTR.symbol_type, PointSymbol.ToString());
+            writer.WriteAttribute(ATTR.point_size, PointSize.ToString());
         }
 
         #endregion

--- a/pwiz_tools/Skyline/TestFunctional/VolcanoPlotFormattingTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/VolcanoPlotFormattingTest.cs
@@ -150,50 +150,6 @@ namespace pwiz.SkylineTestFunctional
                     }, false),
             },
 
-            // Nullable trait test cases: verify that the rendering code applies the correct defaults
-            // (Color.Gray, PointSymbol.Circle, PointSize.small) when traits are omitted from a rule.
-
-            new[]
-            {
-                // Rule specifies color only (null symbol, null size) — matched points get the default symbol+size
-                new MatchExprInfo(new MatchExpression(string.Empty, new[] {MatchOption.BelowLeftCutoff}),
-                    new VolcanoPlotPointsInfo(17, Color.Cyan, false, null, null),
-                    new List<string>
-                    {
-                        "VFWIEVALFWR",
-                        "SDFQVPCQYSQQLK",
-                        "WWGQEITELAQGPGR",
-                        "AGDQILAINEINVK",
-                        "AGSWQITMK",
-                        "FAEDHFAHEATK",
-                        "NLAPLVEDVQSK",
-                        "CSSLLWAGAAWLR",
-                        "ETGLMAFTNLK",
-                        "MLSGFIPLKPTVK",
-                        "LQTEGDGIYTLNSEK",
-                        "SVVDIGLIK",
-                        "IAELFSDLEER",
-                        "FSISTDYSLK",
-                        "EVLPELGIK",
-                        "ALYQAEAFVADFK",
-                        "IAELFSELDER"
-                    }, false),
-            },
-
-            new[]
-            {
-                // Rule specifies symbol+size only (no color) — matched points get the default color (Color.Gray)
-                new MatchExprInfo(new MatchExpression("CC|DD", new[] {MatchOption.PeptideSequence}),
-                    new VolcanoPlotPointsInfo(4, null, false, PointSymbol.Diamond, PointSize.x_large),
-                    new List<string>
-                    {
-                        "GTITSIAALDDPK",
-                        "CIVDGDDR",
-                        "AFMDCCNYITK",
-                        "DNCCILDER"
-                    }, false),
-            },
-
             new[]
             {
                 new MatchExprInfo(new MatchExpression("XP_", new[] {MatchOption.ProteinName}),
@@ -238,7 +194,7 @@ namespace pwiz.SkylineTestFunctional
                         "NP_001033064",
                         "NP_872280"
                     }, true),
-            },
+            }
         };
 
         private static PointF[] savedLabelPositions =
@@ -250,7 +206,7 @@ namespace pwiz.SkylineTestFunctional
             new PointF(-1.07151949f, 3.96921921f),
             new PointF(-1.0508579f, 2.45434284f)
         };
-
+ 
         #endregion
 
         [TestMethod]
@@ -362,7 +318,7 @@ namespace pwiz.SkylineTestFunctional
                     Assert.AreEqual(initialRowCount + index, rows);
 
                     formattingDlg.AddRow(new MatchRgbHexColor(string.Empty, exprInfo.ExpectedPointsInfo.Labeled,
-                        exprInfo.ExpectedPointsInfo.Color ?? Color.Empty, exprInfo.ExpectedPointsInfo.PointSymbol,
+                        exprInfo.ExpectedPointsInfo.Color, exprInfo.ExpectedPointsInfo.PointSymbol,
                         exprInfo.ExpectedPointsInfo.PointSize));
                     formattingDlg.ClickCreateExpression(rows);
                 });
@@ -414,7 +370,7 @@ namespace pwiz.SkylineTestFunctional
 
         public class VolcanoPlotPointsInfo
         {
-            public VolcanoPlotPointsInfo(int pointCount, Color? color, bool labeled, PointSymbol? pointSymbol, PointSize? pointSize)
+            public VolcanoPlotPointsInfo(int pointCount, Color color, bool labeled, PointSymbol pointSymbol, PointSize pointSize)
             {
                 PointCount = pointCount;
                 Color = color;
@@ -424,10 +380,10 @@ namespace pwiz.SkylineTestFunctional
             }
 
             public int PointCount { get; private set; }
-            public Color? Color { get; private set; }
+            public Color Color { get; private set; }
             public bool Labeled { get; private set; }
-            public PointSymbol? PointSymbol { get; private set; }
-            public PointSize? PointSize { get; private set; }
+            public PointSymbol PointSymbol { get; private set; }
+            public PointSize PointSize { get; private set; }
         }
 
         private void AssertVolcanoPlotCorrect(FoldChangeVolcanoPlot plot, VolcanoPlotPointsInfo[] pointsInfos)
@@ -457,15 +413,10 @@ namespace pwiz.SkylineTestFunctional
                     var lineItem = (LineItem) curveItem;
                     var pointInfo = pointsInfos[i - startIndex];
 
-                    // Apply the same defaults the rendering code uses for null traits
-                    var expectedColor = pointInfo.Color ?? Color.Gray;
-                    var expectedSymbol = pointInfo.PointSymbol ?? PointSymbol.Circle;
-                    var expectedSize = pointInfo.PointSize ?? PointSize.small;
-
-                    Assert.AreEqual(expectedColor, lineItem.Symbol.Fill.Color);
+                    Assert.AreEqual(pointInfo.Color, lineItem.Symbol.Fill.Color);
                     Assert.AreEqual(pointInfo.PointCount, curveItem.Points.Count);
-                    Assert.AreEqual(DotPlotUtil.PointSymbolToSymbolType(expectedSymbol), lineItem.Symbol.Type);
-                    Assert.AreEqual(DotPlotUtil.PointSizeToFloat(expectedSize), lineItem.Symbol.Size);
+                    Assert.AreEqual(DotPlotUtil.PointSymbolToSymbolType(pointInfo.PointSymbol), lineItem.Symbol.Type);
+                    Assert.AreEqual(DotPlotUtil.PointSizeToFloat(pointInfo.PointSize), lineItem.Symbol.Size);
 
                     if (pointInfo.Labeled)
                     {
@@ -479,7 +430,7 @@ namespace pwiz.SkylineTestFunctional
                             Assert.IsInstanceOfType(graphObj, typeof(TextObj));
                             var label = (TextObj) graphObj;
 
-                            Assert.AreEqual(DotPlotUtil.PointSizeToFloat(expectedSize), label.FontSpec.Size);
+                            Assert.AreEqual(DotPlotUtil.PointSizeToFloat(pointInfo.PointSize), label.FontSpec.Size);
                             // With automated label layout label's coordinates do not match the point coordinates.
                             //Assert.AreEqual(label.Location.X, pointPair.X);
                             //Assert.AreEqual(label.Location.Y, pointPair.Y);
@@ -506,7 +457,7 @@ namespace pwiz.SkylineTestFunctional
             var createExprDlg = ShowDialog<CreateMatchExpressionDlg>(() =>
             {
                 formattingDlg.AddRow(new MatchRgbHexColor(string.Empty, exprInfo.ExpectedPointsInfo.Labeled,
-                    exprInfo.ExpectedPointsInfo.Color ?? Color.Empty, exprInfo.ExpectedPointsInfo.PointSymbol,
+                    exprInfo.ExpectedPointsInfo.Color, exprInfo.ExpectedPointsInfo.PointSymbol,
                     exprInfo.ExpectedPointsInfo.PointSize));
                 formattingDlg.ClickCreateExpression(formattingDlg.ResultList.Count - 1);
             });

--- a/pwiz_tools/Skyline/ToolsUI/ColorGrid.Designer.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ColorGrid.Designer.cs
@@ -85,20 +85,20 @@ namespace pwiz.Skyline.ToolsUI
             // 
             // rgbCol
             // 
-            this.rgbCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.rgbCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.rgbCol.DataPropertyName = "Rgb";
             this.rgbCol.HeaderText = "RGB";
-            this.rgbCol.MinimumWidth = 6;
+            this.rgbCol.MinimumWidth = 100;
             this.rgbCol.Name = "rgbCol";
             this.rgbCol.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.rgbCol.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            //
+            // 
             // hexCol
-            //
-            this.hexCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            // 
+            this.hexCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.hexCol.DataPropertyName = "Hex";
             this.hexCol.HeaderText = "HEX";
-            this.hexCol.MinimumWidth = 6;
+            this.hexCol.MinimumWidth = 100;
             this.hexCol.Name = "hexCol";
             // 
             // colBtn

--- a/pwiz_tools/Skyline/ToolsUI/ColorGrid.cs
+++ b/pwiz_tools/Skyline/ToolsUI/ColorGrid.cs
@@ -125,7 +125,6 @@ namespace pwiz.Skyline.ToolsUI
             }
 
             ((T) bindingSource1[rowIndex]).Color = newColor;
-            dataGridViewColors.InvalidateRow(rowIndex);
         }
 
         public void UpdateBindingSource()
@@ -168,47 +167,6 @@ namespace pwiz.Skyline.ToolsUI
             BindingList<T> GetCurrentBindingList();
         }
 
-        private int _useColorColumnIndex = -1;
-
-        /// <summary>
-        /// Adds a "Use color" checkbox column bound to <c>UseColor</c> immediately after the color swatch column.
-        /// When the user checks it with no color set the color picker opens automatically.
-        /// </summary>
-        public void AddUseColorColumn(string headerText)
-        {
-            var col = new DataGridViewCheckBoxColumn
-            {
-                DataPropertyName = @"UseColor",
-                HeaderText = headerText,
-                AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells,
-                SortMode = DataGridViewColumnSortMode.Automatic
-            };
-            dataGridViewColors.Columns.Insert(colorCol.Index + 1, col);
-            _useColorColumnIndex = col.Index;
-            dataGridViewColors.CellContentClick += dataGridViewColors_UseColorCellContentClick;
-        }
-
-        private void dataGridViewColors_UseColorCellContentClick(object sender, DataGridViewCellEventArgs e)
-        {
-            if (e.ColumnIndex != _useColorColumnIndex || e.RowIndex < 0 || e.RowIndex >= bindingSource1.Count)
-                return;
-            // CellContentClick fires BEFORE the checkbox toggles, so Value is still the old (pre-click) state.
-            // If the checkbox is about to become checked and no color is set, assign gray now — before
-            // CurrentCellDirtyStateChanged calls CommitEdit and the binding round-trips through UseColor.get.
-            var currentlyChecked = (bool)(dataGridViewColors[e.ColumnIndex, e.RowIndex].Value ?? false);
-            var colorRow = (T)bindingSource1[e.RowIndex];
-            if (!currentlyChecked && colorRow.Color == Color.Empty)
-            {
-                colorPickerDlg.Color = Color.Red;
-                if (colorPickerDlg.ShowDialog() == DialogResult.OK)
-                    changeRowColor(e.RowIndex, colorPickerDlg.Color);
-            }
-            // Commit manually here — CurrentCellDirtyStateChanged skips this column to prevent
-            // auto-commit while the color picker modal is open (which would revert the checkbox).
-            dataGridViewColors.CommitEdit(DataGridViewDataErrorContexts.Commit);
-            bindingSource1.ResetItem(e.RowIndex);
-        }
-
         private void dataGridViewColors_CellFormatting(object sender, DataGridViewCellFormattingEventArgs e)
         {
             if (e.ColumnIndex != colorCol.Index || _owner == null)
@@ -237,19 +195,19 @@ namespace pwiz.Skyline.ToolsUI
             {
                 var rowIndex = e.RowIndex;
                 var oldColor = ((T)bindingSource1[rowIndex]).Color;
-                colorPickerDlg.Color = oldColor == Color.Empty ? Color.Red : oldColor;
+                colorPickerDlg.Color = oldColor;
+
                 if (colorPickerDlg.ShowDialog() == DialogResult.OK)
+                {
                     changeRowColor(rowIndex, colorPickerDlg.Color);
+                }
             }
         }
 
         private void dataGridViewColors_CurrentCellDirtyStateChanged(object sender, EventArgs e)
         {
             // https://stackoverflow.com/questions/5652957/what-event-catches-a-change-of-value-in-a-combobox-in-a-datagridviewcell
-            // Skip the UseColor checkbox — it is committed manually in CellContentClick, after the color picker closes.
-            if (!(dataGridViewColors.CurrentCell is DataGridViewTextBoxCell) &&
-                dataGridViewColors.IsCurrentCellDirty &&
-                dataGridViewColors.CurrentCell?.ColumnIndex != _useColorColumnIndex)
+            if (!(dataGridViewColors.CurrentCell is DataGridViewTextBoxCell) && dataGridViewColors.IsCurrentCellDirty)
                 dataGridViewColors.CommitEdit(DataGridViewDataErrorContexts.Commit);
         }
 


### PR DESCRIPTION
## Summary

* PR #4110 was prematurely pushed directly to master before testing and review were complete
* Reverts all 13 content commits from that PR (skipping 2 interleaved merge-master commits)
* Work continues on `Skyline/work/20260326_volcanoPlotFormattingImprovements` and will be re-submitted as a proper PR once complete

## Test plan

- [ ] Build passes on master after revert
- [ ] Existing volcano plot tests pass

Co-Authored-By: Claude <noreply@anthropic.com>