### PR TITLE
OspreySharp: Stage 5 cross-impl diagnostic dumps

### DIFF
--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -60,7 +60,10 @@
     Top-to-bottom data flow from mzML + spectral library to BiblioSpecLite
     output. Color indicates port status of the OspreySharp (C#) implementation
     against the Osprey (Rust) reference. Stages 1-4 are proven bit-identical
-    (21 features, 317K entries). Green badges = regression tests; purple badges = C#/Rust perf ratio.
+    on Stellar + Astral (21 PIN features, 317K entries) and Stage 5 is
+    bit-identical on single-file Stellar (end-of-stage dump: score + pep +
+    4 q-values across 462,802 FdrEntry rows at max_diff = 0). Green badges =
+    regression tests; purple badges = C#/Rust perf ratio.
   </p>
 </header>
 
@@ -334,35 +337,30 @@
 <path class="flow" d="M 600 1300 L 600 1340" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 1340)">
-  <rect class="phase-bg-active" x="40" y="0" width="1120" height="260" rx="8"/>
+  <rect class="phase-bg" x="40" y="0" width="1120" height="260" rx="8"/>
   <text class="phase-label" x="60" y="24">stage 5</text>
   <text class="phase-title" x="60" y="42">First-pass FDR (Percolator SVM)</text>
   <text class="phase-note"  x="60" y="58">
     Semi-supervised SVM training with target-decoy competition. Produces
     precursor-level and peptide-level q-values at run and experiment levels.
+    Single-file Stellar: bit-identical cross-impl on score + pep + 4 q-values,
+    max_diff = 0 over 462,802 rows. 3-file validation pending.
   </text>
 
-  <rect class="st-unverif" x="80" y="80" width="1040" height="42" rx="4"/>
+  <rect class="st-done" x="80" y="80" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="100" text-anchor="middle">Best-per-precursor subsampling (across files)</text>
-  <text class="stage-desc"  x="600" y="114" text-anchor="middle">maximizes peptide diversity for SVM training on multi-file experiments</text>
+  <text class="stage-desc"  x="600" y="114" text-anchor="middle">subsample + fold dump matches byte-for-byte on single-file Stellar (3-file pending)</text>
 
-  <rect class="st-unverif" x="80" y="140" width="1040" height="60" rx="4"/>
+  <rect class="st-done" x="80" y="140" width="1040" height="60" rx="4"/>
   <text class="stage-title" x="600" y="160" text-anchor="middle">Iterative non-negative SVM (3-fold stratified CV by peptide)</text>
-  <text class="stage-desc"  x="600" y="176" text-anchor="middle">grid search for C; Percolator-style positive training set; best-iteration tracking;</text>
-  <text class="stage-desc"  x="600" y="190" text-anchor="middle">cross-fold score calibration (Granholm 2012)</text>
+  <text class="stage-desc"  x="600" y="176" text-anchor="middle">grid search for C; Percolator-style positive training set; per-fold SVM weights match byte-for-byte</text>
+  <text class="stage-desc"  x="600" y="190" text-anchor="middle">cross-fold score calibration (Granholm 2012); standardizer mean/std match within 1e-12</text>
 
-  <rect class="st-unverif" x="80" y="218" width="1040" height="32" rx="4"/>
+  <rect class="st-done" x="80" y="218" width="1040" height="32" rx="4"/>
   <text class="stage-title" x="600" y="238" text-anchor="middle">Target-decoy competition + q-values (run + experiment x precursor + peptide) + FDR compaction</text>
 
   <path class="flow" d="M 600 122 L 600 138" marker-end="url(#arrow)"/>
   <path class="flow" d="M 600 200 L 600 216" marker-end="url(#arrow)"/>
-
-  <!-- "You are here" callout -->
-  <g transform="translate(820, 75)">
-    <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
-    <text class="you-are-here" x="136" y="10">YOU ARE</text>
-    <text class="you-are-here" x="136" y="26">HERE</text>
-  </g>
 </g>
 
 <!-- ================================================================= -->
@@ -371,7 +369,7 @@
 <path class="flow" d="M 600 1600 L 600 1640" marker-end="url(#arrow)"/>
 
 <g transform="translate(0, 1640)">
