### PR TITLE
OspreySharp: Percolator streaming path for large datasets (Astral Stage 5 byte parity)

### DIFF
--- a/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp.FDR/PercolatorFdr.cs
@@ -72,6 +72,19 @@ namespace pwiz.OspreySharp.FDR
         /// <summary>Optional feature names for logging (must match feature count).</summary>
         public string[] FeatureNames { get; set; }
 
+        /// <summary>
+        /// If true, <see cref="PercolatorFdr.RunPercolator"/> trains the fold
+        /// models + standardizer and returns early -- skips CV/averaged
+        /// scoring of the input entries, PEP estimation, q-value
+        /// computation, and per-file FDR logging. Used by the streaming
+        /// path in <c>AnalysisPipeline.RunPercolatorStreaming</c>, where
+        /// the caller pre-dedups + subsamples the entries for training,
+        /// then invokes <see cref="PercolatorFdr.ScorePopulationAndComputeFdr"/>
+        /// on the full per-file FdrEntry population. Mirrors Rust's
+        /// <c>PercolatorConfig::train_only</c>.
+        /// </summary>
+        public bool TrainOnly { get; set; }
+
         public PercolatorConfig()
         {
             TrainFdr = 0.01;
@@ -81,6 +94,7 @@ namespace pwiz.OspreySharp.FDR
             Seed = 42;
             CValues = new[] { 0.001, 0.01, 0.1, 1.0, 10.0, 100.0 };
             MaxTrainSize = 300000;
+            TrainOnly = false;
         }
     }
 
@@ -426,6 +440,34 @@ namespace pwiz.OspreySharp.FDR
                 }
             }
 
