### PR TITLE
msconvert: write to .partial file, rename on success; clearer error message

### DIFF
--- a/pwiz/data/msdata/IO.cpp
+++ b/pwiz/data/msdata/IO.cpp
@@ -26,6 +26,7 @@
 #include "IO.hpp"
 #include "References.hpp"
 #include "pwiz/utility/minimxml/SAXParser.hpp"
+#include "pwiz/utility/misc/Exception.hpp"
 #include "pwiz/utility/misc/Filesystem.hpp"
 #include "pwiz/utility/misc/Std.hpp"
 #include "SpectrumWorkerThreads.hpp"
@@ -3013,7 +3014,7 @@ void write(minimxml::XMLWriter& writer, const SpectrumList& spectrumList, const 
                 continue;
             }
             else
-                throw;
+                throw pwiz::util::enumeration_error(e.what());
         }
 
         // save write position
@@ -3145,7 +3146,7 @@ void write(minimxml::XMLWriter& writer, const ChromatogramList& chromatogramList
                     chromatogramPositions->push_back(-1);
                 continue;
             }
-            throw;
+            throw pwiz::util::enumeration_error(e.what());
         }
 
         // save write position

--- a/pwiz/utility/misc/Exception.hpp
+++ b/pwiz/utility/misc/Exception.hpp
@@ -42,6 +42,14 @@ class user_error : public std::runtime_error
     public: user_error(const std::string& what) : std::runtime_error(what) {}
 };
 
+// Thrown when an error occurs while enumerating a single spectrum or chromatogram during
+// serialization. Lets callers distinguish per-item enumeration errors (which --continueOnError
+// can skip) from other write-time errors (e.g. I/O, permissions, unsupported format).
+class enumeration_error : public std::runtime_error
+{
+    public: enumeration_error(const std::string& what) : std::runtime_error(what) {}
+};
+
 } // namespace util
 } // namespace pwiz
 

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -917,6 +917,22 @@ void calculateSourceFilePtrSHA1(const SourceFilePtr& sourceFilePtr)
 }
 
 
+/// Writes an MSData object to a .partial file first, then renames to the final filename on success,
+/// so that incomplete output from a failed conversion is not mistaken for a valid file.
+void writeAtomically(const MSData& msd,
+                     const string& outputFilename,
+                     const MSDataFile::WriteConfig& writeConfig,
+                     const IterationListenerRegistry* pILR)
+{
+    string partialFilename = outputFilename + ".partial";
+    MSDataFile::write(msd, partialFilename, writeConfig, pILR);
+    // bfs::rename fails on Windows if the destination already exists, so remove it first.
+    if (bfs::exists(outputFilename))
+        bfs::remove(outputFilename);
+    bfs::rename(partialFilename, outputFilename);
+}
+
+
 /// Combines multiple input files into a single MSData object. Called
 /// when the --merge argument is present on the command line.
 int mergeFiles(const vector<string>& filenames, const Config& config, const ReaderList& readers)
@@ -993,12 +1009,13 @@ int mergeFiles(const vector<string>& filenames, const Config& config, const Read
         if (config.outputPath == "-")
             MSDataFile::write(msd, cout, configCopy.writeConfig);
         else
-            MSDataFile::write(msd, outputFilename, configCopy.writeConfig, pILR);
+            writeAtomically(msd, outputFilename, configCopy.writeConfig, pILR);
     }
     catch (exception& e)
     {
         failedFileCount = (int)filenames.size();
-        cerr << "Error merging files: " << e.what() << endl;
+        cerr << "Error merging files (aborting): " << e.what() << endl;
+        cerr << "  To skip problematic spectra and write the remaining data, re-run with --continueOnError." << endl;
     }
 
     return failedFileCount;
@@ -1085,7 +1102,7 @@ void processFile(const string& filename, const Config& config, const ReaderList&
                 {
                     throw user_error("[msconvert] Output filepath is the same as input filepath");
                 }
-                MSDataFile::write(msd, outputFilename, configCopy.writeConfig, pILR);
+                writeAtomically(msd, outputFilename, configCopy.writeConfig, pILR);
             }
         }
         catch (user_error&)
@@ -1094,7 +1111,8 @@ void processFile(const string& filename, const Config& config, const ReaderList&
         }
         catch (exception& e)
         {
-            cerr << "Error writing run " << (i+1) << ":\n" << e.what() << endl;
+            cerr << "Error writing run " << (i+1) << " (aborting conversion of this run): " << e.what() << endl;
+            cerr << "  To skip problematic spectra and write the remaining data, re-run with --continueOnError." << endl;
             ++failedRuns;
         }
     }

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -918,7 +918,9 @@ void calculateSourceFilePtrSHA1(const SourceFilePtr& sourceFilePtr)
 
 
 /// Writes an MSData object to a .partial file first, then renames to the final filename on success,