-  <rect class="phase-bg" x="40" y="0" width="1120" height="260" rx="6"/>
+  <rect class="phase-bg-active" x="40" y="0" width="1120" height="260" rx="6"/>
   <text class="phase-label" x="60" y="24">stage 6</text>
   <text class="phase-title" x="60" y="42">Refinement (post-FDR)</text>
   <text class="phase-note"  x="60" y="58">
@@ -393,6 +391,13 @@
 
   <path class="flow" d="M 600 122 L 600 138" marker-end="url(#arrow)"/>
   <path class="flow" d="M 600 182 L 600 198" marker-end="url(#arrow)"/>
+
+  <!-- "You are here" callout -->
+  <g transform="translate(820, 75)">
+    <path class="flow-you" d="M 130 20 L 30 20" marker-end="url(#arrow-thick)"/>
+    <text class="you-are-here" x="136" y="10">YOU ARE</text>
+    <text class="you-are-here" x="136" y="26">HERE</text>
+  </g>
 </g>
 
 <!-- ================================================================= -->
@@ -461,12 +466,32 @@
     <code>ProcessFile</code> calls.
   </p>
   <p>
-    Next targets: Stage 5 (Percolator SVM FDR), upstream the parity-relevant
-    bug fixes and optimizations to <code>maccoss/osprey</code> (first PR
-    <a href="https://github.com/maccoss/osprey/pull/3"><code>maccoss/osprey#3</code></a>
-    posted this session for the unit-bin calibration scorer), Skyline
-    CommonUtil integration.
-    Branch <code>Skyline/work/20260409_osprey_sharp</code>.
+    <strong>Stage 5 (2026-04-22):</strong> single-file Stellar cross-impl
+    bit-parity achieved. Rust and OspreySharp agree exactly on the
+    end-of-Stage-5 dump (<code>score</code>, <code>pep</code>, 4 run/experiment
+    precursor/peptide q-values) across 462,802 <code>FdrEntry</code> rows:
+    per-column <code>max_diff = 0</code>, 0 divergent rows. Both tools report
+    <strong>34,158 precursors at 1% FDR</strong>, 30,712 peptides, 5,471
+    protein groups. Upstream PRs on <code>maccoss/osprey</code>:
+    <a href="https://github.com/maccoss/osprey/pull/16"><code>#16</code></a>
+    (self-parity: PEP non-determinism via sort + serial KDE),
+    <a href="https://github.com/maccoss/osprey/pull/17"><code>#17</code></a>
+    (cross-parity: <code>grid_search_c</code> tie-break +
+    <code>count_passing_targets_svm</code> formula), and
+    <a href="https://github.com/maccoss/osprey/pull/18"><code>#18</code></a>
+    (diagnostic dumps). OspreySharp side:
+    <a href="https://github.com/ProteoWizard/pwiz/pull/4159"><code>pwiz#4159</code></a>
+    (VERSION + C grid sync with v26.4) and
+    <a href="https://github.com/ProteoWizard/pwiz/pull/4160"><code>pwiz#4160</code></a>
+    (matching diagnostic dumps + <code>Compare-Percolator.ps1</code>).
+    Multi-file (3-file) Stage 5 validation pending as the first step of
+    Stage 6 work.
+  </p>
+  <p>
+    Next targets: Stage 5 multi-file validation (Stellar + Astral 3-file),
+    Stage 6 refinement (multi-charge consensus, cross-run reconciliation,
+    second-pass re-score), Stage 7 protein FDR, Stage 8 .blib output
+    parity. See <code>ai/todos/active/TODO-20260420_osprey_sharp.md</code>.
   </p>
 </footer>
 </body>

--- a/pwiz_tools/OspreySharp/Osprey-workflow.html
+++ b/pwiz_tools/OspreySharp/Osprey-workflow.html
@@ -340,12 +340,12 @@
   <rect class="phase-bg" x="40" y="0" width="1120" height="260" rx="8"/>
   <text class="phase-label" x="60" y="24">stage 5</text>
   <text class="phase-title" x="60" y="42">First-pass FDR (Percolator SVM)</text>
