### PR TITLE
Fix spectrum context menu

### DIFF
--- a/pwiz_tools/Skyline/SkylineGraphs.cs
+++ b/pwiz_tools/Skyline/SkylineGraphs.cs
@@ -1105,6 +1105,7 @@ namespace pwiz.Skyline
 
         void GraphSpectrum.IStateProvider.BuildSpectrumMenu(bool isProteomic, ZedGraphControl zedGraphControl, ContextMenuStrip menuStrip)
         {
+            PrepareZedGraphContextMenu(zedGraphControl, menuStrip);
             using var spectrumContextMenu = new SpectrumContextMenu(this);
             spectrumContextMenu.BuildSpectrumMenu(isProteomic, zedGraphControl, menuStrip);
         }


### PR DESCRIPTION
Fixed missing "Copy Data" right-click menu and removed extraneous menu items (reported by Rita)