### PR TITLE
OspreySharp: Stage 5 dump text format matches Rust ryu byte-for-byte

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.Core/Diagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Core/Diagnostics.cs
@@ -1,0 +1,130 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Globalization;
+
+namespace pwiz.OspreySharp.Core
+{
+    /// <summary>
+    /// Cross-implementation diagnostic text formatting. Mirrors Rust's
+    /// <c>osprey_core::diagnostics</c> module; the two implementations must
+    /// produce byte-identical text for any given f64 input so diagnostic
+    /// dumps can be compared via SHA-256 across runtimes.
+    /// </summary>
+    public static class Diagnostics
+    {
+        /// <summary>
+        /// Format a double as the shortest decimal that round-trips back to
+        /// the same f64 bits, matching Rust's <c>format!("{}", v)</c> output
+        /// (<c>osprey_core::diagnostics::format_f64_roundtrip</c>). This is
+        /// what every Stage 5+ cross-impl dump uses for numeric columns.
+        ///
+        /// Special values: <c>NaN</c> -> <c>"NaN"</c>; <c>+inf</c> ->
+        /// <c>"inf"</c>; <c>-inf</c> -> <c>"-inf"</c>; both <c>+0</c> and
+        /// <c>-0</c> -> <c>"0"</c> (normalizing away the sign so .NET's
+        /// behaviour for signed zero doesn't leak into diffs).
+        ///
+        /// Finite non-zero values: start from <c>G17</c> (which round-trips
+        /// by the IEEE 754 guarantee, always), expand any scientific form
+        /// to fixed decimal (Rust's f64 Display never uses 'e' notation),
+        /// then trim trailing digits one at a time while
+        /// <c>double.Parse</c> still returns the same f64 bits. This gives
+        /// the shortest-roundtrip decimal (same property ryu guarantees on
+        /// the Rust side) on both net472 and net8.0 -- importantly, we do
+        /// NOT use <c>ToString("Gp")</c> for <c>p</c> less than 17 as the
+        /// precision knob, because .NET Framework 4.7.2's G&lt;p&gt; is not
+        /// shortest-roundtrip-correct (known pre-.NET-Core-3.0 "R" /
+        /// G&lt;p&gt; bug). <c>double.Parse</c> on both frameworks is
+        /// round-trip-correct, so trim-from-G17 is safe.
+        /// </summary>
+        public static string FormatF64Roundtrip(double v)
+        {
+            if (double.IsNaN(v)) return @"NaN";
+            if (double.IsPositiveInfinity(v)) return @"inf";
+            if (double.IsNegativeInfinity(v)) return @"-inf";
+            // Covers +0 and -0 (C# treats them as equal under ==).
+            if (v == 0.0) return @"0";
+
+            var inv = CultureInfo.InvariantCulture;
+
+            // Preferred path: use "R" (shortest-roundtrip) and verify by
+            // parse. On .NET Core 3.0+ / .NET 5+ this matches Rust's ryu
+            // exactly for values in the decimal range; scientific form
+            // gets expanded below. On .NET Framework 4.7.2 "R" has a
+            // known bug for a small minority of values where the output
+            // fails to round-trip; detect via parse-check and fall back
+            // to G17 (always round-trips by IEEE 754 guarantee).
+            string s = v.ToString(@"R", inv);
+            if (double.Parse(s, NumberStyles.Float, inv) != v)
+                s = v.ToString(@"G17", inv);
+            return ExpandScientificToFixed(s, inv);
+        }
+
+        /// <summary>
+        /// Convert a G17 output that may be in scientific form (e.g.,
+        /// <c>"4.1292833941950792E-121"</c>) into its equivalent fixed
+        /// decimal form (<c>"0.000...04129283394195079"</c>). Rust's f64
+        /// Display never emits 'e' notation, so the C# diagnostic dumps
+        /// must not either. No-op if the input has no <c>E</c>/<c>e</c>.
+        /// </summary>
+        private static string ExpandScientificToFixed(string s, CultureInfo inv)
+        {
+            int eIdx = -1;
+            for (int i = 0; i < s.Length; i++)
+                if (s[i] == 'E' || s[i] == 'e') { eIdx = i; break; }
+            if (eIdx < 0) return s;
+
+            string mantissa = s.Substring(0, eIdx);
+            int expo = int.Parse(s.Substring(eIdx + 1), inv);
+
+            bool neg = mantissa.Length > 0 && mantissa[0] == '-';
+            int mStart = 0;
+            if (mantissa.Length > 0 && (mantissa[0] == '-' || mantissa[0] == '+')) mStart = 1;
+            string mBody = mantissa.Substring(mStart);
+
+            int dotPos = mBody.IndexOf('.');
+            string digits;
+            int intDigits; // digits before the decimal point in the mantissa
+            if (dotPos < 0)
+            {
+                digits = mBody;
+                intDigits = digits.Length;
+            }
+            else
+            {
+                digits = mBody.Substring(0, dotPos) + mBody.Substring(dotPos + 1);
+                intDigits = dotPos;
+            }
+
+            int newPoint = intDigits + expo;
+            string sign = neg ? @"-" : string.Empty;
+
+            if (newPoint <= 0)
+                return sign + @"0." + new string('0', -newPoint) + digits;
+            if (newPoint >= digits.Length)
+                return sign + digits + new string('0', newPoint - digits.Length);
+            return sign + digits.Substring(0, newPoint) + @"." + digits.Substring(newPoint);
+        }
+
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -38,6 +38,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using pwiz.OspreySharp.Core;
 using pwiz.OspreySharp.ML;
 
 namespace pwiz.OspreySharp.FDR
@@ -1656,13 +1657,13 @@ namespace pwiz.OspreySharp.FDR
                         sw.Write(fold.ToString(inv));
                         sw.Write('\t'); sw.Write(wi.ToString(inv));
                         sw.Write('\t'); sw.Write(name);
-                        sw.Write('\t'); sw.Write(weights[wi].ToString(@"G17", inv));
+                        sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(weights[wi]));
                         sw.Write('\t'); sw.WriteLine(iters.ToString(inv));
                     }
                     sw.Write(fold.ToString(inv));
                     sw.Write('\t'); sw.Write(weights.Length.ToString(inv));
                     sw.Write('\t'); sw.Write(@"bias");