-  <text class="phase-note"  x="60" y="58">
-    Semi-supervised SVM training with target-decoy competition. Produces
-    precursor-level and peptide-level q-values at run and experiment levels.
-    Single-file Stellar: bit-identical cross-impl on score + pep + 4 q-values,
-    max_diff = 0 over 462,802 rows. 3-file validation pending.
-  </text>
+  <text class="phase-note"  x="60" y="58">Semi-supervised SVM training with target-decoy competition. Produces precursor-level and peptide-level q-values at run and experiment levels.</text>
+  <text class="phase-note"  x="60" y="72">Single-file Stellar: bit-identical cross-impl on score + pep + 4 q-values, max_diff = 0 over 462,802 rows. 3-file validation pending.</text>
+
+  <!-- Stage 5 perf badge (C# join-only wall clock on single-file Stellar;
+       Rust measured 2026-04-22 = 66s at dump-exit point). -->
+  <text x="1115" y="24" text-anchor="end"><tspan class="badge-label badge-perf">Perf: </tspan><tspan class="badge-value badge-perf">137s (2.1x Rust)</tspan></text>
 
   <rect class="st-done" x="80" y="80" width="1040" height="42" rx="4"/>
   <text class="stage-title" x="600" y="100" text-anchor="middle">Best-per-precursor subsampling (across files)</text>

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -220,6 +220,19 @@ namespace pwiz.OspreySharp.FDR
             Console.Error.WriteLine(
                 $"[TIMING]   Percolator setup + standardize: {swSetup.Elapsed.TotalSeconds:F1}s ({n} entries x {nFeatures} features)");
 
+            // Stage 5 standardizer dump. Gated by OSPREY_DUMP_STANDARDIZER=1;
+            // exits via OSPREY_STANDARDIZER_ONLY=1. Mirrors Rust
+            // dump_stage5_standardizer in osprey-fdr/src/percolator.rs.
+            if (string.Equals(Environment.GetEnvironmentVariable(@"OSPREY_DUMP_STANDARDIZER"), @"1"))
+            {
+                WriteStage5StandardizerDump(standardizer, config.FeatureNames);
+                if (string.Equals(Environment.GetEnvironmentVariable(@"OSPREY_STANDARDIZER_ONLY"), @"1"))
+                {
+                    Console.Error.WriteLine(@"[BISECT] OSPREY_STANDARDIZER_ONLY set - aborting after dump");
+                    Environment.Exit(0);
+                }
+            }
+
             // 3a. Best-per-precursor: pick the single best-scoring observation per
             //     (base_id, isDecoy) tuple across all files. With N files per peptide,
             //     this avoids the SVM seeing the same precursor's target/decoy pair
@@ -1652,6 +1665,39 @@ namespace pwiz.OspreySharp.FDR
                 }
             }
             Console.Error.WriteLine(@"Wrote Stage 5 SVM weights dump: {0} ({1} folds)", path, foldModels.Length);
+        }
+
+        /// <summary>
+        /// Cross-impl bisection dump of the feature standardizer state,
+        /// taken right after FitTransform returns and before subsampling
+        /// / fold assignment. Mirrors dump_stage5_standardizer in Rust.
+        /// Writes cs_stage5_standardizer.tsv with one row per feature.
+        /// Columns: feature_idx, feature_name, mean, std.
+        /// </summary>
+        private static void WriteStage5StandardizerDump(
+            FeatureStandardizer standardizer,
+            string[] featureNames)
+        {
+            const string path = @"cs_stage5_standardizer.tsv";
+            var inv = CultureInfo.InvariantCulture;
+            var means = standardizer.Means;
+            var stds = standardizer.Stds;
+
+            using (var sw = new StreamWriter(path) { NewLine = "\n" })
+            {
+                sw.WriteLine(@"feature_idx	feature_name	mean	std");
+                for (int i = 0; i < means.Length; i++)
+                {
+                    string name = (featureNames != null && i < featureNames.Length)
+                        ? featureNames[i]
+                        : @"unknown";
+                    sw.Write(i.ToString(inv));
+                    sw.Write('\t'); sw.Write(name);
+                    sw.Write('\t'); sw.Write(means[i].ToString(@"G17", inv));
+                    sw.Write('\t'); sw.WriteLine(stds[i].ToString(@"G17", inv));
+                }
+            }
+            Console.Error.WriteLine(@"Wrote Stage 5 standardizer dump: {0} ({1} features)", path, means.Length);
         }
 
         // ============================================================

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -397,6 +397,21 @@ namespace pwiz.OspreySharp.FDR
             Console.Error.WriteLine("[TIMING]   Percolator train all folds (parallel): {0:F1}s",
                 swTrain.Elapsed.TotalSeconds);
 
