### PR TITLE
Tightened OspreySharp Gauss-Jordan robustness (abs pivot + tolerance)

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.ML/GaussSolver.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.ML/GaussSolver.cs
@@ -30,6 +30,8 @@
 // Copyright (c) 2022 Michael Lazear
 // Licensed under the MIT License
 
+using System;
+
 namespace pwiz.OspreySharp.ML
 {
     /// <summary>
@@ -64,7 +66,7 @@ namespace pwiz.OspreySharp.ML
             return null;
         }
 
-        private static Matrix SolveInner(Matrix left, Matrix right, double eps)
+        internal static Matrix SolveInner(Matrix left, Matrix right, double eps)
         {
             // Clone the matrices so we don't modify the originals
             var leftData = new double[left.Rows * left.Cols];
@@ -104,6 +106,7 @@ namespace pwiz.OspreySharp.ML
         /// </summary>
         private bool LeftSolved()
         {
+            const double TOL = 1E-8;
             int n = _left.Cols;
             for (int i = 0; i < n; i++)
             {
@@ -112,10 +115,10 @@ namespace pwiz.OspreySharp.ML
                     double x = _left[i, j];
                     if (i == j)
                     {
-                        if (x != 1.0 && x != 0.0)
+                        if (Math.Abs(x - 1.0) > TOL && Math.Abs(x) > TOL)
                             return false;
                     }
-                    else if (x > 1E-8)
+                    else if (Math.Abs(x) > TOL)
                     {
                         return false;
                     }
@@ -129,6 +132,7 @@ namespace pwiz.OspreySharp.ML
         /// </summary>
         private void Echelon()
         {
+            const double EPS = 1E-12;
             int m = _left.Rows;
             int n = _left.Cols;
             int h = 0;
@@ -136,19 +140,23 @@ namespace pwiz.OspreySharp.ML
 
             while (h < m && k < n)
             {
-                // Find the row with the largest value in column k
+                // Partial pivoting: pick the row with the largest-magnitude
+                // value in the current pivot column. Using the signed value
+                // skips large-magnitude negatives in favor of small positives,
+                // which hurts numerical stability.
                 int maxRow = h;
-                double maxVal = double.MinValue;
+                double maxAbs = 0.0;
                 for (int i = h; i < m; i++)
                 {
-                    if (_left[i, k] >= maxVal)
+                    double absVal = Math.Abs(_left[i, k]);
+                    if (absVal > maxAbs)
                     {
-                        maxVal = _left[i, k];
+                        maxAbs = absVal;
                         maxRow = i;
                     }
                 }
 
-                if (_left[maxRow, k] == 0.0)
+                if (maxAbs < EPS)
                 {
                     k++;
                     continue;

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/MLTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/MLTest.cs
@@ -517,6 +517,53 @@ namespace pwiz.OspreySharp.Test
 
         #endregion
 
+        #region Gauss Solver Tests
+
+        /// <summary>
+        /// Regression test for abs-value pivot selection.
+        ///
+        /// Column 0 contains a large-magnitude negative (-4) and a zero. Signed-
+        /// max pivoting picks the zero (because 0 > -4), skips the column, and
+        /// produces a permuted-identity result that LeftSolved rejects through
+        /// every eps in the ladder. Abs-max pivoting picks -4 and solves exactly.
+        ///
+        /// Must use the same numeric inputs as the Rust gauss_negative_pivot test.
+        /// </summary>
+        [TestMethod]
+        public void TestGaussNegativePivot()
+        {
+            var left = new Matrix(new[] { -4.0, 2.0, 0.0, 3.0 }, 2, 2);
+            var right = new Matrix(new[] { 1.0, 6.0 }, 2, 1);
+            // Use SolveInner with eps=0 for an exact answer; the outer Solve
+            // adds a 1e-8 diagonal perturbation that prevents bit-exact matches.
+            var solution = GaussSolver.SolveInner(left, right, 0.0);
+            Assert.IsNotNull(solution, "SolveInner should succeed");
+            Assert.AreEqual(2, solution.Rows);
+            Assert.AreEqual(1, solution.Cols);
+            Assert.AreEqual(0.75, solution[0, 0], 1e-12);
+            Assert.AreEqual(2.0, solution[1, 0], 1e-12);
+        }
+
+        /// <summary>
+        /// Regression test for rank-deficient input.
+        ///
+        /// Left has rank 1 (row 2 = 2 * row 1). With eps = 0 (no diagonal
+        /// perturbation), SolveInner must return null because echelon produces
+        /// a zero row on left, and the surviving non-zero off-diagonal entry
+        /// fails the LeftSolved tolerance check.
+        ///
+        /// Must use the same numeric inputs as the Rust gauss_near_singular_returns_none test.
+        /// </summary>
+        [TestMethod]
+        public void TestGaussNearSingularReturnsNull()
+        {
+            var left = new Matrix(new[] { 1.0, 2.0, 2.0, 4.0 }, 2, 2);
+            var right = new Matrix(new[] { 1.0, 2.0 }, 2, 1);
+            Assert.IsNull(GaussSolver.SolveInner(left, right, 0.0));
+        }
+
+        #endregion
+
         #region Linear Discriminant Tests
 
         [TestMethod]


### PR DESCRIPTION
## Summary

Addresses three Copilot threads deferred from #4155 (parity-affecting; requires a coordinated Rust PR). Paired with **maccoss/osprey#15**, which both must be CI-green before merging together.

* `Echelon` pivot selection now uses `Math.Abs` so a large-magnitude negative is preferred over a small positive — signed-max could skip the correct row entirely. Zero-pivot guard is `|pivot| < 1E-12` instead of exact equality. ([discussion_r3111986866](https://github.com/ProteoWizard/pwiz/pull/4155#discussion_r3111986866))
* `LeftSolved` uses a 1E-8 tolerance on both diagonal (`|x - 1| < TOL || |x| < TOL`) and off-diagonal (`|x| < TOL`) checks, instead of exact `==` on diagonals and a signed `x > 1E-8` off-diagonal check that accepted arbitrarily negative residuals. ([discussion_r3111986886](https://github.com/ProteoWizard/pwiz/pull/4155#discussion_r3111986886))
* Added two regression tests in `MLTest.cs` under a new "Gauss Solver Tests" region using the same numeric inputs as the Rust `gauss_negative_pivot` and `gauss_near_singular_returns_none` tests. The negative-pivot test fails against the old echelon (verified by temporarily reverting the fix locally). ([discussion_r3111987020](https://github.com/ProteoWizard/pwiz/pull/4155#discussion_r3111987020))
* Promoted `SolveInner` from `private` to `internal` so the near-singular test can pass `eps = 0` directly, symmetric with Rust's `pub fn solve_inner`.

### Parity-affecting

`GaussSolver.Solve` is on the LDA training path (`Sw * x = Sb`), so changing pivoting or tolerance would change LDA output on inputs where the decision diverges. The Rust and C# sides land together to keep the tools in lockstep.

### Verification

* `Build-OspreySharp.ps1 -RunInspection -RunTests` — 216/216 pass, ReSharper green.
* Cross-tool parity with the paired Rust PR: Stellar (317 842 entries) and Astral (1 051 741 entries) at 1e-6, **21/21** PIN features on both datasets.
* **Fix-impact measurement**: with the C# fix stashed, re-ran the same parity tests against the already-patched Rust binary. Still 21/21 on both datasets. So on these production inputs the fix has **no observable effect** — this is defensive hygiene for corner cases (large-magnitude negative pivots, near-singular matrices) outside the current test data. The Stellar parity breakage observed during Session 20 of the #4155 work (which led to deferring these threads) was therefore misattributed to this change.

## Test plan

- [x] TestGaussNegativePivot — regression test for abs-pivot selection
- [x] TestGaussNearSingularReturnsNull — regression test for rank-deficient input
- [x] MLTest.cs full suite (216 tests)
- [x] Build-OspreySharp.ps1 -RunInspection (ReSharper green)
- [x] Test-Features.ps1 -Dataset Stellar (21/21 at 1e-6)
- [x] Test-Features.ps1 -Dataset Astral (21/21 at 1e-6)
- [x] Fix-impact measurement: stashed C# fix, re-ran Stellar + Astral (21/21 at 1e-6)

Co-Authored-By: Claude <noreply@anthropic.com>