-                    sw.Write('\t'); sw.Write(model.Bias.ToString(@"G17", inv));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(model.Bias));
                     sw.Write('\t'); sw.WriteLine(iters.ToString(inv));
                 }
             }
@@ -1696,8 +1697,8 @@ namespace pwiz.OspreySharp.FDR
                         : @"unknown";
                     sw.Write(i.ToString(inv));
                     sw.Write('\t'); sw.Write(name);
-                    sw.Write('\t'); sw.Write(means[i].ToString(@"G17", inv));
-                    sw.Write('\t'); sw.WriteLine(stds[i].ToString(@"G17", inv));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(means[i]));
+                    sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(stds[i]));
                 }
             }
             Console.Error.WriteLine(@"Wrote Stage 5 standardizer dump: {0} ({1} features)", path, means.Length);

--- a/pwiz_tools/OspreySharp/OspreySharp.Test/DiagnosticsTest.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.Test/DiagnosticsTest.cs
@@ -1,0 +1,125 @@
+/*
+ * Original author: Brendan MacLean <brendanx .at. uw.edu>,
+ *                  MacCoss Lab, Department of Genome Sciences, UW
+ * AI assistance: Claude Code (Claude Opus 4) <noreply .at. anthropic.com>
+ *
+ * Based on osprey (https://github.com/MacCossLab/osprey)
+ *   by Michael J. MacCoss, MacCoss Lab, Department of Genome Sciences, UW
+ *
+ * Copyright 2026 University of Washington - Seattle, WA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using pwiz.OspreySharp.Core;
+
+namespace pwiz.OspreySharp.Test
+{
+    /// <summary>
+    /// Tests for pwiz.OspreySharp.Core.Diagnostics helpers. Mirrors
+    /// osprey_core::diagnostics::tests on the Rust side -- the two
+    /// implementations must produce byte-identical text for any given f64.
+    /// </summary>
+    [TestClass]
+    public class DiagnosticsTest
+    {
+        [TestMethod]
+        public void TestFormatF64RoundtripSpecialValues()
+        {
+            // Mirrors Rust's format_f64_roundtrip_handles_special_values.
+            Assert.AreEqual("NaN", Diagnostics.FormatF64Roundtrip(double.NaN));
+            Assert.AreEqual("inf", Diagnostics.FormatF64Roundtrip(double.PositiveInfinity));
+            Assert.AreEqual("-inf", Diagnostics.FormatF64Roundtrip(double.NegativeInfinity));
+            Assert.AreEqual("0", Diagnostics.FormatF64Roundtrip(0.0));
+            // -0.0 must not render as "-0", since we normalize signed zero
+            // so that Rust's and .NET's behaviour can't leak into diffs.
+            Assert.AreEqual("0", Diagnostics.FormatF64Roundtrip(-0.0));
+            Assert.AreEqual("1.5", Diagnostics.FormatF64Roundtrip(1.5));
+            Assert.AreEqual("-1.5", Diagnostics.FormatF64Roundtrip(-1.5));
+        }
+
+        [TestMethod]
+        public void TestFormatF64RoundtripIsShortest()
+        {
+            // The value 5.598374948209159 came out of a real Stellar Stage 5
+            // standardizer dump: Rust ryu emits 16 significant digits (no
+            // trailing "9" that G17 would pad on). On .NET Core 3+/.NET 5+,
+            // "R" produces the same short form, so the helper returns
+            // exactly "5.598374948209159". On .NET Framework 4.7.2, "R" is
+            // historically 17 digits for this value; we only require the
+            // helper's output to round-trip (length allowed to vary).
+            double v = 5.598374948209159;
+            string s = Diagnostics.FormatF64Roundtrip(v);
+            double parsed = double.Parse(s, CultureInfo.InvariantCulture);
+            Assert.AreEqual(v, parsed, "FormatF64Roundtrip must round-trip: got {0}", s);
+#if NETCOREAPP || NET5_0_OR_GREATER
+            Assert.AreEqual("5.598374948209159", s,
+                ".NET Core 3+ should emit ryu-shortest byte-matching Rust");
+#endif
+        }
+
+        [TestMethod]
+        public void TestFormatF64RoundtripIntegerValues()
+        {
+            // Rust's ryu elides the decimal point for integer-valued f64,
+            // e.g. 1.0 -> "1", 100.0 -> "100". The C# helper must match.
+            Assert.AreEqual("0", Diagnostics.FormatF64Roundtrip(0.0));
+            Assert.AreEqual("1", Diagnostics.FormatF64Roundtrip(1.0));
+            Assert.AreEqual("-1", Diagnostics.FormatF64Roundtrip(-1.0));
+            Assert.AreEqual("100", Diagnostics.FormatF64Roundtrip(100.0));
+        }
+
+        [TestMethod]
+        public void TestFormatF64RoundtripMatchesRustOnRealStdsValue()
+        {
+            // Real Stellar Stage 5 peak_sharpness std value; Rust's ryu
+            // emits this as "6354533.401694356" (16 sig digits). On .NET
+            // Core 3+, ToString("R") matches byte-for-byte. On .NET
+            // Framework 4.7.2, "R" falls back to G17 (17 digits) because
+            // of the long-standing "R" bug. We only require round-trip
+            // there; the Compare-Stage5 harness defaults to net8.0 to
+            // get byte-identity with Rust.
+            double v = System.BitConverter.Int64BitsToDouble(0x41583D9959B55C3F);
+            string s = Diagnostics.FormatF64Roundtrip(v);
+            Assert.AreEqual(v, double.Parse(s, CultureInfo.InvariantCulture),
+                "FormatF64Roundtrip must round-trip: got {0}", s);
+#if NETCOREAPP || NET5_0_OR_GREATER
+            Assert.AreEqual("6354533.401694356", s,
+                ".NET Core 3+ should emit ryu-shortest byte-matching Rust");
+#endif
+        }
+
+        [TestMethod]
+        public void TestFormatF64RoundtripPreservesEveryBit()
+        {
+            // Cover a handful of near-boundary values that tend to expose
+            // classic "R" / G17 roundtrip bugs on .NET Framework.
+            double[] samples = {
+                0.1, 0.2, 0.3, // repeating-binary classics
+                0.0005,        // 1e-4 boundary (below which C# G<p> flips to scientific)
+                615245.6525365515,
+                -0.01825951711444074,
+                0.13212324912096937,
+            };
+            foreach (double v in samples)
+            {
+                string s = Diagnostics.FormatF64Roundtrip(v);
+                double parsed = double.Parse(s, CultureInfo.InvariantCulture);
+                Assert.AreEqual(v, parsed,
+                    "FormatF64Roundtrip({0}) returned {1} which did not round-trip", v, s);
+            }
+        }
+    }
+}

--- a/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/OspreyDiagnostics.cs
@@ -43,13 +43,15 @@ namespace pwiz.OspreySharp
     /// equivalents. Two floating-point formats are in use by convention:
     /// <list type="bullet">
     /// <item><description>Stages 1-4 dumps use <see cref="F10"/>
-    /// (10 decimal places), matching the Rust equivalents for those
-    /// stages.</description></item>
-    /// <item><description>Stage 5 dumps (standardizer, subsample, SVM
-    /// weights, Percolator) use invariant-culture "G17" (17-digit
-    /// roundtrippable) to match Rust's G17 choice there and to avoid
-    /// .NET Framework's historical "R"-format roundtrip bugs. Do not
-    /// switch these fields to F10.</description></item>
+    /// (10 decimal places, round-half-to-even), matching the Rust
+    /// equivalents for those stages.</description></item>
+    /// <item><description>Stage 5+ dumps (standardizer, subsample, SVM
+    /// weights, Percolator) use
+    /// <see cref="Diagnostics.FormatF64Roundtrip"/>, which emits the
+    /// shortest decimal that round-trips to the same f64 -- matching
+    /// Rust's ryu-based <c>format!("{}", v)</c> output byte-for-byte.
+    /// Do not switch these fields to F10 or to raw "G17".</description>
+    /// </item>
     /// </list>
     /// </summary>
     public static class OspreyDiagnostics
@@ -836,12 +838,12 @@ namespace pwiz.OspreySharp
                     sw.Write('\t'); sw.Write(e.Charge.ToString(inv));
                     sw.Write('\t'); sw.Write(e.ModifiedSequence ?? string.Empty);
                     sw.Write('\t'); sw.Write(e.IsDecoy ? @"true" : @"false");
-                    sw.Write('\t'); sw.Write(e.Score.ToString(@"G17", inv));
-                    sw.Write('\t'); sw.Write(e.Pep.ToString(@"G17", inv));
-                    sw.Write('\t'); sw.Write(e.RunPrecursorQvalue.ToString(@"G17", inv));
-                    sw.Write('\t'); sw.Write(e.RunPeptideQvalue.ToString(@"G17", inv));
-                    sw.Write('\t'); sw.Write(e.ExperimentPrecursorQvalue.ToString(@"G17", inv));
-                    sw.Write('\t'); sw.WriteLine(e.ExperimentPeptideQvalue.ToString(@"G17", inv));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.Score));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.Pep));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPrecursorQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.RunPeptideQvalue));
+                    sw.Write('\t'); sw.Write(Diagnostics.FormatF64Roundtrip(e.ExperimentPrecursorQvalue));
+                    sw.Write('\t'); sw.WriteLine(Diagnostics.FormatF64Roundtrip(e.ExperimentPeptideQvalue));
                 }
             }
             LogAction(string.Format(@"Wrote Stage 5 Percolator dump: {0} ({1} rows)", path, rows.Count));


### PR DESCRIPTION
## Summary

* New `pwiz.OspreySharp.Core.Diagnostics.FormatF64Roundtrip(double)` helper. Uses `"R"` + `double.Parse` round-trip check, falls back to `"G17"`, then expands any scientific-form output to fixed decimal form so the text matches Rust's `format!("{}", v)` byte-for-byte on `.NET Core 3+` / `.NET 5+` / `.NET 8`.
* Replaces 10 `.ToString("G17", inv)` call sites in the three Stage 5 dump writers (`standardizer`, `SVM weights`, end-of-Stage-5 `Percolator`).
* Reconciles the class-level `OspreyDiagnostics` XML doc: Stages 1-4 use `F10`; Stages 5+ use `Core.Diagnostics.FormatF64Roundtrip`. Yesterday's (#4160) note that "Stage 5 uses G17 to match Rust's G17 choice" was incorrect — Rust uses `format!("{}", v)` which is ryu-shortest, not G17.
* Adds `DiagnosticsTest.cs`: special-value handling, integer-valued f64, a real Stellar standardizer value (`5.598374948209159`), and a `#if NETCOREAPP || NET5_0_OR_GREATER` byte-match assertion on `0x41583D9959B55C3F`.

### Framework caveat

`.NET Framework 4.7.2`'s `Double.ToString("R")` has a long-standing bug where a minority of values don't round-trip. The helper detects this via parse-check and falls back to G17, so net472 output still round-trips but may be slightly longer than ryu-shortest for the affected values. The parity harness defaults to net8.0 for correct byte-identity.

### Evidence

Before the fix, an independent SHA-256 byte-parity check across all 3 Stellar single-files failed on 3 of 4 Stage 5 dumps (only the integer-only subsample dump passed). After the fix, **3/3 Stellar files byte-identical on all four dumps**:

```
Stellar Ste-2024-12-02_HeLa_4mz_sDIA_400-900_20   PASS
Stellar Ste-2024-12-02_HeLa_4mz_sDIA_400-900_21   PASS
Stellar Ste-2024-12-02_HeLa_4mz_sDIA_400-900_22   PASS
```

## Test plan

- [x] `Build-OspreySharp.ps1 -RunInspection -RunTests` — all unit tests pass on both net472 and net8.0, zero R# warnings.
- [x] `Compare-Stage5-AllFiles.ps1 -Dataset Stellar` — 3/3 byte-identical.
- [ ] `Compare-Stage5-AllFiles.ps1 -Dataset Astral` — pending Astral Parquet regeneration.

Co-Authored-By: Claude <noreply@anthropic.com>