+            // Stage 5 SVM-internals dump. Gated by OSPREY_DUMP_SVM_WEIGHTS=1;
+            // exits via OSPREY_SVM_WEIGHTS_ONLY=1. Captures per-fold weights,
+            // bias, and iteration count right after SVM training converges
+            // and before Granholm calibration. Mirrors rust side in
+            // osprey-fdr/src/percolator.rs::dump_stage5_svm_weights.
+            if (string.Equals(Environment.GetEnvironmentVariable(@"OSPREY_DUMP_SVM_WEIGHTS"), @"1"))
+            {
+                WriteStage5SvmWeightsDump(foldModels, foldIterations, config.FeatureNames);
+                if (string.Equals(Environment.GetEnvironmentVariable(@"OSPREY_SVM_WEIGHTS_ONLY"), @"1"))
+                {
+                    Console.Error.WriteLine(@"[BISECT] OSPREY_SVM_WEIGHTS_ONLY set - aborting after dump");
+                    Environment.Exit(0);
+                }
+            }
+
             // Score ALL entries with trained models
             if (trainSubset != null)
             {
@@ -1589,6 +1604,54 @@ namespace pwiz.OspreySharp.FDR
                 }
             }
             Console.Error.WriteLine(@"Wrote Stage 5 subsample dump: {0} ({1} rows)", path, n);
+        }
+
+        /// <summary>
+        /// Cross-impl bisection dump of per-fold SVM weights, taken right
+        /// after training converges and before Granholm cross-fold
+        /// calibration. Mirrors dump_stage5_svm_weights in Rust. Writes
+        /// cs_stage5_svm_weights.tsv with one row per (fold, weight) pair:
+        /// 21 feature weights + 1 bias per fold.
+        ///
+        /// Columns: fold, weight_idx, feature_name, value, fold_iterations.
+        /// Sorted by (fold, weight_idx) for stable inspection; compare is
+        /// hash-joined.
+        /// </summary>
+        private static void WriteStage5SvmWeightsDump(
+            LinearSvmClassifier[] foldModels,
+            int[] foldIterations,
+            string[] featureNames)
+        {
+            const string path = @"cs_stage5_svm_weights.tsv";
+            var inv = CultureInfo.InvariantCulture;
+
+            using (var sw = new StreamWriter(path) { NewLine = "\n" })
+            {
+                sw.WriteLine(@"fold	weight_idx	feature_name	value	fold_iterations");
+                for (int fold = 0; fold < foldModels.Length; fold++)
+                {
+                    var model = foldModels[fold];
+                    var weights = model.Weights;
+                    int iters = fold < foldIterations.Length ? foldIterations[fold] : 0;
+                    for (int wi = 0; wi < weights.Length; wi++)
+                    {
+                        string name = (featureNames != null && wi < featureNames.Length)
+                            ? featureNames[wi]
+                            : @"unknown";
+                        sw.Write(fold.ToString(inv));
+                        sw.Write('\t'); sw.Write(wi.ToString(inv));
+                        sw.Write('\t'); sw.Write(name);
+                        sw.Write('\t'); sw.Write(weights[wi].ToString(@"G17", inv));
+                        sw.Write('\t'); sw.WriteLine(iters.ToString(inv));
+                    }
+                    sw.Write(fold.ToString(inv));
+                    sw.Write('\t'); sw.Write(weights.Length.ToString(inv));
+                    sw.Write('\t'); sw.Write(@"bias");
+                    sw.Write('\t'); sw.Write(model.Bias.ToString(@"G17", inv));
+                    sw.Write('\t'); sw.WriteLine(iters.ToString(inv));
+                }
+            }
+            Console.Error.WriteLine(@"Wrote Stage 5 SVM weights dump: {0} ({1} folds)", path, foldModels.Length);
         }
 
         // ============================================================

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -36,6 +36,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.IO;
 using pwiz.OspreySharp.ML;
 
 namespace pwiz.OspreySharp.FDR