+            // Train-only mode: return fold models + standardizer; skip the
+            // CV/averaged scoring of the input entries, PEP, and q-values.
+            // Used by the streaming path where the caller (AnalysisPipeline)
+            // will apply the averaged model to ALL FdrEntry values and
+            // compute q-values on the full, scored population. Mirrors
+            // Rust's `config.train_only` short-circuit in
+            // osprey-fdr/src/percolator.rs.
+            if (config.TrainOnly)
+            {
+                var trainFoldWeights = new List<double[]>(config.NFolds);
+                var trainFoldBiases = new List<double>(config.NFolds);
+                var trainIterations = new List<int>(config.NFolds);
+                for (int fold = 0; fold < config.NFolds; fold++)
+                {
+                    trainFoldWeights.Add(foldModels[fold].Weights);
+                    trainFoldBiases.Add(foldModels[fold].Bias);
+                    trainIterations.Add(foldIterations[fold]);
+                }
+                return new PercolatorResults
+                {
+                    Entries = new List<PercolatorResult>(),
+                    FoldWeights = trainFoldWeights,
+                    FoldBiases = trainFoldBiases,
+                    Standardizer = standardizer,
+                    IterationsPerFold = trainIterations
+                };
+            }
+
             // Score ALL entries with trained models
             if (trainSubset != null)
             {
@@ -580,6 +622,181 @@ namespace pwiz.OspreySharp.FDR
                 FoldBiases = foldBiases,
                 Standardizer = standardizer,
                 IterationsPerFold = iterationsPerFold
+            };
+        }
+
+        /// <summary>
+        /// Streaming-path continuation: given the <paramref name="trainResults"/>
+        /// returned by <see cref="RunPercolator"/> with <c>TrainOnly = true</c>
+        /// on a pre-dedup + subsampled training set, apply the averaged fold
+        /// model + standardizer to score ALL entries in the population, fit
+        /// PEP on the global target-decoy competition winners, and compute
+        /// per-run / experiment precursor + peptide q-values on that flat
+        /// score array. Mirrors phases 4-5 of Rust's streaming
+        /// <c>run_percolator_fdr</c> (pipeline.rs:4460-4800).
+        ///
+        /// The returned <see cref="PercolatorResults"/> has one
+        /// <see cref="PercolatorResult"/> per input entry (sorted in the
+        /// same order) plus the training model carried through from
+        /// <paramref name="trainResults"/>.
+        /// </summary>
+        public static PercolatorResults ScorePopulationAndComputeFdr(
+            IList<PercolatorEntry> entries,
+            PercolatorResults trainResults,
+            PercolatorConfig config)
+        {
+            int n = entries.Count;
+            if (n == 0)
+            {
+                return new PercolatorResults
+                {
+                    Entries = new List<PercolatorResult>(),
+                    FoldWeights = trainResults.FoldWeights,
+                    FoldBiases = trainResults.FoldBiases,
+                    Standardizer = trainResults.Standardizer,
+                    IterationsPerFold = trainResults.IterationsPerFold
+                };
+            }
+
+            int nFeatures = entries[0].Features.Length;
+            int nModels = trainResults.FoldWeights.Count;
+            if (nModels == 0)
+                throw new InvalidOperationException(
+                    @"ScorePopulationAndComputeFdr: trainResults contains no fold models");
+
+            // Average fold weights + biases. Matches Rust streaming:
+            //   avg_weights[j] = mean_f(fold_weights[f][j])
+            //   avg_bias       = mean_f(fold_biases[f])
+            var avgWeights = new double[nFeatures];
+            double avgBias = 0.0;
+            for (int f = 0; f < nModels; f++)
+            {
+                double[] foldW = trainResults.FoldWeights[f];
+                for (int j = 0; j < nFeatures; j++)
+                    avgWeights[j] += foldW[j];
+                avgBias += trainResults.FoldBiases[f];
+            }
+            double nModelsD = nModels;
+            for (int j = 0; j < nFeatures; j++)
+                avgWeights[j] /= nModelsD;
+            avgBias /= nModelsD;
+
+            // Apply standardizer + averaged SVM model to every entry.
+            // Serial (not parallel) so float accumulation order stays
+            // deterministic for byte-for-byte cross-impl parity.
+            var standardizer = trainResults.Standardizer;
+            var finalScores = new double[n];
+            var labels = new bool[n];
+            var entryIds = new uint[n];
+            var peptides = new string[n];
+            var fileNames = new string[n];
+            var featureBuf = new double[nFeatures];
+            for (int i = 0; i < n; i++)
+            {
+                var entry = entries[i];
+                labels[i] = entry.IsDecoy;
+                entryIds[i] = entry.EntryId;
+                peptides[i] = entry.Peptide;
+                fileNames[i] = entry.FileName;
+
+                Array.Copy(entry.Features, 0, featureBuf, 0, nFeatures);
+                standardizer.TransformSlice(featureBuf);
+                double score = avgBias;
+                for (int j = 0; j < nFeatures; j++)
+                    score += avgWeights[j] * featureBuf[j];
+                finalScores[i] = score;
+            }
+
+            // PEP via global target-decoy competition. CompeteAll returns
+            // winners sorted by score-descending (matches the direct-path
+            // Percolator flow and is what ComputeConservativeQvalues needs
+            // downstream). Rust's streaming path uses compute_fdr_from_stubs
+            // instead, which iterates a base_id-ascending-sorted union of
+            // targets + decoys -- because PepEstimator.FitDefault's KDE sum
+            // is NOT associative and HashMap iteration order would leak 1-
+            // ULP-level noise into every PEP value. For cross-impl byte
+            // parity we must feed PepEstimator in the same base_id-sorted
+            // order Rust uses, not CompeteAll's score-sorted order. Reorder
+            // a parallel copy here; the score-sorted arrays stay intact for
+            // the per-run / experiment q-value calls below.
+            int[] winnerIndices;
+            double[] winnerScores;
+            bool[] winnerIsDecoy;
+            CompeteAll(finalScores, labels, entryIds,
+                out winnerIndices, out winnerScores, out winnerIsDecoy);
+
+            int nWinners = winnerIndices.Length;
+            var pepOrder = new int[nWinners];
+            for (int k = 0; k < nWinners; k++)
+                pepOrder[k] = k;
+            Array.Sort(pepOrder, (a, b) =>
+            {
+                uint ba = entryIds[winnerIndices[a]] & BASE_ID_MASK;
+                uint bb = entryIds[winnerIndices[b]] & BASE_ID_MASK;
+                return ba.CompareTo(bb);
+            });
+            var pepScores = new double[nWinners];
+            var pepIsDecoy = new bool[nWinners];
+            for (int k = 0; k < nWinners; k++)
+            {
+                pepScores[k] = winnerScores[pepOrder[k]];
+                pepIsDecoy[k] = winnerIsDecoy[pepOrder[k]];
+            }
+
+            var pepEstimator = PepEstimator.FitDefault(pepScores, pepIsDecoy);
+            var peps = new double[n];
+            for (int i = 0; i < n; i++)
+                peps[i] = 1.0;
+            foreach (int idx in winnerIndices)
+                peps[idx] = pepEstimator.PosteriorError(finalScores[idx]);
+
+            // Per-run precursor + peptide q-values (each file independently).
+            var runPrecursorQvalues = ComputePerRunPrecursorQvalues(
+                finalScores, labels, entryIds, fileNames);
+            var runPeptideQvalues = ComputePerRunPeptideQvalues(
+                finalScores, labels, entryIds, fileNames, peptides);
+
+            // Experiment-level q-values: single-file shortcut matches
+            // direct-path semantics.
+            var uniqueFiles = new HashSet<string>(fileNames);
+            bool isSingleFile = uniqueFiles.Count <= 1;
+            double[] expPrecursorQvalues;
+            double[] expPeptideQvalues;
+            if (isSingleFile)
+            {
+                expPrecursorQvalues = (double[])runPrecursorQvalues.Clone();
+                expPeptideQvalues = (double[])runPeptideQvalues.Clone();
+            }
+            else
+            {
+                expPrecursorQvalues = ComputeExperimentPrecursorQvalues(
+                    finalScores, labels, entryIds);
+                expPeptideQvalues = ComputeExperimentPeptideQvalues(
+                    finalScores, labels, entryIds, peptides);
+            }
+
+            var results = new List<PercolatorResult>(n);
+            for (int i = 0; i < n; i++)
+            {
+                results.Add(new PercolatorResult
+                {
+                    Id = entries[i].Id,
+                    Score = finalScores[i],
+                    RunPrecursorQvalue = runPrecursorQvalues[i],
+                    RunPeptideQvalue = runPeptideQvalues[i],
+                    ExperimentPrecursorQvalue = expPrecursorQvalues[i],
+                    ExperimentPeptideQvalue = expPeptideQvalues[i],
+                    Pep = peps[i]
+                });
+            }
+
+            return new PercolatorResults
+            {
+                Entries = results,
+                FoldWeights = trainResults.FoldWeights,
+                FoldBiases = trainResults.FoldBiases,
+                Standardizer = standardizer,
+                IterationsPerFold = trainResults.IterationsPerFold
             };
         }
 

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -4204,6 +4204,57 @@ namespace pwiz.OspreySharp
         /// 21-feature vector is computed during coelution scoring in
         /// <see cref="ScoreCandidate"/> and stored on the entry.
         /// </summary>
