### PR TITLE
Fix full scan graph IM heatmap display issues

### DIFF
--- a/pwiz_tools/Shared/MSGraph/HeatMapData.cs
+++ b/pwiz_tools/Shared/MSGraph/HeatMapData.cs
@@ -174,6 +174,15 @@ namespace pwiz.MSGraph
                 if (_cells == null)
                     _cells = CreateCells();
 
+                // If subdivision made no progress (all points share the same
+                // coordinates), treat this cell as a leaf.
+                if (_cells[0] == null && _cells[1] == null &&
+                    _cells[2] == null && _cells[3] == null)
+                {
+                    returnedPoints.Add(_maxPoint);
+                    return;
+                }
+
                 // Add the maximum intensity points from each of the 4 cells inside this cell (and recurse to
                 // the right cell size).
                 for (int i = 0; i < 4; i++)
@@ -210,9 +219,13 @@ namespace pwiz.MSGraph
                     if (pointLists[i].Count > 0)
                     {
                         var newCell = new Cell(pointLists[i]);
-                        // Make sure there was a maximum point, or the boundaries
-                        // will end up float.MinValue and float.MaxValue
-                        if (newCell.MaxPoint != null)
+                        // Skip cells with no positive-Z points (bounds would be
+                        // float.MinValue/MaxValue), and skip cells whose bounds
+                        // match the parent exactly (no spatial progress was made,
+                        // which would cause infinite recursion).
+                        if (newCell.MaxPoint != null &&
+                            !(newCell._xMin == _xMin && newCell._xMax == _xMax &&
+                              newCell._yMin == _yMin && newCell._yMax == _yMax))
                             cells[i] = newCell;
                     }
                 }

--- a/pwiz_tools/Shared/MSGraph/HeatMapGraphPane.cs
+++ b/pwiz_tools/Shared/MSGraph/HeatMapGraphPane.cs
@@ -44,6 +44,12 @@ namespace pwiz.MSGraph
                 return;
             }
             GraphHeatMap(this,_heatMapData,MaxDotRadius,MinDotRadius,_yMin,_yMax,true,0);