@@ -301,6 +303,22 @@ namespace pwiz.OspreySharp.FDR
             // 4. Assign folds on the (possibly subsampled) set
             int[] foldAssignments = CreateStratifiedFoldsByPeptide(
                 subLabels, subPeptides, subEntryIds, config.NFolds);
+
+            // Stage 5 sub-stage diagnostic dump. Gated by OSPREY_DUMP_SUBSAMPLE=1;
+            // exits via OSPREY_SUBSAMPLE_ONLY=1. Captures subsample membership and
+            // fold assignment per entry, mirroring the Rust dump in
+            // osprey-fdr/src/percolator.rs. The dump is inlined here (not routed
+            // through OspreyDiagnostics) because OspreySharp.FDR does not
+            // reference the main OspreySharp assembly.
+            if (string.Equals(Environment.GetEnvironmentVariable(@"OSPREY_DUMP_SUBSAMPLE"), @"1"))
+            {
+                WriteStage5SubsampleDump(entries, trainSubset, foldAssignments);
+                if (string.Equals(Environment.GetEnvironmentVariable(@"OSPREY_SUBSAMPLE_ONLY"), @"1"))
+                {
+                    Console.Error.WriteLine(@"[BISECT] OSPREY_SUBSAMPLE_ONLY set - aborting after dump");
+                    Environment.Exit(0);
+                }
+            }
 
             // 5. Find best initial feature
             double trainFdr = config.TrainFdr;
@@ -1514,6 +1532,63 @@ namespace pwiz.OspreySharp.FDR
 
             selected.Sort();
             return selected.ToArray();
+        }
+
+        /// <summary>
+        /// Cross-impl bisection dump of Stage 5 subsample + fold-assignment
+        /// state, written to cs_stage5_subsample.tsv. Mirrors the Rust dump
+        /// in osprey-fdr/src/percolator.rs so Compare-Subsample.ps1 can
+        /// hash-join on entry_id.
+        ///
+        /// Columns: entry_id, native_position, charge, modified_sequence,
+        /// is_decoy, base_id, in_subsample, fold_id. native_position is
+        /// the entry's index in the input list -- divergence here means
+        /// the two tools populate their arrays in different order. Rows
+        /// sorted by entry_id for stable human inspection; compare is
+        /// sort-order-agnostic.
+        /// </summary>
+        private static void WriteStage5SubsampleDump(
+            IList<PercolatorEntry> entries,
+            int[] trainSubset,
+            int[] foldAssignments)
+        {
+            const string path = @"cs_stage5_subsample.tsv";
+            var inv = CultureInfo.InvariantCulture;
+            int n = entries.Count;
+
+            var inSub = new bool[n];
+            var foldFor = new int[n];
+            for (int i = 0; i < n; i++) foldFor[i] = -1;
+
+            for (int subPos = 0; subPos < trainSubset.Length; subPos++)
+            {
+                int nativePos = trainSubset[subPos];
+                inSub[nativePos] = true;
+                foldFor[nativePos] = foldAssignments[subPos];
+            }
+
+            var order = new int[n];
+            for (int i = 0; i < n; i++) order[i] = i;
+            Array.Sort(order, (a, b) => entries[a].EntryId.CompareTo(entries[b].EntryId));
+
+            using (var sw = new StreamWriter(path) { NewLine = "\n" })
+            {
+                sw.WriteLine(@"entry_id	native_position	charge	modified_sequence	is_decoy	base_id	in_subsample	fold_id");
+                foreach (int i in order)
+                {
+                    var e = entries[i];
+                    uint baseId = e.EntryId & BASE_ID_MASK;
+                    sw.Write(e.EntryId.ToString(inv));
+                    sw.Write('\t'); sw.Write(i.ToString(inv));
+                    sw.Write('\t'); sw.Write(e.Charge.ToString(inv));
+                    sw.Write('\t'); sw.Write(e.Peptide ?? string.Empty);
+                    sw.Write('\t'); sw.Write(e.IsDecoy ? @"true" : @"false");
+                    sw.Write('\t'); sw.Write(baseId.ToString(inv));
+                    sw.Write('\t'); sw.Write(inSub[i] ? @"true" : @"false");
+                    sw.Write('\t'); sw.WriteLine(foldFor[i].ToString(inv));
+                }
+            }
+            Console.Error.WriteLine(@"Wrote Stage 5 subsample dump: {0} ({1} rows)", path, n);
         }
 
         // ============================================================

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -1599,8 +1599,9 @@ namespace pwiz.OspreySharp.FDR
             for (int i = 0; i < n; i++) order[i] = i;
             Array.Sort(order, (a, b) => entries[a].EntryId.CompareTo(entries[b].EntryId));
 