+        private double[] BuildBasicFeatures(
+            FdrEntry entry, Dictionary<uint, LibraryEntry> libraryById)
+        {
+            double[] features = new double[NUM_PIN_FEATURES];
+
+            // 0: coelution_sum
+            features[0] = entry.CoelutionSum;
+            // 1: coelution_max (approximate as coelution_sum for basic version)
+            features[1] = entry.CoelutionSum * 0.5;
+            // 2: n_coeluting_fragments
+            features[2] = 3.0;
+            // 3: peak_apex
+            features[3] = 0.0;
+            // 4: peak_area
+            features[4] = 0.0;
+            // 5: peak_sharpness
+            features[5] = 0.0;
+            // 6: xcorr
+            features[6] = 0.0;
+            // 7: consecutive_ions
+            features[7] = 0.0;
+            // 8: explained_intensity
+            features[8] = 0.0;
+            // 9: mass_accuracy_mean
+            features[9] = 0.0;
+            // 10: abs_mass_accuracy_mean
+            features[10] = 0.0;
+            // 11: rt_deviation
+            features[11] = 0.0;
+            // 12: abs_rt_deviation
+            features[12] = 0.0;
+            // 13: ms1_precursor_coelution
+            features[13] = 0.0;
+            // 14: ms1_isotope_cosine
+            features[14] = 0.0;
+            // 15: median_polish_cosine
+            features[15] = 0.0;
+            // 16: median_polish_residual_ratio
+            features[16] = 0.0;
+            // 17: sg_weighted_xcorr
+            features[17] = 0.0;
+            // 18: sg_weighted_cosine
+            features[18] = 0.0;
+            // 19: median_polish_min_fragment_r2
+            features[19] = 0.0;
+            // 20: median_polish_residual_correlation
+            features[20] = 0.0;
+
+            return features;
+        }
+
         /// <summary>
         /// Streaming Percolator dispatch for multi-observation-per-precursor
         /// inputs (total entries above <c>MaxTrainSize * 2</c>). Mirrors
@@ -4314,57 +4365,6 @@ namespace pwiz.OspreySharp
 
             // 4. Apply averaged model to ALL entries and compute q-values.
             return PercolatorFdr.ScorePopulationAndComputeFdr(percEntries, trainResults, percConfig);