+            // GraphHeatMap may early-return without populating CurveList if cell dimensions
+            // are degenerate (e.g. axis Min == Max because the data range collapsed). In
+            // that case, fall back to base.SetScale so the axes still get drawn instead
+            // of leaving an entirely blank graph.
+            if (CurveList.Count == 0)
+                base.SetScale(g);
         }
 
         public static void GraphHeatMap(GraphPane graphPane, HeatMapData heatMapData, int maxDotRadius, int minDotRadius, float yMin, float yMax, bool logScale, int cutoff)

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -1331,11 +1331,15 @@ namespace pwiz.Skyline.Controls.Graphs
             else
             {
                 double minDriftTime, maxDriftTime;
-                _msDataFileScanHelper.GetIonMobilityFilterDisplayRange(out minDriftTime, out maxDriftTime, _msDataFileScanHelper.Source);
-                if (minDriftTime > double.MinValue && maxDriftTime < double.MaxValue)
+                bool hasIM = _msDataFileScanHelper.GetIonMobilityFilterDisplayRange(out minDriftTime, out maxDriftTime, _msDataFileScanHelper.Source);
+                // hasIM may be false (e.g. when the originally clicked transition's source
+                // doesn't match the currently selected scan type) and leave the out values
+                // at MaxValue/MinValue, which would invert the Y axis. Require a valid range.
+                if (hasIM && minDriftTime < maxDriftTime &&
+                    minDriftTime > double.MinValue && maxDriftTime < double.MaxValue)
                 {
                     double range = filterBtn.Checked
-                        ? (maxDriftTime - minDriftTime)/2 
+                        ? (maxDriftTime - minDriftTime)/2
                         : (maxDriftTime - minDriftTime)*2;
                     yScale.Min = minDriftTime - range;
                     yScale.Max = maxDriftTime + range;
@@ -1920,6 +1924,8 @@ namespace pwiz.Skyline.Controls.Graphs
         public double XAxisMax { get { return GraphPane.XAxis.Scale.Max; }}
         public double YAxisMin { get { return GraphPane.YAxis.Scale.Min; }}
         public double YAxisMax { get { return GraphPane.YAxis.Scale.Max; }}
+        // True if the purple ion-mobility filter band is currently drawn on the heatmap.
+        public bool HasIonMobilityFilterBand { get { return GraphPane.GraphObjList.OfType<BoxObj>().Any(); } }
 
         public bool IsScanTypeSelected(ChromSource source)
         {

--- a/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
+++ b/pwiz_tools/Skyline/Controls/Graphs/GraphFullScan.cs
@@ -1514,6 +1514,10 @@ namespace pwiz.Skyline.Controls.Graphs
             public override void SetScale(Graphics g)
             {
                 base.SetScale(g);
+                // AxisChange (called by base.SetScale) updates axis Min/Max but does not
+                // call SetupScaleData, so the pixel-to-data transform used by
+                // ReverseTransform can be stale from a previous zoom level.
+                XAxis.Scale.SetupScaleData(this, XAxis);
                 // Enforce a minimum rendered width of 1 pixel for extraction boxes so they
                 // remain visible when the m/z axis is zoomed out to a wide range.
                 double minWidth = Math.Abs(XAxis.Scale.ReverseTransform(1) - XAxis.Scale.ReverseTransform(0));

--- a/pwiz_tools/Skyline/Model/Results/MsDataFileScanHelper.cs
+++ b/pwiz_tools/Skyline/Model/Results/MsDataFileScanHelper.cs
@@ -173,6 +173,14 @@ namespace pwiz.Skyline.Model.Results
             minIonMobility = double.MaxValue;
             maxIonMobility = double.MinValue;
             var hasIonMobilityInfo = false;
+            // When the originally clicked transition matches the requested source type, use only
+            // that specific transition's IM range (per-transition high-energy offsets can give
+            // different fragments different IM ranges, and we want to show the one the user
+            // clicked on). Otherwise (e.g. user clicked on a precursor and then switched scan
+            // type to fragment via the combo box), fall back to using any matching transition.
+            bool clickedTransitionMatchesSource = sourceType != ChromSource.unknown &&
+                TransitionIndex >= 0 && TransitionIndex < ScanProvider.Transitions.Length &&
+                ScanProvider.Transitions[TransitionIndex].Source == sourceType;
             int i = 0;
             foreach (var transition in ScanProvider.Transitions)
             {
@@ -194,7 +202,9 @@ namespace pwiz.Skyline.Model.Results
                     minIonMobility = double.MinValue;
                     maxIonMobility = double.MaxValue;
                 }
-                else if (sourceType == ChromSource.unknown || (transition.Source == sourceType && i == TransitionIndex))
+                else if (sourceType == ChromSource.unknown ||
+                         (transition.Source == sourceType &&
+                          (!clickedTransitionMatchesSource || i == TransitionIndex)))
                 {
                     // Products and precursors may have different expected ion mobility values in Waters MsE
                     double startIM = transition.IonMobilityInfo.IonMobility.Mobility.Value -

--- a/pwiz_tools/Skyline/TestFunctional/FullScanGraphTest.cs
+++ b/pwiz_tools/Skyline/TestFunctional/FullScanGraphTest.cs
@@ -251,6 +251,25 @@ namespace pwiz.SkylineTestFunctional
             SetZoom(true);
             TestScale(452, 456, 2.61, 4.34);
 
+            // Regression: switching scan type from MS1 to MS/MS in heatmap+magnify mode used
+            // to leave the Y axis inverted (yMin > yMax) and the IM filter band missing,
+            // because GetIonMobilityFilterRange only matched the originally-clicked transition
+            // index, which pointed to a precursor (ms1) rather than any fragment transition.
+            // After the fix, the Y axis should be a valid range and the IM band should be drawn.
+            SetScanType(ChromSource.fragment, 33.24, 27.9);
+            RunUI(() =>
+            {
+                Assert.IsTrue(SkylineWindow.GraphFullScan.YAxisMin < SkylineWindow.GraphFullScan.YAxisMax,
+                    "Heatmap Y axis is inverted/degenerate after switching to MS/MS in magnify mode " +
+                    "(yMin={0}, yMax={1})",
+                    SkylineWindow.GraphFullScan.YAxisMin, SkylineWindow.GraphFullScan.YAxisMax);
+                Assert.IsTrue(SkylineWindow.GraphFullScan.HasIonMobilityFilterBand,
+                    "IM filter band not drawn in MS/MS heatmap with magnify on");
+            });
+            // Restore precursor view for the remaining tests.
+            SetScanType(ChromSource.ms1, 33.23, 27.9);
+            TestScale(452, 456, 2.61, 4.34);
+
             // Check click on ion label.
             SetSpectrum(true);
             SetZoom(false);


### PR DESCRIPTION
## Summary
This fixes a couple of longstanding unreported issues with ion mobility heatmap display, as well as one recently introduced.

 Extraction bar scaling — The extraction box minimum-width enforcement  (added in #4087) used ReverseTransform to compute 1 pixel in m/z units,  but AxisChange (called by base.SetScale) does not call SetupScaleData, leaving the pixel-to-data transform stale from the previous zoom level.
  This caused boxes to disappear when zooming out and become wildly oversized when zooming back in. Fix: call SetupScaleData after AxisChange to refresh the transform.

  Blank MS/MS heatmap when Zoom To Selection is on — Switching scan type from MS1 to MS/MS in heatmap mode with magnify on produced a completely blank graph (no axes, no data). GetIonMobilityFilterRange required the transition at TransitionIndex to match the requested source type, which fails when the user clicks a precursor chromatogram and then  switches to MS/MS (TransitionIndex still points to the ms1 transition). This left the IM range inverted (MaxValue/MinValue), collapsing the Y axis. Latent since the 2019 per-transition IM high-energy offset change.
  Fix: fall back to all matching-source transitions when the clicked transition's source doesn't match, preserving the original single-transition narrowing when sources do match.

  StackOverflowException in HeatMapData quad-tree — When all points share the same coordinates, CreateCells produces a child cell identical to its parent, causing infinite recursion. Fix: detect when subdivision makes no spatial progress and treat the cell as a leaf.

## Test plan
- [ ] Run `TestFullScanGraph` 
- [ ] Open full scan graph, toggle Zoom To Selection on/off, verify extraction bars remain visible and correctly scaled at all zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)