-            using (var sw = new StreamWriter(path) { NewLine = "\n" })
+            using (var sw = new StreamWriter(path))
             {
+                sw.NewLine = "\n";
                 sw.WriteLine(@"entry_id	native_position	charge	modified_sequence	is_decoy	base_id	in_subsample	fold_id");
                 foreach (int i in order)
                 {
@@ -1638,8 +1639,9 @@ namespace pwiz.OspreySharp.FDR
             const string path = @"cs_stage5_svm_weights.tsv";
             var inv = CultureInfo.InvariantCulture;
 
-            using (var sw = new StreamWriter(path) { NewLine = "\n" })
+            using (var sw = new StreamWriter(path))
             {
+                sw.NewLine = "\n";
                 sw.WriteLine(@"fold	weight_idx	feature_name	value	fold_iterations");
                 for (int fold = 0; fold < foldModels.Length; fold++)
                 {
@@ -1683,8 +1685,9 @@ namespace pwiz.OspreySharp.FDR
             var means = standardizer.Means;
             var stds = standardizer.Stds;
 
-            using (var sw = new StreamWriter(path) { NewLine = "\n" })
+            using (var sw = new StreamWriter(path))
             {
+                sw.NewLine = "\n";
                 sw.WriteLine(@"feature_idx	feature_name	mean	std");
                 for (int i = 0; i < means.Length; i++)
                 {

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -389,6 +389,18 @@ namespace pwiz.OspreySharp
                 LogInfo(string.Format("Total: {0} precursors pass run-level FDR across all files",
                     passingTargets));
 
+                // Stage 5 diagnostic dump. Gated by OSPREY_DUMP_PERCOLATOR=1;
+                // exits when OSPREY_PERCOLATOR_ONLY=1 is also set. Writes all
+                // four q-values plus SVM score and PEP for every FdrEntry,
+                // before compaction drops any rows, so the cross-impl diff
+                // sees both targets and decoys.
+                if (OspreyDiagnostics.DumpPercolator)
+                {
+                    OspreyDiagnostics.WriteStage5PercolatorDump(perFileEntries);
+                    if (OspreyDiagnostics.PercolatorOnly)
+                        OspreyDiagnostics.ExitAfterDump("OSPREY_PERCOLATOR_ONLY");
+                }
+
                 // Stage 6-7: Reconciliation (TODO for multi-file)
                 if (config.InputFiles.Count > 1)
                 {

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -39,8 +39,18 @@ namespace pwiz.OspreySharp
     ///
     /// Dump format must remain byte-for-byte stable -- these files are
     /// diffed against the Rust osprey reference to bisect cross-impl drift.
-    /// Use <see cref="F10"/> for doubles, invariant culture, and the same
-    /// field ordering as the Rust equivalents.
+    /// Use invariant culture and the same field ordering as the Rust
+    /// equivalents. Two floating-point formats are in use by convention:
+    /// <list type="bullet">
+    /// <item><description>Stages 1-4 dumps use <see cref="F10"/>
+    /// (10 decimal places), matching the Rust equivalents for those
+    /// stages.</description></item>
+    /// <item><description>Stage 5 dumps (standardizer, subsample, SVM
+    /// weights, Percolator) use invariant-culture "G17" (17-digit
+    /// roundtrippable) to match Rust's G17 choice there and to avoid
+    /// .NET Framework's historical "R"-format roundtrip bugs. Do not
+    /// switch these fields to F10.</description></item>
+    /// </list>
     /// </summary>
     public static class OspreyDiagnostics
     {
@@ -814,8 +824,9 @@ namespace pwiz.OspreySharp
                 return a.Value.EntryId.CompareTo(b.Value.EntryId);
             });
 
-            using (var sw = new StreamWriter(path) { NewLine = "\n" })
+            using (var sw = new StreamWriter(path))
             {
+                sw.NewLine = "\n";
                 sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	experiment_precursor_q	experiment_peptide_q");
                 foreach (var row in rows)
                 {

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -814,7 +814,7 @@ namespace pwiz.OspreySharp
                 return a.Value.EntryId.CompareTo(b.Value.EntryId);
             });
 
-            using (var sw = new StreamWriter(path))
+            using (var sw = new StreamWriter(path) { NewLine = "\n" })
             {
                 sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	experiment_precursor_q	experiment_peptide_q");
                 foreach (var row in rows)

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -93,6 +93,17 @@ namespace pwiz.OspreySharp
         public static readonly bool LoessInputOnly = IsOne(@"OSPREY_LOESS_INPUT_ONLY");
 
         /// <summary>
+        /// OSPREY_DUMP_PERCOLATOR: dump per-precursor Stage 5 state
+        /// (score, pep, 4 q-values) after first-pass Percolator FDR
+        /// completes and before first-pass protein FDR / compaction.
+        /// Cross-impl parity gate (cs_stage5_percolator.tsv).
+        /// </summary>
+        public static readonly bool DumpPercolator = IsOne(@"OSPREY_DUMP_PERCOLATOR");
+
+        /// <summary>OSPREY_PERCOLATOR_ONLY: exit after cs_stage5_percolator.tsv dump.</summary>
+        public static readonly bool PercolatorOnly = IsOne(@"OSPREY_PERCOLATOR_ONLY");
+
+        /// <summary>
         /// OSPREY_DIAG_XIC_ENTRY_ID: the entry ID to dump chromatogram for
         /// during calibration scoring. null = no dump.
         /// </summary>
@@ -767,6 +778,62 @@ namespace pwiz.OspreySharp
                     set.Add(id);
             }
             return set.Count > 0 ? set : null;
+        }
+
+        /// <summary>
+        /// Dump per-precursor Stage 5 (first-pass Percolator FDR) state to
+        /// cs_stage5_percolator.tsv, mirroring Rust's rust_stage5_percolator.tsv.
+        /// All four q-values plus score and pep are populated on every FdrEntry
+        /// at this point (before compaction or first-pass protein FDR), so the
+        /// cross-impl diff sees both targets and decoys.
+        ///
+        /// Columns: file_name, entry_id, charge, modified_sequence, is_decoy,
+        /// score, pep, run_precursor_q, run_peptide_q, experiment_precursor_q,
+        /// experiment_peptide_q. Rows sorted by (file_name, entry_id) for
+        /// stable human inspection; Compare-Percolator.ps1 hash-joins on the
+        /// composite key and is sort-order-agnostic. Floats use G17 (17-digit
+        /// roundtrippable) to avoid .NET Framework's historical "R"-format
+        /// roundtrip bugs.
+        /// </summary>
+        public static void WriteStage5PercolatorDump(List<KeyValuePair<string, List<FdrEntry>>> perFileEntries)
+        {
+            const string path = @"cs_stage5_percolator.tsv";
+            var inv = CultureInfo.InvariantCulture;
+
+            var rows = new List<KeyValuePair<string, FdrEntry>>();
+            foreach (var kvp in perFileEntries)
+            {
+                string fileName = kvp.Key;
+                foreach (var e in kvp.Value)
+                    rows.Add(new KeyValuePair<string, FdrEntry>(fileName, e));
+            }
+            rows.Sort((a, b) =>
+            {
+                int cmp = string.CompareOrdinal(a.Key, b.Key);
+                if (cmp != 0) return cmp;
+                return a.Value.EntryId.CompareTo(b.Value.EntryId);
+            });
+
+            using (var sw = new StreamWriter(path))
+            {
+                sw.WriteLine(@"file_name	entry_id	charge	modified_sequence	is_decoy	score	pep	run_precursor_q	run_peptide_q	experiment_precursor_q	experiment_peptide_q");
+                foreach (var row in rows)
+                {
+                    var e = row.Value;
+                    sw.Write(row.Key);
+                    sw.Write('\t'); sw.Write(e.EntryId.ToString(inv));
+                    sw.Write('\t'); sw.Write(e.Charge.ToString(inv));
+                    sw.Write('\t'); sw.Write(e.ModifiedSequence ?? string.Empty);
+                    sw.Write('\t'); sw.Write(e.IsDecoy ? @"true" : @"false");
+                    sw.Write('\t'); sw.Write(e.Score.ToString(@"G17", inv));
+                    sw.Write('\t'); sw.Write(e.Pep.ToString(@"G17", inv));
+                    sw.Write('\t'); sw.Write(e.RunPrecursorQvalue.ToString(@"G17", inv));
+                    sw.Write('\t'); sw.Write(e.RunPeptideQvalue.ToString(@"G17", inv));
+                    sw.Write('\t'); sw.Write(e.ExperimentPrecursorQvalue.ToString(@"G17", inv));
+                    sw.Write('\t'); sw.WriteLine(e.ExperimentPeptideQvalue.ToString(@"G17", inv));
+                }
+            }
+            LogAction(string.Format(@"Wrote Stage 5 Percolator dump: {0} ({1} rows)", path, rows.Count));
         }
     }
 }


### PR DESCRIPTION
## Summary

Four env-var-gated Stage 5 diagnostic dumps on the OspreySharp side, mirroring the Rust osprey companion PR (https://github.com/maccoss/osprey/pull/18). All dumps are opt-in and off by default — no production behavior change.

* **`OSPREY_DUMP_PERCOLATOR`** / `OSPREY_PERCOLATOR_ONLY=1`: `cs_stage5_percolator.tsv` with 11 columns per FdrEntry (file_name, entry_id, charge, modified_sequence, is_decoy, score, pep, 4 run/experiment precursor/peptide q-values) right after first-pass Percolator FDR.
* **`OSPREY_DUMP_SUBSAMPLE`** / `OSPREY_SUBSAMPLE_ONLY=1`: subsample membership + fold assignment per entry after `CreateStratifiedFoldsByPeptide`. Inlined in `PercolatorFdr.cs` because `OspreySharp.FDR` can't reference the main `OspreySharp` assembly (would create a circular dependency).
* **`OSPREY_DUMP_SVM_WEIGHTS`** / `OSPREY_SVM_WEIGHTS_ONLY=1`: per-fold SVM weights + bias + iteration count right after training converges, before Granholm calibration.
* **`OSPREY_DUMP_STANDARDIZER`** / `OSPREY_STANDARDIZER_ONLY=1`: per-feature mean + std from `FeatureStandardizer.FitTransform`.

All C# dumps use `StreamWriter { NewLine = "\n" }` and G17 float format so the output byte-matches Rust's ryu-shortest-roundtrippable when values are numerically equal. `OspreyDiagnostics.DumpPercolator` / `PercolatorOnly` flags live on the `OspreyDiagnostics` class; the other three are inline in `PercolatorFdr.cs`.

## Test plan

- [x] `OspreySharp.sln` builds clean (Release|x64, net472 + net8.0)
- [x] `OspreySharp.Test` 214/214 passes
- [x] ReSharper inspection clean
- [x] Each dump validated byte-identical across two consecutive `--join-only` runs on Stellar single-file (self-parity)
- [x] Each dump cross-compared against Rust osprey's matching `rust_stage5_*.tsv` outputs and used to drive the end-to-end Stage 5 cross-impl parity bisection

See ai/todos/active/TODO-20260420_osprey_sharp.md

Co-Authored-By: Claude <noreply@anthropic.com>