-        }
-
-        private double[] BuildBasicFeatures(
-            FdrEntry entry, Dictionary<uint, LibraryEntry> libraryById)
-        {
-            double[] features = new double[NUM_PIN_FEATURES];
-
-            // 0: coelution_sum
-            features[0] = entry.CoelutionSum;
-            // 1: coelution_max (approximate as coelution_sum for basic version)
-            features[1] = entry.CoelutionSum * 0.5;
-            // 2: n_coeluting_fragments
-            features[2] = 3.0;
-            // 3: peak_apex
-            features[3] = 0.0;
-            // 4: peak_area
-            features[4] = 0.0;
-            // 5: peak_sharpness
-            features[5] = 0.0;
-            // 6: xcorr
-            features[6] = 0.0;
-            // 7: consecutive_ions
-            features[7] = 0.0;
-            // 8: explained_intensity
-            features[8] = 0.0;
-            // 9: mass_accuracy_mean
-            features[9] = 0.0;
-            // 10: abs_mass_accuracy_mean
-            features[10] = 0.0;
-            // 11: rt_deviation
-            features[11] = 0.0;
-            // 12: abs_rt_deviation
-            features[12] = 0.0;
-            // 13: ms1_precursor_coelution
-            features[13] = 0.0;
-            // 14: ms1_isotope_cosine
-            features[14] = 0.0;
-            // 15: median_polish_cosine
-            features[15] = 0.0;
-            // 16: median_polish_residual_ratio
-            features[16] = 0.0;
-            // 17: sg_weighted_xcorr
-            features[17] = 0.0;
-            // 18: sg_weighted_cosine
-            features[18] = 0.0;
-            // 19: median_polish_min_fragment_r2
-            features[19] = 0.0;
-            // 20: median_polish_residual_correlation
-            features[20] = 0.0;
-
-            return features;
         }
 
         /// <summary>

--- a/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
+++ b/pwiz_tools/OspreySharp/OspreySharp/AnalysisPipeline.cs
@@ -4100,7 +4100,25 @@ namespace pwiz.OspreySharp
                 FeatureNames = ParquetScoreCache.PIN_FEATURE_NAMES
             };
 
-            var results = PercolatorFdr.RunPercolator(percEntries, percConfig);
+            // Streaming vs direct dispatch, matching Rust
+            // osprey/src/pipeline.rs::run_percolator_fdr. Above the
+            // MaxTrainSize * 2 threshold the training set is dominated by
+            // multi-observation-per-precursor redundancy; best-per-precursor
+            // dedup + peptide-grouped subsample give the SVM a diverse
+            // per-peptide training pool (same approach mokapot takes) and
+            // keep the Stage 5 standardizer fit on the subset -- essential
+            // for cross-impl byte parity with Rust once Astral-scale inputs
+            // push past the threshold.
+            PercolatorResults results;
+            if (percConfig.MaxTrainSize > 0 &&
+                percEntries.Count > percConfig.MaxTrainSize * 2)
+            {
+                results = RunPercolatorStreaming(percEntries, percConfig);
+            }
+            else
+            {
+                results = PercolatorFdr.RunPercolator(percEntries, percConfig);
+            }
 
             // Map results back to FdrEntry stubs
             var resultMap = new Dictionary<string, PercolatorResult>();
@@ -4186,6 +4204,118 @@ namespace pwiz.OspreySharp
         /// 21-feature vector is computed during coelution scoring in
         /// <see cref="ScoreCandidate"/> and stored on the entry.
         /// </summary>
