### PR TITLE
OspreySharp: sync with maccoss/osprey v26.4 (VERSION + C grid)

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -76,7 +76,7 @@ namespace pwiz.OspreySharp.FDR
             MaxIterations = 10;
             NFolds = 3;
             Seed = 42;
-            CValues = new[] { 0.01, 0.1, 1.0, 10.0, 100.0 };
+            CValues = new[] { 0.001, 0.01, 0.1, 1.0, 10.0, 100.0 };
             MaxTrainSize = 300000;
         }
     }

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/ProgramTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pwiz.OspreySharp.Core;
@@ -287,7 +288,26 @@ namespace pwiz.OspreySharp.Test
 
         private const string VALID_SEARCH = "search-hash-aaa";
         private const string VALID_LIB = "lib-hash-bbb";
-        private const string CURRENT_VERSION = "26.3.0";
+
+        // Track Program.VERSION so happy-path and drift tests stay
+        // meaningful after upstream version bumps.
+        private const string CURRENT_VERSION = Program.VERSION;
+        private static readonly string PATCH_DRIFT_VERSION = DriftVersion(0, 0, 5);
+        private static readonly string MINOR_DRIFT_VERSION = DriftVersion(0, 1, 0);
+        private static readonly string MAJOR_DRIFT_VERSION = DriftVersion(1, 0, 0);
+
+        private static string DriftVersion(int majorDelta, int minorDelta, int patchDelta)
+        {
+            var parts = CURRENT_VERSION.Split('.');
+            int major = int.Parse(parts[0], CultureInfo.InvariantCulture);
+            int minor = int.Parse(parts[1], CultureInfo.InvariantCulture);
+            int patch = int.Parse(parts[2], CultureInfo.InvariantCulture);
+            // Reset lower-level components when a higher-level one drifts.
+            int driftMinor = majorDelta != 0 ? 0 : minor + minorDelta;
+            int driftPatch = (majorDelta != 0 || minorDelta != 0) ? 0 : patch + patchDelta;
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}",
+                major + majorDelta, driftMinor, driftPatch);
+        }
 
         private static string CheckMd(
             string cachedV, string cachedS, string cachedL, out string warning)
@@ -322,7 +342,7 @@ namespace pwiz.OspreySharp.Test
         public void TestMetadataHappyPathNoWarning()
         {
             string warn;
-            string err = CheckMd("26.3.0", VALID_SEARCH, VALID_LIB, out warn);
+            string err = CheckMd(CURRENT_VERSION, VALID_SEARCH, VALID_LIB, out warn);
             Assert.IsNull(err);
             Assert.IsNull(warn);
         }
@@ -331,7 +351,7 @@ namespace pwiz.OspreySharp.Test
         public void TestMetadataPatchDriftWarnsButSucceeds()
         {
             string warn;
-            string err = CheckMd("26.3.5", VALID_SEARCH, VALID_LIB, out warn);
+            string err = CheckMd(PATCH_DRIFT_VERSION, VALID_SEARCH, VALID_LIB, out warn);
             Assert.IsNull(err);
             Assert.IsNotNull(warn);
             StringAssert.Contains(warn, "patch-version drift");
@@ -340,7 +360,7 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestMetadataMinorVersionDriftAborts()
         {
-            string err = CheckMd("26.4.0", VALID_SEARCH, VALID_LIB, out _);
+            string err = CheckMd(MINOR_DRIFT_VERSION, VALID_SEARCH, VALID_LIB, out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "major/minor");
         }
@@ -348,7 +368,7 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestMetadataMajorVersionDriftAborts()
         {
-            string err = CheckMd("27.0.0", VALID_SEARCH, VALID_LIB, out _);
+            string err = CheckMd(MAJOR_DRIFT_VERSION, VALID_SEARCH, VALID_LIB, out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "major/minor");
         }
@@ -364,7 +384,7 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestMetadataMissingSearchHashAborts()
         {
-            string err = CheckMd("26.3.0", null, VALID_LIB, out _);
+            string err = CheckMd(CURRENT_VERSION, null, VALID_LIB, out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "osprey.search_hash");
         }
@@ -372,7 +392,7 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestMetadataMissingLibraryHashAborts()
         {
-            string err = CheckMd("26.3.0", VALID_SEARCH, null, out _);
+            string err = CheckMd(CURRENT_VERSION, VALID_SEARCH, null, out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "osprey.library_hash");
         }
@@ -380,7 +400,7 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestMetadataSearchHashMismatchNamesFieldAndFile()
         {
-            string err = CheckMd("26.3.0", "wrong-hash", VALID_LIB, out _);
+            string err = CheckMd(CURRENT_VERSION, "wrong-hash", VALID_LIB, out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "search_hash mismatch");
             StringAssert.Contains(err, "test.scores.parquet");
@@ -390,7 +410,7 @@ namespace pwiz.OspreySharp.Test
         [TestMethod]
         public void TestMetadataLibraryHashMismatchNamesFieldAndFile()
         {
-            string err = CheckMd("26.3.0", VALID_SEARCH, "wrong-lib", out _);
+            string err = CheckMd(CURRENT_VERSION, VALID_SEARCH, "wrong-lib", out _);
             Assert.IsNotNull(err);
             StringAssert.Contains(err, "library_hash mismatch");
             StringAssert.Contains(err, "test.scores.parquet");

--- a/pwiz_tools/OspreySharp/OspreySharp/Program.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/Program.cs
@@ -38,7 +38,7 @@ namespace pwiz.OspreySharp
         // Tracks the Rust Osprey upstream version this OspreySharp port
         // is aligned with. Used in parquet footer metadata; the Phase 3
         // validator requires same major.minor across cross-impl handoff.
-        internal const string VERSION = "26.3.0";
+        internal const string VERSION = "26.4.0";
         internal const string VERSION_STRING = VERSION;
 
         static int Main(string[] args)


### PR DESCRIPTION
## Summary

Two small drift ports from upstream Rust since the OspreySharp Phase 1-3 sprint:

* Bump `Program.VERSION` from `26.3.0` to `26.4.0` to match upstream `maccoss/osprey` head (v26.4.0, commit `bd15572`). The Parquet footer validator added in Phase 3 requires same `major.minor` across cross-impl Parquet handoff, so `26.3` vs `26.4` was aborting `--join-only` reads of Rust-written Parquets.
* Add `0.001` to `PercolatorConfig.CValues` so the C grid matches upstream `[0.001, 0.01, 0.1, 1.0, 10.0, 100.0]`. Verified zero behavior change on Stellar: the grid search does not select the new value under current settings, but aligning is the right long-term posture for cross-impl parity.

## Test plan

- [x] `OspreySharp.sln` builds clean (Release|x64, net472 + net8.0)
- [x] `OspreySharp.Test` 214/214 passes
- [x] ReSharper inspection clean
- [x] Cross-impl `--no-join`/`--join-only` Parquet round-trip with Rust osprey v26.4.0 now succeeds (was aborting on version mismatch before this PR)

See ai/todos/active/TODO-20260420_osprey_sharp.md

Co-Authored-By: Claude <noreply@anthropic.com>