-/// so that incomplete output from a failed conversion is not mistaken for a valid file.
+/// so that incomplete output from a failed conversion is not mistaken for a valid file. If an output
+/// file already exists at outputFilename, it is preserved under a temporary backup name until the
+/// new file has been promoted, and restored if the final rename fails.
 void writeAtomically(const MSData& msd,
                      const string& outputFilename,
                      const MSDataFile::WriteConfig& writeConfig,
@@ -926,10 +928,29 @@ void writeAtomically(const MSData& msd,
 {
     string partialFilename = outputFilename + ".partial";
     MSDataFile::write(msd, partialFilename, writeConfig, pILR);
-    // bfs::rename fails on Windows if the destination already exists, so remove it first.
+
+    // bfs::rename fails on Windows if the destination already exists, so preserve any existing
+    // output under a temporary backup name until the new file has been promoted.
+    string backupFilename;
     if (bfs::exists(outputFilename))
-        bfs::remove(outputFilename);
-    bfs::rename(partialFilename, outputFilename);
+    {
+        backupFilename = outputFilename + ".backup-" + bfs::unique_path("%%%%-%%%%").string();
+        bfs::rename(outputFilename, backupFilename);
+    }
+
+    try
+    {
+        bfs::rename(partialFilename, outputFilename);
+    }
+    catch (...)
+    {
+        if (!backupFilename.empty())
+            bfs::rename(backupFilename, outputFilename); // restore old output
+        throw;
+    }
+
+    if (!backupFilename.empty())
+        bfs::remove(backupFilename);
 }
 
 
@@ -1011,11 +1032,16 @@ int mergeFiles(const vector<string>& filenames, const Config& config, const Read
         else
             writeAtomically(msd, outputFilename, configCopy.writeConfig, pILR);
     }
-    catch (exception& e)
+    catch (pwiz::util::enumeration_error& e)
     {
         failedFileCount = (int)filenames.size();
         cerr << "Error merging files (aborting): " << e.what() << endl;
         cerr << "  To skip problematic spectra and write the remaining data, re-run with --continueOnError." << endl;
+    }
+    catch (exception& e)
+    {
+        failedFileCount = (int)filenames.size();
+        cerr << "Error merging files (aborting): " << e.what() << endl;
     }
 
     return failedFileCount;
@@ -1109,10 +1135,15 @@ void processFile(const string& filename, const Config& config, const ReaderList&
         {
             throw;
         }
-        catch (exception& e)
+        catch (pwiz::util::enumeration_error& e)
         {
             cerr << "Error writing run " << (i+1) << " (aborting conversion of this run): " << e.what() << endl;
             cerr << "  To skip problematic spectra and write the remaining data, re-run with --continueOnError." << endl;
+            ++failedRuns;
+        }
+        catch (exception& e)
+        {
+            cerr << "Error writing run " << (i+1) << " (aborting conversion of this run): " << e.what() << endl;
             ++failedRuns;
         }
     }

--- a/pwiz_tools/commandline/msconvert.cpp
+++ b/pwiz_tools/commandline/msconvert.cpp
@@ -917,10 +917,11 @@ void calculateSourceFilePtrSHA1(const SourceFilePtr& sourceFilePtr)
 }
 
 
-/// Writes an MSData object to a .partial file first, then renames to the final filename on success,
-/// so that incomplete output from a failed conversion is not mistaken for a valid file. If an output
-/// file already exists at outputFilename, it is preserved under a temporary backup name until the
-/// new file has been promoted, and restored if the final rename fails.
+/// Writes an MSData object to a .partial file first, then renames it onto the final filename on
+/// success, so that incomplete output from a failed conversion is not mistaken for a valid file.
+/// bfs::rename atomically replaces any existing output (MoveFileEx with MOVEFILE_REPLACE_EXISTING
+/// on Windows, ::rename on POSIX); since .partial sits in the same directory as the output, the
+/// replacement is on the same volume and therefore atomic.
 void writeAtomically(const MSData& msd,
                      const string& outputFilename,
                      const MSDataFile::WriteConfig& writeConfig,
@@ -928,29 +929,7 @@ void writeAtomically(const MSData& msd,
 {
     string partialFilename = outputFilename + ".partial";
     MSDataFile::write(msd, partialFilename, writeConfig, pILR);
-
-    // bfs::rename fails on Windows if the destination already exists, so preserve any existing
-    // output under a temporary backup name until the new file has been promoted.
-    string backupFilename;
-    if (bfs::exists(outputFilename))
-    {
-        backupFilename = outputFilename + ".backup-" + bfs::unique_path("%%%%-%%%%").string();
-        bfs::rename(outputFilename, backupFilename);
-    }
-
-    try
-    {
-        bfs::rename(partialFilename, outputFilename);
-    }
-    catch (...)
-    {
-        if (!backupFilename.empty())
-            bfs::rename(backupFilename, outputFilename); // restore old output
-        throw;
-    }
-
-    if (!backupFilename.empty())
-        bfs::remove(backupFilename);
+    bfs::rename(partialFilename, outputFilename);
 }
 
 


### PR DESCRIPTION
## Summary
- msconvert now writes converted output to `<outputFilename>.partial` and renames to the final name only after the write completes successfully. Previously, when a conversion failed mid-run (e.g. vendor library fails to centroid a scan), a partial file with the final extension was left on disk and could be mistaken for a valid conversion.
- The per-run error message now notes that conversion of that run is aborting, and suggests `--continueOnError` as a way to skip problematic spectra and continue writing.
- Refactored shared write logic into a `writeAtomically()` helper used by both `mergeFiles()` and `processFile()`.

## Example before/after

Before (on a Thermo RAW file where vendor centroiding fails on some scans):
```
Error writing run 1:
[SpectrumList_Thermo::spectrum()] Error retrieving spectrum "controllerType=0 controllerNumber=1 scan=137414": [RawFileThreadImpl::getMassList()] failed to centroid scan
```
...and a 2 GB `.mzML` file left behind that looks valid but is truncated.

After:
```
Error writing run 1 (aborting conversion of this run): [SpectrumList_Thermo::spectrum()] Error retrieving spectrum "controllerType=0 controllerNumber=1 scan=137414": [RawFileThreadImpl::getMassList()] failed to centroid scan
  To skip problematic spectra and write the remaining data, re-run with --continueOnError.
```
...and the truncated file is left as `.mzML.partial` so it is obviously not a completed conversion.

## Test plan
- [x] Verified failure case: truncated output is named `.mzML.partial`, error message includes aborting hint.
- [x] Verified success case with `--continueOnError`: final `.mzML` is written, no `.partial` file remains.
- [ ] CI build across platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)