+        /// <summary>
+        /// Streaming Percolator dispatch for multi-observation-per-precursor
+        /// inputs (total entries above <c>MaxTrainSize * 2</c>). Mirrors
+        /// Rust's <c>run_percolator_fdr</c> streaming branch
+        /// (osprey/src/pipeline.rs:4232-4580):
+        /// <list type="number">
+        /// <item>Best-per-precursor dedup across all per-file entries (one
+        /// target + one decoy per base_id, by Features[0] = coelution_sum).
+        /// </item>
+        /// <item>Peptide-grouped subsample to <c>MaxTrainSize</c> using the
+        /// same XOR-shift RNG and peptide-key sort order as Rust.</item>
+        /// <item>Train fold models + standardizer on that subset
+        /// (<c>TrainOnly = true</c>) -- the standardizer is fit on the
+        /// subset, matching Rust's run_percolator-on-subset behaviour
+        /// instead of fitting on the full 1M+ observation pool.</item>
+        /// <item>Apply the averaged model to ALL entries for scoring, then
+        /// compute PEP and per-run / experiment q-values on that flat
+        /// score array.</item>
+        /// </list>
+        /// The selection uses <see cref="PercolatorFdr.SelectBestPerPrecursor"/>
+        /// and <see cref="PercolatorFdr.SubsampleByPeptideGroup"/> -- the
+        /// same helpers the direct path calls internally, so both paths
+        /// select identical 300K subsets when given identical input.
+        /// </summary>
+        private PercolatorResults RunPercolatorStreaming(
+            List<PercolatorEntry> percEntries,
+            PercolatorConfig percConfig)
+        {
+            int n = percEntries.Count;
+            int maxTrain = percConfig.MaxTrainSize;
+
+            // Pull labels / entry IDs / peptides into flat arrays for the
+            // subset helpers.
+            var labels = new bool[n];
+            var entryIds = new uint[n];
+            var peptides = new string[n];
+            for (int i = 0; i < n; i++)
+            {
+                labels[i] = percEntries[i].IsDecoy;
+                entryIds[i] = percEntries[i].EntryId;
+                peptides[i] = percEntries[i].Peptide;
+            }
+
+            // 1. Best-per-precursor dedup.
+            int[] bestIdx = PercolatorFdr.SelectBestPerPrecursor(labels, entryIds, percEntries);
+            int dedupTargets = 0, dedupDecoys = 0;
+            for (int i = 0; i < bestIdx.Length; i++)
+            {
+                if (labels[bestIdx[i]]) dedupDecoys++;
+                else dedupTargets++;
+            }
+            LogInfo(string.Format(
+                "[COUNT] Percolator streaming best-per-precursor: {0} entries ({1} targets, {2} decoys) from {3} total",
+                bestIdx.Length, dedupTargets, dedupDecoys, n));
+
+            // 2. Peptide-grouped subsample if dedup count still exceeds MaxTrainSize.
+            int[] trainSubsetGlobalIdx;
+            if (maxTrain > 0 && bestIdx.Length > maxTrain)
+            {
+                var dedupLabels = new bool[bestIdx.Length];
+                var dedupEntryIds = new uint[bestIdx.Length];
+                var dedupPeptides = new string[bestIdx.Length];
+                for (int i = 0; i < bestIdx.Length; i++)
+                {
+                    int gi = bestIdx[i];
+                    dedupLabels[i] = labels[gi];
+                    dedupEntryIds[i] = entryIds[gi];
+                    dedupPeptides[i] = peptides[gi];
+                }
+                int[] localSelected = PercolatorFdr.SubsampleByPeptideGroup(
+                    dedupLabels, dedupEntryIds, dedupPeptides, maxTrain, percConfig.Seed);
+                trainSubsetGlobalIdx = new int[localSelected.Length];
+                for (int i = 0; i < localSelected.Length; i++)
+                    trainSubsetGlobalIdx[i] = bestIdx[localSelected[i]];
+            }
+            else
+            {
+                trainSubsetGlobalIdx = bestIdx;
+            }
+
+            int subTargets = 0, subDecoys = 0;
+            for (int i = 0; i < trainSubsetGlobalIdx.Length; i++)
+            {
+                if (labels[trainSubsetGlobalIdx[i]]) subDecoys++;
+                else subTargets++;
+            }
+            LogInfo(string.Format(
+                "[COUNT] Percolator streaming subsample: {0} entries ({1} targets, {2} decoys)",
+                trainSubsetGlobalIdx.Length, subTargets, subDecoys));
+
+            // 3. Build subset entry list + train.
+            var subsetEntries = new List<PercolatorEntry>(trainSubsetGlobalIdx.Length);
+            foreach (int i in trainSubsetGlobalIdx)
+                subsetEntries.Add(percEntries[i]);
+            var trainConfig = new PercolatorConfig
+            {
+                TrainFdr = percConfig.TrainFdr,
+                TestFdr = percConfig.TestFdr,
+                MaxIterations = percConfig.MaxIterations,
+                NFolds = percConfig.NFolds,
+                Seed = percConfig.Seed,
+                CValues = percConfig.CValues,
+                MaxTrainSize = percConfig.MaxTrainSize,
+                FeatureNames = percConfig.FeatureNames,
+                TrainOnly = true
+            };
+            PercolatorResults trainResults = PercolatorFdr.RunPercolator(subsetEntries, trainConfig);
+
+            // 4. Apply averaged model to ALL entries and compute q-values.
+            return PercolatorFdr.ScorePopulationAndComputeFdr(percEntries, trainResults, percConfig);
+        }
+
         private double[] BuildBasicFeatures(
             FdrEntry entry, Dictionary<uint, LibraryEntry> libraryById)
         {

--- a/scripts/misc/vcs_trigger_and_paths_config.py
+++ b/scripts/misc/vcs_trigger_and_paths_config.py
@@ -110,6 +110,7 @@ matchPaths = [
     ("pwiz_tools/Skyline/.*DataSource.*", merge(targets['SkylineWithTestConnected'], targets['Container'])),
     ("pwiz_tools/Skyline/.*", merge(targets['Skyline'], targets['Container'])),
     ("pwiz_tools/Shared/.*", merge(targets['Skyline'], targets['BumbershootRelease'], targets['Container'])),
+    ("pwiz_tools/OspreySharp/.*", {}),  # OspreySharp has no dedicated TeamCity build config yet; this silences the build-trigger-gate warning without firing unrelated builds. If/when OspreySharp gets wired into Skyline's build or its own config, map to the appropriate targets.
     ("pwiz_tools/.*", targets['All']),
     ("Jamroot.jam", targets['All']),
     (".*\\.bat", targets['Windows']),


### PR DESCRIPTION
## Summary

* Ports the Rust `run_percolator_fdr` **streaming branch** (`maccoss/osprey/crates/osprey/src/pipeline.rs:4186-4580`, introduced 2026-03-25) to OspreySharp so Stage 5 output stays byte-identical with Rust above the 600K-observation threshold.
* Adds `AnalysisPipeline.RunPercolatorStreaming`: best-per-precursor dedup + peptide-grouped subsample → train-only Percolator on the ~300K subset → averaged fold model + standardizer applied to **all** entries → PEP + per-run/experiment q-values on the flat score array. Dispatched from `RunPercolatorFdr` on the same `total_entries > MaxTrainSize * 2` gate Rust uses.
* Adds `PercolatorConfig.TrainOnly` + an early return in `PercolatorFdr.RunPercolator`; adds `PercolatorFdr.ScorePopulationAndComputeFdr` that mirrors Rust phases 4-5.
* PEP winner ordering matches `compute_fdr_from_stubs` (base_id-ascending) rather than `compete_all` (score-descending), since `PepEstimator.FitDefault`'s KDE sum is not associative and the 1-ULP drift leaks into every PEP value.

### Root cause

Rust's streaming branch was introduced on 2026-03-25 (commit `1d4a9a0e`, predating OspreySharp Phase 1-3 port). On datasets with > 600K observations (Astral single-file has 1.68M), Rust fits the Stage 5 feature standardizer on the 300K best-per-precursor subset; OspreySharp was fitting it on all 1.68M. That cascade of different standardizers → different SVM weights → different scores.

Stellar (462K) takes the direct path on both tools, so the gap went undetected until the 2026-04-23 multi-file validation.

### Evidence

Before: Astral 0/3 files (structural divergence — subsample dump row count differed).
After: **3/3 Stellar + 3/3 Astral files byte-identical on all four Stage 5 dumps** (standardizer / subsample / svm_weights / percolator).

```
Stellar file 20  std=PASS  sub=PASS  svm=PASS  perc=PASS  =>  PASS
Stellar file 21  std=PASS  sub=PASS  svm=PASS  perc=PASS  =>  PASS
Stellar file 22  std=PASS  sub=PASS  svm=PASS  perc=PASS  =>  PASS
Astral  file 49  std=PASS  sub=PASS  svm=PASS  perc=PASS  =>  PASS
Astral  file 55  std=PASS  sub=PASS  svm=PASS  perc=PASS  =>  PASS
Astral  file 60  std=PASS  sub=PASS  svm=PASS  perc=PASS  =>  PASS
```

Phase 4 Stage 6 forward walk depends on this being in master.

## Test plan

- [x] `Build-OspreySharp.ps1 -RunInspection -RunTests` — 221/221 tests pass on net472 + net8.0, zero R# warnings.
- [x] `Compare-Stage5-AllFiles.ps1 -Dataset Stellar` — 3/3 byte-identical (regression check; Stellar still takes the direct path).
- [x] `Compare-Stage5-AllFiles.ps1 -Dataset Astral` — 3/3 byte-identical (new parity via streaming path).

Co-Authored-By: Claude <noreply@anthropic.com>